### PR TITLE
Remove restriction that a crate must be in the database to get a download URL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,9 @@
 # `postgres://postgres:@localhost/cargo_registry`.
 export DATABASE_URL=""
 
+# If you are running a mirror of crates.io, uncomment this line.
+# export MIRROR=1
+
 # Key to sign and encrypt cookies with. Change this to a long, random string
 # for production.
 export SESSION_KEY="badkey"

--- a/src/bin/fill-in-user-id.rs
+++ b/src/bin/fill-in-user-id.rs
@@ -33,6 +33,7 @@ fn main() {
         db_url: env("DATABASE_URL"),
         env: cargo_registry::Env::Production,
         max_upload_size: 0,
+        mirror: false,
     };
     let app = cargo_registry::App::new(&config);
     {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -57,6 +57,7 @@ fn main() {
         db_url: env("DATABASE_URL"),
         env: cargo_env,
         max_upload_size: 10 * 1024 * 1024,
+        mirror: env::var("MIRROR").is_ok(),
     };
     let app = cargo_registry::App::new(&config);
     let app = cargo_registry::middleware(Arc::new(app));

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub db_url: String,
     pub env: ::Env,
     pub max_upload_size: u64,
+    pub mirror: bool,
 }
 
 impl Config {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -90,6 +90,7 @@ fn app() -> (record::Bomb, Arc<App>, conduit_middleware::MiddlewareBuilder) {
         db_url: env("TEST_DATABASE_URL"),
         env: cargo_registry::Env::Test,
         max_upload_size: 1000,
+        mirror: false,
     };
     INIT.call_once(|| db_setup(&config.db_url));
     let app = App::new(&config);


### PR DESCRIPTION
So I've been thinking about/working on making it easier to run a crates.io mirror. The mirror in particular that I'm working on would basically just mirror the crates.io API:

- A cargo user would change their registry index URL in their `.cargo/config` to point to [an alternate index](https://gitlab.com/integer32llc/crates.io-index)
- That index would be a clone of the official index with one extra commit changing the config.json to point to [an alternate crates.io instance](https://cratesio-mirror.herokuapp.com/)
- The crates.io instance would have its `S3_BUCKET` set to `crates-io` and its `S3_REGION` set to `us-west-1`, so it would NOT be mirroring the actual crate files

The problem I hit was that in order to get a redirect from `/crates/:crate_id/:version/download` to S3, the crate and version needed to be in the database, because the current code would try to update the download counts.

I thought about creating a script that would load the contents of the index back into a database, but then it would have to keep that in sync as changes to the index happened, so I stepped back from that tactic and decided to try this.

This PR tries to increment the download count, but if that isn't possible for any reason, return the redirect to S3 anyway. Cargo checks the index it has before requesting the URL from the API anyway, so as long as the index is a (possibly lagging behind) mirror, cargo should not be requesting files that don't exist on S3. If it does, cargo will just say "failed to download package whatever from http://...s3". This might cause other problems to go unnoticed, but seeing as this is just the download count and any problems with the database would likely manifest in other ways, I think this is ok.

Is there a more idiomatic way to use the `Result` but ignore errors? I know that's not recommended in general, but that's really what I'm trying to do here :)

With this patch deployed to https://cratesio-mirror.herokuapp.com/, I'm able to set my `.cargo/config` to use https://gitlab.com/integer32llc/crates.io-index and install crates!

I'm totally open to other ideas if there's a better way to solve this problem! 