### PR TITLE
controllers/application: Remove obsolete scrollTo(0, 0) call

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,7 +1,5 @@
 import Ember from 'ember';
 
-const { observer } = Ember;
-
 export default Ember.Controller.extend({
     searchController: Ember.inject.controller('search'),
 
@@ -60,15 +58,6 @@ export default Ember.Controller.extend({
         this.set('flashError', this.get('nextFlashError'));
         this.set('nextFlashError', null);
     },
-
-    _scrollToTop() {
-        window.scrollTo(0, 0);
-    },
-
-    // TODO: remove observer & DOM mutation in controller..
-    currentPathChanged: observer('currentPath', function() {
-        Ember.run.scheduleOnce('afterRender', this, this._scrollToTop);
-    }),
 
     actions: {
         search() {


### PR DESCRIPTION
This is handled by [ember-router-scroll](https://github.com/dollarshaveclub/ember-router-scroll) already

Closes https://github.com/rust-lang/crates.io/pull/824