### PR TITLE
Allows users to see download numbers on overlapping lines

### DIFF
--- a/app/controllers/crate/index.js
+++ b/app/controllers/crate/index.js
@@ -192,6 +192,7 @@ export default Ember.ObjectController.extend({
                         viewWindow: { min: 0, },
                     },
                     isStacked: true,
+                    focusTarget: 'category',
                 });
             };
 


### PR DESCRIPTION
Allows users to see a box with the number of downloads for each crate version on a given day instead of examining each data point independently. This helps when multiple versions have 0 downloads on a given day and their chart lines overlap.

![screen shot 2015-01-02 at 2 42 09 pm](https://cloud.githubusercontent.com/assets/965436/5599626/82eb16c4-9298-11e4-95c8-d2861e44215a.png)
