### PR TITLE
Fix users/stats endpoint erroring when the user doesn't own any crate

### DIFF
--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -252,6 +252,27 @@ fn user_total_downloads() {
 }
 
 #[test]
+fn user_total_downloads_no_crates() {
+    let (_b, app, middle) = ::app();
+    let u;
+    {
+        let conn = app.diesel_database.get().unwrap();
+
+        u = ::new_user("foo").create_or_update(&conn).unwrap();
+    }
+
+    let mut req = ::req(app, Method::Get, &format!("/api/v1/users/{}/stats", u.id));
+    let mut response = ok_resp!(middle.call(&mut req));
+
+    #[derive(Deserialize)]
+    struct Response {
+        total_downloads: i64,
+    }
+    let response: Response = ::json(&mut response);
+    assert_eq!(response.total_downloads, 0);
+}
+
+#[test]
 fn updating_existing_user_doesnt_change_api_token() {
     let (_b, app, _middle) = ::app();
     let conn = t!(app.diesel_database.get());


### PR DESCRIPTION
Spot this while setting up a local instance today, but it seems production is also affected. Because diesel's `sum` returns an error when the sum result is null, the endpoint returned a 500 error and the Dashboard page would not load up.

The fix I applied is making a separate query to count the number of crates owned. Ideally, we should use [COALESCE](https://www.postgresql.org/docs/9.2/static/functions-conditional.html#FUNCTIONS-COALESCE-NVL-IFNULL "PostgresQL COALESCE documentation entry") to make it a single query, but I couldn't find any information in Diesel's documentation.