### PR TITLE
Switch several category routes over to diesel

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -201,7 +201,7 @@ impl Category {
             "\
             SELECT COUNT(*) \
             FROM categories \
-            WHERE category NOT LIKE '%::%'"
+            WHERE category NOT LIKE '%::%'",
         );
         let count = query.get_result(&*conn)?;
         Ok(count)
@@ -366,9 +366,10 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
     let id = &req.params()["category_id"];
     let conn = req.db_conn()?;
     let cat = categories.filter(slug.eq(id)).first::<Category>(&*conn)?;
-    let subcats = cat.subcategories(&*conn)?.into_iter().map(|s| {
-        s.encodable()
-    }).collect();
+    let subcats = cat.subcategories(&*conn)?
+        .into_iter()
+        .map(|s| s.encodable())
+        .collect();
 
     let cat = cat.encodable();
     let cat_with_subcats = EncodableCategoryWithSubcategories {

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -35,8 +35,12 @@ fn index() {
     // Create a category and a subcategory
     {
         let conn = t!(app.diesel_database.get());
-        ::new_category("foo", "foo").create_or_update(&conn).unwrap();
-        ::new_category("foo::bar", "foo::bar").create_or_update(&conn).unwrap();
+        ::new_category("foo", "foo")
+            .create_or_update(&conn)
+            .unwrap();
+        ::new_category("foo::bar", "foo::bar")
+            .create_or_update(&conn)
+            .unwrap();
     }
     let mut response = ok_resp!(middle.call(&mut req));
     let json: CategoryList = ::json(&mut response);
@@ -89,8 +93,7 @@ fn update_crate() {
         let user = t!(::new_user("foo").create_or_update(&conn));
         t!(::new_category("cat1", "cat1").create_or_update(&conn));
         t!(::new_category("Category 2", "category-2").create_or_update(&conn));
-        ::CrateBuilder::new("foo_crate", user.id)
-            .expect_build(&conn)
+        ::CrateBuilder::new("foo_crate", user.id).expect_build(&conn)
     };
 
     // Updating with no categories has no effect
@@ -128,11 +131,7 @@ fn update_crate() {
     // Adding 2 categories
     {
         let conn = t!(app.diesel_database.get());
-        Category::update_crate(
-            &conn,
-            &krate,
-            &["cat1", "category-2"],
-        ).unwrap();
+        Category::update_crate(&conn, &krate, &["cat1", "category-2"]).unwrap();
     }
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 1);
@@ -148,11 +147,7 @@ fn update_crate() {
     // Attempting to add one valid category and one invalid category
     let invalid_categories = {
         let conn = t!(app.diesel_database.get());
-        Category::update_crate(
-            &conn,
-            &krate,
-            &["cat1", "catnope"],
-        ).unwrap()
+        Category::update_crate(&conn, &krate, &["cat1", "catnope"]).unwrap()
     };
     assert_eq!(invalid_categories, vec!["catnope".to_string()]);
     assert_eq!(cnt(&mut req, "cat1"), 1);
@@ -177,12 +172,10 @@ fn update_crate() {
     // Add a category and its subcategory
     {
         let conn = t!(app.diesel_database.get());
-        t!(::new_category("cat1::bar", "cat1::bar").create_or_update(&conn));
-        Category::update_crate(
+        t!(::new_category("cat1::bar", "cat1::bar").create_or_update(
             &conn,
-            &krate,
-            &["cat1", "cat1::bar"],
-        ).unwrap();
+        ));
+        Category::update_crate(&conn, &krate, &["cat1", "cat1::bar"]).unwrap();
     }
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "cat1::bar"), 1);

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,7 +1,6 @@
 use conduit::{Handler, Method};
 use conduit_test::MockRequest;
 
-use cargo_registry::db::RequestTransaction;
 use cargo_registry::category::{Category, EncodableCategory, EncodableCategoryWithSubcategories};
 
 #[derive(RustcDecodable)]
@@ -25,7 +24,7 @@ struct CategoryWithSubcategories {
 #[test]
 fn index() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/categories");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories");
 
     // List 0 categories if none exist
     let mut response = ok_resp!(middle.call(&mut req));
@@ -34,9 +33,11 @@ fn index() {
     assert_eq!(json.meta.total, 0);
 
     // Create a category and a subcategory
-    ::mock_category(&mut req, "foo", "foo");
-    ::mock_category(&mut req, "foo::bar", "foo::bar");
-
+    {
+        let conn = t!(app.diesel_database.get());
+        ::new_category("foo", "foo").create_or_update(&conn).unwrap();
+        ::new_category("foo::bar", "foo::bar").create_or_update(&conn).unwrap();
+    }
     let mut response = ok_resp!(middle.call(&mut req));
     let json: CategoryList = ::json(&mut response);
 
@@ -51,13 +52,18 @@ fn show() {
     let (_b, app, middle) = ::app();
 
     // Return not found if a category doesn't exist
-    let mut req = ::req(app, Method::Get, "/api/v1/categories/foo-bar");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories/foo-bar");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
     // Create a category and a subcategory
-    ::mock_category(&mut req, "Foo Bar", "foo-bar");
-    ::mock_category(&mut req, "Foo Bar::Baz", "foo-bar::baz");
+    {
+        let conn = t!(app.diesel_database.get());
+
+        // Create a category and a subcategory
+        t!(::new_category("Foo Bar", "foo-bar").create_or_update(&conn));
+        t!(::new_category("Foo Bar::Baz", "foo-bar::baz").create_or_update(&conn));
+    }
 
     // The category and its subcategories should be in the json
     let mut response = ok_resp!(middle.call(&mut req));
@@ -71,57 +77,83 @@ fn show() {
 #[test]
 fn update_crate() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/api/v1/categories/foo");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories/foo");
     let cnt = |req: &mut MockRequest, cat: &str| {
         req.with_path(&format!("/api/v1/categories/{}", cat));
         let mut response = ok_resp!(middle.call(req));
         ::json::<GoodCategory>(&mut response).category.crates_cnt as usize
     };
-    ::mock_user(&mut req, ::user("foo"));
-    let (krate, _) = ::mock_crate(&mut req, ::krate("foocat"));
-    ::mock_category(&mut req, "cat1", "cat1");
-    ::mock_category(&mut req, "Category 2", "category-2");
+
+    let krate = {
+        let conn = t!(app.diesel_database.get());
+        let user = t!(::new_user("foo").create_or_update(&conn));
+        t!(::new_category("cat1", "cat1").create_or_update(&conn));
+        t!(::new_category("Category 2", "category-2").create_or_update(&conn));
+        ::CrateBuilder::new("foo_crate", user.id)
+            .expect_build(&conn)
+    };
 
     // Updating with no categories has no effect
-    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(&conn, &krate, &[]).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Happy path adding one category
-    Category::update_crate_old(req.tx().unwrap(), &krate, &["cat1".to_string()]).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(&conn, &krate, &["cat1"]).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Replacing one category with another
-    Category::update_crate_old(req.tx().unwrap(), &krate, &["category-2".to_string()]).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(&conn, &krate, &["category-2"]).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 1);
 
     // Removing one category
-    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(&conn, &krate, &[]).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Adding 2 categories
-    Category::update_crate_old(
-        req.tx().unwrap(),
-        &krate,
-        &["cat1".to_string(), "category-2".to_string()],
-    ).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(
+            &conn,
+            &krate,
+            &["cat1", "category-2"],
+        ).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 1);
 
     // Removing all categories
-    Category::update_crate_old(req.tx().unwrap(), &krate, &[]).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(&conn, &krate, &[]).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Attempting to add one valid category and one invalid category
-    let invalid_categories = Category::update_crate_old(
-        req.tx().unwrap(),
-        &krate,
-        &["cat1".to_string(), "catnope".to_string()],
-    ).unwrap();
+    let invalid_categories = {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(
+            &conn,
+            &krate,
+            &["cat1", "catnope"],
+        ).unwrap()
+    };
     assert_eq!(invalid_categories, vec!["catnope".to_string()]);
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 0);
@@ -135,17 +167,23 @@ fn update_crate() {
     assert_eq!(json.meta.total, 2);
 
     // Attempting to add a category by display text; must use slug
-    Category::update_crate_old(req.tx().unwrap(), &krate, &["Category 2".to_string()]).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        Category::update_crate(&conn, &krate, &["Category 2"]).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 0);
     assert_eq!(cnt(&mut req, "category-2"), 0);
 
     // Add a category and its subcategory
-    ::mock_category(&mut req, "cat1::bar", "cat1::bar");
-    Category::update_crate_old(
-        req.tx().unwrap(),
-        &krate,
-        &["cat1".to_string(), "cat1::bar".to_string()],
-    ).unwrap();
+    {
+        let conn = t!(app.diesel_database.get());
+        t!(::new_category("cat1::bar", "cat1::bar").create_or_update(&conn));
+        Category::update_crate(
+            &conn,
+            &krate,
+            &["cat1", "cat1::bar"],
+        ).unwrap();
+    }
     assert_eq!(cnt(&mut req, "cat1"), 1);
     assert_eq!(cnt(&mut req, "cat1::bar"), 1);
     assert_eq!(cnt(&mut req, "category-2"), 0);

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -189,10 +189,10 @@ fn index_queries() {
     {
         let conn = app.diesel_database.get().unwrap();
         ::new_category("Category 1", "cat1")
-            .find_or_create(&conn)
+            .create_or_update(&conn)
             .unwrap();
         ::new_category("Category 1::Ba'r", "cat1::bar")
-            .find_or_create(&conn)
+            .create_or_update(&conn)
             .unwrap();
         Category::update_crate(&conn, &krate, &["cat1"]).unwrap();
         Category::update_crate(&conn, &krate2, &["cat1::bar"]).unwrap();
@@ -1510,7 +1510,7 @@ fn good_categories() {
     {
         let conn = app.diesel_database.get().unwrap();
         ::new_category("Category 1", "cat1")
-            .find_or_create(&conn)
+            .create_or_update(&conn)
             .unwrap();
     }
     let mut response = ok_resp!(middle.call(&mut req));


### PR DESCRIPTION
All tests are green on stable and beta, however I think I'm hitting a bug in nightly as I get a segfault on the test krate::index_queries with nightly `rustc 1.20.0-nightly (445077963 2017-06-20)`.
```
$ RUST_TEST_THREADS=1 RUST_BACKTRACE=1 rustup run beta cargo test krate::index_queries --verbose
[...]
running 1 test
test krate::index_queries ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 98 filtered out

$ RUST_TEST_THREADS=1 RUST_BACKTRACE=1 rustup run nightly cargo test krate::index_queries --verbose
[...]
running 1 test
test krate::index_queries ... error: process didn't exit successfully: `/home/jtgeibel/repos/github.com/rust-lang/crates.io/target/debug/deps/all-12d198baf6ed1586 krate::index_queries` (signal: 4, SIGILL: illegal instruction)
```