### PR TITLE
Make crates.io publishable on crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,48 +1,11 @@
 [root]
-name = "cargo-registry"
+name = "cargo-registry-s3"
 version = "0.1.0"
 dependencies = [
- "bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-cookie 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-json-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-log-requests 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-router 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-static 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-test 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_codegen 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_full_text_search 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dotenv 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "flate2 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "license-exprs 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "migrate 0.1.0",
- "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2-diesel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2_postgres 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "s3 0.0.1",
- "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -103,6 +66,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "byteorder"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cargo-registry"
+version = "0.1.0"
+dependencies = [
+ "bufstream 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-registry-migrate 0.1.0",
+ "cargo-registry-s3 0.1.0",
+ "chrono 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.118 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-cookie 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-json-parser 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-log-requests 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-router 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-static 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-test 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_codegen 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_full_text_search 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dotenv 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "license-exprs 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "postgres 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2-diesel 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2_postgres 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo-registry-migrate"
+version = "0.1.0"
+dependencies = [
+ "postgres 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cargo_metadata"
@@ -582,13 +599,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "migrate"
-version = "0.1.0"
-dependencies = [
- "postgres 0.13.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "miniz-sys"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,16 +865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-serialize"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "s3"
-version = "0.0.1"
-dependencies = [
- "curl 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl 0.9.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "cargo-registry"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 version = "0.1.0"
+license = "MIT/Apache-2.0"
+repository = "https://github.com/rust-lang/crates.io"
 
 [profile.release]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "all"
 path = "src/tests/all.rs"
 
 [dependencies]
-s3 = { path = "src/s3", version = "0.0.1" }
-migrate = { path = "src/migrate", version = "0.1.0" }
+cargo-registry-s3 = { path = "src/s3", version = "0.1.0" }
+cargo-registry-migrate = { path = "src/migrate", version = "0.1.0" }
 rand = "0.3"
 time = "0.1"
 git2 = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 
+[workspace]
+
 [profile.release]
 opt-level = 2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ name = "all"
 path = "src/tests/all.rs"
 
 [dependencies]
-s3 = { path = "src/s3" }
-migrate = { path = "src/migrate" }
+s3 = { path = "src/s3", version = "0.0.1" }
+migrate = { path = "src/migrate", version = "0.1.0" }
 rand = "0.3"
 time = "0.1"
 git2 = "0.6.4"

--- a/src/migrate/Cargo.toml
+++ b/src/migrate/Cargo.toml
@@ -1,5 +1,5 @@
 [project]
-name = "migrate"
+name = "cargo-registry-migrate"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 version = "0.1.0"
 

--- a/src/migrate/Cargo.toml
+++ b/src/migrate/Cargo.toml
@@ -2,6 +2,8 @@
 name = "cargo-registry-migrate"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 version = "0.1.0"
+license = "MIT/Apache-2.0"
+repository = "https://github.com/rust-lang/crates.io"
 
 [lib]
 name = "migrate"

--- a/src/s3/Cargo.toml
+++ b/src/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "s3"
+name = "cargo-registry-s3"
 version = "0.0.1"
 authors = []
 

--- a/src/s3/Cargo.toml
+++ b/src/s3/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 
 name = "cargo-registry-s3"
-version = "0.0.1"
-authors = []
+version = "0.1.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
 
 [lib]
 

--- a/src/s3/Cargo.toml
+++ b/src/s3/Cargo.toml
@@ -3,6 +3,8 @@
 name = "cargo-registry-s3"
 version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/rust-lang/crates.io"
 
 [lib]
 


### PR DESCRIPTION
These changes should make the cargo-registry crate publishable on crates.io, which I want to do to make the docs about crates.io's code available on docs.rs to help people working on crates.io.

This will also involve publishing the crates in src/s3 and src/migrate.

<img src="https://upload.wikimedia.org/wikipedia/commons/7/71/Serpiente_alquimica.jpg" />