### PR TITLE
add autofocus attribute to search field

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -17,6 +17,7 @@
         {{input type="text" class="search" name="q"
                 placeholder="Search"
                 value=search
+                autofocus="autofocus"
                 tabindex="1"}}
     </form>
 


### PR DESCRIPTION
Most people come to the site to search for a package, so why not save them a click or pressing tab once? ;)

On browsers that don't support the autofocus attribute it should just be ignored.