### PR TITLE
Update index creation message

### DIFF
--- a/script/init-local-index.sh
+++ b/script/init-local-index.sh
@@ -30,10 +30,24 @@ cd ../..
 touch tmp/index-co/.git/git-daemon-export-ok
 
 cat - <<-EOF
-Please add the following to your HOME/.cargo/config:
+Your local git index is ready to go!
 
-    [registry]
-    index = "http://localhost:8888/git/index"
+You'll want to build crates.io by running:
+
+   cargo build
+
+Follow up by changing your HOME/.cargo/config: 
+
+   [source]
+
+   [source.local]
+   registry = "https://localhost:8888/crates.io-index"
+
+   [source.crates-io]
+   replace-with = "local"
+   registry = 'https://doesnt-matter-but-must-be-present'
 
 You will also need to generate a token from in the app itself
+
+Please refer to https://github.com/rust-lang/crates.io/blob/master/README.md for more info!
 EOF


### PR DESCRIPTION
This change rewrites the message at the end of the script to be more consistent with the README file. The README says to run the script but not to modify the config file until after running. The ending message states these instructions, uses the replace-with key, and provides a URL to the README for convenience. Fixes #471.