### PR TITLE
Trim white spaces from search term

### DIFF
--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -8,6 +8,10 @@ export default Ember.Route.extend({
     },
 
     model(params) {
+        if (params.q !== null) {
+            params.q = params.q.trim();
+        }
+
         return this.store.query('crate', params);
     },
 });


### PR DESCRIPTION
It trims white spaces from search term to provide a more accurate results (Ember takes params as it is, including white spaces)

E.g. right now two similar queries would yield different results due to white space:
"conduit" - gives exact match
"conduit "- gives no exact match

It is a minor thing, but occasionally you can copy-pate name with white spaces and etc...
So might be a bit annoying that it changes your result.
I'm not sure that white space is a legal character for crate's name.