### PR TITLE
Use `replaceWith` to transition from missing crate

### DIFF
--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -10,17 +10,16 @@ export default Ember.Route.extend({
             version = parts[1];
         }
         var self = this;
-        var a = Ember.RSVP.hash({
+        return Ember.RSVP.hash({
             crate: this.store.find('crate', crate_id).catch(function(e) {
                 if (e.status === 404) {
                     self.controllerFor('application').set('nextFlashError',
                             'No crate named: ' + params.crate_id);
-                    return self.transitionTo('index');
+                    return self.replaceWith('index');
                 }
             }),
             version: version,
         });
-        return a;
     },
 
     serialize: function(model) {


### PR DESCRIPTION
When visiting a crate that doesn't exist the application uses
`transitionTo` to change the route to the index route. This allows the
user to navigate back to the same missing crate route which breaks the
browsers back button.

* Replace `transitionTo` with `replaceWith` to avoid adding history
  entry.

https://github.com/rust-lang/crates.io/issues/141