### PR TITLE
Use crate.id with links to force ember to load all the crate data

### DIFF
--- a/app/templates/components/crate-downloads-list.hbs
+++ b/app/templates/components/crate-downloads-list.hbs
@@ -1,7 +1,7 @@
 <ul>
     {{#each crates as |crate|}}
         <li>
-            {{#link-to 'crate' crate class='name'}}
+            {{#link-to 'crate' crate.id class='name'}}
                 {{ crate.name }} ({{ crate.max_version }})
                 <div class='right'>
                     <img class="download-clear-back" src="/assets/download-clear-back.png"/>

--- a/app/templates/components/crate-list.hbs
+++ b/app/templates/components/crate-list.hbs
@@ -1,7 +1,7 @@
 <ul>
     {{#each crates as |crate|}}
         <li>
-            {{#link-to 'crate' crate class='name'}}
+            {{#link-to 'crate' crate.id class='name'}}
                 <span>{{ crate.name }} ({{ crate.max_version }})</span>
                 <img class="right-arrow" src="/assets/right-arrow.png"/>
             {{/link-to}}

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -1,6 +1,6 @@
 <div class='desc'>
     <div class='info'>
-        {{#link-to 'crate' crate}}{{ crate.name }}{{/link-to}}
+        {{#link-to 'crate' crate.id}}{{ crate.name }}{{/link-to}}
         <span class='vers small'>{{ crate.max_version }}</span>
     </div>
     <div class='summary'>

--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -1,5 +1,5 @@
 <div class='all-versions-back'>
-    {{#link-to 'crate' crate}}&#11013; Back to {{ crate.name }}{{/link-to}}
+    {{#link-to 'crate' crate.id}}&#11013; Back to {{ crate.name }}{{/link-to}}
 </div>
 
 <div id='results'>


### PR DESCRIPTION
Fixes #331. Thanks to @locks, who knew exactly what the problem was!!!!

On crate list pages, we had *some* data about each crate, but not
keywords. The way the links were constructed, ember saw the partial data
that matched and would use that on the crate page instead of reloading
the whole crate from the crate show api JSON, which *does* have keywords
available. Using the id with the links instead of the whole model forces
the request for all the data to happen.