### PR TITLE
Installation guide for PostgresQL on Fedora was missing a package

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -157,7 +157,7 @@ methods we'd recommend for each operating system:
   following distributions:
 
   - Ubuntu: `sudo apt-get install postgresql postgresql-contrib libpq-dev`
-  - Fedora: `sudo dnf install postgresql-server postgresql-contrib`
+  - Fedora: `sudo dnf install postgresql-server postgresql-contrib postgresql-devel`
 
   > If you're missing a package, when you try to `cargo install` or `cargo
   > build` later, you'll get an error that looks like this:


### PR DESCRIPTION
The package including postgres' header files was in Ubuntu's list of package but not in Fedora's one.