### PR TITLE
Add security headers

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -342,3 +342,11 @@ h1 {
         padding: 5px;
     }
 }
+
+.arrow-in-list svg {
+    background: #fff;
+}
+
+a.arrow svg {
+    background: #EEECDD;
+}

--- a/app/templates/components/category-list.hbs
+++ b/app/templates/components/category-list.hbs
@@ -3,7 +3,9 @@
         <li>
             {{#link-to 'category' category.slug class='name'}}
                 <span>{{ category.category }} ({{ format-num category.crates_cnt }})</span>
-                {{svg-jar "right-arrow"}}
+                <div class='arrow-in-list'>
+                    {{svg-jar "right-arrow"}}
+                </div>
             {{/link-to}}
         </li>
     {{/each}}

--- a/app/templates/components/crate-list.hbs
+++ b/app/templates/components/crate-list.hbs
@@ -3,7 +3,9 @@
         <li>
             {{#link-to 'crate' crate.id class='name'}}
                 <span>{{ crate.name }} ({{ crate.max_version }})</span>
-                {{svg-jar "right-arrow"}}
+                <div class='arrow-in-list'>
+                    {{svg-jar "right-arrow"}}
+                </div>
             {{/link-to}}
         </li>
     {{/each}}

--- a/app/templates/components/keyword-list.hbs
+++ b/app/templates/components/keyword-list.hbs
@@ -3,7 +3,9 @@
         <li>
             {{#link-to 'keyword' keyword class='name'}}
                 <span>{{ keyword.id }} ({{ format-num keyword.crates_cnt }})</span>
-                {{svg-jar "right-arrow"}}
+                <div class='arrow-in-list'>
+                    {{svg-jar "right-arrow"}}
+                </div>
             {{/link-to}}
         </li>
     {{/each}}

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -40,9 +40,6 @@
     </div>
 </div>
 
-{{! This is used to set the url of to actually download a file }}
-<iframe id='download-frame' style='display:none'></iframe>
-
 {{#if currentVersion.yanked}}
     <div class='crate-info'>
         <div>

--- a/app/templates/crate/versions.hbs
+++ b/app/templates/crate/versions.hbs
@@ -22,7 +22,7 @@
                 {{/if}}
             </div>
             {{#link-to 'crate.version' version.num class='arrow'}}
-                {{svg-jar "right-arrow" style="background-color: #EEECDD"}}
+                {{svg-jar "right-arrow"}}
             {{/link-to}}
         </div>
     {{/each}}

--- a/public/assets/right-arrow.svg
+++ b/public/assets/right-arrow.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background: #FFFFFF;">
+<svg width="20px" height="20px" viewBox="0 0 20 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <polygon fill="#1A9C5D" points="10 15 10 12 5 12 5 8 10 8 10 5 15 10"></polygon>
 </svg>

--- a/src/http.rs
+++ b/src/http.rs
@@ -107,7 +107,7 @@ impl Middleware for SecurityHeadersMiddleware {
                     "default-src 'self'; \
                       connect-src 'self' https://docs.rs; \
                       script-src 'self' https://www.google-analytics.com https://www.google.com; \
-                      style-src 'self' https://www.google.com; \
+                      style-src 'self' https://www.google.com https://ajax.googleapis.com; \
                       img-src *; \
                       object-src 'none'"
                         .into(),

--- a/src/http.rs
+++ b/src/http.rs
@@ -105,6 +105,7 @@ impl Middleware for SecurityHeadersMiddleware {
                 "Content-Security-Policy".into(),
                 vec![
                     "default-src 'self'; \
+                      connect-src 'self' https://docs.rs; \
                       script-src 'self' https://www.google-analytics.com https://www.google.com; \
                       style-src 'self' https://www.google.com; \
                       img-src *; \

--- a/src/http.rs
+++ b/src/http.rs
@@ -91,6 +91,7 @@ pub fn token(token: String) -> Token {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
 pub struct SecurityHeadersMiddleware;
 
 impl Middleware for SecurityHeadersMiddleware {

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,5 @@
+use conduit::{Request, Response};
+use conduit_middleware::Middleware;
 use curl;
 use curl::easy::{Easy, List};
 use oauth2::*;
@@ -6,7 +8,7 @@ use util::{CargoResult, internal, ChainError, human};
 use serde_json;
 use serde::Deserialize;
 use std::str;
-
+use std::error::Error;
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
 /// because custom error-code handling may be desirable. Use
@@ -86,5 +88,40 @@ pub fn token(token: String) -> Token {
         access_token: token,
         scopes: Vec::new(),
         token_type: String::new(),
+    }
+}
+
+pub struct SecurityHeadersMiddleware;
+
+impl Middleware for SecurityHeadersMiddleware {
+    fn after(&self, _: &mut Request, mut res: Result<Response, Box<Error+Send>>)
+        -> Result<Response, Box<Error+Send>> {
+        if let Ok(ref mut response) = res {
+            response.headers.insert(
+                "Content-Security-Policy".into(),
+                vec!["default-src 'self'; \
+                      script-src 'self' https://www.google-analytics.com https://www.google.com; \
+                      style-src 'self' https://www.google.com; \
+                      img-src *; \
+                      object-src 'none'".into()],
+            );
+            response.headers.insert(
+                "X-Content-Type-Options".into(),
+                vec!["nosniff".into()],
+            );
+            response.headers.insert(
+                "X-Frame-Options".into(),
+                vec!["SAMEORIGIN".into()],
+            );
+            response.headers.insert(
+                "X-XSS-Protection".into(),
+                vec!["1; mode=block".into()],
+            );
+            response.headers.insert(
+                "Strict-Transport-Security".into(),
+                vec!["max-age=31536000; includeSubDomains".into()],
+            );
+        }
+        res
     }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -101,6 +101,11 @@ impl Middleware for SecurityHeadersMiddleware {
         mut res: Result<Response, Box<Error + Send>>,
     ) -> Result<Response, Box<Error + Send>> {
         if let Ok(ref mut response) = res {
+            // It would be better if we didn't have to have 'unsafe-eval' in the `script-src`
+            // policy, but google charts (used for the download graph on crate pages) uses `eval`
+            // to load scripts. Remove 'unsafe-eval' if google fixes the issue:
+            // https://github.com/google/google-visualization-issues/issues/1356
+            // or if we switch to a different graph generation library.
             response.headers.insert(
                 "Content-Security-Policy".into(),
                 vec![

--- a/src/http.rs
+++ b/src/http.rs
@@ -117,10 +117,6 @@ impl Middleware for SecurityHeadersMiddleware {
                 "X-XSS-Protection".into(),
                 vec!["1; mode=block".into()],
             );
-            response.headers.insert(
-                "Strict-Transport-Security".into(),
-                vec!["max-age=31536000; includeSubDomains".into()],
-            );
         }
         res
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -106,7 +106,8 @@ impl Middleware for SecurityHeadersMiddleware {
                 vec![
                     "default-src 'self'; \
                       connect-src 'self' https://docs.rs; \
-                      script-src 'self' https://www.google-analytics.com https://www.google.com; \
+                      script-src 'self' 'unsafe-eval' \
+                                 https://www.google-analytics.com https://www.google.com; \
                       style-src 'self' https://www.google.com https://ajax.googleapis.com; \
                       img-src *; \
                       object-src 'none'"

--- a/src/http.rs
+++ b/src/http.rs
@@ -95,16 +95,22 @@ pub fn token(token: String) -> Token {
 pub struct SecurityHeadersMiddleware;
 
 impl Middleware for SecurityHeadersMiddleware {
-    fn after(&self, _: &mut Request, mut res: Result<Response, Box<Error+Send>>)
-        -> Result<Response, Box<Error+Send>> {
+    fn after(
+        &self,
+        _: &mut Request,
+        mut res: Result<Response, Box<Error + Send>>,
+    ) -> Result<Response, Box<Error + Send>> {
         if let Ok(ref mut response) = res {
             response.headers.insert(
                 "Content-Security-Policy".into(),
-                vec!["default-src 'self'; \
+                vec![
+                    "default-src 'self'; \
                       script-src 'self' https://www.google-analytics.com https://www.google.com; \
                       style-src 'self' https://www.google.com; \
                       img-src *; \
-                      object-src 'none'".into()],
+                      object-src 'none'"
+                        .into(),
+                ],
             );
             response.headers.insert(
                 "X-Content-Type-Options".into(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,9 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
         cookie::Key::from_master(app.session_key.as_bytes()),
         env == Env::Production,
     ));
+    if env == Env::Production {
+        m.add(http::SecurityHeadersMiddleware);
+    }
     m.add(app::AppMiddleware::new(app));
 
     // Run each request in a transaction and roll back the transaction if the request results


### PR DESCRIPTION
These headers are all pretty straightforward except CSP. For CSP I
defined the sources based on what was loaded from visiting the main page
and all crates. Images should be safe, so I've allowed them from all
sources.

This should be checked on staging before deploying.

Fixes #586.