### PR TITLE
Make the bounds on `human` and `internal` a bit more explicit

### DIFF
--- a/src/bin/fill-in-user-id.rs
+++ b/src/bin/fill-in-user-id.rs
@@ -69,7 +69,7 @@ fn update(app: &App, tx: &postgres::transaction::Transaction) {
             let ghuser: GithubUser = http::parse_github_response(handle, resp)?;
             if let Some(ref avatar) = avatar {
                 if !avatar.contains(&ghuser.id.to_string()) {
-                    return Err(human(format!("avatar: {}", avatar)))
+                    return Err(human(&format_args!("avatar: {}", avatar)))
                 }
             }
             if ghuser.login == login {
@@ -77,7 +77,7 @@ fn update(app: &App, tx: &postgres::transaction::Transaction) {
                            &[&ghuser.id, &id])?;
                 Ok(())
             } else {
-                Err(human(format!("different login: {}", ghuser.login)))
+                Err(human(&format_args!("different login: {}", ghuser.login)))
             }
         })();
         if let Err(e) = res {

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -38,7 +38,7 @@ fn required_string_from_toml<'a>(toml: &'a toml::Table, key: &str) -> CargoResul
     toml.get(key)
         .and_then(toml::Value::as_str)
         .chain_error(|| {
-            internal(format!("Expected category TOML attribute '{}' to be a String", key))
+            internal(&format_args!("Expected category TOML attribute '{}' to be a String", key))
         })
 }
 
@@ -53,7 +53,7 @@ fn categories_from_toml(categories: &toml::Table, parent: Option<&Category>) -> 
 
     for (slug, details) in categories {
         let details = details.as_table().chain_error(|| {
-            internal(format!("category {} was not a TOML table", slug))
+            internal(&format_args!("category {} was not a TOML table", slug))
         })?;
 
         let category = Category::from_parent(
@@ -65,7 +65,7 @@ fn categories_from_toml(categories: &toml::Table, parent: Option<&Category>) -> 
 
         if let Some(categories) = details.get("categories") {
             let categories = categories.as_table().chain_error(|| {
-                internal(format!("child categories of {} were not a table", slug))
+                internal(&format_args!("child categories of {} were not a table", slug))
             })?;
 
             result.extend(

--- a/src/db.rs
+++ b/src/db.rs
@@ -146,7 +146,7 @@ impl Transaction {
     pub fn conn(&self) -> CargoResult<&r2d2::PooledConnection<r2d2_postgres::PostgresConnectionManager>> {
         if !self.slot.filled() {
             let conn = self.app.database.get().map_err(|e| {
-                internal(format!("failed to get a database connection: {}", e))
+                internal(&format_args!("failed to get a database connection: {}", e))
             })?;
             self.slot.fill(Box::new(conn));
         }

--- a/src/git.rs
+++ b/src/git.rs
@@ -81,7 +81,7 @@ pub fn yank(app: &App, krate: &str, version: &semver::Version,
         File::open(&dst).and_then(|mut f| f.read_to_string(&mut prev))?;
         let new = prev.lines().map(|line| {
             let mut git_crate = json::decode::<Crate>(line).map_err(|_| {
-                internal(format!("couldn't decode: `{}`", line))
+                internal(&format_args!("couldn't decode: `{}`", line))
             })?;
             if git_crate.name != krate ||
                git_crate.vers.to_string() != version.to_string() {

--- a/src/http.rs
+++ b/src/http.rs
@@ -53,7 +53,7 @@ pub fn parse_github_response<T: Decodable>(mut resp: Easy, data: Vec<u8>)
         }
         n => {
             let resp = String::from_utf8_lossy(&data);
-            return Err(internal(format!("didn't get a 200 result from \
+            return Err(internal(&format_args!("didn't get a 200 result from \
                                         github, got {} with: {}", n, resp)));
         }
     }

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -144,16 +144,16 @@ impl<'a> NewCrate<'a> {
                 None => return Ok(())
             };
             let url = Url::parse(url).map_err(|_| {
-                human(format!("`{}` is not a valid url: `{}`", field, url))
+                human(&format_args!("`{}` is not a valid url: `{}`", field, url))
             })?;
             match &url.scheme()[..] {
                 "http" | "https" => {}
-                s => return Err(human(format!("`{}` has an invalid url \
-                                               scheme: `{}`", field, s)))
+                s => return Err(human(&format_args!("`{}` has an invalid url \
+                                                    scheme: `{}`", field, s)))
             }
             if url.cannot_be_a_base() {
-                return Err(human(format!("`{}` must have relative scheme \
-                                                        data: {}", field, url)))
+                return Err(human(&format_args!("`{}` must have relative scheme \
+                                               data: {}", field, url)))
             }
             Ok(())
         }
@@ -169,9 +169,9 @@ impl<'a> NewCrate<'a> {
         if let Some(ref license) = self.license {
             for part in license.split("/") {
                license_exprs::validate_license_expr(part)
-                   .map_err(|e| human(format!("{}; see http://opensource.org/licenses \
-                                              for options, and http://spdx.org/licenses/ \
-                                              for their identifiers", e)))?;
+                   .map_err(|e| human(&format_args!("{}; see http://opensource.org/licenses \
+                                                    for options, and http://spdx.org/licenses/ \
+                                                    for their identifiers", e)))?;
             }
         } else if license_file.is_some() {
             // If no license is given, but a license file is given, flag this
@@ -326,15 +326,15 @@ impl Crate {
                 None => return Ok(())
             };
             let url = Url::parse(url).map_err(|_| {
-                human(format!("`{}` is not a valid url: `{}`", field, url))
+                human(&format_args!("`{}` is not a valid url: `{}`", field, url))
             })?;
             match &url.scheme()[..] {
                 "http" | "https" => {}
-                s => return Err(human(format!("`{}` has an invalid url \
+                s => return Err(human(&format_args!("`{}` has an invalid url \
                                                scheme: `{}`", field, s)))
             }
             if url.cannot_be_a_base() {
-                return Err(human(format!("`{}` must have relative scheme \
+                return Err(human(&format_args!("`{}` must have relative scheme \
                                                         data: {}", field, url)))
             }
             Ok(())
@@ -345,7 +345,7 @@ impl Crate {
                    .map(license_exprs::validate_license_expr)
                    .collect::<Result<Vec<_>, _>>()
                    .map(|_| ())
-                   .map_err(|e| human(format!("{}; see http://opensource.org/licenses \
+                   .map_err(|e| human(&format_args!("{}; see http://opensource.org/licenses \
                                                   for options, and http://spdx.org/licenses/ \
                                                   for their identifiers", e)))
         }
@@ -474,7 +474,7 @@ impl Crate {
             Ok(Owner::Team(team)) => if team.contains_user(app, req_user)? {
                 Owner::Team(team)
             } else {
-                return Err(human(format!("only members of {} can add it as \
+                return Err(human(&format_args!("only members of {} can add it as \
                                           an owner", login)));
             },
             Err(err) => if login.contains(":") {
@@ -508,7 +508,7 @@ impl Crate {
                         _req_user: &User,
                         login: &str) -> CargoResult<()> {
         let owner = Owner::find_by_login(conn, login).map_err(|_| {
-            human(format!("could not find owner with login `{}`", login))
+            human(&format_args!("could not find owner with login `{}`", login))
         })?;
         conn.execute("UPDATE crate_owners
                               SET deleted = TRUE
@@ -526,7 +526,7 @@ impl Crate {
                        -> CargoResult<Version> {
         match Version::find_by_num(conn, self.id, ver)? {
             Some(..) => {
-                return Err(human(format!("crate version `{}` is already uploaded",
+                return Err(human(&format_args!("crate version `{}` is already uploaded",
                                          ver)))
             }
             None => {}
@@ -851,7 +851,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
     }
 
     if krate.name != name {
-        return Err(human(format!("crate was previously named `{}`", krate.name)))
+        return Err(human(&format_args!("crate was previously named `{}`", krate.name)))
     }
 
     let length = req.content_length().chain_error(|| {
@@ -860,7 +860,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
     let max = krate.max_upload_size.map(|m| m as u64)
                    .unwrap_or(app.config.max_upload_size);
     if length > max {
-        return Err(human(format!("max upload size is: {}", max)))
+        return Err(human(&format_args!("max upload size is: {}", max)))
     }
 
     // Persist the new version of this crate
@@ -905,7 +905,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
         yanked: Some(false),
     };
     git::add_crate(&**req.app(), &git_crate).chain_error(|| {
-        internal(format!("could not add crate `{}` to the git repo", name))
+        internal(&format_args!("could not add crate `{}` to the git repo", name))
     })?;
 
     // Now that we've come this far, we're committed!
@@ -934,7 +934,7 @@ fn parse_new_headers(req: &mut Request) -> CargoResult<(upload::NewCrate, User)>
     let amt = read_le_u32(req.body())? as u64;
     let max = req.app().config.max_upload_size;
     if amt > max {
-        return Err(human(format!("max upload size is: {}", max)))
+        return Err(human(&format_args!("max upload size is: {}", max)))
     }
     let mut json = vec![0; amt as usize];
     read_fill(req.body(), &mut json)?;
@@ -942,7 +942,7 @@ fn parse_new_headers(req: &mut Request) -> CargoResult<(upload::NewCrate, User)>
         human("json body was not valid utf-8")
     })?;
     let new: upload::NewCrate = json::decode(&json).map_err(|e| {
-        human(format!("invalid upload request: {:?}", e))
+        human(&format_args!("invalid upload request: {:?}", e))
     })?;
 
     // Make sure required fields are provided
@@ -959,7 +959,7 @@ fn parse_new_headers(req: &mut Request) -> CargoResult<(upload::NewCrate, User)>
         missing.push("authors");
     }
     if missing.len() > 0 {
-        return Err(human(format!("missing or empty metadata fields: {}. Please \
+        return Err(human(&format_args!("missing or empty metadata fields: {}. Please \
             see http://doc.crates.io/manifest.html#package-metadata for \
             how to upload metadata", missing.join(", "))));
     }
@@ -1205,7 +1205,7 @@ fn modify_owners(req: &mut Request, add: bool) -> CargoResult<Response> {
     for login in &logins {
         if add {
             if owners.iter().any(|owner| owner.login() == *login) {
-                return Err(human(format!("`{}` is already an owner", login)))
+                return Err(human(&format_args!("`{}` is already an owner", login)))
             }
             krate.owner_add(req.app(), tx, &user, &login)?;
         } else {

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -124,7 +124,7 @@ impl Team {
         }
 
         if let Some(c) = org_name.chars().find(whitelist) {
-            return Err(human(format!("organization cannot contain special \
+            return Err(human(&format_args!("organization cannot contain special \
                                         characters like {}", c)));
         }
 
@@ -144,7 +144,7 @@ impl Team {
 
         let team = teams.into_iter().find(|team| team.slug == team_name)
             .ok_or_else(|| {
-                human(format!("could not find the github team {}/{}",
+                human(&format_args!("could not find the github team {}/{}",
                               org_name, team_name))
             })?;
 
@@ -239,11 +239,11 @@ impl Owner {
                          name: &str) -> CargoResult<Owner> {
         let owner = if name.contains(":") {
             Owner::Team(Team::find_by_login(conn, name).map_err(|_|
-                human(format!("could not find team with name {}", name))
+                human(&format_args!("could not find team with name {}", name))
             )?)
         } else {
             Owner::User(User::find_by_login(conn, name).map_err(|_|
-                human(format!("could not find user with login `{}`", name))
+                human(&format_args!("could not find user with login `{}`", name))
             )?)
         };
         Ok(owner)

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -72,14 +72,14 @@ impl Uploader {
                             Ok(data.len())
                         }).unwrap();
                         s3req.perform().chain_error(|| {
-                            internal(format!("failed to upload to S3: `{}`", path))
+                            internal(&format_args!("failed to upload to S3: `{}`", path))
                         })?;
                     }
                     (response, body.finalize())
                 };
                 if handle.response_code().unwrap() != 200 {
                     let response = String::from_utf8_lossy(&response);
-                    return Err(internal(format!("failed to get a 200 response from S3: {}",
+                    return Err(internal(&format_args!("failed to get a 200 response from S3: {}",
                                                 response)))
                 }
 

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -282,10 +282,8 @@ pub fn github_access_token(req: &mut Request) -> CargoResult<Response> {
     }
 
     // Fetch the access token from github using the code we just got
-    let token = match req.app().github.exchange(code.clone()) {
-        Ok(token) => token,
-        Err(s) => return Err(human(s)),
-    };
+    let token = req.app().github.exchange(code.clone())
+        .map_err(|s| human(&s))?;
 
     let (handle, resp) = http::github(req.app(), "/user", &token)?;
     let ghuser: GithubUser = http::parse_github_response(handle, resp)?;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -207,7 +207,7 @@ pub fn internal_error(error: &str, detail: &str) -> Box<CargoError> {
     })
 }
 
-pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
+pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
         detail: None,
@@ -216,7 +216,7 @@ pub fn internal<S: fmt::Display>(error: S) -> Box<CargoError> {
     })
 }
 
-pub fn human<S: fmt::Display>(error: S) -> Box<CargoError> {
+pub fn human<S: ToString + ?Sized>(error: &S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),
         detail: None,

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -105,7 +105,7 @@ impl<'a> RequestUtils for Request + 'a {
         let limit = query.get("per_page").and_then(|s| s.parse::<usize>().ok())
                          .unwrap_or(default);
         if limit > max {
-            return Err(human(format!("cannot request more than {} items", max)))
+            return Err(human(&format_args!("cannot request more than {} items", max)))
         }
         if page == 0 {
             return Err(human("page indexing starts from 1, page 0 is invalid"))

--- a/src/version.rs
+++ b/src/version.rs
@@ -131,10 +131,10 @@ impl Version {
                           -> CargoResult<(Dependency, Crate)> {
         let name = &dep.name;
         let krate = Crate::find_by_name(conn, name).map_err(|_| {
-            human(format!("no known crate named `{}`", &**name))
+            human(&format_args!("no known crate named `{}`", &**name))
         })?;
         if dep.version_req.0 == semver::VersionReq::parse("*").unwrap() {
-            return Err(human(format!("wildcard (`*`) dependency constraints are not allowed \
+            return Err(human(&format_args!("wildcard (`*`) dependency constraints are not allowed \
                                       on crates.io. See http://doc.crates.io/faq.html#can-\
                                       libraries-use--as-a-version-for-their-dependencies for more \
                                       information")));
@@ -309,13 +309,13 @@ fn version_and_crate(req: &mut Request) -> CargoResult<(Version, Crate)> {
     let crate_name = &req.params()["crate_id"];
     let semver = &req.params()["version"];
     let semver = semver::Version::parse(semver).map_err(|_| {
-        human(format!("invalid semver: {}", semver))
+        human(&format_args!("invalid semver: {}", semver))
     })?;
     let tx = req.tx()?;
     let krate = Crate::find_by_name(tx, crate_name)?;
     let version = Version::find_by_num(tx, krate.id, &semver)?;
     let version = version.chain_error(|| {
-        human(format!("crate `{}` does not have a version `{}`",
+        human(&format_args!("crate `{}` does not have a version `{}`",
                       crate_name, semver))
     })?;
     Ok((version, krate))


### PR DESCRIPTION
These functions have no reason to take their arguments by value, since
they're just calling `.to_string` on it anyway. Additionally, everywhere
that was passing `format!` can pass `format_args!` instead and skip the
intermediate string