### PR TITLE
Ensure Diesel NotFound results in a 404

### DIFF
--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -774,6 +774,21 @@ fn dependencies() {
 }
 
 #[test]
+fn diesel_not_found_results_in_404() {
+    let (_b, app, middle) = ::app();
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/crates/foo_following/following");
+
+    {
+        let conn = app.diesel_database.get().unwrap();
+        let user = ::new_user("foo").create_or_update(&conn).unwrap();
+        ::sign_in_as(&mut req, &user);
+    }
+
+    let response = middle.call(&mut req).unwrap();
+    assert_eq!((404, "Not Found"), response.status);
+}
+
+#[test]
 fn following() {
     #[derive(RustcDecodable)] struct F { following: bool }
     #[derive(RustcDecodable)] struct O { ok: bool }


### PR DESCRIPTION
Any method in Diesel's API which returns a single record (specifically
`.get_result` and `.first`) treats 0 records as an error case by
default (calling `.optional` on the `Result` turns it into a
Result<Option<T>>`). However, right now if a
`diesel::result::Error::NotFound` is returned, the server will return a
500. We don't test every possible place a 404 can be returned, so this
is never apparent in tests.

The implementation is a bit of a kludge, but I'm not sure that there's a
better way to do this without either requiring nightly for
specialization or significantly reworking the error handling of the
application (I do think that we should eventually do the latter)