### PR TITLE
Add docs.rs integration

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -8,7 +8,6 @@ export default Ember.Route.extend({
 
     model(params) {
         const requestedVersion = params.version_num === 'all' ? '' : params.version_num;
-
         const crate = this.modelFor('crate');
         const controller = this.controllerFor(this.routeName);
         const maxVersion = crate.get('max_version');
@@ -36,7 +35,8 @@ export default Ember.Route.extend({
         };
 
         const fetchCrateDocumentation = () => {
-            if (!crate.get('documentation')) {
+            if (!crate.get('documentation') ||
+                crate.get('documentation').substr(0, 16) === 'https://docs.rs/') {
                 let crateName = crate.get('name');
                 let crateVersion = params.version_num;
                 ajax(`https://docs.rs/crate/${crateName}/${crateVersion}/builds.json`)

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -68,6 +68,17 @@ export default Ember.Route.extend({
                 .finally(() => controller.set('fetchingFollowing', false));
         }
 
+        if (!crate.get('documentation')) {
+            let crateName = crate.get('name');
+            let crateVersion = params.version_num;
+            ajax(`https://docs.rs/crate/${crateName}/${crateVersion}/builds.json`)
+                .then((r) => {
+                    if (r.length > 0 && r[0].build_status === true) {
+                        crate.set('documentation', `https://docs.rs/${crateName}/${crateVersion}/${crateName}/`);
+                    }
+                });
+        }
+
         // Find version model
         return crate.get('versions')
             .then(versions => {

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -74,7 +74,7 @@ export default Ember.Route.extend({
             ajax(`https://docs.rs/crate/${crateName}/${crateVersion}/builds.json`)
                 .then((r) => {
                     if (r.length > 0 && r[0].build_status === true) {
-                        crate.set('documentation', `https://docs.rs/${crateName}/${crateVersion}/${crateName}/`);
+                        crate.set('documentation', `https://docs.rs/${crateName}/${crateVersion}/`);
                     }
                 });
         }


### PR DESCRIPTION
When a crate does not specify a documentation link, we query docs.rs to know
if the documentation for the requested version was successfully built. If
if is, we set the crate's documentation link to the corresponding docs.rs
page, if not nothing changes.

Fixes #419.