### PR TITLE
Implemented 'sort by relevance/downloads' for search results

### DIFF
--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -4,10 +4,15 @@ import PaginationMixin from '../mixins/pagination';
 const { computed } = Ember;
 
 export default Ember.Controller.extend(PaginationMixin, {
-    queryParams: ['q', 'page', 'per_page'],
+    queryParams: ['q', 'page', 'per_page', 'sort'],
     q: null,
     page: '1',
     per_page: 10,
+    sort: null,
 
     totalItems: computed.readOnly('model.meta.total'),
+
+    currentSortBy: computed('sort', function() {
+        return (this.get('sort') === 'downloads') ? 'Downloads' : 'Relevance';
+    }),
 });

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -4,6 +4,7 @@ export default Ember.Route.extend({
     queryParams: {
         q: { refreshModel: true },
         page: { refreshModel: true },
+        sort: { refreshModel: true },
     },
 
     model(params) {

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -18,6 +18,31 @@
             of <span class='total'>{{ totalItems }}</span> total results
         </span>
     </div>
+
+	<div class='sort'>
+		<span class='small'>Sort by </span>
+		
+		{{#rl-dropdown-container class="dropdown-container"}}
+			{{#rl-dropdown-toggle tagName="a" class="dropdown"}}
+				<img class="sort" src="/assets/sort.png"/>
+				{{ currentSortBy }}
+				<span class='arrow'></span>
+			{{/rl-dropdown-toggle}}
+
+			{{#rl-dropdown tagName="ul" class="dropdown" closeOnChildClick="a:link"}}
+				<li>
+					{{#link-to (query-params page=1 sort="")}}
+						Relevance
+					{{/link-to}}
+				</li>
+				<li>
+					{{#link-to (query-params page=1 sort="downloads")}}
+						Downloads
+					{{/link-to}}
+				</li>
+			{{/rl-dropdown}}
+		{{/rl-dropdown-container}}
+	</div>
 </div>
 
 <div id='crates' class='white-rows'>

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -19,7 +19,7 @@ test('searching for "rust"', function(assert) {
         assert.notOk(find('a[href="/search?page=3&q=rust"]')[0]);
 
         hasText(assert, '#crates-heading', 'Search Results for \'rust\'');
-        hasText(assert, '#results', 'Displaying 1-10 of 18 total results');
+        hasText(assert, '#results', 'Displaying 1-10 of 18 total results Sort by Relevance Relevance Downloads');
 
         hasText(assert, '#crates .row:first .desc .info', 'rust_mixin 0.0.1');
         hasText(assert, '#crates .row:first .desc .summary', 'Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)');
@@ -35,7 +35,7 @@ test('searching for "rust"', function(assert) {
         assert.notOk(find('a[href="/search?page=3&q=rust"]')[0]);
 
         hasText(assert, '#crates-heading', 'Search Results for \'rust\'');
-        hasText(assert, '#results', 'Displaying 11-18 of 18 total results');
+        hasText(assert, '#results', 'Displaying 11-18 of 18 total results Sort by Relevance Relevance Downloads');
 
         hasText(assert, '#crates .row:first .desc .info', 'rusted_cypher 0.7.1');
     });


### PR DESCRIPTION
I have updated the crates API endpoint to be slightly more robust to be able to accept both search terms and sorting parameters. I have also updated the front-end for the search results to mimic the "sort by" functionality found on other pages. 

In my opinion I believe this also addresses issue #281 