### PR TITLE
Fix alignment of crate-follow button

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -9,6 +9,9 @@
     @include align-items(center);
 
     .wide {
+        @include display-flex;
+        @include flex-wrap(wrap);
+        @include align-items(center);
         width: 100%;
     }
 


### PR DESCRIPTION
After my insertion of quick-links in Crate headers in #668, the follow-crate button became mis-aligned, which I failed to notice because I wasn't logged in.
Thanks @kureuil for reporting [here](https://github.com/rust-lang/crates.io/issues/608#issuecomment-292310505)

This fixes the alignment by copying the relevant css flex attributes into the new div style that I introduced.