### PR TITLE
Fix the infinite spinner on the follow button

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -2,6 +2,9 @@ import Ember from 'ember';
 import ajax from 'ic-ajax';
 
 export default Ember.Route.extend({
+    refreshAfterLogin: Ember.observer('session.isLoggedIn', function() {
+        this.refresh();
+    }),
 
     model(params) {
         const requestedVersion = params.version_num === 'all' ? '' : params.version_num;


### PR DESCRIPTION
Currently, when you log in on a page, it would seem only the `session.currentUser` object gets updated. This automatically updates the menu and that's fine for most of the pages. However, on crate/version, `session.currentUser` is used in the template but its value is not watched in the route, which means that the template knows that a user logged in but the route doesn't.
This PR forces the route to reload when the `session.isLoggedIn` value is changed, allowing the route to correctly update the follow button.

Fixes #644 