### PR TITLE
Fix category query to look up on slug

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -672,8 +672,8 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
         query = query.filter(crates::id.eq_any(
             crates_categories::table.select(crates_categories::crate_id)
                 .inner_join(categories::table)
-                .filter(categories::category.eq(cat).or(
-                        categories::category.like(format!("{}::%", cat))))
+                .filter(categories::slug.eq(cat).or(
+                        categories::slug.like(format!("{}::%", cat))))
         ));
     } else if let Some(user_id) = params.get("user_id").and_then(|s| s.parse::<i32>().ok()) {
         query = query.filter(crates::id.eq_any((

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -143,8 +143,8 @@ fn index_queries() {
     let mut response = ok_resp!(middle.call(req.with_query("keyword=kw2")));
     assert_eq!(::json::<CrateList>(&mut response).crates.len(), 0);
 
-    ::new_category("cat1", "cat1").find_or_create(req.db_conn().unwrap()).unwrap();
-    ::new_category("cat1::bar", "cat1::bar").find_or_create(req.db_conn().unwrap()).unwrap();
+    ::new_category("Category 1", "cat1").find_or_create(req.db_conn().unwrap()).unwrap();
+    ::new_category("Category 1::Ba'r", "cat1::bar").find_or_create(req.db_conn().unwrap()).unwrap();
     Category::update_crate(req.db_conn().unwrap(), &krate, &["cat1"]).unwrap();
     Category::update_crate(req.db_conn().unwrap(), &krate2, &["cat1::bar"]).unwrap();
     let mut response = ok_resp!(middle.call(req.with_query("category=cat1")));


### PR DESCRIPTION
Also make the test catch this bug by having slug != category.

Sorry I didn't catch this when reviewing #609, but at least I caught it before I deployed it to production!!!!

Ultimately this is my fault for writing tests that had the same value for the category display name and slug, which isn't what the real data is like, so the tests passed for #609 :(