### PR TITLE
Don't tie the lifetime of the db connection to the request

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,6 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     m.add(conduit_cookie::SessionMiddleware::new("cargo_session",
                                                  env == Env::Production));
     m.add(app::AppMiddleware::new(app));
-    m.add(db::DieselMiddleware);
     if env != Env::Test {
         m.add(db::TransactionMiddleware);
     }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -341,7 +341,7 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
     let name = &req.params()["user_id"];
     let conn = req.db_conn()?;
     let user = users.filter(gh_login.eq(name))
-        .first::<User>(conn)?;
+        .first::<User>(&*conn)?;
 
     #[derive(RustcEncodable)]
     struct R {
@@ -374,7 +374,7 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
             crates::name,
             sql::<BigInt>("COUNT(*) OVER ()"),
         ))
-        .load::<(Version, String, i64)>(conn)?;
+        .load::<(Version, String, i64)>(&*conn)?;
 
     let more = data.get(0)
         .map(|&(_, _, count)| count > offset + limit)


### PR DESCRIPTION
Consider code like the following:

```rust
let conn = req.db_conn()?;
let body = req.body();
```

Since the `body` function requires `&mut self`, this code will fail
since the lifetime of the connection is tied to the lifetime of the
request. These are of course disjoint, but the compiler can't know that.

Really there's no reason to stick the request in `extensions` like we
are. I think the reason the postgres code did it that way was to allow
mocking the connection out in tests, but we just set the pool size to 1.

Additionally, some endpoints (like `crates#summary` are embarassingly
parallelizable, so we should expose the capability for multiple database
connections in a single request.