### PR TITLE
Update postgres version used on travis to 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: rust
 rust: stable
 sudo: false
+dist: trusty
 
 cache:
   directories:
@@ -29,7 +30,7 @@ after_success:
   - travis-cargo coveralls --no-sudo
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.5"
   apt:
     sources:
       - kalakris-cmake


### PR DESCRIPTION
Since we've upgraded the version of postgres crates.io is using in prod, it should use the same version in tests.

This also means the [dist needs to be trusty](https://docs.travis-ci.com/user/database-setup/#Using-a-different-PostgreSQL-Version).