### PR TITLE
Use `file://` and an absolute path in init-local-index.

### DIFF
--- a/script/init-local-index.sh
+++ b/script/init-local-index.sh
@@ -24,7 +24,7 @@ cat > config.json <<-EOF
 EOF
 git add config.json
 git commit -qm 'Initial commit'
-git remote add origin ../index-bare
+git remote add origin file://`pwd`/../index-bare
 git push -q origin master -u > /dev/null
 cd ../..
 touch tmp/index-co/.git/git-daemon-export-ok
@@ -37,4 +37,3 @@ Please add the following to your HOME/.cargo/config:
 
 You will also need to generate a token from in the app itself
 EOF
-


### PR DESCRIPTION
This works for me, unlike no `file://` and/or a relative path.
