### PR TITLE
Annotate next/prev page links.

### DIFF
--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -65,7 +65,7 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev"}}
+    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
@@ -73,7 +73,7 @@
             {{ page }}
         {{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next"}}
+    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -65,7 +65,7 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
+    {{#link-to (query-params page=prevPage) class="prev" rel="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
@@ -73,7 +73,7 @@
             {{ page }}
         {{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
+    {{#link-to (query-params page=nextPage) class="next" rel="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/keyword/index.hbs
+++ b/app/templates/keyword/index.hbs
@@ -45,13 +45,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev"}}
+    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next"}}
+    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/keyword/index.hbs
+++ b/app/templates/keyword/index.hbs
@@ -45,13 +45,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
+    {{#link-to (query-params page=prevPage) class="prev" rel="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
+    {{#link-to (query-params page=nextPage) class="next" rel="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/keywords.hbs
+++ b/app/templates/keywords.hbs
@@ -52,13 +52,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev"}}
+    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next"}}
+    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/keywords.hbs
+++ b/app/templates/keywords.hbs
@@ -52,13 +52,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
+    {{#link-to (query-params page=prevPage) class="prev" rel="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
+    {{#link-to (query-params page=nextPage) class="next" rel="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -46,13 +46,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
+    {{#link-to (query-params page=prevPage) class="prev" rel="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
+    {{#link-to (query-params page=nextPage) class="next" rel="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -46,13 +46,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev"}}
+    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next"}}
+    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/me/following.hbs
+++ b/app/templates/me/following.hbs
@@ -46,13 +46,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
+    {{#link-to (query-params page=prevPage) class="prev" rel="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
+    {{#link-to (query-params page=nextPage) class="next" rel="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>

--- a/app/templates/me/following.hbs
+++ b/app/templates/me/following.hbs
@@ -46,13 +46,13 @@
 </div>
 
 <div class='pagination'>
-    {{#link-to (query-params page=prevPage) class="prev"}}
+    {{#link-to (query-params page=prevPage) class="prev" title="previous page"}}
         <img class="left-pag" src="/assets/left-pag.png"/>
     {{/link-to}}
     {{#each pages as |page|}}
         {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
     {{/each}}
-    {{#link-to (query-params page=nextPage) class="next"}}
+    {{#link-to (query-params page=nextPage) class="next" title="next page"}}
         <img class="right-pag" src="/assets/right-pag.png"/>
     {{/link-to}}
 </div>


### PR DESCRIPTION
The titles help blind users and the rel attributes help search engines (in
theory at least).

These also allow users of extensions like vimperator to navigate forwards and
backwards using hotkeys (`[[` and `]]`).