### PR TITLE
Revert "Don't parse `Version#num` for reads"

### DIFF
--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -10,6 +10,7 @@
 extern crate cargo_registry;
 extern crate postgres;
 extern crate time;
+extern crate semver;
 
 use std::env;
 use std::io;
@@ -37,6 +38,7 @@ fn delete(tx: &postgres::transaction::Transaction) {
         None => { println!("needs a version argument"); return }
         Some(s) => s,
     };
+    let version = semver::Version::parse(&version).unwrap();
 
     let krate = Crate::find_by_name(tx, &name).unwrap();
     let v = Version::find_by_num(tx, krate.id, &version).unwrap().unwrap();

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -8,6 +8,7 @@
 extern crate cargo_registry;
 extern crate postgres;
 extern crate time;
+extern crate semver;
 
 use std::env;
 use std::io;

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,6 +4,7 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
+use semver;
 use git2;
 use rustc_serialize::json;
 
@@ -68,7 +69,7 @@ pub fn add_crate(app: &App, krate: &Crate) -> CargoResult<()> {
     })
 }
 
-pub fn yank(app: &App, krate: &str, version: &str,
+pub fn yank(app: &App, krate: &str, version: &semver::Version,
             yanked: bool) -> CargoResult<()> {
     let repo = app.git_repo.lock().unwrap();
     let repo = &*repo;

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -5,7 +5,6 @@ use std::io::prelude::*;
 use std::io;
 use std::mem;
 use std::sync::Arc;
-use std::borrow::Cow;
 
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
@@ -65,7 +64,7 @@ pub struct EncodableCrate {
     pub badges: Option<Vec<EncodableBadge>>,
     pub created_at: String,
     pub downloads: i32,
-    pub max_version: Cow<'static, str>,
+    pub max_version: String,
     pub description: Option<String>,
     pub homepage: Option<String>,
     pub documentation: Option<String>,
@@ -233,13 +232,13 @@ impl Crate {
     }
 
     pub fn minimal_encodable(self,
-                             max_version: Cow<'static, str>,
+                             max_version: semver::Version,
                              badges: Option<Vec<Badge>>) -> EncodableCrate {
         self.encodable(max_version, None, None, None, badges)
     }
 
     pub fn encodable(self,
-                     max_version: Cow<'static, str>,
+                     max_version: semver::Version,
                      versions: Option<Vec<i32>>,
                      keywords: Option<&[Keyword]>,
                      categories: Option<&[Category]>,
@@ -269,7 +268,7 @@ impl Crate {
             keywords: keyword_ids,
             categories: category_ids,
             badges: badges,
-            max_version: max_version,
+            max_version: max_version.to_string(),
             documentation: documentation,
             homepage: homepage,
             description: description,
@@ -284,14 +283,14 @@ impl Crate {
         }
     }
 
-    pub fn max_version(&self, conn: &GenericConnection) -> CargoResult<Cow<'static, str>> {
+    pub fn max_version(&self, conn: &GenericConnection) -> CargoResult<semver::Version> {
         let stmt = conn.prepare("SELECT num FROM versions WHERE crate_id = $1
                                  AND yanked = 'f'")?;
         let rows = stmt.query(&[&self.id])?;
         Ok(rows.iter()
-            .map(|r| Cow::Owned(r.get("num")))
-            .max_by_key(|v| semver::Version::parse(&v).ok())
-            .unwrap_or_else(|| Cow::Borrowed("0.0.0")))
+            .map(|r| semver::Version::parse(&r.get::<_, String>("num")).unwrap())
+            .max()
+            .unwrap_or_else(|| semver::Version::parse("0.0.0").unwrap()))
     }
 
     pub fn versions(&self, conn: &GenericConnection) -> CargoResult<Vec<Version>> {
@@ -389,7 +388,7 @@ impl Crate {
                        features: &HashMap<String, Vec<String>>,
                        authors: &[String])
                        -> CargoResult<Version> {
-        match Version::find_by_num(conn, self.id, &ver.to_string())? {
+        match Version::find_by_num(conn, self.id, ver)? {
             Some(..) => {
                 return Err(human(format!("crate version `{}` is already uploaded",
                                          ver)))

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -219,10 +219,10 @@ fn sign_in_as(req: &mut Request, user: &User) {
 }
 
 fn mock_crate(req: &mut Request, krate: Crate) -> (Crate, Version) {
-    mock_crate_vers(req, krate, "1.0.0")
+    mock_crate_vers(req, krate, &semver::Version::parse("1.0.0").unwrap())
 }
 
-fn mock_crate_vers(req: &mut Request, krate: Crate, v: &str)
+fn mock_crate_vers(req: &mut Request, krate: Crate, v: &semver::Version)
                    -> (Crate, Version) {
     let user = req.extensions().find::<User>().unwrap();
     let mut krate = Crate::find_or_insert(req.tx().unwrap(), &krate.name,
@@ -234,8 +234,7 @@ fn mock_crate_vers(req: &mut Request, krate: Crate, v: &str)
                                           &krate.license,
                                           &None,
                                           krate.max_upload_size).unwrap();
-    let v = semver::Version::parse(v).unwrap();
-    let v = krate.add_version(req.tx().unwrap(), &v, &HashMap::new(), &[]);
+    let v = krate.add_version(req.tx().unwrap(), v, &HashMap::new(), &[]);
     (krate, v.unwrap())
 }
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1156,12 +1156,14 @@ fn ignored_badges() {
 fn reverse_dependencies() {
     let (_b, app, middle) = ::app();
 
+    let v100 = semver::Version::parse("1.0.0").unwrap();
+    let v110 = semver::Version::parse("1.1.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
-    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
-    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), "1.1.0");
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
+    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
+    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), &v110);
 
     ::mock_dep(&mut req, &c2v1, &c1, None);
     ::mock_dep(&mut req, &c2v2, &c1, None);
@@ -1185,12 +1187,15 @@ fn reverse_dependencies() {
 fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     let (_b, app, middle) = ::app();
 
+    let v100 = semver::Version::parse("1.0.0").unwrap();
+    let v110 = semver::Version::parse("1.1.0").unwrap();
+    let v200 = semver::Version::parse("2.0.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.1.0");
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
-    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), "2.0.0");
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v110);
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
+    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), &v200);
 
     ::mock_dep(&mut req, &c2v2, &c1, None);
 
@@ -1205,12 +1210,14 @@ fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
 fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     let (_b, app, middle) = ::app();
 
+    let v100 = semver::Version::parse("1.0.0").unwrap();
+    let v200 = semver::Version::parse("2.0.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
-    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "2.0.0");
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
+    let (_, c2v1) = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v200);
 
     ::mock_dep(&mut req, &c2v1, &c1, None);
 
@@ -1224,13 +1231,15 @@ fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
 fn prerelease_versions_not_included_in_reverse_dependencies() {
     let (_b, app, middle) = ::app();
 
+    let v100 = semver::Version::parse("1.0.0").unwrap();
+    let v110_pre = semver::Version::parse("1.1.0-pre").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "1.1.0-pre");
-    let (_, c3v1) = ::mock_crate_vers(&mut req, ::krate("c3"), "1.0.0");
-    let _ = ::mock_crate_vers(&mut req, ::krate("c3"), "1.1.0-pre");
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v110_pre);
+    let (_, c3v1) = ::mock_crate_vers(&mut req, ::krate("c3"), &v100);
+    let _ = ::mock_crate_vers(&mut req, ::krate("c3"), &v110_pre);
 
     ::mock_dep(&mut req, &c3v1, &c1, None);
 
@@ -1245,12 +1254,14 @@ fn prerelease_versions_not_included_in_reverse_dependencies() {
 fn yanked_versions_not_included_in_reverse_dependencies() {
     let (_b, app, middle) = ::app();
 
+    let v100 = semver::Version::parse("1.0.0").unwrap();
+    let v200 = semver::Version::parse("2.0.0").unwrap();
     let mut req = ::req(app, Method::Get,
                         "/api/v1/crates/c1/reverse_dependencies");
     ::mock_user(&mut req, ::user("foo"));
-    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), "1.0.0");
-    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), "1.0.0");
-    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), "2.0.0");
+    let (c1, _) = ::mock_crate_vers(&mut req, ::krate("c1"), &v100);
+    let _ = ::mock_crate_vers(&mut req, ::krate("c2"), &v100);
+    let (_, c2v2) = ::mock_crate_vers(&mut req, ::krate("c2"), &v200);
 
     ::mock_dep(&mut req, &c2v2, &c1, None);
 


### PR DESCRIPTION
Reverts rust-lang/crates.io#610

Fixes #614. I don't think the change is worth keeping given the number of places we're having to add parsing where we do care, I'd rather make these bugs difficult to introduce.