### PR TITLE
Add descriptions to crates so that they're publishable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 version = "0.1.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
+description = "Backend of crates.io"
 
 [workspace]
 

--- a/src/s3/Cargo.toml
+++ b/src/s3/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
+description = "Interaction between crates.io and S3 for storing crate files"
 
 [lib]
 


### PR DESCRIPTION
I forgot to add descriptions [earlier](https://github.com/rust-lang/crates.io/pull/691) :( Not adding a description to the migration crate because [I think we should delete it instead](https://github.com/rust-lang/crates.io/pull/707).