### PR TITLE
Port categories/index and categories/show over to Diesel

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use time::Timespec;
 
 use conduit::{Request, Response};
@@ -68,17 +67,6 @@ impl Category {
         })
     }
 
-    pub fn find_by_slug(conn: &GenericConnection, slug: &str) -> CargoResult<Category> {
-        let stmt = conn.prepare(
-            "SELECT * FROM categories \
-             WHERE slug = LOWER($1)",
-        )?;
-        let rows = stmt.query(&[&slug])?;
-        rows.iter().next().chain_error(|| NotFound).map(|row| {
-            Model::from_row(&row)
-        })
-    }
-
     pub fn encodable(self) -> EncodableCategory {
         let Category {
             crates_cnt,
@@ -132,78 +120,13 @@ impl Category {
         })
     }
 
-    pub fn update_crate_old(
-        conn: &GenericConnection,
-        krate: &Crate,
-        categories: &[String],
-    ) -> CargoResult<Vec<String>> {
-        let old_categories = krate.categories(conn)?;
-        let old_categories_ids: HashSet<_> = old_categories.iter().map(|cat| cat.id).collect();
+    pub fn count_toplevel(conn: &PgConnection) -> QueryResult<i64> {
+        use self::categories::dsl::*;
 
-        // If a new category specified is not in the database, filter
-        // it out and don't add it. Return it to be able to warn about it.
-        let mut invalid_categories = vec![];
-        let new_categories: Vec<Category> = categories
-            .iter()
-            .flat_map(|c| match Category::find_by_slug(conn, c) {
-                Ok(cat) => Some(cat),
-                Err(_) => {
-                    invalid_categories.push(c.to_string());
-                    None
-                }
-            })
-            .collect();
-
-        let new_categories_ids: HashSet<_> = new_categories.iter().map(|cat| cat.id).collect();
-
-        let to_rm: Vec<_> = old_categories_ids
-            .difference(&new_categories_ids)
-            .cloned()
-            .collect();
-        let to_add: Vec<_> = new_categories_ids
-            .difference(&old_categories_ids)
-            .cloned()
-            .collect();
-
-        if !to_rm.is_empty() {
-            conn.execute(
-                "DELETE FROM crates_categories \
-                 WHERE category_id = ANY($1) \
-                 AND crate_id = $2",
-                &[&to_rm, &krate.id],
-            )?;
-        }
-
-        if !to_add.is_empty() {
-            let insert: Vec<_> = to_add
-                .into_iter()
-                .map(|id| format!("({}, {})", krate.id, id))
-                .collect();
-            let insert = insert.join(", ");
-            conn.execute(
-                &format!(
-                    "INSERT INTO crates_categories \
-                     (crate_id, category_id) VALUES {}",
-                    insert
-                ),
-                &[],
-            )?;
-        }
-
-        Ok(invalid_categories)
-    }
-
-    pub fn count_toplevel(conn: &GenericConnection) -> CargoResult<i64> {
-        let sql = format!(
-            "\
-             SELECT COUNT(*) \
-             FROM {} \
-             WHERE category NOT LIKE '%::%'",
-            Model::table_name(None::<Self>)
-        );
-        let stmt = conn.prepare(&sql)?;
-        let rows = stmt.query(&[])?;
-        Ok(rows.iter().next().unwrap().get("count"))
+        categories
+            .filter(category.not_like("%::%"))
+            .count()
+            .get_result(conn)
     }
 
     pub fn toplevel(
@@ -269,23 +192,23 @@ impl Category {
         Ok(categories)
     }
 
-    pub fn subcategories(&self, conn: &GenericConnection) -> CargoResult<Vec<Category>> {
-        let stmt = conn.prepare(
-            "\
-             SELECT c.id, c.category, c.slug, c.description, c.created_at, \
-             COALESCE (( \
-             SELECT sum(c2.crates_cnt)::int \
-             FROM categories as c2 \
-             WHERE c2.slug = c.slug \
-             OR c2.slug LIKE c.slug || '::%' \
-             ), 0) as crates_cnt \
-             FROM categories as c \
-             WHERE c.category ILIKE $1 || '::%' \
-             AND c.category NOT ILIKE $1 || '::%::%'",
-        )?;
+    pub fn subcategories(&self, conn: &PgConnection) -> QueryResult<Vec<Category>> {
+        use diesel::expression::dsl::*;
+        use diesel::types::Text;
 
-        let rows = stmt.query(&[&self.category])?;
-        Ok(rows.iter().map(|r| Model::from_row(&r)).collect())
+        sql(
+            "SELECT c.id, c.category, c.slug, c.description, \
+            COALESCE (( \
+                SELECT sum(c2.crates_cnt)::int \
+                FROM categories as c2 \
+                WHERE c2.slug = c.slug \
+                OR c2.slug LIKE c.slug || '::%' \
+            ), 0) as crates_cnt, c.created_at \
+            FROM categories as c \
+            WHERE c.category ILIKE $1 || '::%' \
+            AND c.category NOT ILIKE $1 || '::%::%'",
+        ).bind::<Text, _>(&self.category)
+            .load(conn)
     }
 }
 
@@ -332,16 +255,16 @@ impl Model for Category {
 
 /// Handles the `GET /categories` route.
 pub fn index(req: &mut Request) -> CargoResult<Response> {
-    let conn = req.tx()?;
+    let conn = req.db_conn()?;
     let (offset, limit) = req.pagination(10, 100)?;
     let query = req.query();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 
-    let categories = Category::toplevel_old(conn, sort, limit, offset)?;
+    let categories = Category::toplevel(&conn, sort, limit, offset)?;
     let categories = categories.into_iter().map(Category::encodable).collect();
 
     // Query for the total count of categories
-    let total = Category::count_toplevel(conn)?;
+    let total = Category::count_toplevel(&conn)?;
 
     #[derive(RustcEncodable)]
     struct R {
@@ -362,11 +285,13 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
 /// Handles the `GET /categories/:category_id` route.
 pub fn show(req: &mut Request) -> CargoResult<Response> {
     let slug = &req.params()["category_id"];
-    let conn = req.tx()?;
-    let cat = Category::find_by_slug(conn, slug)?;
-    let subcats = cat.subcategories(conn)?
+    let conn = req.db_conn()?;
+    let cat = categories::table
+        .filter(categories::slug.eq(::lower(slug)))
+        .first::<Category>(&*conn)?;
+    let subcats = cat.subcategories(&conn)?
         .into_iter()
-        .map(|s| s.encodable())
+        .map(Category::encodable)
         .collect();
     let cat = cat.encodable();
     let cat_with_subcats = EncodableCategoryWithSubcategories {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -35,7 +35,7 @@ use cargo_registry::user::NewUser;
 use cargo_registry::owner::{CrateOwner, NewTeam, Team};
 use cargo_registry::version::NewVersion;
 use cargo_registry::user::AuthenticationSource;
-use cargo_registry::{User, Crate, Version, Dependency, Category, Model, Replica};
+use cargo_registry::{User, Crate, Version, Dependency, Replica};
 use conduit::{Request, Method};
 use conduit_test::MockRequest;
 use diesel::pg::PgConnection;
@@ -513,18 +513,6 @@ fn new_category<'a>(category: &'a str, slug: &'a str) -> NewCategory<'a> {
         slug: slug,
         ..NewCategory::default()
     }
-}
-
-fn mock_category(req: &mut Request, name: &str, slug: &str) -> Category {
-    let conn = req.tx().unwrap();
-    let stmt = conn.prepare(
-        " \
-         INSERT INTO categories (category, slug) \
-         VALUES ($1, $2) \
-         RETURNING *",
-    ).unwrap();
-    let rows = stmt.query(&[&name, &slug]).unwrap();
-    Model::from_row(&rows.iter().next().unwrap())
 }
 
 fn logout(req: &mut Request) {

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,7 +1,5 @@
 use conduit::{Handler, Method};
-use conduit_test::MockRequest;
 
-use cargo_registry::db::RequestTransaction;
 use cargo_registry::category::{Category, EncodableCategory, EncodableCategoryWithSubcategories};
 
 #[derive(RustcDecodable)]
@@ -25,7 +23,7 @@ struct CategoryWithSubcategories {
 #[test]
 fn index() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/categories");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories");
 
     // List 0 categories if none exist
     let mut response = ok_resp!(middle.call(&mut req));
@@ -33,9 +31,14 @@ fn index() {
     assert_eq!(json.categories.len(), 0);
     assert_eq!(json.meta.total, 0);
 
-    // Create a category and a subcategory
-    ::mock_category(&mut req, "foo", "foo");
-    ::mock_category(&mut req, "foo::bar", "foo::bar");
+    {
+        let conn = app.diesel_database.get().unwrap();
+        // Create a category and a subcategory
+        ::new_category("foo", "foo").find_or_create(&conn).unwrap();
+        ::new_category("foo::bar", "foo::bar")
+            .find_or_create(&conn)
+            .unwrap();
+    }
 
     let mut response = ok_resp!(middle.call(&mut req));
     let json: CategoryList = ::json(&mut response);
@@ -51,13 +54,19 @@ fn show() {
     let (_b, app, middle) = ::app();
 
     // Return not found if a category doesn't exist
-    let mut req = ::req(app, Method::Get, "/api/v1/categories/foo-bar");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories/foo-bar");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
-    // Create a category and a subcategory
-    ::mock_category(&mut req, "Foo Bar", "foo-bar");
-    ::mock_category(&mut req, "Foo Bar::Baz", "foo-bar::baz");
+    {
+        let conn = app.diesel_database.get().unwrap();
+        ::new_category("Foo Bar", "foo-bar")
+            .find_or_create(&conn)
+            .unwrap();
+        ::new_category("Foo Bar::Baz", "foo-bar::baz")
+            .find_or_create(&conn)
+            .unwrap();
+    }
 
     // The category and its subcategories should be in the json
     let mut response = ok_resp!(middle.call(&mut req));
@@ -71,60 +80,70 @@ fn show() {
 #[test]
 fn update_crate() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/categories/foo");
-    let cnt = |req: &mut MockRequest, cat: &str| {
-        req.with_path(&format!("/api/v1/categories/{}", cat));
-        let mut response = ok_resp!(middle.call(req));
-        ::json::<GoodCategory>(&mut response).category.crates_cnt as usize
-    };
-    ::mock_user(&mut req, ::user("foo"));
-    let (krate, _) = ::mock_crate(&mut req, ::krate("foocat"));
-    ::mock_category(&mut req, "cat1", "cat1");
-    ::mock_category(&mut req, "Category 2", "category-2");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories/foo");
+    macro_rules! cnt {
+        ($req: expr, $cat: expr) => {{
+            $req.with_path(&format!("/api/v1/categories/{}", $cat));
+            let mut response = ok_resp!(middle.call($req));
+            ::json::<GoodCategory>(&mut response).category.crates_cnt as usize
+        }}
+    }
+    let krate;
+    {
+        let conn = app.diesel_database.get().unwrap();
+        let u = ::new_user("foo").create_or_update(&conn).unwrap();
+        krate = ::CrateBuilder::new("foocat", u.id).expect_build(&conn);
+        ::new_category("cat1", "cat1")
+            .find_or_create(&conn)
+            .unwrap();
+        ::new_category("Category 2", "category-2")
+            .find_or_create(&conn)
+            .unwrap();
+    }
 
     // Updating with no categories has no effect
-    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 0);
-    assert_eq!(cnt(&mut req, "category-2"), 0);
+    Category::update_crate(&app.diesel_database.get().unwrap(), &krate, &[]).unwrap();
+    assert_eq!(cnt!(&mut req, "cat1"), 0);
+    assert_eq!(cnt!(&mut req, "category-2"), 0);
 
     // Happy path adding one category
-    Category::update_crate_old(req.tx().unwrap(), &krate, &["cat1".to_string()]).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 1);
-    assert_eq!(cnt(&mut req, "category-2"), 0);
+    Category::update_crate(&app.diesel_database.get().unwrap(), &krate, &["cat1"]).unwrap();
+    assert_eq!(cnt!(&mut req, "cat1"), 1);
+    assert_eq!(cnt!(&mut req, "category-2"), 0);
 
     // Replacing one category with another
-    Category::update_crate_old(req.tx().unwrap(), &krate, &["category-2".to_string()]).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 0);
-    assert_eq!(cnt(&mut req, "category-2"), 1);
+    Category::update_crate(&app.diesel_database.get().unwrap(), &krate, &["category-2"]).unwrap();
+    assert_eq!(cnt!(&mut req, "cat1"), 0);
+    assert_eq!(cnt!(&mut req, "category-2"), 1);
 
     // Removing one category
-    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 0);
-    assert_eq!(cnt(&mut req, "category-2"), 0);
+    Category::update_crate(&app.diesel_database.get().unwrap(), &krate, &[]).unwrap();
+    assert_eq!(cnt!(&mut req, "cat1"), 0);
+    assert_eq!(cnt!(&mut req, "category-2"), 0);
 
     // Adding 2 categories
-    Category::update_crate_old(
-        req.tx().unwrap(),
+    Category::update_crate(
+        &app.diesel_database.get().unwrap(),
         &krate,
-        &["cat1".to_string(), "category-2".to_string()],
+        &["cat1", "category-2"],
     ).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 1);
-    assert_eq!(cnt(&mut req, "category-2"), 1);
+    assert_eq!(cnt!(&mut req, "cat1"), 1);
+    assert_eq!(cnt!(&mut req, "category-2"), 1);
 
     // Removing all categories
-    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 0);
-    assert_eq!(cnt(&mut req, "category-2"), 0);
+    Category::update_crate(&app.diesel_database.get().unwrap(), &krate, &[]).unwrap();
+    assert_eq!(cnt!(&mut req, "cat1"), 0);
+    assert_eq!(cnt!(&mut req, "category-2"), 0);
 
     // Attempting to add one valid category and one invalid category
-    let invalid_categories = Category::update_crate_old(
-        req.tx().unwrap(),
+    let invalid_categories = Category::update_crate(
+        &app.diesel_database.get().unwrap(),
         &krate,
-        &["cat1".to_string(), "catnope".to_string()],
+        &["cat1", "catnope"],
     ).unwrap();
-    assert_eq!(invalid_categories, vec!["catnope".to_string()]);
-    assert_eq!(cnt(&mut req, "cat1"), 1);
-    assert_eq!(cnt(&mut req, "category-2"), 0);
+    assert_eq!(invalid_categories, vec!["catnope"]);
+    assert_eq!(cnt!(&mut req, "cat1"), 1);
+    assert_eq!(cnt!(&mut req, "category-2"), 0);
 
     // Does not add the invalid category to the category list
     // (unlike the behavior of keywords)
@@ -135,18 +154,19 @@ fn update_crate() {
     assert_eq!(json.meta.total, 2);
 
     // Attempting to add a category by display text; must use slug
-    Category::update_crate_old(req.tx().unwrap(), &krate, &["Category 2".to_string()]).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 0);
-    assert_eq!(cnt(&mut req, "category-2"), 0);
+    Category::update_crate(&app.diesel_database.get().unwrap(), &krate, &["Category 2"]).unwrap();
+    assert_eq!(cnt!(&mut req, "cat1"), 0);
+    assert_eq!(cnt!(&mut req, "category-2"), 0);
 
     // Add a category and its subcategory
-    ::mock_category(&mut req, "cat1::bar", "cat1::bar");
-    Category::update_crate_old(
-        req.tx().unwrap(),
-        &krate,
-        &["cat1".to_string(), "cat1::bar".to_string()],
-    ).unwrap();
-    assert_eq!(cnt(&mut req, "cat1"), 1);
-    assert_eq!(cnt(&mut req, "cat1::bar"), 1);
-    assert_eq!(cnt(&mut req, "category-2"), 0);
+    {
+        let conn = app.diesel_database.get().unwrap();
+        ::new_category("cat1::bar", "cat1::bar")
+            .find_or_create(&conn)
+            .unwrap();
+        Category::update_crate(&conn, &krate, &["cat1", "cat1::bar"]).unwrap();
+    }
+    assert_eq!(cnt!(&mut req, "cat1"), 1);
+    assert_eq!(cnt!(&mut req, "cat1::bar"), 1);
+    assert_eq!(cnt!(&mut req, "category-2"), 0);
 }


### PR DESCRIPTION
I don't think `tests::categories::update_crate` is testing enough shit. Damn that's a long test. I changed `cnt` to a macro rather than a function so I could see the line that was failing when one of the 100 invocations of it was wrong (otherwise it just gives the body of the function as the line)