### PR TITLE
Add a link to reverse dependencies for crates.

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -32,7 +32,8 @@ export default Ember.Controller.extend({
                           'crate.wiki',
                           'crate.mailing_list',
                           'crate.documentation',
-                          'crate.repository'),
+                          'crate.repository',
+                          'crate.reverse_dependencies'),
 
     displayedAuthors: computed('currentVersion.authors.[]', function() {
         return DS.PromiseArray.create({

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -128,6 +128,13 @@
             {{#if crate.repository}}
                 <li><a href="{{crate.repository}}">Repository</a></li>
             {{/if}}
+            {{#if crate.reverse_dependencies}}
+                <li>
+                  {{#link-to 'crate.reverse_dependencies' (query-params dependency=crate.crate_id)}}
+                    Dependent crates
+                  {{/link-to}}
+                </li>
+            {{/if}}
           </ul>
         </div>
     {{/if}}


### PR DESCRIPTION
Fixes #99.

I would have liked to include a number for how many total dependents there are, but couldn't figure out how to get the actual number. Taking `reverse_dependencies.length` is limited by pagination so tops out at 10.