### PR TITLE
Use queryRecord() instead of find()

### DIFF
--- a/app/adapters/team.js
+++ b/app/adapters/team.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+    queryRecord(store, type, query) {
+        let url = this.urlForFindRecord(query.team_id, 'team');
+        return this.ajax(url, 'GET');
+    },
+});

--- a/app/adapters/user.js
+++ b/app/adapters/user.js
@@ -1,0 +1,8 @@
+import ApplicationAdapter from './application';
+
+export default ApplicationAdapter.extend({
+    queryRecord(store, type, query) {
+        let url = this.urlForFindRecord(query.user_id, 'user');
+        return this.ajax(url, 'GET');
+    },
+});

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -19,7 +19,7 @@ export default Ember.Route.extend({
     model(params) {
         const { team_id } = params;
 
-        return this.store.find('team', team_id).then(
+        return this.store.queryRecord('team', { team_id }).then(
             (team) => {
                 params.team_id = team.get('id');
                 return Ember.RSVP.hash({

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -12,7 +12,7 @@ export default Ember.Route.extend({
 
     model(params) {
         const { user_id } = params;
-        return this.store.find('user', user_id).then(
+        return this.store.queryRecord('user', { user_id }).then(
             (user) => {
                 params.user_id = user.get('id');
                 return Ember.RSVP.hash({


### PR DESCRIPTION
`find()` expects to get a record with the same ID that was passed in, but in this case we're passing in a string (login) and receiving a numeric ID causing warnings like:

> WARNING: You requested a record of type 'user' with id 'blabaere' but the adapter returned a payload with primary data having an id of '1'. Use 'store.findRecord()' when the requested id is the same as the one returned by the adapter. In other cases use 'store.queryRecord()' instead

/cc @sivakumar-kailasam 