### PR TITLE
Rename krate in json to crate

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -51,6 +51,7 @@ pub struct NewVersion {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EncodableVersion {
     pub id: i32,
+    #[serde(rename = "crate")]
     pub krate: String,
     pub num: String,
     pub dl_path: String,


### PR DESCRIPTION
This was changed when switching from rustc serialize to serde; ember
expects the key in the JSON to be "crate" but Rust needs the field in
the struct to be named "krate". The tests didn't catch this because we
aren't testing the serialized JSON string at all; a round trip through
JSON totally worked :-/

This breaks the reverse dependencies page-- the name of the dependent crate doesn't show up.

I checked everywhere that has `krate:`; it looks like all the other places have serde renaming appropriately.

Found this while testing on staging before deploying to prod-- @sgrif you around to review?