### PR TITLE
quick-links in crate header

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -5,6 +5,7 @@
     margin-bottom: 20px;
     @include border-radius(5px);
     @include display-flex;
+    @include flex-wrap(wrap);
     @include align-items(center);
 
     .info {

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -129,21 +129,24 @@
     .downloads { @include display-flex; @include align-items(center); }
 
     .rev-dep-downloads {padding-left: 7px}
+}
 
-    .quick-links {
-        ul {
-            @include display-flex;
-            font-size: 80%;
-            list-style-type: none;
-            margin: 1em 0 0 0;
-            padding: 0;
+.quick-links {
+    ul {
+        @include display-flex;
+        @include flex-direction(row);
 
-            li {
-                margin-right: 1em;
+        font-size: 80%;
+        list-style-type: none;
+        margin: 1em 0 0 0;
+        padding: 0;
 
-                &:last-child {
-                    margin-right: 0;
-                }
+
+        li {
+            margin-right: 1em;
+
+            &:last-child {
+                margin-right: 0;
             }
         }
     }

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -8,6 +8,10 @@
     @include flex-wrap(wrap);
     @include align-items(center);
 
+    .wide {
+        width: 100%;
+    }
+
     .info {
         @include display-flex;
         @include flex-wrap(wrap);

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -31,7 +31,20 @@
                 </a>
             --}}
         </div>
+    </div>
+
+    <div class="quick-links">
+    <ul>
+        {{#if crate.homepage}}
+          <li><a href="{{crate.homepage}}">Homepage</a></li>
         {{/if}}
+        {{#if crate.documentation}}
+          <li><a href="{{crate.documentation}}">Documentation</a></li>
+        {{/if}}
+        {{#if crate.repository}}
+          <li><a href="{{crate.repository}}">Repository</a></li>
+        {{/if}}
+    </ul>
     </div>
 </div>
 

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -1,34 +1,37 @@
 {{title crate.name}}
 
 <div id='crates-heading'>
-    <div class='info'>
-        <img class='logo crate' src="/assets/crate.png"/>
-        <h1>{{ crate.name }}</h1>
-        <h2>{{ currentVersion.num }}</h2>
-    </div>
+    <div style="width: 100%">
+        <div class='info'>
+            <img class='logo crate' src="/assets/crate.png"/>
+            <h1>{{ crate.name }}</h1>
+            <h2>{{ currentVersion.num }}</h2>
+        </div>
 
-    <div class='right'>
-        {{#if session.currentUser}}
-            <button class='tan-button' {{action 'toggleFollow' this}}>
-                {{#if fetchingFollowing}}
-                    <img src="/assets/ajax-loader.gif"/>
-                {{else}}
-                    {{#if following}}
-                        Unfollow
+        <div class='right'>
+            {{#if session.currentUser}}
+                <button class='tan-button' {{action 'toggleFollow' this}}>
+                    {{#if fetchingFollowing}}
+                        <img src="/assets/ajax-loader.gif"/>
                     {{else}}
-                        Follow
+                        {{#if following}}
+                            Unfollow
+                        {{else}}
+                            Follow
+                        {{/if}}
                     {{/if}}
-                {{/if}}
-            </button>
+                </button>
+            {{/if}}
+            {{!--
+                <a class='yellow-button' download
+                   {{action 'download' currentVersion}}
+                   href='{{currentVersion.dl_path}}'>
+                    <img class="button-download" src="/assets/button-download.png"/>
+                    Download
+                </a>
+            --}}
+        </div>
         {{/if}}
-        {{!--
-            <a class='yellow-button' download
-               {{action 'download' currentVersion}}
-               href='{{currentVersion.dl_path}}'>
-                <img class="button-download" src="/assets/button-download.png"/>
-                Download
-            </a>
-        --}}
     </div>
 </div>
 

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -1,7 +1,7 @@
 {{title crate.name}}
 
 <div id='crates-heading'>
-    <div style="width: 100%">
+    <div class="wide">
         <div class='info'>
             <img class='logo crate' src="/assets/crate.png"/>
             <h1>{{ crate.name }}</h1>


### PR DESCRIPTION
As per issue #608 , I've copied the quick-links from crate listings into the header on a crate's detail page.

This required some tweaking to the crate.scss, in order to reuse the quicklink styling, as well as introducing an extra div to keep the layout under control.

I'm certain there are more elegant solutions, feel free to provide tips/tricks/criticism!

I've intentionally made tiny commits, to make it easier to follow my reasoning (for both myself and for others). If you'd prefer everything squashed into a single commit, I'll gladly make one.