### PR TITLE
fix vertical alignment of crate name and version

### DIFF
--- a/app/styles/_helpers.scss
+++ b/app/styles/_helpers.scss
@@ -50,6 +50,11 @@
     align-items: $how;
 }
 
+@mixin align-self($how) {
+    -webkit-align-self: $how;
+    align-self: $how;
+}
+
 @mixin flex-wrap($how) {
     -webkit-flex-wrap: $how;
     flex-wrap: $how;

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -18,7 +18,10 @@
     .info {
         @include display-flex;
         @include flex-wrap(wrap);
-        @include align-items(center);
+        @include align-items(baseline);
+        img {
+            @include align-self(center);
+        }
     }
     h1 {
         padding-left: 10px;


### PR DESCRIPTION
(I have not tried building locally with changes made, just translated working CSS code into @include statements etc, fingers crossed!)

e.g. on this page: https://crates.io/crates/reffers

at the top now "reffers" and "0.4.2" should be baseline-aligned while keeping the image centered.