### PR TITLE
rustup command: hide curl progress output

### DIFF
--- a/app/templates/install.hbs
+++ b/app/templates/install.hbs
@@ -9,7 +9,7 @@
 </p>
 
 <pre>
-$ curl https://static.rust-lang.org/rustup.sh | sudo bash
+$ curl -sS https://static.rust-lang.org/rustup.sh | sudo bash
 </pre>
 
 <h2>Only Cargo</h2>


### PR DESCRIPTION
This is the same as https://github.com/rust-lang/cargo/pull/896
