### PR TITLE
Force Travis to get the latest versions of diesel_cli and rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - yarn
   - yarn run bower install
   - cargo install --force diesel_cli --debug --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
-  - cargo install rustfmt
+  - cargo install --force rustfmt
   - rustfmt --version
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
   - yarn
   - yarn run bower install
-  - cargo install diesel_cli --debug --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
+  - cargo install --force diesel_cli --debug --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
   - cargo install rustfmt
   - rustfmt --version
 


### PR DESCRIPTION
This should hopefully fix https://github.com/rust-lang/crates.io/issues/776.

As noted by @carols10cents, `--force` is needed to get the latest version of diesel_cli because [we added cargo caching](https://github.com/rust-lang/crates.io/commit/209dab0f40bbcaa7826188dd3d3ff85b72005ecd#diff-354f30a63fb0907d4ad57269548329e3).