### PR TITLE
Change most used to most directly depended upon

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -12,7 +12,7 @@ export default Ember.Route.extend({
     };
     return ajax('/summary').then(function(data) {
         addCrates(data.new_crates);
-        addCrates(data.most_downloaded);
+        addCrates(data.most_directly_depended_upon);
         addCrates(data.just_updated);
         return data;
     });

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -40,9 +40,9 @@
         <h2>New Crates</h2>
         {{render "crate-list" new_crates}}
     </div>
-    <div id='most-downloaded'>
-        <h2>Most Downloaded</h2>
-        {{render "crate-list" most_downloaded}}
+    <div id='most-depended-upon'>
+        <h2>Most Depended Upon</h2>
+        {{render "crate-list" most_directly_depended_upon}}
     </div>
     <div id='just-updated'>
         <h2>Just Updated</h2>

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -550,22 +550,22 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
                                         WHERE updated_at::timestamp(0) !=
                                               created_at::timestamp(0)
                                         ORDER BY updated_at DESC LIMIT 10"));
-    let most_downloaded = try!(tx.prepare("SELECT * FROM crates \
-                                           ORDER BY downloads DESC LIMIT 10"));
+    let most_directly_depended_upon = try!(tx.prepare("SELECT * FROM crates \
+                                        ORDER BY dependencies-on DESC LIMIT 10"));
 
     #[derive(RustcEncodable)]
     struct R {
         num_downloads: i64,
         num_crates: i64,
         new_crates: Vec<EncodableCrate>,
-        most_downloaded: Vec<EncodableCrate>,
+        most_directly_depended_upon: Vec<EncodableCrate>,
         just_updated: Vec<EncodableCrate>,
     }
     Ok(req.json(&R {
         num_downloads: num_downloads,
         num_crates: num_crates,
         new_crates: try!(to_crates(new_crates)),
-        most_downloaded: try!(to_crates(most_downloaded)),
+        most_directly_depended_upon: try!(to_crates(most_directly_depended_upon)),
         just_updated: try!(to_crates(just_updated)),
     }))
 }


### PR DESCRIPTION
Fixes #110 

<s>This is very verbose (it calls it `Most Directly Depended Upon`).</s>
This calls the field `Most Depended Upon`, but is still verbose with the data field, calling the property `most_directly_depended_upon`.
Is this what we want?

@alexcrichton you mentioned in the issue to sort by `dependencies-on`.
Is this sufficient to count _only_ direct dependencies?