### PR TITLE
Second try making the graph legend fit without wrap

### DIFF
--- a/app/controllers/crate/index.js
+++ b/app/controllers/crate/index.js
@@ -206,7 +206,7 @@ export default Ember.ObjectController.extend({
                 }
                 var chart = new google.visualization.AreaChart(el);
                 chart.draw(myData, {
-                    chartArea: {'width': '80%', 'height': '80%'},
+                    chartArea: {'left': 85, 'width': '77%', 'height': '80%'},
                     hAxis: {
                         minorGridlines: { count: 8 },
                     },


### PR DESCRIPTION
Should be good for at least a 100,000 downloads and 5 digit versions without resorting to wrapping. It's shifted because staying centered tends to keep it too far to the right (the diagram stays centered while the legend gets closer to the edge).

Regex crate:
![regex](https://cloud.githubusercontent.com/assets/4156987/9186572/4d0ecc18-3f94-11e5-9ca9-f10c5bf0cb17.png)
