### PR TITLE
Drop the old schema_migrations table

### DIFF
--- a/migrations/20170502181306_drop_schema_migrations/down.sql
+++ b/migrations/20170502181306_drop_schema_migrations/down.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    id              SERIAL PRIMARY KEY,
+    version         INT8 NOT NULL UNIQUE
+);

--- a/migrations/20170502181306_drop_schema_migrations/up.sql
+++ b/migrations/20170502181306_drop_schema_migrations/up.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS schema_migrations;


### PR DESCRIPTION
We haven't been using this since we switched to diesel;
`__diesel_schema_migrations` manages this now. We left this around just
in case we needed to roll back the switch to diesel in production, but
we're good and switched now.

The existence checks are so that these migrations won't error if people
are starting from a database that either does or does not have a
schema_migrations table.