### PR TITLE
Made the header for exact matches be a link to the crate homepage. Th…

### DIFF
--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -49,7 +49,9 @@
     {{#each model as |crate|}}
         {{#if crate.exact_match}}
             <div class='exact-match'>
-                <h1>Exact Match</h1>
+                {{#link-to "crate" crate}}
+                    <h1>Exact Match</h1>
+                {{/link-to}}
                 {{crate-row crate=crate}}
             </div>
         {{else}}


### PR DESCRIPTION
…is fixes #683.

When displaying search results, the `Exact Match` header will be a link to the crate's homepage. Exactly as if the user clicked the crate's name.