### PR TITLE
Show first page on new searches

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -35,7 +35,9 @@ export default Ember.Controller.extend({
 
     actions: {
         search: function(query) {
-            this.transitionToRoute('search', {queryParams: {q: query}});
+            this.transitionToRoute('search', {
+              queryParams: {q: query, page: 1}
+            });
         },
 
         toggleUserOptions: function() {


### PR DESCRIPTION
The `page` query param is not reset when searching and can show no
results when the new search has less results than the previous search.

eg: Search for `http` and then for `docopt`
