### PR TITLE
Handle keyword not found by flashing message

### DIFF
--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    model(params) {
+        return this.store.find('keyword', params.keyword_id).catch(e => {
+            if (e.errors.any(e => e.detail === 'Not Found')) {
+                this.controllerFor('application').set('flashError', `Keyword '${params.keyword_id}' does not exist`);
+            }
+        });
+    }
+});

--- a/app/templates/keyword/error.hbs
+++ b/app/templates/keyword/error.hbs
@@ -1,0 +1,1 @@
+{{ title 'Keyword Not Found' }}


### PR DESCRIPTION
This is to address issue #436

Follows the same format as the crate not found page for consistency, taken from PR #421 

Example:
![screen shot 2016-09-26 at 12 32 22 am](https://cloud.githubusercontent.com/assets/3835633/18822711/c4007d36-8380-11e6-832d-775b37f910ad.png)
