### PR TITLE
Added a base font size

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -26,6 +26,7 @@ html, body { margin: 0; }
 
 body {
   font-family: "Helvetica Neue","Helvetica",Helvetica,Arial,sans-serif;
+  font-size: 16px;
   @include display-flex;
   @include flex-direction(column);
   @include align-items(center);


### PR DESCRIPTION
I just added a base font size, because it seems there is none right now and it results in a weird display on different browser for the inline code. Here is a screenshot of firefox (same with chrome):

<img width="358" alt="capture d ecran 2017-04-28 a 16 37 57" src="https://cloud.githubusercontent.com/assets/1575946/25533493/116a9ca6-2c31-11e7-9575-f0a688a8c9ee.png">

You can see the `rustc` and `cargo new` are really smaller and there is no reason(?). I think a base font size for the site may be better. Here is a screenshot with base font-size:

<img width="361" alt="capture d ecran 2017-04-28 a 16 46 09" src="https://cloud.githubusercontent.com/assets/1575946/25533855/58fc2958-2c32-11e7-87ba-4a615620a2d9.png">

It seems more readable. Sorry if this PR is useless (I'm not sure it's my first PR here and I'm not a CSS master)