### PR TITLE
Fix reverse dependencies page that didn't work after ember upgrade

### DIFF
--- a/app/adapters/dependency.js
+++ b/app/adapters/dependency.js
@@ -8,7 +8,7 @@ export default ApplicationAdapter.extend({
         delete query.reverse;
         var { crate } = query;
         delete query.crate;
-        return this.ajax(`${this.urlPrefix()}/crates/${crate.get('id')}/reverse_dependencies`,
+        return this.ajax(`/${this.urlPrefix()}/crates/${crate.get('id')}/reverse_dependencies`,
             'GET', { data: query });
     },
 });

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -27,10 +27,10 @@ export default function() {
 
     this.get('/api/v1/crates/nanomsg', () => crateFixture);
     this.get('/api/v1/crates/nanomsg/versions', () => crateVersionsFixture);
-    this.get('/api/v1/crates/nanomsg/0.4.2/authors', () => crateAuthorsFixture);
+    this.get('/api/v1/crates/nanomsg/:version_num/authors', () => crateAuthorsFixture);
     this.get('/api/v1/crates/nanomsg/owners', () => crateOwnersFixture);
     this.get('/api/v1/crates/nanomsg/reverse_dependencies', () => crateReverseDependenciesFixture);
-    this.get('/api/v1/crates/nanomsg/0.4.2/dependencies', () => crateDependenciesFixture);
+    this.get('/api/v1/crates/nanomsg/:version_num/dependencies', () => crateDependenciesFixture);
     this.get('/api/v1/crates/nanomsg/downloads', () => crateDownloadsFixture);
     this.get('/api/v1/keywords/network', () => keywordFixture);
 }

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,6 +1,14 @@
 import summaryFixture from '../mirage/fixtures/summary';
 import searchFixture from '../mirage/fixtures/search';
 import categoriesFixture from '../mirage/fixtures/categories';
+import crateFixture from '../mirage/fixtures/crate';
+import crateVersionsFixture from '../mirage/fixtures/crate_versions';
+import crateAuthorsFixture from '../mirage/fixtures/crate_authors';
+import crateOwnersFixture from '../mirage/fixtures/crate_owners';
+import crateReverseDependenciesFixture from '../mirage/fixtures/crate_reverse_dependencies';
+import crateDependenciesFixture from '../mirage/fixtures/crate_dependencies';
+import crateDownloadsFixture from '../mirage/fixtures/crate_downloads';
+import keywordFixture from '../mirage/fixtures/keyword';
 
 export default function() {
     this.get('/summary', () => summaryFixture);
@@ -16,6 +24,15 @@ export default function() {
     });
 
     this.get('/api/v1/categories', () => categoriesFixture);
+
+    this.get('/api/v1/crates/nanomsg', () => crateFixture);
+    this.get('/api/v1/crates/nanomsg/versions', () => crateVersionsFixture);
+    this.get('/api/v1/crates/nanomsg/0.4.2/authors', () => crateAuthorsFixture);
+    this.get('/api/v1/crates/nanomsg/owners', () => crateOwnersFixture);
+    this.get('/api/v1/crates/nanomsg/reverse_dependencies', () => crateReverseDependenciesFixture);
+    this.get('/api/v1/crates/nanomsg/0.4.2/dependencies', () => crateDependenciesFixture);
+    this.get('/api/v1/crates/nanomsg/downloads', () => crateDownloadsFixture);
+    this.get('/api/v1/keywords/network', () => keywordFixture);
 }
 
 function pageParams(request) {

--- a/mirage/fixtures/crate.js
+++ b/mirage/fixtures/crate.js
@@ -1,0 +1,248 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "categories": [],
+    "crate": {
+        "badges": [],
+        "categories": [],
+        "created_at": "2014-12-08T02:08:06Z",
+        "description": "A high-level, Rust idiomatic wrapper around nanomsg.",
+        "documentation": "https://github.com/thehydroimpulse/nanomsg.rs",
+        "downloads": 3888,
+        "homepage": "https://github.com/thehydroimpulse/nanomsg.rs",
+        "id": "nanomsg",
+        "keywords": [
+            "network",
+        ],
+        "license": "MIT",
+        "links": {
+            "owners": "/api/v1/crates/nanomsg/owners",
+            "reverse_dependencies": "/api/v1/crates/nanomsg/reverse_dependencies",
+            "version_downloads": "/api/v1/crates/nanomsg/downloads",
+            "versions": null
+        },
+        "max_version": "0.6.1",
+        "name": "nanomsg",
+        "repository": "https://github.com/thehydroimpulse/nanomsg.rs",
+        "updated_at": "2016-12-27T08:40:00Z",
+        "versions": [
+            40905,
+            28431,
+            21273,
+            18445,
+            17384,
+            13574,
+            9014,
+            8236,
+            7190,
+            4944,
+            940,
+            924
+        ]
+    },
+    "keywords": [
+        {
+            "crates_cnt": 38,
+            "created_at": "2014-11-23T06:47:40Z",
+            "id": "network",
+            "keyword": "network"
+        }
+    ],
+    "versions": [
+        {
+            "crate": "nanomsg",
+            "created_at": "2016-12-27T08:40:00Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.6.1/download",
+            "downloads": 260,
+            "features": {
+                "bundled": [
+                    "nanomsg-sys/bundled"
+                ]
+            },
+            "id": 40905,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.6.1/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.6.1/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.6.1/downloads"
+            },
+            "num": "0.6.1",
+            "updated_at": "2016-12-27T08:40:00Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2016-06-10T20:03:55Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.6.0/download",
+            "downloads": 904,
+            "features": {},
+            "id": 28431,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.6.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.6.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.6.0/downloads"
+            },
+            "num": "0.6.0",
+            "updated_at": "2016-06-10T20:03:55Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2016-01-24T22:07:58Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.5.0/download",
+            "downloads": 1217,
+            "features": {},
+            "id": 21273,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.5.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.5.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.5.0/downloads"
+            },
+            "num": "0.5.0",
+            "updated_at": "2016-01-24T22:07:58Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-11-23T12:10:09Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.4.2/download",
+            "downloads": 318,
+            "features": {},
+            "id": 18445,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.4.2/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.4.2/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.4.2/downloads"
+            },
+            "num": "0.4.2",
+            "updated_at": "2015-12-16T00:01:56Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-10-29T22:13:45Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.4.1/download",
+            "downloads": 168,
+            "features": {},
+            "id": 17384,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.4.1/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.4.1/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.4.1/downloads"
+            },
+            "num": "0.4.1",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-07-23T05:54:44Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.4.0/download",
+            "downloads": 311,
+            "features": {},
+            "id": 13574,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.4.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.4.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.4.0/downloads"
+            },
+            "num": "0.4.0",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-04-18T20:45:03Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.4/download",
+            "downloads": 237,
+            "features": {},
+            "id": 9014,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.4/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.4/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.4/downloads"
+            },
+            "num": "0.3.4",
+            "updated_at": "2015-12-15T00:03:39Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-04-06T18:57:47Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.3/download",
+            "downloads": 99,
+            "features": {},
+            "id": 8236,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.3/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.3/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.3/downloads"
+            },
+            "num": "0.3.3",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-03-26T06:51:10Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.2/download",
+            "downloads": 98,
+            "features": {},
+            "id": 7190,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.2/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.2/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.2/downloads"
+            },
+            "num": "0.3.2",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-02-12T20:20:32Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.1/download",
+            "downloads": 95,
+            "features": {},
+            "id": 4944,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.1/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.1/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.1/downloads"
+            },
+            "num": "0.3.1",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2014-12-08T16:21:01Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.0/download",
+            "downloads": 102,
+            "features": {},
+            "id": 940,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.0/downloads"
+            },
+            "num": "0.3.0",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2014-12-08T02:08:06Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.2.0/download",
+            "downloads": 79,
+            "features": {},
+            "id": 924,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.2.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.2.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.2.0/downloads"
+            },
+            "num": "0.2.0",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        }
+    ]
+};

--- a/mirage/fixtures/crate_authors.js
+++ b/mirage/fixtures/crate_authors.js
@@ -1,0 +1,16 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "meta": {
+        "names": [
+            "Daniel Fagnan <someone@example.com>",
+            "Jason E. Aten",
+            "David C. Bishop",
+            "Dennis Lawler",
+            "Zachary Tong",
+            "Dan Burkert",
+            "Benoît Labaere <someoneelse@example.com>",
+            "Chip Collier"
+        ]
+    },
+    "users": []
+};

--- a/mirage/fixtures/crate_dependencies.js
+++ b/mirage/fixtures/crate_dependencies.js
@@ -1,0 +1,27 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "dependencies": [
+        {
+            "crate_id": "libc",
+            "default_features": true,
+            "features": "",
+            "id": 146231,
+            "kind": "normal",
+            "optional": false,
+            "req": "^0.2.18",
+            "target": null,
+            "version_id": 40905
+        },
+        {
+            "crate_id": "nanomsg-sys",
+            "default_features": true,
+            "features": "",
+            "id": 146232,
+            "kind": "normal",
+            "optional": false,
+            "req": "^0.6.1",
+            "target": null,
+            "version_id": 40905
+        }
+    ]
+};

--- a/mirage/fixtures/crate_downloads.js
+++ b/mirage/fixtures/crate_downloads.js
@@ -1,0 +1,35 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "meta": {
+        "extra_downloads": [
+            {
+                "date": "2017-02-02",
+                "downloads": 41
+            },
+            {
+                "date": "2017-02-07",
+                "downloads": 14
+            }
+        ]
+    },
+    "version_downloads": [
+        {
+            "date": "2017-02-10T00:00:00Z",
+            "downloads": 2,
+            "id": 3023900,
+            "version": 40905
+        },
+        {
+            "date": "2017-02-10T00:00:00Z",
+            "downloads": 1,
+            "id": 3024236,
+            "version": 18445
+        },
+        {
+            "date": "2017-02-11T00:00:00Z",
+            "downloads": 1,
+            "id": 3027018,
+            "version": 40905
+        }
+    ]
+};

--- a/mirage/fixtures/crate_owners.js
+++ b/mirage/fixtures/crate_owners.js
@@ -1,0 +1,23 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "users": [
+        {
+            "avatar": "https://avatars.githubusercontent.com/u/565790?v=3",
+            "email": "someone@example.com",
+            "id": 2,
+            "kind": "user",
+            "login": "thehydroimpulse",
+            "name": "Daniel Fagnan",
+            "url": "https://github.com/thehydroimpulse"
+        },
+        {
+            "avatar": "https://avatars.githubusercontent.com/u/9447137?v=3",
+            "email": null,
+            "id": 303,
+            "kind": "user",
+            "login": "blabaere",
+            "name": "Benoît Labaere",
+            "url": "https://github.com/blabaere"
+        }
+    ]
+};

--- a/mirage/fixtures/crate_reverse_dependencies.js
+++ b/mirage/fixtures/crate_reverse_dependencies.js
@@ -1,0 +1,19 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "dependencies": [
+        {
+            "crate_id": "unicorn-rpc",
+            "default_features": true,
+            "features": "",
+            "id": 90880,
+            "kind": "normal",
+            "optional": false,
+            "req": "^0.5.0",
+            "target": null,
+            "version_id": 28674
+        }
+    ],
+    "meta": {
+        "total": 1
+    }
+};

--- a/mirage/fixtures/crate_versions.js
+++ b/mirage/fixtures/crate_versions.js
@@ -1,0 +1,212 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "versions": [
+        {
+            "crate": "nanomsg",
+            "created_at": "2016-12-27T08:40:00Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.6.1/download",
+            "downloads": 260,
+            "features": {
+                "bundled": [
+                    "nanomsg-sys/bundled"
+                ]
+            },
+            "id": 40905,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.6.1/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.6.1/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.6.1/downloads"
+            },
+            "num": "0.6.1",
+            "updated_at": "2016-12-27T08:40:00Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2016-06-10T20:03:55Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.6.0/download",
+            "downloads": 904,
+            "features": {
+            },
+            "id": 28431,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.6.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.6.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.6.0/downloads"
+            },
+            "num": "0.6.0",
+            "updated_at": "2016-06-10T20:03:55Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2016-01-24T22:07:58Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.5.0/download",
+            "downloads": 1217,
+            "features": {
+            },
+            "id": 21273,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.5.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.5.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.5.0/downloads"
+            },
+            "num": "0.5.0",
+            "updated_at": "2016-01-24T22:07:58Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-11-23T12:10:09Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.4.2/download",
+            "downloads": 318,
+            "features": {
+            },
+            "id": 18445,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.4.2/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.4.2/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.4.2/downloads"
+            },
+            "num": "0.4.2",
+            "updated_at": "2015-12-16T00:01:56Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-10-29T22:13:45Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.4.1/download",
+            "downloads": 168,
+            "features": {
+            },
+            "id": 17384,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.4.1/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.4.1/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.4.1/downloads"
+            },
+            "num": "0.4.1",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-07-23T05:54:44Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.4.0/download",
+            "downloads": 311,
+            "features": {
+            },
+            "id": 13574,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.4.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.4.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.4.0/downloads"
+            },
+            "num": "0.4.0",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-04-18T20:45:03Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.4/download",
+            "downloads": 237,
+            "features": {
+            },
+            "id": 9014,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.4/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.4/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.4/downloads"
+            },
+            "num": "0.3.4",
+            "updated_at": "2015-12-15T00:03:39Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-04-06T18:57:47Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.3/download",
+            "downloads": 99,
+            "features": {
+            },
+            "id": 8236,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.3/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.3/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.3/downloads"
+            },
+            "num": "0.3.3",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-03-26T06:51:10Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.2/download",
+            "downloads": 98,
+            "features": {
+            },
+            "id": 7190,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.2/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.2/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.2/downloads"
+            },
+            "num": "0.3.2",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2015-02-12T20:20:32Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.1/download",
+            "downloads": 95,
+            "features": {
+            },
+            "id": 4944,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.1/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.1/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.1/downloads"
+            },
+            "num": "0.3.1",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2014-12-08T16:21:01Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.3.0/download",
+            "downloads": 102,
+            "features": {
+            },
+            "id": 940,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.3.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.3.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.3.0/downloads"
+            },
+            "num": "0.3.0",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        },
+        {
+            "crate": "nanomsg",
+            "created_at": "2014-12-08T02:08:06Z",
+            "dl_path": "/api/v1/crates/nanomsg/0.2.0/download",
+            "downloads": 79,
+            "features": {
+            },
+            "id": 924,
+            "links": {
+                "authors": "/api/v1/crates/nanomsg/0.2.0/authors",
+                "dependencies": "/api/v1/crates/nanomsg/0.2.0/dependencies",
+                "version_downloads": "/api/v1/crates/nanomsg/0.2.0/downloads"
+            },
+            "num": "0.2.0",
+            "updated_at": "2015-12-11T23:54:29Z",
+            "yanked": false
+        }
+    ]
+};

--- a/mirage/fixtures/keyword.js
+++ b/mirage/fixtures/keyword.js
@@ -1,0 +1,9 @@
+// jscs:disable validateQuoteMarks
+export default {
+    "keyword": {
+        "crates_cnt": 38,
+        "created_at": "2014-11-23T06:47:40Z",
+        "id": "network",
+        "keyword": "network"
+    }
+};

--- a/mirage/fixtures/summary.js
+++ b/mirage/fixtures/summary.js
@@ -7,7 +7,7 @@ export default {
         "downloads": 552,
         "homepage": "https://github.com/thehydroimpulse/nanomsg.rs",
         "id": "nanomsg",
-        "keywords": ["nanomsg", "binding", "network", "pub", "sub"],
+        "keywords": ["network"],
         "license": "MIT",
         "links": {
             "owners": "/api/v1/crates/nanomsg/owners",

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -24,7 +24,8 @@
     "currentURL",
     "currentPath",
     "currentRouteName",
-    "hasText"
+    "hasText",
+    "matchesText"
   ],
   "node": false,
   "browser": false,

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -12,3 +12,12 @@ test('visiting a crate page from the front page', function(assert) {
         assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
     });
 });
+
+test('visiting a crate page directly', function(assert) {
+    visit('/crates/nanomsg');
+
+    andThen(function() {
+        assert.equal(currentURL(), '/crates/nanomsg');
+        assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
+    });
+});

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -21,3 +21,12 @@ test('visiting a crate page directly', function(assert) {
         assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
     });
 });
+
+test('navigating to the all versions page', function(assert) {
+    visit('/crates/nanomsg');
+    click('#crate-versions span.small a');
+
+    andThen(function() {
+        matchesText(assert, '.info', /All 12 versions of nanomsg since December \d+, 2014/);
+    });
+});

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -30,3 +30,16 @@ test('navigating to the all versions page', function(assert) {
         matchesText(assert, '.info', /All 12 versions of nanomsg since December \d+, 2014/);
     });
 });
+
+test('navigating to the reverse dependencies page', function(assert) {
+    visit('/crates/nanomsg');
+    click('a:contains("Dependent crates")');
+
+    andThen(function() {
+        assert.equal(currentURL(), '/crates/nanomsg/reverse_dependencies');
+
+        const $revDep = findWithAssert('#crate-all-reverse-dependencies a[href="/crates/unicorn-rpc"]:first');
+
+        hasText(assert, $revDep, 'unicorn-rpc');
+    });
+});

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,0 +1,14 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'cargo/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | crate page');
+
+test('visiting a crate page from the front page', function(assert) {
+    visit('/');
+    click('#just-updated ul > li:first a');
+
+    andThen(function() {
+        assert.equal(currentURL(), '/crates/nanomsg');
+        assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
+    });
+});

--- a/tests/helpers/matches-text.js
+++ b/tests/helpers/matches-text.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Test.registerHelper('matchesText', function(app, assert, selector, expectedRegex) {
+    const $selected = findWithAssert(selector);
+    const $actual = $selected.text().trim().replace(/\s+/g, ' ');
+    assert.notEqual(
+        null,
+        $actual.match(expectedRegex),
+        `Text found ('${$actual}') did not match regex ('${expectedRegex}')`
+    );
+});

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 import './has-text';
+import './matches-text';
 
 export default function startApp(attrs) {
     let application;


### PR DESCRIPTION
Apparently some behavior around `baseURL`/`rootURL` changed with the ember upgrade, and the reverse dependencies adapter constructs a custom URL that started being relative when it should be absolute. 

I also added a bunch more acceptance tests, which meant a bunch more mirage fixtures, to help us feel more confident about ember upgrades not breaking things in the future :)

I merged and deployed the ember upgrade (PR #501) last night, then I reverted the deploy but not the code today when I saw #553. So no git gymnastics needed, just a merge and then a deploy :)
