### PR TITLE
Remove the `max_version` column from Crates

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -29,7 +29,7 @@ export default Ember.Route.extend({
         return crate.get('versions')
             .then(versions => {
                 const version = versions.find(version => version.get('num') === params.version_num);
-                if (!version) {
+                if (params.version_num && !version) {
                     this.controllerFor('application').set('nextFlashError',
                         `Version '${params.version_num}' of crate '${crate.get('name')}' does not exist`);
                 }

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -11,7 +11,7 @@ export default Ember.Route.extend({
         const maxVersion = crate.get('max_version');
 
         // Fall back to the crate's `max_version` property
-        if (!requestedVersion) {
+        if (!requestedVersion && maxVersion !== '0.0.0') {
             params.version_num = maxVersion;
         }
 

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -868,19 +868,6 @@ fn migrations() -> Vec<Migration> {
             tx.execute("DROP TABLE reserved_crate_names", &[])?;
             Ok(())
         }),
-        Migration::new(20170305123234, |tx| {
-            tx.execute("ALTER TABLE crates DROP COLUMN max_version", &[])?;
-            Ok(())
-        }, |tx| {
-            tx.execute("ALTER TABLE crates ADD COLUMN max_version VARCHAR NOT NULL DEFAULT '0.0.0'", &[])?;
-            tx.execute("UPDATE crates SET max_version = COALESCE((
-                SELECT num FROM VERSIONS
-                 WHERE num SIMILAR TO '[0-9]+\\.[0-9]+\\.[0-9]+'
-              ORDER BY split_part(num, '.', 1)::int, split_part(num, '.', 2)::int, split_part(num, '.', 3)::int
-              LIMIT 1
-            ), '0.0.0')", &[])?;
-            Ok(())
-        }),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`
 

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -868,6 +868,12 @@ fn migrations() -> Vec<Migration> {
             tx.execute("DROP TABLE reserved_crate_names", &[])?;
             Ok(())
         }),
+        Migration::new(20170305123234, |tx| {
+            tx.execute("ALTER TABLE crates DROP COLUMN max_version", &[])?;
+            Ok(())
+        }, |_| {
+            panic!("Unreversible migration")
+        }),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`
 

--- a/src/bin/migrate.rs
+++ b/src/bin/migrate.rs
@@ -871,8 +871,15 @@ fn migrations() -> Vec<Migration> {
         Migration::new(20170305123234, |tx| {
             tx.execute("ALTER TABLE crates DROP COLUMN max_version", &[])?;
             Ok(())
-        }, |_| {
-            panic!("Unreversible migration")
+        }, |tx| {
+            tx.execute("ALTER TABLE crates ADD COLUMN max_version VARCHAR NOT NULL DEFAULT '0.0.0'", &[])?;
+            tx.execute("UPDATE crates SET max_version = COALESCE((
+                SELECT num FROM VERSIONS
+                 WHERE num SIMILAR TO '[0-9]+\\.[0-9]+\\.[0-9]+'
+              ORDER BY split_part(num, '.', 1)::int, split_part(num, '.', 2)::int, split_part(num, '.', 3)::int
+              LIMIT 1
+            ), '0.0.0')", &[])?;
+            Ok(())
         }),
     ];
     // NOTE: Generate a new id via `date +"%Y%m%d%H%M%S"`

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -193,7 +193,6 @@ fn krate(name: &str) -> Crate {
         updated_at: time::now().to_timespec(),
         created_at: time::now().to_timespec(),
         downloads: 10,
-        max_version: semver::Version::parse("0.0.0").unwrap(),
         documentation: None,
         homepage: None,
         description: None,

--- a/src/tests/http-data/krate_publish_after_yank_max_version
+++ b/src/tests/http-data/krate_publish_after_yank_max_version
@@ -1,0 +1,41 @@
+===REQUEST 339
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-1.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+
+
+===REQUEST 339
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-2.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+

--- a/src/tests/http-data/krate_yank_max_version
+++ b/src/tests/http-data/krate_yank_max_version
@@ -1,0 +1,41 @@
+===REQUEST 339
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-1.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+
+
+===REQUEST 339
+PUT http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-2.0.0.crate HTTP/1.1
+Accept: */*
+Proxy-Connection: Keep-Alive
+Authorization: AWS AKIAJF3GEK7N44BACDZA:GDxGb6r3SIqo9wXuzHrgMNWekwk=
+Content-Length: 0
+Host: alexcrichton-test.s3.amazonaws.com
+Content-Type: application/x-tar
+Date: Sun, 28 Jun 2015 14:07:17 -0700
+
+
+===RESPONSE 258
+HTTP/1.1 200
+x-amz-request-id: CB0E925D8E3AB3E8
+x-amz-id-2: SiaMwszM1p2TzXlLauvZ6kRKcUCg7HoyBW29vts42w9ArrLwkJWl8vuvPuGFkpM6XGH+YXN852g=
+date: Sun, 28 Jun 2015 21:07:51 GMT
+etag: "d41d8cd98f00b204e9800998ecf8427e"
+content-length: 0
+server: AmazonS3
+

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -337,8 +337,9 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
 
     // Encode everything!
     let crates = crates.into_iter().map(|c| {
-        c.minimal_encodable(None)
-    }).collect();
+        let max_version = c.max_version(tx)?;
+        Ok(c.minimal_encodable(max_version, None))
+    }).collect::<CargoResult<_>>()?;
     let versions = versions.into_iter().map(|v| {
         let id = v.crate_id;
         v.encodable(&map[&id])


### PR DESCRIPTION
Updating columns like this tends to be pretty brittle unless it's done
via a trigger. We can't update this one from a trigger, since PG doesn't
know about semver's comparison rules. Either way, we don't really need
to cache this unless it turns out to be a performance bottleneck. We can
instead calculate the value on the fly.

This does introduce some N+1 queries, and those may end up being a
hotspot. We can definitely get rid of them, but it's a pain in the ass
to do manually and Diesel has support for it built in, so I'd rather
just fix them as we move those endpoints over.