### PR TITLE
Follow the Diesel

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -38,9 +38,6 @@ export default Ember.Controller.extend({
             var page = (this.get('myFeed').length / 10) + 1;
 
             ajax(`/me/updates?page=${page}`).then((data) => {
-                data.crates.forEach(crate =>
-                    this.store.push(this.store.normalize('crate', crate)));
-
                 var versions = data.versions.map(version =>
                     this.store.push(this.store.normalize('version', version)));
 

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -1,4 +1,5 @@
 import DS from 'ember-data';
+import Ember from 'ember';
 
 export default DS.Model.extend({
     num: DS.attr('string'),
@@ -14,6 +15,10 @@ export default DS.Model.extend({
     authors: DS.hasMany('users', { async: true }),
     dependencies: DS.hasMany('dependency', { async: true }),
     version_downloads: DS.hasMany('version-download', { async: true }),
+
+    crateName: Ember.computed('crate', function() {
+        return this.belongsTo('crate').id();
+    }),
 
     getDownloadUrl() {
         return this.store.adapterFor('version').getDownloadUrl(this.get('dl_path'));

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -49,10 +49,12 @@
             {{#each myFeed as |version|}}
                 <div class='row'>
                     <div class='info'>
-                        {{link-to version.crate.name 'crate.version' version.num}}
+                        {{#link-to 'crate.version' version.crateName version.num}}
+                        {{ version.crateName }}
                         <span class='small'>{{ version.num }}</span>
+                        {{/link-to}}
                         <span class='date small'>
-                            {{from-now version.created_at}}
+                            {{moment-from-now version.created_at}}
                         </span>
                     </div>
                 </div>

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,12 +1,13 @@
 #![deny(warnings)]
 
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
 extern crate bufstream;
 extern crate cargo_registry;
 extern crate conduit;
 extern crate conduit_middleware;
 extern crate conduit_test;
 extern crate curl;
-extern crate diesel;
 extern crate dotenv;
 extern crate git2;
 extern crate postgres;

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -769,63 +769,53 @@ fn dependencies() {
 
 #[test]
 fn following() {
-    // #[derive(RustcDecodable)] struct F { following: bool }
-    // #[derive(RustcDecodable)] struct O { ok: bool }
+    #[derive(RustcDecodable)] struct F { following: bool }
+    #[derive(RustcDecodable)] struct O { ok: bool }
 
     let (_b, app, middle) = ::app();
     let mut req = ::req(app.clone(), Method::Get, "/api/v1/crates/foo_following/following");
 
     let user;
-    let krate;
     {
         let conn = app.diesel_database.get().unwrap();
         user = ::new_user("foo").create_or_update(&conn).unwrap();
         ::sign_in_as(&mut req, &user);
-        krate = ::new_crate("foo_following").create_or_update(&conn, None, user.id).unwrap();
-
-        // FIXME: Go back to hitting the actual endpoint once it's using Diesel
-        conn
-            .execute(&format!("INSERT INTO follows (user_id, crate_id) VALUES ({}, {})",
-                              user.id, krate.id))
-            .unwrap();
+        ::new_crate("foo_following").create_or_update(&conn, None, user.id).unwrap();
     }
 
-    // let mut response = ok_resp!(middle.call(&mut req));
-    // assert!(!::json::<F>(&mut response).following);
+    let mut response = ok_resp!(middle.call(&mut req));
+    assert!(!::json::<F>(&mut response).following);
 
-    // req.with_path("/api/v1/crates/foo_following/follow")
-    //    .with_method(Method::Put);
-    // let mut response = ok_resp!(middle.call(&mut req));
-    // assert!(::json::<O>(&mut response).ok);
-    // let mut response = ok_resp!(middle.call(&mut req));
-    // assert!(::json::<O>(&mut response).ok);
+    req.with_path("/api/v1/crates/foo_following/follow")
+       .with_method(Method::Put);
+    let mut response = ok_resp!(middle.call(&mut req));
+    assert!(::json::<O>(&mut response).ok);
+    let mut response = ok_resp!(middle.call(&mut req));
+    assert!(::json::<O>(&mut response).ok);
 
-    // req.with_path("/api/v1/crates/foo_following/following")
-    //    .with_method(Method::Get);
-    // let mut response = ok_resp!(middle.call(&mut req));
-    // assert!(::json::<F>(&mut response).following);
+    req.with_path("/api/v1/crates/foo_following/following")
+       .with_method(Method::Get);
+    let mut response = ok_resp!(middle.call(&mut req));
+    assert!(::json::<F>(&mut response).following);
 
     req.with_path("/api/v1/crates")
-       .with_query("following=1");
+        .with_method(Method::Get)
+        .with_query("following=1");
     let mut response = ok_resp!(middle.call(&mut req));
     let l = ::json::<CrateList>(&mut response);
     assert_eq!(l.crates.len(), 1);
 
-    // FIXME: Go back to hitting the actual endpoint once it's using Diesel
-    req.db_conn().unwrap()
-        .execute("TRUNCATE TABLE follows")
-        .unwrap();
-    // req.with_path("/api/v1/crates/foo_following/follow")
-    //    .with_method(Method::Delete);
-    // let mut response = ok_resp!(middle.call(&mut req));
-    // assert!(::json::<O>(&mut response).ok);
-    // let mut response = ok_resp!(middle.call(&mut req));
-    // assert!(::json::<O>(&mut response).ok);
+    req.with_path("/api/v1/crates/foo_following/follow")
+       .with_method(Method::Delete);
+    let mut response = ok_resp!(middle.call(&mut req));
+    assert!(::json::<O>(&mut response).ok);
+    let mut response = ok_resp!(middle.call(&mut req));
+    assert!(::json::<O>(&mut response).ok);
 
-    // req.with_path("/api/v1/crates/foo_following/following")
-    //    .with_method(Method::Get);
-    // let mut response = ok_resp!(middle.call(&mut req));
-    // assert!(!::json::<F>(&mut response).following);
+    req.with_path("/api/v1/crates/foo_following/following")
+       .with_method(Method::Get);
+    let mut response = ok_resp!(middle.call(&mut req));
+    assert!(!::json::<F>(&mut response).following);
 
     req.with_path("/api/v1/crates")
        .with_query("following=1")


### PR DESCRIPTION
Get it? Because this ports the follow endpoints. To Diesel. ...Anyone?

This ports 4 endpoints over to Diesel. The 3 endpoints which manipulate
the `follows` table, as well as the `/me/updates` endpoint since it
is only hit by the tests for the follows endpoints.

I ended up changing the updates endpoint quite a bit. I wanted to
eliminate the N+1 queries on the max version, and was wondering why we
needed the max version at all here. I went to go look at it in the UI,
and it turns out that the dashboard page which displayed it is actually
broken as well. After fixing it, I noticed that it doesn't need the
crates at all, just the name (which we tell Ember is the id).

I couldn't actually find a good way in Ember to reference the ID of an
association without loading the whole thing. If anybody knows a better
way to do it than what I'm doing here, please let me know.

Since we don't need the crates, I've just opted not to include that data
in the response body (note that just not including the max version is a
bad idea, since ember caches stuff and it could result in a page that
does need the max version displaying wrong later).

While I was touching these endpoints, I also went ahead and reduced them
all to a single query.

Fixes #438.