### PR TITLE
Replace normalize-css bower component with npm one

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "name": "cargo",
   "dependencies": {
     "Faker": "3.1.0",
-    "normalize-css": "5.0.0",
     "pretender": "1.4.2",
     "clipboard": "1.6.1"
   }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,7 +20,7 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  app.import('bower_components/normalize-css/normalize.css');
+  app.import('node_modules/normalize.css/normalize.css');
   app.import('bower_components/clipboard/dist/clipboard.js');
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "ember-suave": "4.0.1",
     "emberx-select": "^3.0.1",
     "loader.js": "4.2.3"
+  },
+  "dependencies": {
+    "normalize.css": "^5.0.0"
   }
 }


### PR DESCRIPTION
Bower is dead, so I thought I'd start replacing bower components bit by bit.