### PR TITLE
Fix a deprecation warning about `initialize` arguments

### DIFF
--- a/app/initializers/session.js
+++ b/app/initializers/session.js
@@ -1,7 +1,7 @@
 export default {
     name: 'app.session',
 
-    initialize(container, application) {
+    initialize(application) {
         application.inject('controller', 'session', 'service:session');
         application.inject('route', 'session', 'service:session');
     }


### PR DESCRIPTION
This shows up in the browser console. Fixed as suggested at:
http://emberjs.com/deprecations/v2.x/#toc_initializer-arity

pssst hi @steveklabnik, this is relevant to #375 :)