### PR TITLE
Remove needless feature from `diesel_codegen`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,6 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "diesel 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_infer_schema 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -290,16 +289,6 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "diesel 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "diesel_infer_schema"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "diesel 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -972,7 +961,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum diesel 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2f872f59c19519db52506648a00d18ec5e3aa81eb99710f6837715eae41f3c76"
 "checksum diesel_codegen 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bf8115b73ca2640b8c6abdb0e34fd80f05cd8a7fee92067ba17d24448db8db5b"
 "checksum diesel_full_text_search 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7bd6a9d8f3c1a87fef80454adf60ce10985502b3e950eeb83058da23405504b1"
-"checksum diesel_infer_schema 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5573f6506105cfbca35d69fccc9ab8d6dc41d54a58fe18c9f9011abe3284b4a4"
 "checksum dotenv 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eea1395d2df3b5344dc577809296d9578303296e8d105c408aa80ed67d598ef1"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
 "checksum env_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99971fb1b635fe7a0ee3c4d065845bb93cca80a23b5613b5613391ece5de4144"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ license-exprs = "^1.3"
 dotenv = "0.8.0"
 toml = "0.2"
 diesel = { version = "0.11.0", features = ["postgres", "serde_json", "deprecated-time"] }
-diesel_codegen = { version = "0.11.0", features = ["postgres"] }
+diesel_codegen = "0.11.0"
 r2d2-diesel = "0.11.0"
 diesel_full_text_search = "0.11.0"
 serde_json = "0.9.9"


### PR DESCRIPTION
Since we're not using `infer_schema`, we don't need to provide a backend
to `diesel_codegen`. This drops the transitive dependency on
`diesel_infer_schema`.