### PR TITLE
Make search field require input before searching

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -22,7 +22,7 @@
                 value=search
                 autofocus="autofocus"
                 tabindex="1"
-                required}}
+                required=true}}
     </form>
 
     <div class='nav'>
@@ -103,7 +103,7 @@
             value=search
             autocorrect="off"
             tabindex="1"
-            required}}
+            required=true}}
 </form>
 
 <div id="main" class='inner-content'>

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -21,7 +21,8 @@
                 placeholder="Search"
                 value=search
                 autofocus="autofocus"
-                tabindex="1"}}
+                tabindex="1"
+                required}}
     </form>
 
     <div class='nav'>
@@ -101,7 +102,8 @@
             placeholder="Search"
             value=search
             autocorrect="off"
-            tabindex="1"}}
+            tabindex="1"
+            required}}
 </form>
 
 <div id="main" class='inner-content'>

--- a/app/templates/catch-all.hbs
+++ b/app/templates/catch-all.hbs
@@ -7,5 +7,5 @@
             placeholder="Search"
             value=search
             enter="search"
-            required}}
+            required=true}}
 </p>

--- a/app/templates/catch-all.hbs
+++ b/app/templates/catch-all.hbs
@@ -6,5 +6,6 @@
     {{input type="text" class="search"
             placeholder="Search"
             value=search
-            enter="search"}}
+            enter="search"
+            required}}
 </p>


### PR DESCRIPTION
If you search for nothing (click the field and hit enter), it responds with zero results.
Might as well disable it from doing so.