### PR TITLE
Remove pointless column and index from `crate_owners`

### DIFF
--- a/migrations/20170308191449_crate_owners_does_not_need_id/down.sql
+++ b/migrations/20170308191449_crate_owners_does_not_need_id/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE crate_owners DROP CONSTRAINT crate_owners_pkey;
+ALTER TABLE crate_owners ADD CONSTRAINT crate_owners_unique_owner_per_crate UNIQUE (crate_id, owner_id, owner_kind);
+ALTER TABLE crate_owners ADD COLUMN id SERIAL PRIMARY KEY;
+CREATE INDEX index_crate_owners_crate_id ON crate_owners (crate_id);
+DROP INDEX crate_owners_not_deleted;

--- a/migrations/20170308191449_crate_owners_does_not_need_id/up.sql
+++ b/migrations/20170308191449_crate_owners_does_not_need_id/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE crate_owners DROP COLUMN id;
+ALTER TABLE crate_owners DROP CONSTRAINT crate_owners_unique_owner_per_crate;
+ALTER TABLE crate_owners ADD PRIMARY KEY (crate_id, owner_id, owner_kind);
+DROP INDEX index_crate_owners_crate_id;
+CREATE UNIQUE INDEX crate_owners_not_deleted ON crate_owners (crate_id, owner_id, owner_kind) WHERE NOT deleted;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -30,8 +30,7 @@ table! {
 }
 
 table! {
-    crate_owners (id) {
-        id -> Int4,
+    crate_owners (crate_id, owner_id, owner_kind) {
         crate_id -> Int4,
         owner_id -> Int4,
         created_at -> Timestamp,


### PR DESCRIPTION
`crate_owners` has a primary key column called `id`. This column is
never referenced in the code, and is not the real primary key. All
places that we need to uniquely identify a row in this table, we do so
with a combination of `crate_id`, `owner_id`, and `owner_kind`. Let's
just make this the actual primary key.

Additionally, we don't need a separate index on just `crate_id`, PG can
use the primary key index. We can, however, benefit from a duplicate
index that is scoped to `NOT deleted`, as this lets the query in
`Crate#owners` go from

```
 Nested Loop  (cost=0.30..16.41 rows=1 width=200)
   ->  Index Scan using crate_owners_pkey on crate_owners  (cost=0.15..8.23 rows=1 width=4)
         Index Cond: ((crate_id = 1) AND (owner_kind = 0))
         Filter: (NOT deleted)
   ->  Index Scan using users_pkey on users  (cost=0.15..8.17 rows=1 width=200)
         Index Cond: (id = crate_owners.owner_id)
```

to

```
 Nested Loop  (cost=0.27..16.32 rows=1 width=200)
   ->  Index Scan using crate_owners_not_deleted on crate_owners  (cost=0.12..8.14 rows=1 width=4)
         Index Cond: ((crate_id = 1) AND (owner_kind = 0))
   ->  Index Scan using users_pkey on users  (cost=0.15..8.17 rows=1 width=200)
         Index Cond: (id = crate_owners.owner_id)
```
