### PR TITLE
Add Categorization!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,7 @@ dependencies = [
  "s3 0.0.1",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -610,6 +611,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "3c7ec6d62a20df54e07ab3b78b9a3932972f4b7981de295563686849eb3989af"
+"checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum unicode-bidi 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c1f7ceb96afdfeedee42bade65a0d585a6a0106f681b6749c8ff4daa8df30b3f"
 "checksum unicode-normalization 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "26643a2f83bac55f1976fb716c10234485f9202dcd65cfbdf9da49867b271172"
 "checksum url 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f024e241a55f5c88401595adc1d4af0c9649e91da82d0e190fe55950231ae575"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ env_logger = "0.3"
 rustc-serialize = "0.3"
 license-exprs = "^1.3"
 dotenv = "0.8.0"
+toml = "0.2"
 
 conduit = "0.8"
 conduit-conditional-get = "0.8"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,21 @@ follows:
     ```
     cargo test
     ```
+    
+## Categories
+
+The list of categories available on crates.io is stored in
+`src/categories.toml`. To propose adding, removing, or changing a category,
+send a pull request making the appropriate change to that file as noted in the
+comment at the top of the file. Please add a description that will help others
+to know what crates are in that category.
+
+For new categories, it's helpful to note in your PR description examples of
+crates that would fit in that category, and describe what distinguishes the new
+category from existing categories.
+
+After your PR is accepted, the next time that crates.io is deployed the
+categories will be synced from this file.
 
 ## Deploying & Using a Mirror
 

--- a/app/adapters/category-slug.js
+++ b/app/adapters/category-slug.js
@@ -1,0 +1,11 @@
+import ApplicationAdapter from './application';
+import Ember from 'ember';
+
+export default ApplicationAdapter.extend({
+    pathForType(modelName) {
+        var decamelized = Ember.String.underscore(
+          Ember.String.decamelize(modelName)
+        );
+        return Ember.String.pluralize(decamelized);
+    }
+});

--- a/app/controllers/categories.js
+++ b/app/controllers/categories.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+import PaginationMixin from '../mixins/pagination';
+
+const { computed } = Ember;
+
+export default Ember.Controller.extend(PaginationMixin, {
+    queryParams: ['page', 'per_page', 'sort'],
+    page: '1',
+    per_page: 10,
+    sort: 'alpha',
+
+    totalItems: computed.readOnly('model.meta.total'),
+
+    currentSortBy: computed('sort', function() {
+        return (this.get('sort') === 'crates') ? '# Crates' : 'Alphabetical';
+    }),
+});

--- a/app/controllers/category/index.js
+++ b/app/controllers/category/index.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+import PaginationMixin from '../../mixins/pagination';
+
+const { computed } = Ember;
+
+export default Ember.Controller.extend(PaginationMixin, {
+    queryParams: ['page', 'per_page', 'sort'],
+    page: '1',
+    per_page: 10,
+    sort: 'alpha',
+
+    totalItems: computed.readOnly('model.meta.total'),
+
+    currentSortBy: computed('sort', function() {
+        return (this.get('sort') === 'downloads') ? 'Downloads' : 'Alphabetical';
+    }),
+});

--- a/app/controllers/category/index.js
+++ b/app/controllers/category/index.js
@@ -7,7 +7,7 @@ export default Ember.Controller.extend(PaginationMixin, {
     queryParams: ['page', 'per_page', 'sort'],
     page: '1',
     per_page: 10,
-    sort: 'alpha',
+    sort: 'downloads',
 
     totalItems: computed.readOnly('model.meta.total'),
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -19,6 +19,7 @@ export default Ember.Controller.extend({
     currentVersion: computed.alias('model'),
     requestedVersion: null,
     keywords: computed.alias('crate.keywords'),
+    categories: computed.alias('crate.categories'),
 
     sortedVersions: computed.readOnly('crate.versions'),
 
@@ -49,6 +50,7 @@ export default Ember.Controller.extend({
     }),
 
     anyKeywords: computed.gt('keywords.length', 0),
+    anyCategories: computed.gt('categories.length', 0),
 
     currentDependencies: computed('currentVersion.dependencies', function() {
         var deps = this.get('currentVersion.dependencies');

--- a/app/models/category-slug.js
+++ b/app/models/category-slug.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+    slug: DS.attr('string'),
+});

--- a/app/models/category.js
+++ b/app/models/category.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+    category: DS.attr('string'),
+    created_at: DS.attr('date'),
+    crates_cnt: DS.attr('number'),
+
+    crates: DS.hasMany('crate', { async: true })
+});

--- a/app/models/category.js
+++ b/app/models/category.js
@@ -2,6 +2,7 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
     category: DS.attr('string'),
+    slug: DS.attr('string'),
     created_at: DS.attr('date'),
     crates_cnt: DS.attr('number'),
 

--- a/app/models/category.js
+++ b/app/models/category.js
@@ -6,5 +6,7 @@ export default DS.Model.extend({
     created_at: DS.attr('date'),
     crates_cnt: DS.attr('number'),
 
+    subcategories: DS.attr(),
+
     crates: DS.hasMany('crate', { async: true })
 });

--- a/app/models/category.js
+++ b/app/models/category.js
@@ -3,6 +3,7 @@ import DS from 'ember-data';
 export default DS.Model.extend({
     category: DS.attr('string'),
     slug: DS.attr('string'),
+    description: DS.attr('string'),
     created_at: DS.attr('date'),
     crates_cnt: DS.attr('number'),
 

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -20,6 +20,7 @@ export default DS.Model.extend({
     owners: DS.hasMany('users', { async: true }),
     version_downloads: DS.hasMany('version-download', { async: true }),
     keywords: DS.hasMany('keywords', { async: true }),
+    categories: DS.hasMany('categories', { async: true }),
     reverse_dependencies: DS.hasMany('dependency', { async: true }),
 
     follow() {

--- a/app/router.js
+++ b/app/router.js
@@ -35,6 +35,7 @@ Router.map(function() {
     this.route('keyword', { path: '/keywords/:keyword_id' }, function() {
         this.route('index', { path: '/' });
     });
+    this.route('categories');
     this.route('catchAll', { path: '*path' });
 });
 

--- a/app/router.js
+++ b/app/router.js
@@ -36,6 +36,9 @@ Router.map(function() {
         this.route('index', { path: '/' });
     });
     this.route('categories');
+    this.route('category', { path: '/categories/:category_id' }, function() {
+        this.route('index', { path: '/' });
+    });
     this.route('catchAll', { path: '*path' });
 });
 

--- a/app/router.js
+++ b/app/router.js
@@ -39,6 +39,7 @@ Router.map(function() {
     this.route('category', { path: '/categories/:category_id' }, function() {
         this.route('index', { path: '/' });
     });
+    this.route('category_slugs');
     this.route('catchAll', { path: '*path' });
 });
 

--- a/app/routes/categories.js
+++ b/app/routes/categories.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    queryParams: {
+        page: { refreshModel: true },
+        sort: { refreshModel: true },
+    },
+
+    model(params) {
+        return this.store.query('category', params);
+    },
+});

--- a/app/routes/category-slugs.js
+++ b/app/routes/category-slugs.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    queryParams: {
+        page: { refreshModel: true },
+        sort: { refreshModel: true },
+    },
+
+    model(params) {
+        return this.store.query('category-slug', params);
+    },
+});

--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    model(params) {
+        return this.store.find('category', params.category_id).catch(e => {
+            if (e.errors.any(e => e.detail === 'Not Found')) {
+                this.controllerFor('application').set('flashError', `Category '${params.category_id}' does not exist`);
+            }
+        });
+    }
+});

--- a/app/routes/category/index.js
+++ b/app/routes/category/index.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    queryParams: {
+        page: { refreshModel: true },
+        sort: { refreshModel: true },
+    },
+
+    model(params) {
+        params.category = this.modelFor('category').id;
+        return this.store.query('crate', params);
+    },
+
+    setupController(controller, model) {
+        controller.set('category', this.modelFor('category'));
+        this._super(controller, model);
+    },
+});

--- a/app/templates/categories.hbs
+++ b/app/templates/categories.hbs
@@ -1,0 +1,66 @@
+{{ title 'Categories' }}
+
+<div id='crates-heading'>
+    <img class='logo crate' src="/assets/crate.png"/>
+    <h1>All Categories</h1>
+</div>
+
+<div id='results'>
+    <div class='nav'>
+        <span class='amt small'>
+            Displaying
+            <span class='cur'>{{ currentPageStart }}-{{ currentPageEnd }}</span>
+            of <span class='total'>{{ totalItems }}</span> total results
+        </span>
+    </div>
+
+    <div class='sort'>
+        <span class='small'>Sort by</span>
+        {{#rl-dropdown-container class="dropdown-container"}}
+            {{#rl-dropdown-toggle tagName="a" class="dropdown"}}
+                <img class="sort" src="/assets/sort.png"/>
+                {{ currentSortBy }}
+                <span class='arrow'></span>
+            {{/rl-dropdown-toggle}}
+
+            {{#rl-dropdown tagName="ul" class="dropdown" closeOnChildClick="a:link"}}
+                <li>
+                    {{#link-to (query-params sort="alpha")}}
+                        Alphabetical
+                    {{/link-to}}
+                </li>
+                <li>
+                    {{#link-to (query-params sort="crates")}}
+                        # Crates
+                    {{/link-to}}
+                </li>
+            {{/rl-dropdown}}
+        {{/rl-dropdown-container}}
+    </div>
+</div>
+
+<div class='white-rows'>
+    {{#each model as |category|}}
+        <div class='row'>
+            <div class='info'>
+                {{ category.category }}
+                <span class='vers small'>
+                    {{ format-num category.crates_cnt }}
+                    crates
+                </span>
+            </div>
+        </div>
+    {{/each}}
+</div>
+
+<div class='pagination'>
+    {{#link-to (query-params page=prevPage) class="prev" rel="prev" title="previous page"}}
+        <img class="left-pag" src="/assets/left-pag.png"/>
+    {{/link-to}}
+    {{#each pages as |page|}}
+        {{#link-to (query-params page=page)}}{{ page }}{{/link-to}}
+    {{/each}}
+    {{#link-to (query-params page=nextPage) class="next" rel="next" title="next page"}}
+        <img class="right-pag" src="/assets/right-pag.png"/>
+    {{/link-to}}
+</div>

--- a/app/templates/categories.hbs
+++ b/app/templates/categories.hbs
@@ -42,12 +42,19 @@
 <div class='white-rows'>
     {{#each model as |category|}}
         <div class='row'>
-            <div class='info'>
-                {{link-to category.category "category" category.slug}}
-                <span class='vers small'>
-                    {{ format-num category.crates_cnt }}
-                    crates
-                </span>
+            <div class='desc'>
+                <div class='info'>
+                    {{link-to category.category "category" category.slug}}
+                    <span class='small'>
+                        {{ format-num category.crates_cnt }}
+                        crates
+                    </span>
+                </div>
+                <div class='summary'>
+                    <span class='small'>
+                        {{ truncate-text category.description }}
+                    </span>
+                </div>
             </div>
         </div>
     {{/each}}

--- a/app/templates/categories.hbs
+++ b/app/templates/categories.hbs
@@ -43,7 +43,7 @@
     {{#each model as |category|}}
         <div class='row'>
             <div class='info'>
-                {{link-to category.id "category" category}}
+                {{link-to category.category "category" category.slug}}
                 <span class='vers small'>
                     {{ format-num category.crates_cnt }}
                     crates

--- a/app/templates/category/error.hbs
+++ b/app/templates/category/error.hbs
@@ -1,0 +1,1 @@
+{{ title 'Category Not Found' }}

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -1,8 +1,9 @@
-{{ title 'Categories' }}
+{{ title category.category ' - Categories' }}
 
 <div id='crates-heading'>
     <img class='logo crate' src="/assets/crate.png"/>
-    <h1>All Categories</h1>
+    <h1>All Crates</h1>
+    <h2>for category '{{ category.category }}'</h2>
 </div>
 
 <div id='results'>
@@ -30,8 +31,8 @@
                     {{/link-to}}
                 </li>
                 <li>
-                    {{#link-to (query-params sort="crates")}}
-                        # Crates
+                    {{#link-to (query-params sort="downloads")}}
+                        Downloads
                     {{/link-to}}
                 </li>
             {{/rl-dropdown}}
@@ -39,17 +40,9 @@
     </div>
 </div>
 
-<div class='white-rows'>
-    {{#each model as |category|}}
-        <div class='row'>
-            <div class='info'>
-                {{link-to category.id "category" category}}
-                <span class='vers small'>
-                    {{ format-num category.crates_cnt }}
-                    crates
-                </span>
-            </div>
-        </div>
+<div id='crates' class='white-rows'>
+    {{#each model as |crate|}}
+        {{crate-row crate=crate}}
     {{/each}}
 </div>
 

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -2,8 +2,7 @@
 
 <div id='crates-heading'>
     <img class='logo crate' src="/assets/crate.png"/>
-    <h1>All Crates</h1>
-    <h2>for category '{{ category.category }}'</h2>
+    <h1>{{ category.category }} Crates</h1>
 </div>
 
 <div id='results'>

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -5,6 +5,25 @@
     <h1>{{ category.category }} Crates</h1>
 </div>
 
+{{#if category.subcategories }}
+  <div id='subcategories'>
+      <h2>Subcategories</h2>
+      <div class='white-rows'>
+          {{#each category.subcategories as |subcategory| }}
+              <div class='row'>
+                  <div class='info'>
+                      {{link-to subcategory.category "category" subcategory.slug}}
+                      <span class='vers small'>
+                          {{ format-num subcategory.crates_cnt }}
+                          crates
+                      </span>
+                  </div>
+              </div>
+          {{/each}}
+      </div>
+  </div>
+{{/if}}
+
 <div id='results'>
     <div class='nav'>
         <span class='amt small'>

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -11,12 +11,19 @@
       <div class='white-rows'>
           {{#each category.subcategories as |subcategory| }}
               <div class='row'>
-                  <div class='info'>
-                      {{link-to subcategory.category "category" subcategory.slug}}
-                      <span class='vers small'>
-                          {{ format-num subcategory.crates_cnt }}
-                          crates
-                      </span>
+                  <div class='desc'>
+                      <div class='info'>
+                          {{link-to subcategory.category "category" subcategory.slug}}
+                          <span class='small'>
+                              {{ format-num subcategory.crates_cnt }}
+                              crates
+                          </span>
+                      </div>
+                      <div class='summary'>
+                          <span class='small'>
+                              {{ truncate-text subcategory.description }}
+                          </span>
+                      </div>
                   </div>
               </div>
           {{/each}}

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -2,7 +2,7 @@
 
 <div id='crates-heading'>
     <img class='logo crate' src="/assets/crate.png"/>
-    <h1>{{ category.category }} Crates</h1>
+    <h1>{{ category.category }}</h1>
 </div>
 
 {{#if category.subcategories }}
@@ -31,6 +31,7 @@
   </div>
 {{/if}}
 
+<h2>Crates</h2>
 <div id='results'>
     <div class='nav'>
         <span class='amt small'>

--- a/app/templates/category_slugs.hbs
+++ b/app/templates/category_slugs.hbs
@@ -1,0 +1,14 @@
+{{ title 'Category Slugs' }}
+
+<div id='crates-heading'>
+    <img class='logo crate' src="/assets/crate.png"/>
+    <h1>All Valid Category Slugs</h1>
+</div>
+
+<div class='white-rows'>
+    <ul>
+      {{#each model as |slug|}}
+          <li>{{slug.slug}}</li>
+      {{/each}}
+    </ul>
+</div>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -104,6 +104,19 @@
                 {{/if}}
             {{/unless}}
 
+            {{#unless crate.categories.isPending}}
+                {{#if anyCategories}}
+                    <div>
+                        <h3>Categories</h3>
+                        <ul class='categories'>
+                            {{#each categories as |category|}}
+                                <li>{{link-to category.id 'category' category}}</li>
+                            {{/each}}
+                        </ul>
+                    </div>
+                {{/if}}
+            {{/unless}}
+
             <div>
                 <h3>Owners</h3>
                 <ul class='owners'>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -110,7 +110,7 @@
                         <h3>Categories</h3>
                         <ul class='categories'>
                             {{#each categories as |category|}}
-                                <li>{{link-to category.id 'category' category}}</li>
+                                <li>{{link-to category.category 'category' category.slug}}</li>
                             {{/each}}
                         </ul>
                     </div>

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -768,6 +768,7 @@ fn migrations() -> Vec<Migration> {
             id               SERIAL PRIMARY KEY, \
             category         VARCHAR NOT NULL UNIQUE, \
             slug             VARCHAR NOT NULL UNIQUE, \
+            description      VARCHAR NOT NULL DEFAULT '', \
             crates_cnt       INTEGER NOT NULL DEFAULT 0, \
             created_at       TIMESTAMP NOT NULL DEFAULT current_timestamp"),
         Migration::add_table(20161115111828, "crates_categories", " \

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -767,6 +767,7 @@ fn migrations() -> Vec<Migration> {
         Migration::add_table(20161115110541, "categories", " \
             id               SERIAL PRIMARY KEY, \
             category         VARCHAR NOT NULL UNIQUE, \
+            slug             VARCHAR NOT NULL UNIQUE, \
             crates_cnt       INTEGER NOT NULL DEFAULT 0, \
             created_at       TIMESTAMP NOT NULL DEFAULT current_timestamp"),
         Migration::add_table(20161115111828, "crates_categories", " \

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -62,6 +62,8 @@ fn main() {
     let app = cargo_registry::App::new(&config);
     let app = cargo_registry::middleware(Arc::new(app));
 
+    cargo_registry::categories::sync().unwrap();
+
     let port = if heroku {
         8888
     } else {

--- a/src/bin/sync-categories.rs
+++ b/src/bin/sync-categories.rs
@@ -1,0 +1,48 @@
+// Sync available crate categories from `src/categories.txt`.
+// Only needs to be run for new databases or when `src/categories.txt`
+// has been updated.
+//
+// Usage:
+//      cargo run --bin sync-categories
+
+#![deny(warnings)]
+
+extern crate cargo_registry;
+extern crate postgres;
+
+use cargo_registry::env;
+
+fn main() {
+    let conn = postgres::Connection::connect(&env("DATABASE_URL")[..],
+                                             postgres::TlsMode::None).unwrap();
+    let tx = conn.transaction().unwrap();
+    sync(&tx).unwrap();
+    tx.set_commit();
+    tx.finish().unwrap();
+}
+
+fn sync(tx: &postgres::transaction::Transaction) -> postgres::Result<()> {
+    let categories = include_str!("../categories.txt");
+    let categories: Vec<_> = categories.lines().collect();
+    let insert = categories.iter()
+                           .map(|c| format!("('{}')", c))
+                           .collect::<Vec<_>>()
+                           .join(",");
+    let in_clause = categories.iter()
+                              .map(|c| format!("'{}'", c))
+                              .collect::<Vec<_>>()
+                              .join(",");
+
+    try!(tx.batch_execute(
+        &format!(" \
+            INSERT INTO categories (category) \
+            VALUES {} \
+            ON CONFLICT (category) DO NOTHING; \
+            DELETE FROM categories \
+            WHERE category NOT IN ({});",
+            insert,
+            in_clause
+        )[..]
+    ));
+    Ok(())
+}

--- a/src/bin/sync-categories.rs
+++ b/src/bin/sync-categories.rs
@@ -23,23 +23,29 @@ fn main() {
 
 fn sync(tx: &postgres::transaction::Transaction) -> postgres::Result<()> {
     let categories = include_str!("../categories.txt");
-    let categories: Vec<_> = categories.lines().collect();
-    let insert = categories.iter()
-                           .map(|c| format!("('{}')", c))
-                           .collect::<Vec<_>>()
-                           .join(",");
-    let in_clause = categories.iter()
-                              .map(|c| format!("'{}'", c))
-                              .collect::<Vec<_>>()
-                              .join(",");
+
+    let slug_categories: Vec<_> = categories.lines().map(|c| {
+        let mut parts = c.split(' ');
+        let slug = parts.next().expect("No slug found!");
+        let name = parts.collect::<Vec<_>>().join(" ");
+        (slug, name)
+    }).collect();
+
+    let insert = slug_categories.iter().map(|&(ref slug, ref name)| {
+        format!("(LOWER('{}'), '{}')", slug, name)
+    }).collect::<Vec<_>>().join(",");
+
+    let in_clause = slug_categories.iter().map(|&(slug, _)| {
+        format!("LOWER('{}')", slug)
+    }).collect::<Vec<_>>().join(",");
 
     try!(tx.batch_execute(
         &format!(" \
-            INSERT INTO categories (category) \
+            INSERT INTO categories (slug, category) \
             VALUES {} \
-            ON CONFLICT (category) DO NOTHING; \
+            ON CONFLICT (slug) DO UPDATE SET category = EXCLUDED.category; \
             DELETE FROM categories \
-            WHERE category NOT IN ({});",
+            WHERE slug NOT IN ({});",
             insert,
             in_clause
         )[..]

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -1,30 +1,96 @@
-// Sync available crate categories from `src/categories.txt`.
+// Sync available crate categories from `src/categories.toml`.
 // Runs when the server is started.
 
+use toml;
 use pg;
 use env;
-use util::errors::CargoResult;
+use util::errors::{CargoResult, ChainError, internal};
+
+struct Category {
+    name: String,
+    slug: String,
+}
+
+impl Category {
+    fn concat(&self, child: &Category) -> Category {
+        Category {
+            name: format!("{}::{}", self.name, child.name),
+            slug: format!("{}::{}", self.slug, child.slug),
+        }
+    }
+}
+
+fn concat_parent_and_child(parent: Option<&Category>, child: Category)
+                           -> Category {
+    parent.map(|p| p.concat(&child)).unwrap_or(child)
+}
+
+fn required_string_from_toml(toml: &toml::Table, key: &str)
+                             -> CargoResult<String> {
+    toml.get(key)
+        .and_then(toml::Value::as_str)
+        .map(str::to_string)
+        .chain_error(|| {
+            internal("Expected Category toml attribute to be a String")
+        })
+}
+
+fn category_from_toml(toml: &toml::Value, parent: Option<&Category>)
+                      -> CargoResult<Vec<Category>> {
+    let toml = toml.as_table().chain_error(|| {
+        internal("Category isn't a toml Table")
+    })?;
+
+    let category = Category {
+        slug: required_string_from_toml(&toml, "slug")?,
+        name: required_string_from_toml(&toml, "name")?,
+    };
+
+    let category = concat_parent_and_child(parent, category);
+
+    let mut children: Vec<_> = toml.get("categories")
+        .and_then(toml::Value::as_slice)
+        .map(|children| {
+            children.iter()
+                .flat_map(|ref child| {
+                    category_from_toml(child, Some(&category))
+                        .expect("Could not create child from toml")
+                }).collect()
+        }).unwrap_or(Vec::new());
+
+    children.push(category);
+
+    Ok(children)
+}
 
 pub fn sync() -> CargoResult<()> {
     let conn = pg::Connection::connect(&env("DATABASE_URL")[..],
                                              pg::TlsMode::None).unwrap();
     let tx = conn.transaction().unwrap();
 
-    let categories = include_str!("./categories.txt");
+    let categories = include_str!("./categories.toml");
+    let toml = toml::Parser::new(categories).parse().expect(
+        "Could not parse categories.toml"
+    );
 
-    let slug_categories: Vec<_> = categories.lines().map(|c| {
-        let mut parts = c.splitn(2, ' ');
-        let slug = parts.next().expect("No slug found!");
-        let name = parts.next().expect("No display name found!");
-        (slug, name)
-    }).collect();
+    let categories = toml.get("categories")
+                         .expect("No categories key found")
+                         .as_slice()
+                         .expect("Categories isn't a toml::Array");
 
-    let insert = slug_categories.iter().map(|&(ref slug, ref name)| {
-        format!("(LOWER('{}'), '{}')", slug, name)
+    let categories: Vec<_> = categories
+        .iter()
+        .flat_map(|c| {
+            category_from_toml(c, None)
+                .expect("Categories from toml failed")
+        }).collect();
+
+    let insert = categories.iter().map(|ref category| {
+        format!("(LOWER('{}'), '{}')", category.slug, category.name)
     }).collect::<Vec<_>>().join(",");
 
-    let in_clause = slug_categories.iter().map(|&(slug, _)| {
-        format!("LOWER('{}')", slug)
+    let in_clause = categories.iter().map(|ref category| {
+        format!("LOWER('{}')", category.slug)
     }).collect::<Vec<_>>().join(",");
 
     try!(tx.batch_execute(

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -13,9 +13,9 @@ pub fn sync() -> CargoResult<()> {
     let categories = include_str!("./categories.txt");
 
     let slug_categories: Vec<_> = categories.lines().map(|c| {
-        let mut parts = c.split(' ');
+        let mut parts = c.splitn(2, ' ');
         let slug = parts.next().expect("No slug found!");
-        let name = parts.collect::<Vec<_>>().join(" ");
+        let name = parts.next().expect("No display name found!");
         (slug, name)
     }).collect();
 

--- a/src/categories.toml
+++ b/src/categories.toml
@@ -1,32 +1,27 @@
-[[categories]]
-slug = "development-tools"
+[development-tools]
 name = "Development Tools"
 description = "Ways to make developing in Rust better"
 
-[[categories.categories]]
-  slug = "testing"
+  [development-tools.categories.testing]
   name = "Testing"
   description = "Additions to automated testing features"
 
-  [[categories.categories.categories]]
-    slug = "mocking"
+    [development-tools.categories.testing.categories.mocking]
     name = "Mocking"
+    description = "Mocks are not the same as stubs!"
 
-[[categories]]
-slug = "libraries"
+[libraries]
 name = "Libraries"
+description = "Libraries are reusable pieces of code"
 
-[[categories.categories]]
-  slug = "async"
+  [libraries.categories.async]
   name = "Async"
   description = "Code that can take time to run but won't block"
 
-[[categories.categories]]
-  slug = "date-and-time"
+  [libraries.categories.date-and-time]
   name = "Date and Time"
   description = "Date and time math"
 
-[[categories]]
-slug = "games"
+[games]
 name = "Games"
 description = "Share fun things"

--- a/src/categories.toml
+++ b/src/categories.toml
@@ -1,0 +1,27 @@
+[[categories]]
+slug = "development-tools"
+name = "Development Tools"
+
+[[categories.categories]]
+  slug = "testing"
+  name = "Testing"
+
+  [[categories.categories.categories]]
+    slug = "mocking"
+    name = "Mocking"
+
+[[categories]]
+slug = "libraries"
+name = "Libraries"
+
+[[categories.categories]]
+  slug = "async"
+  name = "Async"
+
+[[categories.categories]]
+  slug = "date-and-time"
+  name = "Date and Time"
+
+[[categories]]
+slug = "games"
+name = "Games"

--- a/src/categories.toml
+++ b/src/categories.toml
@@ -1,3 +1,31 @@
+# This is where the categories available on crates.io are defined. To propose
+# a change to the categories, send a pull request with your change made to this
+# file.
+#
+# For help with TOML, see: https://github.com/toml-lang/toml
+#
+# Format:
+#
+# ```toml
+# [slug]
+# name = "Display name"
+# description = "Give an idea of the crates that belong in this category."
+#
+#  [slug.categories.subcategory-slug]
+#  name = "Subcategory display name, not including parent category display name"
+#  description = "Give an idea of the crates that belong in this subcategory."
+# ```
+#
+# Notes:
+# - Slugs are the primary identifier. If you make a change to a category's slug,
+#   crates that have been published with that slug will need to be updated to
+#   use the new slug in order to stay in that category. If you only change
+#   names and descriptions, those attributes CAN be updated without affecting
+#   crates in that category.
+# - Slugs are used in the path of URLs, so they should not contain spaces, `/`,
+#   `@`, `:`, or `.`. They should be all lowercase.
+#
+
 [development-tools]
 name = "Development Tools"
 description = "Ways to make developing in Rust better"

--- a/src/categories.toml
+++ b/src/categories.toml
@@ -1,10 +1,12 @@
 [[categories]]
 slug = "development-tools"
 name = "Development Tools"
+description = "Ways to make developing in Rust better"
 
 [[categories.categories]]
   slug = "testing"
   name = "Testing"
+  description = "Additions to automated testing features"
 
   [[categories.categories.categories]]
     slug = "mocking"
@@ -17,11 +19,14 @@ name = "Libraries"
 [[categories.categories]]
   slug = "async"
   name = "Async"
+  description = "Code that can take time to run but won't block"
 
 [[categories.categories]]
   slug = "date-and-time"
   name = "Date and Time"
+  description = "Date and time math"
 
 [[categories]]
 slug = "games"
 name = "Games"
+description = "Share fun things"

--- a/src/categories.txt
+++ b/src/categories.txt
@@ -1,0 +1,2 @@
+Test
+Attempt

--- a/src/categories.txt
+++ b/src/categories.txt
@@ -1,2 +1,3 @@
-Test
-Attempt
+test Test
+attempt Attempt
+node.js-ruby-ffi Node.js/Ruby FFI

--- a/src/categories.txt
+++ b/src/categories.txt
@@ -1,3 +1,5 @@
-test Test
-attempt Attempt
-node.js-ruby-ffi Node.js/Ruby FFI
+development-tools Development Tools
+development-tools::testing Development Tools::Testing
+libraries Libraries
+libraries::async Libraries::Async
+libraries::date-and-time Libraries::Date and Time

--- a/src/categories.txt
+++ b/src/categories.txt
@@ -1,5 +1,0 @@
-development-tools Development Tools
-development-tools::testing Development Tools::Testing
-libraries Libraries
-libraries::async Libraries::Async
-libraries::date-and-time Libraries::Date and Time

--- a/src/category.rs
+++ b/src/category.rs
@@ -118,7 +118,7 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
     let conn = try!(req.tx());
     let (offset, limit) = try!(req.pagination(10, 100));
     let query = req.query();
-    let sort = query.get("sort").map(|s| &s[..]).unwrap_or("alpha");
+    let sort = query.get("sort").map_or("alpha", String::as_str);
     let sort_sql = match sort {
         "crates" => "ORDER BY crates_cnt DESC",
         _ => "ORDER BY category ASC",

--- a/src/category.rs
+++ b/src/category.rs
@@ -1,0 +1,95 @@
+use time::Timespec;
+
+use conduit::{Request, Response};
+use pg::GenericConnection;
+use pg::rows::Row;
+
+use Model;
+use db::RequestTransaction;
+use util::{RequestUtils, CargoResult};
+
+#[derive(Clone)]
+pub struct Category {
+    pub id: i32,
+    pub category: String,
+    pub created_at: Timespec,
+    pub crates_cnt: i32,
+}
+
+#[derive(RustcEncodable, RustcDecodable)]
+pub struct EncodableCategory {
+    pub id: String,
+    pub category: String,
+    pub created_at: String,
+    pub crates_cnt: i32,
+}
+
+impl Category {
+    pub fn find_by_category(conn: &GenericConnection, name: &str)
+                            -> CargoResult<Option<Category>> {
+        let stmt = try!(conn.prepare("SELECT * FROM categories \
+                                      WHERE category = $1"));
+        let rows = try!(stmt.query(&[&name]));
+        Ok(rows.iter().next().map(|r| Model::from_row(&r)))
+    }
+
+    pub fn encodable(self) -> EncodableCategory {
+        let Category { id: _, crates_cnt, category, created_at } = self;
+        EncodableCategory {
+            id: category.clone(),
+            created_at: ::encode_time(created_at),
+            crates_cnt: crates_cnt,
+            category: category,
+        }
+    }
+}
+
+impl Model for Category {
+    fn from_row(row: &Row) -> Category {
+        Category {
+            id: row.get("id"),
+            created_at: row.get("created_at"),
+            crates_cnt: row.get("crates_cnt"),
+            category: row.get("category"),
+        }
+    }
+    fn table_name(_: Option<Category>) -> &'static str { "categories" }
+}
+
+/// Handles the `GET /categories` route.
+pub fn index(req: &mut Request) -> CargoResult<Response> {
+    let conn = try!(req.tx());
+    let (offset, limit) = try!(req.pagination(10, 100));
+    let query = req.query();
+    let sort = query.get("sort").map(|s| &s[..]).unwrap_or("alpha");
+    let sort_sql = match sort {
+        "crates" => "ORDER BY crates_cnt DESC",
+        _ => "ORDER BY category ASC",
+    };
+
+    // Collect all the categories
+    let stmt = try!(conn.prepare(&format!("SELECT * FROM categories {} \
+                                           LIMIT $1 OFFSET $2",
+                                          sort_sql)));
+
+    let categories: Vec<_> = try!(stmt.query(&[&limit, &offset]))
+        .iter()
+        .map(|row| {
+            let category: Category = Model::from_row(&row);
+            category.encodable()
+        })
+        .collect();
+
+    // Query for the total count of categories
+    let total = try!(Category::count(conn));
+
+    #[derive(RustcEncodable)]
+    struct R { categories: Vec<EncodableCategory>, meta: Meta }
+    #[derive(RustcEncodable)]
+    struct Meta { total: i64 }
+
+    Ok(req.json(&R {
+        categories: categories,
+        meta: Meta { total: total },
+    }))
+}

--- a/src/category.rs
+++ b/src/category.rs
@@ -79,7 +79,7 @@ impl Category {
                                 .cloned()
                                 .collect();
 
-        if to_rm.len() > 0 {
+        if !to_rm.is_empty() {
             try!(conn.execute("DELETE FROM crates_categories \
                                 WHERE category_id = ANY($1) \
                                   AND crate_id = $2",

--- a/src/category.rs
+++ b/src/category.rs
@@ -63,16 +63,23 @@ impl Category {
 
     pub fn update_crate(conn: &GenericConnection,
                         krate: &Crate,
-                        categories: &[String]) -> CargoResult<()> {
+                        categories: &[String]) -> CargoResult<Vec<String>> {
         let old_categories = try!(krate.categories(conn));
         let old_categories_ids: HashSet<_> = old_categories.iter().map(|cat| {
             cat.id
         }).collect();
 
         // If a new category specified is not in the database, filter
-        // it out and don't add it.
+        // it out and don't add it. Return it to be able to warn about it.
+        let mut invalid_categories = vec![];
         let new_categories: Vec<Category> = categories.iter().flat_map(|c| {
-            Category::find_by_slug(conn, &c).ok()
+            match Category::find_by_slug(conn, &c) {
+                Ok(cat) => Some(cat),
+                Err(_) => {
+                    invalid_categories.push(c.to_string());
+                    None
+                },
+            }
         }).collect();
 
         let new_categories_ids: HashSet<_> = new_categories.iter().map(|cat| {
@@ -106,7 +113,7 @@ impl Category {
                               &[]));
         }
 
-        Ok(())
+        Ok(invalid_categories)
     }
 }
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -16,6 +16,7 @@ pub struct Category {
     pub id: i32,
     pub category: String,
     pub slug: String,
+    pub description: String,
     pub created_at: Timespec,
     pub crates_cnt: i32,
 }
@@ -25,6 +26,7 @@ pub struct EncodableCategory {
     pub id: String,
     pub category: String,
     pub slug: String,
+    pub description: String,
     pub created_at: String,
     pub crates_cnt: i32,
 }
@@ -34,6 +36,7 @@ pub struct EncodableCategoryWithSubcategories {
     pub id: String,
     pub category: String,
     pub slug: String,
+    pub description: String,
     pub created_at: String,
     pub crates_cnt: i32,
     pub subcategories: Vec<EncodableCategory>,
@@ -61,10 +64,13 @@ impl Category {
     }
 
     pub fn encodable(self) -> EncodableCategory {
-        let Category { id: _, crates_cnt, category, slug, created_at } = self;
+        let Category {
+            id: _, crates_cnt, category, slug, description, created_at
+        } = self;
         EncodableCategory {
             id: slug.clone(),
             slug: slug.clone(),
+            description: description.clone(),
             created_at: ::encode_time(created_at),
             crates_cnt: crates_cnt,
             category: category,
@@ -155,6 +161,7 @@ impl Model for Category {
             crates_cnt: row.get("crates_cnt"),
             category: row.get("category"),
             slug: row.get("slug"),
+            description: row.get("description"),
         }
     }
     fn table_name(_: Option<Category>) -> &'static str { "categories" }
@@ -174,7 +181,7 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
     // Collect all the top-level categories and sum up the crates_cnt of
     // the crates in all subcategories
     let stmt = try!(conn.prepare(&format!(
-        "SELECT c.id, c.category, c.slug, c.created_at, \
+        "SELECT c.id, c.category, c.slug, c.description, c.created_at, \
                 counts.sum::int as crates_cnt \
          FROM categories as c \
          LEFT JOIN ( \
@@ -224,6 +231,7 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
         id: cat.id,
         category: cat.category,
         slug: cat.slug,
+        description: cat.description,
         created_at: cat.created_at,
         crates_cnt: cat.crates_cnt,
         subcategories: subcats,

--- a/src/category.rs
+++ b/src/category.rs
@@ -147,7 +147,8 @@ impl Category {
     pub fn subcategories(&self, conn: &GenericConnection)
                                 -> CargoResult<Vec<Category>> {
         let stmt = try!(conn.prepare("SELECT * FROM categories \
-                                      WHERE category ILIKE $1 || '::%'"));
+                                      WHERE category ILIKE $1 || '::%'
+                                      AND category NOT ILIKE $1 || '::%::%'"));
         let rows = try!(stmt.query(&[&self.category]));
         Ok(rows.iter().map(|r| Model::from_row(&r)).collect())
     }

--- a/src/category.rs
+++ b/src/category.rs
@@ -115,6 +115,18 @@ impl Category {
 
         Ok(invalid_categories)
     }
+
+    pub fn count_toplevel(conn: &GenericConnection) -> CargoResult<i64> {
+        let sql = format!("\
+            SELECT COUNT(*) \
+            FROM {} \
+            WHERE category NOT LIKE '%::%'",
+            Model::table_name(None::<Self>
+        ));
+        let stmt = try!(conn.prepare(&sql));
+        let rows = try!(stmt.query(&[]));
+        Ok(rows.iter().next().unwrap().get("count"))
+    }
 }
 
 impl Model for Category {
@@ -141,10 +153,13 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
         _ => "ORDER BY category ASC",
     };
 
-    // Collect all the categories
-    let stmt = try!(conn.prepare(&format!("SELECT * FROM categories {} \
-                                           LIMIT $1 OFFSET $2",
-                                          sort_sql)));
+    // Collect all the top-level categories
+    let stmt = try!(conn.prepare(&format!(
+        "SELECT * FROM categories \
+         WHERE category NOT LIKE '%::%' {} \
+         LIMIT $1 OFFSET $2",
+         sort_sql
+    )));
 
     let categories: Vec<_> = try!(stmt.query(&[&limit, &offset]))
         .iter()
@@ -155,7 +170,7 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
         .collect();
 
     // Query for the total count of categories
-    let total = try!(Category::count(conn));
+    let total = try!(Category::count_toplevel(conn));
 
     #[derive(RustcEncodable)]
     struct R { categories: Vec<EncodableCategory>, meta: Meta }

--- a/src/category.rs
+++ b/src/category.rs
@@ -146,9 +146,18 @@ impl Category {
 
     pub fn subcategories(&self, conn: &GenericConnection)
                                 -> CargoResult<Vec<Category>> {
-        let stmt = try!(conn.prepare("SELECT * FROM categories \
-                                      WHERE category ILIKE $1 || '::%'
-                                      AND category NOT ILIKE $1 || '::%::%'"));
+        let stmt = try!(conn.prepare("\
+            SELECT c.id, c.category, c.slug, c.description, c.created_at, \
+            COALESCE (( \
+                SELECT sum(c2.crates_cnt)::int \
+                FROM categories as c2 \
+                WHERE c2.slug = c.slug \
+                OR c2.slug LIKE c.slug || '::%' \
+            ), 0) as crates_cnt \
+            FROM categories as c \
+            WHERE c.category ILIKE $1 || '::%' \
+            AND c.category NOT ILIKE $1 || '::%::%'"));
+
         let rows = try!(stmt.query(&[&self.category]));
         Ok(rows.iter().map(|r| Model::from_row(&r)).collect())
     }
@@ -183,15 +192,13 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
     // the crates in all subcategories
     let stmt = try!(conn.prepare(&format!(
         "SELECT c.id, c.category, c.slug, c.description, c.created_at, \
-                counts.sum::int as crates_cnt \
+            COALESCE (( \
+                SELECT sum(c2.crates_cnt)::int \
+                FROM categories as c2 \
+                WHERE c2.slug = c.slug \
+                OR c2.slug LIKE c.slug || '::%' \
+            ), 0) as crates_cnt \
          FROM categories as c \
-         LEFT JOIN ( \
-             SELECT split_part(categories.category, '::', 1), \
-                    sum(categories.crates_cnt) \
-             FROM categories \
-             GROUP BY split_part(categories.category, '::', 1) \
-         ) as counts \
-         ON c.category = counts.split_part \
          WHERE c.category NOT LIKE '%::%' {} \
          LIMIT $1 OFFSET $2",
          sort_sql

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -693,7 +693,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
 
     let categories = new_crate.categories.as_ref().map(|s| &s[..])
                                      .unwrap_or(&[]);
-    let categories = categories.iter().map(|k| k[..].to_string()).collect::<Vec<_>>();
+    let categories: Vec<_> = categories.iter().map(|k| k[..].to_string()).collect();
 
     // Persist the new crate, if it doesn't already exist
     let mut krate = try!(Crate::find_or_insert(try!(req.tx()), name, user.id,

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -530,7 +530,8 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
                         INNER JOIN categories \
                                 ON crates_categories.category_id = \
                                    categories.id \
-                        WHERE lower(categories.category) = lower($1)";
+                        WHERE categories.slug = $1 OR \
+                              categories.slug LIKE $1 || '::%'";
             (format!("SELECT crates.* {} ORDER BY {} LIMIT $2 OFFSET $3", base, sort_sql),
              format!("SELECT COUNT(crates.*) {}", base))
         })

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -248,7 +248,7 @@ impl Crate {
             None => Some(format!("/api/v1/crates/{}/versions", name)),
         };
         let keyword_ids = keywords.map(|kws| kws.iter().map(|kw| kw.keyword.clone()).collect());
-        let category_ids = categories.map(|cats| cats.iter().map(|cat| cat.category.clone()).collect());
+        let category_ids = categories.map(|cats| cats.iter().map(|cat| cat.slug.clone()).collect());
         EncodableCrate {
             id: name.clone(),
             name: name.clone(),

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -229,6 +229,10 @@ impl Crate {
         parts.next().is_none()
     }
 
+    pub fn minimal_encodable(self) -> EncodableCrate {
+        self.encodable(None, None, None)
+    }
+
     pub fn encodable(self,
                      versions: Option<Vec<i32>>,
                      keywords: Option<&[Keyword]>,
@@ -582,7 +586,7 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
     let mut crates = Vec::new();
     for row in try!(stmt.query(&args)).iter() {
         let krate: Crate = Model::from_row(&row);
-        crates.push(krate.encodable(None, None, None));
+        crates.push(krate.minimal_encodable());
     }
 
     // Query for the total count of crates
@@ -617,7 +621,7 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
         let rows = try!(stmt.query(&[]));
         Ok(rows.iter().map(|r| {
             let krate: Crate = Model::from_row(&r);
-            krate.encodable(None, None, None)
+            krate.minimal_encodable()
         }).collect::<Vec<EncodableCrate>>())
     };
     let new_crates = try!(tx.prepare("SELECT * FROM crates \
@@ -796,7 +800,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
 
     #[derive(RustcEncodable)]
     struct R { krate: EncodableCrate }
-    Ok(req.json(&R { krate: krate.encodable(None, None, None) }))
+    Ok(req.json(&R { krate: krate.minimal_encodable() }))
 }
 
 fn parse_new_headers(req: &mut Request) -> CargoResult<(upload::NewCrate, User)> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ extern crate conduit_router;
 extern crate conduit_static;
 
 pub use app::App;
+pub use self::category::Category;
 pub use config::Config;
 pub use self::dependency::Dependency;
 pub use self::download::{CrateDownload, VersionDownload};
@@ -51,6 +52,7 @@ use conduit_middleware::MiddlewareBuilder;
 use util::{C, R, R404};
 
 pub mod app;
+pub mod category;
 pub mod config;
 pub mod db;
 pub mod dependency;
@@ -100,6 +102,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     api_router.get("/versions/:version_id", C(version::show));
     api_router.get("/keywords", C(keyword::index));
     api_router.get("/keywords/:keyword_id", C(keyword::show));
+    api_router.get("/categories", C(category::index));
     api_router.get("/users/:user_id", C(user::show));
     let api_router = Arc::new(R404(api_router));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     api_router.get("/keywords", C(keyword::index));
     api_router.get("/keywords/:keyword_id", C(keyword::show));
     api_router.get("/categories", C(category::index));
+    api_router.get("/categories/:category_id", C(category::show));
     api_router.get("/users/:user_id", C(user::show));
     let api_router = Arc::new(R404(api_router));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ use conduit_middleware::MiddlewareBuilder;
 use util::{C, R, R404};
 
 pub mod app;
+pub mod categories;
 pub mod category;
 pub mod config;
 pub mod db;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     api_router.get("/keywords/:keyword_id", C(keyword::show));
     api_router.get("/categories", C(category::index));
     api_router.get("/categories/:category_id", C(category::show));
+    api_router.get("/category_slugs", C(category::slugs));
     api_router.get("/users/:user_id", C(user::show));
     let api_router = Arc::new(R404(api_router));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ extern crate s3;
 extern crate semver;
 extern crate time;
 extern crate url;
+extern crate toml;
 
 extern crate conduit;
 extern crate conduit_conditional_get;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -272,20 +272,21 @@ fn new_req(app: Arc<App>, krate: &str, version: &str) -> MockRequest {
 fn new_req_full(app: Arc<App>, krate: Crate, version: &str,
                 deps: Vec<u::CrateDependency>) -> MockRequest {
     let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
-    req.with_body(&new_req_body(krate, version, deps, Vec::new()));
+    req.with_body(&new_req_body(krate, version, deps, Vec::new(), Vec::new()));
     return req;
 }
 
 fn new_req_with_keywords(app: Arc<App>, krate: Crate, version: &str,
                          kws: Vec<String>) -> MockRequest {
     let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
-    req.with_body(&new_req_body(krate, version, Vec::new(), kws));
+    req.with_body(&new_req_body(krate, version, Vec::new(), kws, Vec::new()));
     return req;
 }
 
 fn new_req_body(krate: Crate, version: &str, deps: Vec<u::CrateDependency>,
-                kws: Vec<String>) -> Vec<u8> {
+                kws: Vec<String>, cats: Vec<String>) -> Vec<u8> {
     let kws = kws.into_iter().map(u::Keyword).collect();
+    let cats = cats.into_iter().map(u::Category).collect();
     new_crate_to_body(&u::NewCrate {
         name: u::CrateName(krate.name),
         vers: u::CrateVersion(semver::Version::parse(version).unwrap()),
@@ -297,6 +298,7 @@ fn new_req_body(krate: Crate, version: &str, deps: Vec<u::CrateDependency>,
         documentation: krate.documentation,
         readme: krate.readme,
         keywords: Some(u::KeywordList(kws)),
+        categories: Some(u::CategoryList(cats)),
         license: Some("MIT".to_string()),
         license_file: None,
         repository: krate.repository,

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -283,6 +283,13 @@ fn new_req_with_keywords(app: Arc<App>, krate: Crate, version: &str,
     return req;
 }
 
+fn new_req_with_categories(app: Arc<App>, krate: Crate, version: &str,
+                           cats: Vec<String>) -> MockRequest {
+    let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
+    req.with_body(&new_req_body(krate, version, Vec::new(), Vec::new(), cats));
+    return req;
+}
+
 fn new_req_body_foo_version_2() -> Vec<u8> {
     new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new())
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -26,7 +26,7 @@ use conduit_test::MockRequest;
 use cargo_registry::app::App;
 use cargo_registry::db::{self, RequestTransaction};
 use cargo_registry::dependency::Kind;
-use cargo_registry::{User, Crate, Version, Keyword, Dependency};
+use cargo_registry::{User, Crate, Version, Keyword, Dependency, Category, Model};
 use cargo_registry::upload as u;
 
 macro_rules! t {
@@ -63,6 +63,7 @@ struct Error { detail: String }
 #[derive(RustcDecodable)]
 struct Bad { errors: Vec<Error> }
 
+mod category;
 mod keyword;
 mod krate;
 mod user;
@@ -250,10 +251,19 @@ fn mock_keyword(req: &mut Request, name: &str) -> Keyword {
     Keyword::find_or_insert(req.tx().unwrap(), name).unwrap()
 }
 
+fn mock_category(req: &mut Request, name: &str) -> Category {
+    let conn = req.tx().unwrap();
+    let stmt = conn.prepare(" \
+        INSERT INTO categories (category) \
+        VALUES ($1) \
+        RETURNING *").unwrap();
+    let rows = stmt.query(&[&name]).unwrap();
+    Model::from_row(&rows.iter().next().unwrap())
+}
+
 fn logout(req: &mut Request) {
     req.mut_extensions().pop::<User>();
 }
-
 
 fn new_req(app: Arc<App>, krate: &str, version: &str) -> MockRequest {
     new_req_full(app, ::krate(krate), version, Vec::new())

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -251,13 +251,13 @@ fn mock_keyword(req: &mut Request, name: &str) -> Keyword {
     Keyword::find_or_insert(req.tx().unwrap(), name).unwrap()
 }
 
-fn mock_category(req: &mut Request, name: &str) -> Category {
+fn mock_category(req: &mut Request, name: &str, slug: &str) -> Category {
     let conn = req.tx().unwrap();
     let stmt = conn.prepare(" \
-        INSERT INTO categories (category) \
-        VALUES ($1) \
+        INSERT INTO categories (category, slug) \
+        VALUES ($1, $2) \
         RETURNING *").unwrap();
-    let rows = stmt.query(&[&name]).unwrap();
+    let rows = stmt.query(&[&name, &slug]).unwrap();
     Model::from_row(&rows.iter().next().unwrap())
 }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -64,13 +64,13 @@ struct Error { detail: String }
 struct Bad { errors: Vec<Error> }
 
 mod category;
+mod git;
 mod keyword;
 mod krate;
-mod user;
 mod record;
-mod git;
-mod version;
 mod team;
+mod user;
+mod version;
 
 fn app() -> (record::Bomb, Arc<App>, conduit_middleware::MiddlewareBuilder) {
     dotenv::dotenv().ok();

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -283,6 +283,10 @@ fn new_req_with_keywords(app: Arc<App>, krate: Crate, version: &str,
     return req;
 }
 
+fn new_req_body_foo_version_2() -> Vec<u8> {
+    new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new())
+}
+
 fn new_req_body(krate: Crate, version: &str, deps: Vec<u::CrateDependency>,
                 kws: Vec<String>, cats: Vec<String>) -> Vec<u8> {
     let kws = kws.into_iter().map(u::Keyword).collect();

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -290,8 +290,8 @@ fn new_req_with_categories(app: Arc<App>, krate: Crate, version: &str,
     return req;
 }
 
-fn new_req_body_foo_version_2() -> Vec<u8> {
-    new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new())
+fn new_req_body_version_2(krate: Crate) -> Vec<u8> {
+    new_req_body(krate, "2.0.0", Vec::new(), Vec::new(), Vec::new())
 }
 
 fn new_req_body(krate: Crate, version: &str, deps: Vec<u::CrateDependency>,

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -16,14 +16,21 @@ struct GoodCategory { category: EncodableCategory }
 fn index() {
     let (_b, app, middle) = ::app();
     let mut req = ::req(app, Method::Get, "/api/v1/categories");
+
+    // List 0 categories if none exist
     let mut response = ok_resp!(middle.call(&mut req));
     let json: CategoryList = ::json(&mut response);
     assert_eq!(json.categories.len(), 0);
     assert_eq!(json.meta.total, 0);
 
+    // Create a category and a subcategory
     ::mock_category(&mut req, "foo", "foo");
+    ::mock_category(&mut req, "foo::bar", "foo::bar");
+
     let mut response = ok_resp!(middle.call(&mut req));
     let json: CategoryList = ::json(&mut response);
+
+    // Only the top-level categories should be on the page
     assert_eq!(json.categories.len(), 1);
     assert_eq!(json.meta.total, 1);
     assert_eq!(json.categories[0].category, "foo");

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -6,6 +6,8 @@ use cargo_registry::category::EncodableCategory;
 struct CategoryList { categories: Vec<EncodableCategory>, meta: CategoryMeta }
 #[derive(RustcDecodable)]
 struct CategoryMeta { total: i32 }
+#[derive(RustcDecodable)]
+struct GoodCategory { category: EncodableCategory }
 
 #[test]
 fn index() {
@@ -22,4 +24,17 @@ fn index() {
     assert_eq!(json.categories.len(), 1);
     assert_eq!(json.meta.total, 1);
     assert_eq!(json.categories[0].category, "foo");
+}
+
+#[test]
+fn show() {
+    let (_b, app, middle) = ::app();
+    let mut req = ::req(app, Method::Get, "/api/v1/categories/foo");
+    let response = t_resp!(middle.call(&mut req));
+    assert_eq!(response.status.0, 404);
+
+    ::mock_category(&mut req, "foo");
+    let mut response = ok_resp!(middle.call(&mut req));
+    let json: GoodCategory = ::json(&mut response);
+    assert_eq!(json.category.category, "foo");
 }

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,6 +1,9 @@
-use conduit::{Handler, Method};
+use postgres::GenericConnection;
+use conduit::{Handler, Request, Method};
+use conduit_test::MockRequest;
 
-use cargo_registry::category::EncodableCategory;
+use cargo_registry::db::RequestTransaction;
+use cargo_registry::category::{Category, EncodableCategory};
 
 #[derive(RustcDecodable)]
 struct CategoryList { categories: Vec<EncodableCategory>, meta: CategoryMeta }
@@ -37,4 +40,67 @@ fn show() {
     let mut response = ok_resp!(middle.call(&mut req));
     let json: GoodCategory = ::json(&mut response);
     assert_eq!(json.category.category, "foo");
+}
+
+fn tx(req: &Request) -> &GenericConnection { req.tx().unwrap() }
+
+#[test]
+fn update_crate() {
+    let (_b, app, middle) = ::app();
+    let mut req = ::req(app, Method::Get, "/api/v1/categories/foo");
+    let cnt = |req: &mut MockRequest, cat: &str| {
+        req.with_path(&format!("/api/v1/categories/{}", cat));
+        let mut response = ok_resp!(middle.call(req));
+        ::json::<GoodCategory>(&mut response).category.crates_cnt as usize
+    };
+    ::mock_user(&mut req, ::user("foo"));
+    let (krate, _) = ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_category(&mut req, "cat1");
+    ::mock_category(&mut req, "cat2");
+
+    // Updating with no categories has no effect
+    Category::update_crate(tx(&req), &krate, &[]).unwrap();
+    assert_eq!(cnt(&mut req, "cat1"), 0);
+    assert_eq!(cnt(&mut req, "cat2"), 0);
+
+    // Happy path adding one category
+    Category::update_crate(tx(&req), &krate, &["cat1".to_string()]).unwrap();
+    assert_eq!(cnt(&mut req, "cat1"), 1);
+    assert_eq!(cnt(&mut req, "cat2"), 0);
+
+    // Replacing one category with another
+    Category::update_crate(tx(&req), &krate, &["cat2".to_string()]).unwrap();
+    assert_eq!(cnt(&mut req, "cat1"), 0);
+    assert_eq!(cnt(&mut req, "cat2"), 1);
+
+    // Removing one category
+    Category::update_crate(tx(&req), &krate, &[]).unwrap();
+    assert_eq!(cnt(&mut req, "cat1"), 0);
+    assert_eq!(cnt(&mut req, "cat2"), 0);
+
+    // Adding 2 categories
+    Category::update_crate(tx(&req), &krate, &["cat1".to_string(),
+                                               "cat2".to_string()]).unwrap();
+    assert_eq!(cnt(&mut req, "cat1"), 1);
+    assert_eq!(cnt(&mut req, "cat2"), 1);
+
+    // Removing all categories
+    Category::update_crate(tx(&req), &krate, &[]).unwrap();
+    assert_eq!(cnt(&mut req, "cat1"), 0);
+    assert_eq!(cnt(&mut req, "cat2"), 0);
+
+    // Attempting to add one valid category and one invalid category
+    Category::update_crate(tx(&req), &krate, &["cat1".to_string(),
+                                               "catnope".to_string()]).unwrap();
+
+    assert_eq!(cnt(&mut req, "cat1"), 1);
+    assert_eq!(cnt(&mut req, "cat2"), 0);
+
+    // Does not add the invalid category to the category list
+    // (unlike the behavior of keywords)
+    req.with_path("/api/v1/categories");
+    let mut response = ok_resp!(middle.call(&mut req));
+    let json: CategoryList = ::json(&mut response);
+    assert_eq!(json.categories.len(), 2);
+    assert_eq!(json.meta.total, 2);
 }

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,0 +1,25 @@
+use conduit::{Handler, Method};
+
+use cargo_registry::category::EncodableCategory;
+
+#[derive(RustcDecodable)]
+struct CategoryList { categories: Vec<EncodableCategory>, meta: CategoryMeta }
+#[derive(RustcDecodable)]
+struct CategoryMeta { total: i32 }
+
+#[test]
+fn index() {
+    let (_b, app, middle) = ::app();
+    let mut req = ::req(app, Method::Get, "/api/v1/categories");
+    let mut response = ok_resp!(middle.call(&mut req));
+    let json: CategoryList = ::json(&mut response);
+    assert_eq!(json.categories.len(), 0);
+    assert_eq!(json.meta.total, 0);
+
+    ::mock_category(&mut req, "foo");
+    let mut response = ok_resp!(middle.call(&mut req));
+    let json: CategoryList = ::json(&mut response);
+    assert_eq!(json.categories.len(), 1);
+    assert_eq!(json.meta.total, 1);
+    assert_eq!(json.categories[0].category, "foo");
+}

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -94,9 +94,11 @@ fn update_crate() {
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Attempting to add one valid category and one invalid category
-    Category::update_crate(tx(&req), &krate, &["cat1".to_string(),
-                                               "catnope".to_string()]).unwrap();
-
+    let invalid_categories = Category::update_crate(
+        tx(&req), &krate, &["cat1".to_string(),
+                            "catnope".to_string()]
+    ).unwrap();
+    assert_eq!(invalid_categories, vec!["catnope".to_string()]);
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -74,7 +74,7 @@ fn update_crate() {
         ::json::<GoodCategory>(&mut response).category.crates_cnt as usize
     };
     ::mock_user(&mut req, ::user("foo"));
-    let (krate, _) = ::mock_crate(&mut req, ::krate("foo"));
+    let (krate, _) = ::mock_crate(&mut req, ::krate("foocat"));
     ::mock_category(&mut req, "cat1", "cat1");
     ::mock_category(&mut req, "Category 2", "category-2");
 

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -3,7 +3,7 @@ use conduit::{Handler, Request, Method};
 use conduit_test::MockRequest;
 
 use cargo_registry::db::RequestTransaction;
-use cargo_registry::category::{Category, EncodableCategory};
+use cargo_registry::category::{Category, EncodableCategory, EncodableCategoryWithSubcategories};
 
 #[derive(RustcDecodable)]
 struct CategoryList { categories: Vec<EncodableCategory>, meta: CategoryMeta }
@@ -11,6 +11,10 @@ struct CategoryList { categories: Vec<EncodableCategory>, meta: CategoryMeta }
 struct CategoryMeta { total: i32 }
 #[derive(RustcDecodable)]
 struct GoodCategory { category: EncodableCategory }
+#[derive(RustcDecodable)]
+struct CategoryWithSubcategories {
+    category: EncodableCategoryWithSubcategories
+}
 
 #[test]
 fn index() {
@@ -39,15 +43,23 @@ fn index() {
 #[test]
 fn show() {
     let (_b, app, middle) = ::app();
+
+    // Return not found if a category doesn't exist
     let mut req = ::req(app, Method::Get, "/api/v1/categories/foo-bar");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
+    // Create a category and a subcategory
     ::mock_category(&mut req, "Foo Bar", "foo-bar");
+    ::mock_category(&mut req, "Foo Bar::Baz", "foo-bar::baz");
+
+    // The category and its subcategories should be in the json
     let mut response = ok_resp!(middle.call(&mut req));
-    let json: GoodCategory = ::json(&mut response);
+    let json: CategoryWithSubcategories = ::json(&mut response);
     assert_eq!(json.category.category, "Foo Bar");
     assert_eq!(json.category.slug, "foo-bar");
+    assert_eq!(json.category.subcategories.len(), 1);
+    assert_eq!(json.category.subcategories[0].category, "Foo Bar::Baz");
 }
 
 fn tx(req: &Request) -> &GenericConnection { req.tx().unwrap() }

--- a/src/tests/http-data/krate_good_categories
+++ b/src/tests/http-data/krate_good_categories
@@ -1,0 +1,21 @@
+===REQUEST 331
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+
+

--- a/src/tests/http-data/krate_good_categories
+++ b/src/tests/http-data/krate_good_categories
@@ -1,5 +1,5 @@
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+===REQUEST 349
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_good_cat/foo_good_cat-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=

--- a/src/tests/http-data/krate_ignored_categories
+++ b/src/tests/http-data/krate_ignored_categories
@@ -1,0 +1,21 @@
+===REQUEST 331
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+
+

--- a/src/tests/http-data/krate_ignored_categories
+++ b/src/tests/http-data/krate_ignored_categories
@@ -1,5 +1,5 @@
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+===REQUEST 355
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_ignored_cat/foo_ignored_cat-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=

--- a/src/tests/http-data/krate_new_crate_owner
+++ b/src/tests/http-data/krate_new_crate_owner
@@ -1,5 +1,5 @@
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+===REQUEST 344
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_owner/foo_owner-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Host: alexcrichton-test.s3.amazonaws.com
@@ -19,8 +19,8 @@ etag: "d41d8cd98f00b204e9800998ecf8427e"
 date: Sun, 28 Jun 2015 21:07:51 GMT
 
 
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-2.0.0.crate HTTP/1.1
+===REQUEST 344
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_owner/foo_owner-2.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Authorization: AWS AKIAJF3GEK7N44BACDZA:wz9J18+QxEhMIqIDnzwP6fGGeGY=

--- a/src/tests/http-data/krate_new_krate
+++ b/src/tests/http-data/krate_new_krate
@@ -1,5 +1,5 @@
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+===REQUEST 339
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_new/foo_new-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=

--- a/src/tests/http-data/krate_new_krate_git_upload
+++ b/src/tests/http-data/krate_new_krate_git_upload
@@ -1,5 +1,5 @@
 ===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/fgt/fgt-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Host: alexcrichton-test.s3.amazonaws.com

--- a/src/tests/http-data/krate_new_krate_git_upload_appends
+++ b/src/tests/http-data/krate_new_krate_git_upload_appends
@@ -1,5 +1,5 @@
 ===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/FOO/FOO-1.0.0.crate HTTP/1.1
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/FPP/FPP-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Authorization: AWS AKIAJF3GEK7N44BACDZA:mLugvy/BSBS8JgZ6pK7tURu3OTU=

--- a/src/tests/http-data/krate_new_krate_git_upload_with_conflicts
+++ b/src/tests/http-data/krate_new_krate_git_upload_with_conflicts
@@ -1,5 +1,5 @@
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+===REQUEST 351
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_conflicts/foo_conflicts-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=

--- a/src/tests/http-data/krate_new_krate_too_big_but_whitelisted
+++ b/src/tests/http-data/krate_new_krate_too_big_but_whitelisted
@@ -1,5 +1,5 @@
-===REQUEST 2334
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.1.0.crate HTTP/1.1
+===REQUEST 2354
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_whitelist/foo_whitelist-1.1.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Type: application/x-tar

--- a/src/tests/http-data/krate_new_krate_twice
+++ b/src/tests/http-data/krate_new_krate_twice
@@ -1,5 +1,5 @@
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-2.0.0.crate HTTP/1.1
+===REQUEST 343
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_twice/foo_twice-2.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Content-Length: 0

--- a/src/tests/http-data/krate_new_krate_weird_version
+++ b/src/tests/http-data/krate_new_krate_weird_version
@@ -1,5 +1,5 @@
-===REQUEST 335
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-0.0.0-pre.crate HTTP/1.1
+===REQUEST 347
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_weird/foo_weird-0.0.0-pre.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Host: alexcrichton-test.s3.amazonaws.com

--- a/src/tests/http-data/krate_new_krate_with_dependency
+++ b/src/tests/http-data/krate_new_krate_with_dependency
@@ -1,5 +1,5 @@
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/new/new-1.0.0.crate HTTP/1.1
+===REQUEST 339
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/new_dep/new_dep-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Date: Sun, 28 Jun 2015 14:07:18 -0700

--- a/src/tests/http-data/krate_yank
+++ b/src/tests/http-data/krate_yank
@@ -1,5 +1,5 @@
 ===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate HTTP/1.1
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Date: Sun, 28 Jun 2015 14:07:18 -0700

--- a/src/tests/http-data/team_publish_owned
+++ b/src/tests/http-data/team_publish_owned
@@ -155,8 +155,8 @@ cache-control: private, max-age=60, s-maxage=60
 x-content-type-options: nosniff
 
 {"state":"active","url":"https://api.github.com/teams/1699377/memberships/crates-tester-1"}
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-2.0.0.crate HTTP/1.1
+===REQUEST 353
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_team_owned/foo_team_owned-2.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Host: alexcrichton-test.s3.amazonaws.com

--- a/src/tests/http-data/team_remove_team_as_team_owner
+++ b/src/tests/http-data/team_remove_team_as_team_owner
@@ -194,8 +194,8 @@ x-frame-options: deny
 x-ratelimit-reset: 1439881924
 
 {"state":"active","url":"https://api.github.com/teams/1699377/memberships/crates-tester-1"}
-===REQUEST 331
-PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-2.0.0.crate HTTP/1.1
+===REQUEST 367
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_remove_team_owner/foo_remove_team_owner-2.0.0.crate HTTP/1.1
 Accept: */*
 Proxy-Connection: Keep-Alive
 Date: Mon, 17 Aug 2015 23:12:52 -0700

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -65,7 +65,7 @@ fn update_crate() {
         ::json::<GoodKeyword>(&mut response).keyword.crates_cnt as usize
     };
     ::mock_user(&mut req, ::user("foo"));
-    let (krate, _) = ::mock_crate(&mut req, ::krate("foo"));
+    let (krate, _) = ::mock_crate(&mut req, ::krate("fookey"));
     ::mock_keyword(&mut req, "kw1");
     ::mock_keyword(&mut req, "kw2");
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -48,6 +48,7 @@ fn new_crate(name: &str) -> u::NewCrate {
         documentation: None,
         readme: None,
         keywords: None,
+        categories: None,
         license: Some("MIT".to_string()),
         license_file: None,
         repository: None,
@@ -190,7 +191,7 @@ fn exact_match_on_queries_with_sort() {
     krate4.description = Some("other const".to_string());
     krate4.downloads = 999999;
     let (k4, _) = ::mock_crate(&mut req, krate4.clone());
-    
+
     {
         let req2: &mut Request = &mut req;
         let tx = req2.tx().unwrap();
@@ -461,7 +462,9 @@ fn new_crate_owner() {
     assert_eq!(::json::<CrateList>(&mut response).crates.len(), 1);
 
     // And upload a new crate as the first user
-    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
+    let body = ::new_req_body(
+        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
+    );
     req.mut_extensions().insert(u2);
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                                .with_method(Method::Put)

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -462,9 +462,7 @@ fn new_crate_owner() {
     assert_eq!(::json::<CrateList>(&mut response).crates.len(), 1);
 
     // And upload a new crate as the first user
-    let body = ::new_req_body(
-        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
-    );
+    let body = ::new_req_body_foo_version_2();
     req.mut_extensions().insert(u2);
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                                .with_method(Method::Put)

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -66,7 +66,7 @@ fn index() {
     assert_eq!(json.crates.len(), 0);
     assert_eq!(json.meta.total, 0);
 
-    let krate = ::krate("foo");
+    let krate = ::krate("fooindex");
     ::mock_user(&mut req, ::user("foo"));
     ::mock_crate(&mut req, krate.clone());
     let mut response = ok_resp!(middle.call(&mut req));
@@ -85,11 +85,11 @@ fn index_queries() {
 
     let mut req = ::req(app, Method::Get, "/api/v1/crates");
     let u = ::mock_user(&mut req, ::user("foo"));
-    let mut krate = ::krate("foo");
+    let mut krate = ::krate("foo_index_queries");
     krate.readme = Some("readme".to_string());
     krate.description = Some("description".to_string());
     let (krate, _) = ::mock_crate(&mut req, krate.clone());
-    let krate2 = ::krate("BAR");
+    let krate2 = ::krate("BAR_INDEX_QUERIES");
     let (krate2, _) = ::mock_crate(&mut req, krate2.clone());
     Keyword::update_crate(tx(&req), &krate, &["kw1".into()]).unwrap();
     Keyword::update_crate(tx(&req), &krate2, &["KW1".into()]).unwrap();
@@ -136,39 +136,39 @@ fn exact_match_first_on_queries() {
 
     let mut req = ::req(app, Method::Get, "/api/v1/crates");
     let _ = ::mock_user(&mut req, ::user("foo"));
-    let mut krate = ::krate("foo");
-    krate.description = Some("bar baz".to_string());
+    let mut krate = ::krate("foo_exact");
+    krate.description = Some("bar_exact baz_exact".to_string());
     let (_, _) = ::mock_crate(&mut req, krate.clone());
-    let mut krate2 = ::krate("bar");
-    krate2.description = Some("foo baz foo baz".to_string());
+    let mut krate2 = ::krate("bar_exact");
+    krate2.description = Some("foo_exact baz_exact foo_exact baz_exact".to_string());
     let (_, _) = ::mock_crate(&mut req, krate2.clone());
-    let mut krate3 = ::krate("baz");
-    krate3.description = Some("foo bar foo bar foo bar".to_string());
+    let mut krate3 = ::krate("baz_exact");
+    krate3.description = Some("foo_exact bar_exact foo_exact bar_exact foo_exact bar_exact".to_string());
     let (_, _) = ::mock_crate(&mut req, krate3.clone());
-    let mut krate4 = ::krate("other");
-    krate4.description = Some("other".to_string());
+    let mut krate4 = ::krate("other_exact");
+    krate4.description = Some("other_exact".to_string());
     let (_, _) = ::mock_crate(&mut req, krate4.clone());
 
-    let mut response = ok_resp!(middle.call(req.with_query("q=foo")));
+    let mut response = ok_resp!(middle.call(req.with_query("q=foo_exact")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "foo");
-    assert_eq!(json.crates[1].name, "baz");
-    assert_eq!(json.crates[2].name, "bar");
+    assert_eq!(json.crates[0].name, "foo_exact");
+    assert_eq!(json.crates[1].name, "baz_exact");
+    assert_eq!(json.crates[2].name, "bar_exact");
 
-    let mut response = ok_resp!(middle.call(req.with_query("q=bar")));
+    let mut response = ok_resp!(middle.call(req.with_query("q=bar_exact")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "bar");
-    assert_eq!(json.crates[1].name, "baz");
-    assert_eq!(json.crates[2].name, "foo");
+    assert_eq!(json.crates[0].name, "bar_exact");
+    assert_eq!(json.crates[1].name, "baz_exact");
+    assert_eq!(json.crates[2].name, "foo_exact");
 
-    let mut response = ok_resp!(middle.call(req.with_query("q=baz")));
+    let mut response = ok_resp!(middle.call(req.with_query("q=baz_exact")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "baz");
-    assert_eq!(json.crates[1].name, "bar");
-    assert_eq!(json.crates[2].name, "foo");
+    assert_eq!(json.crates[0].name, "baz_exact");
+    assert_eq!(json.crates[1].name, "bar_exact");
+    assert_eq!(json.crates[2].name, "foo_exact");
 }
 
 #[test]
@@ -177,20 +177,20 @@ fn exact_match_on_queries_with_sort() {
 
     let mut req = ::req(app, Method::Get, "/api/v1/crates");
     let _ = ::mock_user(&mut req, ::user("foo"));
-    let mut krate = ::krate("foo");
-    krate.description = Some("bar baz const".to_string());
+    let mut krate = ::krate("foo_sort");
+    krate.description = Some("bar_sort baz_sort const".to_string());
     krate.downloads = 50;
     let (k, _) = ::mock_crate(&mut req, krate.clone());
-    let mut krate2 = ::krate("bar");
-    krate2.description = Some("foo baz foo baz const".to_string());
+    let mut krate2 = ::krate("bar_sort");
+    krate2.description = Some("foo_sort baz_sort foo_sort baz_sort const".to_string());
     krate2.downloads = 3333;
     let (k2, _) = ::mock_crate(&mut req, krate2.clone());
-    let mut krate3 = ::krate("baz");
-    krate3.description = Some("foo bar foo bar foo bar const".to_string());
+    let mut krate3 = ::krate("baz_sort");
+    krate3.description = Some("foo_sort bar_sort foo_sort bar_sort foo_sort bar_sort const".to_string());
     krate3.downloads = 100000;
     let (k3, _) = ::mock_crate(&mut req, krate3.clone());
-    let mut krate4 = ::krate("other");
-    krate4.description = Some("other const".to_string());
+    let mut krate4 = ::krate("other_sort");
+    krate4.description = Some("other_sort const".to_string());
     krate4.downloads = 999999;
     let (k4, _) = ::mock_crate(&mut req, krate4.clone());
 
@@ -207,42 +207,42 @@ fn exact_match_on_queries_with_sort() {
                     WHERE id = $2", &[&krate4.downloads, &k4.id]).unwrap();
     }
 
-    let mut response = ok_resp!(middle.call(req.with_query("q=foo&sort=downloads")));
+    let mut response = ok_resp!(middle.call(req.with_query("q=foo_sort&sort=downloads")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "foo");
-    assert_eq!(json.crates[1].name, "baz");
-    assert_eq!(json.crates[2].name, "bar");
+    assert_eq!(json.crates[0].name, "foo_sort");
+    assert_eq!(json.crates[1].name, "baz_sort");
+    assert_eq!(json.crates[2].name, "bar_sort");
 
-    let mut response = ok_resp!(middle.call(req.with_query("q=bar&sort=downloads")));
+    let mut response = ok_resp!(middle.call(req.with_query("q=bar_sort&sort=downloads")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "bar");
-    assert_eq!(json.crates[1].name, "baz");
-    assert_eq!(json.crates[2].name, "foo");
+    assert_eq!(json.crates[0].name, "bar_sort");
+    assert_eq!(json.crates[1].name, "baz_sort");
+    assert_eq!(json.crates[2].name, "foo_sort");
 
-    let mut response = ok_resp!(middle.call(req.with_query("q=baz&sort=downloads")));
+    let mut response = ok_resp!(middle.call(req.with_query("q=baz_sort&sort=downloads")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "baz");
-    assert_eq!(json.crates[1].name, "bar");
-    assert_eq!(json.crates[2].name, "foo");
+    assert_eq!(json.crates[0].name, "baz_sort");
+    assert_eq!(json.crates[1].name, "bar_sort");
+    assert_eq!(json.crates[2].name, "foo_sort");
 
     let mut response = ok_resp!(middle.call(req.with_query("q=const&sort=downloads")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 4);
-    assert_eq!(json.crates[0].name, "other");
-    assert_eq!(json.crates[1].name, "baz");
-    assert_eq!(json.crates[2].name, "bar");
-    assert_eq!(json.crates[3].name, "foo");
+    assert_eq!(json.crates[0].name, "other_sort");
+    assert_eq!(json.crates[1].name, "baz_sort");
+    assert_eq!(json.crates[2].name, "bar_sort");
+    assert_eq!(json.crates[3].name, "foo_sort");
 }
 
 #[test]
 fn show() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_show");
     ::mock_user(&mut req, ::user("foo"));
-    let mut krate = ::krate("foo");
+    let mut krate = ::krate("foo_show");
     krate.description = Some(format!("description"));
     krate.documentation = Some(format!("https://example.com"));
     krate.homepage = Some(format!("http://example.com"));
@@ -263,7 +263,7 @@ fn show() {
     assert_eq!(json.versions[0].id, versions[0]);
     assert_eq!(json.versions[0].krate, json.krate.id);
     assert_eq!(json.versions[0].num, "1.0.0".to_string());
-    let suffix = "/api/v1/crates/foo/1.0.0/download";
+    let suffix = "/api/v1/crates/foo_show/1.0.0/download";
     assert!(json.versions[0].dl_path.ends_with(suffix),
             "bad suffix {}", json.versions[0].dl_path);
     assert_eq!(1, json.keywords.len());
@@ -273,9 +273,9 @@ fn show() {
 #[test]
 fn versions() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo/versions");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_versions/versions");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_versions"));
     let mut response = ok_resp!(middle.call(&mut req));
     let json: VersionsList = ::json(&mut response);
     assert_eq!(json.versions.len(), 1);
@@ -320,26 +320,26 @@ fn new_bad_names() {
 #[test]
 fn new_krate() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "foo_new", "1.0.0");
     let user = ::mock_user(&mut req, ::user("foo"));
     ::logout(&mut req);
     req.header("Authorization", &user.api_token);
     let mut response = ok_resp!(middle.call(&mut req));
     let json: GoodCrate = ::json(&mut response);
-    assert_eq!(json.krate.name, "foo");
+    assert_eq!(json.krate.name, "foo_new");
     assert_eq!(json.krate.max_version, "1.0.0");
 }
 
 #[test]
 fn new_krate_weird_version() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "0.0.0-pre");
+    let mut req = ::new_req(app, "foo_weird", "0.0.0-pre");
     let user = ::mock_user(&mut req, ::user("foo"));
     ::logout(&mut req);
     req.header("Authorization", &user.api_token);
     let mut response = ok_resp!(middle.call(&mut req));
     let json: GoodCrate = ::json(&mut response);
-    assert_eq!(json.krate.name, "foo");
+    assert_eq!(json.krate.name, "foo_weird");
     assert_eq!(json.krate.max_version, "0.0.0-pre");
 }
 
@@ -347,7 +347,7 @@ fn new_krate_weird_version() {
 fn new_krate_with_dependency() {
     let (_b, app, middle) = ::app();
     let dep = u::CrateDependency {
-        name: u::CrateName("foo".to_string()),
+        name: u::CrateName("foo_dep".to_string()),
         optional: false,
         default_features: true,
         features: Vec::new(),
@@ -355,9 +355,9 @@ fn new_krate_with_dependency() {
         target: None,
         kind: None,
     };
-    let mut req = ::new_req_full(app, ::krate("new"), "1.0.0", vec![dep]);
+    let mut req = ::new_req_full(app, ::krate("new_dep"), "1.0.0", vec![dep]);
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_dep"));
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<GoodCrate>(&mut response);
 }
@@ -366,7 +366,7 @@ fn new_krate_with_dependency() {
 fn new_krate_with_wildcard_dependency() {
     let (_b, app, middle) = ::app();
     let dep = u::CrateDependency {
-        name: u::CrateName("foo".to_string()),
+        name: u::CrateName("foo_wild".to_string()),
         optional: false,
         default_features: true,
         features: Vec::new(),
@@ -374,9 +374,9 @@ fn new_krate_with_wildcard_dependency() {
         target: None,
         kind: None,
     };
-    let mut req = ::new_req_full(app, ::krate("new"), "1.0.0", vec![dep]);
+    let mut req = ::new_req_full(app, ::krate("new_wild"), "1.0.0", vec![dep]);
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_wild"));
     let json = bad_resp!(middle.call(&mut req));
     assert!(json.errors[0].detail.contains("dependency constraints"), "{:?}", json.errors);
 }
@@ -384,11 +384,11 @@ fn new_krate_with_wildcard_dependency() {
 #[test]
 fn new_krate_twice() {
     let (_b, app, middle) = ::app();
-    let mut krate = ::krate("foo");
+    let mut krate = ::krate("foo_twice");
     krate.description = Some("description".to_string());
     let mut req = ::new_req_full(app, krate.clone(), "2.0.0", Vec::new());
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_twice"));
     let mut response = ok_resp!(middle.call(&mut req));
     let json: GoodCrate = ::json(&mut response);
     assert_eq!(json.krate.name, krate.name);
@@ -399,11 +399,11 @@ fn new_krate_twice() {
 fn new_krate_wrong_user() {
     let (_b, app, middle) = ::app();
 
-    let mut req = ::new_req(app, "foo", "2.0.0");
+    let mut req = ::new_req(app, "foo_wrong", "2.0.0");
 
     // Create the 'foo' crate with one user
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_wrong"));
 
     // But log in another
     ::mock_user(&mut req, ::user("bar"));
@@ -440,7 +440,7 @@ fn new_crate_owner() {
     let (_b, app, middle) = ::app();
 
     // Create a crate under one user
-    let mut req = ::new_req(app.clone(), "foo", "1.0.0");
+    let mut req = ::new_req(app.clone(), "foo_owner", "1.0.0");
     let u2 = ::mock_user(&mut req, ::user("bar"));
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
@@ -448,11 +448,11 @@ fn new_crate_owner() {
 
     // Flag the second user as an owner
     let body = r#"{"users":["bar"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_owner/owners")
                                                .with_method(Method::Put)
                                                .with_body(body.as_bytes())));
     assert!(::json::<O>(&mut response).ok);
-    bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_owner/owners")
                              .with_method(Method::Put)
                              .with_body(body.as_bytes())));
 
@@ -464,7 +464,7 @@ fn new_crate_owner() {
     assert_eq!(::json::<CrateList>(&mut response).crates.len(), 1);
 
     // And upload a new crate as the first user
-    let body = ::new_req_body_foo_version_2();
+    let body = ::new_req_body_version_2(::krate("foo_owner"));
     req.mut_extensions().insert(u2);
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                                .with_method(Method::Put)
@@ -484,21 +484,21 @@ fn valid_feature_names() {
 #[test]
 fn new_krate_too_big() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "foo_big", "1.0.0");
     ::mock_user(&mut req, ::user("foo"));
-    let body = ::new_crate_to_body(&new_crate("foo"), &[b'a'; 2000]);
+    let body = ::new_crate_to_body(&new_crate("foo_big"), &[b'a'; 2000]);
     bad_resp!(middle.call(req.with_body(&body)));
 }
 
 #[test]
 fn new_krate_too_big_but_whitelisted() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.1.0");
+    let mut req = ::new_req(app, "foo_whitelist", "1.1.0");
     ::mock_user(&mut req, ::user("foo"));
-    let mut krate = ::krate("foo");
+    let mut krate = ::krate("foo_whitelist");
     krate.max_upload_size = Some(2 * 1000 * 1000);
     ::mock_crate(&mut req, krate);
-    let body = ::new_crate_to_body(&new_crate("foo"), &[b'a'; 2000]);
+    let body = ::new_crate_to_body(&new_crate("foo_whitelist"), &[b'a'; 2000]);
     let mut response = ok_resp!(middle.call(req.with_body(&body)));
     ::json::<GoodCrate>(&mut response);
 }
@@ -506,9 +506,9 @@ fn new_krate_too_big_but_whitelisted() {
 #[test]
 fn new_krate_duplicate_version() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "foo_dupe", "1.0.0");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_dupe"));
     let json = bad_resp!(middle.call(&mut req));
     assert!(json.errors[0].detail.contains("already uploaded"),
             "{:?}", json.errors);
@@ -517,9 +517,9 @@ fn new_krate_duplicate_version() {
 #[test]
 fn new_crate_similar_name() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.1.0");
+    let mut req = ::new_req(app, "foo_similar", "1.1.0");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("Foo"));
+    ::mock_crate(&mut req, ::krate("Foo_similar"));
     let json = bad_resp!(middle.call(&mut req));
     assert!(json.errors[0].detail.contains("previously named"),
             "{:?}", json.errors);
@@ -529,18 +529,18 @@ fn new_crate_similar_name() {
 fn new_crate_similar_name_hyphen() {
     {
         let (_b, app, middle) = ::app();
-        let mut req = ::new_req(app, "foo-bar", "1.1.0");
+        let mut req = ::new_req(app, "foo-bar-hyphen", "1.1.0");
         ::mock_user(&mut req, ::user("foo"));
-        ::mock_crate(&mut req, ::krate("foo_bar"));
+        ::mock_crate(&mut req, ::krate("foo_bar_hyphen"));
         let json = bad_resp!(middle.call(&mut req));
         assert!(json.errors[0].detail.contains("previously named"),
                 "{:?}", json.errors);
     }
     {
         let (_b, app, middle) = ::app();
-        let mut req = ::new_req(app, "foo_bar", "1.1.0");
+        let mut req = ::new_req(app, "foo_bar_underscore", "1.1.0");
         ::mock_user(&mut req, ::user("foo"));
-        ::mock_crate(&mut req, ::krate("foo-bar"));
+        ::mock_crate(&mut req, ::krate("foo-bar-underscore"));
         let json = bad_resp!(middle.call(&mut req));
         assert!(json.errors[0].detail.contains("previously named"),
                 "{:?}", json.errors);
@@ -550,17 +550,17 @@ fn new_crate_similar_name_hyphen() {
 #[test]
 fn new_krate_git_upload() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "fgt", "1.0.0");
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<GoodCrate>(&mut response);
 
-    let path = ::git::checkout().join("3/f/foo");
+    let path = ::git::checkout().join("3/f/fgt");
     assert!(path.exists());
     let mut contents = String::new();
     File::open(&path).unwrap().read_to_string(&mut contents).unwrap();
     let p: GitCrate = json::decode(&contents).unwrap();
-    assert_eq!(p.name, "foo");
+    assert_eq!(p.name, "fgt");
     assert_eq!(p.vers, "1.0.0");
     assert!(p.deps.is_empty());
     assert_eq!(p.cksum,
@@ -570,13 +570,13 @@ fn new_krate_git_upload() {
 #[test]
 fn new_krate_git_upload_appends() {
     let (_b, app, middle) = ::app();
-    let path = ::git::checkout().join("3/f/foo");
+    let path = ::git::checkout().join("3/f/fpp");
     fs::create_dir_all(path.parent().unwrap()).unwrap();
     File::create(&path).unwrap().write_all(
-        br#"{"name":"FOO","vers":"0.0.1","deps":[],"cksum":"3j3"}
+        br#"{"name":"FPP","vers":"0.0.1","deps":[],"cksum":"3j3"}
 "#).unwrap();
 
-    let mut req = ::new_req(app, "FOO", "1.0.0");
+    let mut req = ::new_req(app, "FPP", "1.0.0");
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<GoodCrate>(&mut response);
@@ -587,10 +587,10 @@ fn new_krate_git_upload_appends() {
     let p1: GitCrate = json::decode(lines.next().unwrap().trim()).unwrap();
     let p2: GitCrate = json::decode(lines.next().unwrap().trim()).unwrap();
     assert!(lines.next().is_none());
-    assert_eq!(p1.name, "FOO");
+    assert_eq!(p1.name, "FPP");
     assert_eq!(p1.vers, "0.0.1");
     assert!(p1.deps.is_empty());
-    assert_eq!(p2.name, "FOO");
+    assert_eq!(p2.name, "FPP");
     assert_eq!(p2.vers, "1.0.0");
     assert!(p2.deps.is_empty());
 }
@@ -609,7 +609,7 @@ fn new_krate_git_upload_with_conflicts() {
                     &[&parent]).unwrap();
     }
 
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "foo_conflicts", "1.0.0");
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<GoodCrate>(&mut response);
@@ -621,18 +621,18 @@ fn new_krate_dependency_missing() {
     let dep = u::CrateDependency {
         optional: false,
         default_features: true,
-        name: u::CrateName("bar".to_string()),
+        name: u::CrateName("bar_missing".to_string()),
         features: Vec::new(),
         version_req: u::CrateVersionReq(semver::VersionReq::parse(">= 0.0.0").unwrap()),
         target: None,
         kind: None,
     };
-    let mut req = ::new_req_full(app, ::krate("foo"), "1.0.0", vec![dep]);
+    let mut req = ::new_req_full(app, ::krate("foo_missing"), "1.0.0", vec![dep]);
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
     let json = ::json::<::Bad>(&mut response);
     assert!(json.errors[0].detail
-                .contains("no known crate named `bar`"));
+                .contains("no known crate named `bar_missing`"));
 }
 
 #[test]
@@ -645,22 +645,22 @@ fn summary_doesnt_die() {
 #[test]
 fn download() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo/1.0.0/download");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_download/1.0.0/download");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_download"));
     let resp = t_resp!(middle.call(&mut req));
     assert_eq!(resp.status.0, 302);
 
-    req.with_path("/api/v1/crates/foo/1.0.0/downloads");
+    req.with_path("/api/v1/crates/foo_download/1.0.0/downloads");
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 1);
 
-    req.with_path("/api/v1/crates/FOO/1.0.0/download");
+    req.with_path("/api/v1/crates/FOO_DOWNLOAD/1.0.0/download");
     let resp = t_resp!(middle.call(&mut req));
     assert_eq!(resp.status.0, 302);
 
-    req.with_path("/api/v1/crates/FOO/1.0.0/downloads");
+    req.with_path("/api/v1/crates/FOO_DOWNLOAD/1.0.0/downloads");
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 1);
@@ -669,9 +669,9 @@ fn download() {
 #[test]
 fn download_bad() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo/0.1.0/download");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_bad/0.1.0/download");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_bad"));
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<::Bad>(&mut response);
 }
@@ -680,17 +680,17 @@ fn download_bad() {
 fn dependencies() {
     let (_b, app, middle) = ::app();
 
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo/1.0.0/dependencies");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_deps/1.0.0/dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (_, v) = ::mock_crate(&mut req, ::krate("foo"));
-    let (c, _) = ::mock_crate(&mut req, ::krate("bar"));
+    let (_, v) = ::mock_crate(&mut req, ::krate("foo_deps"));
+    let (c, _) = ::mock_crate(&mut req, ::krate("bar_deps"));
     ::mock_dep(&mut req, &v, &c, None);
 
     let mut response = ok_resp!(middle.call(&mut req));
     let deps = ::json::<Deps>(&mut response);
-    assert_eq!(deps.dependencies[0].crate_id, "bar");
+    assert_eq!(deps.dependencies[0].crate_id, "bar_deps");
 
-    req.with_path("/api/v1/crates/foo/1.0.2/dependencies");
+    req.with_path("/api/v1/crates/foo_deps/1.0.2/dependencies");
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<::Bad>(&mut response);
 }
@@ -701,21 +701,21 @@ fn following() {
     #[derive(RustcDecodable)] struct O { ok: bool }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo/following");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_following/following");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_following"));
 
     let mut response = ok_resp!(middle.call(&mut req));
     assert!(!::json::<F>(&mut response).following);
 
-    req.with_path("/api/v1/crates/foo/follow")
+    req.with_path("/api/v1/crates/foo_following/follow")
        .with_method(Method::Put);
     let mut response = ok_resp!(middle.call(&mut req));
     assert!(::json::<O>(&mut response).ok);
     let mut response = ok_resp!(middle.call(&mut req));
     assert!(::json::<O>(&mut response).ok);
 
-    req.with_path("/api/v1/crates/foo/following")
+    req.with_path("/api/v1/crates/foo_following/following")
        .with_method(Method::Get);
     let mut response = ok_resp!(middle.call(&mut req));
     assert!(::json::<F>(&mut response).following);
@@ -726,14 +726,14 @@ fn following() {
     let l = ::json::<CrateList>(&mut response);
     assert_eq!(l.crates.len(), 1);
 
-    req.with_path("/api/v1/crates/foo/follow")
+    req.with_path("/api/v1/crates/foo_following/follow")
        .with_method(Method::Delete);
     let mut response = ok_resp!(middle.call(&mut req));
     assert!(::json::<O>(&mut response).ok);
     let mut response = ok_resp!(middle.call(&mut req));
     assert!(::json::<O>(&mut response).ok);
 
-    req.with_path("/api/v1/crates/foo/following")
+    req.with_path("/api/v1/crates/foo_following/following")
        .with_method(Method::Get);
     let mut response = ok_resp!(middle.call(&mut req));
     assert!(!::json::<F>(&mut response).following);
@@ -751,11 +751,11 @@ fn owners() {
     #[derive(RustcDecodable)] struct O { ok: bool }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo/owners");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_owners/owners");
     let other = ::user("foobar");
     ::mock_user(&mut req, other);
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_owners"));
 
     let mut response = ok_resp!(middle.call(&mut req));
     let r: R = ::json(&mut response);
@@ -799,10 +799,10 @@ fn yank() {
     #[derive(RustcDecodable)] struct O { ok: bool }
     #[derive(RustcDecodable)] struct V { version: EncodableVersion }
     let (_b, app, middle) = ::app();
-    let path = ::git::checkout().join("3/f/foo");
+    let path = ::git::checkout().join("3/f/fyk");
 
     // Upload a new crate, putting it in the git index
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "fyk", "1.0.0");
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<GoodCrate>(&mut response);
@@ -812,38 +812,38 @@ fn yank() {
 
     // make sure it's not yanked
     let mut r = ok_resp!(middle.call(req.with_method(Method::Get)
-                                        .with_path("/api/v1/crates/foo/1.0.0")));
+                                        .with_path("/api/v1/crates/fyk/1.0.0")));
     assert!(!::json::<V>(&mut r).version.yanked);
 
     // yank it
     let mut r = ok_resp!(middle.call(req.with_method(Method::Delete)
-                                        .with_path("/api/v1/crates/foo/1.0.0/yank")));
+                                        .with_path("/api/v1/crates/fyk/1.0.0/yank")));
     assert!(::json::<O>(&mut r).ok);
     let mut contents = String::new();
     File::open(&path).unwrap().read_to_string(&mut contents).unwrap();
     assert!(contents.contains("\"yanked\":true"));
     let mut r = ok_resp!(middle.call(req.with_method(Method::Get)
-                                        .with_path("/api/v1/crates/foo/1.0.0")));
+                                        .with_path("/api/v1/crates/fyk/1.0.0")));
     assert!(::json::<V>(&mut r).version.yanked);
 
     // un-yank it
     let mut r = ok_resp!(middle.call(req.with_method(Method::Put)
-                                        .with_path("/api/v1/crates/foo/1.0.0/unyank")));
+                                        .with_path("/api/v1/crates/fyk/1.0.0/unyank")));
     assert!(::json::<O>(&mut r).ok);
     let mut contents = String::new();
     File::open(&path).unwrap().read_to_string(&mut contents).unwrap();
     assert!(contents.contains("\"yanked\":false"));
     let mut r = ok_resp!(middle.call(req.with_method(Method::Get)
-                                        .with_path("/api/v1/crates/foo/1.0.0")));
+                                        .with_path("/api/v1/crates/fyk/1.0.0")));
     assert!(!::json::<V>(&mut r).version.yanked);
 }
 
 #[test]
 fn yank_not_owner() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Delete, "/api/v1/crates/foo/1.0.0/yank");
+    let mut req = ::req(app, Method::Delete, "/api/v1/crates/foo_not/1.0.0/yank");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_not"));
     ::mock_user(&mut req, ::user("bar"));
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<::Bad>(&mut response);
@@ -853,7 +853,7 @@ fn yank_not_owner() {
 fn bad_keywords() {
     let (_b, app, middle) = ::app();
     {
-        let krate = ::krate("foo");
+        let krate = ::krate("foo_bad_key");
         let kws = vec!["super-long-keyword-name-oh-no".into()];
         let mut req = ::new_req_with_keywords(app.clone(), krate, "1.0.0", kws);
         ::mock_user(&mut req, ::user("foo"));
@@ -861,7 +861,7 @@ fn bad_keywords() {
         ::json::<::Bad>(&mut response);
     }
     {
-        let krate = ::krate("foo");
+        let krate = ::krate("foo_bad_key2");
         let kws = vec!["?@?%".into()];
         let mut req = ::new_req_with_keywords(app.clone(), krate, "1.0.0", kws);
         ::mock_user(&mut req, ::user("foo"));
@@ -869,7 +869,7 @@ fn bad_keywords() {
         ::json::<::Bad>(&mut response);
     }
     {
-        let krate = ::krate("foo");
+        let krate = ::krate("foo_bad_key_3");
         let kws = vec!["?@?%".into()];
         let mut req = ::new_req_with_keywords(app.clone(), krate, "1.0.0", kws);
         ::mock_user(&mut req, ::user("foo"));
@@ -877,7 +877,7 @@ fn bad_keywords() {
         ::json::<::Bad>(&mut response);
     }
     {
-        let krate = ::krate("foo");
+        let krate = ::krate("foo_bad_key4");
         let kws = vec!["áccênts".into()];
         let mut req = ::new_req_with_keywords(app.clone(), krate, "1.0.0", kws);
         ::mock_user(&mut req, ::user("foo"));
@@ -889,14 +889,14 @@ fn bad_keywords() {
 #[test]
 fn good_categories() {
     let (_b, app, middle) = ::app();
-    let krate = ::krate("foo");
+    let krate = ::krate("foo_good_cat");
     let cats = vec!["cat1".into()];
     let mut req = ::new_req_with_categories(app, krate, "1.0.0", cats);
     ::mock_category(&mut req, "cat1", "cat1");
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
     let json: GoodCrate = ::json(&mut response);
-    assert_eq!(json.krate.name, "foo");
+    assert_eq!(json.krate.name, "foo_good_cat");
     assert_eq!(json.krate.max_version, "1.0.0");
     assert_eq!(json.warnings.invalid_categories.len(), 0);
 }
@@ -904,13 +904,13 @@ fn good_categories() {
 #[test]
 fn ignored_categories() {
     let (_b, app, middle) = ::app();
-    let krate = ::krate("foo");
+    let krate = ::krate("foo_ignored_cat");
     let cats = vec!["bar".into()];
     let mut req = ::new_req_with_categories(app, krate, "1.0.0", cats);
     ::mock_user(&mut req, ::user("foo"));
     let mut response = ok_resp!(middle.call(&mut req));
     let json: GoodCrate = ::json(&mut response);
-    assert_eq!(json.krate.name, "foo");
+    assert_eq!(json.krate.name, "foo_ignored_cat");
     assert_eq!(json.krate.max_version, "1.0.0");
     assert_eq!(json.warnings.invalid_categories, vec!["bar".to_string()]);
 }
@@ -952,7 +952,7 @@ fn author_license_and_description_required() {
     ::user("foo");
 
     let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
-    let mut new_crate = new_crate("foo");
+    let mut new_crate = new_crate("foo_metadata");
     new_crate.license = None;
     new_crate.description = None;
     new_crate.authors = Vec::new();

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -26,7 +26,9 @@ struct CrateMeta { total: i32 }
 #[derive(RustcDecodable)]
 struct GitCrate { name: String, vers: String, deps: Vec<String>, cksum: String }
 #[derive(RustcDecodable)]
-struct GoodCrate { krate: EncodableCrate, warnings: Vec<String> }
+struct Warnings { invalid_categories: Vec<String> }
+#[derive(RustcDecodable)]
+struct GoodCrate { krate: EncodableCrate, warnings: Warnings }
 #[derive(RustcDecodable)]
 struct CrateResponse { krate: EncodableCrate, versions: Vec<EncodableVersion>, keywords: Vec<EncodableKeyword> }
 #[derive(RustcDecodable)]
@@ -896,7 +898,7 @@ fn good_categories() {
     let json: GoodCrate = ::json(&mut response);
     assert_eq!(json.krate.name, "foo");
     assert_eq!(json.krate.max_version, "1.0.0");
-    assert_eq!(json.warnings.len(), 0);
+    assert_eq!(json.warnings.invalid_categories.len(), 0);
 }
 
 #[test]
@@ -910,8 +912,7 @@ fn ignored_categories() {
     let json: GoodCrate = ::json(&mut response);
     assert_eq!(json.krate.name, "foo");
     assert_eq!(json.krate.max_version, "1.0.0");
-    assert_eq!(json.warnings, vec!["\'bar\' is not a recognized category name \
-                                    and has been ignored.".to_string()]);
+    assert_eq!(json.warnings.invalid_categories, vec!["bar".to_string()]);
 }
 
 #[test]

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -134,9 +134,7 @@ fn remove_team_as_named_owner() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(
-        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
-    );
+    let body = ::new_req_body_foo_version_2();
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -166,9 +164,7 @@ fn remove_team_as_team_owner() {
     assert!(json.errors[0].detail.contains("don't have permission"),
             "{:?}", json.errors);
 
-    let body = ::new_req_body(
-        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
-    );
+    let body = ::new_req_body_foo_version_2();
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));
@@ -189,9 +185,7 @@ fn publish_not_owned() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(
-        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
-    );
+    let body = ::new_req_body_foo_version_2();
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -213,9 +207,7 @@ fn publish_owned() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(
-        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
-    );
+    let body = ::new_req_body_foo_version_2();
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -134,7 +134,9 @@ fn remove_team_as_named_owner() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
+    let body = ::new_req_body(
+        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
+    );
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -164,7 +166,9 @@ fn remove_team_as_team_owner() {
     assert!(json.errors[0].detail.contains("don't have permission"),
             "{:?}", json.errors);
 
-    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
+    let body = ::new_req_body(
+        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
+    );
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));
@@ -185,7 +189,9 @@ fn publish_not_owned() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
+    let body = ::new_req_body(
+        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
+    );
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -207,7 +213,9 @@ fn publish_owned() {
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body(::krate("foo"), "2.0.0", Vec::new(), Vec::new());
+    let body = ::new_req_body(
+        ::krate("foo"), "2.0.0", Vec::new(), Vec::new(), Vec::new()
+    );
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -29,10 +29,10 @@ fn not_github() {
     let (_b, app, middle) = ::app();
     let mut req = ::new_req(app, "foo", "2.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_not_github"));
 
     let body = r#"{"users":["dropbox:foo:foo"]}"#;
-    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_not_github/owners")
                                         .with_method(Method::Put)
                                         .with_body(body.as_bytes())));
     assert!(json.errors[0].detail.contains("unknown organization"),
@@ -44,10 +44,10 @@ fn weird_name() {
     let (_b, app, middle) = ::app();
     let mut req = ::new_req(app, "foo", "2.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_weird_name"));
 
     let body = r#"{"users":["github:foo/../bar:wut"]}"#;
-    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_weird_name/owners")
                                         .with_method(Method::Put)
                                         .with_body(body.as_bytes())));
     assert!(json.errors[0].detail.contains("organization cannot contain"),
@@ -60,10 +60,10 @@ fn one_colon() {
     let (_b, app, middle) = ::app();
     let mut req = ::new_req(app, "foo", "2.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_one_colon"));
 
     let body = r#"{"users":["github:foo"]}"#;
-    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_one_colon/owners")
                                         .with_method(Method::Put)
                                         .with_body(body.as_bytes())));
     assert!(json.errors[0].detail.contains("missing github team"),
@@ -75,10 +75,10 @@ fn nonexistent_team() {
     let (_b, app, middle) = ::app();
     let mut req = ::new_req(app, "foo", "2.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_nonexistent"));
 
     let body = r#"{"users":["github:crates-test-org:this-does-not-exist"]}"#;
-    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_nonexistent/owners")
                                         .with_method(Method::Put)
                                         .with_body(body.as_bytes())));
     assert!(json.errors[0].detail.contains("could not find the github team"),
@@ -91,10 +91,10 @@ fn add_team_as_member() {
     let (_b, app, middle) = ::app();
     let mut req = ::new_req(app, "foo", "2.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_team_member"));
 
     let body = body_for_team_x();
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_team_member/owners")
                             .with_method(Method::Put)
                             .with_body(body.as_bytes())));
 }
@@ -105,10 +105,10 @@ fn add_team_as_non_member() {
     let (_b, app, middle) = ::app();
     let mut req = ::new_req(app, "foo", "2.0.0");
     ::mock_user(&mut req, mock_user_on_only_x());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_team_non_member"));
 
     let body = body_for_team_y();
-    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_team_non_member/owners")
                                         .with_method(Method::Put)
                                         .with_body(body.as_bytes())));
     assert!(json.errors[0].detail.contains("only members"),
@@ -119,22 +119,22 @@ fn add_team_as_non_member() {
 #[test]
 fn remove_team_as_named_owner() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "foo_remove_team", "1.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_remove_team"));
 
     let body = body_for_team_x();
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_remove_team/owners")
                             .with_method(Method::Put)
                             .with_body(body.as_bytes())));
 
     let body = body_for_team_x();
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_remove_team/owners")
                             .with_method(Method::Delete)
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body_foo_version_2();
+    let body = ::new_req_body_version_2(::krate("foo_remove_team"));
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -146,25 +146,25 @@ fn remove_team_as_named_owner() {
 #[test]
 fn remove_team_as_team_owner() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app, "foo", "1.0.0");
+    let mut req = ::new_req(app, "foo_remove_team_owner", "1.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_remove_team_owner"));
 
     let body = body_for_team_x();
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_remove_team_owner/owners")
                             .with_method(Method::Put)
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
     let body = body_for_team_x();
-    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_remove_team_owner/owners")
                                         .with_method(Method::Delete)
                                         .with_body(body.as_bytes())));
 
     assert!(json.errors[0].detail.contains("don't have permission"),
             "{:?}", json.errors);
 
-    let body = ::new_req_body_foo_version_2();
+    let body = ::new_req_body_version_2(::krate("foo_remove_team_owner"));
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));
@@ -175,17 +175,17 @@ fn remove_team_as_team_owner() {
 fn publish_not_owned() {
     let (_b, app, middle) = ::app();
 
-    let mut req = ::new_req(app.clone(), "foo", "1.0.0");
+    let mut req = ::new_req(app.clone(), "foo_not_owned", "1.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_not_owned"));
 
     let body = body_for_team_y();
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_not_owned/owners")
                             .with_method(Method::Put)
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body_foo_version_2();
+    let body = ::new_req_body_version_2(::krate("foo_not_owned"));
     let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/new")
                                         .with_body(&body)
                                         .with_method(Method::Put)));
@@ -197,17 +197,17 @@ fn publish_not_owned() {
 #[test]
 fn publish_owned() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app.clone(), "foo", "1.0.0");
+    let mut req = ::new_req(app.clone(), "foo_team_owned", "1.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_team_owned"));
 
     let body = body_for_team_x();
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_team_owned/owners")
                             .with_method(Method::Put)
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
-    let body = ::new_req_body_foo_version_2();
+    let body = ::new_req_body_version_2(::krate("foo_team_owned"));
     ok_resp!(middle.call(req.with_path("/api/v1/crates/new")
                             .with_body(&body)
                             .with_method(Method::Put)));
@@ -217,18 +217,18 @@ fn publish_owned() {
 #[test]
 fn add_owners_as_team_owner() {
     let (_b, app, middle) = ::app();
-    let mut req = ::new_req(app.clone(), "foo", "1.0.0");
+    let mut req = ::new_req(app.clone(), "foo_add_owner", "1.0.0");
     ::mock_user(&mut req, mock_user_on_x_and_y());
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_add_owner"));
 
     let body = body_for_team_x();
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_add_owner/owners")
                             .with_method(Method::Put)
                             .with_body(body.as_bytes())));
 
     ::mock_user(&mut req, mock_user_on_only_x());
     let body = r#"{"users":["FlashCat"]}"#;     // User doesn't matter
-    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo/owners")
+    let json = bad_resp!(middle.call(req.with_path("/api/v1/crates/foo_add_owner/owners")
                                         .with_method(Method::Put)
                                         .with_body(body.as_bytes())));
     assert!(json.errors[0].detail.contains("don't have permission"),

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -91,7 +91,7 @@ fn my_packages() {
     let (_b, app, middle) = ::app();
     let mut req = ::req(app, Method::Get, "/api/v1/crates");
     let u = ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_my_packages"));
     req.with_query(&format!("user_id={}", u.id));
     let mut response = ok_resp!(middle.call(&mut req));
 
@@ -113,8 +113,8 @@ fn following() {
     let (_b, app, middle) = ::app();
     let mut req = ::req(app, Method::Get, "/");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
-    ::mock_crate(&mut req, ::krate("bar"));
+    ::mock_crate(&mut req, ::krate("foo_fighters"));
+    ::mock_crate(&mut req, ::krate("bar_fighters"));
 
     let mut response = ok_resp!(middle.call(req.with_path("/me/updates")
                                                .with_method(Method::Get)));
@@ -122,9 +122,9 @@ fn following() {
     assert_eq!(r.versions.len(), 0);
     assert_eq!(r.meta.more, false);
 
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo/follow")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/foo_fighters/follow")
                             .with_method(Method::Put)));
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/bar/follow")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/bar_fighters/follow")
                             .with_method(Method::Put)));
 
     let mut response = ok_resp!(middle.call(req.with_path("/me/updates")
@@ -140,7 +140,7 @@ fn following() {
     assert_eq!(r.versions.len(), 1);
     assert_eq!(r.meta.more, true);
 
-    ok_resp!(middle.call(req.with_path("/api/v1/crates/bar/follow")
+    ok_resp!(middle.call(req.with_path("/api/v1/crates/bar_fighters/follow")
                             .with_method(Method::Delete)));
     let mut response = ok_resp!(middle.call(req.with_path("/me/updates")
                                                .with_method(Method::Get)

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -26,7 +26,7 @@ fn index() {
 
     let (v1, v2) = {
         ::mock_user(&mut req, ::user("foo"));
-        let (c, _) = ::mock_crate(&mut req, ::krate("foo"));
+        let (c, _) = ::mock_crate(&mut req, ::krate("foo_vers_index"));
         let req: &mut Request = &mut req;
         let tx = req.tx().unwrap();
         let m = HashMap::new();
@@ -46,7 +46,7 @@ fn show() {
     let mut req = ::req(app, Method::Get, "/api/v1/versions");
     let v = {
         ::mock_user(&mut req, ::user("foo"));
-        let (krate, _) = ::mock_crate(&mut req, ::krate("foo"));
+        let (krate, _) = ::mock_crate(&mut req, ::krate("foo_vers_show"));
         let req: &mut Request = &mut req;
         let tx = req.tx().unwrap();
         Version::insert(tx, krate.id, &sv("2.0.0"), &HashMap::new(), &[]).unwrap()
@@ -60,9 +60,9 @@ fn show() {
 #[test]
 fn authors() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo/1.0.0/authors");
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_authors/1.0.0/authors");
     ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo"));
+    ::mock_crate(&mut req, ::krate("foo_authors"));
     let mut response = ok_resp!(middle.call(&mut req));
     let mut s = String::new();
     response.body.read_to_string(&mut s).unwrap();

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -336,7 +336,7 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
     }
 
     // Encode everything!
-    let crates = crates.into_iter().map(|c| c.encodable(None, None, None)).collect();
+    let crates = crates.into_iter().map(|c| c.minimal_encodable()).collect();
     let versions = versions.into_iter().map(|v| {
         let id = v.crate_id;
         v.encodable(&map[&id])

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -336,7 +336,7 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
     }
 
     // Encode everything!
-    let crates = crates.into_iter().map(|c| c.encodable(None, None)).collect();
+    let crates = crates.into_iter().map(|c| c.encodable(None, None, None)).collect();
     let versions = versions.into_iter().map(|v| {
         let id = v.crate_id;
         v.encodable(&map[&id])


### PR DESCRIPTION
Hiiii! This is the first part of adding categories to crates.io!

## What this PR does

- On server startup, take the list of categories in `src/categories.txt` and add or remove categories from the database as needed to make the database match the categories. This way, the list of available categories can be changed via pull request to this repo. 
- A `/categories` page not yet linked from anywhere that displays all the categories in alphabetical order
- A `/categories/whatever` page that will list all the crates in a category
- If a crate has categories, they will be listed on that crate's page in the sidebar under Keywords
- If categories are specified in the metadata uploaded with a new crate request from cargo, they will be added to the crate. (Implemented in rust-lang/cargo#3301)

## Testing this PR

```
$ cargo build
$ cargo run --bin migrate
$ cargo run --bin sync-categories
$ cargo run --bin server
```

Start the frontend as well (Note: I had to use `ember server --proxy http://127.0.0.1:8888` instead of `yarn run start:local` with the latest version of yarn in order to actually use my local backend, I'm investigating why this is the case)

- You should be able to go to `/categories` and see 2 categories, "Development Tools" and "Libraries"
- You should be able to click on those categories and see 0 crates. They each have subcategories, that should also have 0 crates.
- Publish a crate to your local crates.io (I had to comment out code uploading to s3 since I didn't want to do that)
- Using rust-lang/cargo#3301, publish to your local index
- You should see your crate on that category's page
- You should see the category on the crate's page (might have to do a shift-reload because of ember caching)

## Deploying this PR 

It should be totally fine to deploy this PR to crates.io. Nothing links to /categories, and cargo does not publish category metadata yet-- and neither cargo nor crates.io will complain if a crate is not in any categories.

## After this PR is merged

- I will start a PR to categories.txt where we can bikeshed what we actually want the initial set of categories to be
- I will open a PR to add a link to /categories somewhere 
- I will send some popular crates PRs to add categories
