### PR TITLE
Show which dependencies are optional on the crate page

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -146,6 +146,10 @@ span.small {
     }
 }
 
+.optional {
+    font-size: 80%;
+}
+
 .yanked {
     font-size: 80%;
     color: rgb(166, 0, 0)

--- a/app/templates/components/link-to-dep.hbs
+++ b/app/templates/components/link-to-dep.hbs
@@ -2,4 +2,7 @@
   {{#link-to 'crate' dep.crate_id}}
       {{ dep.crate_id }} {{ format-req dep.req }}
   {{/link-to}}
+  {{#if dep.optional}}
+      <span class='optional'>optional</span>
+  {{/if}}
 </li>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -137,6 +137,9 @@
     <ul>
       {{#each currentDependencies as |dep|}}
         {{link-to-dep dep=dep}}
+        {{#if dep.optional}}
+            <span class='optional'>optional</span>
+        {{/if}}
       {{else}}
           <li>None</li>
       {{/each}}

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -137,9 +137,6 @@
     <ul>
       {{#each currentDependencies as |dep|}}
         {{link-to-dep dep=dep}}
-        {{#if dep.optional}}
-            <span class='optional'>optional</span>
-        {{/if}}
       {{else}}
           <li>None</li>
       {{/each}}


### PR DESCRIPTION
Same idea & style as the yanked marker (but not red).

Fixes #233 