### PR TITLE
Start using ember-cli-mirage factories

### DIFF
--- a/mirage/factories/category.js
+++ b/mirage/factories/category.js
@@ -1,0 +1,20 @@
+import { Factory, faker } from 'ember-cli-mirage';
+import Ember from 'ember';
+
+export default Factory.extend({
+    category(i) {
+        return `Category ${i}`;
+    },
+
+    id() {
+        return Ember.String.dasherize(this.category);
+    },
+
+    slug() {
+        return Ember.String.dasherize(this.category);
+    },
+
+    description: () => faker.lorem.sentence(),
+    created_at: () => faker.date.past(),
+    crates_cnt: () => faker.random.number({ max: 5000 }),
+});

--- a/mirage/factories/crate.js
+++ b/mirage/factories/crate.js
@@ -1,0 +1,48 @@
+import { Factory, trait, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+    id(i) {
+        return `crate-${i}`;
+    },
+
+    name() {
+        return this.id;
+    },
+
+    description: () => faker.lorem.sentence(),
+    downloads: () => faker.random.number({ max: 10000 }),
+    documentation: () => faker.internet.url(),
+    homepage: () => faker.internet.url(),
+    repository: () => faker.internet.url(),
+    license: () => faker.hacker.abbreviation(),
+    max_version: () => faker.system.semver(),
+
+    created_at: () => faker.date.past(),
+    updated_at() {
+        return faker.date.between(this.created_at, new Date());
+    },
+
+    badges: () => [],
+    categories: () => [],
+    keywords: () => [],
+    versions: () => [],
+    _extra_downloads: () => [],
+    _owner_teams: () => [],
+    _owner_users: () => [],
+
+    links() {
+        return {
+            'owner_user': `/api/v1/crates/${this.id}/owner_user`,
+            'owner_team': `/api/v1/crates/${this.id}/owner_team`,
+            'reverse_dependencies': `/api/v1/crates/${this.id}/reverse_dependencies`,
+            'version_downloads': `/api/v1/crates/${this.id}/downloads`,
+            'versions': `/api/v1/crates/${this.id}/versions`,
+        };
+    },
+
+    withVersion: trait({
+        afterCreate(crate, server) {
+            server.create('version', { crate: crate.id });
+        }
+    }),
+});

--- a/mirage/factories/version.js
+++ b/mirage/factories/version.js
@@ -1,0 +1,37 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+    id: i => i,
+
+    // crate: '...',
+
+    num: () => faker.system.semver(),
+
+    created_at: () => faker.date.past(),
+    updated_at() {
+        return faker.date.between(this.created_at, new Date());
+    },
+
+    yanked: false,
+
+    dl_path() {
+        return `/api/v1/crates/${this.crate}/${this.num}/download`;
+    },
+
+    downloads: () => faker.random.number({ max: 10000 }),
+    features: () => {},
+    _authors: () => [],
+
+    links() {
+        return {
+            'authors': `/api/v1/crates/${this.crate}/${this.num}/authors`,
+            'dependencies': `/api/v1/crates/${this.crate}/${this.num}/dependencies`,
+            'version_downloads': `/api/v1/crates/${this.crate}/${this.num}/downloads`,
+        };
+    },
+
+    afterCreate(version, server) {
+        let crate = server.schema.crates.find(version.crate);
+        crate.update({ versions: crate.versions.concat(parseInt(version.id, 10)) });
+    }
+});

--- a/tests/acceptance/categories-test.js
+++ b/tests/acceptance/categories-test.js
@@ -5,7 +5,9 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | categories');
 
 test('listing categories', async function(assert) {
-    server.loadFixtures();
+    server.create('category', { category: 'API bindings', crates_cnt: 0 });
+    server.create('category', { category: 'Algorithms', crates_cnt: 1 });
+    server.create('category', { category: 'Asynchronous', crates_cnt: 3910 });
 
     await visit('/categories');
 

--- a/tests/acceptance/categories-test.js
+++ b/tests/acceptance/categories-test.js
@@ -5,6 +5,8 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | categories');
 
 test('listing categories', async function(assert) {
+    server.loadFixtures();
+
     await visit('/categories');
 
     hasText(assert, '.row:eq(0) .desc .info span', '0 crates');

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -6,7 +6,7 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | crate page');
 
 test('visiting a crate page from the front page', async function(assert) {
-    server.loadFixtures();
+    server.create('crate', 'withVersion', { id: 'nanomsg' });
 
     await visit('/');
     await click('#just-updated ul > li:first a');
@@ -16,7 +16,9 @@ test('visiting a crate page from the front page', async function(assert) {
 });
 
 test('visiting /crates/nanomsg', async function(assert) {
-    server.loadFixtures();
+    server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    server.create('version', { crate: 'nanomsg', num: '0.6.0' });
+    server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
     await visit('/crates/nanomsg');
 
@@ -29,7 +31,9 @@ test('visiting /crates/nanomsg', async function(assert) {
 });
 
 test('visiting /crates/nanomsg/', async function(assert) {
-    server.loadFixtures();
+    server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    server.create('version', { crate: 'nanomsg', num: '0.6.0' });
+    server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
     await visit('/crates/nanomsg/');
 
@@ -42,7 +46,9 @@ test('visiting /crates/nanomsg/', async function(assert) {
 });
 
 test('visiting /crates/nanomsg/0.6.0', async function(assert) {
-    server.loadFixtures();
+    server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    server.create('version', { crate: 'nanomsg', num: '0.6.0' });
+    server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
     await visit('/crates/nanomsg/0.6.0');
 

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -6,6 +6,8 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | crate page');
 
 test('visiting a crate page from the front page', async function(assert) {
+    server.loadFixtures();
+
     await visit('/');
     await click('#just-updated ul > li:first a');
 
@@ -14,6 +16,8 @@ test('visiting a crate page from the front page', async function(assert) {
 });
 
 test('visiting /crates/nanomsg', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg');
 
     assert.equal(currentURL(), '/crates/nanomsg');
@@ -25,6 +29,8 @@ test('visiting /crates/nanomsg', async function(assert) {
 });
 
 test('visiting /crates/nanomsg/', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg/');
 
     assert.equal(currentURL(), '/crates/nanomsg/');
@@ -36,6 +42,8 @@ test('visiting /crates/nanomsg/', async function(assert) {
 });
 
 test('visiting /crates/nanomsg/0.6.0', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg/0.6.0');
 
     assert.equal(currentURL(), '/crates/nanomsg/0.6.0');
@@ -47,6 +55,8 @@ test('visiting /crates/nanomsg/0.6.0', async function(assert) {
 });
 
 test('navigating to the all versions page', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg');
     await click('#crate-versions span.small a');
 
@@ -54,6 +64,8 @@ test('navigating to the all versions page', async function(assert) {
 });
 
 test('navigating to the reverse dependencies page', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg');
     await click('a:contains("Dependent crates")');
 
@@ -65,6 +77,8 @@ test('navigating to the reverse dependencies page', async function(assert) {
 });
 
 test('navigating to a user page', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg');
     await click('.owners li:last a');
 
@@ -73,6 +87,8 @@ test('navigating to a user page', async function(assert) {
 });
 
 test('navigating to a team page', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg');
     await click('.owners li:first a ');
 
@@ -81,6 +97,8 @@ test('navigating to a team page', async function(assert) {
 });
 
 test('crates having user-owners', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg');
 
     findWithAssert('ul.owners li:first a[href="/teams/github:org:thehydroimpulse"] img[src="https://avatars.githubusercontent.com/u/565790?v=3&s=64"]');
@@ -88,6 +106,8 @@ test('crates having user-owners', async function(assert) {
 });
 
 test('crates having team-owners', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates/nanomsg');
 
     findWithAssert('ul.owners li:first a[href="/teams/github:org:thehydroimpulse"]');

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -5,6 +5,8 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | crates page');
 
 test('visiting the crates page from the front page', async function(assert) {
+    server.loadFixtures();
+
     await visit('/');
     await click('a[href="/crates"]');
 
@@ -13,6 +15,8 @@ test('visiting the crates page from the front page', async function(assert) {
 });
 
 test('visiting the crates page directly', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates');
     await click('a[href="/crates"]');
 
@@ -21,6 +25,8 @@ test('visiting the crates page directly', async function(assert) {
 });
 
 test('listing crates', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates');
 
     hasText(assert, '.amt.small .cur', '1-10');
@@ -28,6 +34,8 @@ test('listing crates', async function(assert) {
 });
 
 test('navigating to next page of crates', async function(assert) {
+    server.loadFixtures();
+
     await visit('/crates');
     await click('.pagination .next');
 

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -5,6 +5,8 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | front page');
 
 test('visiting /', async function(assert) {
+    server.loadFixtures();
+
     await visit('/');
 
     assert.equal(currentURL(), '/');

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -5,6 +5,8 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | search');
 
 test('searching for "rust"', async function(assert) {
+    server.loadFixtures();
+
     await visit('/');
     await fillIn('input.search', 'rust');
 
@@ -26,6 +28,8 @@ test('searching for "rust"', async function(assert) {
 });
 
 test('pressing S key to focus the search bar', async function(assert) {
+    server.loadFixtures();
+
     const KEYCODE_S = 83;
     const KEYCODE_A = 65;
 

--- a/tests/acceptance/team-page-test.js
+++ b/tests/acceptance/team-page-test.js
@@ -5,6 +5,8 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | team page');
 
 test('has team organization display', async function(assert) {
+    server.loadFixtures();
+
     await visit('/teams/github:org:thehydroimpulse');
 
     hasText(assert, '.team-info h1', 'org');
@@ -12,6 +14,8 @@ test('has team organization display', async function(assert) {
 });
 
 test('has link to github in team header', async function(assert) {
+    server.loadFixtures();
+
     await visit('/teams/github:org:thehydroimpulse');
 
     const $githubLink = findWithAssert('.info a');
@@ -19,6 +23,8 @@ test('has link to github in team header', async function(assert) {
 });
 
 test('github link has image in team header', async function(assert) {
+    server.loadFixtures();
+
     await visit('/teams/github:org:thehydroimpulse');
 
     const $githubImg = findWithAssert('.info a img');
@@ -26,6 +32,8 @@ test('github link has image in team header', async function(assert) {
 });
 
 test('team organization details has github profile icon', async function(assert) {
+    server.loadFixtures();
+
     await visit('/teams/github:org:thehydroimpulse');
 
     const $githubProfileImg = findWithAssert('.info img');

--- a/tests/acceptance/user-page-test.js
+++ b/tests/acceptance/user-page-test.js
@@ -5,12 +5,16 @@ import hasText from 'cargo/tests/helpers/has-text';
 moduleForAcceptance('Acceptance | user page');
 
 test('has user display', async function(assert) {
+    server.loadFixtures();
+
     await visit('/users/thehydroimpulse');
 
     hasText(assert, '#crates-heading h1', 'thehydroimpulse');
 });
 
 test('has link to github in user header', async function(assert) {
+    server.loadFixtures();
+
     await visit('/users/thehydroimpulse');
 
     const $githubLink = findWithAssert('#crates-heading a');
@@ -18,6 +22,8 @@ test('has link to github in user header', async function(assert) {
 });
 
 test('github link has image in user header', async function(assert) {
+    server.loadFixtures();
+
     await visit('/users/thehydroimpulse');
 
     const $githubImg = findWithAssert('#crates-heading a img');
@@ -25,6 +31,8 @@ test('github link has image in user header', async function(assert) {
 });
 
 test('user details has github profile icon', async function(assert) {
+    server.loadFixtures();
+
     await visit('/users/thehydroimpulse');
 
     const $githubProfileImg = findWithAssert('#crates-heading img');


### PR DESCRIPTION
Instead of using fixtures it is recommended to use factories to setup acceptance tests. This PR introduces a first set of factories and uses them in a few of the existing tests to simplify them. This PR is not yet converting everything to factories, but can be merged at any point.

@samselikoff would be awesome if you could give this a quick review :)