### PR TITLE
use pagination for version downloads

### DIFF
--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -700,12 +700,18 @@ fn download() {
     assert_eq!(downloads.version_downloads.len(), 1);
 
     let yesterday = now_utc() + Duration::days(-1);
-    let yesterday = "before_date=".to_string() + &strftime("%Y-%m-%d", &yesterday).unwrap();
     req.with_path("/api/v1/crates/FOO_DOWNLOAD/1.0.0/downloads");
-    req.with_query(&yesterday);
+    req.with_query(&("before_date=".to_string() + &strftime("%Y-%m-%d", &yesterday).unwrap()));
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 0);
+
+    let tomorrow = now_utc() + Duration::days(1);
+    req.with_path("/api/v1/crates/FOO_DOWNLOAD/1.0.0/downloads");
+    req.with_query(&("before_date=".to_string() + &strftime("%Y-%m-%d", &tomorrow).unwrap()));
+    let mut resp = ok_resp!(middle.call(&mut req));
+    let downloads = ::json::<Downloads>(&mut resp);
+    assert_eq!(downloads.version_downloads.len(), 1);
 
 }
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -677,6 +677,7 @@ fn summary_doesnt_die() {
 
 #[test]
 fn download() {
+    use ::time::{Duration, now_utc, strftime};
     let (_b, app, middle) = ::app();
     let mut req = ::req(app, Method::Get, "/api/v1/crates/foo_download/1.0.0/download");
     ::mock_user(&mut req, ::user("foo"));
@@ -697,6 +698,15 @@ fn download() {
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 1);
+
+    let yesterday = now_utc() + Duration::days(-1);
+    let yesterday = "before_date=".to_string() + &strftime("%Y-%m-%d", &yesterday).unwrap();
+    req.with_path("/api/v1/crates/FOO_DOWNLOAD/1.0.0/downloads");
+    req.with_query(&yesterday);
+    let mut resp = ok_resp!(middle.call(&mut req));
+    let downloads = ::json::<Downloads>(&mut resp);
+    assert_eq!(downloads.version_downloads.len(), 0);
+
 }
 
 #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -303,11 +303,11 @@ pub fn downloads(req: &mut Request) -> CargoResult<Response> {
     let cutoff_end_date = req.query().get("before_date")
         .and_then(|d| strptime(d, "%Y-%m-%d").ok())
         .unwrap_or(now_utc()).to_timespec();
-    let cutoff_start_date = cutoff_end_date + Duration::days(-90);
+    let cutoff_start_date = cutoff_end_date + Duration::days(-89);
 
     let tx = req.tx()?;
     let stmt = tx.prepare("SELECT * FROM version_downloads
-                                WHERE date > $1 AND date <= $2 AND version_id = $3
+                                WHERE date BETWEEN $1 AND $2 AND version_id = $3
                                 ORDER BY date ASC")?;
     let downloads = stmt.query(&[&cutoff_start_date, &cutoff_end_date, &version.id])?
         .iter().map(|row| VersionDownload::from_row(&row).encodable()).collect();

--- a/src/version.rs
+++ b/src/version.rs
@@ -6,8 +6,7 @@ use pg::GenericConnection;
 use pg::rows::Row;
 use rustc_serialize::json;
 use semver;
-use time::Duration;
-use time::Timespec;
+use time::{Duration, Timespec, now_utc, strptime};
 use url;
 
 use {Model, Crate};
@@ -300,17 +299,18 @@ pub fn dependencies(req: &mut Request) -> CargoResult<Response> {
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
 pub fn downloads(req: &mut Request) -> CargoResult<Response> {
-    let (offset, limit) = req.pagination(90, 100)?;
     let (version, _) = version_and_crate(req)?;
+    let cutoff_end_date = req.query().get("before_date")
+        .and_then(|d| strptime(d, "%Y-%m-%d").ok())
+        .unwrap_or(now_utc()).to_timespec();
+    let cutoff_start_date = cutoff_end_date + Duration::days(-90);
 
     let tx = req.tx()?;
-    let cutoff_end_date = ::now() + Duration::days(-offset);
-    let cutoff_start_date = cutoff_end_date + Duration::days(-limit);
     let stmt = tx.prepare("SELECT * FROM version_downloads
                                 WHERE date > $1 AND date <= $2 AND version_id = $3
                                 ORDER BY date ASC")?;
     let downloads = stmt.query(&[&cutoff_start_date, &cutoff_end_date, &version.id])?
-        .iter().map(|row| { VersionDownload::from_row(&row).encodable() }).collect();
+        .iter().map(|row| VersionDownload::from_row(&row).encodable()).collect();
 
     #[derive(RustcEncodable)]
     struct R { version_downloads: Vec<EncodableVersionDownload> }


### PR DESCRIPTION
This is draft of fix for issues/557. Inspired by @carols10cents comment I tried to use the same pagination code as is used for the other endpoints.