### PR TITLE
Add Cargo guide link to the top nav bar.

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -98,6 +98,12 @@ body {
 
         &.open { display: block; }
     }
+    #doc-links {
+        display: none;
+        left: auto;
+
+        &.open { display: block; }
+    }
     @media only screen and (max-width: 820px) {
         .menu { display: block; }
         .nav { display: none; }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -25,6 +25,25 @@
             Browse All Crates
         {{/link-to}}
         <span class="sep">|</span>
+        {{#rl-dropdown-container class="dropdown-container"}}
+            {{#rl-dropdown-toggle class="dropdown"}}
+                Documentation
+                <span class='arrow'></span>
+            {{/rl-dropdown-toggle}}
+
+            {{#rl-dropdown tagName="ul" id="doc-links" class="dropdown" closeOnChildClick="a:link"}}
+                <li><a href='http://doc.crates.io/index.html'>Getting Started</a></li>
+                <li><a href='http://doc.crates.io/guide.html'>Guide</a></li>
+                <li><a href='http://doc.crates.io/crates-io.html'>Using crates.io</a></li>
+                <li><a href='http://doc.crates.io/faq.html'>FAQ</a></li>
+                <li><a href='http://doc.crates.io/manifest.html'>Manifest Format</a></li>
+                <li><a href='http://doc.crates.io/build-script.html'>Build Scripts</a></li>
+                <li><a href='http://doc.crates.io/config.html'>Configuration</a></li>
+                <li><a href='http://doc.crates.io/pkgid-spec.html'>Package ID specs</a></li>
+                <li><a href='http://doc.crates.io/environment-variables.html'>Environment Variables</a></li>
+            {{/rl-dropdown}}
+        {{/rl-dropdown-container}}
+        <span class="sep">|</span>
         {{#if session.currentUser}}
             {{#rl-dropdown-container class="dropdown-container"}}
                 {{#rl-dropdown-toggle class="dropdown"}}


### PR DESCRIPTION
(This is just a quick change; haven't tested locally if it looks like it is supposed to.)

I think that the links to the cargo docs are much too hard to find at the bottom of the page. (Especially since you can't find it by searching for "doc".) Neither is the "Getting started" button on the index page a good entry point, since it is only present on that page.

This is kind of what #139 suggests, but without the full drop-down.