### PR TITLE
Allow whitespace in package.license

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -188,7 +188,7 @@ impl Crate {
             match license {
                 Some(license) => {
                     let ok = license.split('/').all(|l| {
-                        KNOWN_LICENSES.binary_search_elem(&l).found().is_some()
+                        KNOWN_LICENSES.binary_search_elem(&l.trim()).found().is_some()
                     });
                     if ok {
                         Ok(())


### PR DESCRIPTION
Allow e.g. `license = "MIT / Apache-2.0"` rather than just `license = "MIT/Apache-2.0"`.

(This is completely untested.)
