### PR TITLE
fix highlight bar going outside rounded corner

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -228,6 +228,7 @@ ul.dropdown {
     border: 1px solid $gray-border;
     list-style: none;
     z-index: 10;
+    overflow: hidden;
     @include border-radius(5px);
 
     li a {


### PR DESCRIPTION
The problem:
![untitled](https://cloud.githubusercontent.com/assets/1329716/11922805/b3987066-a7ee-11e5-8684-0a3a58bcf884.png)

With the fix:
![untitled2](https://cloud.githubusercontent.com/assets/1329716/11922808/ba9b2fca-a7ee-11e5-8150-d38aa710346a.png)
