### PR TITLE
Remove obsolete user_id column on crates table

### DIFF
--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -728,6 +728,17 @@ fn migrations() -> Vec<Migration> {
         }, |_tx| {
             Ok(())
         }),
+        Migration::run(20160717173343,
+            "DROP INDEX index_crates_user_id",
+            "CREATE INDEX index_crates_user_id \
+             ON crates (user_id)",
+        ),
+        undo_foreign_key(20160717174005, "crates", "user_id",
+                         "user_id", "users (id)"),
+        Migration::run(20160717174656,
+            "ALTER TABLE crates DROP COLUMN user_id",
+            "ALTER TABLE crates ADD COLUMN user_id INTEGER NOT NULL",
+        ),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -39,7 +39,6 @@ use version::EncodableVersion;
 pub struct Crate {
     pub id: i32,
     pub name: String,
-    pub user_id: i32,
     pub updated_at: Timespec,
     pub created_at: Timespec,
     pub downloads: i32,
@@ -157,13 +156,12 @@ impl Crate {
         }
 
         let stmt = try!(conn.prepare("INSERT INTO crates
-                                      (name, user_id, description, homepage,
+                                      (name, description, homepage,
                                        documentation, readme,
                                        repository, license, max_upload_size)
-                                      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+                                      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                                       RETURNING *"));
-        let rows = try!(stmt.query(&[&name, &user_id,
-                                     &description, &homepage,
+        let rows = try!(stmt.query(&[&name, &description, &homepage,
                                      &documentation, &readme,
                                      &repository, &license, &max_upload_size]));
         let ret: Crate = Model::from_row(&try!(rows.iter().next().chain_error(|| {
@@ -239,7 +237,7 @@ impl Crate {
         let Crate {
             name, created_at, updated_at, downloads, max_version, description,
             homepage, documentation, license, repository,
-            readme: _, id: _, user_id: _, max_upload_size: _,
+            readme: _, id: _, max_upload_size: _,
         } = self;
         let versions_link = match versions {
             Some(..) => None,
@@ -434,7 +432,6 @@ impl Model for Crate {
         Crate {
             id: row.get("id"),
             name: row.get("name"),
-            user_id: row.get("user_id"),
             updated_at: row.get("updated_at"),
             created_at: row.get("created_at"),
             downloads: row.get("downloads"),

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -181,7 +181,6 @@ fn krate(name: &str) -> Crate {
     cargo_registry::krate::Crate {
         id: NEXT_ID.fetch_add(1, Ordering::SeqCst) as i32,
         name: name.to_string(),
-        user_id: 100,
         updated_at: time::now().to_timespec(),
         created_at: time::now().to_timespec(),
         downloads: 10,


### PR DESCRIPTION
user_id has been replaced with a join to the crate_owners table since
multiple owners was implemented, but the user_id column on the crates
table still had a non-null foreign key constraint on it.

Discovered during the course of working on ✨secret things✨ ; let me know if there's a use for this that I'm not seeing!