### PR TITLE
Add a table to track rust version compatibiltiy of crates

### DIFF
--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -482,6 +482,12 @@ fn migrations() -> Vec<Migration> {
                              UNIQUE (owner_id, crate_id)", &[]));
             Ok(())
         }),
+        Migration::add_table(20150908213737, "rust_versions", "
+            id              SERIAL PRIMARY KEY,
+            crate_id        INTEGER NOT NULL,
+            name            VARCHAR NOT NULL UNIQUE
+        "),
+        foreign_key(20150908214925, "rust_versions", "crate_id", "crates (id)"),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`
 


### PR DESCRIPTION
The rust_version table will track what rust versions is a given
crate compatible with. There is a foreign key relationship
with the crates table on crate id.