### PR TITLE
Link to docs.rs if no documentation is provided

### DIFF
--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -30,6 +30,8 @@
         {{/if}}
         {{#if crate.documentation}}
           <li><a href="{{crate.documentation}}">Documentation</a></li>
+        {{else}}
+          <li><a href="https://docs.rs/crate/{{crate.name}}">Documentation</a></li>
         {{/if}}
         {{#if crate.repository}}
           <li><a href="{{crate.repository}}">Repository</a></li>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -155,6 +155,8 @@
             {{/if}}
             {{#if crate.documentation}}
                 <li><a href="{{crate.documentation}}">Documentation</a></li>
+            {{else}}
+                <li><a href="https://docs.rs/crate/{{crate.name}}">Documentation</a></li>
             {{/if}}
             {{#if crate.repository}}
                 <li><a href="{{crate.repository}}">Repository</a></li>


### PR DESCRIPTION
/r/golang asked if we autolink to docs.rs, and we don't, but I think that's a really good idea!

I'm only touching UI code here so that the "default" docs.rs links don't filter down to the models and then the database.

r? @steveklabnik @wycats @carols10cents 