### PR TITLE
Travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ addons:
       - libdw-dev
 
 matrix:
+  fast_finish: true
+  allow_failures:
+    - rust: nightly
   include:
   - rust: stable
     env: RUSTFMT=YESPLEASE
@@ -50,6 +53,14 @@ matrix:
     env: CLIPPY=YESPLEASE
     script:
     - cargo rustc --lib --features "lint" -- -Zno-trans
+  - rust: beta
+    script:
+    - cargo build
+    - cargo test
+  - rust: nightly
+    script:
+    - cargo build
+    - cargo test
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ addons:
 matrix:
   include:
   - rust: stable
+    env: RUSTFMT=YESPLEASE
     script:
     - cargo fmt -- --write-mode=diff
   - rust: stable


### PR DESCRIPTION
Tests are failing on nightly. Even though we're not a lib and we always deploy on stable, I want to start testing beta and nightly to help QA Rust :) Nightly is allowed to fail.

Also have a tweak to add an env var mentioning rustfmt so it's easier to see which job does what on the results page.