### PR TITLE
Port `crates#index` to use Diesel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "s3 0.0.1",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -266,6 +267,7 @@ dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,11 @@ rustc-serialize = "0.3"
 license-exprs = "^1.3"
 dotenv = "0.8.0"
 toml = "0.2"
-diesel = { version = "0.11.0", features = ["postgres", "serde_json"] }
+diesel = { version = "0.11.0", features = ["postgres", "serde_json", "deprecated-time"] }
 diesel_codegen = { version = "0.11.0", features = ["postgres"] }
 r2d2-diesel = "0.11.0"
 diesel_full_text_search = "0.11.0"
+serde_json = "0.9.0"
 
 conduit = "0.8"
 conduit-conditional-get = "0.8"

--- a/migrations/20170307211844_versions_yanked_is_not_nullalbe/down.sql
+++ b/migrations/20170307211844_versions_yanked_is_not_nullalbe/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE versions ALTER COLUMN yanked DROP NOT NULL;

--- a/migrations/20170307211844_versions_yanked_is_not_nullalbe/up.sql
+++ b/migrations/20170307211844_versions_yanked_is_not_nullalbe/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE versions ALTER COLUMN yanked SET NOT NULL;

--- a/src/app.rs
+++ b/src/app.rs
@@ -54,7 +54,8 @@ impl App {
             .helper_threads(if config.env == ::Env::Production {3} else {1})
             .build();
         let diesel_db_config = r2d2::Config::builder()
-            .pool_size(if config.env == ::Env::Production {1} else {1})
+            .pool_size(if config.env == ::Env::Production {50} else {1})
+            .min_idle(if config.env == ::Env::Production {Some(5)} else {None})
             .helper_threads(if config.env == ::Env::Production {3} else {1})
             .build();
 

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -1,12 +1,16 @@
-use util::CargoResult;
-use krate::Crate;
 use Model;
+use krate::Crate;
+use schema::badges;
+use util::CargoResult;
 
-use std::collections::HashMap;
+use diesel::pg::Pg;
+use diesel::prelude::*;
 use pg::GenericConnection;
 use pg::rows::Row;
 use rustc_serialize::Decodable;
 use rustc_serialize::json::{Json, Decoder};
+use serde_json;
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Badge {
@@ -25,6 +29,17 @@ pub enum Badge {
 pub struct EncodableBadge {
     pub badge_type: String,
     pub attributes: HashMap<String, String>,
+}
+
+impl Queryable<badges::SqlType, Pg> for Badge {
+    type Row = (i32, String, serde_json::Value);
+
+    fn build((_, badge_type, attributes): Self::Row) -> Self {
+        let attributes = serde_json::from_value::<HashMap<String, String>>(attributes)
+            .expect("attributes was not a map in the database");
+        Self::from_attributes(&badge_type, &attributes)
+            .expect("invalid badge in the database")
+    }
 }
 
 impl Model for Badge {

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -9,10 +9,13 @@ use std::sync::Arc;
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use curl::easy::Easy;
+use diesel::prelude::*;
+use diesel::pg::{Pg, PgConnection};
+use diesel::pg::upsert::*;
+use diesel_full_text_search::*;
 use license_exprs;
 use pg::GenericConnection;
 use pg::rows::Row;
-use pg::types::ToSql;
 use pg;
 use rustc_serialize::hex::ToHex;
 use rustc_serialize::json;
@@ -31,13 +34,14 @@ use category::EncodableCategory;
 use badge::EncodableBadge;
 use upload;
 use user::RequestUser;
-use owner::{EncodableOwner, Owner, Rights, OwnerKind, Team, rights};
+use owner::{EncodableOwner, Owner, Rights, OwnerKind, Team, rights, CrateOwner};
 use util::errors::NotFound;
 use util::{LimitErrorReader, HashingReader};
 use util::{RequestUtils, CargoResult, internal, ChainError, human};
 use version::EncodableVersion;
+use schema::*;
 
-#[derive(Clone)]
+#[derive(Clone, Queryable, Identifiable, AsChangeset)]
 pub struct Crate {
     pub id: i32,
     pub name: String,
@@ -52,6 +56,19 @@ pub struct Crate {
     pub repository: Option<String>,
     pub max_upload_size: Option<i32>,
 }
+
+/// We literally never want to select textsearchable_index_col
+/// so we provide this type and constant to pass to `.select`
+type AllColumns = (crates::id, crates::name, crates::updated_at,
+    crates::created_at, crates::downloads, crates::description,
+    crates::homepage, crates::documentation, crates::readme, crates::license,
+    crates::repository, crates::max_upload_size);
+
+pub const ALL_COLUMNS: AllColumns = (crates::id, crates::name,
+    crates::updated_at, crates::created_at, crates::downloads,
+    crates::description, crates::homepage, crates::documentation,
+    crates::readme, crates::license, crates::repository,
+    crates::max_upload_size);
 
 #[derive(RustcEncodable, RustcDecodable)]
 pub struct EncodableCrate {
@@ -79,6 +96,133 @@ pub struct CrateLinks {
     pub versions: Option<String>,
     pub owners: Option<String>,
     pub reverse_dependencies: String,
+}
+
+#[derive(Insertable, AsChangeset, Default)]
+#[table_name="crates"]
+pub struct NewCrate<'a> {
+    pub name: &'a str,
+    pub description: Option<&'a str>,
+    pub homepage: Option<&'a str>,
+    pub documentation: Option<&'a str>,
+    pub readme: Option<&'a str>,
+    pub repository: Option<&'a str>,
+    pub license: Option<&'a str>,
+    pub max_upload_size: Option<i32>,
+}
+
+impl<'a> NewCrate<'a> {
+    pub fn create_or_update(
+        mut self,
+        conn: &PgConnection,
+        license_file: Option<&str>,
+        uploader: i32,
+    ) -> CargoResult<Crate> {
+        use diesel::update;
+
+        self.validate(license_file)?;
+        self.ensure_name_not_reserved(conn)?;
+
+        // To avoid race conditions, we try to insert
+        // first so we know whether to add an owner
+        if let Some(krate) = self.save_new_crate(conn, uploader)? {
+            return Ok(krate)
+        }
+
+        // We don't want to change the max_upload_size
+        self.max_upload_size = None;
+
+        let target = crates::table.filter(
+            canon_crate_name(crates::name)
+                .eq(canon_crate_name(self.name)));
+        update(target).set(&self)
+            .returning(ALL_COLUMNS)
+            .get_result(conn)
+            .map_err(Into::into)
+    }
+
+    fn validate(&mut self, license_file: Option<&str>) -> CargoResult<()> {
+        fn validate_url(url: Option<&str>, field: &str) -> CargoResult<()> {
+            let url = match url {
+                Some(s) => s,
+                None => return Ok(())
+            };
+            let url = Url::parse(url).map_err(|_| {
+                human(format!("`{}` is not a valid url: `{}`", field, url))
+            })?;
+            match &url.scheme()[..] {
+                "http" | "https" => {}
+                s => return Err(human(format!("`{}` has an invalid url \
+                                               scheme: `{}`", field, s)))
+            }
+            if url.cannot_be_a_base() {
+                return Err(human(format!("`{}` must have relative scheme \
+                                                        data: {}", field, url)))
+            }
+            Ok(())
+        }
+
+        validate_url(self.homepage, "homepage")?;
+        validate_url(self.documentation, "documentation")?;
+        validate_url(self.repository, "repository")?;
+        self.validate_license(license_file)?;
+        Ok(())
+    }
+
+    fn validate_license(&mut self, license_file: Option<&str>) -> CargoResult<()> {
+        if let Some(ref license) = self.license {
+            for part in license.split("/") {
+               license_exprs::validate_license_expr(part)
+                   .map_err(|e| human(format!("{}; see http://opensource.org/licenses \
+                                              for options, and http://spdx.org/licenses/ \
+                                              for their identifiers", e)))?;
+            }
+        } else if license_file.is_some() {
+            // If no license is given, but a license file is given, flag this
+            // crate as having a nonstandard license. Note that we don't
+            // actually do anything else with license_file currently.
+            self.license = Some("non-standard");
+        }
+        Ok(())
+    }
+
+    fn ensure_name_not_reserved(&self, conn: &PgConnection) -> CargoResult<()> {
+        use schema::reserved_crate_names::dsl::*;
+        use diesel::select;
+        use diesel::expression::dsl::exists;
+
+        let reserved_name = select(exists(reserved_crate_names
+            .filter(canon_crate_name(name).eq(canon_crate_name(self.name)))
+            )).get_result::<bool>(conn)?;
+        if reserved_name {
+            Err(human("cannot upload a crate with a reserved name"))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn save_new_crate(&self, conn: &PgConnection, user_id: i32) -> CargoResult<Option<Crate>> {
+        use schema::crates::dsl::*;
+        use diesel::insert;
+
+        let maybe_inserted = insert(&self.on_conflict_do_nothing()).into(crates)
+            .returning(ALL_COLUMNS)
+            .get_result::<Crate>(conn)
+            .optional()?;
+
+        if let Some(ref krate) = maybe_inserted {
+            let owner = CrateOwner {
+                crate_id: krate.id,
+                owner_id: user_id,
+                created_by: user_id,
+                owner_kind: OwnerKind::User as i32,
+            };
+            insert(&owner).into(crate_owners::table)
+                .execute(conn)?;
+        }
+
+        Ok(maybe_inserted)
+    }
 }
 
 impl Crate {
@@ -490,136 +634,88 @@ impl Model for Crate {
 /// Handles the `GET /crates` route.
 #[allow(trivial_casts)]
 pub fn index(req: &mut Request) -> CargoResult<Response> {
-    let conn = req.tx()?;
+    let conn = req.db_conn()?;
     let (offset, limit) = req.pagination(10, 100)?;
-    let query = req.query();
-    let sort = query.get("sort").map(|s| &s[..]).unwrap_or("alpha");
-    let sort_sql = match sort {
-        "downloads" => "crates.downloads DESC",
-        _ => "crates.name ASC",
-    };
+    let params = req.query();
 
-    // Different queries for different parameters.
-    //
-    // Sure wish we had an arel-like thing here...
-    let mut pattern = String::new();
-    let mut id = -1;
-    let (mut needs_id, mut needs_pattern) = (false, false);
-    let mut args = vec![&limit as &ToSql, &offset];
-    let (q, cnt) = query.get("q").map(|query| {
-        args.insert(0, query);
-        let rank_sort_sql = match sort {
-            "downloads" => format!("{}, rank DESC", sort_sql),
-            _ => format!("rank DESC, {}", sort_sql),
-        };
-        (format!("SELECT crates.* FROM crates,
-                               plainto_tsquery($1) q,
-                               ts_rank_cd(textsearchable_index_col, q) rank
-          WHERE q @@ textsearchable_index_col
-          ORDER BY name = $1 DESC, {}
-          LIMIT $2 OFFSET $3", rank_sort_sql),
-         "SELECT COUNT(crates.*) FROM crates,
-                                      plainto_tsquery($1) q
-          WHERE q @@ textsearchable_index_col".to_string())
-    }).or_else(|| {
-        query.get("letter").map(|letter| {
-            pattern = format!("{}%", letter.chars().next().unwrap()
+    // This is a bit of a hack, but Boxed queries in Diesel don't implement `.clone()` and we need
+    // the query twice so we can `.count` it. This function is basically free, but it'd be nice to
+    // not have to wrap this in a funciton.
+    fn crates_query<'a>(params: &'a HashMap<String, String>, user: CargoResult<&User>)
+        -> CargoResult<crates::BoxedQuery<'a, Pg, <AllColumns as Expression>::SqlType>> {
+        let mut query = crates::table.select(ALL_COLUMNS).into_boxed();
+
+        if let Some(q_string) = params.get("q") {
+            let q = plainto_tsquery(q_string);
+            query = query.filter(q.matches(crates::textsearchable_index_col));
+        } else if let Some(letter) = params.get("letter") {
+            let pattern = format!("{}%", letter.chars().next().unwrap()
                                            .to_lowercase().collect::<String>());
-            needs_pattern = true;
-            (format!("SELECT * FROM crates WHERE canon_crate_name(name) \
-                      LIKE $1 ORDER BY {} LIMIT $2 OFFSET $3", sort_sql),
-             "SELECT COUNT(*) FROM crates WHERE canon_crate_name(name) \
-              LIKE $1".to_string())
-        })
-    }).or_else(|| {
-        query.get("keyword").map(|kw| {
-            args.insert(0, kw);
-            let base = "FROM crates
-                        INNER JOIN crates_keywords
-                                ON crates.id = crates_keywords.crate_id
-                        INNER JOIN keywords
-                                ON crates_keywords.keyword_id = keywords.id
-                        WHERE lower(keywords.keyword) = lower($1)";
-            (format!("SELECT crates.* {} ORDER BY {} LIMIT $2 OFFSET $3", base, sort_sql),
-             format!("SELECT COUNT(crates.*) {}", base))
-        })
-    }).or_else(|| {
-        query.get("category").map(|cat| {
-            args.insert(0, cat);
-            let base = "FROM crates
-                        INNER JOIN crates_categories
-                                ON crates.id = crates_categories.crate_id
-                        INNER JOIN categories
-                                ON crates_categories.category_id =
-                                   categories.id
-                        WHERE categories.slug = $1 OR
-                              categories.slug LIKE $1 || '::%'";
-            (format!("SELECT DISTINCT crates.* {} ORDER BY {} LIMIT $2 OFFSET $3", base, sort_sql),
-             format!("SELECT COUNT(DISTINCT crates.*) {}", base))
-        })
-    }).or_else(|| {
-        query.get("user_id").and_then(|s| s.parse::<i32>().ok()).map(|user_id| {
-            id = user_id;
-            needs_id = true;
-            (format!("SELECT crates.* FROM crates
-                       INNER JOIN crate_owners
-                          ON crate_owners.crate_id = crates.id
-                       WHERE crate_owners.owner_id = $1
-                       AND crate_owners.owner_kind = {}
-                       ORDER BY {}
-                      LIMIT $2 OFFSET $3",
-                     OwnerKind::User as i32, sort_sql),
-             format!("SELECT COUNT(crates.*) FROM crates
-               INNER JOIN crate_owners
-                  ON crate_owners.crate_id = crates.id
-               WHERE crate_owners.owner_id = $1 \
-                 AND crate_owners.owner_kind = {}",
-                 OwnerKind::User as i32))
-        })
-    }).or_else(|| {
-        query.get("following").map(|_| {
-            needs_id = true;
-            (format!("SELECT crates.* FROM crates
-                      INNER JOIN follows
-                         ON follows.crate_id = crates.id AND
-                            follows.user_id = $1 ORDER BY
-                      {} LIMIT $2 OFFSET $3", sort_sql),
-             "SELECT COUNT(crates.*) FROM crates
-              INNER JOIN follows
-                 ON follows.crate_id = crates.id AND
-                    follows.user_id = $1".to_string())
-        })
-    }).unwrap_or_else(|| {
-        (format!("SELECT * FROM crates ORDER BY {} LIMIT $1 OFFSET $2",
-                 sort_sql),
-         "SELECT COUNT(*) FROM crates".to_string())
-    });
-
-    if needs_id {
-        if id == -1 {
-            id = req.user()?.id;
+            query = query.filter(canon_crate_name(crates::name).like(pattern));
+        } else if let Some(kw) = params.get("keyword") {
+            query = query.filter(crates::id.eq_any(
+                crates_keywords::table.select(crates_keywords::crate_id)
+                    .inner_join(keywords::table)
+                    .filter(lower(keywords::keyword).eq(lower(kw)))
+            ));
+        } else if let Some(cat) = params.get("category") {
+            query = query.filter(crates::id.eq_any(
+                crates_categories::table.select(crates_categories::crate_id)
+                    .inner_join(categories::table)
+                    .filter(categories::category.eq(cat).or(
+                            categories::category.like(format!("{}::%", cat))))
+            ));
+        } else if let Some(user_id) = params.get("user_id").and_then(|s| s.parse::<i32>().ok()) {
+            query = query.filter(crates::id.eq_any((
+                crate_owners::table.select(crate_owners::crate_id)
+                    .filter(crate_owners::owner_id.eq(user_id))
+                    .filter(crate_owners::owner_kind.eq(OwnerKind::User as i32))
+            )));
+        } else if params.get("following").is_some() {
+            query = query.filter(crates::id.eq_any((
+                follows::table.select(follows::crate_id)
+                    .filter(follows::user_id.eq(user?.id))
+            )));
         }
-        args.insert(0, &id);
-    } else if needs_pattern {
-        args.insert(0, &pattern);
+        Ok(query)
     }
 
-    // Collect all the crates
-    let stmt = conn.prepare(&q)?;
-    let mut crates = Vec::new();
-    for row in stmt.query(&args)?.iter() {
-        let krate: Crate = Model::from_row(&row);
-        let badges = krate.badges(conn)?;
-        let max_version = krate.max_version(conn)?;
-        crates.push(krate.minimal_encodable(max_version, Some(badges)));
+    let mut query = crates_query(&params, req.user())?;
+    let sort = params.get("sort").map(|s| &**s).unwrap_or("alpha");
+    match (params.get("q"), sort) {
+        (Some(q), "downloads") => {
+            query = query.order((crates::name.eq(q).desc(), crates::downloads.desc()))
+        }
+        (Some(q_string), _) => {
+            let q = plainto_tsquery(q_string);
+            let rank = ts_rank_cd(crates::textsearchable_index_col, q);
+            query = query.order((crates::name.eq(q_string).desc(), rank.desc()))
+        }
+        (None, "downloads") => query = query.order(crates::downloads.desc()),
+        _ => query = query.order(crates::name.asc()),
     }
 
-    // Query for the total count of crates
-    let stmt = conn.prepare(&cnt)?;
-    let args = if args.len() > 2 {&args[..1]} else {&args[..0]};
-    let rows = stmt.query(args)?;
-    let row = rows.iter().next().unwrap();
-    let total = row.get(0);
+    let crates = query.limit(limit).offset(offset).load::<Crate>(conn)?;
+    let versions = Version::belonging_to(&crates)
+        .load::<Version>(conn)?
+        .grouped_by(&crates)
+        .into_iter()
+        .map(|versions| {
+            versions.into_iter()
+                .map(|v| v.num)
+                .max()
+                .unwrap_or_else(|| semver::Version::parse("0.0.0").unwrap())
+        });
+
+    let crates = versions.zip(crates).map(|(max_version, krate)| {
+        // FIXME: If we add crate_id to the Badge enum we can eliminate
+        // this N+1
+        let badges = badges::table.filter(badges::crate_id.eq(krate.id))
+            .load::<Badge>(conn)?;
+        Ok(krate.minimal_encodable(max_version, Some(badges)))
+    }).collect::<Result<_, ::diesel::result::Error>>()?;
+
+    let total = crates_query(&params, req.user())?.count().get_result(conn)?;
 
     #[derive(RustcEncodable)]
     struct R { crates: Vec<EncodableCrate>, meta: Meta }
@@ -781,11 +877,11 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
     }
 
     // Update all keywords for this crate
-    Keyword::update_crate(req.tx()?, &krate, &keywords)?;
+    Keyword::update_crate_old(req.tx()?, &krate, &keywords)?;
 
     // Update all categories for this crate, collecting any invalid categories
     // in order to be able to warn about them
-    let ignored_invalid_categories = Category::update_crate(req.tx()?, &krate, &categories)?;
+    let ignored_invalid_categories = Category::update_crate_old(req.tx()?, &krate, &categories)?;
 
     // Update all badges for this crate, collecting any invalid badges in
     // order to be able to warn about them
@@ -1202,3 +1298,7 @@ pub fn reverse_dependencies(req: &mut Request) -> CargoResult<Response> {
     struct Meta { total: i64 }
     Ok(req.json(&R{ dependencies: rev_deps, meta: Meta { total: total } }))
 }
+
+use diesel::types::Text;
+sql_function!(canon_crate_name, canon_crate_name_t, (x: Text) -> Text);
+sql_function!(lower, lower_t, (x: Text) -> Text);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate r2d2_postgres;
 extern crate rand;
 extern crate s3;
 extern crate semver;
+extern crate serde_json;
 extern crate time;
 extern crate url;
 extern crate toml;

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -6,6 +6,16 @@ use util::{CargoResult, ChainError, human};
 use util::errors::NotFound;
 use http;
 use app::App;
+use schema::crate_owners;
+
+#[derive(Insertable)]
+#[table_name="crate_owners"]
+pub struct CrateOwner {
+    pub crate_id: i32,
+    pub owner_id: i32,
+    pub created_by: i32,
+    pub owner_kind: i32,
+}
 
 #[repr(u32)]
 pub enum OwnerKind {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -48,12 +48,11 @@ table! {
         updated_at -> Timestamp,
         created_at -> Timestamp,
         downloads -> Int4,
-        max_version -> Nullable<Varchar>,
         description -> Nullable<Varchar>,
         homepage -> Nullable<Varchar>,
         documentation -> Nullable<Varchar>,
         readme -> Nullable<Varchar>,
-        textsearchable_index_col -> Nullable<::diesel_full_text_search::TsVector>,
+        textsearchable_index_col -> ::diesel_full_text_search::TsVector,
         license -> Nullable<Varchar>,
         repository -> Nullable<Varchar>,
         max_upload_size -> Nullable<Int4>,
@@ -114,6 +113,12 @@ table! {
 }
 
 table! {
+    reserved_crate_names (name) {
+        name -> Text,
+    }
+}
+
+table! {
     teams (id) {
         id -> Int4,
         login -> Varchar,
@@ -165,6 +170,6 @@ table! {
         created_at -> Timestamp,
         downloads -> Int4,
         features -> Nullable<Varchar>,
-        yanked -> Nullable<Bool>,
+        yanked -> Bool,
     }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -276,7 +276,7 @@ fn mock_keyword(req: &mut Request, name: &str) -> Keyword {
 }
 
 fn new_category<'a>(category: &'a str, slug: &'a str) -> NewCategory<'a> {
-    NewCategory { category, slug, ..NewCategory::default() }
+    NewCategory { category: category, slug: slug, ..NewCategory::default() }
 }
 
 fn mock_category(req: &mut Request, name: &str, slug: &str) -> Category {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -183,7 +183,6 @@ fn new_user(login: &str) -> NewUser {
         name: None,
         gh_avatar: None,
         gh_access_token: "some random token",
-        api_token: "some random token",
     }
 }
 

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -76,41 +76,41 @@ fn update_crate() {
     ::mock_category(&mut req, "Category 2", "category-2");
 
     // Updating with no categories has no effect
-    Category::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
+    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Happy path adding one category
-    Category::update_crate(req.tx().unwrap(), &krate, &["cat1".to_string()]).unwrap();
+    Category::update_crate_old(req.tx().unwrap(), &krate, &["cat1".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Replacing one category with another
-    Category::update_crate(
+    Category::update_crate_old(
         req.tx().unwrap(), &krate, &["category-2".to_string()]
     ).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 1);
 
     // Removing one category
-    Category::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
+    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Adding 2 categories
-    Category::update_crate(
+    Category::update_crate_old(
         req.tx().unwrap(), &krate, &["cat1".to_string(),
                             "category-2".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 1);
 
     // Removing all categories
-    Category::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
+    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Attempting to add one valid category and one invalid category
-    let invalid_categories = Category::update_crate(
+    let invalid_categories = Category::update_crate_old(
         req.tx().unwrap(), &krate, &["cat1".to_string(),
                             "catnope".to_string()]
     ).unwrap();
@@ -127,7 +127,7 @@ fn update_crate() {
     assert_eq!(json.meta.total, 2);
 
     // Attempting to add a category by display text; must use slug
-    Category::update_crate(
+    Category::update_crate_old(
         req.tx().unwrap(), &krate, &["Category 2".to_string()]
     ).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 0);
@@ -135,7 +135,7 @@ fn update_crate() {
 
     // Add a category and its subcategory
     ::mock_category(&mut req, "cat1::bar", "cat1::bar");
-    Category::update_crate(
+    Category::update_crate_old(
         req.tx().unwrap(), &krate, &["cat1".to_string(),
                             "cat1::bar".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "cat1"), 1);

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -66,28 +66,28 @@ fn update_crate() {
     ::mock_keyword(&mut req, "kw1");
     ::mock_keyword(&mut req, "kw2");
 
-    Keyword::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
+    Keyword::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 
-    Keyword::update_crate(req.tx().unwrap(), &krate, &["kw1".to_string()]).unwrap();
+    Keyword::update_crate_old(req.tx().unwrap(), &krate, &["kw1".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 1);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 
-    Keyword::update_crate(req.tx().unwrap(), &krate, &["kw2".to_string()]).unwrap();
+    Keyword::update_crate_old(req.tx().unwrap(), &krate, &["kw2".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 1);
 
-    Keyword::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
+    Keyword::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 
-    Keyword::update_crate(req.tx().unwrap(), &krate, &["kw1".to_string(),
+    Keyword::update_crate_old(req.tx().unwrap(), &krate, &["kw1".to_string(),
                                               "kw2".to_string()]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 1);
     assert_eq!(cnt(&mut req, "kw2"), 1);
 
-    Keyword::update_crate(req.tx().unwrap(), &krate, &[]).unwrap();
+    Keyword::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
     assert_eq!(cnt(&mut req, "kw1"), 0);
     assert_eq!(cnt(&mut req, "kw2"), 0);
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -143,8 +143,8 @@ fn index_queries() {
     let mut response = ok_resp!(middle.call(req.with_query("keyword=kw2")));
     assert_eq!(::json::<CrateList>(&mut response).crates.len(), 0);
 
-    ::new_category("cat1", "cat1").create_or_update(req.db_conn().unwrap()).unwrap();
-    ::new_category("cat1::bar", "cat1::bar").create_or_update(req.db_conn().unwrap()).unwrap();
+    ::new_category("cat1", "cat1").find_or_create(req.db_conn().unwrap()).unwrap();
+    ::new_category("cat1::bar", "cat1::bar").find_or_create(req.db_conn().unwrap()).unwrap();
     Category::update_crate(req.db_conn().unwrap(), &krate, &["cat1"]).unwrap();
     Category::update_crate(req.db_conn().unwrap(), &krate2, &["cat1::bar"]).unwrap();
     let mut response = ok_resp!(middle.call(req.with_query("category=cat1")));

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -106,11 +106,20 @@ fn reset_token() {
 }
 
 #[test]
-fn my_packages() {
+fn crates_by_user_id() {
     let (_b, app, middle) = ::app();
+    let u;
+    {
+        let conn = app.diesel_database.get().unwrap();
+        u = ::new_user("foo")
+            .create_or_update(&conn)
+            .unwrap();
+        ::new_crate("foo_my_packages")
+            .create_or_update(&conn, None, u.id)
+            .unwrap();
+    }
+
     let mut req = ::req(app, Method::Get, "/api/v1/crates");
-    let u = ::mock_user(&mut req, ::user("foo"));
-    ::mock_crate(&mut req, ::krate("foo_my_packages"));
     req.with_query(&format!("user_id={}", u.id));
     let mut response = ok_resp!(middle.call(&mut req));
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -192,6 +192,20 @@ impl Version {
                      &[&yanked, &self.id])?;
         Ok(())
     }
+
+    pub fn max<T>(versions: T) -> semver::Version where
+        T: IntoIterator<Item=semver::Version>,
+    {
+        versions.into_iter()
+            .max()
+            .unwrap_or_else(|| semver::Version {
+                major: 0,
+                minor: 0,
+                patch: 0,
+                pre: vec![],
+                build: vec![],
+            })
+    }
 }
 
 impl Queryable<versions::SqlType, Pg> for Version {

--- a/src/version.rs
+++ b/src/version.rs
@@ -10,18 +10,22 @@ use time::Duration;
 use time::Timespec;
 use url;
 
-use {Model, Crate};
 use app::RequestApp;
 use db::RequestTransaction;
+use diesel::prelude::*;
+use diesel::pg::Pg;
 use dependency::{Dependency, EncodableDependency, Kind};
 use download::{VersionDownload, EncodableVersionDownload};
 use git;
+use owner::{rights, Rights};
+use schema::versions;
 use upload;
 use user::RequestUser;
-use owner::{rights, Rights};
 use util::{RequestUtils, CargoResult, ChainError, internal, human};
+use {Model, Crate};
 
-#[derive(Clone)]
+#[derive(Clone, Identifiable, Associations)]
+#[belongs_to(Crate)]
 pub struct Version {
     pub id: i32,
     pub crate_id: i32,
@@ -187,6 +191,26 @@ impl Version {
         conn.execute("UPDATE versions SET yanked = $1 WHERE id = $2",
                      &[&yanked, &self.id])?;
         Ok(())
+    }
+}
+
+impl Queryable<versions::SqlType, Pg> for Version {
+    type Row = (i32, i32, String, Timespec, Timespec, i32, Option<String>, bool);
+
+    fn build(row: Self::Row) -> Self {
+        let features = row.6.map(|s| {
+            json::decode(&s).unwrap()
+        }).unwrap_or_else(|| HashMap::new());
+        Version {
+            id: row.0,
+            crate_id: row.1,
+            num: semver::Version::parse(&row.2).unwrap(),
+            updated_at: row.3,
+            created_at: row.4,
+            downloads: row.5,
+            features: features,
+            yanked: row.7,
+        }
     }
 }
 


### PR DESCRIPTION
I decided to tackle this one next since we have an N+1 queries bug on
the max versions, it's a relatively high traffic endpoint, and the code
benefitted the most from Diesel.

There was probably more code added to support migrating the tests over
than to support the actual `index` function, but all those pieces will
start to get used as more endpoints are ported over. There were a few
tests that were hitting the followings and owners endpoints which I have
temporarily changed to hit the database directly instead.

Porting those endpoints would mean porting over more tests, which might
mean porting over more endpoints, etc. We didn't lose any coverage
overall, but we should still go back to hitting the endpoints directly
in tests when we can.