### PR TITLE
Add clippy, make it pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,13 @@ addons:
       - libelf-dev
       - libdw-dev
 
+matrix:
+  include:
+  - rust: nightly-2017-03-04
+    env: CLIPPY=YESPLEASE
+    script:
+    - cargo rustc --lib --features "lint" -- -Zno-trans
+
 env:
   global:
     - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "civet 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-cookie 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,6 +86,16 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cargo_metadata"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "civet"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +110,28 @@ dependencies = [
 name = "civet-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "clippy"
+version = "0.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cargo_metadata 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clippy_lints"
+version = "0.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cmake"
@@ -637,6 +670,11 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "quine-mc_cluskey"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "quote"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +782,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +797,11 @@ dependencies = [
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -940,8 +991,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b48dbe2ff0e98fa2f03377d204a9637d3c9816cd431bfe05a8abbd0ea11d074"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum cargo_metadata 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "34fdab49a2904acb112c83b62f0118de3de3ce28e52a9188dec2858e43878f25"
 "checksum civet 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d8158a63bb12df912168a638a0a4e2de5d50f587b9fa20b2f7aeb85433a8c926"
 "checksum civet-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "958d15372bf28b7983cb35e1d4bf36dd843b0d42e507c1c73aad7150372c5936"
+"checksum clippy 0.0.118 (registry+https://github.com/rust-lang/crates.io-index)" = "6cb0894ce1af2464033706bf9b33e28c4a8fc72df8449fcd60f7a5162a7a9630"
+"checksum clippy_lints 0.0.118 (registry+https://github.com/rust-lang/crates.io-index)" = "67d4bf7c7bb21b11b4d62146bcc8abaaf4e230a6346a21c9e88fa0c3540c71a4"
 "checksum cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "a3a6805df695087e7c1bcd9a82e03ad6fb864c8e67ac41b1348229ce5b7f0407"
 "checksum conduit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c71871e85346d0f0c72a9f207748423eeb198d5d07284c74f8a3652dd87bd63a"
 "checksum conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "614f67083e437fd0b8fb9f13067203f358f1c6f52989eb6539292fde007fc6d6"
@@ -1002,6 +1056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum postgres-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ba919eba78ade418bdee00d325caccb0946ab0ccfeaeb364c0fe157d2a81c382"
 "checksum postgres-shared 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "857ef343933a7d81e365a334f505a07db16ab7be64d9d7cd82c78d2f486777e4"
 "checksum pq-sys 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b9304824c6f013d5cb3db2e3e4fbb07379dec552afaae67b652a0f20adf0ec"
+"checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "7375cf7ad34a92e8fd18dd9c42f58b9a11def59ab48bec955bf359a788335592"
 "checksum r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecfed1b03be2e66624ec87cef173dad54253f25405bd3c918b321e4dda3ad32"
 "checksum r2d2-diesel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bea35c212f6cc1c408512a1289196299882950546b44449bb843f287f7a4402"
@@ -1015,7 +1070,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum route-recognizer 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "4f0a750d020adb1978f5964ea7bca830585899b09da7cbb3f04961fc2400122d"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
+"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fff3c9c5a54636ab95acd8c1349926e04cb1eb8cd70b5adced8a1d1f703a67"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "a702319c807c016e51f672e5c77d6f0b46afddd744b5e437d6b8436b888b458f"
 "checksum serde_codegen_internals 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d52006899f910528a10631e5b727973fe668f3228109d1707ccf5bad5490b6e"
 "checksum serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f15ea24bd037b2d64646b4d934fa99c649be66e3f7b29fb595a5543b212b1452"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ diesel_full_text_search = "0.12.0"
 serde_json = "0.9.9"
 serde_derive = "0.9.11"
 serde = "0.9.11"
+clippy = { version = "=0.0.118", optional = true }
 
 conduit = "0.8"
 conduit-conditional-get = "0.8"
@@ -54,10 +55,10 @@ conduit-static = "0.8"
 conduit-git-http-backend = "0.8"
 civet = "0.9"
 
-
 [dev-dependencies]
 conduit-test = "0.8"
 bufstream = "0.1"
 
 [features]
 unstable = []
+lint = ["clippy"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,7 +58,7 @@ impl App {
             .build();
 
         let repo = git2::Repository::open(&config.git_repo_checkout).unwrap();
-        return App {
+        App {
             database: db::pool(&config.db_url, db_config),
             diesel_database: db::diesel_pool(&config.db_url, diesel_db_config),
             github: github,
@@ -66,15 +66,15 @@ impl App {
             git_repo: Mutex::new(repo),
             git_repo_checkout: config.git_repo_checkout.clone(),
             config: config.clone(),
-        };
+        }
     }
 
     pub fn handle(&self) -> Easy {
         let mut handle = Easy::new();
-        if let Some(ref proxy) = self.config.uploader.proxy() {
+        if let Some(proxy) = self.config.uploader.proxy() {
             handle.proxy(proxy).unwrap();
         }
-        return handle
+        handle
     }
 }
 

--- a/src/bin/fill-in-user-id.rs
+++ b/src/bin/fill-in-user-id.rs
@@ -66,7 +66,7 @@ fn update(app: &App, tx: &postgres::transaction::Transaction) {
         let res = (|| -> CargoResult<()> {
             let url = format!("/users/{}", login);
             let (handle, resp) = http::github(app, &url, &token)?;
-            let ghuser: GithubUser = http::parse_github_response(handle, resp)?;
+            let ghuser: GithubUser = http::parse_github_response(handle, &resp)?;
             if let Some(ref avatar) = avatar {
                 if !avatar.contains(&ghuser.id.to_string()) {
                     return Err(human(&format_args!("avatar: {}", avatar)))

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -58,8 +58,8 @@ fn categories_from_toml(categories: &toml::Table, parent: Option<&Category>) -> 
 
         let category = Category::from_parent(
             slug,
-            required_string_from_toml(&details, "name")?,
-            optional_string_from_toml(&details, "description"),
+            required_string_from_toml(details, "name")?,
+            optional_string_from_toml(details, "description"),
             parent,
         );
 
@@ -92,7 +92,7 @@ pub fn sync() -> CargoResult<()> {
         "Could not convert categories from TOML"
     );
 
-    for category in categories.iter() {
+    for category in &categories {
         tx.execute("\
             INSERT INTO categories (slug, category, description) \
             VALUES (LOWER($1), $2, $3) \
@@ -103,7 +103,7 @@ pub fn sync() -> CargoResult<()> {
         )?;
     }
 
-    let in_clause = categories.iter().map(|ref category| {
+    let in_clause = categories.iter().map(|category| {
         format!("LOWER('{}')", category.slug)
     }).collect::<Vec<_>>().join(",");
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -79,7 +79,7 @@ impl Category {
 
     pub fn encodable(self) -> EncodableCategory {
         let Category {
-            id: _, crates_cnt, category, slug, description, created_at
+            crates_cnt, category, slug, description, created_at, ..
         } = self;
         EncodableCategory {
             id: slug.clone(),
@@ -125,7 +125,7 @@ impl Category {
         // it out and don't add it. Return it to be able to warn about it.
         let mut invalid_categories = vec![];
         let new_categories: Vec<Category> = categories.iter().flat_map(|c| {
-            match Category::find_by_slug(conn, &c) {
+            match Category::find_by_slug(conn, c) {
                 Ok(cat) => Some(cat),
                 Err(_) => {
                     invalid_categories.push(c.to_string());
@@ -324,8 +324,8 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
 pub fn show(req: &mut Request) -> CargoResult<Response> {
     let slug = &req.params()["category_id"];
     let conn = req.tx()?;
-    let cat = Category::find_by_slug(&*conn, &slug)?;
-    let subcats = cat.subcategories(&*conn)?.into_iter().map(|s| {
+    let cat = Category::find_by_slug(conn, slug)?;
+    let subcats = cat.subcategories(conn)?.into_iter().map(|s| {
         s.encodable()
     }).collect();
     let cat = cat.encodable();

--- a/src/db.rs
+++ b/src/db.rs
@@ -153,7 +153,7 @@ impl Transaction {
         Ok(&**self.slot.borrow().unwrap())
     }
 
-    fn tx<'a>(&'a self) -> CargoResult<&'a (GenericConnection + 'a)> {
+    fn tx(&self) -> CargoResult<&GenericConnection> {
         // Similar to above, the transaction for this request is actually tied
         // to the connection in the request itself, not 'static. We transmute it
         // to static as its paired with the inner connection to achieve the
@@ -167,7 +167,7 @@ impl Transaction {
             }
         }
         let tx = self.tx.borrow();
-        let tx: &'a pg::transaction::Transaction<'static> = tx.unwrap();
+        let tx: &pg::transaction::Transaction<'static> = tx.unwrap();
         Ok(tx)
     }
 
@@ -201,7 +201,7 @@ impl Middleware for TransactionMiddleware {
                 Box::new(e) as Box<Error + Send>
             })?;
         }
-        return res
+        res
     }
 }
 

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -11,8 +11,8 @@ pub struct Middleware {
     dist: Static,
 }
 
-impl Middleware {
-    pub fn new() -> Middleware {
+impl Default for  Middleware {
+    fn default() -> Middleware {
         Middleware {
             handler: None,
             dist: Static::new("dist"),

--- a/src/download.rs
+++ b/src/download.rs
@@ -21,8 +21,7 @@ pub struct EncodableVersionDownload {
 
 impl VersionDownload {
     pub fn encodable(self) -> EncodableVersionDownload {
-        let VersionDownload { id, version_id, downloads, counted: _,
-                              date } = self;
+        let VersionDownload { id, version_id, downloads, date, .. } = self;
         EncodableVersionDownload {
             id: id,
             version: version_id,

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,7 +9,7 @@ use std::str;
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
 /// because custom error-code handling may be desirable. Use
-/// parse_github_response to handle the "common" processing of responses.
+/// `parse_github_response` to handle the "common" processing of responses.
 pub fn github(app: &App, url: &str, auth: &Token)
               -> Result<(Easy, Vec<u8>), curl::Error> {
     let url = format!("{}://api.github.com{}", app.config.api_protocol, url);
@@ -38,7 +38,7 @@ pub fn github(app: &App, url: &str, auth: &Token)
 }
 
 /// Checks for normal responses
-pub fn parse_github_response<T: Decodable>(mut resp: Easy, data: Vec<u8>)
+pub fn parse_github_response<T: Decodable>(mut resp: Easy, data: &[u8])
                                             -> CargoResult<T> {
     match resp.response_code().unwrap() {
         200 => {} // Ok!
@@ -52,13 +52,13 @@ pub fn parse_github_response<T: Decodable>(mut resp: Easy, data: Vec<u8>)
                               https://crates.io/login"));
         }
         n => {
-            let resp = String::from_utf8_lossy(&data);
+            let resp = String::from_utf8_lossy(data);
             return Err(internal(&format_args!("didn't get a 200 result from \
                                         github, got {} with: {}", n, resp)));
         }
     }
 
-    let json = str::from_utf8(&data).ok().chain_error(|| {
+    let json = str::from_utf8(data).ok().chain_error(|| {
         internal("github didn't send a utf8-response")
     })?;
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -110,7 +110,7 @@ impl Decodable for KeywordList {
         if inner.len() > 5 {
             return Err(d.error("a maximum of 5 keywords per crate are allowed"))
         }
-        for val in inner.iter() {
+        for val in &inner {
             if val.len() > 20 {
                 return Err(d.error("keywords must contain less than 20 \
                                     characters"))
@@ -225,16 +225,12 @@ impl Deref for Feature {
 
 impl Deref for CrateVersion {
     type Target = semver::Version;
-    fn deref<'a>(&'a self) -> &'a semver::Version {
-        let CrateVersion(ref s) = *self; s
-    }
+    fn deref(&self) -> &semver::Version { &self.0 }
 }
 
 impl Deref for CrateVersionReq {
     type Target = semver::VersionReq;
-    fn deref<'a>(&'a self) -> &'a semver::VersionReq {
-        let CrateVersionReq(ref s) = *self; s
-    }
+    fn deref(&self) -> &semver::VersionReq { &self.0 }
 }
 
 impl Deref for KeywordList {

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -142,7 +142,7 @@ pub struct Bomb {
 impl Drop for Bomb {
     fn drop(&mut self) {
         if let Some(ref path) = self.path {
-            if let Err(e) = self.app.config.uploader.delete(self.app.clone(), &path) {
+            if let Err(e) = self.app.config.uploader.delete(self.app.clone(), path) {
                 println!("unable to delete {}, {:?}", path, e);
             }
         }

--- a/src/user/middleware.rs
+++ b/src/user/middleware.rs
@@ -37,7 +37,7 @@ impl conduit_middleware::Middleware for Middleware {
 
                         // Look for a user in the database with a matching API token
                         let tx = req.tx().map_err(std_error)?;
-                        match User::find_by_api_token(tx, &headers[0]) {
+                        match User::find_by_api_token(tx, headers[0]) {
                             Ok(user) => user,
                             Err(..) => return Ok(())
                         }

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -15,7 +15,7 @@ use util::json_response;
 
 pub trait CargoError: Send + fmt::Display + 'static {
     fn description(&self) -> &str;
-    fn cause<'a>(&'a self) -> Option<&'a (CargoError)> { None }
+    fn cause(&self) -> Option<&(CargoError)> { None }
 
     fn response(&self) -> Option<Response> {
         if self.human() {
@@ -150,9 +150,8 @@ struct ConcreteCargoError {
 impl fmt::Display for ConcreteCargoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.description)?;
-        match self.detail  {
-            Some(ref s) => write!(f, " ({})", s)?,
-            None => {}
+        if let Some(ref s) = self.detail {
+            write!(f, " ({})", s)?;
         }
         Ok(())
     }
@@ -174,7 +173,7 @@ impl CargoError for NotFound {
             errors: vec![StringError { detail: "Not Found".to_string() }],
         });
         response.status = (404, "Not Found");
-        return Some(response);
+        Some(response)
     }
 }
 
@@ -196,7 +195,7 @@ impl CargoError for Unauthorized {
             }],
         });
         response.status = (403, "Forbidden");
-        return Some(response);
+        Some(response)
     }
 }
 

--- a/src/util/hasher.rs
+++ b/src/util/hasher.rs
@@ -24,6 +24,6 @@ impl<R: Read> Read for HashingReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let amt = self.inner.read(buf)?;
         self.hasher.update(&buf[..amt]).unwrap();
-        return Ok(amt)
+        Ok(amt)
     }
 }

--- a/src/util/head.rs
+++ b/src/util/head.rs
@@ -6,14 +6,9 @@ use conduit_middleware::AroundMiddleware;
 
 use util::RequestProxy;
 
+#[derive(Default)]
 pub struct Head {
     handler: Option<Box<Handler>>,
-}
-
-impl Head {
-    pub fn new() -> Head {
-        Head { handler: None }
-    }
 }
 
 impl AroundMiddleware for Head {

--- a/src/util/io_util.rs
+++ b/src/util/io_util.rs
@@ -27,7 +27,7 @@ impl<R: Read> Read for LimitErrorReader<R> {
 pub fn read_le_u32<R: Read + ?Sized>(r: &mut R) -> io::Result<u32> {
     let mut b = [0; 4];
     read_fill(r, &mut b)?;
-    Ok(((b[0] as u32) <<  0) |
+    Ok( (b[0] as u32)        |
        ((b[1] as u32) <<  8) |
        ((b[2] as u32) << 16) |
        ((b[3] as u32) << 24))
@@ -35,7 +35,7 @@ pub fn read_le_u32<R: Read + ?Sized>(r: &mut R) -> io::Result<u32> {
 
 pub fn read_fill<R: Read + ?Sized>(r: &mut R, mut slice: &mut [u8])
                                    -> io::Result<()> {
-    while slice.len() > 0 {
+    while !slice.is_empty() {
         let n = r.read(slice)?;
         if n == 0 {
             return Err(io::Error::new(io::ErrorKind::Other,

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -19,7 +19,7 @@ impl<'a> Request for RequestProxy<'a> {
         self.other.conduit_version()
     }
     fn method(&self) -> conduit::Method {
-        self.method.unwrap_or(self.other.method())
+        self.method.unwrap_or_else(|| self.other.method())
     }
     fn scheme(&self) -> conduit::Scheme { self.other.scheme() }
     fn host(&self) -> conduit::Host { self.other.host() }
@@ -27,7 +27,7 @@ impl<'a> Request for RequestProxy<'a> {
         self.other.virtual_root()
     }
     fn path(&self) -> &str {
-        self.path.map(|s| &*s).unwrap_or(self.other.path())
+        self.path.map(|s| &*s).unwrap_or_else(|| self.other.path())
     }
     fn query_string(&self) -> Option<&str> {
         self.other.query_string()


### PR DESCRIPTION
Adds the ability to run clippy against the project (disabled by default since it requires nightly), and makes all the required changes to make it pass. The failures were mostly to make the code idiomatic, though there were a batch that was due to requiring unnecessary allocations. I plan on enabling some additional lints to make this more pedantic in future PRs, this is just the default set of lints.