### PR TITLE
Don't parse `Version#num` for reads

### DIFF
--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -10,7 +10,6 @@
 extern crate cargo_registry;
 extern crate postgres;
 extern crate time;
-extern crate semver;
 
 use std::env;
 use std::io;
@@ -38,7 +37,6 @@ fn delete(tx: &postgres::transaction::Transaction) {
         None => { println!("needs a version argument"); return }
         Some(s) => s,
     };
-    let version = semver::Version::parse(&version).unwrap();
 
     let krate = Crate::find_by_name(tx, &name).unwrap();
     let v = Version::find_by_num(tx, krate.id, &version).unwrap().unwrap();

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -8,7 +8,6 @@
 extern crate cargo_registry;
 extern crate postgres;
 extern crate time;
-extern crate semver;
 
 use std::env;
 use std::io;

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,7 +4,6 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
-use semver;
 use git2;
 use rustc_serialize::json;
 
@@ -69,7 +68,7 @@ pub fn add_crate(app: &App, krate: &Crate) -> CargoResult<()> {
     })
 }
 
-pub fn yank(app: &App, krate: &str, version: &semver::Version,
+pub fn yank(app: &App, krate: &str, version: &str,
             yanked: bool) -> CargoResult<()> {
     let repo = app.git_repo.lock().unwrap();
     let repo = &*repo;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -216,10 +216,10 @@ fn mock_user(req: &mut Request, u: User) -> User {
 }
 
 fn mock_crate(req: &mut Request, krate: Crate) -> (Crate, Version) {
-    mock_crate_vers(req, krate, &semver::Version::parse("1.0.0").unwrap())
+    mock_crate_vers(req, krate, "1.0.0")
 }
 
-fn mock_crate_vers(req: &mut Request, krate: Crate, v: &semver::Version)
+fn mock_crate_vers(req: &mut Request, krate: Crate, v: &str)
                    -> (Crate, Version) {
     let user = req.extensions().find::<User>().unwrap();
     let mut krate = Crate::find_or_insert(req.tx().unwrap(), &krate.name,
@@ -231,7 +231,8 @@ fn mock_crate_vers(req: &mut Request, krate: Crate, v: &semver::Version)
                                           &krate.license,
                                           &None,
                                           krate.max_upload_size).unwrap();
-    let v = krate.add_version(req.tx().unwrap(), v, &HashMap::new(), &[]);
+    let v = semver::Version::parse(v).unwrap();
+    let v = krate.add_version(req.tx().unwrap(), &v, &HashMap::new(), &[]);
     (krate, v.unwrap())
 }
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1156,14 +1156,12 @@ fn ignored_badges() {
 fn reverse_dependencies() {
     let (_b, app, middle) = ::app();
 
-    let v100 = semver::Version::parse("1.0.0").unwrap();
-    let v110 = semver::Version::parse("1.1.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
-    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
-    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), &v110);
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
+    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
+    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), "1.1.0");
 
     ::mock_dep(&mut req, &c2v1, &c1, None);
     ::mock_dep(&mut req, &c2v2, &c1, None);
@@ -1187,15 +1185,12 @@ fn reverse_dependencies() {
 fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     let (_b, app, middle) = ::app();
 
-    let v100 = semver::Version::parse("1.0.0").unwrap();
-    let v110 = semver::Version::parse("1.1.0").unwrap();
-    let v200 = semver::Version::parse("2.0.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v110);
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
-    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), &v200);
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.1.0");
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
+    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), "2.0.0");
 
     ::mock_dep(&mut req, &c2v2, &c1, None);
 
@@ -1210,14 +1205,12 @@ fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
 fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     let (_b, app, middle) = ::app();
 
-    let v100 = semver::Version::parse("1.0.0").unwrap();
-    let v200 = semver::Version::parse("2.0.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
-    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v200);
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
+    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "2.0.0");
 
     ::mock_dep(&mut req, &c2v1, &c1, None);
 
@@ -1231,15 +1224,13 @@ fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
 fn prerelease_versions_not_included_in_reverse_dependencies() {
     let (_b, app, middle) = ::app();
 
-    let v100 = semver::Version::parse("1.0.0").unwrap();
-    let v110_pre = semver::Version::parse("1.1.0-pre").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v110_pre);
-    let (_, c3v1) = ::mock_crate_vers(&mut req, ::krate("c3"), &v100);
-    let _ = ::mock_crate_vers(&mut req, ::krate("c3"), &v110_pre);
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "1.1.0-pre");
+    let (_, c3v1) = ::mock_crate_vers(&mut req, ::krate("c3"), "1.0.0");
+    let _ = ::mock_crate_vers(&mut req, ::krate("c3"), "1.1.0-pre");
 
     ::mock_dep(&mut req, &c3v1, &c1, None);
 
@@ -1254,14 +1245,12 @@ fn prerelease_versions_not_included_in_reverse_dependencies() {
 fn yanked_versions_not_included_in_reverse_dependencies() {
     let (_b, app, middle) = ::app();
 
-    let v100 = semver::Version::parse("1.0.0").unwrap();
-    let v200 = semver::Version::parse("2.0.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
-    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), &v200);
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
+    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), "2.0.0");
 
     ::mock_dep(&mut req, &c2v2, &c1, None);
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -25,7 +25,7 @@ use util::{RequestUtils, CargoResult, ChainError, internal, human};
 pub struct Version {
     pub id: i32,
     pub crate_id: i32,
-    pub num: semver::Version,
+    pub num: String,
     pub updated_at: Timespec,
     pub created_at: Timespec,
     pub downloads: i32,
@@ -61,9 +61,8 @@ pub struct VersionLinks {
 impl Version {
     pub fn find_by_num(conn: &GenericConnection,
                        crate_id: i32,
-                       num: &semver::Version)
+                       num: &str)
                        -> CargoResult<Option<Version>> {
-        let num = num.to_string();
         let stmt = conn.prepare("SELECT * FROM versions \
                                       WHERE crate_id = $1 AND num = $2")?;
         let rows = stmt.query(&[&crate_id, &num])?;
@@ -192,7 +191,6 @@ impl Version {
 
 impl Model for Version {
     fn from_row(row: &Row) -> Version {
-        let num: String = row.get("num");
         let features: Option<String> = row.get("features");
         let features = features.map(|s| {
             json::decode(&s).unwrap()
@@ -200,7 +198,7 @@ impl Model for Version {
         Version {
             id: row.get("id"),
             crate_id: row.get("crate_id"),
-            num: semver::Version::parse(&num).unwrap(),
+            num: row.get("num"),
             updated_at: row.get("updated_at"),
             created_at: row.get("created_at"),
             downloads: row.get("downloads"),
@@ -271,9 +269,6 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
 fn version_and_crate(req: &mut Request) -> CargoResult<(Version, Crate)> {
     let crate_name = &req.params()["crate_id"];
     let semver = &req.params()["version"];
-    let semver = semver::Version::parse(semver).map_err(|_| {
-        human(format!("invalid semver: {}", semver))
-    })?;
     let tx = req.tx()?;
     let krate = Crate::find_by_name(tx, crate_name)?;
     let version = Version::find_by_num(tx, krate.id, &semver)?;


### PR DESCRIPTION
On the majority of endpoints involving versions, we're parsing the
version (using `.unwrap` even, which could take down the server) only to
immediately convert it back into a string. This causes needless
allocations, and a larger surface for errors to appear.

We really only care about semver when ensuring a version is valid, and
when determining the max version for a crate. Everywhere else, we can
just use a String.