### PR TITLE
Add a deploy to heroku button and instructions on running a mirror!

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ To deploy the API on Heroku, use this button:
 
 [deploy]: https://heroku.com/deploy
 
-You do not need to fill in any of the optional fields.
+The only config variable you need to set is `GIT_REPO_URL`, which should be the
+git URL of your crates index repository; see the next section for setup
+instructions for that.
 
 ### Index mirror setup
 

--- a/README.md
+++ b/README.md
@@ -196,4 +196,9 @@ registry = "https://[host and path to your git server]/crates.io-index"
 
 [source.crates-io]
 replace-with = "mirror"
+registry = 'https://doesnt-matter-but-must-be-present'
 ```
+
+Once [rust-lang/cargo#3089](https://github.com/rust-lang/cargo/pull/3089) is
+released, it won't be necessary to specify a registry URL for a source being
+replaced.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,16 @@ For more information on using ember-cli, visit
 For more information on using cargo, visit
 [doc.crates.io](http://doc.crates.io/).
 
-## Deploy a read-only, download-API-only mirror
+## Deploying a Mirror
+
+**DISCLAIMER: The process of setting up a mirror is a work-in-progress and is
+likely to change. It is not currently recommended for mission-critical
+production use. It also requires a version of cargo newer than 0.13.0-nightly
+(f09ef68 2016-08-02); the version of cargo currently on rustc's beta channel
+fulfils this requirement and will be shipped with rustc 1.12.0 scheduled to be
+released on 2016-09-29.**
+
+### Current functionality: a read-only, download-API-only mirror
 
 This mirror will function as a read-only duplicate of crates.io's API. You will
 be able to download crates using your index and your mirror, but the crate files
@@ -135,7 +144,7 @@ Your mirror will not:
 - Keep track of any statistics
 - Display available crates in its UI
 
-### API server
+### API server setup
 
 To deploy the API on Heroku, use this button:
 
@@ -145,7 +154,7 @@ To deploy the API on Heroku, use this button:
 
 You do not need to fill in any of the optional fields.
 
-### Index mirror
+### Index mirror setup
 
 You also need a mirror of the crates.io git index, and your index needs to point
 to your API server.
@@ -162,21 +171,27 @@ to your API server.
 
 3. Commit and push to wherever you will be hosting your index (ex: github,
     gitlab, an internal git server)
-4. In your cargo project, replace the crates.io source with your source by
-    changing your `.cargo/config` to point to wherever you are hosting your git
-    index:
 
-    ```toml
-    [source]
-
-    [source.mirror]
-    registry = "https://[host and path to your git server]/crates.io-index"
-
-    [source.crates-io]
-    replace-with = "mirror"
-    registry = 'https://doesnt-matter-but-must-be-present'
-    ```
-
-5. In order to keep your mirror index up to date, schedule a `git pull` of the
+4. In order to keep your mirror index up to date, schedule a `git pull` of the
     official index. How to do this depends on how you are hosting your index,
     but could be done through `cron` or a scheduled CI job, for example.
+
+### Cargo setup
+
+**NOTE: The following configuration requires a cargo version newer than
+0.13.0-nightly (f09ef68 2016-08-02). The version of cargo that comes with rust
+1.12.0 fulfils this requirement; this version is currently on the beta channel
+and is scheduled to be released on 2016-09-29.**
+
+In the project where you want to use your mirror, change your `.cargo/config`
+to replace the crates.io source to point to your crates index:
+
+```toml
+[source]
+
+[source.mirror]
+registry = "https://[host and path to your git server]/crates.io-index"
+
+[source.crates-io]
+replace-with = "mirror"
+```

--- a/app.json
+++ b/app.json
@@ -3,8 +3,9 @@
   "description": "A mirror of crates.io",
   "repository": "https://github.com/rust-lang/crates.io",
   "env": {
-      "HEROKU": "1",
-      "MIRROR": "1",
+      "GIT_REPO_URL": {
+          "description": "The git URL of your crates index repository.",
+      },
       "GH_CLIENT_ID": {
           "value": "",
           "required": false
@@ -13,8 +14,6 @@
           "value": "",
           "required": false
       },
-      "GIT_REPO_CHECKOUT": "./tmp/index-co",
-      "GIT_REPO_URL": "https://github.com/rust-lang/crates.io-index.git",
       "S3_BUCKET": "crates-io",
       "S3_ACCESS_KEY": {
           "value": "",
@@ -26,7 +25,10 @@
       },
       "SESSION_KEY": {
           "generator": "secret"
-      }
+      },
+      "HEROKU": "1",
+      "MIRROR": "1",
+      "GIT_REPO_CHECKOUT": "./tmp/index-co"
   },
   "formation": {
       "web": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,54 @@
+{
+  "name": "Crates.io Mirror",
+  "description": "A mirror of crates.io",
+  "repository": "https://github.com/rust-lang/crates.io",
+  "env": {
+      "HEROKU": "1",
+      "MIRROR": "1",
+      "GH_CLIENT_ID": {
+          "value": "",
+          "required": false
+      },
+      "GH_CLIENT_SECRET": {
+          "value": "",
+          "required": false
+      },
+      "GIT_REPO_CHECKOUT": "./tmp/index-co",
+      "GIT_REPO_URL": "https://github.com/rust-lang/crates.io-index.git",
+      "S3_BUCKET": "crates-io",
+      "S3_ACCESS_KEY": {
+          "value": "",
+          "required": false
+      },
+      "S3_SECRET_KEY": {
+          "value": "",
+          "required": false
+      },
+      "SESSION_KEY": {
+          "generator": "secret"
+      }
+  },
+  "formation": {
+      "web": {
+          "quantity": 1,
+          "size": "Free"
+      }
+  },
+  "addons": [
+      "heroku-postgresql:hobby-dev"
+  ],
+  "buildpacks": [
+      {
+        "url": "https://github.com/rcaught/heroku-buildpack-cmake"
+      },
+      {
+        "url": "https://github.com/alexcrichton/heroku-buildpack-rust"
+      },
+      {
+        "url": "https://github.com/tonycoco/heroku-buildpack-ember-cli"
+      },
+      {
+        "url": "https://github.com/ryandotsmith/nginx-buildpack.git"
+      }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -41,16 +41,16 @@
   ],
   "buildpacks": [
       {
-        "url": "https://github.com/rcaught/heroku-buildpack-cmake"
+        "url": "https://github.com/rcaught/heroku-buildpack-cmake.git#e4e2c9e"
       },
       {
-        "url": "https://github.com/alexcrichton/heroku-buildpack-rust"
+        "url": "https://github.com/alexcrichton/heroku-buildpack-rust.git#ca218b5"
       },
       {
-        "url": "https://github.com/tonycoco/heroku-buildpack-ember-cli"
+        "url": "https://github.com/tonycoco/heroku-buildpack-ember-cli.git#e4aed2b"
       },
       {
-        "url": "https://github.com/ryandotsmith/nginx-buildpack.git"
+        "url": "https://github.com/ryandotsmith/nginx-buildpack.git#005ca03"
       }
   ]
 }


### PR DESCRIPTION
I am able to install crates from a heroku instance created using this app.json, at https://cratesio-mirror.herokuapp.com/ !

I have an index mirror at https://gitlab.com/integer32llc/crates.io-index that I'm updating every 10 min. I tested out installing a crate through this index and my mirror server, updating that crate on crates.io, verifying that a `cargo update` does not see the update, waiting until my index fetches the changes, then getting the update with a `cargo update` run after that.

It's still probably not doing what people would expect when they hear "mirror", so I tried to add clear caveats about what this does and does not do right now.

Again, this is a baby step in a series of baby steps I hope to help with, but I think it's a step worth taking! 👣 