### PR TITLE
Port `bin/update-crates` over to Diesel

### DIFF
--- a/migrations/20170706165855_dont_touch_timestamps_unless_row_changed/down.sql
+++ b/migrations/20170706165855_dont_touch_timestamps_unless_row_changed/down.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION set_updated_at_ignore_downloads() RETURNS trigger AS $$
+BEGIN
+    IF (NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at AND
+        NEW.downloads = OLD.downloads) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+

--- a/migrations/20170706165855_dont_touch_timestamps_unless_row_changed/up.sql
+++ b/migrations/20170706165855_dont_touch_timestamps_unless_row_changed/up.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE FUNCTION set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at = CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION set_updated_at_ignore_downloads() RETURNS trigger AS $$
+DECLARE
+    new_downloads integer;
+BEGIN
+    new_downloads := NEW.downloads;
+    OLD.downloads := NEW.downloads;
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at = CURRENT_TIMESTAMP;
+    END IF;
+    NEW.downloads := new_downloads;
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -19,7 +19,7 @@ use cargo_registry::Crate;
 
 #[allow(dead_code)]
 fn main() {
-    let conn = cargo_registry::db::connect_now();
+    let conn = cargo_registry::db::connect_now_old();
     {
         let tx = conn.transaction().unwrap();
         delete(&tx);

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -20,7 +20,7 @@ use cargo_registry::{Crate, Version};
 
 #[allow(dead_code)]
 fn main() {
-    let conn = cargo_registry::db::connect_now();
+    let conn = cargo_registry::db::connect_now_old();
     {
         let tx = conn.transaction().unwrap();
         delete(&tx);

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -17,7 +17,7 @@ use rand::{StdRng, Rng};
 
 #[allow(dead_code)]
 fn main() {
-    let conn = cargo_registry::db::connect_now();
+    let conn = cargo_registry::db::connect_now_old();
     {
         let tx = conn.transaction().unwrap();
         update(&tx).unwrap();

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -20,7 +20,7 @@ use cargo_registry::Model;
 
 #[allow(dead_code)]
 fn main() {
-    let conn = cargo_registry::db::connect_now();
+    let conn = cargo_registry::db::connect_now_old();
     {
         let tx = conn.transaction().unwrap();
         transfer(&tx);

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -2,25 +2,40 @@
 
 extern crate cargo_registry;
 extern crate chrono;
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_codegen;
 extern crate openssl;
-extern crate postgres;
 extern crate semver;
 extern crate time;
 
-use std::collections::HashMap;
+use chrono::NaiveDate;
+use diesel::prelude::*;
+use diesel::pg::PgConnection;
+use diesel::pg::upsert::*;
 use std::env;
 use std::time::Duration;
 
-use cargo_registry::{VersionDownload, Version, Model};
+use cargo_registry::VersionDownload;
+use cargo_registry::schema::*;
 
 static LIMIT: i64 = 1000;
+
+#[derive(Insertable)]
+#[table_name = "crate_downloads"]
+struct CrateDownload {
+    crate_id: i32,
+    downloads: i32,
+    date: NaiveDate,
+}
 
 #[allow(dead_code)] // dead in tests
 fn main() {
     let daemon = env::args().nth(1).as_ref().map(|s| &s[..]) == Some("daemon");
     let sleep = env::args().nth(2).map(|s| s.parse().unwrap());
     loop {
-        let conn = cargo_registry::db::connect_now();
+        let conn = cargo_registry::db::connect_now().unwrap();
         update(&conn).unwrap();
         drop(conn);
         if daemon {
@@ -31,401 +46,335 @@ fn main() {
     }
 }
 
-fn update(conn: &postgres::GenericConnection) -> postgres::Result<()> {
-    let mut max = 0;
-    loop {
-        // FIXME(rust-lang/rust#27401): weird declaration to make sure this
-        // variable gets dropped.
-        let tx;
-        tx = conn.transaction()?;
-        {
-            let stmt = tx.prepare(
-                "SELECT * FROM version_downloads \
-                                        WHERE processed = FALSE AND id > $1
-                                        ORDER BY id ASC
-                                        LIMIT $2",
-            )?;
-            let mut rows = stmt.query(&[&max, &LIMIT])?;
-            match collect(&tx, &mut rows)? {
-                None => break,
-                Some(m) => max = m,
-            }
-        }
-        tx.set_commit();
-        tx.finish()?;
+fn update(conn: &PgConnection) -> QueryResult<()> {
+    use version_downloads::dsl::*;
+    let mut max = Some(0);
+    while let Some(m) = max {
+        conn.transaction::<_, diesel::result::Error, _>(|| {
+            let rows = version_downloads
+                .filter(processed.eq(false))
+                .filter(id.gt(m))
+                .order(id)
+                .limit(LIMIT)
+                .load(conn)?;
+            collect(conn, &rows)?;
+            max = rows.last().map(|d| d.id);
+            Ok(())
+        })?;
     }
     Ok(())
 }
 
-fn collect(
-    tx: &postgres::transaction::Transaction,
-    rows: &mut postgres::rows::Rows,
-) -> postgres::Result<Option<i32>> {
+fn collect(conn: &PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
+    use diesel::{insert, update};
+
     // Anything older than 24 hours ago will be frozen and will not be queried
     // against again.
     let now = chrono::UTC::now();
     let cutoff = now.naive_utc().date() - chrono::Duration::days(1);
 
-    let mut map = HashMap::new();
-    for row in rows.iter() {
-        let download: VersionDownload = Model::from_row(&row);
-        assert!(map.insert(download.id, download).is_none());
-    }
     println!(
         "updating {} versions (cutoff {})",
-        map.len(),
+        rows.len(),
         now.to_rfc2822()
     );
-    if map.len() == 0 {
-        return Ok(None);
-    }
 
-    let mut max = 0;
     let mut total = 0;
-    for (id, download) in map.iter() {
-        if *id > max {
-            max = *id;
-        }
-        if download.date > cutoff && download.counted == download.downloads {
-            continue;
-        }
+    for download in rows {
         let amt = download.downloads - download.counted;
+        total += amt as i64;
 
         // Flag this row as having been processed if we're passed the cutoff,
         // and unconditionally increment the number of counted downloads.
-        tx.execute(
-            "UPDATE version_downloads
-                         SET processed = $2, counted = counted + $3
-                         WHERE id = $1",
-            &[id, &(download.date < cutoff), &amt],
-        )?;
-        total += amt as i64;
-
-        if amt == 0 {
-            continue;
-        }
-
-        let crate_id = Version::find(tx, download.version_id).unwrap().crate_id;
+        update(version_downloads::table.find(download.id))
+            .set((
+                version_downloads::processed.eq(download.date < cutoff),
+                version_downloads::counted.eq(
+                    version_downloads::counted + amt,
+                ),
+            ))
+            .execute(conn)?;
 
         // Update the total number of version downloads
-        tx.execute(
-            "UPDATE versions
-                         SET downloads = downloads + $1
-                         WHERE id = $2",
-            &[&amt, &download.version_id],
-        )?;
+        let crate_id = update(versions::table.find(download.version_id))
+            .set(versions::downloads.eq(versions::downloads + amt))
+            .returning(versions::crate_id)
+            .get_result(conn)?;
+
         // Update the total number of crate downloads
-        tx.execute(
-            "UPDATE crates SET downloads = downloads + $1
-                         WHERE id = $2",
-            &[&amt, &crate_id],
-        )?;
+        update(crates::table.find(crate_id))
+            .set(crates::downloads.eq(crates::downloads + amt))
+            .execute(conn)?;
 
         // Update the total number of crate downloads for today
-        let cnt = tx.execute(
-            "UPDATE crate_downloads
-                                   SET downloads = downloads + $2
-                                   WHERE crate_id = $1 AND date = $3",
-            &[&crate_id, &amt, &download.date],
-        )?;
-        if cnt == 0 {
-            tx.execute(
-                "INSERT INTO crate_downloads
-                             (crate_id, downloads, date)
-                             VALUES ($1, $2, $3)",
-                &[&crate_id, &amt, &download.date],
-            )?;
-        }
+        let crate_download = CrateDownload {
+            crate_id: crate_id,
+            downloads: amt,
+            date: download.date,
+        };
+        insert(&crate_download.on_conflict(
+            (
+                crate_downloads::crate_id,
+                crate_downloads::date,
+            ),
+            do_update().set(
+                crate_downloads::downloads.eq(
+                    crate_downloads::downloads +
+                        amt,
+                ),
+            ),
+        )).into(crate_downloads::table)
+            .execute(conn)?;
     }
 
     // After everything else is done, update the global counter of total
     // downloads.
-    tx.execute(
-        "UPDATE metadata SET total_downloads = total_downloads + $1",
-        &[&total],
-    )?;
+    update(metadata::table)
+        .set(metadata::total_downloads.eq(
+            metadata::total_downloads + total,
+        ))
+        .execute(conn)?;
 
-    Ok(Some(max))
+    Ok(())
 }
 
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
 
-    use time;
-    use time::Duration;
-
-    use postgres;
     use semver;
 
-    use cargo_registry::{Version, Crate, User, Model, env};
+    use diesel::expression::dsl::sql;
+    use diesel::types::Integer;
+    use super::*;
+    use cargo_registry::env;
+    use cargo_registry::krate::{Crate, NewCrate};
+    use cargo_registry::user::{User, NewUser};
+    use cargo_registry::version::{Version, NewVersion};
 
-    fn conn() -> postgres::Connection {
-        postgres::Connection::connect(&env("TEST_DATABASE_URL")[..], postgres::TlsMode::None)
+    fn conn() -> PgConnection {
+        let conn = PgConnection::establish(&env("TEST_DATABASE_URL")).unwrap();
+        conn.begin_test_transaction().unwrap();
+        conn
+    }
+
+    fn user(conn: &PgConnection) -> User {
+        NewUser::new(2, "login", None, None, None, "access_token")
+            .create_or_update(conn)
             .unwrap()
     }
 
-    fn user(conn: &postgres::transaction::Transaction) -> User {
-        User::find_or_insert(conn, 2, "login", None, None, None, "access_token").unwrap()
+    fn crate_and_version(conn: &PgConnection, user_id: i32) -> (Crate, Version) {
+        let krate = NewCrate {
+            name: "foo",
+            ..Default::default()
+        }.create_or_update(&conn, None, user_id)
+            .unwrap();
+        let version = NewVersion::new(
+            krate.id,
+            &semver::Version::parse("1.0.0").unwrap(),
+            &HashMap::new(),
+            None,
+            None,
+        ).unwrap();
+        let version = version.save(&conn, &[]).unwrap();
+        (krate, version)
     }
 
-    fn crate_downloads(tx: &postgres::transaction::Transaction, id: i32, expected: usize) {
-        let stmt = tx.prepare(
-            "SELECT * FROM crate_downloads
-                               WHERE crate_id = $1",
-        ).unwrap();
-        let dl: i32 = stmt.query(&[&id]).unwrap().iter().next().unwrap().get(
-            "downloads",
-        );
-        assert_eq!(dl, expected as i32);
+    macro_rules! crate_downloads {
+        ($conn: expr, $id: expr, $expected: expr) => {
+            let dl = crate_downloads::table
+                .filter(crate_downloads::crate_id.eq($id))
+                .select(crate_downloads::downloads)
+                .first($conn);
+            assert_eq!(Ok($expected as i32), dl);
+        }
     }
 
     #[test]
     fn increment() {
         let conn = conn();
-        let tx = conn.transaction().unwrap();
-        let user = user(&tx);
-        let krate = Crate::find_or_insert(
-            &tx,
-            "foo",
-            user.id,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            None,
-        ).unwrap();
-        let version = Version::insert(
-            &tx,
-            krate.id,
-            &semver::Version::parse("1.0.0").unwrap(),
-            &HashMap::new(),
-            &[],
-        ).unwrap();
-        tx.execute(
+        let user = user(&conn);
+        let (krate, version) = crate_and_version(&conn, user.id);
+        // FIXME: Diesel 0.15 or 1.0 can do this:
+        // insert((version_id.eq(version.id),))
+        //     .into(version_downloads)
+        //     .execute(&conn)
+        //     .unwrap();
+        // insert((
+        //     version_id.eq(version.id),
+        //     date.eq(now - 1.day()),
+        //     processed.eq(true)
+        //  )).into(version_downloads)
+        //      .execute(&conn)
+        //      .unwrap();
+        sql::<Integer>(
             "INSERT INTO version_downloads \
                     (version_id)
                     VALUES ($1)",
-            &[&version.id],
-        ).unwrap();
-        tx.execute(
+        ).bind::<Integer, _>(version.id)
+            .execute(&conn)
+            .unwrap();
+        sql::<Integer>(
             "INSERT INTO version_downloads \
                     (version_id, date, processed)
                     VALUES ($1, current_date - interval '1 day', true)",
-            &[&version.id],
-        ).unwrap();
-        ::update(&tx).unwrap();
-        assert_eq!(Version::find(&tx, version.id).unwrap().downloads, 1);
-        assert_eq!(Crate::find(&tx, krate.id).unwrap().downloads, 1);
-        crate_downloads(&tx, krate.id, 1);
-        ::update(&tx).unwrap();
-        assert_eq!(Version::find(&tx, version.id).unwrap().downloads, 1);
+        ).bind::<Integer, _>(version.id)
+            .execute(&conn)
+            .unwrap();
+        ::update(&conn).unwrap();
+        let version_downloads = versions::table
+            .find(version.id)
+            .select(versions::downloads)
+            .first(&conn);
+        assert_eq!(Ok(1), version_downloads);
+        let crate_downloads = crates::table
+            .find(krate.id)
+            .select(crates::downloads)
+            .first(&conn);
+        assert_eq!(Ok(1), crate_downloads);
+        crate_downloads!(&conn, krate.id, 1);
+        ::update(&conn).unwrap();
+        let version_downloads = versions::table
+            .find(version.id)
+            .select(versions::downloads)
+            .first(&conn);
+        assert_eq!(Ok(1), version_downloads);
     }
 
     #[test]
     fn set_processed_true() {
         let conn = conn();
-        let tx = conn.transaction().unwrap();
-        let user = user(&tx);
-        let krate = Crate::find_or_insert(
-            &tx,
-            "foo",
-            user.id,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            None,
-        ).unwrap();
-        let version = Version::insert(
-            &tx,
-            krate.id,
-            &semver::Version::parse("1.0.0").unwrap(),
-            &HashMap::new(),
-            &[],
-        ).unwrap();
-        tx.execute(
+        let user = user(&conn);
+        let (_, version) = crate_and_version(&conn, user.id);
+        sql::<Integer>(
             "INSERT INTO version_downloads \
                     (version_id, downloads, counted, date, processed)
                     VALUES ($1, 2, 2, current_date - interval '2 days', false)",
-            &[&version.id],
-        ).unwrap();
-        ::update(&tx).unwrap();
-        let stmt = tx.prepare(
-            "SELECT processed FROM version_downloads
-                               WHERE version_id = $1",
-        ).unwrap();
-        let processed: bool = stmt.query(&[&version.id])
-            .unwrap()
-            .iter()
-            .next()
-            .unwrap()
-            .get("processed");
-        assert!(processed);
+        ).bind::<Integer, _>(version.id)
+            .execute(&conn)
+            .unwrap();
+        ::update(&conn).unwrap();
+        let processed = version_downloads::table
+            .filter(version_downloads::version_id.eq(version.id))
+            .select(version_downloads::processed)
+            .first(&conn);
+        assert_eq!(Ok(true), processed);
     }
 
     #[test]
     fn dont_process_recent_row() {
         let conn = conn();
-        let tx = conn.transaction().unwrap();
-        let user = user(&tx);
-        let krate = Crate::find_or_insert(
-            &tx,
-            "foo",
-            user.id,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            None,
-        ).unwrap();
-        let version = Version::insert(
-            &tx,
-            krate.id,
-            &semver::Version::parse("1.0.0").unwrap(),
-            &HashMap::new(),
-            &[],
-        ).unwrap();
-        let time = time::now_utc().to_timespec() - Duration::hours(2);
-        tx.execute(
+        let user = user(&conn);
+        let (_, version) = crate_and_version(&conn, user.id);
+        sql::<Integer>(
             "INSERT INTO version_downloads \
                     (version_id, downloads, counted, date, processed)
-                    VALUES ($1, 2, 2, date($2), false)",
-            &[&version.id, &time],
-        ).unwrap();
-        ::update(&tx).unwrap();
-        let stmt = tx.prepare(
-            "SELECT processed FROM version_downloads
-                               WHERE version_id = $1",
-        ).unwrap();
-        let processed: bool = stmt.query(&[&version.id])
-            .unwrap()
-            .iter()
-            .next()
-            .unwrap()
-            .get("processed");
-        assert!(!processed);
+                    VALUES ($1, 2, 2, DATE(NOW() - INTERVAL '2 hours'), false)",
+        ).bind::<Integer, _>(version.id)
+            .execute(&conn)
+            .unwrap();
+        ::update(&conn).unwrap();
+        let processed = version_downloads::table
+            .filter(version_downloads::version_id.eq(version.id))
+            .select(version_downloads::processed)
+            .first(&conn);
+        assert_eq!(Ok(false), processed);
     }
 
     #[test]
     fn increment_a_little() {
+        use diesel::expression::dsl::*;
+        use diesel::update;
+
         let conn = conn();
-        let tx = conn.transaction().unwrap();
-        let user = user(&tx);
-        let krate = Crate::find_or_insert(
-            &tx,
-            "foo",
-            user.id,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            None,
-        ).unwrap();
-        let version = Version::insert(
-            &tx,
-            krate.id,
-            &semver::Version::parse("1.0.0").unwrap(),
-            &HashMap::new(),
-            &[],
-        ).unwrap();
-        tx.execute(
-            "UPDATE versions
-                       SET updated_at = current_date - interval '2 hours'",
-            &[],
-        ).unwrap();
-        tx.execute(
-            "UPDATE crates
-                       SET updated_at = current_date - interval '2 hours'",
-            &[],
-        ).unwrap();
-        tx.execute(
+        let user = user(&conn);
+        let (krate, version) = crate_and_version(&conn, user.id);
+        update(versions::table)
+            .set(versions::updated_at.eq(now - 2.hours()))
+            .execute(&conn)
+            .unwrap();
+        update(crates::table)
+            .set(crates::updated_at.eq(now - 2.hours()))
+            .execute(&conn)
+            .unwrap();
+        sql::<Integer>(
             "INSERT INTO version_downloads \
                     (version_id, downloads, counted, date, processed)
                     VALUES ($1, 2, 1, current_date, false)",
-            &[&version.id],
-        ).unwrap();
-        tx.execute(
+        ).bind::<Integer, _>(version.id)
+            .execute(&conn)
+            .unwrap();
+        sql::<Integer>(
             "INSERT INTO version_downloads \
                     (version_id, date)
                     VALUES ($1, current_date - interval '1 day')",
-            &[&version.id],
-        ).unwrap();
+        ).bind::<Integer, _>(version.id)
+            .execute(&conn)
+            .unwrap();
 
-        let version_before = Version::find(&tx, version.id).unwrap();
-        let krate_before = Crate::find(&tx, krate.id).unwrap();
-        ::update(&tx).unwrap();
-        let version2 = Version::find(&tx, version.id).unwrap();
+        let version_before = versions::table
+            .find(version.id)
+            .first::<Version>(&conn)
+            .unwrap();
+        let krate_before = Crate::all()
+            .filter(crates::id.eq(krate.id))
+            .first::<Crate>(&conn)
+            .unwrap();
+        ::update(&conn).unwrap();
+        let version2 = versions::table
+            .find(version.id)
+            .first::<Version>(&conn)
+            .unwrap();
         assert_eq!(version2.downloads, 2);
         assert_eq!(version2.updated_at, version_before.updated_at);
-        let krate2 = Crate::find(&tx, krate.id).unwrap();
+        let krate2 = Crate::all()
+            .filter(crates::id.eq(krate.id))
+            .first::<Crate>(&conn)
+            .unwrap();
         assert_eq!(krate2.downloads, 2);
         assert_eq!(krate2.updated_at, krate_before.updated_at);
-        crate_downloads(&tx, krate.id, 1);
-        ::update(&tx).unwrap();
-        assert_eq!(Version::find(&tx, version.id).unwrap().downloads, 2);
+        crate_downloads!(&conn, krate.id, 1);
+        ::update(&conn).unwrap();
+        let version3 = versions::table
+            .find(version.id)
+            .first::<Version>(&conn)
+            .unwrap();
+        assert_eq!(version3.downloads, 2);
     }
 
     #[test]
     fn set_processed_no_set_updated_at() {
+        use diesel::update;
+        use diesel::expression::dsl::*;
+
         let conn = conn();
-        let tx = conn.transaction().unwrap();
-        let user = user(&tx);
-        let krate = Crate::find_or_insert(
-            &tx,
-            "foo",
-            user.id,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            &None,
-            None,
-        ).unwrap();
-        let version = Version::insert(
-            &tx,
-            krate.id,
-            &semver::Version::parse("1.0.0").unwrap(),
-            &HashMap::new(),
-            &[],
-        ).unwrap();
-        tx.execute(
-            "UPDATE versions
-                       SET updated_at = current_date - interval '2 days'",
-            &[],
-        ).unwrap();
-        tx.execute(
-            "UPDATE crates
-                       SET updated_at = current_date - interval '2 days'",
-            &[],
-        ).unwrap();
-        tx.execute(
+        let user = user(&conn);
+        let (_, version) = crate_and_version(&conn, user.id);
+        update(versions::table)
+            .set(versions::updated_at.eq(now - 2.days()))
+            .execute(&conn)
+            .unwrap();
+        update(crates::table)
+            .set(crates::updated_at.eq(now - 2.days()))
+            .execute(&conn)
+            .unwrap();
+        sql::<Integer>(
             "INSERT INTO version_downloads \
                     (version_id, downloads, counted, date, processed)
                     VALUES ($1, 2, 2, current_date - interval '2 days', false)",
-            &[&version.id],
-        ).unwrap();
+        ).bind::<Integer, _>(version.id)
+            .execute(&conn)
+            .unwrap();
 
-        let version_before = Version::find(&tx, version.id).unwrap();
-        let krate_before = Crate::find(&tx, krate.id).unwrap();
-        ::update(&tx).unwrap();
-        let version2 = Version::find(&tx, version.id).unwrap();
-        assert_eq!(version2.updated_at, version_before.updated_at);
-        let krate2 = Crate::find(&tx, krate.id).unwrap();
-        assert_eq!(krate2.updated_at, krate_before.updated_at);
+        ::update(&conn).unwrap();
+        let versions_changed = versions::table
+            .select(versions::updated_at.ne(now - 2.days()))
+            .get_result(&conn);
+        let crates_changed = crates::table
+            .select(crates::updated_at.ne(now - 2.days()))
+            .get_result(&conn);
+        assert_eq!(Ok(false), versions_changed);
+        assert_eq!(Ok(false), crates_changed);
     }
 }

--- a/src/bin/update-licenses.rs
+++ b/src/bin/update-licenses.rs
@@ -11,7 +11,7 @@ extern crate postgres;
 use std::io::prelude::*;
 
 fn main() {
-    let conn = cargo_registry::db::connect_now();
+    let conn = cargo_registry::db::connect_now_old();
     {
         let tx = conn.transaction().unwrap();
         transfer(&tx);

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -88,7 +88,7 @@ fn categories_from_toml(
 }
 
 pub fn sync() -> CargoResult<()> {
-    let conn = db::connect_now();
+    let conn = db::connect_now_old();
     let tx = conn.transaction().unwrap();
 
     let categories = include_str!("./categories.toml");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -170,8 +170,6 @@ table! {
     }
 }
 
-numeric_expr!(version_downloads::downloads);
-
 table! {
     versions (id) {
         id -> Int4,
@@ -185,3 +183,10 @@ table! {
         license -> Nullable<Varchar>,
     }
 }
+
+numeric_expr!(crate_downloads::downloads);
+numeric_expr!(crates::downloads);
+numeric_expr!(metadata::total_downloads);
+numeric_expr!(version_downloads::counted);
+numeric_expr!(version_downloads::downloads);
+numeric_expr!(versions::downloads);


### PR DESCRIPTION
I thought we were done, but we're not... I forgot the binaries. Sorry.
:(

This one was pretty straightforward. There's a bit of refactoring in
here as well, and I moved some of the integrity checks that this code
was doing to the database. It's worth noting that the new body of
`set_updated_at` is identical to `diesel_set_updated_at`, but I can't
actually call that function from the other since it's `RETURNS trigger`.
Not sure if it's worth resolving, since the function is unlikely to
change.