### PR TITLE
Reserve windows crate names.

### DIFF
--- a/migrations/20170430202433_reserve_windows_crate_names/down.sql
+++ b/migrations/20170430202433_reserve_windows_crate_names/down.sql
@@ -1,0 +1,4 @@
+DELETE FROM reserved_crate_names WHERE name IN
+    ('nul', 'con', 'prn', 'aux', 'com1', 'com2', 'com3', 'com4',
+    'com5', 'com6', 'com7', 'com8', 'com9', 'lpt1', 'lpt2',
+    'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9');

--- a/migrations/20170430202433_reserve_windows_crate_names/up.sql
+++ b/migrations/20170430202433_reserve_windows_crate_names/up.sql
@@ -1,0 +1,4 @@
+INSERT INTO reserved_crate_names (name) VALUES
+    ('nul'), ('con'), ('prn'), ('aux'), ('com1'), ('com2'), ('com3'), ('com4'),
+    ('com5'), ('com6'), ('com7'), ('com8'), ('com9'), ('lpt1'), ('lpt2'),
+    ('lpt3'), ('lpt4'), ('lpt5'), ('lpt6'), ('lpt7'), ('lpt8'), ('lpt9');


### PR DESCRIPTION
These names will break cargo on windows machines if uploaded to
the registry.