### PR TITLE
Automatically install bower dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ sudo: false
 
 before_script:
   - psql -c 'create database cargo_registry_test;' -U postgres
-  - npm install -g phantomjs ember-cli bower
+  - npm install -g phantomjs ember-cli
   - npm install
-  - bower install
 
 script:
   - cargo build

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Source code for the default registry for Cargo users. Can be found online at
 
 * `git clone` this repository
 * `npm install`
-* `bower install`
 
 ## Making UI tweaks or changes
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "tests"
   },
   "scripts": {
+    "postinstall": "bower install",
     "start": "ember server",
     "startui": "ember server --proxy https://staging-crates-io.herokuapp.com",
     "build": "ember build",
@@ -20,6 +21,7 @@
   "license": "MIT",
   "devDependencies": {
     "body-parser": "^1.2.0",
+    "bower": "^1.3.12",
     "broccoli-asset-rev": "0.1.1",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
     "broccoli-sass": "^0.2.2",


### PR DESCRIPTION
Makes `npm install` "just work" and doesn't require bower to be installed globally.

npm is clever enough to prepend `PATH` with `./node_modules/.bin` for the postinstall script, which ensures that the right version of bower is used.