### PR TITLE
Remove logging of dates from update-downloads

### DIFF
--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -91,8 +91,6 @@ fn collect(tx: &postgres::transaction::Transaction,
                          SET processed = $2, counted = counted + $3
                          WHERE id = $1",
                    &[id, &(download.date < cutoff), &amt])?;
-        println!("{}\n{}", time::at(download.date).rfc822(),
-                 time::at(cutoff).rfc822());
         total += amt as i64;
 
         if amt == 0 {


### PR DESCRIPTION
A not-insignificant portion of our production logs is the update-downloads worker printing the date:

```
Mar 07 11:47:38 crates-io app/worker.1: Mon, 06 Mar 2017 19:47:37 GMT 
Mar 07 11:47:38 crates-io app/worker.1: Tue, 07 Mar 2017 00:00:00 GMT 
Mar 07 11:47:38 crates-io app/worker.1: Mon, 06 Mar 2017 19:47:37 GMT 
Mar 07 11:47:38 crates-io app/worker.1: Tue, 07 Mar 2017 00:00:00 GMT 
Mar 07 11:47:38 crates-io app/worker.1: Mon, 06 Mar 2017 19:47:37 GMT 
```

I think this is printing like... 1000 times every 30 seconds or so. 

In addition to removing log noise, this should hopefully help our papertrail quota stretch a bit farther.