### PR TITLE
Update the readme: remove an `npm`, add info about running frontend with fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This will run a local frontend using the staging backend (hosted on Heroku at
 [staging-crates-io.herokuapp.com](https://staging-crates-io.herokuapp.com)).
 
 If you'd like to run the frontend with a specific backend endpoint, you can 
-specify arguments to `npm start`. For example you can set the proxy to 
+specify arguments to `yarn start`. For example you can set the proxy to 
 `https://crates.io/` to use the production version. 
 
 **Note: it is also possible to make changes to the production data**

--- a/README.md
+++ b/README.md
@@ -28,9 +28,18 @@ yarn run start:staging
 This will run a local frontend using the staging backend (hosted on Heroku at 
 [staging-crates-io.herokuapp.com](https://staging-crates-io.herokuapp.com)).
 
-If you'd like to run the frontend with a specific backend endpoint, you can 
-specify arguments to `yarn start`. For example you can set the proxy to 
-`https://crates.io/` to use the production version. 
+If you want to set up a particular situation, you can edit the fixture data used
+for tests in `app/mirage/fixtures`. Note that the fixture data does not contain
+JSON needed to support every page, so some pages might not load correctly. To
+run the frontend and use that data, don't specify any backend:
+
+```bash
+yarn run start
+```
+
+If you'd like to run the frontend with a specific backend endpoint, you can
+specify arguments to `yarn start`. For example you can set the proxy to
+`https://crates.io/` to use the production version.
 
 **Note: it is also possible to make changes to the production data**
 


### PR DESCRIPTION
I just found another useful way to run the frontend without the backend-- don't specify any arguments to `yarn run start`, and it'll use the mirage fixtures!

Figured that could be useful for others to know :)

Also found one remaining use of the `npm` command where it should be `yarn`.