### PR TITLE
Use computed property for versions length

### DIFF
--- a/app/controllers/crate/index.js
+++ b/app/controllers/crate/index.js
@@ -36,6 +36,10 @@ export default Ember.ObjectController.extend({
              this.get('repository');
     }.property('homepage', 'wiki', 'mailing_list', 'documentation', 'repository'),
 
+    versionsCount: function() {
+      return this.get('versions.length');
+    }.property('versions.@each'),
+
     displayedAuthors: function() {
         var self = this;
         if (!this.get('currentVersion')) {

--- a/app/templates/crate/index.hbs
+++ b/app/templates/crate/index.hbs
@@ -200,7 +200,7 @@
         <div class='stat'>
             <span {{bind-attr class="crate.versions.isPending:loading :num"}}>
                 <img src="/assets/package.png"/>
-                {{ versions.length }}
+                {{ versionsCount }}
             </span>
             <span class='desc small'>Versions published</span>
         </div>


### PR DESCRIPTION
A bug is causing `versions` to be fetched once for each version causing
excessive queries to slow down or freeze the page.

* Turn versions.length into a computed property to prevent extra
  requests

This only happens when you visit from the search. I found this by looking for "hyper" and clicking the first link and experiencing unresponsiveness. I'm not totally sure, but I think this might be a result of having both a `versions` attribute that is null from the search and having a `versions` attribute in `links`.

This could probably be avoided altogether by passing `version_ids` instead of the objects or links in addition to coalescing the requests. If you decide to go that way and need some help on the Ember side I'm more than happy to help implement that.