### PR TITLE
fixing link to github team page via crates team page

### DIFF
--- a/mirage/fixtures/team.js
+++ b/mirage/fixtures/team.js
@@ -5,6 +5,6 @@ export default {
         "id": 1,
         "login": "github:org_test:thehydroimpulseteam",
         "name": "thehydroimpulseteam",
-        "url": "https://github.com/thehydroimpulse",
+        "url": "https://github.com/org_test",
     }
 };

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -263,9 +263,8 @@ impl Team {
         login_pieces.next();
 
         format!(
-            "https://github.com/orgs/{}/teams/{}",
+            "https://github.com/{}",
             login_pieces.next().expect("org failed"),
-            login_pieces.next().expect("team failed")
         )
     }
 }

--- a/tests/acceptance/team-page-test.js
+++ b/tests/acceptance/team-page-test.js
@@ -17,7 +17,7 @@ test('has link to github in team header', function(assert) {
 
     andThen(function() {
         const $githubLink = findWithAssert('.info a');
-        assert.equal($githubLink.attr('href').trim(), 'https://github.com/thehydroimpulse');
+        assert.equal($githubLink.attr('href').trim(), 'https://github.com/org_test');
     });
 
 });


### PR DESCRIPTION
The team's GitHub link on the team's crates page was broken when trying to access `/org/org_name/team/team_name`. This could be because not all teams are publicly viewable, so the link was changed to instead go to the organization's GitHub page.