### PR TITLE
add a "badge" route for crates

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1019,3 +1019,12 @@ pub fn reverse_dependencies(req: &mut Request) -> CargoResult<Response> {
     struct Meta { total: i64 }
     Ok(req.json(&R{ dependencies: rev_deps, meta: Meta { total: total } }))
 }
+
+pub fn shield(req: &mut Request) -> CargoResult<Response> {
+    let name = &req.params()["crate_id"];
+    let conn = try!(req.tx());
+    let krate = try!(Crate::find_by_name(conn, &name));
+    Ok(req.redirect(format!(
+                "https://img.shields.io/badge/crates.io-{}-green.svg",
+                krate.max_version)))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     api_router.delete("/crates/:crate_id/:version/yank", C(version::yank));
     api_router.put("/crates/:crate_id/:version/unyank", C(version::unyank));
     api_router.get("/crates/:crate_id/reverse_dependencies", C(krate::reverse_dependencies));
+    api_router.get("/crates/:crate_id.svg", C(krate::shield));
     api_router.get("/versions", C(version::index));
     api_router.get("/versions/:version_id", C(version::show));
     api_router.get("/keywords", C(keyword::index));


### PR DESCRIPTION
The route /crates/foo.svg will redirect to shields.io, of an svg showing
the latest version of the crate on crates.io.

Example: [![0.3.7](https://img.shields.io/badge/crates.io-0.3.7-green.svg)](https://crates.io/crates/hyper)

This could be shown in the UI somehow, but for now, exposing a route is quite cheap, and shields.io encourages use like this. A use case is including the badge in the README on github, so visitors can see what is the latest version published, even if master is a little ahead.