### PR TITLE
Let's use caret requirements (^) instead of tilde requirements (~)

### DIFF
--- a/app/templates/crate/index.hbs
+++ b/app/templates/crate/index.hbs
@@ -49,7 +49,7 @@
         {{/if}}
         <div class='install'>
             <div class='action'>Cargo.toml</div>
-            <code>{{ name }} = "~{{ currentVersion.num }}"</code>
+            <code>{{ name }} = "{{ currentVersion.num }}"</code>
         </div>
     </div>
     <div class='authorship'>


### PR DESCRIPTION
Supposing that cargos use the semantic versioning, caret requirements(^) is the perfect default option to show since tilde requirements(~) can be somewhat unnecessarily strict.

I think most people will use caret instead of tilde. Why don't we show caret?

![](http://i.imgur.com/ch0Zfl5.png)
###### Reference
- http://semver.org
- https://github.com/rust-lang/semver#requirements
- https://nodesource.com/blog/semver-tilde-and-caret
