### PR TITLE
Wrap instead of hiding crate list sections on mobile.

### DIFF
--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -121,18 +121,21 @@
     }
     li a:hover { background-color: darken($main-bg-dark, 5%); }
 
-    @media only screen and (max-width: 750px) {
-        #just-updated { display: none; }
-    }
-    @media only screen and (max-width: 550px) {
-        #new-crates { display: none; }
-    }
 }
 
-#home-crates > div {
-    @include flex(1);
+#home-crates {
+    @include flex-wrap(wrap);
+    @include justify-content(center);
 
-    // flexbox trick to help truncate text and prevent overflow
-    // https://css-tricks.com/flexbox-truncated-text/
-    min-width: 0;
+    > div {
+      margin: 0;
+      padding: 0 15px;
+      width: 33.33%;
+      @media only screen and (max-width: 750px) {
+        width: 50%;
+      }
+      @media only screen and (max-width: 550px) {
+        width: 100%;
+      }
+    }
 }


### PR DESCRIPTION
It is currently impossible to view the Just Updated and New Crates list on mobile as they are set to hide at <= 750px and <= 550px respectively. Instead of completely hiding them, I made them wrap at the same breakpoints used right now, so at <= 750px, there are 2 lists per row, and at <= 550px there is only 1 per row now.

Screenshots (after applying the changes in this PR):

At around 750px:

![crates io-750px](https://cloud.githubusercontent.com/assets/217126/19013264/5a7be73e-87e9-11e6-9cab-d1b0ef114c3d.png)

At around 550px:

![crates io-550px](https://cloud.githubusercontent.com/assets/217126/19013266/5e30a82e-87e9-11e6-939d-b38b21202912.png)

I would really appreciate if someone can test this out to double check I didn't mess anything else.