### PR TITLE
Make graph version numbers not wrap

### DIFF
--- a/app/controllers/crate/index.js
+++ b/app/controllers/crate/index.js
@@ -206,7 +206,7 @@ export default Ember.ObjectController.extend({
                 }
                 var chart = new google.visualization.AreaChart(el);
                 chart.draw(myData, {
-                    chartArea: {'width': '80%', 'height': '80%'},
+                    chartArea: {'width': '78%', 'height': '80%'},
                     hAxis: {
                         minorGridlines: { count: 8 },
                     },


### PR DESCRIPTION
Crates such as [regex](https://crates.io/crates/regex) have their version numbers wrapping in the graph which shouldn't be happening. Make the graph smaller so it stops happening.

Note: I couldn't test this because no test crates have version numbers high enough to trigger wrap-around. I'm not sure if I'm able to upload to it or if an admin has to do it. Either way, I'd upload a crate with a version number like `42.12.88` (admittedly, a crate with 6 digits might be unlikely...not sure) so the graph can be sized accordingly.

Then I'd change the size so it doesn't wrap.