### PR TITLE
adding current version badge to crate's page

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -5,6 +5,7 @@
         <img class='logo crate' src="/assets/crate.png"/>
         <h1>{{ crate.name }}</h1>
         <h2>{{ currentVersion.num }}</h2>
+
     </div>
 
     <div class='right'>
@@ -67,6 +68,12 @@
                 <div class='date'>{{moment-from-now crate.updated_at}}</div>
             </div>
 
+            <div>
+                <img src="https://img.shields.io/crates/dv/{{ crate.name}}.svg"
+                    alt="{{ crate.name }}’s download count badge"
+                    title="{{ crate.name }}’s download count badge" />
+            </div>
+
             <div class="authors">
                 <h3>Authors</h3>
                 <ul>
@@ -110,6 +117,8 @@
                     {{/each}}
                 </ul>
             </div>
+
+            
         </div>
     </div>
 </div>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -5,7 +5,6 @@
         <img class='logo crate' src="/assets/crate.png"/>
         <h1>{{ crate.name }}</h1>
         <h2>{{ currentVersion.num }}</h2>
-
     </div>
 
     <div class='right'>
@@ -117,8 +116,6 @@
                     {{/each}}
                 </ul>
             </div>
-
-            
         </div>
     </div>
 </div>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -69,8 +69,8 @@
 
             <div>
                 <img src="https://img.shields.io/crates/v/{{ crate.name }}.svg"
-                    alt="{{ crate.name }}’s download count badge"
-                    title="{{ crate.name }}’s download count badge" />
+                    alt="{{ crate.name }}’s current version badge"
+                    title="{{ crate.name }}’s current version badge" />
             </div>
 
             <div class="authors">

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -65,12 +65,18 @@
             <div>
                 <div class='last-update'><span class='small'>Last Updated</span></div>
                 <div class='date'>{{moment-from-now crate.updated_at}}</div>
-            </div>
-
-            <div>
-                <img src="https://img.shields.io/crates/v/{{ crate.name }}.svg"
-                    alt="{{ crate.name }}’s current version badge"
-                    title="{{ crate.name }}’s current version badge" />
+                <p>
+                    <img 
+                        src="https://img.shields.io/crates/v/{{ crate.name }}.svg"
+                        alt="{{ crate.name }}’s current version badge"
+                        title="{{ crate.name }}’s current version badge" />
+                </p>
+                <p>
+                    <img 
+                        src="https://img.shields.io/crates/d/{{ crate.name }}.svg"
+                        alt="{{ crate.name }}’s current version downloads badge"
+                        title="{{ crate.name }}’s current version downloads badge" />
+                </p>
             </div>
 
             <div class="authors">
@@ -88,6 +94,7 @@
                 <div>
                     <h3>License</h3>
                     <p>{{ crate.license }}</p>
+                    <p><img src="https://img.shields.io/crates/l/{{ crate.name }}.svg" alt="{{ crate.name }}’s current version license badge" title="{{ crate.name }}’s current version license badge" /></p>
                 </div>
             {{/if}}
 

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -68,7 +68,7 @@
             </div>
 
             <div>
-                <img src="https://img.shields.io/crates/v/{{ crate.name}}.svg"
+                <img src="https://img.shields.io/crates/v/{{ crate.name }}.svg"
                     alt="{{ crate.name }}’s download count badge"
                     title="{{ crate.name }}’s download count badge" />
             </div>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -68,7 +68,7 @@
             </div>
 
             <div>
-                <img src="https://img.shields.io/crates/dv/{{ crate.name}}.svg"
+                <img src="https://img.shields.io/crates/v/{{ crate.name}}.svg"
                     alt="{{ crate.name }}’s download count badge"
                     title="{{ crate.name }}’s download count badge" />
             </div>


### PR DESCRIPTION
Adds a badge to crate page to fix #114 

Let me know if this should be put in a different location and I can update it.
I had it down below with the other stats at first but it just looked and felt better up top.