### PR TITLE
Display the version badge on crate list pages

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -117,7 +117,12 @@
         text-decoration: none;
         font-size: 120%;
     }
-    .vers { margin-left: 10px; }
+    .vers {
+        margin-left: 10px;
+        img {
+            margin-bottom: -4px;
+        }
+    }
 
     .stats {
         width: 15%;

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -1,7 +1,12 @@
 <div class='desc'>
     <div class='info'>
         {{#link-to 'crate' crate.id}}{{ crate.name }}{{/link-to}}
-        <span class='vers small'>{{ crate.max_version }}</span>
+        <span class='vers'>
+            <img
+                src="https://img.shields.io/crates/v/{{ crate.name }}.svg"
+                alt="{{ crate.max_version }}"
+                title="{{ crate.name }}’s current version badge" />
+        </span>
     </div>
     <div class='summary'>
         <span class='small'>


### PR DESCRIPTION
Instead of the plain-text version number.

This has the advantage of quickly showing pre-1.0 (orange) vs. post-1.0
(blue) when scanning down a list of crates.

Since people might want to copy the version number of a crate from the
crate list page, I've changed the alt text of the image to just be the
version number that used to appear here, so that you can highlight the
image and copy the version number.

Screenshot:

<img width="847" alt="screen shot 2016-11-30 at 10 32 50 am" src="https://cloud.githubusercontent.com/assets/193874/20758746/ce012e8e-b6e8-11e6-8413-11fd417fa227.png">
