### PR TITLE
Update publisher token file name.

### DIFF
--- a/app/templates/me/index.hbs
+++ b/app/templates/me/index.hbs
@@ -32,7 +32,7 @@
 
     <p>
         If you want to use package commands from the command line, you'll need a
-        <code>~/.cargo/config</code>, the first step to creating this
+        <code>~/.cargo/credentials</code>, the first step to creating this
         is to generate a new token using the button above.
     </p>
 


### PR DESCRIPTION
Based on the instructions on the [crates.io publishing page](http://doc.crates.io/crates-io.html), these instructions should now refer to the `~/.cargo/credentials` file.