### PR TITLE
Add "Specifying Dependencies" in Docs drop down

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -35,7 +35,8 @@
             {{#rl-dropdown tagName="ul" id="doc-links" class="dropdown" closeOnChildClick="a:link"}}
                 <li><a href='http://doc.crates.io/index.html'>Getting Started</a></li>
                 <li><a href='http://doc.crates.io/guide.html'>Guide</a></li>
-                <li><a href='http://doc.crates.io/crates-io.html'>Using crates.io</a></li>
+                <li><a href='http://doc.crates.io/specifying-dependencies.html'>Specifying Dependencies</a></li>
+                <li><a href='http://doc.crates.io/crates-io.html'>Publishing on crates.io</a></li>
                 <li><a href='http://doc.crates.io/faq.html'>FAQ</a></li>
                 <li><a href='http://doc.crates.io/manifest.html'>Cargo.toml Format</a></li>
                 <li><a href='http://doc.crates.io/build-script.html'>Build Scripts</a></li>


### PR DESCRIPTION
This PR synchronizes the Docs drop down from doc.crates.io to crates.io:

* Added the missing "Specifying Dependencies" link 
* "Using crates.io" has been renamed to "Publishing on crates.io"

(This list should be converted to a shared template in future, I think.)