### PR TITLE
Properly sideload keywords in crates#show

### DIFF
--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -311,7 +311,7 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
     }
 
     // Encode everything!
-    let crates = crates.into_iter().map(|c| c.encodable(None)).collect();
+    let crates = crates.into_iter().map(|c| c.encodable(None, None)).collect();
     let versions = versions.into_iter().map(|v| {
         let id = v.crate_id;
         v.encodable(&map[&id])


### PR DESCRIPTION
The data is sent properly in this endpoint, but they aren't actually
associated with the crate as the ids aren't present. This appears to be
the only endpoint where these are sideloaded.

I've added a test for this, but haven't visually verified the fix (as I
don't have everything set up to run the backend locally), so this should
be tested on staging before deployment.

Fixes #271