### PR TITLE
adding docs.rs badge to crate sidebar

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -71,6 +71,14 @@
                         alt="{{ crate.name }}’s current version badge"
                         title="{{ crate.name }}’s current version badge" />
                 </p>
+                <p>
+                    <a href="https://docs.rs/{{ crate.name }}">
+                        <img
+                            src="https://docs.rs/{{ crate.name }}/badge.svg"
+                            alt="{{ crate.name }}'s  https://docs.rs badge"
+                            title="{{ crate.name }}'s  https://docs.rs badge" />
+                    </a>
+                </p>
             </div>
 
             <div class="authors">


### PR DESCRIPTION
fixes #419 

Adding a docs.rs badge and link to the sidebar.

The initial issue said to replace the documentation link but I think that badge will look a bit funny down in a text list so I put it in the sidebar. It also sounds like enough people would be in favor of docs.rs by default and we also already have the crates.io badge up there.

![screen shot 2016-10-17 at 9 32 06 pm](https://cloud.githubusercontent.com/assets/868959/19464454/521bc5f8-94b1-11e6-8a1c-5713a6beee95.png)
