### PR TITLE
Rely on the database for data things

### DIFF
--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -492,7 +492,8 @@ fn migrations() -> Vec<Migration> {
             ALTER TABLE version_downloads ALTER date SET DEFAULT current_date;
             ALTER TABLE version_downloads ALTER processed SET DEFAULT 'f';
 
-
+            ALTER TABLE keywords ALTER created_at SET DEFAULT current_timestamp;
+            ALTER TABLE keywords ALTER crates_cnt SET DEFAULT 0;
             "));
             Ok(())
 
@@ -503,7 +504,8 @@ fn migrations() -> Vec<Migration> {
             ALTER TABLE version_downloads ALTER date DROP DEFAULT;
             ALTER TABLE version_downloads ALTER processed DROP DEFAULT;
 
-
+            ALTER TABLE keywords ALTER created_at DROP DEFAULT;
+            ALTER TABLE keywords ALTER crates_cnt DROP DEFAULT;
             "));
             Ok(())
         }),

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -485,6 +485,28 @@ fn migrations() -> Vec<Migration> {
         }),
         Migration::add_column(20151118135514, "crates", "max_upload_size",
                               "INTEGER"),
+        Migration::new(20151126095136, |tx| {
+            try!(tx.batch_execute("
+            ALTER TABLE version_downloads ALTER downloads SET DEFAULT 1;
+            ALTER TABLE version_downloads ALTER counted SET DEFAULT 0;
+            ALTER TABLE version_downloads ALTER date SET DEFAULT current_date;
+            ALTER TABLE version_downloads ALTER processed SET DEFAULT 'f';
+
+
+            "));
+            Ok(())
+
+        }, |tx| {
+            try!(tx.batch_execute("
+            ALTER TABLE version_downloads ALTER downloads DROP DEFAULT;
+            ALTER TABLE version_downloads ALTER counted DROP DEFAULT;
+            ALTER TABLE version_downloads ALTER date DROP DEFAULT;
+            ALTER TABLE version_downloads ALTER processed DROP DEFAULT;
+
+
+            "));
+            Ok(())
+        }),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`
 

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -504,6 +504,10 @@ fn migrations() -> Vec<Migration> {
             ALTER TABLE crate_owners ALTER updated_at SET DEFAULT current_timestamp;
             ALTER TABLE crate_owners ALTER deleted SET DEFAULT 'f';
 
+            ALTER TABLE versions ALTER created_at SET DEFAULT current_timestamp;
+            ALTER TABLE versions ALTER updated_at SET DEFAULT current_timestamp;
+            ALTER TABLE versions ALTER downloads SET DEFAULT 0;
+
             CREATE FUNCTION update_keywords_crates_cnt() RETURNS trigger AS $$
             BEGIN
                 IF (TG_OP = 'INSERT') THEN
@@ -540,6 +544,10 @@ fn migrations() -> Vec<Migration> {
             ALTER TABLE crate_owners ALTER created_at DROP DEFAULT;
             ALTER TABLE crate_owners ALTER updated_at DROP DEFAULT;
             ALTER TABLE crate_owners ALTER deleted DROP DEFAULT;
+
+            ALTER TABLE versions ALTER created_at DROP DEFAULT;
+            ALTER TABLE versions ALTER updated_at DROP DEFAULT;
+            ALTER TABLE versions ALTER downloads DROP DEFAULT;
 
             DROP TRIGGER trigger_update_keywords_crates_cnt ON crates_keywords;
             DROP FUNCTION update_keywords_crates_cnt();

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -495,6 +495,11 @@ fn migrations() -> Vec<Migration> {
             ALTER TABLE keywords ALTER created_at SET DEFAULT current_timestamp;
             ALTER TABLE keywords ALTER crates_cnt SET DEFAULT 0;
 
+            ALTER TABLE crates ALTER created_at SET DEFAULT current_timestamp;
+            ALTER TABLE crates ALTER updated_at SET DEFAULT current_timestamp;
+            ALTER TABLE crates ALTER downloads SET DEFAULT 0;
+            ALTER TABLE crates ALTER max_version SET DEFAULT '0.0.0';
+
             CREATE FUNCTION update_keywords_crates_cnt() RETURNS trigger AS $$
             BEGIN
                 IF (TG_OP = 'INSERT') THEN
@@ -522,6 +527,11 @@ fn migrations() -> Vec<Migration> {
 
             ALTER TABLE keywords ALTER created_at DROP DEFAULT;
             ALTER TABLE keywords ALTER crates_cnt DROP DEFAULT;
+
+            ALTER TABLE crates ALTER created_at DROP DEFAULT;
+            ALTER TABLE crates ALTER updated_at DROP DEFAULT;
+            ALTER TABLE crates ALTER downloads DROP DEFAULT;
+            ALTER TABLE crates ALTER max_version DROP DEFAULT;
 
             DROP TRIGGER trigger_update_keywords_crates_cnt ON crates_keywords;
             DROP FUNCTION update_keywords_crates_cnt();

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -536,6 +536,10 @@ fn migrations() -> Vec<Migration> {
             CREATE TRIGGER trigger_crate_owners_set_updated_at BEFORE UPDATE
             ON crate_owners
             FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+            CREATE TRIGGER trigger_crates_set_updated_at BEFORE UPDATE
+            ON crates
+            FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
             "));
             Ok(())
 
@@ -566,6 +570,7 @@ fn migrations() -> Vec<Migration> {
             DROP FUNCTION update_keywords_crates_cnt();
 
             DROP TRIGGER trigger_crate_owners_set_updated_at ON crate_owners;
+            DROP TRIGGER trigger_crates_set_updated_at ON crates;
 
             DROP FUNCTION set_updated_at();
             "));

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -540,6 +540,10 @@ fn migrations() -> Vec<Migration> {
             CREATE TRIGGER trigger_crates_set_updated_at BEFORE UPDATE
             ON crates
             FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+            CREATE TRIGGER trigger_versions_set_updated_at BEFORE UPDATE
+            ON versions
+            FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
             "));
             Ok(())
 
@@ -571,6 +575,7 @@ fn migrations() -> Vec<Migration> {
 
             DROP TRIGGER trigger_crate_owners_set_updated_at ON crate_owners;
             DROP TRIGGER trigger_crates_set_updated_at ON crates;
+            DROP TRIGGER trigger_versions_set_updated_at ON versions;
 
             DROP FUNCTION set_updated_at();
             "));

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -500,6 +500,10 @@ fn migrations() -> Vec<Migration> {
             ALTER TABLE crates ALTER downloads SET DEFAULT 0;
             ALTER TABLE crates ALTER max_version SET DEFAULT '0.0.0';
 
+            ALTER TABLE crate_owners ALTER created_at SET DEFAULT current_timestamp;
+            ALTER TABLE crate_owners ALTER updated_at SET DEFAULT current_timestamp;
+            ALTER TABLE crate_owners ALTER deleted SET DEFAULT 'f';
+
             CREATE FUNCTION update_keywords_crates_cnt() RETURNS trigger AS $$
             BEGIN
                 IF (TG_OP = 'INSERT') THEN
@@ -532,6 +536,10 @@ fn migrations() -> Vec<Migration> {
             ALTER TABLE crates ALTER updated_at DROP DEFAULT;
             ALTER TABLE crates ALTER downloads DROP DEFAULT;
             ALTER TABLE crates ALTER max_version DROP DEFAULT;
+
+            ALTER TABLE crate_owners ALTER created_at DROP DEFAULT;
+            ALTER TABLE crate_owners ALTER updated_at DROP DEFAULT;
+            ALTER TABLE crate_owners ALTER deleted DROP DEFAULT;
 
             DROP TRIGGER trigger_update_keywords_crates_cnt ON crates_keywords;
             DROP FUNCTION update_keywords_crates_cnt();

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -47,8 +47,8 @@ fn update(tx: &postgres::Transaction) -> postgres::Result<()> {
             let moment = now + Duration::days(-day);
             dls += rng.gen_range(-100, 100);
             try!(tx.execute("INSERT INTO version_downloads \
-                              (version_id, downloads, counted, date, processed) \
-                              VALUES ($1, $2, 0, $3, false)",
+                              (version_id, downloads, date) \
+                              VALUES ($1, $2, $3)",
                             &[&id, &dls, &moment]));
         }
     }

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -167,12 +167,12 @@ mod test {
                                       &semver::Version::parse("1.0.0").unwrap(),
                                       &HashMap::new(), &[]).unwrap();
         tx.execute("INSERT INTO version_downloads \
-                    (version_id, downloads, counted, date, processed)
-                    VALUES ($1, 1, 0, current_date, false)",
+                    (version_id)
+                    VALUES ($1)",
                    &[&version.id]).unwrap();
         tx.execute("INSERT INTO version_downloads \
-                    (version_id, downloads, counted, date, processed)
-                    VALUES ($1, 1, 0, current_date, true)",
+                    (version_id, processed)
+                    VALUES ($1, true)",
                    &[&version.id]).unwrap();
         ::update(&tx).unwrap();
         assert_eq!(Version::find(&tx, version.id).unwrap().downloads, 1);
@@ -221,8 +221,8 @@ mod test {
                     VALUES ($1, 2, 1, current_date, false)",
                    &[&version.id]).unwrap();
         tx.execute("INSERT INTO version_downloads \
-                    (version_id, downloads, counted, date, processed)
-                    VALUES ($1, 1, 0, current_date, false)",
+                    (version_id)
+                    VALUES ($1)",
                    &[&version.id]).unwrap();
         ::update(&tx).unwrap();
         assert_eq!(Version::find(&tx, version.id).unwrap().downloads, 2);

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -92,10 +92,6 @@ impl Keyword {
         }).map(|(_, v)| v.id).collect::<Vec<_>>();
 
         if to_rm.len() > 0 {
-            try!(conn.execute("UPDATE keywords
-                                  SET crates_cnt = crates_cnt - 1
-                                WHERE id = ANY($1)",
-                              &[&Slice(&to_rm)]));
             try!(conn.execute("DELETE FROM crates_keywords
                                 WHERE keyword_id = ANY($1)
                                   AND crate_id = $2",
@@ -103,10 +99,6 @@ impl Keyword {
         }
 
         if to_add.len() > 0 {
-            try!(conn.execute("UPDATE keywords
-                                  SET crates_cnt = crates_cnt + 1
-                                WHERE id = ANY($1)",
-                              &[&Slice(&to_add)]));
             let insert = to_add.iter().map(|id| {
                 let crate_id: i32 = krate.id;
                 let id: i32 = *id;

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -47,12 +47,9 @@ impl Keyword {
             return Ok(Model::from_row(&row))
         }
 
-        let stmt = try!(conn.prepare("INSERT INTO keywords \
-                                      (keyword, created_at, crates_cnt)
-                                      VALUES ($1, $2, 0) \
+        let stmt = try!(conn.prepare("INSERT INTO keywords (keyword) VALUES ($1)
                                       RETURNING *"));
-        let now = ::now();
-        let rows = try!(stmt.query(&[&name, &now]));
+        let rows = try!(stmt.query(&[&name]));
         Ok(Model::from_row(&try!(rows.iter().next().chain_error(|| {
             internal("no version returned")
         }))))

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -322,11 +322,10 @@ impl Crate {
         // First try to un-delete if they've been soft deleted previously, then
         // do an insert if that didn't actually affect anything.
         let amt = try!(conn.execute("UPDATE crate_owners
-                                        SET deleted = FALSE, updated_at = $1
-                                      WHERE crate_id = $2 AND owner_id = $3
-                                        AND owner_kind = $4",
-                                    &[&::now(), &self.id, &owner.id(),
-                                      &owner.kind()]));
+                                        SET deleted = FALSE
+                                      WHERE crate_id = $1 AND owner_id = $2
+                                        AND owner_kind = $3",
+                                    &[&self.id, &owner.id(), &owner.kind()]));
         assert!(amt <= 1);
         if amt == 0 {
             try!(conn.execute("INSERT INTO crate_owners
@@ -347,10 +346,10 @@ impl Crate {
             human(format!("could not find owner with login `{}`", login))
         }));
         try!(conn.execute("UPDATE crate_owners
-                              SET deleted = TRUE, updated_at = $1
-                            WHERE crate_id = $2 AND owner_id = $3
-                              AND owner_kind = $4",
-                          &[&::now(), &self.id, &owner.id(), &owner.kind()]));
+                              SET deleted = TRUE
+                            WHERE crate_id = $1 AND owner_id = $2
+                              AND owner_kind = $3",
+                          &[&self.id, &owner.id(), &owner.kind()]));
         Ok(())
     }
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -910,7 +910,7 @@ pub fn downloads(req: &mut Request) -> CargoResult<Response> {
                  version_id = versions.id
            WHERE version_downloads.date > $1
              AND versions.crate_id = $2
-             AND NOT (versions.id = ANY($3))
+             AND versions.id != ALL($3)
         GROUP BY DATE(version_downloads.date)
         ORDER BY DATE(version_downloads.date) ASC"));
     let mut extra = Vec::new();

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -868,9 +868,7 @@ pub fn download(req: &mut Request) -> CargoResult<Response> {
                               &[&version_id, &now]));
     if amt == 0 {
         try!(tx.execute("INSERT INTO version_downloads
-                         (version_id, downloads, counted, date, processed)
-                         VALUES ($1, 1, 0, date($2), false)",
-                        &[&version_id, &now]));
+                         (version_id) VALUES ($1)", &[&version_id]));
     }
 
     // Now that we've done our business, redirect to the actual data.

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -173,12 +173,10 @@ impl Crate {
             internal("no crate returned")
         })));
 
-        let now = ::now();
         try!(conn.execute("INSERT INTO crate_owners
-                           (crate_id, owner_id, created_by, created_at,
-                             updated_at, deleted, owner_kind)
-                           VALUES ($1, $2, $2, $3, $3, FALSE, $4)",
-                          &[&ret.id, &user_id, &now, &(OwnerKind::User as i32)]));
+                           (crate_id, owner_id, created_by, owner_kind)
+                           VALUES ($1, $2, $2, $3)",
+                          &[&ret.id, &user_id, &(OwnerKind::User as i32)]));
         return Ok(ret);
 
         fn validate_url(url: Option<&str>, field: &str) -> CargoResult<()> {
@@ -332,10 +330,9 @@ impl Crate {
         assert!(amt <= 1);
         if amt == 0 {
             try!(conn.execute("INSERT INTO crate_owners
-                               (crate_id, owner_id, created_at, updated_at,
-                                created_by, owner_kind, deleted)
-                               VALUES ($1, $2, $3, $3, $4, $5, FALSE)",
-                              &[&self.id, &owner.id(), &::now(), &req_user.id,
+                               (crate_id, owner_id, created_by, owner_kind)
+                               VALUES ($1, $2, $3, $4)",
+                              &[&self.id, &owner.id(), &req_user.id,
                                 &owner.kind()]));
         }
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -160,16 +160,12 @@ impl Crate {
         }
 
         let stmt = try!(conn.prepare("INSERT INTO crates
-                                      (name, user_id, created_at,
-                                       updated_at, downloads, max_version,
-                                       description, homepage, documentation,
-                                       readme, keywords, repository, license,
-                                       max_upload_size)
-                                      VALUES ($1, $2, $3, $3, 0, '0.0.0',
-                                              $4, $5, $6, $7, $8, $9, $10, $11)
+                                      (name, user_id, description, homepage,
+                                       documentation, readme, keywords,
+                                       repository, license, max_upload_size)
+                                      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                                       RETURNING *"));
-        let now = ::now();
-        let rows = try!(stmt.query(&[&name, &user_id, &now,
+        let rows = try!(stmt.query(&[&name, &user_id,
                                      &description, &homepage,
                                      &documentation, &readme, &keywords,
                                      &repository, &license, &max_upload_size]));
@@ -177,6 +173,7 @@ impl Crate {
             internal("no crate returned")
         })));
 
+        let now = ::now();
         try!(conn.execute("INSERT INTO crate_owners
                            (crate_id, owner_id, created_by, created_at,
                              updated_at, deleted, owner_kind)

--- a/src/version.rs
+++ b/src/version.rs
@@ -81,12 +81,10 @@ impl Version {
         let num = num.to_string();
         let features = json::encode(features).unwrap();
         let stmt = try!(conn.prepare("INSERT INTO versions \
-                                      (crate_id, num, updated_at, \
-                                       created_at, downloads, features) \
-                                      VALUES ($1, $2, $3, $3, 0, $4) \
+                                      (crate_id, num, features) \
+                                      VALUES ($1, $2, $3) \
                                       RETURNING *"));
-        let now = ::now();
-        let rows = try!(stmt.query(&[&crate_id, &num, &now, &features]));
+        let rows = try!(stmt.query(&[&crate_id, &num, &features]));
         let ret: Version = Model::from_row(&try!(rows.iter().next().chain_error(|| {
             internal("no version returned")
         })));


### PR DESCRIPTION
There's a lot of places in the code where there's duplicated hard coded default values for certain tables, or manual updating of things which the database can handle for us (like counter caches and `updated_at`). This updates as many of these cases as I could find to rely on the database when possible. 

We shouldn't require the person adding new code to know that they have to manually increment a counter on another table, or manually set `updated_at` to the right value when they change a row. (As an example of this point, I found that `versions.updated_at` was never actually changed after insert, and several places that it seems we would want `crates.updated_at` to be set, but weren't).

The trigger to update the counter cache on `keywords` will end up performing more queries than what we were doing before (one per deleted row instead of one per delete statement), however this should not cause any problems, as we're not paying a DB round trip cost, and the index should still only be updated once at the end of the trigger.

One other case that might make sense, but I did not do here is to move the setting of `max_version` to a database trigger as well. However, implementing proper semver comparison is arguably more logic than I think belongs in the database.

I've kept each change as a separate commit to ease reverting if there's any specific changes here where there's contention, but I'll be happy to squash if these changes look good.

/cc @alexcrichton 