### PR TITLE
Implement request extensions on `T: Request` not `Request`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -101,7 +101,7 @@ pub trait RequestApp {
     fn app(&self) -> &Arc<App>;
 }
 
-impl<'a> RequestApp for Request + 'a {
+impl<T: Request + ?Sized> RequestApp for T {
     fn app(&self) -> &Arc<App> {
         self.extensions().find::<Arc<App>>()
             .expect("Missing app")

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -7,7 +7,6 @@
 
 #![deny(warnings)]
 
-#[macro_use]
 extern crate cargo_registry;
 extern crate postgres;
 extern crate time;

--- a/src/db.rs
+++ b/src/db.rs
@@ -209,7 +209,7 @@ pub trait RequestTransaction {
     fn commit(&self);
 }
 
-impl<'a> RequestTransaction for Request + 'a {
+impl<T: Request + ?Sized> RequestTransaction for T {
     fn db_conn(&self) -> CargoResult<&r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>> {
         self.extensions().find::<Transaction>()
             .expect("Transaction not present in request")

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,6 +1,5 @@
-use conduit::{Request, Method};
+use conduit::Method;
 use conduit_test::MockRequest;
-use postgres::GenericConnection;
 
 use cargo_registry::badge::Badge;
 use cargo_registry::db::RequestTransaction;
@@ -16,8 +15,6 @@ struct BadgeRef {
     gitlab: Badge,
     gitlab_attributes: HashMap<String, String>,
 }
-
-fn tx(req: &Request) -> &GenericConnection { req.tx().unwrap() }
 
 fn set_up() -> (MockRequest, Crate, BadgeRef) {
     let (_b, app, _middle) = ::app();
@@ -88,8 +85,8 @@ fn update_no_badges() {
     let badges = HashMap::new();
 
     // Updating with no badges has no effect
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![]);
 }
 
 #[test]
@@ -102,8 +99,8 @@ fn update_add_appveyor() {
         String::from("appveyor"),
         test_badges.appveyor_attributes
     );
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![test_badges.appveyor]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![test_badges.appveyor]);
 }
 
 #[test]
@@ -116,8 +113,8 @@ fn update_add_travis_ci() {
         String::from("travis-ci"),
         test_badges.travis_ci_attributes
     );
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![test_badges.travis_ci]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![test_badges.travis_ci]);
 }
 
 #[test]
@@ -130,8 +127,8 @@ fn update_add_gitlab() {
         String::from("gitlab"),
         test_badges.gitlab_attributes
     );
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![test_badges.gitlab]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![test_badges.gitlab]);
 }
 
 #[test]
@@ -145,8 +142,8 @@ fn replace_badge() {
         String::from("gitlab"),
         test_badges.gitlab_attributes
     );
-    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![test_badges.gitlab]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges.clone()).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![test_badges.gitlab]);
 
     // Replace with another badge
     badges.clear();
@@ -154,8 +151,8 @@ fn replace_badge() {
         String::from("travis-ci"),
         test_badges.travis_ci_attributes.clone()
     );
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![test_badges.travis_ci]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![test_badges.travis_ci]);
 }
 
 #[test]
@@ -169,8 +166,8 @@ fn update_attributes() {
         String::from("travis-ci"),
         test_badges.travis_ci_attributes
     );
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    let current_badges = krate.badges(tx(&req)).unwrap();
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    let current_badges = krate.badges(req.tx().unwrap()).unwrap();
     assert_eq!(current_badges.len(), 1);
     assert!(current_badges.contains(&test_badges.travis_ci));
 
@@ -189,8 +186,8 @@ fn update_attributes() {
         String::from("travis-ci"),
         badge_attributes_travis_ci2.clone()
     );
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    let current_badges = krate.badges(tx(&req)).unwrap();
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    let current_badges = krate.badges(req.tx().unwrap()).unwrap();
     assert_eq!(current_badges.len(), 1);
     assert!(current_badges.contains(&travis_ci2));
 }
@@ -215,9 +212,9 @@ fn clear_badges() {
         String::from("gitlab"),
         test_badges.gitlab_attributes
     );
-    Badge::update_crate(tx(&req), &krate, badges.clone()).unwrap();
+    Badge::update_crate(req.tx().unwrap(), &krate, badges.clone()).unwrap();
 
-    let current_badges = krate.badges(tx(&req)).unwrap();
+    let current_badges = krate.badges(req.tx().unwrap()).unwrap();
     assert_eq!(current_badges.len(), 3);
     assert!(current_badges.contains(&test_badges.appveyor));
     assert!(current_badges.contains(&test_badges.travis_ci));
@@ -225,8 +222,8 @@ fn clear_badges() {
 
     // Removing all badges
     badges.clear();
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![]);
 }
 
 #[test]
@@ -247,8 +244,8 @@ fn appveyor_extra_keys() {
         test_badges.appveyor_attributes
     );
 
-    Badge::update_crate(tx(&req), &krate, badges).unwrap();
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![test_badges.appveyor]);
+    Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![test_badges.appveyor]);
 }
 
 #[test]
@@ -265,10 +262,10 @@ fn travis_ci_required_keys() {
         test_badges.travis_ci_attributes
     );
 
-    let invalid_badges = Badge::update_crate(tx(&req), &krate, badges).unwrap();
+    let invalid_badges = Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
     assert_eq!(invalid_badges.len(), 1);
     assert!(invalid_badges.contains(&String::from("travis-ci")));
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![]);
 }
 
 #[test]
@@ -285,10 +282,10 @@ fn gitlab_required_keys() {
         test_badges.gitlab_attributes
     );
 
-    let invalid_badges = Badge::update_crate(tx(&req), &krate, badges).unwrap();
+    let invalid_badges = Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
     assert_eq!(invalid_badges.len(), 1);
     assert!(invalid_badges.contains(&String::from("gitlab")));
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![]);
 }
 
 #[test]
@@ -309,8 +306,8 @@ fn unknown_badge() {
         invalid_attributes
     );
 
-    let invalid_badges = Badge::update_crate(tx(&req), &krate, badges).unwrap();
+    let invalid_badges = Badge::update_crate(req.tx().unwrap(), &krate, badges).unwrap();
     assert_eq!(invalid_badges.len(), 1);
     assert!(invalid_badges.contains(&String::from("not-a-badge")));
-    assert_eq!(krate.badges(tx(&req)).unwrap(), vec![]);
+    assert_eq!(krate.badges(req.tx().unwrap()).unwrap(), vec![]);
 }

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,5 +1,4 @@
-use postgres::GenericConnection;
-use conduit::{Handler, Request, Method};
+use conduit::{Handler, Method};
 use conduit_test::MockRequest;
 
 use cargo_registry::db::RequestTransaction;
@@ -53,8 +52,6 @@ fn uppercase() {
     assert_eq!(json.keyword.keyword, "upper".to_string());
 }
 
-fn tx(req: &Request) -> &GenericConnection { req.tx().unwrap() }
-
 #[test]
 fn update_crate() {
     let (_b, app, middle) = ::app();
@@ -69,28 +66,28 @@ fn update_crate() {
     ::mock_keyword(&mut req, "kw1");
     ::mock_keyword(&mut req, "kw2");
 
-    Keyword::update_crate(tx(&req), &krate, &[]).unwrap();
+    Keyword::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 
-    Keyword::update_crate(tx(&req), &krate, &["kw1".to_string()]).unwrap();
+    Keyword::update_crate(req.tx().unwrap(), &krate, &["kw1".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 1);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 
-    Keyword::update_crate(tx(&req), &krate, &["kw2".to_string()]).unwrap();
+    Keyword::update_crate(req.tx().unwrap(), &krate, &["kw2".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 1);
 
-    Keyword::update_crate(tx(&req), &krate, &[]).unwrap();
+    Keyword::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 
-    Keyword::update_crate(tx(&req), &krate, &["kw1".to_string(),
+    Keyword::update_crate(req.tx().unwrap(), &krate, &["kw1".to_string(),
                                               "kw2".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 1);
     assert_eq!(cnt(&mut req, "kw2"), 1);
 
-    Keyword::update_crate(tx(&req), &krate, &[]).unwrap();
+    Keyword::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use rustc_serialize::json::Json;
 
-use conduit::{Handler, Request, Method};
+use conduit::{Handler, Method};
 use semver;
 
 use cargo_registry::db::RequestTransaction;
@@ -27,7 +27,6 @@ fn index() {
     let (v1, v2) = {
         ::mock_user(&mut req, ::user("foo"));
         let (c, _) = ::mock_crate(&mut req, ::krate("foo_vers_index"));
-        let req: &mut Request = &mut req;
         let tx = req.tx().unwrap();
         let m = HashMap::new();
         let v1 = Version::insert(tx, c.id, &sv("2.0.0"), &m, &[]).unwrap();
@@ -47,7 +46,6 @@ fn show() {
     let v = {
         ::mock_user(&mut req, ::user("foo"));
         let (krate, _) = ::mock_crate(&mut req, ::krate("foo_vers_show"));
-        let req: &mut Request = &mut req;
         let tx = req.tx().unwrap();
         Version::insert(tx, krate.id, &sv("2.0.0"), &HashMap::new(), &[]).unwrap()
     };


### PR DESCRIPTION
There are a bunch of tests which are explicitly casting `&MockRequest`
into a `&Request` trait object, because the extension methods provided
are only on the trait object, not anything which implements the trait.

By changing from `Request + 'a` to `T: Request + ?Sized` (which is more
ideomatic anyway), we can just call the method directly on `MockRequest`
in tests.

The deletion of the `#[macro_use]` line was to get the tests to compile locally. It's an unused annotation which emits a warning on my machine.