### PR TITLE
Search field keyboard shortcut

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -9,6 +9,53 @@ export default Ember.Controller.extend({
     nextFlashError: null,
     search: Ember.computed.oneWay('searchController.q'),
 
+    init() {
+        this._super(...arguments);
+        Ember.$(document).on('keypress', this.handleKeyPress.bind(this));
+        Ember.$(document).on('keydown', this.handleKeyPress.bind(this));
+    },
+
+    // Gets the human-readable string for the virtual-key code of the
+    // given KeyboardEvent, ev.
+    //
+    // This function is meant as a polyfill for KeyboardEvent#key,
+    // since it is not supported in Trident.  We also test for
+    // KeyboardEvent#keyCode because the handleShortcut handler is
+    // also registered for the keydown event, because Blink doesn't fire
+    // keypress on hitting the Escape key.
+    //
+    // So I guess you could say things are getting pretty interoperable.
+    getVirtualKey(ev) {
+        if ("key" in ev && typeof ev.key !== "undefined") {
+            return ev.key;
+        }
+        const c = ev.charCode || ev.keyCode;
+        if (c === 27) {
+            return "Escape";
+        }
+        return String.fromCharCode(c);
+    },
+
+    handleKeyPress(evt) {
+        // Don't focus the search field if the user is already using an input element
+        if (evt.target.tagName === 'INPUT' || evt.target.tagName === 'TEXTAREA' || evt.target.tagName === 'SELECT') {
+            return;
+        }
+        // Only match plain keys, no modifiers keys
+        if (evt.ctrlKey || evt.altKey || evt.metaKey) {
+            return;
+        }
+        if (this.getVirtualKey(evt).toLowerCase() === 's') {
+            evt.preventDefault();
+            Ember.$('#cargo-desktop-search').focus();
+        }
+    },
+
+    willDestroy() {
+        Ember.$(document).off('keypress');
+        Ember.$(document).off('keydown');
+    },
+
     stepFlash() {
         this.set('flashError', this.get('nextFlashError'));
         this.set('nextFlashError', null);

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -26,12 +26,12 @@ export default Ember.Controller.extend({
     //
     // So I guess you could say things are getting pretty interoperable.
     getVirtualKey(ev) {
-        if ("key" in ev && typeof ev.key !== "undefined") {
+        if ('key' in ev && typeof ev.key !== 'undefined') {
             return ev.key;
         }
         const c = ev.charCode || ev.keyCode;
         if (c === 27) {
-            return "Escape";
+            return 'Escape';
         }
         return String.fromCharCode(c);
     },

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -116,9 +116,11 @@ body {
         @include flex-grow(1);
     }
     @media only screen and (max-width: 820px) {
+        form.search { display: none; }
+    }
+    @media only screen and (max-width: 900px) {
         .menu { display: block; }
         .nav { display: none; }
-        form.search { display: none; }
     }
 }
 

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -66,12 +66,14 @@ body {
 
     .sep { margin: 0 10px; color: darken($html-bg, 10%); }
     .nav, .menu {
-        @include flex-grow(2);
         text-align: right;
         margin-right: 5px;
     }
 
-    .menu { display: none; }
+    .menu {
+        @include flex-grow(2);
+        display: none;
+    }
     .menu ul.dropdown {
         right: 0;
         left: auto;
@@ -109,6 +111,10 @@ body {
 
         &.open { display: block; }
     }
+    form.search {
+        @include display-flex;
+        @include flex-grow(1);
+    }
     @media only screen and (max-width: 820px) {
         .menu { display: block; }
         .nav { display: none; }
@@ -128,6 +134,12 @@ body {
     background-position: 6px 6px;
     background-size: 14px 15px;
     @include border-radius(15px);
+}
+
+#header input.search {
+    width: 100%;
+    margin-left: 16px;
+    margin-right: 16px;
 }
 
 #mobile-search {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -17,8 +17,8 @@
     {{/link-to}}
 
     <form class='search' action='/search' {{ action "search" on="submit" }} >
-        {{input type="text" class="search" name="q"
-                placeholder="Search"
+        {{input type="text" class="search" name="q" id="cargo-desktop-search"
+                placeholder="Click or press 'S' to search..."
                 value=search
                 autofocus="autofocus"
                 tabindex="1"

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -50,3 +50,28 @@ test('searching for "rust"', function(assert) {
         findWithAssert('#crates .row:first .desc .info .vers img[alt="0.7.1"]');
     });
 });
+
+test('pressing S key to focus the search bar', function(assert) {
+    function assertSearchBarIsFocused() {
+        const $searchBar = find('#cargo-desktop-search');
+        assert.equal($searchBar[0], document.activeElement);
+        $searchBar.blur();
+    }
+
+    visit('/');
+    andThen(function() {
+        findWithAssert('#cargo-desktop-search').blur();
+    });
+
+    keyEvent(document, 'keypress', 65);
+    andThen(function assertSearchBarIsNotFocused() {
+        const $searchBar = find('#cargo-desktop-search');
+        assert.notEqual($searchBar[0], document.activeElement);
+        $searchBar.blur();
+    });
+
+    keyEvent(document, 'keypress', 83);
+    andThen(assertSearchBarIsFocused);
+    keyEvent(document, 'keydown', 83);
+    andThen(assertSearchBarIsFocused);
+});

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -52,6 +52,9 @@ test('searching for "rust"', function(assert) {
 });
 
 test('pressing S key to focus the search bar', function(assert) {
+    const KEYCODE_S = 83;
+    const KEYCODE_A = 65;
+
     function assertSearchBarIsFocused() {
         const $searchBar = find('#cargo-desktop-search');
         assert.equal($searchBar[0], document.activeElement);
@@ -63,15 +66,15 @@ test('pressing S key to focus the search bar', function(assert) {
         findWithAssert('#cargo-desktop-search').blur();
     });
 
-    keyEvent(document, 'keypress', 65);
+    keyEvent(document, 'keypress', KEYCODE_A);
     andThen(function assertSearchBarIsNotFocused() {
         const $searchBar = find('#cargo-desktop-search');
         assert.notEqual($searchBar[0], document.activeElement);
         $searchBar.blur();
     });
 
-    keyEvent(document, 'keypress', 83);
+    keyEvent(document, 'keypress', KEYCODE_S);
     andThen(assertSearchBarIsFocused);
-    keyEvent(document, 'keydown', 83);
+    keyEvent(document, 'keydown', KEYCODE_S);
     andThen(assertSearchBarIsFocused);
 });


### PR DESCRIPTION
Hey there, first PR to this project, I hope I did not make too much mistakes.

Most of the code was adapted from rust-doc (wondering if and how I should credit them) to using with Ember, though it doesn't really feel Ember *-ish* it would seem that adding custom events to an entire application isn't. I found some addons that achieved this but I wasn't sure it was worth to add a dependency for one keyboard shortcut.

This functionality required adding an ID to the search bar in order to be able to grab its focus as its name is not unique in the document (the mobile search bar shares the same name 'q').
I also made an acceptance test for this feature.

Fixes #643 