### PR TITLE
Add Gitlab CI badge support.

### DIFF
--- a/app/components/badge-gitlab.js
+++ b/app/components/badge-gitlab.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+    tagName: 'span',
+    classNames: ['badge'],
+    repository: Ember.computed.alias('badge.attributes.repository'),
+    branch: Ember.computed('badge.attributes.branch', function() {
+        return this.get('badge.attributes.branch') || 'master';
+    }),
+    text: Ember.computed('badge', function() {
+        return `Gitlab build status for the ${ this.get('branch') } branch`;
+    })
+});

--- a/app/mirage/fixtures/search.js
+++ b/app/mirage/fixtures/search.js
@@ -32,6 +32,13 @@ export default {
                     "repository": "huonw/external_mixin"
                 },
                 "badge_type": "travis-ci"
+            },
+            {
+                "attributes": {
+                    "branch": "master",
+                    "repository": "huonw/external_mixin"
+                },
+                "badge_type": "gitlab"
             }
         ],
         "versions": null

--- a/app/templates/components/badge-gitlab.hbs
+++ b/app/templates/components/badge-gitlab.hbs
@@ -1,0 +1,6 @@
+<a href="https://gitlab.com/{{ repository }}/pipelines">
+    <img
+        src="https://gitlab.com/{{ repository }}/badges/{{ branch }}/build.svg"
+        alt="{{ text }}"
+        title="{{ text }}" />
+</a>

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -24,7 +24,9 @@ test('searching for "rust"', function(assert) {
         hasText(assert, '#crates .row:first .desc .info', 'rust_mixin');
         findWithAssert('#crates .row:first .desc .info .vers img[alt="0.0.1"]');
 
+        findWithAssert('#crates .row:first .desc .info .badge:first a[href="https://ci.appveyor.com/project/huonw/external_mixin"]');
         findWithAssert('#crates .row:first .desc .info .badge:first a img[src="https://ci.appveyor.com/api/projects/status/github/huonw/external_mixin?svg=true&branch=master"]');
+        findWithAssert('#crates .row:first .desc .info .badge:eq(1) a[href="https://travis-ci.org/huonw/external_mixin"]');
         findWithAssert('#crates .row:first .desc .info .badge:eq(1) a img[src="https://travis-ci.org/huonw/external_mixin.svg?branch=master"]');
 
         hasText(assert, '#crates .row:first .desc .summary', 'Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)');

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -26,8 +26,10 @@ test('searching for "rust"', function(assert) {
 
         findWithAssert('#crates .row:first .desc .info .badge:first a[href="https://ci.appveyor.com/project/huonw/external_mixin"]');
         findWithAssert('#crates .row:first .desc .info .badge:first a img[src="https://ci.appveyor.com/api/projects/status/github/huonw/external_mixin?svg=true&branch=master"]');
-        findWithAssert('#crates .row:first .desc .info .badge:eq(1) a[href="https://travis-ci.org/huonw/external_mixin"]');
-        findWithAssert('#crates .row:first .desc .info .badge:eq(1) a img[src="https://travis-ci.org/huonw/external_mixin.svg?branch=master"]');
+        findWithAssert('#crates .row:first .desc .info .badge:eq(1) a[href="https://gitlab.com/huonw/external_mixin/pipelines"]');
+        findWithAssert('#crates .row:first .desc .info .badge:eq(1) a img[src="https://gitlab.com/huonw/external_mixin/badges/master/build.svg"]');
+        findWithAssert('#crates .row:first .desc .info .badge:eq(2) a[href="https://travis-ci.org/huonw/external_mixin"]');
+        findWithAssert('#crates .row:first .desc .info .badge:eq(2) a img[src="https://travis-ci.org/huonw/external_mixin.svg?branch=master"]');
 
         hasText(assert, '#crates .row:first .desc .summary', 'Yo dawg, use Rust to generate Rust, right in your Rust. (See `external_mixin` to use scripting languages.)');
         hasText(assert, '#crates .row:first .downloads', '477');


### PR DESCRIPTION
Resolves #537.

I tested this code by modifying `app/mirage/fixtures/search.js` with data from my `gattii` crate, which has Gitlab CI configured. None of the existing projects in this file have gitlab CI, so should I add my `gattii` crate information to this file? If so, is there an easy way to grab this info (maybe a REST call to the real crates.io)?

I know there are badge tests in `src/tests/badge.rs`, but it's all one big complicated test. Should I try to integrate a gitlab badge into that existing test or create a new one? I'm not really certain what to do here that would be best so some guidance here would be helpful.