### PR TITLE
Normalise keywords to lowercase when searching for crates.

### DIFF
--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -440,6 +440,14 @@ fn migrations() -> Vec<Migration> {
                              ON crates (lower(name))", &[]));
             Ok(())
         }),
+        Migration::new(20150320174400, |tx| {
+            try!(tx.execute("CREATE INDEX index_keywords_lower_keyword ON keywords (lower(keyword))",
+                            &[]));
+            Ok(())
+        }, |tx| {
+            try!(tx.execute("DROP INDEX index_keywords_lower_keyword", &[]));
+            Ok(())
+        }),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -463,7 +463,7 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
                                 ON crates.id = crates_keywords.crate_id
                         INNER JOIN keywords
                                 ON crates_keywords.keyword_id = keywords.id
-                        WHERE keywords.keyword = $1";
+                        WHERE lower(keywords.keyword) = lower($1)";
             (format!("SELECT crates.* {} {} LIMIT $2 OFFSET $3", base, sort_sql),
              format!("SELECT COUNT(crates.*) {}", base))
         })

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -68,7 +68,9 @@ fn index_queries() {
     krate.readme = Some("readme".to_string());
     krate.description = Some("description".to_string());
     ::mock_crate(&mut req, krate);
-    ::mock_crate(&mut req, ::krate("BAR"));
+    let mut krate2 = ::krate("BAR");
+    krate2.keywords.push("KW1".to_string());
+    ::mock_crate(&mut req, krate2);
 
     let mut response = ok_resp!(middle.call(req.with_query("q=baz")));
     assert_eq!(::json::<CrateList>(&mut response).meta.total, 0);
@@ -77,7 +79,7 @@ fn index_queries() {
     let mut response = ok_resp!(middle.call(req.with_query("q=foo")));
     assert_eq!(::json::<CrateList>(&mut response).meta.total, 1);
     let mut response = ok_resp!(middle.call(req.with_query("q=kw1")));
-    assert_eq!(::json::<CrateList>(&mut response).meta.total, 1);
+    assert_eq!(::json::<CrateList>(&mut response).meta.total, 2);
     let mut response = ok_resp!(middle.call(req.with_query("q=readme")));
     assert_eq!(::json::<CrateList>(&mut response).meta.total, 1);
     let mut response = ok_resp!(middle.call(req.with_query("q=description")));
@@ -99,7 +101,9 @@ fn index_queries() {
     assert_eq!(::json::<CrateList>(&mut response).crates.len(), 0);
 
     let mut response = ok_resp!(middle.call(req.with_query("keyword=kw1")));
-    assert_eq!(::json::<CrateList>(&mut response).crates.len(), 1);
+    assert_eq!(::json::<CrateList>(&mut response).crates.len(), 2);
+    let mut response = ok_resp!(middle.call(req.with_query("keyword=KW1")));
+    assert_eq!(::json::<CrateList>(&mut response).crates.len(), 2);
     let mut response = ok_resp!(middle.call(req.with_query("keyword=kw2")));
     assert_eq!(::json::<CrateList>(&mut response).crates.len(), 0);
 }


### PR DESCRIPTION
Currently keyword search is case-sensitive, but this is often unhelpful,
as they are heuristic classification tools, not hard guarantees.  It's
not particularly helpful to search for
["fft"](https://crates.io/keywords/fft) and not get the crates tagged
["FFT"](https://crates.io/keywords/FFT).

Closes #100.