### PR TITLE
Set the tab index of the search input to 1.

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -15,7 +15,8 @@
         {{input type="text" class="search" name="q"
                 placeholder="Search"
                 value=search
-                action="search"}}
+                action="search"
+                tabindex="1"}}
     </form>
 
     <div class='nav'>


### PR DESCRIPTION
I try to tab-select the search box every time I visit crates.io, but other elements such as the 'Fork me' ribbon have priority by default.  This is a simple change that makes things a little bit nicer.

Perhaps as well some other links should have an index assigned to them, but I am not sure which ones to assign or in what order they should be assigned.  Maybe just 'Browse All' and 'Log In', left-to-right, would be enough?