### PR TITLE
Fixes the code that caused the index corruption today

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -906,10 +906,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
             .save(&conn, &new_crate.authors)?;
 
         // Link this new version to all dependencies
-        let deps = dependency::add_dependencies(&conn, &new_crate.deps, version.id)?
-            .into_iter()
-            .map(|dep| dep.git_encode(&krate.name))
-            .collect();
+        let git_deps = dependency::add_dependencies(&conn, &new_crate.deps, version.id)?;
 
         // Update all keywords for this crate
         Keyword::update_crate(&conn, &krate, &keywords)?;
@@ -938,7 +935,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
             vers: vers.to_string(),
             cksum: cksum.to_hex(),
             features: features,
-            deps: deps,
+            deps: git_deps,
             yanked: Some(false),
         };
         git::add_crate(&**req.app(), &git_crate).chain_error(|| {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -424,6 +424,16 @@ fn new_krate_with_dependency() {
 
     let mut response = ok_resp!(middle.call(&mut req));
     ::json::<GoodCrate>(&mut response);
+
+    let path = ::git::checkout().join("ne/w_/new_dep");
+    assert!(path.exists());
+    let mut contents = String::new();
+    File::open(&path).unwrap().read_to_string(&mut contents).unwrap();
+    let p: git::Crate = json::decode(&contents).unwrap();
+    assert_eq!(p.name, "new_dep");
+    assert_eq!(p.vers, "1.0.0");
+    assert_eq!(p.deps.len(), 1);
+    assert_eq!(p.deps[0].name, "foo_dep");
 }
 
 #[test]


### PR DESCRIPTION
So that we aren't writing the crate name as its dependencies' names in the git index.

r? @sgrif, there might be better ways to do some of the stuff involving `NewDependency` that interacts with diesel, but idk because the dependencies table doesn't care about the dependencies' names :( 