### PR TITLE
Versions should be sorted in semver order in crate show json

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -814,8 +814,11 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
     let name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(name).first::<Crate>(&*conn)?;
-    let versions = Version::belonging_to(&krate).load::<Version>(&*conn)?;
+
+    let mut versions = Version::belonging_to(&krate).load::<Version>(&*conn)?;
+    versions.sort_by(|a, b| b.num.cmp(&a.num));
     let ids = versions.iter().map(|v| v.id).collect();
+
     let kws = CrateKeyword::belonging_to(&krate)
         .inner_join(keywords::table)
         .select(keywords::all_columns)
@@ -1166,6 +1169,8 @@ pub fn following(req: &mut Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/versions` route.
+/// FIXME: Not sure why this is necessary since /crates/:crate_id returns
+/// this information already, but ember is definitely requesting it
 pub fn versions(req: &mut Request) -> CargoResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let tx = req.tx()?;

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1169,8 +1169,8 @@ pub fn following(req: &mut Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/versions` route.
-/// FIXME: Not sure why this is necessary since /crates/:crate_id returns
-/// this information already, but ember is definitely requesting it
+// FIXME: Not sure why this is necessary since /crates/:crate_id returns
+// this information already, but ember is definitely requesting it
 pub fn versions(req: &mut Request) -> CargoResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let tx = req.tx()?;

--- a/src/version.rs
+++ b/src/version.rs
@@ -278,7 +278,7 @@ impl Model for Version {
 }
 
 /// Handles the `GET /versions` route.
-/// FIXME: where/how is this used?
+// FIXME: where/how is this used?
 pub fn index(req: &mut Request) -> CargoResult<Response> {
     let conn = req.tx()?;
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -278,6 +278,7 @@ impl Model for Version {
 }
 
 /// Handles the `GET /versions` route.
+/// FIXME: where/how is this used?
 pub fn index(req: &mut Request) -> CargoResult<Response> {
     let conn = req.tx()?;
 


### PR DESCRIPTION
Fixes #664.

Also added a test for /crates/:crate_id/versions; that was functioning
correctly before this commit though since it's still calling
krate::versions.

Also added some notes-- I'm not sure why /crates/:crate_id/versions
exists (and I am seeing ember request it) if the version information is
included in the crate show json. I also don't know where or how the
/api/v1/versions endpoint is used, with the `ids=[]` params... I wanted
a reminder to investigate that some other time.

r? @sgrif 