### PR TITLE
another stab at fixing the trailing-slash redirect

### DIFF
--- a/app/routes/crate/index.js
+++ b/app/routes/crate/index.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
     redirect() {
-        this.replaceWith('crate.version', '');
+        this.transitionTo('crate.version', '');
     }
 });

--- a/app/routes/crate/index.js
+++ b/app/routes/crate/index.js
@@ -1,7 +1,12 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-    redirect() {
-        this.transitionTo('crate.version', '');
+    beforeModel() {
+        const url = this.get('router.url');
+        if (url.startsWith('/crates/') && !url.endsWith('/')) {
+            this.replaceWith('crate.version', '');
+        } else {
+            this.transitionTo('crate.version', '');
+        }
     }
 });


### PR DESCRIPTION
According to my calculations, this reverts #251 while still fixing #236 but _not_ causing #252.

I'm not sure this is the right way to do it (checking the actual URL) but it seems to work.

Fixes #236 (again).
Fixes #252.

I may have missed something, so someone else please check the back button behavior in all these use cases:

- External site links to a crate page (with or without a trailing slash)
- Type in the URL to a crate page
- Homepage links to a crate
- Link from a crate to dependency
- Do a search from a crate page