### PR TITLE
Add rendering category and subcategories

### DIFF
--- a/src/categories.toml
+++ b/src/categories.toml
@@ -249,7 +249,7 @@ Crates that record, output, or process video.
 [multimedia.categories.images]
 name = "Images"
 description = """
-Crates that process or render images.
+Crates that process or build images.
 """
 
 [multimedia.categories.encoding]
@@ -295,6 +295,33 @@ description = """
 Crates to help create parsers of binary and text \
 formats. Format-specific parsers belong in other, more specific \
 categories.\
+"""
+
+[rendering]
+name = "Rendering"
+description = """
+Real-time or offline rendering of 2D or 3D graphics, \
+usually with the help of a graphics card.\
+"""
+
+[rendering.categories.engine]
+name = "Rendering engine"
+description = """
+High-level solutions for rendering on the screen.\
+"""
+
+[rendering.categories.graphics-api]
+name = "Graphics APIs"
+description = """
+Crates that provide direct access to the hardware's or the operating \
+system's rendering capabilities.\
+"""
+
+[rendering.categories.data-formats]
+name = "Data formats"
+description = """
+Loading and parsing of data formats related to 2D or 3D rendering, like \
+3D models or animation sheets.\
 """
 
 [rust-patterns]


### PR DESCRIPTION
I think a new category for this is justified, because of the large number of crates that belong in there.

Example crates:

For "engine": sdl, skia, ggez, kiss3d, piston-graphics and some of its plugins, the 2 or 3 ray tracing crates, etc. and the numerous bindings to existing libraries in other languages
For "graphics-api": gl, glutin, glfw, glium, gfx and all its plugins, glitter, the 4 or 5 vulkan bindings, the 4 metal bindings, directx, libovr, openvr, etc.
For "data-formats": the 4 crates that parse wavefront, the 4 bindings for assimp, gltf, collada, spine, text-related crates like freetype, etc.

For the base "rendering" category, everything that doesn't fit elsewhere: scene management (gfx_scene), maybe maths crates that have quaternions, frustrums and stuff (eg. cgmath).
I don't think it was worth creating more categories. Maybe in practice they will be needed but for now I don't think so.
