### PR TITLE
Add support for showing Travis and Appveyor current build status badges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "openssl 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "postgres-protocol 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ git2 = "0.6"
 flate2 = "0.2"
 semver = "0.5"
 url = "1.2.1"
-postgres = { version = "0.13", features = ["with-time", "with-openssl"] }
+postgres = { version = "0.13", features = ["with-time", "with-openssl", "with-rustc-serialize"] }
 r2d2 = "0.7.0"
 r2d2_postgres = "0.11"
 openssl = "0.9"

--- a/app/components/badge-appveyor.js
+++ b/app/components/badge-appveyor.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    tagName: 'span',
+    classNames: ['badge'],
+    repository: Ember.computed.alias('badge.attributes.repository'),
+    branch: Ember.computed('badge.attributes.branch', function() {
+        return this.get('badge.attributes.branch') || 'master';
+    }),
+    service: Ember.computed('badge.attributes.service', function() {
+        return this.get('badge.attributes.service') || 'github';
+    }),
+    text: Ember.computed('badge', function() {
+        return `Appveyor build status for the ${ this.get('branch') } branch`;
+    })
+});

--- a/app/components/badge-travis-ci.js
+++ b/app/components/badge-travis-ci.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    tagName: 'span',
+    classNames: ['badge'],
+    repository: Ember.computed.alias('badge.attributes.repository'),
+    branch: Ember.computed('badge.attributes.branch', function() {
+        return this.get('badge.attributes.branch') || 'master';
+    }),
+    text: Ember.computed('branch', function() {
+        return `Travis CI build status for the ${ this.get('branch') } branch`;
+    })
+});

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -20,6 +20,7 @@ export default Ember.Controller.extend({
     requestedVersion: null,
     keywords: computed.alias('crate.keywords'),
     categories: computed.alias('crate.categories'),
+    badges: computed.alias('crate.badges'),
 
     sortedVersions: computed.readOnly('crate.versions'),
 

--- a/app/mirage/fixtures/search.js
+++ b/app/mirage/fixtures/search.js
@@ -19,6 +19,21 @@ export default {
         "name": "rust_mixin",
         "repository": "https://github.com/huonw/external_mixin",
         "updated_at": "2015-02-27T11:52:13Z",
+        "badges": [
+            {
+                "attributes": {
+                    "repository": "huonw/external_mixin"
+                },
+                "badge_type": "appveyor"
+            },
+            {
+                "attributes": {
+                    "branch": "master",
+                    "repository": "huonw/external_mixin"
+                },
+                "badge_type": "travis-ci"
+            }
+        ],
         "versions": null
     }, {
         "created_at": "2015-02-27T11:51:58Z",

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 
 export default DS.Model.extend({
     name: DS.attr('string'),
@@ -17,6 +18,16 @@ export default DS.Model.extend({
     license: DS.attr('string'),
 
     versions: DS.hasMany('versions', { async: true }),
+    badges: DS.attr(),
+    enhanced_badges: Ember.computed.map('badges', badge => ({
+        // jshint ignore:start
+        // needed until https://github.com/jshint/jshint/issues/2991 is fixed
+        ...badge,
+        // jshint ignore:end
+        component_name: `badge-${badge.badge_type}`
+    })),
+    badge_sort: ['badge_type'],
+    annotated_badges: Ember.computed.sort('enhanced_badges', 'badge_sort'),
     owners: DS.hasMany('users', { async: true }),
     version_downloads: DS.hasMany('version-download', { async: true }),
     keywords: DS.hasMany('keywords', { async: true }),

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -119,9 +119,6 @@
     }
     .vers {
         margin-left: 10px;
-        img {
-            margin-bottom: -4px;
-        }
     }
 
     .stats {

--- a/app/templates/components/badge-appveyor.hbs
+++ b/app/templates/components/badge-appveyor.hbs
@@ -1,0 +1,6 @@
+<a href="https://ci.appveyor.com/project/{{ repository }}">
+    <img
+        src="https://ci.appveyor.com/api/projects/status/{{ service }}/{{ repository }}?svg=true&branch={{ branch }}"
+        alt="{{ text }}"
+        title="{{ text }}" />
+</a>

--- a/app/templates/components/badge-travis-ci.hbs
+++ b/app/templates/components/badge-travis-ci.hbs
@@ -1,0 +1,6 @@
+<a href="https://travis-ci.org/{{ repository }}">
+    <img
+        src="https://travis-ci.org/{{ repository }}.svg?branch={{ branch }}"
+        alt="{{ text }}"
+        title="{{ text }}" />
+</a>

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -7,6 +7,9 @@
                 alt="{{ crate.max_version }}"
                 title="{{ crate.name }}’s current version badge" />
         </span>
+        {{#each crate.annotated_badges as |badge|}}
+            {{component badge.component_name badge=badge}}
+        {{/each}}
     </div>
     <div class='summary'>
         <span class='small'>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -71,6 +71,12 @@
                         alt="{{ crate.name }}’s current version badge"
                         title="{{ crate.name }}’s current version badge" />
                 </p>
+
+                {{#each crate.annotated_badges as |badge|}}
+                    <p>
+                        {{component badge.component_name badge=badge}}
+                    </p>
+                {{/each}}
             </div>
 
             <div class="authors">

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -1,0 +1,194 @@
+use util::CargoResult;
+use krate::Crate;
+use Model;
+
+use std::collections::HashMap;
+use pg::GenericConnection;
+use pg::rows::Row;
+use rustc_serialize::json::Json;
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Badge {
+    TravisCi {
+        repository: String, branch: Option<String>,
+    },
+    Appveyor {
+        repository: String, branch: Option<String>, service: Option<String>,
+    },
+}
+
+#[derive(RustcEncodable, RustcDecodable, PartialEq, Debug)]
+pub struct EncodableBadge {
+    pub badge_type: String,
+    pub attributes: HashMap<String, String>,
+}
+
+impl Model for Badge {
+    fn from_row(row: &Row) -> Badge {
+        let attributes: Json = row.get("attributes");
+        if let Json::Object(attributes) = attributes {
+            let badge_type: String = row.get("badge_type");
+            match badge_type.as_str() {
+                "travis-ci" => {
+                    Badge::TravisCi {
+                        branch: attributes.get("branch")
+                                          .and_then(Json::as_string)
+                                          .map(str::to_string),
+                        repository: attributes.get("repository")
+                                        .and_then(Json::as_string)
+                                        .map(str::to_string)
+                                        .expect("Invalid TravisCi badge \
+                                                 without repository in the \
+                                                 database"),
+                    }
+                },
+                "appveyor" => {
+                    Badge::Appveyor {
+                        service: attributes.get("service")
+                                           .and_then(Json::as_string)
+                                           .map(str::to_string),
+                        branch: attributes.get("branch")
+                                          .and_then(Json::as_string)
+                                          .map(str::to_string),
+                        repository: attributes.get("repository")
+                                        .and_then(Json::as_string)
+                                        .map(str::to_string)
+                                        .expect("Invalid Appveyor badge \
+                                                 without repository in the \
+                                                 database"),
+                    }
+                },
+                _ => {
+                    panic!("Unknown badge type {} in the database", badge_type);
+                },
+            }
+        } else {
+            panic!(
+                "badge attributes {:?} in the database was not a JSON object",
+                attributes
+            );
+        }
+    }
+    fn table_name(_: Option<Badge>) -> &'static str { "badges" }
+}
+
+impl Badge {
+    pub fn encodable(self) -> EncodableBadge {
+        EncodableBadge {
+            badge_type: self.badge_type().to_string(),
+            attributes: self.attributes(),
+        }
+    }
+
+    pub fn badge_type(&self) -> &'static str {
+        match *self {
+            Badge::TravisCi {..} => "travis-ci",
+            Badge::Appveyor {..} => "appveyor",
+        }
+    }
+
+    pub fn json_attributes(self) -> Json {
+        Json::Object(self.attributes().into_iter().map(|(k, v)| {
+            (k, Json::String(v))
+        }).collect())
+    }
+
+    fn attributes(self) -> HashMap<String, String> {
+        let mut attributes = HashMap::new();
+
+        match self {
+            Badge::TravisCi { branch, repository } => {
+                attributes.insert(String::from("repository"), repository);
+                if let Some(branch) = branch {
+                    attributes.insert(
+                        String::from("branch"),
+                        branch
+                    );
+                }
+            },
+            Badge::Appveyor { service, branch, repository } => {
+                attributes.insert(String::from("repository"), repository);
+                if let Some(branch) = branch {
+                    attributes.insert(
+                        String::from("branch"),
+                        branch
+                    );
+                }
+                if let Some(service) = service {
+                    attributes.insert(
+                        String::from("service"),
+                        service
+                    );
+                }
+            }
+        }
+
+        attributes
+    }
+
+    fn from_attributes(badge_type: &str,
+                       attributes: &HashMap<String, String>)
+                       -> Result<Badge, String> {
+        match badge_type {
+            "travis-ci" => {
+                match attributes.get("repository") {
+                    Some(repository) => {
+                        Ok(Badge::TravisCi {
+                            repository: repository.to_string(),
+                            branch: attributes.get("branch")
+                                              .map(String::to_string),
+                        })
+                    },
+                    None => Err(badge_type.to_string()),
+                }
+            },
+            "appveyor" => {
+                match attributes.get("repository") {
+                    Some(repository) => {
+                        Ok(Badge::Appveyor {
+                            repository: repository.to_string(),
+                            branch: attributes.get("branch")
+                                              .map(String::to_string),
+                            service: attributes.get("service")
+                                              .map(String::to_string),
+
+                        })
+                    },
+                    None => Err(badge_type.to_string()),
+                }
+           },
+           _ => Err(badge_type.to_string()),
+        }
+    }
+
+    pub fn update_crate(conn: &GenericConnection,
+                        krate: &Crate,
+                        badges: HashMap<String, HashMap<String, String>>)
+                        -> CargoResult<Vec<String>> {
+
+        let mut invalid_badges = vec![];
+
+        let badges: Vec<_> = badges.iter().filter_map(|(k, v)| {
+            Badge::from_attributes(k, v).map_err(|invalid_badge| {
+                invalid_badges.push(invalid_badge)
+            }).ok()
+        }).collect();
+
+        conn.execute("\
+            DELETE FROM badges \
+            WHERE crate_id = $1;",
+            &[&krate.id]
+        )?;
+
+        for badge in badges {
+            conn.execute("\
+                INSERT INTO badges (crate_id, badge_type, attributes) \
+                VALUES ($1, $2, $3) \
+                ON CONFLICT (crate_id, badge_type) DO UPDATE \
+                    SET attributes = EXCLUDED.attributes;",
+                &[&krate.id, &badge.badge_type(), &badge.json_attributes()]
+            )?;
+        }
+        Ok(invalid_badges)
+    }
+}

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -819,6 +819,18 @@ fn migrations() -> Vec<Migration> {
                 ON crates_categories;"));
             Ok(())
         }),
+        Migration::add_table(20170102131034, "badges", " \
+            crate_id         INTEGER NOT NULL, \
+            badge_type       VARCHAR NOT NULL, \
+            attributes       JSONB NOT NULL"),
+        Migration::new(20170102145236, |tx| {
+            try!(tx.execute("CREATE UNIQUE INDEX badges_crate_type \
+                             ON badges (crate_id, badge_type)", &[]));
+            Ok(())
+        }, |tx| {
+            try!(tx.execute("DROP INDEX badges_crate_type", &[]));
+            Ok(())
+        }),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ extern crate conduit_router;
 extern crate conduit_static;
 
 pub use app::App;
+pub use self::badge::Badge;
 pub use self::category::Category;
 pub use config::Config;
 pub use self::dependency::Dependency;
@@ -53,6 +54,7 @@ use conduit_middleware::MiddlewareBuilder;
 use util::{C, R, R404};
 
 pub mod app;
+pub mod badge;
 pub mod categories;
 pub mod category;
 pub mod config;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -63,6 +63,7 @@ struct Error { detail: String }
 #[derive(RustcDecodable)]
 struct Bad { errors: Vec<Error> }
 
+mod badge;
 mod category;
 mod git;
 mod keyword;
@@ -272,30 +273,49 @@ fn new_req(app: Arc<App>, krate: &str, version: &str) -> MockRequest {
 fn new_req_full(app: Arc<App>, krate: Crate, version: &str,
                 deps: Vec<u::CrateDependency>) -> MockRequest {
     let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
-    req.with_body(&new_req_body(krate, version, deps, Vec::new(), Vec::new()));
+    req.with_body(&new_req_body(
+        krate, version, deps, Vec::new(), Vec::new(), HashMap::new()
+    ));
     return req;
 }
 
 fn new_req_with_keywords(app: Arc<App>, krate: Crate, version: &str,
                          kws: Vec<String>) -> MockRequest {
     let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
-    req.with_body(&new_req_body(krate, version, Vec::new(), kws, Vec::new()));
+    req.with_body(&new_req_body(
+        krate, version, Vec::new(), kws, Vec::new(), HashMap::new()
+    ));
     return req;
 }
 
 fn new_req_with_categories(app: Arc<App>, krate: Crate, version: &str,
                            cats: Vec<String>) -> MockRequest {
     let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
-    req.with_body(&new_req_body(krate, version, Vec::new(), Vec::new(), cats));
+    req.with_body(&new_req_body(
+        krate, version, Vec::new(), Vec::new(), cats, HashMap::new()
+    ));
+    return req;
+}
+
+fn new_req_with_badges(app: Arc<App>, krate: Crate, version: &str,
+                       badges: HashMap<String, HashMap<String, String>>)
+                       -> MockRequest {
+    let mut req = ::req(app, Method::Put, "/api/v1/crates/new");
+    req.with_body(&new_req_body(
+        krate, version, Vec::new(), Vec::new(), Vec::new(), badges
+    ));
     return req;
 }
 
 fn new_req_body_version_2(krate: Crate) -> Vec<u8> {
-    new_req_body(krate, "2.0.0", Vec::new(), Vec::new(), Vec::new())
+    new_req_body(
+        krate, "2.0.0", Vec::new(), Vec::new(), Vec::new(), HashMap::new()
+    )
 }
 
 fn new_req_body(krate: Crate, version: &str, deps: Vec<u::CrateDependency>,
-                kws: Vec<String>, cats: Vec<String>) -> Vec<u8> {
+                kws: Vec<String>, cats: Vec<String>,
+                badges: HashMap<String, HashMap<String, String>>) -> Vec<u8> {
     let kws = kws.into_iter().map(u::Keyword).collect();
     let cats = cats.into_iter().map(u::Category).collect();
     new_crate_to_body(&u::NewCrate {
@@ -313,6 +333,7 @@ fn new_req_body(krate: Crate, version: &str, deps: Vec<u::CrateDependency>,
         license: Some("MIT".to_string()),
         license_file: None,
         repository: krate.repository,
+        badges: Some(badges),
     }, &[])
 }
 

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,0 +1,154 @@
+use conduit::{Request, Method};
+use postgres::GenericConnection;
+
+use cargo_registry::db::RequestTransaction;
+use cargo_registry::badge::Badge;
+
+use std::collections::HashMap;
+
+fn tx(req: &Request) -> &GenericConnection { req.tx().unwrap() }
+
+#[test]
+fn update_crate() {
+    let (_b, app, _middle) = ::app();
+    let mut req = ::req(app, Method::Get, "/api/v1/crates/badged_crate");
+
+    ::mock_user(&mut req, ::user("foo"));
+    let (krate, _) = ::mock_crate(&mut req, ::krate("badged_crate"));
+
+    let appveyor = Badge::Appveyor {
+        service: Some(String::from("github")),
+        branch: None,
+        repository: String::from("rust-lang/cargo"),
+    };
+    let mut badge_attributes_appveyor = HashMap::new();
+    badge_attributes_appveyor.insert(
+        String::from("service"),
+        String::from("github")
+    );
+    badge_attributes_appveyor.insert(
+        String::from("repository"),
+        String::from("rust-lang/cargo")
+    );
+
+    let travis_ci = Badge::TravisCi {
+        branch: Some(String::from("beta")),
+        repository: String::from("rust-lang/rust"),
+    };
+    let mut badge_attributes_travis_ci = HashMap::new();
+    badge_attributes_travis_ci.insert(
+        String::from("branch"),
+        String::from("beta")
+    );
+    badge_attributes_travis_ci.insert(
+        String::from("repository"),
+        String::from("rust-lang/rust")
+    );
+
+    let mut badges = HashMap::new();
+
+    // Updating with no badges has no effect
+    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
+    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+
+    // Happy path adding one badge
+    badges.insert(
+        String::from("appveyor"),
+        badge_attributes_appveyor.clone()
+    );
+    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
+    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![appveyor.clone()]);
+
+    // Replacing one badge with another
+    badges.clear();
+    badges.insert(
+        String::from("travis-ci"),
+        badge_attributes_travis_ci.clone()
+    );
+    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
+    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![travis_ci.clone()]);
+
+    // Updating badge attributes
+    let travis_ci2 = Badge::TravisCi {
+        branch: None,
+        repository: String::from("rust-lang/rust"),
+    };
+    let mut badge_attributes_travis_ci2 = HashMap::new();
+    badge_attributes_travis_ci2.insert(
+        String::from("repository"),
+        String::from("rust-lang/rust")
+    );
+    badges.insert(
+        String::from("travis-ci"),
+        badge_attributes_travis_ci2.clone()
+    );
+    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
+    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![travis_ci2.clone()]);
+
+    // Removing one badge
+    badges.clear();
+    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
+    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+
+    // Adding 2 badges
+    badges.insert(
+        String::from("appveyor"),
+        badge_attributes_appveyor.clone()
+    );
+    badges.insert(
+        String::from("travis-ci"),
+        badge_attributes_travis_ci.clone()
+    );
+    Badge::update_crate(
+        tx(&req), &krate, badges.clone()
+    ).unwrap();
+
+    let current_badges = krate.badges(tx(&req)).unwrap();
+    assert_eq!(current_badges.len(), 2);
+    assert!(current_badges.contains(&appveyor));
+    assert!(current_badges.contains(&travis_ci));
+
+    // Removing all badges
+    badges.clear();
+    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
+    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+
+    // Attempting to add one valid badge (appveyor) and two invalid badges
+    // (travis-ci without a required attribute and an unknown badge type)
+
+    // Extra invalid keys are fine, we'll just ignore those
+    badge_attributes_appveyor.insert(
+        String::from("extra"),
+        String::from("info")
+    );
+    badges.insert(
+        String::from("appveyor"),
+        badge_attributes_appveyor.clone()
+    );
+
+    // Repository is a required key
+    badge_attributes_travis_ci.remove("repository");
+    badges.insert(
+        String::from("travis-ci"),
+        badge_attributes_travis_ci.clone()
+    );
+
+    // This is not a badge that crates.io knows about
+    let mut invalid_attributes = HashMap::new();
+    invalid_attributes.insert(
+        String::from("not-a-badge-attribute"),
+        String::from("not-a-badge-value")
+    );
+    badges.insert(
+        String::from("not-a-badge"),
+        invalid_attributes.clone()
+    );
+
+    let invalid_badges = Badge::update_crate(
+        tx(&req), &krate, badges.clone()
+    ).unwrap();
+    assert_eq!(invalid_badges.len(), 2);
+    assert!(invalid_badges.contains(&String::from("travis-ci")));
+    assert!(invalid_badges.contains(&String::from("not-a-badge")));
+    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![appveyor.clone()]);
+}

--- a/src/tests/http-data/krate_good_badges
+++ b/src/tests/http-data/krate_good_badges
@@ -1,0 +1,21 @@
+===REQUEST 343
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foobadger/foobadger-1.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+
+

--- a/src/tests/http-data/krate_ignored_badges
+++ b/src/tests/http-data/krate_ignored_badges
@@ -1,0 +1,21 @@
+===REQUEST 359
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/foo_ignored_badge/foo_ignored_badge-1.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+
+

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -24,6 +24,7 @@ pub struct NewCrate {
     pub license: Option<String>,
     pub license_file: Option<String>,
     pub repository: Option<String>,
+    pub badges: Option<HashMap<String, HashMap<String, String>>>,
 }
 
 #[derive(PartialEq, Eq, Hash)]

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -336,7 +336,9 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
     }
 
     // Encode everything!
-    let crates = crates.into_iter().map(|c| c.minimal_encodable()).collect();
+    let crates = crates.into_iter().map(|c| {
+        c.minimal_encodable(None)
+    }).collect();
     let versions = versions.into_iter().map(|v| {
         let id = v.crate_id;
         v.encodable(&map[&id])

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -23,6 +23,10 @@ test('searching for "rust"', function(assert) {
 
         hasText(assert, '#crates .row:first .desc .info', 'rust_mixin');
         findWithAssert('#crates .row:first .desc .info .vers img[alt="0.0.1"]');
+
+        findWithAssert('#crates .row:first .desc .info .badge:first a img[src="https://ci.appveyor.com/api/projects/status/github/huonw/external_mixin?svg=true&branch=master"]');
+        findWithAssert('#crates .row:first .desc .info .badge:eq(1) a img[src="https://travis-ci.org/huonw/external_mixin.svg?branch=master"]');
+
         hasText(assert, '#crates .row:first .desc .summary', 'Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)');
         hasText(assert, '#crates .row:first .downloads', '477');
     });


### PR DESCRIPTION
This goes with corresponding PR rust-lang/cargo#3546. It probably makes the most sense for this one to go in first.

If a maintainer is testing their project on Travis and Appveyor and so chooses, they can specify attributes for badges for the crate's current build status in its Cargo.toml. 

The badges will then get displayed in alphabetical order on both pages that list crates:

<img width="914" alt="preview of badges shown in a list of crates, next to the version badge" src="https://cloud.githubusercontent.com/assets/193874/21969767/7a49d0e8-db6e-11e6-84bb-6b35f056dc10.png">

and an individual crate's page:

<img width="876" alt="preview of badges shown on an individual crate's page, in the sidebar" src="https://cloud.githubusercontent.com/assets/193874/21969775/8c4c0ab8-db6e-11e6-911a-aa82c3cfe56f.png">

If any badges other than appveyor or travis are specified, crates.io will ignore them and send back a warning for cargo to display. If the "repository" attribute for either badge is missing, crates.io will ignore that badge and warn about it. If any attributes other than the ones crates.io knows about for each badge is specified, those will get ignored and not warned about.