### PR TITLE
Add development-tools.procedural-macro-helpers category

### DIFF
--- a/src/categories.toml
+++ b/src/categories.toml
@@ -153,6 +153,12 @@ Crates to help you better interface with other languages. This \
 includes binding generators and helpful language constructs.\
 """
 
+[development-tools.categories.procedural-macro-helpers]
+name = "Procedural macro helpers"
+description = """
+Crates to help you write procedural macros in Rust.
+"""
+
 [development-tools.categories.profiling]
 name = "Profiling"
 description = """


### PR DESCRIPTION
There are two major tools that I think deserve this category on their own, `syn` and `quote`. I'm also working on a small helper for parsing attributes inside procedural macros, which doesn't fit into any of the existing categories directly.

@dtolnay have you looked into categories for `syn` and `quote` yet? Would you apply this category (or something similar) if it existed?

I'm not 100% sold on the name, if anyone can suggest a better one I'd be happy to change it.