### PR TITLE
Change an HTML id used twice into a class

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -94,7 +94,7 @@ body {
         }
     }
 
-    #current-user-links {
+    .current-user-links {
         display: none;
         left: auto;
         right: 0;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -61,7 +61,7 @@
                     <span class='arrow'></span>
                 {{/rl-dropdown-toggle}}
 
-                {{#rl-dropdown tagName="ul" id="current-user-links" class="dropdown" closeOnChildClick="a:link"}}
+                {{#rl-dropdown tagName="ul" class="dropdown current-user-links" closeOnChildClick="a:link"}}
                     <li>{{#link-to 'dashboard'}}Dashboard{{/link-to}}</li>
                     <li>{{#link-to 'me'}}Account Settings{{/link-to}}</li>
                     <li class='last'>{{#link-to 'logout'}}Sign Out{{/link-to}}</li>
@@ -81,7 +81,7 @@
                 Menu
                 <span class='arrow'></span>
             {{/rl-dropdown-toggle}}
-            {{#rl-dropdown tagName='ul' id='current-user-links' class='dropdown' closeOnChildClick='a:link'}}
+            {{#rl-dropdown tagName='ul' class='dropdown current-user-links' closeOnChildClick='a:link'}}
                 <li>{{#link-to "crates"}}Browse All Crates{{/link-to}}</li>
                 {{#if session.currentUser}}
                     <li>{{#link-to 'dashboard'}}Dashboard{{/link-to}}</li>


### PR DESCRIPTION
Sometimes when I run crates.io locally, and I'm signed in, I get this
error in the js console:

```
Error: Assertion Failed: Attempted to register a view with an id already
in use: current-user-links
```

Id isn't required for rl-dropdowns, so I changed current-user-links to
be a class instead.

r? @alexcrichton 