### PR TITLE
Add contact email address in the footer

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -119,4 +119,6 @@
     <a href='http://doc.crates.io'>Getting Started</a>
     <span class="sep">|</span>
     <a href='http://doc.crates.io/guide.html'>Guide</a>
+    <span class="sep">|</span>
+    <a href='mailto:help@crates.io'>Send us an email</a>
 </div>


### PR DESCRIPTION
Update the site to include the email address help@crates.io as described here: rust-lang/crates.io#522 :slightly_smiling_face: 