### PR TITLE
adding check to make sure model.get is function

### DIFF
--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -10,7 +10,9 @@ export default Ember.Route.extend({
     },
 
     afterModel(model) {
-        this.setHeadTags(model);
+        if (typeof model.get === 'function') {
+            this.setHeadTags(model);
+        }
     },
 
     setHeadTags(model) {


### PR DESCRIPTION
a fix for #428 

adds a check to make sure model.get is a function before trying to call it.