### PR TITLE
Remove truncate-text helper on Categories page (Fix #509)

### DIFF
--- a/app/templates/categories.hbs
+++ b/app/templates/categories.hbs
@@ -52,7 +52,7 @@
                 </div>
                 <div class='summary'>
                     <span class='small'>
-                        {{ truncate-text category.description }}
+                        {{ category.description }}
                     </span>
                 </div>
             </div>

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -25,7 +25,7 @@
                       </div>
                       <div class='summary'>
                           <span class='small'>
-                              {{ truncate-text subcategory.description }}
+                              {{ subcategory.description }}
                           </span>
                       </div>
                   </div>


### PR DESCRIPTION
Fixes #509 whereby category descriptions over 200 characters would be truncated.
Since these descriptions are curated, not truncating them should be fine and won't abuse the UI.