### PR TITLE
Update `crate_downloads` schema to match use, kill dead code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "cargo-registry"
 version = "0.1.0"
 dependencies = [
  "bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "civet 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -83,6 +84,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "chrono"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "civet"
@@ -506,6 +516,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +660,7 @@ name = "postgres-shared"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fallible-iterator 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -940,6 +978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b48dbe2ff0e98fa2f03377d204a9637d3c9816cd431bfe05a8abbd0ea11d074"
 "checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "158b0bd7d75cbb6bf9c25967a48a2e9f77da95876b858eadfabaa99cd069de6e"
 "checksum civet 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d8158a63bb12df912168a638a0a4e2de5d50f587b9fa20b2f7aeb85433a8c926"
 "checksum civet-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "958d15372bf28b7983cb35e1d4bf36dd843b0d42e507c1c73aad7150372c5936"
 "checksum cmake 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "a3a6805df695087e7c1bcd9a82e03ad6fb864c8e67ac41b1348229ce5b7f0407"
@@ -988,6 +1027,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum metadeps 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829fffe7ea1d747e23f64be972991bc516b2f1ac2ae4a3b33d8bea150c410151"
 "checksum miniz-sys 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "28eaee17666671fa872e567547e8428e83308ebe5808cdf6a0e28397dbe2c726"
+"checksum num 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "98b15ba84e910ea7a1973bccd3df7b31ae282bf9d8bd2897779950c9b8303d40"
+"checksum num-integer 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "21e4df1098d1d797d27ef0c69c178c3fab64941559b290fcae198e0825c9c8b5"
+"checksum num-iter 0.1.33 (registry+https://github.com/rust-lang/crates.io-index)" = "f7d1891bd7b936f12349b7d1403761c8a0b85a18b148e9da4429d5d102c1a41e"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
 "checksum oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4fcd990d45681b9eba5f4f3fa7d0371ec277f4e4380a94104d26aa4fae386fc"
 "checksum openssl 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0c00da69323449142e00a5410f0e022b39e8bbb7dc569cee8fc6af279279483c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ git2 = "0.6.4"
 flate2 = "0.2"
 semver = "0.5"
 url = "1.2.1"
-postgres = { version = "0.14.0", features = ["with-time", "with-openssl", "with-serde_json"] }
+postgres = { version = "0.14.0", features = ["with-time", "with-openssl", "with-serde_json", "with-chrono"] }
 r2d2 = "0.7.0"
 r2d2_postgres = "0.12.0"
 openssl = "0.9"
@@ -42,6 +42,7 @@ diesel_full_text_search = "0.12.0"
 serde_json = "0.9.9"
 serde_derive = "0.9.11"
 serde = "0.9.11"
+chrono = "0.3.0"
 
 conduit = "0.8"
 conduit-conditional-get = "0.8"

--- a/migrations/20170318181441_downloads_need_no_id/down.sql
+++ b/migrations/20170318181441_downloads_need_no_id/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE crate_downloads DROP PRIMARY KEY;
+ALTER TABLE crate_downloads ALTER COLUMN "date" TYPE timestamp;
+ALTER TABLE crate_downloads ADD COLUMN id SERIAL PRIMARY KEY;

--- a/migrations/20170318181441_downloads_need_no_id/up.sql
+++ b/migrations/20170318181441_downloads_need_no_id/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE crate_downloads DROP COLUMN id;
+ALTER TABLE crate_downloads ALTER COLUMN "date" TYPE date;
+ALTER TABLE crate_downloads ADD PRIMARY KEY (crate_id, date);

--- a/migrations/20170322130523_version_downloads_needs_no_id/down.sql
+++ b/migrations/20170322130523_version_downloads_needs_no_id/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE version_downloads ALTER COLUMN "date" TYPE timestamp;
+DROP INDEX version_downloads_unique;

--- a/migrations/20170322130523_version_downloads_needs_no_id/up.sql
+++ b/migrations/20170322130523_version_downloads_needs_no_id/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE version_downloads ALTER COLUMN "date" TYPE date;
+CREATE UNIQUE INDEX version_downloads_unique ON version_downloads (version_id, date);

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -116,7 +116,7 @@ fn collect(tx: &postgres::transaction::Transaction,
         if cnt == 0 {
             tx.execute("INSERT INTO crate_downloads
                              (crate_id, downloads, date)
-                             VALUES ($1, $2, $3)",
+                             VALUES ($1, $2, date($3))",
                        &[&crate_id, &amt, &download.date])?;
         }
     }

--- a/src/download.rs
+++ b/src/download.rs
@@ -45,23 +45,3 @@ impl Model for VersionDownload {
 
     fn table_name(_: Option<VersionDownload>) -> &'static str { "version_downloads" }
 }
-
-pub struct CrateDownload {
-    pub id: i32,
-    pub crate_id: i32,
-    pub downloads: i32,
-    pub date: Timespec,
-}
-
-impl Model for CrateDownload {
-    fn from_row(row: &Row) -> CrateDownload {
-        CrateDownload {
-            id: row.get("id"),
-            crate_id: row.get("crate_id"),
-            downloads: row.get("downloads"),
-            date: row.get("date"),
-        }
-    }
-
-    fn table_name(_: Option<CrateDownload>) -> &'static str { "crate_downloads" }
-}

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,5 +1,5 @@
+use chrono::NaiveDate;
 use pg::rows::Row;
-use time::Timespec;
 
 use Model;
 
@@ -8,7 +8,7 @@ pub struct VersionDownload {
     pub version_id: i32,
     pub downloads: i32,
     pub counted: i32,
-    pub date: Timespec,
+    pub date: NaiveDate,
 }
 
 #[derive(RustcEncodable, RustcDecodable)]
@@ -21,13 +21,11 @@ pub struct EncodableVersionDownload {
 
 impl VersionDownload {
     pub fn encodable(self) -> EncodableVersionDownload {
-        let VersionDownload { id, version_id, downloads, counted: _,
-                              date } = self;
         EncodableVersionDownload {
-            id: id,
-            version: version_id,
-            downloads: downloads,
-            date: ::encode_time(date),
+            id: self.id,
+            version: self.version_id,
+            downloads: self.downloads,
+            date: self.date.to_string(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use self::badge::Badge;
 pub use self::category::Category;
 pub use config::Config;
 pub use self::dependency::Dependency;
-pub use self::download::{CrateDownload, VersionDownload};
+pub use self::download::VersionDownload;
 pub use self::keyword::Keyword;
 pub use self::krate::Crate;
 pub use self::model::Model;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_json;
 #[macro_use] extern crate serde_derive;
+extern crate chrono;
 extern crate curl;
 extern crate diesel_full_text_search;
 extern crate dotenv;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -21,11 +21,10 @@ table! {
 }
 
 table! {
-    crate_downloads (id) {
-        id -> Int4,
+    crate_downloads (crate_id, date) {
         crate_id -> Int4,
         downloads -> Int4,
-        date -> Timestamp,
+        date -> Date,
     }
 }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -155,7 +155,7 @@ table! {
         version_id -> Int4,
         downloads -> Int4,
         counted -> Int4,
-        date -> Timestamp,
+        date -> Date,
         processed -> Bool,
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -345,7 +345,7 @@ pub fn downloads(req: &mut Request) -> CargoResult<Response> {
 
     let tx = req.tx()?;
     let stmt = tx.prepare("SELECT * FROM version_downloads
-                                WHERE date BETWEEN $1 AND $2 AND version_id = $3
+                                WHERE date BETWEEN date($1) AND date($2) AND version_id = $3
                                 ORDER BY date ASC")?;
     let downloads = stmt.query(&[&cutoff_start_date, &cutoff_end_date, &version.id])?
         .iter().map(|row| VersionDownload::from_row(&row).encodable()).collect();


### PR DESCRIPTION
We expect there to only be one entry per crate per date, so let's
enforce that by making it the primary key. Additionally `date` is always
used as a date, so let's make it a date. Finally, there was some dead
code around this table that's been removed