### PR TITLE
Add testing in description of Development tools

### DIFF
--- a/src/categories.toml
+++ b/src/categories.toml
@@ -123,8 +123,8 @@ dimension.\
 [development-tools]
 name = "Development tools"
 description = """
-Crates that provide developer-facing features such as debugging, linting, \
-performance profiling, autocompletion, formatting, and more.\
+Crates that provide developer-facing features such as testing, debugging, \
+linting, performance profiling, autocompletion, formatting, and more.\
 """
 
 [development-tools.categories.cargo-plugins]


### PR DESCRIPTION
Searching (in the browser) for testing in https://crates.io/categories/ does not find anything. Adding testing in the description of "Development tools" helps find the "Development tools/Testing" subcategory.