### PR TITLE
Uses area chart instead of line chart

### DIFF
--- a/app/controllers/crate/index.js
+++ b/app/controllers/crate/index.js
@@ -151,7 +151,7 @@ export default Ember.ObjectController.extend({
             }
 
             var headers = ['Date'];
-            versions.sort(function(b) { return b.num; });
+            versions.sort(function(b) { return b.num; }).reverse();
             for (i = 0; i < versions.length; i++) {
                 headers.push(versions[i].num);
             }
@@ -181,7 +181,7 @@ export default Ember.ObjectController.extend({
                 if (!el) {
                     return;
                 }
-                var chart = new google.visualization.LineChart(el);
+                var chart = new google.visualization.AreaChart(el);
                 chart.draw(myData, {
                     chartArea: {'width': '80%', 'height': '80%'},
                     hAxis: {
@@ -191,6 +191,7 @@ export default Ember.ObjectController.extend({
                         minorGridlines: { count: 5 },
                         viewWindow: { min: 0, },
                     },
+                    isStacked: true,
                 });
             };
 


### PR DESCRIPTION
This addresses #95.

Here are some screenshots for comparison. These charts are from the gcc crate:

![without-area](https://cloud.githubusercontent.com/assets/965436/5572139/f4c4ce86-8f67-11e4-8f0c-91ed0b6ab008.png)

![with-area](https://cloud.githubusercontent.com/assets/965436/5572142/f824d71a-8f67-11e4-9078-99c47f72eea4.png)

Ultimately this has a lot to do with personal preference so I understand if the line charts are preferred over the area charts. This ended up being a one line fix so no big deal either way. 
