### PR TITLE
In a crate search query, order the results by name in addition to rank

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -476,7 +476,8 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
                                plainto_tsquery($1) q,
                                ts_rank_cd(textsearchable_index_col, q) rank
           WHERE q @@ textsearchable_index_col
-          ORDER BY rank DESC LIMIT $2 OFFSET $3".to_string(),
+          ORDER BY rank DESC, crates.name ASC
+          LIMIT $2 OFFSET $3".to_string(),
          "SELECT COUNT(crates.*) FROM crates,
                                       plainto_tsquery($1) q
           WHERE q @@ textsearchable_index_col".to_string())


### PR DESCRIPTION
Since `ts_rank_cd()` doesn't provide unique ordering using it with `LIMIT ... OFFSET` will lead to inconsistent results, as is apparent from #162. Add ordering by name to break the ties.