### PR TITLE
Update the dependencies schema to match use

### DIFF
--- a/app/models/dependency.js
+++ b/app/models/dependency.js
@@ -3,8 +3,6 @@ import Ember from 'ember';
 
 Ember.Inflector.inflector.irregular('dependency', 'dependencies');
 
-const { computed } = Ember;
-
 export default DS.Model.extend({
     version: DS.belongsTo('version', {
         async: false
@@ -13,11 +11,7 @@ export default DS.Model.extend({
     req: DS.attr('string'),
     optional: DS.attr('boolean'),
     default_features: DS.attr('boolean'),
-    features: DS.attr('string'),
+    features: DS.attr({ defaultValue: () => [] }),
     kind: DS.attr('string'),
     downloads: DS.attr('number'),
-
-    featureList: computed('features', function() {
-        return this.get('features').split(',');
-    })
 });

--- a/migrations/20170315133901_make_dependencies_schema_match_use/down.sql
+++ b/migrations/20170315133901_make_dependencies_schema_match_use/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE dependencies
+  ALTER COLUMN kind DROP DEFAULT,
+  ALTER COLUMN kind DROP NOT NULL,
+  ALTER COLUMN features SET DATA TYPE text USING array_to_string(features, ',');

--- a/migrations/20170315133901_make_dependencies_schema_match_use/up.sql
+++ b/migrations/20170315133901_make_dependencies_schema_match_use/up.sql
@@ -1,0 +1,5 @@
+UPDATE dependencies SET kind = 0 WHERE kind IS NULL;
+ALTER TABLE dependencies
+  ALTER COLUMN kind SET DEFAULT 0,
+  ALTER COLUMN kind SET NOT NULL,
+  ALTER COLUMN features SET DATA TYPE text[] USING string_to_array(features, ',');

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -83,9 +83,9 @@ table! {
         req -> Varchar,
         optional -> Bool,
         default_features -> Bool,
-        features -> Varchar,
+        features -> Array<Text>,
         target -> Nullable<Varchar>,
-        kind -> Nullable<Int4>,
+        kind -> Int4,
     }
 }
 


### PR DESCRIPTION
Dependencies kind is assigned a default value when deserialized from the
database, and all newly inserted values are given a non-null value.
Let's just give it a default at the database level and mark it not-null.

Additionally, we were storing it as a comma-delmited string but there
was really no reason to do so. It was converted back to a string before
being sent to the front-end, but we converted to/from an array in
between so there was no gain from storing it as a string. Additionally,
the front-end never used it as a comma delimited string (actually, it
doesn't use `dependencies.features` at all unless there's some crazy
metaprogramming that doesn't show up when grepping for "features" and
"featureList")

I honestly can't find any reason in the history that they were stored
this way. I suspect it might be because they used to be stored as a
string which used pipes as a delimiter, so that heritage just stuck
around when it moved to being a separate value in the database and
index.