### PR TITLE
Remove ic-ajax in favor of ember-ajax

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,10 +1,12 @@
 import Ember from 'ember';
-import ajax from 'ic-ajax';
 
 const TO_SHOW = 5;
-const { computed } = Ember;
+const { computed, inject: { service } } = Ember;
 
 export default Ember.Controller.extend({
+
+    ajax: service(),
+
     init() {
         this._super(...arguments);
 
@@ -37,7 +39,7 @@ export default Ember.Controller.extend({
             this.set('loadingMore', true);
             let page = (this.get('myFeed').length / 10) + 1;
 
-            ajax(`/me/updates?page=${page}`).then((data) => {
+            this.get('ajax').request(`/me/updates?page=${page}`).then((data) => {
                 let versions = data.versions.map(version =>
                     this.store.push(this.store.normalize('version', version)));
 

--- a/app/controllers/me/index.js
+++ b/app/controllers/me/index.js
@@ -1,8 +1,12 @@
 import Ember from 'ember';
-import ajax from 'ic-ajax';
+
+const { inject: { service } } = Ember;
 
 export default Ember.Controller.extend({
-    flashMessages: Ember.inject.service(),
+
+    ajax: service(),
+
+    flashMessages: service(),
 
     isResetting: false,
 
@@ -10,11 +14,7 @@ export default Ember.Controller.extend({
         resetToken() {
             this.set('isResetting', true);
 
-            ajax({
-                dataType: 'json',
-                url: '/me/reset_token',
-                method: 'put',
-            }).then((d) => {
+            this.get('ajax').put('/me/reset_token').then((d) => {
                 this.get('model').set('api_token', d.api_token);
             }).catch((reason) => {
                 let msg;
@@ -25,7 +25,7 @@ export default Ember.Controller.extend({
                 }
                 this.get('flashMessages').queue(msg);
                 // TODO: this should be an action, the route state machine
-                // should recieve signals not external transitions
+                // should receive signals not external transitions
                 this.transitionToRoute('index');
             }).finally(() => {
                 this.set('isResetting', false);

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,13 +1,17 @@
 import Ember from 'ember';
-import ajax from 'ic-ajax';
+
+const { inject: { service } } = Ember;
 
 export default Ember.Route.extend({
-    flashMessages: Ember.inject.service(),
+
+    ajax: service(),
+
+    flashMessages: service(),
 
     beforeModel() {
         if (this.session.get('isLoggedIn') &&
             this.session.get('currentUser') === null) {
-            ajax('/me').then((response) => {
+            this.get('ajax').request('/me').then((response) => {
                 let user = this.store.push(this.store.normalize('user', response.user));
                 user.set('api_token', response.api_token);
                 this.session.set('currentUser', user);

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -1,8 +1,12 @@
 import Ember from 'ember';
-import ajax from 'ic-ajax';
+
+const { inject: { service } } = Ember;
 
 export default Ember.Route.extend({
-    flashMessages: Ember.inject.service(),
+
+    ajax: service(),
+
+    flashMessages: service(),
 
     refreshAfterLogin: Ember.observer('session.isLoggedIn', function() {
         this.refresh();
@@ -41,7 +45,7 @@ export default Ember.Route.extend({
                 crate.get('documentation').substr(0, 16) === 'https://docs.rs/') {
                 let crateName = crate.get('name');
                 let crateVersion = params.version_num;
-                ajax(`https://docs.rs/crate/${crateName}/${crateVersion}/builds.json`)
+                this.get('ajax').request(`https://docs.rs/crate/${crateName}/${crateVersion}/builds.json`)
                     .then((r) => {
                         if (r.length > 0 && r[0].build_status === true) {
                             crate.set('documentation', `https://docs.rs/${crateName}/${crateVersion}/`);
@@ -81,7 +85,7 @@ export default Ember.Route.extend({
         controller.set('fetchingFollowing', true);
 
         if (this.session.get('currentUser')) {
-            ajax(`/api/v1/crates/${crate.get('name')}/following`)
+            this.get('ajax').request(`/api/v1/crates/${crate.get('name')}/following`)
                 .then((d) => controller.set('following', d.following))
                 .finally(() => controller.set('fetchingFollowing', false));
         }

--- a/app/routes/github-authorize.js
+++ b/app/routes/github-authorize.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-import ajax from 'ic-ajax';
+
+const { inject: { service } } = Ember;
 
 /**
  * This route will be called from the GitHub OAuth flow once the user has
@@ -15,8 +16,11 @@ import ajax from 'ic-ajax';
  * @see `/login` route
  */
 export default Ember.Route.extend({
+
+    ajax: service(),
+
     beforeModel(transition) {
-        return ajax('/authorize', { data: transition.queryParams }).then((d) => {
+        return this.get('ajax').request(`/authorize`, { data: transition.queryParams }).then((d) => {
             let item = JSON.stringify({ ok: true, data: d });
             if (window.opener) {
                 window.opener.github_response = item;

--- a/app/routes/github-login.js
+++ b/app/routes/github-login.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
-import ajax from 'ic-ajax';
+
+const { inject: { service } } = Ember;
 
 /**
  * Calling this route will query the `/authorize_url` API endpoint
@@ -15,8 +16,11 @@ import ajax from 'ic-ajax';
  * @see `/github_authorize` route
  */
 export default Ember.Route.extend({
+
+    ajax: service(),
+
     beforeModel() {
-        return ajax('/authorize_url').then((url) => {
+        return this.get('ajax').request(`/authorize_url`).then((url) => {
             window.location = url.url;
         });
     },

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,7 +1,11 @@
 import Ember from 'ember';
-import ajax from 'ic-ajax';
+
+const { inject: { service } } = Ember;
 
 export default Ember.Route.extend({
+
+    ajax: service(),
+
     headTags: [{
         type: 'meta',
         attrs: {
@@ -17,7 +21,7 @@ export default Ember.Route.extend({
             }
         }
 
-        return ajax('/summary').then((data) => {
+        return this.get('ajax').request('/summary').then((data) => {
             addCrates(this.store, data.new_crates);
             addCrates(this.store, data.most_downloaded);
             addCrates(this.store, data.just_updated);

--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -3,10 +3,10 @@ import Ember from 'ember';
 export default Ember.Route.extend({
     flashMessages: Ember.inject.service(),
 
-    model(params) {
-        return this.store.find('keyword', params.keyword_id).catch(e => {
+    model({ keyword_id }) {
+        return this.store.find('keyword', keyword_id).catch(e => {
             if (e.errors.any(e => e.detail === 'Not Found')) {
-                this.get('flashMessages').show(`Keyword '${params.keyword_id}' does not exist`);
+                this.get('flashMessages').show(`Keyword '${keyword_id}' does not exist`);
             }
         });
     }

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -1,8 +1,13 @@
 import Ember from 'ember';
 
+const { inject: { service } } = Ember;
+
 export default Ember.Route.extend({
+
+    ajax: service(),
+
     activate() {
-        Ember.$.getJSON('/logout', () => {
+        this.get('ajax').request(`/logout`).then(() => {
             Ember.run(() => {
                 this.session.logoutUser();
                 this.transitionTo('index');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "ember-cli-eslint": "^4.0.0",
     "ember-cli-htmlbars": "^2.0.2",
     "ember-cli-htmlbars-inline-precompile": "^0.4.3",
-    "ember-cli-ic-ajax": "1.0.0",
     "ember-cli-inject-live-reload": "1.6.1",
     "ember-cli-meta-tags": "^4.0.0",
     "ember-cli-mirage": "^0.3.3",


### PR DESCRIPTION
This prepares the codebase to move to FastBoot. I've tested this with local, staging & live proxy to avoid any issues.

@Turbo87 I'll raise a separate PR when we're ready to get rid of all the destructured imports in favor of modules 😄 