### PR TITLE
Add explicit size to appveyor badge

### DIFF
--- a/app/templates/components/badge-appveyor.hbs
+++ b/app/templates/components/badge-appveyor.hbs
@@ -2,5 +2,7 @@
     <img
         src="https://ci.appveyor.com/api/projects/status/{{ service }}/{{ repository }}?svg=true&branch={{ branch }}"
         alt="{{ text }}"
+        width="106"
+        height="20"
         title="{{ text }}" />
 </a>


### PR DESCRIPTION
Appveyor badges seem to sporadically not load (for me). Previously, it looked like this:

<img width="743" alt="bildschirmfoto 2017-02-19 um 16 02 22" src="https://cloud.githubusercontent.com/assets/20063/23103558/f7e1eb3a-f6bc-11e6-9a25-af1288fc9bd9.png">

But now, thanks to explicit width and height, it looks at least 42% less shitty:

<img width="844" alt="bildschirmfoto 2017-02-19 um 16 02 45" src="https://cloud.githubusercontent.com/assets/20063/23103563/0a6d5c4e-f6bd-11e6-9751-278ec12d8f1a.png">

I took the 106px width from a "build passing" badge. Let's hope the other variants are of that size, too :)

(Might also be a good idea to do that for the other badges.)