### PR TITLE
Show most popular keywords and categories on the home page

### DIFF
--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -125,7 +125,7 @@
 
 #home-crates {
     @include flex-wrap(wrap);
-    @include justify-content(center);
+    @include justify-content(left);
 
     > div {
       margin: 0;

--- a/app/templates/components/category-list.hbs
+++ b/app/templates/components/category-list.hbs
@@ -1,0 +1,10 @@
+<ul>
+    {{#each categories as |category|}}
+        <li>
+            {{#link-to 'category' category.slug class='name'}}
+                <span>{{ category.category }} ({{ format-num category.crates_cnt }})</span>
+                <img class="right-arrow" src="/assets/right-arrow.png"/>
+            {{/link-to}}
+        </li>
+    {{/each}}
+</ul>

--- a/app/templates/components/keyword-list.hbs
+++ b/app/templates/components/keyword-list.hbs
@@ -1,0 +1,10 @@
+<ul>
+    {{#each keywords as |keyword|}}
+        <li>
+            {{#link-to 'keyword' keyword class='name'}}
+                <span>{{ keyword.id }} ({{ format-num keyword.crates_cnt }})</span>
+                <img class="right-arrow" src="/assets/right-arrow.png"/>
+            {{/link-to}}
+        </li>
+    {{/each}}
+</ul>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -48,4 +48,12 @@
         <h2>Just Updated</h2>
         {{crate-list crates=model.just_updated}}
     </div>
+    <div id='keywords'>
+        <h2>Popular Keywords {{#link-to 'keywords'}}(see all){{/link-to}}</h2>
+        {{keyword-list keywords=model.popular_keywords}}
+    </div>
+    <div id='categories'>
+        <h2>Popular Categories {{#link-to 'categories'}}(see all){{/link-to}}</h2>
+        {{category-list categories=model.popular_categories}}
+    </div>
 </div>

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -650,6 +650,16 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
     let most_downloaded = try!(tx.prepare("SELECT * FROM crates \
                                            ORDER BY downloads DESC LIMIT 10"));
 
+    let popular_keywords = try!(Keyword::all(tx, "crates", 10, 0));
+    let popular_keywords = popular_keywords.into_iter()
+                                           .map(Keyword::encodable)
+                                           .collect();
+
+    let popular_categories = try!(Category::toplevel(tx, "crates", 10, 0));
+    let popular_categories = popular_categories.into_iter()
+                                               .map(Category::encodable)
+                                               .collect();
+
     #[derive(RustcEncodable)]
     struct R {
         num_downloads: i64,
@@ -657,6 +667,8 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
         new_crates: Vec<EncodableCrate>,
         most_downloaded: Vec<EncodableCrate>,
         just_updated: Vec<EncodableCrate>,
+        popular_keywords: Vec<EncodableKeyword>,
+        popular_categories: Vec<EncodableCategory>,
     }
     Ok(req.json(&R {
         num_downloads: num_downloads,
@@ -664,6 +676,8 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
         new_crates: try!(to_crates(new_crates)),
         most_downloaded: try!(to_crates(most_downloaded)),
         just_updated: try!(to_crates(just_updated)),
+        popular_keywords: popular_keywords,
+        popular_categories: popular_categories,
     }))
 }
 


### PR DESCRIPTION
Fixes #490. 

Below the lists of new, most downloaded, and just updated 10 crates will be the 10 most popular keywords and the 10 most popular categories, plus links to /keywords and /categories. It looks like this:

<img width="939" alt="screen shot 2017-01-20 at 4 50 45 pm" src="https://cloud.githubusercontent.com/assets/193874/22166809/e63f4524-df30-11e6-817c-faa6d8267e42.png">
