### PR TITLE
Use the database to generate API tokens

### DIFF
--- a/migrations/20170309122510_generate_api_token_with_sql/down.sql
+++ b/migrations/20170309122510_generate_api_token_with_sql/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ALTER COLUMN api_token DROP DEFAULT;
+DROP FUNCTION random_string(int4);

--- a/migrations/20170309122510_generate_api_token_with_sql/up.sql
+++ b/migrations/20170309122510_generate_api_token_with_sql/up.sql
@@ -1,0 +1,11 @@
+CREATE FUNCTION random_string(int4) RETURNS text AS $$
+  SELECT (array_to_string(array(
+    SELECT substr(
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+      floor(random() * 62)::int4 + 1,
+      1
+    ) FROM generate_series(1, $1)
+  ), ''))
+$$ LANGUAGE SQL;
+
+ALTER TABLE users ALTER COLUMN api_token SET DEFAULT random_string(32);

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -148,7 +148,7 @@ mod test {
 
     fn user(conn: &postgres::transaction::Transaction) -> User{
         User::find_or_insert(conn, 2, "login", None, None, None,
-                             "access_token", "api_token").unwrap()
+                             "access_token").unwrap()
     }
 
     fn crate_downloads(tx: &postgres::transaction::Transaction, id: i32, expected: usize) {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -180,8 +180,8 @@ fn user(login: &str) -> User {
         email: None,
         name: None,
         avatar: None,
-        gh_access_token: User::new_api_token(), // just randomize it
-        api_token: User::new_api_token(),
+        gh_access_token: "some random token".into(),
+        api_token: "some random token".into(),
     }
 }
 
@@ -209,10 +209,13 @@ fn mock_user(req: &mut Request, u: User) -> User {
                                  u.email.as_ref().map(|s| &s[..]),
                                  u.name.as_ref().map(|s| &s[..]),
                                  u.avatar.as_ref().map(|s| &s[..]),
-                                 &u.gh_access_token,
-                                 &u.api_token).unwrap();
-    req.mut_extensions().insert(u.clone());
+                                 &u.gh_access_token).unwrap();
+    sign_in_as(req, &u);
     return u;
+}
+
+fn sign_in_as(req: &mut Request, user: &User) {
+    req.mut_extensions().insert(user.clone());
 }
 
 fn mock_crate(req: &mut Request, krate: Crate) -> (Crate, Version) {


### PR DESCRIPTION
There's a ton of code which is setting this field in misleading ways,
and it seems really odd to pass it to `find_or_insert` when it's
completely ignored in the update case. We can just use a database
default for this, and simplify everything a bit.