### PR TITLE
overflow evaluating requirement error on inner_join

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -19,6 +19,7 @@ use rustc_serialize::json;
 use semver;
 use time::Timespec;
 use url::Url;
+use chrono::NaiveDate;
 
 use app::{App, RequestApp};
 use badge::EncodableBadge;
@@ -38,7 +39,19 @@ use util::{RequestUtils, CargoResult, internal, ChainError, human};
 use version::{EncodableVersion, NewVersion};
 use {Model, User, Keyword, Version, Category, Badge, Replica};
 
-#[derive(Debug, Clone, Queryable, Identifiable, AsChangeset)]
+#[derive(Clone, Queryable, Identifiable, Associations, AsChangeset)]
+#[belongs_to(Crate)]
+#[primary_key(crate_id, date)]
+#[table_name="crate_downloads"]
+pub struct CrateDownload {
+    pub crate_id: i32,
+    pub downloads: i32,
+    pub date: NaiveDate,
+}
+
+#[derive(Debug, Clone, Queryable, Identifiable, AsChangeset, Associations)]
+#[has_many(crate_downloads)]
+#[table_name="crates"]
 pub struct Crate {
     pub id: i32,
     pub name: String,
@@ -779,7 +792,7 @@ impl Model for Crate {
 /// Handles the `GET /crates` route.
 #[allow(trivial_casts)]
 pub fn index(req: &mut Request) -> CargoResult<Response> {
-    use diesel::expression::dsl::sql;
+    use diesel::expression::dsl::*;
     use diesel::types::{BigInt, Bool};
 
     let conn = req.db_conn()?;
@@ -799,6 +812,26 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
 
     if sort == "downloads" {
         query = query.order(crates::downloads.desc())
+    } else if sort == "recent-downloads" {
+        // join crates to crate_download
+        // filter by crate_dls.date less than? 90 days ago
+        // select group by crate_dls.crate_id
+        // select sum crate_dls.downloads
+        // orderby column desc
+
+        // works
+        /*let new_query = crates::table.inner_join(crate_downloads::table)
+            .select((ALL_COLUMNS));*/
+
+
+        // overflow error
+        query = query.inner_join(crate_downloads::table)
+            /*.filter(crate_downloads::date.gt(date(now - 90.days())))
+            .select((
+                    crate_downloads::table.group_by(crate_downloads::crate_id),
+                    sql::<BigInt>("SUM(crate_downloads.downloads)")
+                    ))
+            .order(crate_downloads::downloads.desc())*/
     } else {
         query = query.order(crates::name.asc())
     }
@@ -819,6 +852,8 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
         let perfect_match = crates::name.eq(q_string).desc();
         if sort == "downloads" {
             query = query.order((perfect_match, crates::downloads.desc()));
+        } else if sort == "recent-downloads" {
+            // do same thing as above
         } else {
             let rank = ts_rank_cd(crates::textsearchable_index_col, q);
             query = query.order((perfect_match, rank.desc()))


### PR DESCRIPTION
I'm currently working on issue #702, sorting crates by downloads in the past 90 days. I can't seem to get past the following error when doing an inner_join between crates::table and crate_downloads::table:

```
error[E0275]: overflow evaluating the requirement 
`<diesel::query_builder::BoxedSelectStatement<'_, ((diesel::types::Integer, diesel::types::Text, 
diesel::types::Timestamp, diesel::types::Timestamp, diesel::types::Integer, 
diesel::types::Nullable<diesel::types::Text>, diesel::types::Nullable<diesel::types::Text>, 
diesel::types::Nullable<diesel::types::Text>, diesel::types::Nullable<diesel::types::Text>, 
diesel::types::Nullable<diesel::types::Text>, diesel::types::Nullable<diesel::types::Text>, 
diesel::types::Nullable<diesel::types::Integer>), diesel::types::BigInt, diesel::types::Bool), 
schema::crates::table, _> as diesel::InternalJoinDsl<_, diesel::query_source::joins::Inner, _>>::Output`
      --> src/krate.rs:828:23
       |
   828 |         query = query.inner_join(crate_downloads::table)                                                             
       |                       ^^^^^^^^^^                                                                                    
       |
```

I am at a loss to understand what this error message actually means or what is provoking it. I thought that there might be something going wrong with the imports and the way crates is associated with crate_downloads, however after comparing to and replicating other places in which inner_join is called successfully I can't figure out what is being done differently in this case. 

I read the [Associations documentation](https://nemo157.com/rustdoc-features-example/diesel-impl2/diesel/associations/index.html) as well as the [BoxedDsl documentation](https://nemo157.com/rustdoc-features-example/diesel-impl2/diesel/prelude/trait.BoxedDsl.html#method.into_boxed) and haven't found anything obviously awry.

I also went through the getting started tutorial listed on the diesel website in hopes of finding something fundamental that I'm missing, but most everything done there seems to be done in this case as well. 

The inner_join seems to not error on a single isolated query: 

`let new_query = crates::table.inner_join(crate_downloads::table).select((ALL_COLUMNS));`

This is still commented out in the code with a label of 'works'. Since this standalone query works (compiles), I didn't think that the problem could be due to the crates and crate_downloads tables being set up correctly to do the join. I thought that the problem might instead be coming from the `into_boxed()` function called when initializing `query`, as the error message mentions `BoxedSelectStatement`, however I cannot find any information that supports this.

I have some code for the rest of the query below the inner_join line, however the problem persists with or without the addition of this code. For simplicity I currently have it commented out.

Any help would be very much appreciated! @sgrif @carols10cents 