### PR TITLE
Ensure exact match crates are always returned by search

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -801,7 +801,11 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
 
     if let Some(q_string) = params.get("q") {
         let q = plainto_tsquery(q_string);
-        query = query.filter(q.matches(crates::textsearchable_index_col));
+        query = query.filter(q.matches(crates::textsearchable_index_col).or(
+            crates::name.eq(
+                q_string,
+            ),
+        ));
 
         query = query.select((
             ALL_COLUMNS,


### PR DESCRIPTION
The query assumed that if the name was equal to the query string, that
the full text search would always match that crate. This is not true in
the case where the query string is a stop word (words like a, the, just,
which), which are excluded from full text search.

Explicitly adding an or condition to include a crate whose name matches
is always returned solves the issue. We purposely continue to exclude
crates which would only match because their readme contains a stopword,
as this behavior is important for things like stemming to do their job.

Fixes #321.