### PR TITLE
breaking long words in the crates list

### DIFF
--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -111,6 +111,12 @@
         @include justify-content(space-between);
         @include align-items(center);
 
+        span {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
         img { vertical-align: middle; }
     }
     li a:hover { background-color: darken($main-bg-dark, 5%); }
@@ -123,4 +129,10 @@
     }
 }
 
-#home-crates > div { @include flex(1); }
+#home-crates > div {
+    @include flex(1);
+
+    // flexbox trick to help truncate text and prevent overflow
+    // https://css-tricks.com/flexbox-truncated-text/
+    min-width: 0;
+}

--- a/app/templates/components/crate-list.hbs
+++ b/app/templates/components/crate-list.hbs
@@ -2,7 +2,7 @@
     {{#each crates as |crate|}}
         <li>
             {{#link-to 'crate' crate class='name'}}
-                {{ crate.name }} ({{ crate.max_version }})
+                <span>{{ crate.name }} ({{ crate.max_version }})</span>
                 <img class="right-arrow" src="/assets/right-arrow.png"/>
             {{/link-to}}
         </li>


### PR DESCRIPTION
fixes #451 

(I could no longer see that crate so I just made up a very long version number)

![screen shot 2016-10-06 at 10 21 53 am](https://cloud.githubusercontent.com/assets/868959/19163043/2754d158-8baf-11e6-8947-3db3eef88eb6.png)
