### PR TITLE
Add a backlink to newest for yanked crate versions

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -37,8 +37,13 @@
 
 {{#if currentVersion.yanked}}
     <div class='crate-info'>
-        This crate has been yanked, but it is still available for download for
-        other crates that may be depending on it.
+        <div>
+        <p>This crate has been yanked, but it is still available for download for
+        other crates that may be depending on it.</p>
+        <p>You may wish to
+          {{#link-to 'crate' crate}}view the newest version{{/link-to}} instead.
+        </p>
+        </div>
     </div>
 {{else}}
 <div class='crate-info'>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -41,7 +41,8 @@
         <p>This crate has been yanked, but it is still available for download for
         other crates that may be depending on it.</p>
         <p>You may wish to
-          {{#link-to 'crate' crate}}view the newest version{{/link-to}} instead.
+          {{#link-to 'crate.versions' crate}}view all versions{{/link-to}} to find one that
+          has not been yanked.
         </p>
         </div>
     </div>

--- a/app/templates/crate/versions.hbs
+++ b/app/templates/crate/versions.hbs
@@ -17,7 +17,7 @@
                 {{#link-to 'crate.version' version.num}}{{ version.num }}{{/link-to}}
 
                 <span class='small'>{{moment-format version.created_at 'LL'}}</span>
-                {{#if yanked}}
+                {{#if version.yanked}}
                     <span class='yanked'>yanked</span>
                 {{/if}}
             </div>


### PR DESCRIPTION
Fixes #148.

Both paragraphs need to be wrapped in another `div` under `crate-info` since the stylesheet for `crate-info` makes a column-based layout which is not desirable for this case.