### PR TITLE
add default proxy address to .ember-cli

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
+  "proxy": "http://127.0.0.1:8888/",
   "disableAnalytics": false
 }


### PR DESCRIPTION
so you don't need to remember running "ember s" with:
"--proxy http://localhost:8888"
