### PR TITLE
Tweak layout for elements on crate page to fix some small issues with narrow screens

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -65,7 +65,11 @@ body {
     }
 
     .sep { margin: 0 10px; color: darken($html-bg, 10%); }
-    .nav, .menu { @include flex-grow(2); text-align: right; }
+    .nav, .menu {
+        @include flex-grow(2);
+        text-align: right;
+        margin-right: 5px;
+    }
 
     .menu { display: none; }
     .menu ul.dropdown {
@@ -129,6 +133,8 @@ body {
 #mobile-search {
     display: none;
     margin-bottom: 10px;
+    margin-left: 5px;
+    margin-right: 5px;
     input.search {
         width: 100%;
         margin: 0;

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -9,6 +9,7 @@
 
     .info {
         @include display-flex;
+        @include flex-wrap(wrap);
         @include align-items(center);
     }
     h1 {
@@ -316,6 +317,7 @@
     h3 { margin-bottom: 5px; }
     .section {
         @include flex(1);
+        margin-right: 10px;
         li { line-height: 24px; }
         .date { color: $main-color-light; padding-left: 5px; }
     }


### PR DESCRIPTION
- Add some margin to header nav/menu and mobile search field to keep them away from the edges.
- Set flex-wrap: wrap on name/version heading to wrap rather than overflow (and potentially break layout) when the screen is too narrow. This approach is not the best-looking, but a lot better than doing nothing.
- Add some margin to crate-links sections (Fixes #235 ).

Before:
![screen shot 2017-02-22 at 22 09 58](https://cloud.githubusercontent.com/assets/4187449/23233452/2dc04a64-f94f-11e6-9676-a0631c2bb6ef.png)

After:
![screen shot 2017-02-22 at 22 10 29](https://cloud.githubusercontent.com/assets/4187449/23233475/3ee08480-f94f-11e6-9696-22a4271d6e03.png)

Before:
![screen shot 2017-02-22 at 22 12 51](https://cloud.githubusercontent.com/assets/4187449/23233488/4a052802-f94f-11e6-84da-4f68d708f4f4.png)

After:
![screen shot 2017-02-22 at 22 13 11](https://cloud.githubusercontent.com/assets/4187449/23233521/5e41b376-f94f-11e6-9b73-0e981f11caa6.png)

For the `#crate-links.section` margin it also applies to the right-most element(s), which is not quite optimal. An alternative solution without this minor issue is shown below, but this unfortunately makes the gray divider line too long, so I've stuck with the simple solution.

```diff
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -313,11 +313,14 @@
     padding-bottom: 20px;
     border-bottom: 5px solid $gray-border;
     margin-bottom: 30px;
+    margin-left: -5px;
+    margin-right: -5px;

     h3 { margin-bottom: 5px; }
     .section {
         @include flex(1);
-        margin-right: 10px;
+        padding-left: 5px;
+        padding-right: 5px;
         li { line-height: 24px; }
         .date { color: $main-color-light; padding-left: 5px; }
     }
```