### PR TITLE
Disable name trigger temporarily

### DIFF
--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -73,6 +73,10 @@ fn delete(tx: &postgres::transaction::Transaction) {
                        &[&krate.id]).unwrap();
     println!("  {} deleted", n);
 
+    println!("disabling reserved crate name trigger");
+    let _ = tx.execute("ALTER TABLE crates DISABLE TRIGGER trigger_ensure_crate_name_not_reserved;",
+                       &[]).unwrap();
+
     println!("deleting crate keyword connections");
     let n = tx.execute("DELETE FROM crates_keywords WHERE crate_id = $1",
                        &[&krate.id]).unwrap();
@@ -82,6 +86,10 @@ fn delete(tx: &postgres::transaction::Transaction) {
     let n = tx.execute("DELETE FROM crates_categories WHERE crate_id = $1",
                        &[&krate.id]).unwrap();
     println!("  {} deleted", n);
+
+    println!("enabling reserved crate name trigger");
+    let _ = tx.execute("ALTER TABLE crates ENABLE TRIGGER trigger_ensure_crate_name_not_reserved;",
+                       &[]).unwrap();
 
     println!("deleting crate badges");
     let n = tx.execute("DELETE FROM badges WHERE crate_id = $1",

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -78,6 +78,16 @@ fn delete(tx: &postgres::transaction::Transaction) {
                        &[&krate.id]).unwrap();
     println!("  {} deleted", n);
 
+    println!("deleting crate category connections");
+    let n = tx.execute("DELETE FROM crates_categories WHERE crate_id = $1",
+                       &[&krate.id]).unwrap();
+    println!("  {} deleted", n);
+
+    println!("deleting crate badges");
+    let n = tx.execute("DELETE FROM badges WHERE crate_id = $1",
+                       &[&krate.id]).unwrap();
+    println!("  {} deleted", n);
+
     println!("deleting the crate");
     let n = tx.execute("DELETE FROM crates WHERE id = $1",
                        &[&krate.id]).unwrap();


### PR DESCRIPTION
This builds on top of #698 but I wasn't sure how you'd feel about this, so I wanted to submit a separate PR.

What happened with the `nul` crate was that I deployed #695 to make the Windows files reserved crate names first, and then I tried to delete the crate.

But the keywords and categories tables have triggers that touch the crates table to set `updated_at`, and crates has a trigger to check for reserved crate names on update, which fails once a crate has a reserved name.

So I added a wrapper to disable the reserved crate name trigger around the two statements that need it, and re-enable the trigger right after, within the transaction that the whole delete crate script uses.

This does lock the table until the transaction is rolled back or committed.

I'm also doing this unconditionally, and this situation will hopefully be pretty rare. I'd be up for adding code that checks if the name of the crate being deleted is in the reserved crate name table and only adding these statements if needed, if that sounds better. 