### PR TITLE
Migrate test database at build time instead of runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ civet = "0.9"
 conduit-test = "0.8"
 bufstream = "0.1"
 
+[build-dependencies]
+dotenv = "0.10"
+diesel = { version = "0.13", features = ["postgres"] }
+
 [features]
 unstable = []
 lint = ["clippy"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+extern crate diesel;
+extern crate dotenv;
+
+use diesel::migrations::run_pending_migrations;
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use dotenv::dotenv;
+use std::env;
+
+fn main() {
+    if env::var("PROFILE") == Ok("debug".into()) {
+        let _ = dotenv();
+        if let Ok(database_url) = env::var("TEST_DATABASE_URL") {
+            let connection = PgConnection::establish(&database_url)
+                .expect("Could not connect to TEST_DATABASE_URL");
+            run_pending_migrations(&connection)
+                .expect("Error running migrations");
+        }
+    }
+}


### PR DESCRIPTION
While we're running these in the integration tests, they weren't run
before unit tests. Rather than duplicating the logic for this everywhere
that we have a test that interacts with the database, we can just do
this at compile time.

As best I can tell, Cargo doesn't give you any environment variable to
know that you're building for tests and not just a debug build, so I've
set this up to only try to migrate if the env var is present, and not
error in its absense.

Fixes #762.