### PR TITLE
Fix #529 - Scroll position is reset when going back in history

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -1,8 +1,9 @@
 import Ember from 'ember';
 import config from './config/environment';
 import googlePageview from './mixins/google-pageview';
+import RouterScroll from 'ember-router-scroll';
 
-const Router = Ember.Router.extend(googlePageview, {
+const Router = Ember.Router.extend(googlePageview, RouterScroll, {
     location: config.locationType
 });
 

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,8 @@ module.exports = function(environment) {
     modulePrefix: 'cargo',
     environment: environment,
     baseURL: '/',
-    locationType: 'auto',
+    locationType: 'router-scroll',
+    historySupportMiddleware: true,
     EmberENV: {
       FEATURES: {
         // Here you can enable experimental features on an ember canary build

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "ember-resolver": "^2.0.3",
     "ember-rl-dropdown": "0.7.1",
     "ember-route-alias": "^0.1.3",
+    "ember-router-scroll": "0.1.0",
     "ember-suave": "4.0.0",
     "ember-welcome-page": "^1.0.1",
     "emberx-select": "2.2.2",


### PR DESCRIPTION
Fixes #529 
Uses https://github.com/dollarshaveclub/ember-router-scroll.
Followed the usage steps given.