### PR TITLE
Well-known routes

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,25 @@
+# Credentials for uploading packages to S3, these can be blank if you're not
+# publishing locally.
+S3_BUCKET=
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+# Not needed if the S3 bucket is in US standard
+S3_REGION=      
+
+# Credentials for talking to github, can be blank if you're not logging in.
+#
+# When registering a new application, be sure to set the callback url to the
+# address `http://localhost:4200/authorize/github`.
+GH_CLIENT_ID=
+GH_CLIENT_SECRET=
+
+# Key to sign and encrypt cookies with
+SESSION_KEY=badkey
+
+# Location of the *postgres* database
+# (eg. postgres://postgres:@localhost/cargo_registry)
+DATABASE_URL=postgres://postgres:@localhost/cargo_registry
+
+# Remote and local locations of the registry index
+GIT_REPO_URL=file://./tmp/index-bare
+GIT_REPO_CHECKOUT=./tmp/index-co

--- a/app/controllers/crate/docs.js
+++ b/app/controllers/crate/docs.js
@@ -1,0 +1,4 @@
+import Ember from 'ember';
+
+export default Ember.ObjectController.extend({
+});

--- a/app/router.js
+++ b/app/router.js
@@ -16,6 +16,9 @@ Router.map(function() {
     this.route('download');
     this.route('versions');
     this.route('reverse_dependencies');
+
+    // Well-known routes
+    this.route('docs');
   });
   this.route('me', function() {
     this.route('crates');

--- a/app/routes/crate/docs.js
+++ b/app/routes/crate/docs.js
@@ -11,18 +11,17 @@ export default Ember.Route.extend({
             crate = data.crate;
         }
 
-        var documentation = crate.get('documentation'),
-            self          = this;
+        var documentation = crate.get('documentation');
 
-        setTimeout(function() {
-            if (documentation) {
-                window.location = documentation;
-            } else {
-                // Redirect to the crate's main page if no documentation
-                // URL is found.
-                self.transitionTo('crate', crate);
-            }
-        }, 2500);
+        if (documentation) {
+            window.location = documentation;
+        } else {
+            // Redirect to the crate's main page and show a flash error if
+            // no documentation is found
+            var message = 'Crate does not supply a documentation URL';
+            this.controllerFor('application').set('nextFlashError', message);
+            this.replaceWith('crate', crate);
+        }
 
         this._super(controller, crate);
     },

--- a/app/routes/crate/docs.js
+++ b/app/routes/crate/docs.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+import Crate from 'cargo/models/crate';
+
+export default Ember.Route.extend({
+		afterModel: function(data) {
+        var crate;
+
+				if (data instanceof Crate) {
+						crate = data;
+				} else {
+						crate = data.crate;
+				}
+
+        var documentation = crate.get('documentation');
+
+        if (documentation) {
+            window.location = documentation;
+        } else {
+            // Redirect to the crate's main page if no documentation
+            // URL is found.
+            this.transitionTo('crate', crate);
+        }
+		}
+});

--- a/app/routes/crate/docs.js
+++ b/app/routes/crate/docs.js
@@ -2,23 +2,28 @@ import Ember from 'ember';
 import Crate from 'cargo/models/crate';
 
 export default Ember.Route.extend({
-		afterModel: function(data) {
+    setupController: function(controller, data) {
         var crate;
 
-				if (data instanceof Crate) {
-						crate = data;
-				} else {
-						crate = data.crate;
-				}
-
-        var documentation = crate.get('documentation');
-
-        if (documentation) {
-            window.location = documentation;
+        if (data instanceof Crate) {
+            crate = data;
         } else {
-            // Redirect to the crate's main page if no documentation
-            // URL is found.
-            this.transitionTo('crate', crate);
+            crate = data.crate;
         }
-		}
+
+        var documentation = crate.get('documentation'),
+            self          = this;
+
+        setTimeout(function() {
+            if (documentation) {
+                window.location = documentation;
+            } else {
+                // Redirect to the crate's main page if no documentation
+                // URL is found.
+                this.transitionTo('crate', crate);
+            }
+        }, 2500);
+
+        this._super(controller, crate);
+    },
 });

--- a/app/routes/crate/docs.js
+++ b/app/routes/crate/docs.js
@@ -20,7 +20,7 @@ export default Ember.Route.extend({
             } else {
                 // Redirect to the crate's main page if no documentation
                 // URL is found.
-                this.transitionTo('crate', crate);
+                self.transitionTo('crate', crate);
             }
         }, 2500);
 

--- a/app/templates/crate/docs.hbs
+++ b/app/templates/crate/docs.hbs
@@ -1,0 +1,12 @@
+<div id="crates-heading">
+    <img class="logo" src="/assets/circle-with-i.png"/>
+    <h1>Documentation for <em>{{name}}</em></h1>
+</div>
+
+<p>
+    {{#if documentation}}
+        Redirecting you to <code>{{documentation}}</code>&#8230;
+    {{else}}
+        <strong>{{name}}</strong> is missing a documentation URL, returning to the crate main page&#8230;
+    {{/if}}
+</p>

--- a/app/templates/crate/docs.hbs
+++ b/app/templates/crate/docs.hbs
@@ -4,9 +4,5 @@
 </div>
 
 <p>
-    {{#if documentation}}
-        Redirecting you to <code>{{documentation}}</code>&#8230;
-    {{else}}
-        <strong>{{name}}</strong> is missing a documentation URL, returning to the crate main page&#8230;
-    {{/if}}
+    Redirecting you to <code>{{documentation}}</code>&#8230;
 </p>


### PR DESCRIPTION
Implementation of rust-lang/crates.io#197.

#### Things to discuss:

- [ ] Possible CSRF action if a crate has a malicious `documentation` URL?
- [x] This currently transitions to the crate's main page if there isn't a documentation URL; is that the behavior we want? (Update: No, showing a brief [flash message](#issuecomment-153287635) before redirecting.)
- [ ] Should we take this opportunity to add more well-known paths? (@durka suggested homepage and repository in their original issue.)