### PR TITLE
Update ember and remove an outdated dep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "cargo",
   "dependencies": {
-    "ember": "2.3.1",
+    "ember": "2.4.0",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.1",
     "ember-load-initializers": "0.1.7",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "ember-cli-sri": "^1.2.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "2.4.0",
-    "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-moment": "4.1.0",
     "ember-page-title": "2.0.7",


### PR DESCRIPTION
We recently upgraded ember-data, but not ember itself.

This also removes an unneeded package; it was there for pre-2.0
reasons, but we've upgraded past 2.0.

@wycats , this introduces warnings:

```
DEPRECATION: Support for the `ember-legacy-controllers` addon will end soon, please remove it from your application. [deprecation id: ember-legacy-controllers] See http://emberjs.com/deprecations/v1.x/#toc_objectcontroller for more details.
```

One for views as well. As far as I can tell, none of our code (nor our dependencies' code) uses the deprecated stuff; is this an unconditional warning?