### PR TITLE
Doc dropdown menu: name "Cargo.toml" explicitly

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -37,7 +37,7 @@
                 <li><a href='http://doc.crates.io/guide.html'>Guide</a></li>
                 <li><a href='http://doc.crates.io/crates-io.html'>Using crates.io</a></li>
                 <li><a href='http://doc.crates.io/faq.html'>FAQ</a></li>
-                <li><a href='http://doc.crates.io/manifest.html'>Manifest Format</a></li>
+                <li><a href='http://doc.crates.io/manifest.html'>Cargo.toml Format</a></li>
                 <li><a href='http://doc.crates.io/build-script.html'>Build Scripts</a></li>
                 <li><a href='http://doc.crates.io/config.html'>Configuration</a></li>
                 <li><a href='http://doc.crates.io/pkgid-spec.html'>Package ID specs</a></li>


### PR DESCRIPTION
This is what most people are looking for.  Many might not have heard
of the term "manifest".

See also https://github.com/rust-lang/cargo/pull/2587 for the same in the cargo docs.