### PR TITLE
Add category for built utils

### DIFF
--- a/src/categories.toml
+++ b/src/categories.toml
@@ -133,6 +133,12 @@ Crates that provide developer-facing features such as testing, debugging, \
 linting, performance profiling, autocompletion, formatting, and more.\
 """
 
+[development-tools.categories.build-utils]
+name = "Build Utils"
+description = """
+Utilities for build scripts and other build time steps.\
+"""
+
 [development-tools.categories.cargo-plugins]
 name = "Cargo plugins"
 description = """


### PR DESCRIPTION
Gives utilities for build scripts there own category. 
For example a utility which helps you pack resources into your binary can fall into this category.

### Open Questions
- is the name ok?
- maybe restrict it to build script utilities only?