### PR TITLE
fix: incorrect host when running tests

### DIFF
--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -99,7 +99,8 @@ impl Bucket {
     pub fn host(&self) -> String {
         format!("{}.s3{}.amazonaws.com", self.name,
                 match self.region {
-                    Some(ref r) => format!("-{}", r),
+                    Some(ref r) if r != "" => format!("-{}", r),
+                    Some(_) => String::new(),
                     None => String::new(),
                 })
     }


### PR DESCRIPTION
As noted in https://github.com/rust-lang/crates.io/issues/493#issuecomment-282514820,
the recorded `http-data` in `src/tests` expects "http://alexcrichton-test.s3.amazonaws.com".
But, as the `S3_REGION` env var is loaded as `Some("")`,
it matches wrong leading to wrong host "http://alexcrichton-test-.s3.amazonaws.com".
This fixes it by handling match when region is empty.