### PR TITLE
Adjust db connections

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -53,7 +53,7 @@ impl App {
             .helper_threads(if config.env == ::Env::Production {3} else {1})
             .build();
         let diesel_db_config = r2d2::Config::builder()
-            .pool_size(if config.env == ::Env::Production {50} else {1})
+            .pool_size(if config.env == ::Env::Production {30} else {1})
             .min_idle(if config.env == ::Env::Production {Some(5)} else {None})
             .helper_threads(if config.env == ::Env::Production {3} else {1})
             .build();

--- a/src/app.rs
+++ b/src/app.rs
@@ -49,6 +49,7 @@ impl App {
 
         let db_config = r2d2::Config::builder()
             .pool_size(if config.env == ::Env::Production {10} else {1})
+            .min_idle(if config.env == ::Env::Production {Some(5)} else {None})
             .helper_threads(if config.env == ::Env::Production {3} else {1})
             .build();
         let diesel_db_config = r2d2::Config::builder()


### PR DESCRIPTION
Staging was using 20/20, prod was using 122/120, due to the upgrade in r2d2 with this change? https://github.com/sfackler/r2d2/commit/df5eb7422f2b41d5c55d8d93f86c17c073e2d727

This change makes staging use 10/20 on boot and 16/20 after the first request, seems better.