### PR TITLE
Remove a trailing comma I left in the json

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/rust-lang/crates.io",
   "env": {
       "GIT_REPO_URL": {
-          "description": "The git URL of your crates index repository.",
+          "description": "The git URL of your crates index repository."
       },
       "GH_CLIENT_ID": {
           "value": "",


### PR DESCRIPTION
I left a trailing comma in the app.json so the deploy to heroku button doesn't actually work right now i'm sorry i'm sorry this should fix it :(