### PR TITLE
Remove the versions_to_semver_no_prerelease_idx index

### DIFF
--- a/migrations/20170311180634_remove_semver_index/down.sql
+++ b/migrations/20170311180634_remove_semver_index/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX versions_to_semver_no_prerelease_idx ON versions (crate_id, to_semver_no_prerelease(num) DESC NULLS LAST) WHERE NOT yanked;

--- a/migrations/20170311180634_remove_semver_index/up.sql
+++ b/migrations/20170311180634_remove_semver_index/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX versions_to_semver_no_prerelease_idx;


### PR DESCRIPTION
It's not actually being used in the reverse dependencies query and
heroku postgres doesn't like it.

I'm seeing these errors in the heroku postgres logs:

```
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-1] ERROR:  type "semver_triple" does not exist at character 139 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-2] QUERY:   
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-3] 	  SELECT ( 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-4] 	    split_part($1, '.', 1)::int4, 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-5] 	    split_part($1, '.', 2)::int4, 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-6] 	    split_part(split_part($1, '+', 1), '.', 3)::int4 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-7] 	  )::semver_triple 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-8] 	  WHERE strpos($1, '-') = 0 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-9] 	   
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-10] CONTEXT:  SQL function "to_semver_no_prerelease" during inlining 
Mar 10 19:34:13 crates-io app/postgres.8131: [WHITE] [4-11] automatic analyze of table "d3pk1mpsh8v4v4.public.versions" 
```

@sgrif says it has something to do with the way heroku does their backups, and also hinted that this index probably isn't even being used, which does appear to be true, here's the explain analyze for the reverse_dependencies query:


```
Unique  (cost=7301.26..7301.32 rows=43 width=61) (actual time=429.050..429.457 rows=1200 loops=1)
   ->  Sort  (cost=7301.26..7301.28 rows=43 width=61) (actual time=429.050..429.153 rows=1217 loops=1)
         Sort Key: crates.downloads DESC, crates.name
         Sort Method: quicksort  Memory: 169kB
         ->  Nested Loop  (cost=3737.56..7301.03 rows=43 width=61) (actual time=372.325..428.252 rows=1217 loops=1)
               ->  Nested Loop  (cost=3737.50..7193.61 rows=43 width=51) (actual time=372.317..424.069 rows=1217 loops=1)
                     ->  Subquery Scan on versions  (cost=3737.42..6379.16 rows=226 width=8) (actual time=372.285..400.124 rows=8219 loops=1)
                           Filter: (versions.rn = 1)
                           Rows Removed by Filter: 37088
                           ->  WindowAgg  (cost=3737.42..6221.11 rows=45158 width=133) (actual time=372.281..396.599 rows=45307 loops=1)
                                 ->  Sort  (cost=3737.42..3759.99 rows=45158 width=40) (actual time=372.273..378.909 rows=45307 loops=1)
                                       Sort Key: versions_1.crate_id, (to_semver_no_prerelease((versions_1.num)::text)) DESC NULLS LAST
                                       Sort Method: quicksort  Memory: 5063kB
                                       ->  Seq Scan on versions versions_1  (cost=0.00..3039.15 rows=45158 width=40) (actual time=0.154..306.853 rows=45307 loops=1)
                                             Filter: (NOT yanked)
                                             Rows Removed by Filter: 1290
                     ->  Index Scan using index_dependencies_version_id on dependencies  (cost=0.08..3.60 rows=1 width=47) (actual time=0.003..0.003 rows=0 loops=8219)
                           Index Cond: (version_id = versions.id)
                           Filter: (crate_id = 795)
                           Rows Removed by Filter: 3
               ->  Index Scan using packages_pkey on crates  (cost=0.06..2.50 rows=1 width=18) (actual time=0.003..0.003 rows=1 loops=1217)
                     Index Cond: (id = versions.crate_id)
 Planning time: 1.419 ms
 Execution time: 429.821 ms
```