### PR TITLE
Fixed unaligned Getting Started button in Safari.

### DIFF
--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -23,6 +23,7 @@
 
 .yellow-button {
     @include button(#fede9e, #fdc452);
+    vertical-align: middle;
 }
 
 .tan-button {


### PR DESCRIPTION
The "Getting Started" button was a bit lower compared to "Install Cargo" in Safari.

Tested in OS X 10.11.2 and Safari 9.0.2. Doesn't break in Chrome 47 nor 43.
