### PR TITLE
Organize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,180 +5,41 @@
 Source code for the default [Cargo](http://doc.crates.io) registry. Viewable
 online at [crates.io](https://crates.io).
 
-This project is built on ember-cli and cargo, visit
-[iamstef.net/ember-cli](http://ember-cli.com/) or
-[doc.crates.io](http://doc.crates.io/) respectively for more information.
+## Status of crates.io
 
-## Working on the Frontend
+Any known issues currently affecting the registry running at https://crates.io
+will be posted to [@cratesiostatus](https://twitter.com/cratesiostatus).
 
-Install [Yarn](https://yarnpkg.com), see
-[yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install) for
-instructions for your OS.
+If you are experiencing an issue not addressed there, please contact us in one
+of the following ways:
 
-```bash
-git clone https://github.com/rust-lang/crates.io.git
-cd crates.io/
-yarn
-yarn run bower install
-```
+- [File a new issue](https://github.com/rust-lang/crates.io/issues/new)
+- Email [help@crates.io](mailto:help@crates.io)
+- Chat on irc.mozilla.org in the [#rust-infra](https://kiwiirc.com/client/irc.mozilla.org:+6667/#rust-infra) channel
 
-The website's frontend is built with [Ember.js](http://emberjs.com/). This
-makes it possible to work on the frontend without running a local backend.
-To start the frontend run:
+A volunteer will get back to you as soon as possible.
 
-```bash
-yarn run start:staging
-```
+## Contributing
 
-This will run a local frontend using the staging backend (hosted on Heroku at
-[staging-crates-io.herokuapp.com](https://staging-crates-io.herokuapp.com)).
+Welcome! We love contributions! Crates.io is an [Ember](https://emberjs.com/)
+frontend with a Rust backend, and there are many tasks appropriate for a
+variety of skill levels.
 
-If you want to set up a particular situation, you can edit the fixture data used
-for tests in `mirage/fixtures`. Note that the fixture data does not contain
-JSON needed to support every page, so some pages might not load correctly. To
-run the frontend and use that data, don't specify any backend:
+Please see [docs/CONTRIBUTING.md](https://github.com/rust-lang/crates.io/blob/master/docs/CONTRIBUTING.md) for ideas about what to work on and how to set up a development
+environment.
 
-```bash
-yarn run start
-```
+### Categories
 
-If you'd like to run the frontend with a specific backend endpoint, you can
-specify arguments to `yarn start`. For example you can set the proxy to
-`https://crates.io/` to use the production version.
-
-**Note: it is also possible to make changes to the production data**
-
-To do this, run:
-
-```bash
-yarn start -- --proxy https://crates.io
-# or
-yarn run start:live
-```
-
-**Note**: This requires npm 2.
-
-### Running Tests
-
-Install [phantomjs](http://phantomjs.org/), typically: `npm install
-phantomjs-prebuilt`.
-
-Then run the tests with:
-
-```
-yarn run ember test
-yarn run ember test --server
-```
-
-## Working on the Backend
-
-Working on the backend requires a usable postgres server and to configure
-crates.io to use it. There are slight differences in configuration for
-hosting the backend and running tests, both of which are described in more
-details in the appropriate subsections.
-
-After cloning the repo, do the following:
-
-1. Install [Postgres](https://www.postgresql.org/) >= 9.5. On Linux this is
-   generally available in the distribution repositories as `postgresql` or
-   `postgresql-server`. This will need to be up and running for running tests
-   for hosting the site locally.
-
-2. Copy the `.env.sample` file to `.env`. Some settings will need to be
-   modified. These instructions are in the subsequent sections.
-
-3. Install `diesel_cli` using `cargo install diesel_cli --no-default-features
-   --features postgres`.
-
-### Running Tests
-
-After following the above instructions:
-
-1. Configure the location of the test database. Create a database specifically
-   for testing since running the tests will clear the database. For example,
-   to use a database named `cargo_registry_test`, create it in postgres by
-   running `psql` to connect to postgres, then run `CREATE DATABASE
-   cargo_registry_test;`. The test harness will ensure that migrations are run.
-
-   In your `.env` file, specify your test database URL. Here's an example,
-   assuming your test database is named `cargo_registry_test`:
-
-   ```
-   export TEST_DATABASE_URL=postgres://postgres@localhost/cargo_registry_test
-   ```
-
-2. Run the backend API server tests:
-
-   ```
-   cargo test
-   ```
-
-### Hosting crates.io locally
-
-After following the instructions described in "Working on the Backend":
-
-1. Make sure your local postgres instance is running and create a database for
-   use with the local crates.io instance. `cargo_registry` is a good name to
-   use. You can do this by running `psql` to connect to `postgres` and run:
-
-   ```
-   CREATE DATABASE cargo_registry;
-   ```
-
-2. Modify the `.env` configuration file's `DATABASE_URL` setting to point
-   to the local postgres instance with the database you want to use. If you've
-   followed these instructions it should likely look like:
-
-   ```
-   export DATABASE_URL=postgres://postgres@localhost/cargo_registry
-   ```
-
-3. Set up the git index:
-
-   ```
-   ./script/init-local-index.sh
-   ```
-
-   But *do not* modify your `~/.cargo/config` yet (but record the instructions
-   shown at the end of this step as you'll need them later).
-
-4. Build the server:
-
-   ```
-   cargo build
-   ```
-
-   On OS X 10.11, you will need to install the openssl headers first, and tell
-   cargo where to find them. See https://github.com/sfackler/rust-openssl#osx.
-
-5. Modify your `~/.cargo/config` after successfully building crates.io
-   following the instructions shown at the end of Step 3.
-
-5. Run the migrations:
-
-   ```
-   diesel migration run
-   ```
-
-6. Start the backend server:
-
-   ```
-   ./target/debug/server
-   ```
-
-7. **Optionally** start a local frontend:
-
-   ```
-   yarn run start:local
-   ```
-
-## Categories
+Adding or editing the categories and corresponding descriptions displayed on
+[crates.io/categories](https://crates.io/categories) does not require a full
+development environment set up.
 
 The list of categories available on crates.io is stored in
-`src/categories.toml`. To propose adding, removing, or changing a category,
-send a pull request making the appropriate change to that file as noted in the
-comment at the top of the file. Please add a description that will help others
-to know what crates are in that category.
+[`src/categories.toml`](https://github.com/rust-lang/crates.io/blob/master/src/categories.toml).
+To propose adding, removing, or changing a category, send a pull request making
+the appropriate change to that file as noted in the comment at the top of the
+file. Please add a description that will help others to know what crates are in
+that category.
 
 For new categories, it's helpful to note in your PR description examples of
 crates that would fit in that category, and describe what distinguishes the new
@@ -187,74 +48,6 @@ category from existing categories.
 After your PR is accepted, the next time that crates.io is deployed the
 categories will be synced from this file.
 
-## Deploying & Using a Mirror
+## Running a mirror
 
-**DISCLAIMER: The process of setting up a mirror is a work-in-progress and is
-likely to change. It is not currently recommended for mission-critical
-production use. It also requires Cargo from Rust distribution 1.12.0 or
-later.**
-
-### Current functionality: a read-only, download-API-only mirror
-
-This mirror will function as a read-only duplicate of crates.io's API. You will
-be able to download crates using your index and your mirror, but the crate files
-will still come from crates.io's S3 storage.
-
-Your mirror will not:
-
-- Allow users to sign up/sign in
-- Allow crate publish
-- Keep track of any statistics
-- Display available crates in its UI
-
-### API server setup
-
-To deploy the API on Heroku, use this button:
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)][deploy]
-
-[deploy]: https://heroku.com/deploy
-
-The only config variable you need to set is `GIT_REPO_URL`, which should be the
-git URL of your crates index repository; see the next section for setup
-instructions for that.
-
-### Index Mirror Setup
-
-You also need a mirror of the crates.io git index, and your index needs to point
-to your API server.
-
-1. `git clone https://github.com/rust-lang/crates.io-index.git`
-2. Edit the config.json file to point to your API server so it looks like:
-
-    ```json
-    {
-      "dl": "https://[your heroku app name].herokuapp.com/api/v1/crates",
-      "api": "https://[your heroku app name].herokuapp.com/"
-    }
-    ```
-
-3. Commit and push to wherever you will be hosting your index (ex: github,
-    gitlab, an internal git server)
-
-4. In order to keep your mirror index up to date, schedule a `git pull` of the
-    official index. How to do this depends on how you are hosting your index,
-    but could be done through `cron` or a scheduled CI job, for example.
-
-### Local Cargo Setup
-
-NOTE: The following configuration requires Cargo from Rust 1.12.0
-distribution or later.
-
-In the project where you want to use your mirror, change your `.cargo/config`
-to replace the crates.io source to point to your crates index:
-
-```toml
-[source]
-
-[source.mirror]
-registry = "https://[host and path to your git server]/crates.io-index"
-
-[source.crates-io]
-replace-with = "mirror"
-```
+Please see [docs/MIRROR.md](https://github.com/rust-lang/crates.io/blob/master/docs/MIRROR.md) for instructions on setting up a mirror of crates.io.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,185 @@
+# Contributing to Crates.io
+
+## Finding an issue to work on
+
+We try to keep a variety of issues tagged with
+[E-mentor](https://github.com/rust-lang/crates.io/issues?q=is%3Aopen+is%3Aissue+
+ label%3AE-mentor). These issues should contain, somewhere within the body or
+the comments, clear instructions on what needs to be done and where the changes
+will need to be made. If any E-mentor issues do not contain this information or
+the information isn't clear, we consider this a bug, please comment and ask for
+clarification! Please don't hesitate to ask any questions on these issues,
+we're paying special attention to them and someone will get back to you with
+help as soon as possible.
+
+We'd also love contributions for issues not tagged E-mentor, they just might
+not be as well specified. You may want to browse through the labels that start
+with A-, which stands for "area", to find issues that match with your interests.
+
+If you'd like to work on something that isn't in a current issue, especially if
+it would be a big change, please open a new issue for discussion!
+
+## Setting up a development environment
+
+### Working on the Frontend
+
+Install [Yarn](https://yarnpkg.com), see
+[yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install) for
+instructions for your OS.
+
+```bash
+git clone https://github.com/rust-lang/crates.io.git
+cd crates.io/
+yarn
+yarn run bower install
+```
+
+The website's frontend is built with [Ember.js](http://emberjs.com/). This
+makes it possible to work on the frontend without running a local backend.
+To start the frontend run:
+
+```bash
+yarn run start:staging
+```
+
+This will run a local frontend using the staging backend (hosted on Heroku at
+[staging-crates-io.herokuapp.com](https://staging-crates-io.herokuapp.com)).
+
+If you want to set up a particular situation, you can edit the fixture data used
+for tests in `mirage/fixtures`. Note that the fixture data does not contain
+JSON needed to support every page, so some pages might not load correctly. To
+run the frontend and use that data, don't specify any backend:
+
+```bash
+yarn run start
+```
+
+If you'd like to run the frontend with a specific backend endpoint, you can
+specify arguments to `yarn start`. For example you can set the proxy to
+`https://crates.io/` to use the production version.
+
+**Note: it is also possible to make changes to the production data**
+
+To do this, run:
+
+```bash
+yarn start -- --proxy https://crates.io
+# or
+yarn run start:live
+```
+
+**Note**: This requires npm 2.
+
+#### Running Tests
+
+Install [phantomjs](http://phantomjs.org/), typically: `npm install
+phantomjs-prebuilt`.
+
+Then run the tests with:
+
+```
+yarn run ember test
+yarn run ember test --server
+```
+
+### Working on the Backend
+
+Working on the backend requires a usable postgres server and to configure
+crates.io to use it. There are slight differences in configuration for
+hosting the backend and running tests, both of which are described in more
+details in the appropriate subsections.
+
+After cloning the repo, do the following:
+
+1. Install [Postgres](https://www.postgresql.org/) >= 9.5. On Linux this is
+   generally available in the distribution repositories as `postgresql` or
+   `postgresql-server`. This will need to be up and running for running tests
+   for hosting the site locally.
+
+2. Copy the `.env.sample` file to `.env`. Some settings will need to be
+   modified. These instructions are in the subsequent sections.
+
+3. Install `diesel_cli` using `cargo install diesel_cli --no-default-features
+   --features postgres`.
+
+#### Running Tests
+
+After following the above instructions:
+
+1. Configure the location of the test database. Create a database specifically
+   for testing since running the tests will clear the database. For example,
+   to use a database named `cargo_registry_test`, create it in postgres by
+   running `psql` to connect to postgres, then run `CREATE DATABASE
+   cargo_registry_test;`. The test harness will ensure that migrations are run.
+
+   In your `.env` file, specify your test database URL. Here's an example,
+   assuming your test database is named `cargo_registry_test`:
+
+   ```
+   export TEST_DATABASE_URL=postgres://postgres@localhost/cargo_registry_test
+   ```
+
+2. Run the backend API server tests:
+
+   ```
+   cargo test
+   ```
+
+#### Hosting crates.io locally
+
+After following the instructions described in "Working on the Backend":
+
+1. Make sure your local postgres instance is running and create a database for
+   use with the local crates.io instance. `cargo_registry` is a good name to
+   use. You can do this by running `psql` to connect to `postgres` and run:
+
+   ```
+   CREATE DATABASE cargo_registry;
+   ```
+
+2. Modify the `.env` configuration file's `DATABASE_URL` setting to point
+   to the local postgres instance with the database you want to use. If you've
+   followed these instructions it should likely look like:
+
+   ```
+   export DATABASE_URL=postgres://postgres@localhost/cargo_registry
+   ```
+
+3. Set up the git index:
+
+   ```
+   ./script/init-local-index.sh
+   ```
+
+   But *do not* modify your `~/.cargo/config` yet (but record the instructions
+   shown at the end of this step as you'll need them later).
+
+4. Build the server:
+
+   ```
+   cargo build
+   ```
+
+   On OS X 10.11, you will need to install the openssl headers first, and tell
+   cargo where to find them. See https://github.com/sfackler/rust-openssl#osx.
+
+5. Modify your `~/.cargo/config` after successfully building crates.io
+   following the instructions shown at the end of Step 3.
+
+5. Run the migrations:
+
+   ```
+   diesel migration run
+   ```
+
+6. Start the backend server:
+
+   ```
+   ./target/debug/server
+   ```
+
+7. **Optionally** start a local frontend:
+
+   ```
+   yarn run start:local
+   ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,61 +21,91 @@ it would be a big change, please open a new issue for discussion!
 
 ## Setting up a development environment
 
-### Working on the Frontend
+First, you'll need git to clone the repo. [GitHub has help pages about setting
+up git](https://help.github.com/articles/set-up-git/), and once you've done
+that, you should be able to clone the repo and change into the repo's directory
+from your terminal:
 
-Install [Yarn](https://yarnpkg.com), see
-[yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install) for
-instructions for your OS.
-
-```bash
+```
 git clone https://github.com/rust-lang/crates.io.git
 cd crates.io/
+```
+
+### Working on the Frontend
+
+If the changes you'd like to make only involve:
+
+- HTML
+- JavaScript
+- CSS
+
+and don't need:
+
+- any changes to the JSON returned by the requests to the backend
+- a user to be logged in
+
+then you only need to set up the frontend. Once you've set up a local frontend,
+you can run your frontend against the production API.
+
+If you need to set up the backend, you'll probably want to set up the frontend
+as well.
+
+#### Frontend requirements
+
+In order to run the frontend, you will need to have installed:
+
+- [node](https://nodejs.org/en/) >= 6.10.0
+- [npm](https://www.npmjs.com/get-npm) >= 3.10.10
+- [yarn](https://yarnpkg.com/en/docs/install) >= 0.23.2
+
+Follow the links for each of these tools for their recommended installation
+instructions. If you already have these tools, or you have a different
+preferred method of installing packages like these, that should work fine.
+
+> Note that you may need to install these as root using `sudo` in some cases.
+
+#### Building and serving the frontend
+
+To install the npm and bower libraries that crates.io uses, run:
+
+```
 yarn
 yarn run bower install
 ```
 
-The website's frontend is built with [Ember.js](http://emberjs.com/). This
-makes it possible to work on the frontend without running a local backend.
-To start the frontend run:
+You'll need to run these commands any time the libraries or versions of these
+libraries that crates.io uses change. Usually you'll know they've changed
+because you'll run the next step and it will fail saying it can't find some
+libraries.
 
-```bash
-yarn run start:staging
-```
+To build and serve the frontend assets, use the command `yarn run start`. There
+are variations on this command that change which backend your frontend tries to
+talk to:
 
-This will run a local frontend using the staging backend (hosted on Heroku at
-[staging-crates-io.herokuapp.com](https://staging-crates-io.herokuapp.com)).
+| Command | Backend | Use case |
+|---------|---------|----------|
+| `yarn run start:live` | https://crates.io | Testing UI changes with the full live site's data |
+| `yarn run start:staging` | https://staging-crates-io.herokuapp.com | Testing UI changes with a smaller set of realistic data |
+| `yarn run start` | Static fixture test data in `mirage/fixtures` | Setting up particular situations, see note |
+| `yarn run start:local` | Backend server running locally | See the Working on the backend section for setup |
+| `yarn run start -- --proxy https://crates.io` | Whatever is specified in `--proxy` arg | If your use case is not covered here |
 
-If you want to set up a particular situation, you can edit the fixture data used
-for tests in `mirage/fixtures`. Note that the fixture data does not contain
-JSON needed to support every page, so some pages might not load correctly. To
-run the frontend and use that data, don't specify any backend:
+> Note: If you want to set up a particular situation, you can edit the fixture
+> data used for tests in `mirage/fixtures`. The fixture data does not currently
+> contain JSON needed to support every page, so some pages might not load
+> correctly.
 
-```bash
-yarn run start
-```
+#### Running the frontend tests
 
-If you'd like to run the frontend with a specific backend endpoint, you can
-specify arguments to `yarn start`. For example you can set the proxy to
-`https://crates.io/` to use the production version.
+In order to run the frontend tests, you will need to have installed:
 
-**Note: it is also possible to make changes to the production data**
+- [phantomjs](http://phantomjs.org/) >= 2.1.1
 
-To do this, run:
+`npm install phantomjs-prebuilt` is an easy way to install phantomjs; see its
+website for other installation methods or use your preferred method of
+installing dependencies.
 
-```bash
-yarn start -- --proxy https://crates.io
-# or
-yarn run start:live
-```
-
-**Note**: This requires npm 2.
-
-#### Running Tests
-
-Install [phantomjs](http://phantomjs.org/), typically: `npm install
-phantomjs-prebuilt`.
-
-Then run the tests with:
+Once phantomjs is installed, run the frontend tests with:
 
 ```
 yarn run ember test
@@ -84,102 +114,327 @@ yarn run ember test --server
 
 ### Working on the Backend
 
-Working on the backend requires a usable postgres server and to configure
-crates.io to use it. There are slight differences in configuration for
-hosting the backend and running tests, both of which are described in more
-details in the appropriate subsections.
+#### Backend Requirements
 
-After cloning the repo, do the following:
+In order to run the backend, you will need to have installed:
 
-1. Install [Postgres](https://www.postgresql.org/) >= 9.5. On Linux this is
-   generally available in the distribution repositories as `postgresql` or
-   `postgresql-server`. This will need to be up and running for running tests
-   for hosting the site locally.
+- [Rust](https://www.rust-lang.org/en-US/) stable >= 1.16.0 and cargo, which comes with Rust
+- [Postgres](https://www.postgresql.org/) >= 9.5
+- [CMake](https://cmake.org/download/) >= 3.6.1
+- [OpenSSL](https://www.openssl.org/) >= 1.0.2k
+- [diesel_cli](http://diesel.rs/guides/getting-started/) >= 1.11.0
 
-2. Copy the `.env.sample` file to `.env`. Some settings will need to be
-   modified. These instructions are in the subsequent sections.
+##### Rust
 
-3. Install `diesel_cli` using `cargo install diesel_cli --no-default-features
-   --features postgres`.
+- [rustup](https://rustup.rs/) is the installation method we'd recommend for
+  all platforms.
 
-#### Running Tests
+##### Postgres
 
-After following the above instructions:
+Postgres can be a little finicky to install and get set up. These are the
+methods we'd recommend for each operating system:
 
-1. Configure the location of the test database. Create a database specifically
-   for testing since running the tests will clear the database. For example,
-   to use a database named `cargo_registry_test`, create it in postgres by
-   running `psql` to connect to postgres, then run `CREATE DATABASE
-   cargo_registry_test;`. The test harness will ensure that migrations are run.
+- Windows: use the [Windows installers recommended by
+  Postgres](https://www.postgresql.org/download/windows/)
+- macOS: Either [Postgres.app](https://postgresapp.com/) or through
+  [Homebrew](https://brew.sh/) by running `brew install postgresql` and
+  following the post-installation instructions
+- Linux: Postgres is generally available in the distribution repositories as
+  `postgresql` or `postgresql-server`. You will also need `postgresql-devel`,
+  which might be called `postgresql-contrib`, and possibly `libpq-dev`. Here
+  are some examples of installation commands that have been tested for the
+  following distributions:
 
-   In your `.env` file, specify your test database URL. Here's an example,
-   assuming your test database is named `cargo_registry_test`:
+  - Ubuntu: `sudo apt-get install postgresql postgresql-contrib libpq-dev`
+  - Fedora: `sudo dnf install postgresql-server postgresql-contrib`
 
-   ```
-   export TEST_DATABASE_URL=postgres://postgres@localhost/cargo_registry_test
-   ```
+  > If you're missing a package, when you try to `cargo install` or `cargo
+  > build` later, you'll get an error that looks like this:
+  >
+  >     ```
+  >     error: linking with `cc` failed: exit code: 1
+  >     [lots of output]
+  >     = note: /usr/bin/ld: cannot find -l[something]
+  >     ```
+  >
+  > That `[something]` is what you're missing; you'll need to do some research
+  > to figure out what package will get you the missing library.
 
-2. Run the backend API server tests:
+Then, once Postgres is installed, ensure that you can run `psql` (and then exit
+by typing `\q`) without any errors to connect to your running Postgres server.
 
-   ```
-   cargo test
-   ```
+> Depending on your system, its permissions, and how Postgres was installed, you
+> may need to use the `postgres` user for some operations (by using `sudo su -
+> postgres`). Generally, the problem is that by default the postgres server is
+> only set up to allow connections by the `postrges` user. You'll know if you're
+> in this situation because if you try to run `psql` as yourself, you'll get
+> this error:
+>
+> ```
+> psql: FATAL:  role "yourusername" does not exist
+> ```
+>
+> One way of fixing this is to first give yourself superuser permissions in the
+> database by running this and replacing `[yourusername]` with your username:
+>
+> ```
+> sudo -u postgres createuser --superuser [yourusername]
+> ```
+>
+> Then creating a template database for yourself:
+>
+> ```
+> sudo -u postgres createdb [yourusername]
+> ```
+>
+> Try running `psql` again as yourself. If you're still getting errors, here are
+> some pages with troubleshooting information for some of the Linux
+> distributions:
+>
+> - [Ubuntu](https://help.ubuntu.com/community/PostgreSQL)
+> - [Fedora](https://fedoraproject.org/wiki/PostgreSQL)
+>
+> For other platforms, try searching for the error message and following
+> suggestions from Stack Overflow. Open an issue on this repo if you get stuck,
+> we'll help fix the problem and and will add the solution to these
+> instructions!
 
-#### Hosting crates.io locally
+##### CMake
 
-After following the instructions described in "Working on the Backend":
+- All platforms: CMake [has binary distributions
+  available](https://cmake.org/download/)
+- macOS: you can also install with homebrew by using `brew install cmake`
+- Linux: you should be able to use the distribution repositories by doing `sudo
+  apt-get install cmake` (Ubuntu) or `sudo dnf install cmake` (Fedora) or
+  whatever is appropriate for your distribution.
 
-1. Make sure your local postgres instance is running and create a database for
-   use with the local crates.io instance. `cargo_registry` is a good name to
-   use. You can do this by running `psql` to connect to `postgres` and run:
+##### OpenSSL
 
-   ```
-   CREATE DATABASE cargo_registry;
-   ```
+- Windows: [Win32 OpenSSL Installation
+  Project](http://slproweb.com/products/Win32OpenSSL.html) provides installers
+  for the latest versions. Scroll down to “Download Win32 OpenSSL”, pick the
+  64-bit non-Light version of OpenSSL, and install it.
+- macOS: you can also install with homebrew by using `brew install openssl`
+- Linux: you should be able to use the distribution repositories. It will be
+  called `openssl`, `openssl-devel`, or `libssl-dev`. OpenSSL needs
+  `pkg-config` as well. According to
+  [rust-openssl](https://github.com/sfackler/rust-openssl),
+  - Ubuntu: `sudo apt-get install libssl-dev pkg-config`
+  - Fedora: `sudo dnf install openssl-devel pkg-config`
+  - Arch Linux: `sudo pacman -S openssl pkg-config`
 
-2. Modify the `.env` configuration file's `DATABASE_URL` setting to point
-   to the local postgres instance with the database you want to use. If you've
-   followed these instructions it should likely look like:
+> If you have problems with OpenSSL, see [rust-openssl's
+> README](https://github.com/sfackler/rust-openssl) for some suggestions.
 
-   ```
-   export DATABASE_URL=postgres://postgres@localhost/cargo_registry
-   ```
+##### `diesel_cli`
 
-3. Set up the git index:
+On all platforms, install through `cargo` by running:
 
-   ```
-   ./script/init-local-index.sh
-   ```
+```
+cargo install diesel_cli --no-default-features --features postgres
+```
 
-   But *do not* modify your `~/.cargo/config` yet (but record the instructions
-   shown at the end of this step as you'll need them later).
+This will install a binary named `diesel`, so you should be able to run `diesel
+--version` to confirm successful installation.
 
-4. Build the server:
+> If you're on Linux and this fails with an error that looks like `error:
+> linking with `cc` failed: exit code: 1`, you're probably missing some
+> Postgres related libraries. See the Postgres section above on how to fix this.
 
-   ```
-   cargo build
-   ```
+#### Building and serving the backend
 
-   On OS X 10.11, you will need to install the openssl headers first, and tell
-   cargo where to find them. See https://github.com/sfackler/rust-openssl#osx.
+##### Environment variables
 
-5. Modify your `~/.cargo/config` after successfully building crates.io
-   following the instructions shown at the end of Step 3.
+Copy the `.env.sample` file to `.env`. Modify the settings as appropriate;
+minimally you'll need to specify or modify the value of the `DATABASE_URL` var.
+Try using `postgres://postgres@localhost/cargo_registry` first.
 
-5. Run the migrations:
+> If that doesn't work, change this by filling in this template with the
+> appropriate values where there are `[]`s:
+>
+> ```
+> postgres://[postgresuser]:[password]@[localhost]:[5432]/[database_name]
+> ```
+>
+> - Replace `[postgresuser]` with the user that is allowed to log in to your
+>   Postgres server.
+> - If that user needs a password, put it after the `:` instead of
+>   `[password]`. Remove both `:` and `[password]` if the user doesn't need a
+>   password.
+> - Replace `[localhost]` with the host and `[5432]` with the port where your
+>   Postgres server is running.
+> - Replace `[database_name]` with the name of the database you'd like to use.
+>   We're going to create a database named `cargo_registry` in the next
+>   section; change this if you'd like to name it something else.
 
-   ```
-   diesel migration run
-   ```
+##### Creating the database
 
-6. Start the backend server:
+You can name your development database anything as long as it matches the
+database name in the `DATABASE_URL` value. This example assumes a database
+named `cargo_registry`.
 
-   ```
-   ./target/debug/server
-   ```
+Create a new database by running:
 
-7. **Optionally** start a local frontend:
+```
+createdb cargo_registry
+```
 
-   ```
-   yarn run start:local
-   ```
+Then run the migrations:
+
+```
+diesel migration run
+```
+
+##### Setting up the git index
+
+Set up the git repo for the crate index by running:
+
+```
+./script/init-local-index.sh
+```
+
+##### Starting the server and the frontend
+
+Build and start the server by running this command (you'll need to stop this
+with `CTRL-C` and rerun this command every time you change the backend code):
+
+```
+cargo run --bin server
+```
+
+> If you get an error that looks like:
+>
+> ```
+> thread 'main' panicked at 'must have `GIT_REPO_URL` defined', src/lib.rs:227
+> ```
+>
+> Edit your `.env` and remove the comment after the `S3_REGION` variable. That
+> is, change this:
+>
+> ```
+> export S3_REGION=      # not needed if the S3 bucket is in US standard
+> ```
+>
+> to this:
+>
+> ```
+> export S3_REGION=
+> ```
+>
+> and then try running `cargo run --bin server` again.
+
+Then start a frontend that uses this backend by running this command in another
+terminal session (the frontend picks up frontend changes using live reload
+without a restart needed, and you can leave the frontend running while you
+restart the server):
+
+```
+yarn run start:local
+```
+
+And then you should be able to visit http://localhost:4200!
+
+#### Running the backend tests
+
+In your `.env` file, set `TEST_DATABASE_URL` to a value that's the same as
+`DATABASE_URL` except with a different database name at the end, since
+everything in the test database will be deleted every time you run tests. Try
+using `postgres://postgres@localhost/cargo_registry_test`.
+
+Create the test database by running:
+
+```
+createdb cargo_registry_test
+```
+
+The test harness will ensure that migrations are run.
+
+Run the backend API server tests with this command:
+
+```
+cargo test
+```
+
+#### Using your local crates.io with cargo
+
+Once you have a local instance of crates.io running at http://localhost:4200 by
+following the instructions in the "Working on the Backend" section, you can go
+to another Rust project and tell cargo to use your local crates.io instead of
+production.
+
+##### Publishing a crate to your local crates.io
+
+In order to publish a crate, you need an API token. In order to get an API
+token, you need to be able to log in with GitHub OAuth. In order to be able to
+log in with GitHub, you need to create an application with GitHub and specify
+the `GH_CLIENT_ID` and `GH_CLIENT_SECRET` variables in your `.env`.
+
+To create an application with GitHub, go to [Settings -> Developer Settings ->
+OAuth Applications](https://github.com/settings/developers) and click on the
+"Register a new application" button. Fill in the form as follows:
+
+- Application name: name your application whatever you'd like.
+- Homepage URL: `http://localhost:4200/`
+- Authorization callback URL: `http://localhost:4200/authorize/github`
+
+Create the application, then take the Client ID ad Client Secret values and use
+them as the values of the `GH_CLIENT_ID` and `GH_CLIENT_SECRET` in your `.env`.
+
+Then restart your backend, and you should be able to log in to your local
+crates.io with your GitHub account.
+
+Go to http://localhost:4200/me to get your API token and run the `cargo login`
+command as directed.
+
+Now you should be able to go to the directory of a crate that has no
+dependencies. There's currently restrictions around publishing crates that have
+dependencies installed from other registries than the one you're publishing to,
+so if you have a crate you've been working on that has dependencies from the
+live crates.io, you won't be able to publish that crate locally.
+
+In your crate directory, run:
+
+```
+cargo publish --host file:///path/to/your/crates.io/checkout/tmp/index-co
+```
+
+where `file:///path/to/your/crates.io/checkout` is the directory that you have
+crates.io's code in, and `tmp/index-co` is the directory with the git index
+that `./script/init-local-index.sh` set up. [Yes, `host` dosen't really make
+sense as a name for this flag](https://github.com/rust-lang/cargo/issues/3797).
+
+Note that when you're running crates.io in development mode without the S3
+variables set (which is what we've done in these setup steps), the crate files
+will be stored in `dist/local_uploads/crates` and served from there when a
+crate is downloaded. This directory gets cleared out if you stop and restart
+the frontend. If you try to install a crate from your local crates.io and
+`cargo` can't find the crate files, that's probably why.
+
+##### Downloading a crate from your local crates.io
+
+In *another* crate, you can use the crate you've published as a dependency by
+telling `cargo` to replace crates.io with your local crates.io as a source.
+
+In this other crate's directory, create a `.cargo/config` file with this
+content:
+
+```
+[source]
+
+[source.mirror]
+registry = "file:///path/to/your/crates.io/checkout/tmp/index-co"
+
+[source.crates-io]
+replace-with = "mirror"
+```
+
+Then add the crate you published to your local crates.io as a dependency in
+this crate's `Cargo.toml`, and `cargo build` should display output like this:
+
+```
+    Updating registry `file:///path/to/your/crates.io/checkout/tmp/index-co`
+ Downloading yourcrate v0.1.0 (registry file:///path/to/your/crates.io/checkout/tmp/index-co)
+   Compiling yourcrate v0.1.0
+   Compiling thiscrate v0.1.0 (file:///path/to/thiscrate)
+    Finished dev [unoptimized + debuginfo] target(s) in 0.56 secs
+```

--- a/docs/MIRROR.md
+++ b/docs/MIRROR.md
@@ -1,0 +1,71 @@
+# Deploying & using a mirror
+
+**DISCLAIMER: The process of setting up a mirror is a work-in-progress and is
+likely to change. It is not currently recommended for mission-critical
+production use. It also requires Cargo from Rust distribution 1.12.0 or
+later.**
+
+## Current functionality: a read-only, download-API-only mirror
+
+This mirror will function as a read-only duplicate of crates.io's API. You will
+be able to download crates using your index and your mirror, but the crate files
+will still come from crates.io's S3 storage.
+
+Your mirror will not:
+
+- Allow users to sign up/sign in
+- Allow crate publish
+- Keep track of any statistics
+- Display available crates in its UI
+
+## API server setup
+
+To deploy the API on Heroku, use this button:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)][deploy]
+
+[deploy]: https://heroku.com/deploy?template=https://github.com/rust-lang/crates.io
+
+The only config variable you need to set is `GIT_REPO_URL`, which should be the
+git URL of your crates index repository; see the next section for setup
+instructions for that.
+
+## Index Mirror Setup
+
+You also need a mirror of the crates.io git index, and your index needs to point
+to your API server.
+
+1. `git clone https://github.com/rust-lang/crates.io-index.git`
+2. Edit the config.json file to point to your API server so it looks like:
+
+    ```json
+    {
+      "dl": "https://[your heroku app name].herokuapp.com/api/v1/crates",
+      "api": "https://[your heroku app name].herokuapp.com/"
+    }
+    ```
+
+3. Commit and push to wherever you will be hosting your index (ex: github,
+    gitlab, an internal git server)
+
+4. In order to keep your mirror index up to date, schedule a `git pull` of the
+    official index. How to do this depends on how you are hosting your index,
+    but could be done through `cron` or a scheduled CI job, for example.
+
+## Local Cargo Setup
+
+NOTE: The following configuration requires Cargo from Rust 1.12.0
+distribution or later.
+
+In the project where you want to use your mirror, change your `.cargo/config`
+to replace the crates.io source to point to your crates index:
+
+```toml
+[source]
+
+[source.mirror]
+registry = "https://[host and path to your git server]/crates.io-index"
+
+[source.crates-io]
+replace-with = "mirror"
+```

--- a/script/init-local-index.sh
+++ b/script/init-local-index.sh
@@ -32,22 +32,5 @@ touch tmp/index-co/.git/git-daemon-export-ok
 cat - <<-EOF
 Your local git index is ready to go!
 
-You'll want to build crates.io by running:
-
-   cargo build
-
-Follow up by changing your HOME/.cargo/config: 
-
-   [source]
-
-   [source.local]
-   registry = "https://localhost:8888/crates.io-index"
-
-   [source.crates-io]
-   replace-with = "local"
-   registry = 'https://doesnt-matter-but-must-be-present'
-
-You will also need to generate a token from in the app itself
-
 Please refer to https://github.com/rust-lang/crates.io/blob/master/README.md for more info!
 EOF


### PR DESCRIPTION
At a recent OSS event that I helped out with, [we discovered](https://github.com/rust-lang/crates.io/issues/667) that the setup instructions were missing some things and were organized in a confusing way.

I wanted some room to elaborate, so I moved the dev setup instructions and the mirror setup instructions into their own files.

I also removed the instructions that the init-local-index.sh script printed out, since the instructions for setting up cargo there are confusing (ex: you should not put the `.cargo/config` in your crates.io checkout and then try to build crates.io, which isn't clear) and out of date.

Fixes #667.