### PR TITLE
Add the FMOD non-commercial license

### DIFF
--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -120,6 +120,7 @@ pub const KNOWN_LICENSES: &'static [&'static str] = &[
     "FSFULLR",
     "FTL",
     "Fair",
+    "FMOD-commercial",
     "Frameworx-1.0",
     "GFDL-1.1",
     "GFDL-1.2",


### PR DESCRIPTION
For the full license :
## FMOD NON-COMMERCIAL LICENSE

---

IF YOUR PRODUCT IS NOT INTENDED FOR COMMERCIAL GAIN AND DOES NOT 
INCLUDE THE FMOD LIBRARY FOR RESALE, LICENSE OR OTHER COMMERCIAL 
DISTRIBUTION, THEN USE OF FMOD IS FREE OF CHARGE.  THERE ARE NO 
LICENSE FEES FOR NON-COMMERCIAL APPLICATIONS.
THE USER MAY USE THIS EULA AS EVIDENCE OF THEIR LICENSE WITHOUT 
CONTACTING FIRELIGHT TECHNOLOGIES.

CONDITIONS/LIMITATIONS:
- WHEN USING THIS LICENSE, THE FMOD LIBRARY CANNOT BE USED FOR 
  RESALE OR OTHER COMMERCIAL DISTRIBUTION 
- THIS LICENSE CANNOT BE USED FOR PRODUCTS WHICH DO NOT MAKE 
  PROFIT BUT ARE STILL COMMERCIALLY RELEASED 
- THIS LICENSE CANNOT BE USED FOR COMMERCIAL SERVICES, WHERE THE 
  EXECUTABLE CONTAINING FMOD IS NOT SOLD, BUT THE DATA IS.
- WHEN USING FMOD, A CREDIT LINE IS REQUIRED IN EITHER DOCUMENTATION, 
  OR 'ON SCREEN' FORMAT (IF POSSIBLE). IT SHOULD CONTAIN AT LEAST 
  THE WORDS "FMOD" (OR "FMOD STUDIO" IF APPLICABLE) AND 
  "FIRELIGHT TECHNOLOGIES."
  LOGOS ARE AVAILABLE FOR BOX OR MANUAL ART, BUT ARE NOT MANDATORY. 
  AN EXAMPLE CREDIT COULD BE:
  
  FMOD Sound System, copyright � Firelight Technologies Pty, Ltd., 1994-2014.
  OR
  FMOD Studio, copyright � Firelight Technologies Pty, Ltd., 1994-2014.
  OR 
  Audio Engine supplied by FMOD by Firelight Technologies.
  
  NOTE THIS IN ADVANCE, AS IT MUST BE DONE BEFORE SHIPPING YOUR 
  PRODUCT WITH FMOD.
