### PR TITLE
On /categories, change the # per page to be 100

### DIFF
--- a/app/controllers/categories.js
+++ b/app/controllers/categories.js
@@ -6,7 +6,7 @@ const { computed } = Ember;
 export default Ember.Controller.extend(PaginationMixin, {
     queryParams: ['page', 'per_page', 'sort'],
     page: '1',
-    per_page: 10,
+    per_page: 100,
     sort: 'alpha',
 
     totalItems: computed.readOnly('model.meta.total'),


### PR DESCRIPTION
We only have 37 top-level categories now, so this will show all
top-level categories on one page for the foreseeable future and make for
a better browsing experience.

Fixes #505.