### PR TITLE
Remove mostly unused keywords column from crates table

### DIFF
--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -167,7 +167,7 @@ mod test {
         let tx = conn.transaction().unwrap();
         let user = user(&tx);
         let krate = Crate::find_or_insert(&tx, "foo", user.id, &None, &None,
-                                          &None, &None, &[], &None, &None,
+                                          &None, &None, &None, &None,
                                           &None, None).unwrap();
         let version = Version::insert(&tx, krate.id,
                                       &semver::Version::parse("1.0.0").unwrap(),
@@ -194,7 +194,7 @@ mod test {
         let tx = conn.transaction().unwrap();
         let user = user(&tx);
         let krate = Crate::find_or_insert(&tx, "foo", user.id, &None,
-                                          &None, &None, &None, &[], &None,
+                                          &None, &None, &None, &None,
                                           &None, &None, None).unwrap();
         let version = Version::insert(&tx, krate.id,
                                       &semver::Version::parse("1.0.0").unwrap(),
@@ -217,7 +217,7 @@ mod test {
         let tx = conn.transaction().unwrap();
         let user = user(&tx);
         let krate = Crate::find_or_insert(&tx, "foo", user.id, &None,
-                                          &None, &None, &None, &[], &None,
+                                          &None, &None, &None, &None,
                                           &None, &None, None).unwrap();
         let version = Version::insert(&tx, krate.id,
                                       &semver::Version::parse("1.0.0").unwrap(),
@@ -241,7 +241,7 @@ mod test {
         let tx = conn.transaction().unwrap();
         let user = user(&tx);
         let krate = Crate::find_or_insert(&tx, "foo", user.id, &None,
-                                          &None, &None, &None, &[], &None,
+                                          &None, &None, &None, &None,
                                           &None, &None, None).unwrap();
         let version = Version::insert(&tx, krate.id,
                                       &semver::Version::parse("1.0.0").unwrap(),
@@ -281,7 +281,7 @@ mod test {
         let tx = conn.transaction().unwrap();
         let user = user(&tx);
         let krate = Crate::find_or_insert(&tx, "foo", user.id, &None,
-                                          &None, &None, &None, &[], &None,
+                                          &None, &None, &None, &None,
                                           &None, &None, None).unwrap();
         let version = Version::insert(&tx, krate.id,
                                       &semver::Version::parse("1.0.0").unwrap(),

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -134,7 +134,7 @@ fn remove_team_as_named_owner() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(::krate("foo"), "2.0.0", vec![]);
+    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -164,7 +164,7 @@ fn remove_team_as_team_owner() {
     assert!(json.errors[0].detail.contains("don't have permission"),
             "{:?}", json.errors);
 
-    let body = ::new_req_body(::krate("foo"), "2.0.0", vec![]);
+    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));
@@ -185,7 +185,7 @@ fn publish_not_owned() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(::krate("foo"), "2.0.0", vec![]);
+    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -207,7 +207,7 @@ fn publish_owned() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(::krate("foo"), "2.0.0", vec![]);
+    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));


### PR DESCRIPTION
This column was present both in the table and in the Rust model, but
was only ever used to update the search index on update. The actual
source of keyword info is the crates_keywords table, and it's actually
reasonably easy for this column to get out of sync.

Instead of relying on things calling the `update_crate` function every
time the keywords column is modified, we can instead populate the column
with a subselect which grabs the keywords associated. This also means we
need an additional trigger to touch the crate whenever the
crates_keywords table is modified.