### PR TITLE
Massage the data going into download graph

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -47,7 +47,7 @@ export default Ember.Component.extend({
                 // the line altogether.
                 if (!on[k] && value === 0) {
                     data[i][k + 1] = null;
-                } 
+                }
                 // If we are off and the value is not zero, we
                 // need to turn back on.  (keep the value the same though)
                 else if (!on[k] && value !== 0) {

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -47,10 +47,10 @@ export default Ember.Component.extend({
                 // the line altogether.
                 if (!on[k] && value === 0) {
                     data[i][k + 1] = null;
-
+                } 
                 // If we are off and the value is not zero, we
                 // need to turn back on.  (keep the value the same though)
-                } else if (!on[k] && value !== 0) {
+                else if (!on[k] && value !== 0) {
                     on[k] = true;
 
                     // We previously wrote a null into data[i - 1][k + 1],
@@ -59,9 +59,10 @@ export default Ember.Component.extend({
                     if (i > 1) {
                         data[i - 1][k + 1] = 0;
                     }
+                }
                 // If we are on and the value is zero, turn off
                 // but keep the zero in the array
-                } else if (on[k] && value === 0) {
+                else if (on[k] && value === 0) {
                     on[k] = false;
                 }
             }

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -20,6 +20,53 @@ export default Ember.Component.extend({
 
         let data = this.get('data');
 
+        let datapoints_count = (data[1] || []).length - 1;
+
+        // "on" is an array of booleans where each
+        // element in the array says whether or not the
+        // corresponding line in the data is being drawn or not.
+        //
+        // Each line starts as not being drawn, and can pick up and
+        // be stopped arbitrarily many times before the graph is complete.
+        let on = [];
+        for (let i = 0; i < datapoints_count; i++) {
+            on.push(false);
+        }
+
+        // Start at 1 because the 0th entry in the array
+        // is an array of version numbers
+        for (let i = 1; i < data.length; i++) {
+            for (let k = 0; k < datapoints_count; k++) {
+                // k + 1 because the first entry in the array is the date
+                let value = data[i][k + 1];
+
+                // If we are "off" and are looking at a zero
+                // replace the data at this point with `null`.
+                //
+                // Null tells google.visualization to stop drawing
+                // the line altogether.
+                if (!on[k] && value === 0) {
+                    data[i][k + 1] = null;
+
+                // If we are off and the value is not zero, we
+                // need to turn back on.  (keep the value the same though)
+                } else if (!on[k] && value !== 0) {
+                    on[k] = true;
+
+                    // We previously wrote a null into data[i - 1][k + 1],
+                    // so to make the graph look pretty, we'll switch it back
+                    // to the zero that it was before.
+                    if (i > 1) {
+                        data[i - 1][k + 1] = 0;
+                    }
+                // If we are on and the value is zero, turn off
+                // but keep the zero in the array
+                } else if (on[k] && value === 0) {
+                    on[k] = false;
+                }
+            }
+        }
+
         if (!data || !window.google || !window.googleChartsLoaded) {
             this.$().hide();
             return;


### PR DESCRIPTION
Closes #305

Google graphs does not treat 0-values in a stacked area-graph very well.  The default behavior for something like the crates.io download graph is to draw many lines right over the top of eachother, meaning that a recently released version will have its lines drawn over the top of the the other versions.

This can be fixed by passing google graphs a dataset with nulls instead of zeros for areas where the line shouldn't be drawn.

This is an implementation of an algorithm that detects sequences of zeros and removes all the zeroes in the middle of the sequence, replacing them with null.

For example
```
[1, 2, 0, 0, 0, 0, 5, 10, 0, 0, 0, 3, 0, 0]
```
will become (spaces indicate null)
```
[1, 2, 0,  ,  , 0, 5, 10, 0,  , 0, 3, 0, 0]
```

Leaving the boundary 0s makes the graph look more continuous.

# BEFORE
<img width="444" alt="screen shot 2016-08-30 at 1 06 17 pm" src="https://cloud.githubusercontent.com/assets/573215/18104996/9d576c36-6eb2-11e6-9d2c-5e60f59a3314.png">

# AFTER
<img width="444" alt="screen shot 2016-08-30 at 1 07 45 pm" src="https://cloud.githubusercontent.com/assets/573215/18105037/c9a8ec2e-6eb2-11e6-86b3-f5a2378312d0.png">


