### PR TITLE
Delete crate script should delete categories and badges too

### DIFF
--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -78,6 +78,16 @@ fn delete(tx: &postgres::transaction::Transaction) {
                        &[&krate.id]).unwrap();
     println!("  {} deleted", n);
 
+    println!("deleting crate category connections");
+    let n = tx.execute("DELETE FROM crates_categories WHERE crate_id = $1",
+                       &[&krate.id]).unwrap();
+    println!("  {} deleted", n);
+
+    println!("deleting crate badges");
+    let n = tx.execute("DELETE FROM badges WHERE crate_id = $1",
+                       &[&krate.id]).unwrap();
+    println!("  {} deleted", n);
+
     println!("deleting the crate");
     let n = tx.execute("DELETE FROM crates WHERE id = $1",
                        &[&krate.id]).unwrap();


### PR DESCRIPTION
When deleting the `nul` crate, I couldn't use the delete crate script for a number of reasons, one being that there were categories and when I added categories I forgot to add deleting them to this script :(