### PR TITLE
Improve example .env documentation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,25 +1,34 @@
-# Credentials for uploading packages to S3, these can be blank if you're not
-# publishing locally.
-S3_BUCKET=
-S3_ACCESS_KEY=
-S3_SECRET_KEY=
-# Not needed if the S3 bucket is in US standard
-S3_REGION=      
+# Location of the *postgres* database. For example, if you have created a
+# blank database locally named `cargo_registry`, this would be
+# `postgres://postgres:@localhost/cargo_registry`.
+export DATABASE_URL=""
 
-# Credentials for talking to github, can be blank if you're not logging in.
-#
-# When registering a new application, be sure to set the callback url to the
-# address `http://localhost:4200/authorize/github`.
-GH_CLIENT_ID=
-GH_CLIENT_SECRET=
+# Key to sign and encrypt cookies with. Change this to a long, random string
+# for production.
+export SESSION_KEY="badkey"
 
-# Key to sign and encrypt cookies with
-SESSION_KEY=badkey
+# If you will be running the tests, set this to another database that you
+# have created. Otherwise, leave this blank.
+export TEST_DATABASE_URL=""
 
-# Location of the *postgres* database
-# (eg. postgres://postgres:@localhost/cargo_registry)
-DATABASE_URL=postgres://postgres:@localhost/cargo_registry
+# Credentials for uploading packages to S3. You can leave these blank if
+# you're not publishing to s3 from your crates.io instance.
+# When running `cargo test`, set S3_BUCKET to `alexcrichton-test`.
+export S3_BUCKET=""
+export S3_ACCESS_KEY=""
+export S3_SECRET_KEY=""
+export S3_REGION=""      # not needed if the S3 bucket is in US standard
 
-# Remote and local locations of the registry index
-GIT_REPO_URL=file://./tmp/index-bare
-GIT_REPO_CHECKOUT=./tmp/index-co
+# Remote and local locations of the registry index. You can leave these to
+# use a `tmp` subdirectory of the working directory, which is what the
+# script in `./script/init-local-index.sh` will set up for you.
+export GIT_REPO_URL="file://./tmp/index-bare"
+export GIT_REPO_CHECKOUT="./tmp/index-co"
+
+# Credentials for talking to github. You can leave these blank if you're
+# not logging into your crates.io instance.
+# When registering a new application on github for use with your local
+# crates.io instance, be sure to set the callback url for that application
+# to the address `http://localhost:4200/authorize/github`.
+export GH_CLIENT_ID=""
+export GH_CLIENT_SECRET=""

--- a/README.md
+++ b/README.md
@@ -44,35 +44,8 @@ This requires NPM 2.0.
 If you'd like to change the API server (the Rust backend), then the setup is a
 little more complicated.
 
-1. Define some environment variables:
-
-    ```
-    # Credentials for uploading packages to S3, these can be blank if you're not
-    # publishing locally.
-    export S3_BUCKET=...
-    export S3_ACCESS_KEY=...
-    export S3_SECRET_KEY=...
-    export S3_REGION=...      # not needed if the S3 bucket is in US standard
-
-    # Credentials for talking to github, can be blank if you're not logging in.
-    #
-    # When registering a new application, be sure to set the callback url to the
-    # address `http://localhost:4200/authorize/github`.
-    export GH_CLIENT_ID=...
-    export GH_CLIENT_SECRET=...
-
-    # Key to sign and encrypt cookies with
-    export SESSION_KEY=...
-
-    # Location of the *postgres* database
-    #
-    # e.g. postgres://postgres:@localhost/cargo_registry
-    export DATABASE_URL=...
-
-    # Remote and local locations of the registry index
-    export GIT_REPO_URL=file://`pwd`/tmp/index-bare
-    export GIT_REPO_CHECKOUT=`pwd`/tmp/index-co
-    ```
+1. Copy the `.env.sample` file to `.env` and change any applicable values as
+    directed by the comments in the file.
 
 2. Set up the git index
 
@@ -111,13 +84,22 @@ little more complicated.
     export TEST_DATABASE_URL=...
     ```
 
-2. Run the API server tests
+2. Set the s3 bucket to `alexcrichton-test`. No actual requests to s3 will be
+   made; the requests and responses are recorded in files in
+   `tests/http-data` and the s3 bucket name needs to match the requests in the
+   files.
+
+    ```
+    export S3_BUCKET=alexcrichton-test
+    ```
+
+3. Run the API server tests
 
     ```
     cargo test
     ```
 
-3. Run frontend tests
+4. Run frontend tests
 
     ```
     ember test

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ little more complicated.
     cargo test
     ```
 
-4. Run frontend tests
+4. Install [phantomjs](http://phantomjs.org/)
+
+5. Run frontend tests
 
     ```
     ember test


### PR DESCRIPTION
Hi! I hit a few bumps along my path to getting everything set up and the rust tests passing, so I made these changes to make it a little easier for the next person ❤️ 

- Instead of recommending exporting a bunch of env vars, point out the
  convenient `.env.sample` file that can be customized into your own,
  personalized `.env` file.
- Reorganize `.env.sample` to have the vars you'd most likely need to
  change first.
- Move most of the documentation about the vars into `.env.sample` for
  easy reference while editing it.
- Document the need to have the s3 bucket set to `alexcrichton-test`
  when running `cargo test` in order to get them to pass.

I think it'd be nice to not have to set the s3 bucket to `alexcrichton-test` to get the tests to pass, but I see a bunch of different solutions possible and thought I'd just start with documenting the current state. If you'd like, I'd be happy to, in this PR or a separate one, do one of the following, or some other solution:

- Set the `S3_BUCKET` env var to `alexcrichton-test` in some test setup code to overwrite whatever it is or isn't set to in the environment running the tests
- Remove `alexcrichton-test` from the URLs saved in the `tests/http-data` files, effectively requiring that the S3_BUCKET env var be set to empty string for the tests to pass
- Create a `TEST_S3_BUCKET` env var that works similarly to the `TEST_DATABASE_URL` env var
- Extend the functionality of the test request/response recorder to be able to substitute in variables [like vcr can](https://relishapp.com/vcr/vcr/v/3-0-1/docs/cassettes/dynamic-erb-cassettes) and use whatever the `S3_BUCKET` env var is set or not set to when matching the requests up
- ❓ ❓ ❓ 
