### PR TITLE
Adding ember-route-alias to handle index routes.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -2,15 +2,18 @@ import Ember from 'ember';
 import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
+import RouteAliasResolverMixin from 'cargo/mixins/route-alias-resolver';
 
 let App;
+
+let CargoResolver = Resolver.extend(RouteAliasResolverMixin);
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
 App = Ember.Application.extend({
     modulePrefix: config.modulePrefix,
     podModulePrefix: config.podModulePrefix,
-    Resolver
+    Resolver: CargoResolver
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/app/router.js
+++ b/app/router.js
@@ -16,6 +16,8 @@ Router.map(function() {
         this.route('download');
         this.route('versions');
         this.route('version', { path: '/:version_num' });
+        this.alias('index', '/', 'version');
+
         this.route('reverse_dependencies');
 
         // Well-known routes

--- a/app/routes/crate/index.js
+++ b/app/routes/crate/index.js
@@ -1,7 +1,0 @@
-import Ember from 'ember';
-
-export default Ember.Route.extend({
-    redirect() {
-        this.replaceWith('crate.version', '');
-    }
-});

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -7,7 +7,7 @@ export default Ember.Route.extend({
         const requestedVersion = params.version_num;
 
         const crate = this.modelFor('crate');
-        const controller = this.controllerFor('crate.version');
+        const controller = this.controllerFor(this.routeName);
         const maxVersion = crate.get('max_version');
 
         // Fall back to the crate's `max_version` property
@@ -49,7 +49,7 @@ export default Ember.Route.extend({
     afterModel(model) {
         this._super(...arguments);
 
-        const controller = this.controllerFor('crate.version');
+        const controller = this.controllerFor(this.routeName);
         const context = controller.get('requestedVersion') ? model : this.modelFor('crate');
 
         context.get('version_downloads').then(downloads => {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ember-moment": "4.1.0",
     "ember-page-title": "2.0.7",
     "ember-rl-dropdown": "0.7.0",
+    "ember-route-alias": "^0.1.3",
     "ember-suave": "1.2.3",
     "emberx-select": "2.0.2"
   }


### PR DESCRIPTION
Closes #252, #258, and #261.

Appears to work in all scenarios, hoping somebody else can confirm.