### PR TITLE
Serve git index in production

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -29,9 +29,12 @@ fn main() {
             cb.credentials(cargo_registry::git::credentials);
             let mut opts = git2::FetchOptions::new();
             opts.remote_callbacks(cb);
-            git2::build::RepoBuilder::new()
+            let repo = git2::build::RepoBuilder::new()
                                      .fetch_options(opts)
-                                     .clone(&url, &checkout).unwrap()
+                                     .clone(&url, &checkout).unwrap();
+            let git_daemon_file = checkout.join(".git").join("git-daemon-export-ok");
+            File::create(git_daemon_file).unwrap();
+            repo
         }
     };
     let mut cfg = repo.config().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,15 +120,13 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     router.get("/me/updates", C(user::updates));
     router.get("/summary", C(krate::summary));
 
-    let env = app.config.env;
-    if env == Env::Development {
-        let s = conduit_git_http_backend::Serve(app.git_repo_checkout.clone());
-        let s = Arc::new(s);
-        router.get("/git/index/*path", R(s.clone()));
-        router.post("/git/index/*path", R(s));
-    }
+    let s = conduit_git_http_backend::Serve(app.git_repo_checkout.clone());
+    let s = Arc::new(s);
+    router.get("/git/index/*path", R(s.clone()));
+    router.post("/git/index/*path", R(s));
 
     let mut m = MiddlewareBuilder::new(R404(router));
+    let env = app.config.env;
     if env == Env::Development {
         m.add(DebugMiddleware);
     }


### PR DESCRIPTION
This is a way to fix #373 for running mirrors or private crate servers.