### PR TITLE
disable autocorrect for the mobile search field

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -74,6 +74,7 @@
     {{input type="text" class="search" name="q"
             placeholder="Search"
             value=search
+            autocorrect="off"
             tabindex="1"}}
 </form>
 


### PR DESCRIPTION
Right now, the textfield tells the keyboard (e.g. on mobile Safari) to provide autocompletion/ autocorrect. Most keyboards/phones don't know words/ terms like "https" or "zlib" which causes an autocorrect for these words. 
This commit disables the autocompletion/autocorrect for the mobile search textfield.