### PR TITLE
Remove extraneous left padding from exact match class

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -145,7 +145,6 @@
 .exact-match {
     margin-bottom: 40px;
     border-bottom: solid beige;
-    padding-left: 40px;
     div {
         padding: 10px;
     }


### PR DESCRIPTION
Before:
![before SS](https://i.imgur.com/YhGXyBP.png)

After:
![after SS](https://i.imgur.com/t28IR83.png)

Looks slightly better, IMHO, and Shep said y'all're are open to suggestions.