### PR TITLE
routes/crate: Fix meta.extra_downloads handling

### DIFF
--- a/app/routes/crate/index.js
+++ b/app/routes/crate/index.js
@@ -52,11 +52,7 @@ export default Ember.Route.extend({
             });
 
         }).then(() => {
-            if (controller.get('requestedVersion')) {
-                return controller.get('currentVersion.version_downloads');
-            } else {
-                return controller.get('model.version_downloads');
-            }
+            return controller.get('model.version_downloads');
         }).then((downloads) => {
             var meta = downloads.get('meta');
             controller.set('fetchingDownloads', false);


### PR DESCRIPTION
This might resolve #220 but since I can't reliably reproduce it I'm not sure. In any case it fixes the currently broken download graphs for crate version routes like https://crates.io/crates/libc/0.2.2. 

Sorry about that!