### PR TITLE
Refactor paginating queries to a trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,8 @@ pub mod user;
 pub mod util;
 pub mod version;
 
+mod pagination;
+
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Env {
     Development,

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -1,0 +1,43 @@
+use diesel::prelude::*;
+use diesel::query_builder::*;
+use diesel::types::BigInt;
+use diesel::pg::Pg;
+
+pub struct Paginated<T> {
+    query: T,
+    limit: i64,
+    offset: i64,
+}
+
+pub trait Paginate: AsQuery + Sized {
+    fn paginate(self, limit: i64, offset: i64) -> Paginated<Self::Query> {
+        Paginated {
+            query: self.as_query(),
+            limit,
+            offset,
+        }
+    }
+}
+
+impl<T: AsQuery> Paginate for T {}
+
+impl<T: Query> Query for Paginated<T> {
+    type SqlType = (T::SqlType, BigInt);
+}
+
+impl<T> QueryFragment<Pg> for Paginated<T>
+where
+    T: QueryFragment<Pg>,
+{
+    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+        out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(") t LIMIT ");
+        out.push_bind_param::<BigInt, _>(&self.limit)?;
+        out.push_sql(" OFFSET ");
+        out.push_bind_param::<BigInt, _>(&self.offset)?;
+        Ok(())
+    }
+}
+
+impl_query_id!(Paginated<T>);


### PR DESCRIPTION
This pattern gets duplicated quite a bit (and it should be duplicated
even more since we still have places where we're doing more than one
query to paginate). Additionally, using the `sql` function will cause a
query to be removed from the prepared statement cache (since Diesel
doesn't know if the string was generated dynamically or not).

This moves it out into a trait, and represents a paginated query in a
bit more of an abstract form from the SQL point of view. This will
slightly change the SQL in the places that it's being used, so that it
looks more like what we have in `src/krate_reverse_dependencies.sql`,
applying the limit/offset as late as possible. This will not affect the
query plan unless they are using `distinct`, or if `limit`/`offset` are
called prior to `paginate`. Even if those cases do happen, this query is
probably what we meant anyway.