### PR TITLE
Fix crate/downloads

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1074,7 +1074,7 @@ pub fn downloads(req: &mut Request) -> CargoResult<Response> {
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
 
     let mut versions = Version::belonging_to(&krate).load::<Version>(&*conn)?;
-    versions.sort_by(|a, b| a.num.cmp(&b.num));
+    versions.sort_by(|a, b| b.num.cmp(&a.num));
     let (latest_five, rest) = versions.split_at(cmp::min(5, versions.len()));
 
     let downloads = VersionDownload::belonging_to(latest_five)


### PR DESCRIPTION
I appear to have fucked up in #746. The API was sending the detailed
stats for the oldest 5 versions instead of the newest 5 versions,
causing the whole graph to just show "other". This fixes that error.

(as an aside, I kinda prefer just having the whole picture as one stat
like that)