### PR TITLE
adding ember-cli-meta-tags npm package to provide meta descriptions

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for 'head'}}

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -2,6 +2,13 @@ import Ember from 'ember';
 import ajax from 'ic-ajax';
 
 export default Ember.Route.extend({
+    headTags: [{
+        type: 'meta',
+        attrs: {
+            name: 'description',
+            content: 'cargo is the package manager and crate host for rust'
+        }
+    }],
     model() {
         function addCrates(store, crates) {
             for (var i = 0; i < crates.length; i++) {

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,0 +1,2 @@
+<title>{{ model.title }}</title>
+{{ head-tags headTags=model.headTags }}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-ic-ajax": "1.0.0",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
+    "ember-cli-meta-tags": "^2.0.2",
     "ember-cli-mirage": "0.1.13",
     "ember-cli-moment-shim": "2.0.0",
     "ember-cli-qunit": "3.0.0",


### PR DESCRIPTION
refs #425 

first pass at adding meta descriptions

This PR adds the ember-cli-meta-tags module. It also adds a head template. This is needed when using multiple modules using ember-cli-head which we now are.

There is an entry for the index route to have a meta description tag at `app/routes/index.js`.
This can be added to any route by adding an object:
```
headTags: [{
    type: 'meta',
    attrs: {
        name: 'description',
        content: 'cargo is the package manager and crate host for rust'
    }
}],
```

this produces:
`<meta id="ember823" content="cargo is the package manager and crate host for rust" name="description" class="ember-view">`

Feedback and thoughts on other page descriptions most appreciated.