### PR TITLE
Point to a list of the actual license identifiers

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -195,7 +195,8 @@ impl Crate {
                     } else {
                         Err(human(format!("unknown license `{}`, \
                                            see http://opensource.org/licenses \
-                                           for options", license)))
+                                           for options, and http://spdx.org/licenses/ \
+                                           for their identifiers", license)))
                     }
                 }
                 None => Ok(()),


### PR DESCRIPTION
The format cargo understands is not necessarily obvious from the license name so it is good to point to a place listing the exact text.
