### PR TITLE
Sorting crates by top recently downloaded

### DIFF
--- a/src/recent_downloads_query.sql
+++ b/src/recent_downloads_query.sql
@@ -1,4 +1,18 @@
-SELECT crates.name, sum_downloads 
+SELECT
+    id,
+    name,
+    updated_at,
+    created_at,
+    downloads,
+    description,
+    homepage,
+    documentation,
+    readme,
+    license,
+    repository,
+    max_upload_size,
+    sum_downloads,
+    FALSE
 FROM (
     SELECT crate_id, SUM(downloads) as sum_downloads 
     FROM crate_downloads 
@@ -6,4 +20,6 @@ FROM (
     GROUP BY crate_id
     ) as downloads 
 INNER JOIN crates ON crates.id = downloads.crate_id 
-ORDER BY sum_downloads DESC;
+ORDER BY sum_downloads DESC
+OFFSET $1
+LIMIT $2

--- a/src/recent_downloads_query.sql
+++ b/src/recent_downloads_query.sql
@@ -1,0 +1,9 @@
+SELECT crates.name, sum_downloads 
+FROM (
+    SELECT crate_id, SUM(downloads) as sum_downloads 
+    FROM crate_downloads 
+    WHERE date > CURRENT_DATE - INTERVAL '90 days' 
+    GROUP BY crate_id
+    ) as downloads 
+INNER JOIN crates ON crates.id = downloads.crate_id 
+ORDER BY sum_downloads DESC;


### PR DESCRIPTION
I'm currently working on issue #702, sort crates by number of downloads in the past 90 days. In the function `index` of the file `src/krate.rs`, I'm having trouble converting the SQL query to Diesel and incorporating it into the already formed `query` variable statement.

Even when the `inner_join` is placed above the `into_boxed` function, as @sgrif recommended in my previous pull request #817, a different error persists in which the types are not matching when executing the query. My latest attempt places the `inner_join` after `into_boxed`, as I could not figure out how to keep the logic of the query while calling `inner_join` before `into_boxed`.

The query written in `src/recent_downloads_query.sql` currently works when inserted in straight SQL with Diesel. This is done in lines 912 - 916 of `src/krate.rs`. Currently when served locally, this branch is able to serve only a list of crates sorted by number of downloads in the past 90 days. All other functionality within `fn index` is commented out. I did this to show that the query does successfully get the top crates downloaded in the past 90 days. I can't seem be able to translate correctly to Diesel, or to be able to incorporate it to work correctly with the initialization of `query` and the other ways in which `query` is used.

In terms of functionality, when on the search page we want to be able to both show the list of crates sorted by top recently downloaded and list their respective recent download count instead of the all-time download count. We want this in addition to the current state of sorting crates by all-time downloads.

I'd appreciate some help translating my query into the Diesel code, as well as some serious guidance in incorporating it into the variable `query` in the function `index` in `src/krate.rs`. 

My latest attempt at the Diesel query currently resides in `krate.rs`, lines 820 - 822. The working SQL query is in `src/recent_downloads_query.sql`.

@sgrif @carols10cents 