### PR TITLE
Local upload instead of S3 to enable publishing in development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,7 +16,6 @@ export TEST_DATABASE_URL=
 
 # Credentials for uploading packages to S3. You can leave these blank if
 # you're not publishing to s3 from your crates.io instance.
-# When running `cargo test`, set S3_BUCKET to `alexcrichton-test`.
 export S3_BUCKET=
 export S3_ACCESS_KEY=
 export S3_SECRET_KEY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ env:
   global:
     - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
     - TEST_DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
-    - S3_BUCKET=alexcrichton-test
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -102,16 +102,7 @@ After following the above instructions:
    export TEST_DATABASE_URL=postgres://postgres@localhost/cargo_registry_test
    ```
 
-2. In your `.env` file, set the s3 bucket to `alexcrichton-test`. No actual
-   requests to s3 will be made; the requests and responses are recorded in
-   files in `tests/http-data` and the s3 bucket name needs to match the
-   requests in the files.
-
-   ```
-   export S3_BUCKET=alexcrichton-test
-   ```
-
-3. Run the backend API server tests:
+2. Run the backend API server tests:
 
    ```
    cargo test

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,10 +7,9 @@ use conduit_middleware::Middleware;
 use git2;
 use oauth2;
 use r2d2;
-use s3;
 use curl::easy::Easy;
 
-use {db, Config};
+use {db, Config, Uploader};
 
 /// The `App` struct holds the main components of the application like
 /// the database connection pool and configurations
@@ -23,7 +22,7 @@ pub struct App {
 
     /// The GitHub OAuth2 configuration
     pub github: oauth2::Config,
-    pub bucket: s3::Bucket,
+    pub uploader: Uploader,
     pub s3_proxy: Option<String>,
     pub session_key: String,
     pub git_repo: Mutex<git2::Repository>,
@@ -64,11 +63,7 @@ impl App {
             database: db::pool(&config.db_url, db_config),
             diesel_database: db::diesel_pool(&config.db_url, diesel_db_config),
             github: github,
-            bucket: s3::Bucket::new(config.s3_bucket.clone(),
-                                    config.s3_region.clone(),
-                                    config.s3_access_key.clone(),
-                                    config.s3_secret_key.clone(),
-                                    config.api_protocol()),
+            uploader: Uploader::new_s3(&config),
             s3_proxy: config.s3_proxy.clone(),
             session_key: config.session_key.clone(),
             git_repo: Mutex::new(repo),

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use oauth2;
 use r2d2;
 use curl::easy::Easy;
 
-use {db, Config, Uploader};
+use {db, Config};
 
 /// The `App` struct holds the main components of the application like
 /// the database connection pool and configurations
@@ -22,7 +22,7 @@ pub struct App {
 
     /// The GitHub OAuth2 configuration
     pub github: oauth2::Config,
-    pub uploader: Uploader,
+
     pub session_key: String,
     pub git_repo: Mutex<git2::Repository>,
     pub git_repo_checkout: PathBuf,
@@ -62,7 +62,6 @@ impl App {
             database: db::pool(&config.db_url, db_config),
             diesel_database: db::diesel_pool(&config.db_url, diesel_db_config),
             github: github,
-            uploader: Uploader::new_s3(&config),
             session_key: config.session_key.clone(),
             git_repo: Mutex::new(repo),
             git_repo_checkout: config.git_repo_checkout.clone(),
@@ -72,7 +71,7 @@ impl App {
 
     pub fn handle(&self) -> Easy {
         let mut handle = Easy::new();
-        if let Some(ref proxy) = self.uploader.proxy() {
+        if let Some(ref proxy) = self.config.uploader.proxy() {
             handle.proxy(proxy).unwrap();
         }
         return handle

--- a/src/app.rs
+++ b/src/app.rs
@@ -23,7 +23,6 @@ pub struct App {
     /// The GitHub OAuth2 configuration
     pub github: oauth2::Config,
     pub uploader: Uploader,
-    pub s3_proxy: Option<String>,
     pub session_key: String,
     pub git_repo: Mutex<git2::Repository>,
     pub git_repo_checkout: PathBuf,
@@ -64,7 +63,6 @@ impl App {
             diesel_database: db::diesel_pool(&config.db_url, diesel_db_config),
             github: github,
             uploader: Uploader::new_s3(&config),
-            s3_proxy: config.s3_proxy.clone(),
             session_key: config.session_key.clone(),
             git_repo: Mutex::new(repo),
             git_repo_checkout: config.git_repo_checkout.clone(),
@@ -74,7 +72,7 @@ impl App {
 
     pub fn handle(&self) -> Easy {
         let mut handle = Easy::new();
-        if let Some(ref proxy) = self.s3_proxy {
+        if let Some(ref proxy) = self.uploader.proxy() {
             handle.proxy(proxy).unwrap();
         }
         return handle

--- a/src/bin/fill-in-user-id.rs
+++ b/src/bin/fill-in-user-id.rs
@@ -11,6 +11,7 @@ extern crate cargo_registry;
 extern crate git2;
 extern crate postgres;
 extern crate rustc_serialize;
+extern crate s3;
 
 use std::path::PathBuf;
 
@@ -20,12 +21,19 @@ use cargo_registry::util::{CargoResult, human};
 #[allow(dead_code)]
 fn main() {
     git2::Repository::init("tmp/test").unwrap();
+    let api_protocol = String::from("https");
+    // Candidate for a no-op uploader
+    let uploader = cargo_registry::Uploader::S3 {
+        bucket: s3::Bucket::new(String::new(),
+                                None,
+                                String::new(),
+                                String::new(),
+                                &api_protocol),
+        proxy: None,
+    };
+
     let config = cargo_registry::Config {
-        s3_bucket: String::new(),
-        s3_access_key: String::new(),
-        s3_secret_key: String::new(),
-        s3_region: None,
-        s3_proxy: None,
+        uploader: uploader,
         session_key: String::new(),
         git_repo_checkout: PathBuf::from("tmp/test"),
         gh_client_id: env("GH_CLIENT_ID"),
@@ -34,7 +42,7 @@ fn main() {
         env: cargo_registry::Env::Production,
         max_upload_size: 0,
         mirror: false,
-        api_protocol: String::from("https"),
+        api_protocol: api_protocol,
     };
     let app = cargo_registry::App::new(&config);
     {

--- a/src/bin/fill-in-user-id.rs
+++ b/src/bin/fill-in-user-id.rs
@@ -34,6 +34,7 @@ fn main() {
         env: cargo_registry::Env::Production,
         max_upload_size: 0,
         mirror: false,
+        api_protocol: String::from("https"),
     };
     let app = cargo_registry::App::new(&config);
     {

--- a/src/bin/fill-in-user-id.rs
+++ b/src/bin/fill-in-user-id.rs
@@ -11,7 +11,6 @@ extern crate cargo_registry;
 extern crate git2;
 extern crate postgres;
 extern crate rustc_serialize;
-extern crate s3;
 
 use std::path::PathBuf;
 
@@ -22,16 +21,7 @@ use cargo_registry::util::{CargoResult, human};
 fn main() {
     git2::Repository::init("tmp/test").unwrap();
     let api_protocol = String::from("https");
-    // Candidate for a no-op uploader
-    let uploader = cargo_registry::Uploader::S3 {
-        bucket: s3::Bucket::new(String::new(),
-                                None,
-                                String::new(),
-                                String::new(),
-                                &api_protocol),
-        proxy: None,
-    };
-
+    let uploader = cargo_registry::Uploader::NoOp;
     let config = cargo_registry::Config {
         uploader: uploader,
         session_key: String::new(),

--- a/src/bin/fill-in-user-id.rs
+++ b/src/bin/fill-in-user-id.rs
@@ -14,7 +14,7 @@ extern crate rustc_serialize;
 
 use std::path::PathBuf;
 
-use cargo_registry::{http, env, App};
+use cargo_registry::{http, env, App, Replica};
 use cargo_registry::util::{CargoResult, human};
 
 #[allow(dead_code)]
@@ -31,7 +31,7 @@ fn main() {
         db_url: env("DATABASE_URL"),
         env: cargo_registry::Env::Production,
         max_upload_size: 0,
-        mirror: false,
+        mirror: Replica::Primary,
         api_protocol: api_protocol,
     };
     let app = cargo_registry::App::new(&config);

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -7,7 +7,7 @@ extern crate git2;
 extern crate env_logger;
 extern crate s3;
 
-use cargo_registry::env;
+use cargo_registry::{env, Env};
 use civet::Server;
 use std::env;
 use std::fs::{self, File};
@@ -44,13 +44,13 @@ fn main() {
 
     let heroku = env::var("HEROKU").is_ok();
     let cargo_env = if heroku {
-        cargo_registry::Env::Production
+        Env::Production
     } else {
-        cargo_registry::Env::Development
+        Env::Development
     };
 
     let uploader = match (cargo_env, mirror) {
-        (cargo_registry::Env::Production, false) => {
+        (Env::Production, false) => {
             // `env` panics if these vars are not set
             cargo_registry::Uploader::S3 {
                 bucket: s3::Bucket::new(env("S3_BUCKET"),
@@ -61,7 +61,7 @@ fn main() {
                 proxy: None,
             }
         },
-        (cargo_registry::Env::Production, true) => {
+        (Env::Production, true) => {
             // Read-only mirrors don't need access key or secret key,
             // but they might have them. Definitely need bucket though.
             cargo_registry::Uploader::S3 {
@@ -113,7 +113,7 @@ fn main() {
     } else {
         env::var("PORT").ok().and_then(|s| s.parse().ok()).unwrap_or(8888)
     };
-    let threads = if cargo_env == cargo_registry::Env::Development {1} else {50};
+    let threads = if cargo_env == Env::Development {1} else {50};
     let mut cfg = civet::Config::new();
     cfg.port(port).threads(threads).keep_alive(true);
     let _a = Server::start(cfg, app);

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -73,7 +73,7 @@ fn main() {
                 proxy: None,
             }
         },
-        (cargo_registry::Env::Development, _) => {
+        _ => {
             if env::var("S3_BUCKET").is_ok() {
                 println!("Using S3 uploader");
                 cargo_registry::Uploader::S3 {
@@ -89,8 +89,6 @@ fn main() {
                 cargo_registry::Uploader::Local
             }
         },
-        // See immediately before this match where we choose either prod or dev
-        (cargo_registry::Env::Test, _) => unreachable!(),
     };
 
     let config = cargo_registry::Config {

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -5,6 +5,7 @@ extern crate conduit_middleware;
 extern crate civet;
 extern crate git2;
 extern crate env_logger;
+extern crate s3;
 
 use cargo_registry::env;
 use civet::Server;
@@ -45,12 +46,17 @@ fn main() {
         cargo_registry::Env::Development
     };
     let api_protocol = String::from("https");
+    let uploader = cargo_registry::Uploader::S3 {
+        bucket: s3::Bucket::new(env("S3_BUCKET"),
+                                env::var("S3_REGION").ok(),
+                                env("S3_ACCESS_KEY"),
+                                env("S3_SECRET_KEY"),
+                                &api_protocol),
+        proxy: None,
+    };
+
     let config = cargo_registry::Config {
-        s3_bucket: env("S3_BUCKET"),
-        s3_access_key: env("S3_ACCESS_KEY"),
-        s3_secret_key: env("S3_SECRET_KEY"),
-        s3_region: env::var("S3_REGION").ok(),
-        s3_proxy: None,
+        uploader: uploader,
         session_key: env("SESSION_KEY"),
         git_repo_checkout: checkout,
         gh_client_id: env("GH_CLIENT_ID"),

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -74,14 +74,19 @@ fn main() {
             }
         },
         (cargo_registry::Env::Development, _) => {
-            // Allow for any of these to be blank in development
-            cargo_registry::Uploader::S3 {
-                bucket: s3::Bucket::new(env::var("S3_BUCKET").unwrap_or(String::new()),
-                                        env::var("S3_REGION").ok(),
-                                        env::var("S3_ACCESS_KEY").unwrap_or(String::new()),
-                                        env::var("S3_SECRET_KEY").unwrap_or(String::new()),
-                                        &api_protocol),
-                proxy: None,
+            if env::var("S3_BUCKET").is_ok() {
+                println!("Using S3 uploader");
+                cargo_registry::Uploader::S3 {
+                    bucket: s3::Bucket::new(env("S3_BUCKET"),
+                                            env::var("S3_REGION").ok(),
+                                            env::var("S3_ACCESS_KEY").unwrap_or(String::new()),
+                                            env::var("S3_SECRET_KEY").unwrap_or(String::new()),
+                                            &api_protocol),
+                    proxy: None,
+                }
+            } else {
+                println!("Using local uploader, crate files will be in the dist directory");
+                cargo_registry::Uploader::Local
             }
         },
         // See immediately before this match where we choose either prod or dev

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -44,6 +44,7 @@ fn main() {
     } else {
         cargo_registry::Env::Development
     };
+    let api_protocol = String::from("https");
     let config = cargo_registry::Config {
         s3_bucket: env("S3_BUCKET"),
         s3_access_key: env("S3_ACCESS_KEY"),
@@ -58,6 +59,7 @@ fn main() {
         env: cargo_env,
         max_upload_size: 10 * 1024 * 1024,
         mirror: env::var("MIRROR").is_ok(),
+        api_protocol: api_protocol,
     };
     let app = cargo_registry::App::new(&config);
     let app = cargo_registry::middleware(Arc::new(app));

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -7,7 +7,7 @@ extern crate git2;
 extern crate env_logger;
 extern crate s3;
 
-use cargo_registry::{env, Env};
+use cargo_registry::{env, Env, Uploader};
 use civet::Server;
 use std::env;
 use std::fs::{self, File};
@@ -52,7 +52,7 @@ fn main() {
     let uploader = match (cargo_env, mirror) {
         (Env::Production, false) => {
             // `env` panics if these vars are not set
-            cargo_registry::Uploader::S3 {
+            Uploader::S3 {
                 bucket: s3::Bucket::new(env("S3_BUCKET"),
                                         env::var("S3_REGION").ok(),
                                         env("S3_ACCESS_KEY"),
@@ -64,7 +64,7 @@ fn main() {
         (Env::Production, true) => {
             // Read-only mirrors don't need access key or secret key,
             // but they might have them. Definitely need bucket though.
-            cargo_registry::Uploader::S3 {
+            Uploader::S3 {
                 bucket: s3::Bucket::new(env("S3_BUCKET"),
                                         env::var("S3_REGION").ok(),
                                         env::var("S3_ACCESS_KEY").unwrap_or(String::new()),
@@ -76,7 +76,7 @@ fn main() {
         _ => {
             if env::var("S3_BUCKET").is_ok() {
                 println!("Using S3 uploader");
-                cargo_registry::Uploader::S3 {
+                Uploader::S3 {
                     bucket: s3::Bucket::new(env("S3_BUCKET"),
                                             env::var("S3_REGION").ok(),
                                             env::var("S3_ACCESS_KEY").unwrap_or(String::new()),
@@ -86,7 +86,7 @@ fn main() {
                 }
             } else {
                 println!("Using local uploader, crate files will be in the dist directory");
-                cargo_registry::Uploader::Local
+                Uploader::Local
             }
         },
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use Uploader;
+use {Uploader, Replica};
 
 #[derive(Clone)]
 pub struct Config {
@@ -11,6 +11,6 @@ pub struct Config {
     pub db_url: String,
     pub env: ::Env,
     pub max_upload_size: u64,
-    pub mirror: bool,
+    pub mirror: Replica,
     pub api_protocol: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,12 +15,5 @@ pub struct Config {
     pub env: ::Env,
     pub max_upload_size: u64,
     pub mirror: bool,
-}
-
-impl Config {
-    pub fn api_protocol(&self) -> &'static str {
-        // When testing we route all API traffic over HTTP so we can
-        // sniff/record it, but everywhere else we use https
-        if self.env == ::Env::Test {"http"} else {"https"}
-    }
+    pub api_protocol: String,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,9 @@
 use std::path::PathBuf;
+use Uploader;
 
 #[derive(Clone)]
 pub struct Config {
-    pub s3_bucket: String,
-    pub s3_region: Option<String>,
-    pub s3_access_key: String,
-    pub s3_secret_key: String,
-    pub s3_proxy: Option<String>,
+    pub uploader: Uploader,
     pub session_key: String,
     pub git_repo_checkout: PathBuf,
     pub gh_client_id: String,

--- a/src/http.rs
+++ b/src/http.rs
@@ -12,7 +12,7 @@ use std::str;
 /// parse_github_response to handle the "common" processing of responses.
 pub fn github(app: &App, url: &str, auth: &Token)
               -> Result<(Easy, Vec<u8>), curl::Error> {
-    let url = format!("{}://api.github.com{}", app.config.api_protocol(), url);
+    let url = format!("{}://api.github.com{}", app.config.api_protocol, url);
     info!("GITHUB HTTP: {}", url);
 
     let mut headers = List::new();

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -888,7 +888,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
     // Upload the crate, return way to delete the crate from the server
     // If the git commands fail below, we shouldn't keep the crate on the
     // server.
-    let (cksum, mut bomb) = app.uploader.upload(req, &krate, max, &vers)?;
+    let (cksum, mut bomb) = app.config.uploader.upload(req, &krate, max, &vers)?;
 
     // Register this crate in our local git repo.
     let git_crate = git::Crate {
@@ -978,7 +978,7 @@ pub fn download(req: &mut Request) -> CargoResult<Response> {
         increment_download_counts(req, crate_name, version)?;
     }
 
-    let redirect_url = req.app().uploader.crate_location(crate_name, version);
+    let redirect_url = req.app().config.uploader.crate_location(crate_name, version);
 
     if req.wants_json() {
         #[derive(RustcEncodable)]

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -18,7 +18,7 @@ use semver;
 use time::{Timespec, Duration};
 use url::Url;
 
-use {Model, User, Keyword, Version, Category, Badge};
+use {Model, User, Keyword, Version, Category, Badge, Replica};
 use app::{App, RequestApp};
 use db::RequestTransaction;
 use dependency::{Dependency, EncodableDependency};
@@ -968,7 +968,7 @@ pub fn download(req: &mut Request) -> CargoResult<Response> {
     // API-only mirrors won't have any crates in their database, and
     // incrementing the download count will look up the crate in the
     // database. Mirrors just want to pass along a redirect URL.
-    if req.app().config.mirror {
+    if req.app().config.mirror == Replica::ReadOnlyMirror {
         let _ = increment_download_counts(req, crate_name, version);
     } else {
         increment_download_counts(req, crate_name, version)?;

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -519,10 +519,6 @@ impl Crate {
         Ok(())
     }
 
-    pub fn s3_path(&self, version: &str) -> String {
-        format!("/crates/{}/{}-{}.crate", self.name, self.name, version)
-    }
-
     pub fn add_version(&mut self,
                        conn: &GenericConnection,
                        ver: &semver::Version,

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -974,7 +974,10 @@ pub fn download(req: &mut Request) -> CargoResult<Response> {
         increment_download_counts(req, crate_name, version)?;
     }
 
-    let redirect_url = req.app().config.uploader.crate_location(crate_name, version);
+    let redirect_url = req.app().config.uploader
+        .crate_location(crate_name, version).ok_or_else(||
+            human("crate files not found")
+        )?;
 
     if req.wants_json() {
         #[derive(RustcEncodable)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub use self::krate::Crate;
 pub use self::model::Model;
 pub use self::user::User;
 pub use self::version::Version;
+pub use self::uploaders::{Uploader, Bomb};
 
 use std::sync::Arc;
 use std::error::Error;
@@ -75,6 +76,7 @@ pub mod model;
 pub mod owner;
 pub mod schema;
 pub mod upload;
+pub mod uploaders;
 pub mod user;
 pub mod util;
 pub mod version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,14 @@ pub enum Env {
     Production,
 }
 
+// There may be more ways to run crates.io servers in the future, such as a
+// mirror that also has private crates that crates.io does not have.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub enum Replica {
+    Primary,
+    ReadOnlyMirror,
+}
+
 pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     let mut api_router = RouteBuilder::new();
 

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -13,6 +13,7 @@ use openssl::sign::Signer;
 use openssl::pkey::PKey;
 use rustc_serialize::base64::{ToBase64, STANDARD};
 
+#[derive(Clone)]
 pub struct Bucket {
     name: String,
     region: Option<String>,

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -85,10 +85,10 @@ fn app() -> (record::Bomb, Arc<App>, conduit_middleware::MiddlewareBuilder) {
 
     let (proxy, bomb) = record::proxy();
     let config = cargo_registry::Config {
-        s3_bucket: env::var("S3_BUCKET").unwrap_or(String::new()),
-        s3_access_key: env::var("S3_ACCESS_KEY").unwrap_or(String::new()),
-        s3_secret_key: env::var("S3_SECRET_KEY").unwrap_or(String::new()),
-        s3_region: env::var("S3_REGION").ok(),
+        s3_bucket: String::from("alexcrichton-test"),
+        s3_access_key: String::new(),
+        s3_secret_key: String::new(),
+        s3_region: None,
         s3_proxy: Some(proxy),
         session_key: "test".to_string(),
         git_repo_checkout: git::checkout(),

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -29,7 +29,7 @@ use cargo_registry::dependency::Kind;
 use cargo_registry::krate::NewCrate;
 use cargo_registry::upload as u;
 use cargo_registry::user::NewUser;
-use cargo_registry::{User, Crate, Version, Keyword, Dependency, Category, Model};
+use cargo_registry::{User, Crate, Version, Keyword, Dependency, Category, Model, Replica};
 use conduit::{Request, Method};
 use conduit_test::MockRequest;
 use diesel::pg::PgConnection;
@@ -108,7 +108,7 @@ fn app() -> (record::Bomb, Arc<App>, conduit_middleware::MiddlewareBuilder) {
         db_url: env("TEST_DATABASE_URL"),
         env: cargo_registry::Env::Test,
         max_upload_size: 1000,
-        mirror: false,
+        mirror: Replica::Primary,
         api_protocol: api_protocol,
     };
     INIT.call_once(|| db_setup(&config.db_url));

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -98,6 +98,9 @@ fn app() -> (record::Bomb, Arc<App>, conduit_middleware::MiddlewareBuilder) {
         env: cargo_registry::Env::Test,
         max_upload_size: 1000,
         mirror: false,
+        // When testing we route all API traffic over HTTP so we can
+        // sniff/record it, but everywhere else we use https
+        api_protocol: String::from("http"),
     };
     INIT.call_once(|| db_setup(&config.db_url));
     let app = App::new(&config);

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -32,18 +32,19 @@ impl Uploader {
         }
     }
 
-    pub fn crate_location(&self, crate_name: &str, version: &str) -> String {
+    pub fn crate_location(&self, crate_name: &str, version: &str)
+                          -> Option<String> {
         match *self {
             Uploader::S3 { ref bucket, .. } => {
-                format!("https://{}/{}",
+                Some(format!("https://{}/{}",
                         bucket.host(),
-                        Uploader::crate_path(crate_name, version))
+                        Uploader::crate_path(crate_name, version)))
             },
             Uploader::Local => {
-                format!("/local_uploads/{}",
-                        Uploader::crate_path(crate_name, version))
+                Some(format!("/local_uploads/{}",
+                        Uploader::crate_path(crate_name, version)))
             }
-            Uploader::NoOp => panic!("no-op uploader does not have crate files"),
+            Uploader::NoOp => None,
         }
     }
 

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -19,7 +19,7 @@ impl Uploader {
                                     config.s3_region.clone(),
                                     config.s3_access_key.clone(),
                                     config.s3_secret_key.clone(),
-                                    config.api_protocol()),
+                                    &config.api_protocol),
             proxy: config.s3_proxy.clone(),
         }
     }

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -1,0 +1,96 @@
+use conduit::Request;
+use krate::Crate;
+use util::{CargoResult, internal, ChainError};
+use util::{LimitErrorReader, HashingReader, read_le_u32};
+use {s3, Config};
+use semver;
+use app::{App, RequestApp};
+use std::sync::Arc;
+
+pub enum Uploader {
+    S3 { bucket: s3::Bucket },
+    // next: LocalUploader {},
+}
+
+impl Uploader {
+    pub fn new_s3(config: &Config) -> Uploader {
+        Uploader::S3 {
+            bucket: s3::Bucket::new(config.s3_bucket.clone(),
+                                    config.s3_region.clone(),
+                                    config.s3_access_key.clone(),
+                                    config.s3_secret_key.clone(),
+                                    config.api_protocol()),
+        }
+    }
+
+    pub fn crate_location(&self, crate_name: &str, version: &str) -> String {
+        match *self {
+            Uploader::S3 { ref bucket } => {
+                format!("https://{}/crates/{}/{}-{}.crate",
+                        bucket.host(),
+                        crate_name, crate_name, version)
+            }
+        }
+    }
+
+    pub fn upload(&self, req: &mut Request, krate: &Crate, max: u64, vers: &semver::Version) -> CargoResult<(Vec<u8>, Bomb)> {
+        match *self {
+            Uploader::S3 { ref bucket } => {
+                let mut handle = req.app().handle();
+                let path = krate.s3_path(&vers.to_string());
+                let (response, cksum) = {
+                    let length = read_le_u32(req.body())?;
+                    let body = LimitErrorReader::new(req.body(), max);
+                    let mut body = HashingReader::new(body);
+                    let mut response = Vec::new();
+                    {
+                        let mut s3req = bucket.put(&mut handle, &path, &mut body,
+                                                       "application/x-tar",
+                                                       length as u64);
+                        s3req.write_function(|data| {
+                            response.extend(data);
+                            Ok(data.len())
+                        }).unwrap();
+                        s3req.perform().chain_error(|| {
+                            internal(format!("failed to upload to S3: `{}`", path))
+                        })?;
+                    }
+                    (response, body.finalize())
+                };
+                if handle.response_code().unwrap() != 200 {
+                    let response = String::from_utf8_lossy(&response);
+                    return Err(internal(format!("failed to get a 200 response from S3: {}",
+                                                response)))
+                }
+
+                Ok((cksum, Bomb {
+                    app: req.app().clone(),
+                    path: Some(path),
+                }))
+            }
+        }
+    }
+
+    pub fn delete(&self, app: Arc<App>, path: &str) -> CargoResult<()> {
+        match *self {
+            Uploader::S3 { ref bucket } => {
+                let mut handle = app.handle();
+                bucket.delete(&mut handle, path).perform()?;
+                Ok(())
+            },
+        }
+    }
+}
+
+pub struct Bomb {
+    app: Arc<App>,
+    pub path: Option<String>,
+}
+
+impl Drop for Bomb {
+    fn drop(&mut self) {
+        if let Some(ref path) = self.path {
+            drop(self.app.uploader.delete(self.app.clone(), &path));
+        }
+    }
+}

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -142,7 +142,9 @@ pub struct Bomb {
 impl Drop for Bomb {
     fn drop(&mut self) {
         if let Some(ref path) = self.path {
-            drop(self.app.config.uploader.delete(self.app.clone(), &path));
+            if let Err(e) = self.app.config.uploader.delete(self.app.clone(), &path) {
+                println!("unable to delete {}, {:?}", path, e);
+            }
         }
     }
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,7 +16,7 @@ pub use self::errors::{CargoError, CargoResult, internal, human, internal_error}
 pub use self::errors::{ChainError, std_error};
 pub use self::hasher::{HashingReader};
 pub use self::head::Head;
-pub use self::io_util::LimitErrorReader;
+pub use self::io_util::{LimitErrorReader, read_le_u32, read_fill};
 pub use self::lazy_cell::LazyCell;
 pub use self::request_proxy::RequestProxy;
 


### PR DESCRIPTION
This should make working on crates.io LOTS easier, I hope :)

In order to test out stuff with a development instance of crates.io running locally, it's nice to be able to publish to your local instance and see what happens. But currently, crates.io tries to upload crate files to S3 even if you don't have any values in the S3 config vars. I've gotten around this by having a commit that comments out the S3 publishing parts and running that code when I want to publish, but that's pretty annoying.

Instead, with this PR, if you're running locally (the env var HEROKU is not set) and you have not set the S3_BUCKET env var, then when you publish a crate to your crates.io with `cargo publish --host file:///path/to/crates.io/tmp/index-co`, it'll put the `.crate` tarball in `dist/local_uploads`. Then if you try to download that crate, it'll take advantage of the static file serving that's already happening for things in `dist` and it'll all work!

You still have to set up github oauth so that you can log in and get a token.

I have to delete all the S3 env vars from `.env` to get this to work, but I didn't remove them from `.env.sample` because I'd rather [fix this](https://github.com/slapresta/rust-dotenv/issues/54) and be able to leave them there as a template.

Also, I hardcoded the S3 bucket to `alexcrichton-test` when running the tests, since the tests fail if you don't have that as the value anyway. And there's also a `NoOp` uploader, because I saw one of the scripts basically constructed an uploader that wouldn't do anything anyway.

I did test that uploading to actual S3 actually still works if you choose to set up a bucket and all the variables. When the HEROKU env var is set (ie we're running in production), the server will still panic if any of these variables aren't set. I also tested that files would still be deleted from s3 (and would also be deleted locally if that's what you're running) if the git commit to the index failed, which I tested by putting a sleep in the new crate function just before the git commit and then moving `tmp/index-co` out of the way while a new crate request was sleeping.

I like how this also makes s3 more of an implementation detail that could be swapped out for some other storage someday, by gathering all the s3 functionality into one spot. I didn't go so far as to make the uploader functionality a a trait+trait objects yet, though.