### PR TITLE
Show and sort by downloads on reverse dependency page

### DIFF
--- a/app/models/dependency.js
+++ b/app/models/dependency.js
@@ -15,6 +15,7 @@ export default DS.Model.extend({
     default_features: DS.attr('boolean'),
     features: DS.attr('string'),
     kind: DS.attr('string'),
+    downloads: DS.attr('number'),
 
     featureList: computed('features', function() {
         return this.get('features').split(',');

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -127,6 +127,8 @@
     }
     .downloads { @include display-flex; @include align-items(center); }
 
+    .rev-dep-downloads {padding-left: 7px}
+
     .quick-links {
         ul {
             @include display-flex;

--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -15,7 +15,7 @@
 
 <div class='white-rows'>
     {{#each model as |dependency|}}
-        <div class='row'>
+        <div class='crate row'>
             <div>
             {{#link-to 'crate' dependency.crate_id}}{{dependency.crate_id}}{{/link-to}} requires {{dependency.req}}
             </div>

--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -13,15 +13,16 @@
     </div>
 </div>
 
-<div id='crate-all-reverse-dependencies' class='white-rows'>
+<div class='white-rows'>
     {{#each model as |dependency|}}
         <div class='row'>
             <div>
             {{#link-to 'crate' dependency.crate_id}}{{dependency.crate_id}}{{/link-to}} requires {{dependency.req}}
             </div>
-            {{#link-to 'crate' dependency.crate_id class='arrow'}}
-                <img class="right-arrow-all-versions" src="/assets/right-arrow-all-versions.png"/>
-            {{/link-to}}
+            <div class='stats downloads'>
+                <img class='download-clear-back' src="/assets/download-clear-back.png"/>
+                <span class='num rev-dep-downloads'>{{ format-num dependency.downloads }}</span>
+            </div>
         </div>
     {{/each}}
 </div>

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -29,6 +29,7 @@ pub struct EncodableDependency {
     pub features: String,
     pub target: Option<String>,
     pub kind: Kind,
+    pub downloads: i32,
 }
 
 #[derive(Copy, Clone)]
@@ -76,9 +77,17 @@ impl Dependency {
         }
     }
 
-    pub fn encodable(self, crate_name: &str) -> EncodableDependency {
-        let Dependency { id, version_id, crate_id: _, req, optional,
-                         default_features, features, target, kind } = self;
+    // `downloads` need only be specified when generating a reverse dependency
+    pub fn encodable(self, crate_name: &str, downloads: Option<i32>) -> EncodableDependency {
+        let Dependency { id,
+                         version_id,
+                         crate_id: _,
+                         req,
+                         optional,
+                         default_features,
+                         features,
+                         target,
+                         kind } = self;
         EncodableDependency {
             id: id,
             version_id: version_id,
@@ -89,6 +98,7 @@ impl Dependency {
             features: features.join(","),
             target: target,
             kind: kind,
+            downloads: downloads.unwrap_or(0),
         }
     }
 }

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -420,30 +420,32 @@ impl Crate {
         Ok(rows.iter().map(|r| Model::from_row(&r)).collect())
     }
 
-    /// Returns (dependency, dependent crate name)
+    /// Returns (dependency, dependent crate name, dependent crate downloads)
     pub fn reverse_dependencies(&self,
                                 conn: &GenericConnection,
                                 offset: i64,
                                 limit: i64)
-                                -> CargoResult<(Vec<(Dependency, String)>, i64)> {
+                                -> CargoResult<(Vec<(Dependency, String, i32)>, i64)> {
         let select_sql = "
               FROM dependencies
               INNER JOIN versions
                 ON versions.id = dependencies.version_id
               INNER JOIN crates
                 ON crates.id = versions.crate_id
+              INNER JOIN crate_downloads
+                ON crate_downloads.crate_id = versions.crate_id
               WHERE dependencies.crate_id = $1
                 AND versions.num = crates.max_version
         ";
-        let fetch_sql = format!("SELECT DISTINCT ON (crate_name)
-                                        dependencies.*,
+        let fetch_sql = format!("SELECT dependencies.*,
+                                        crate_downloads.downloads AS crate_downloads,
                                         crates.name AS crate_name
                                         {}
-                               ORDER BY crate_name ASC
+                               ORDER BY crate_downloads DESC
                                  OFFSET $2
-                                  LIMIT $3", select_sql);
-        let count_sql = format!("SELECT COUNT(DISTINCT(crates.id)) {}",
+                                  LIMIT $3",
                                 select_sql);
+        let count_sql = format!("SELECT COUNT(DISTINCT(crates.id)) {}", select_sql);
 
         let stmt = try!(conn.prepare(&fetch_sql));
         let vec: Vec<_> = try!(stmt.query(&[&self.id, &offset, &limit]))
@@ -1172,12 +1174,11 @@ pub fn reverse_dependencies(req: &mut Request) -> CargoResult<Response> {
     let name = &req.params()["crate_id"];
     let conn = try!(req.tx());
     let krate = try!(Crate::find_by_name(conn, &name));
-    let tx = try!(req.tx());
     let (offset, limit) = try!(req.pagination(10, 100));
-    let (rev_deps, total) = try!(krate.reverse_dependencies(tx, offset, limit));
-    let rev_deps = rev_deps.into_iter().map(|(dep, crate_name)| {
-        dep.encodable(&crate_name)
-    }).collect();
+    let (rev_deps, total) = try!(krate.reverse_dependencies(conn, offset, limit));
+    let rev_deps = rev_deps.into_iter()
+        .map(|(dep, crate_name, downloads)| dep.encodable(&crate_name, Some(downloads)))
+        .collect();
 
     #[derive(RustcEncodable)]
     struct R { dependencies: Vec<EncodableDependency>, meta: Meta }

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -449,9 +449,9 @@ impl Crate {
 
         let stmt = try!(conn.prepare(&fetch_sql));
         let vec: Vec<_> = try!(stmt.query(&[&self.id, &offset, &limit]))
-                                   .iter().map(|r| {
-            (Model::from_row(&r), r.get("crate_name"))
-        }).collect();
+            .iter()
+            .map(|r| (Model::from_row(&r), r.get("crate_name"), r.get("crate_downloads")))
+            .collect();
         let stmt = try!(conn.prepare(&count_sql));
         let cnt: i64 = try!(stmt.query(&[&self.id])).iter().next().unwrap().get(0);
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -435,22 +435,22 @@ impl Crate {
               WHERE dependencies.crate_id = $1
                 AND versions.num = crates.max_version
         ";
-        let fetch_sql = format!("SELECT DISTINCT ON (crate_name)
+        let fetch_sql = format!("SELECT DISTINCT ON (crate_downloads, crate_name)
                                         dependencies.*,
                                         crates.downloads AS crate_downloads,
                                         crates.name AS crate_name
                                         {}
+                               ORDER BY crate_downloads DESC
                                  OFFSET $2
                                   LIMIT $3",
                                 select_sql);
         let count_sql = format!("SELECT COUNT(DISTINCT(crates.id)) {}", select_sql);
 
         let stmt = try!(conn.prepare(&fetch_sql));
-        let mut vec: Vec<_> = try!(stmt.query(&[&self.id, &offset, &limit]))
+        let vec: Vec<_> = try!(stmt.query(&[&self.id, &offset, &limit]))
             .iter()
             .map(|r| (Model::from_row(&r), r.get("crate_name"), r.get("crate_downloads")))
             .collect();
-        vec.sort_by(|a: &(_, _, i32), b: &(_, _, i32)| b.2.cmp(&a.2));
         let stmt = try!(conn.prepare(&count_sql));
         let cnt: i64 = try!(stmt.query(&[&self.id])).iter().next().unwrap().get(0);
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -432,13 +432,11 @@ impl Crate {
                 ON versions.id = dependencies.version_id
               INNER JOIN crates
                 ON crates.id = versions.crate_id
-              INNER JOIN crate_downloads
-                ON crate_downloads.crate_id = versions.crate_id
               WHERE dependencies.crate_id = $1
                 AND versions.num = crates.max_version
         ";
         let fetch_sql = format!("SELECT dependencies.*,
-                                        crate_downloads.downloads AS crate_downloads,
+                                        crates.downloads AS crate_downloads,
                                         crates.name AS crate_name
                                         {}
                                ORDER BY crate_downloads DESC

--- a/src/version.rs
+++ b/src/version.rs
@@ -296,7 +296,7 @@ pub fn dependencies(req: &mut Request) -> CargoResult<Response> {
     let tx = try!(req.tx());
     let deps = try!(version.dependencies(tx));
     let deps = deps.into_iter().map(|(dep, crate_name)| {
-        dep.encodable(&crate_name)
+        dep.encodable(&crate_name, None)
     }).collect();
 
     #[derive(RustcEncodable)]


### PR DESCRIPTION
Fixes #495 

I swapped the redundant arrow link on the right for the download count, I don't think anybody used it (?).
