### PR TITLE
Update to Diesel 0.13.1.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
  "conduit-static 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-test 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_codegen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_full_text_search 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -422,7 +422,7 @@ name = "diesel_codegen"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -433,7 +433,7 @@ name = "diesel_full_text_search"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -892,7 +892,7 @@ name = "r2d2-diesel"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1274,7 +1274,7 @@ dependencies = [
 "checksum curl-sys 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d5481162dc4f424d088581db2f979fa7d4c238fe9794595de61d8d7522e277de"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
-"checksum diesel 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "90edf3024e90c3bf92ff71c6e9e809648b0e482a653dc006d5639fdc40cd78a3"
+"checksum diesel 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1961b9a3f3744901100a9b3cf8d022163e21205c4e0a26f0fd1804333b8051d1"
 "checksum diesel_codegen 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb4ee459a5b4a5c7dfd08c573cfa8d922539bcbe0515a8feea0a5d22606f50cb"
 "checksum diesel_full_text_search 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d97f70b958c54bfc1aa87d62c9593356d4af070d058ab334b6d9859b06e644be"
 "checksum digest 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a68d759d7a66a4f63d5bd2a2b14ad7e8cf93fe8c9be227031cd4e72ab0e9ee8"

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -252,6 +252,27 @@ fn user_total_downloads() {
 }
 
 #[test]
+fn user_total_downloads_no_crates() {
+    let (_b, app, middle) = ::app();
+    let u;
+    {
+        let conn = app.diesel_database.get().unwrap();
+
+        u = ::new_user("foo").create_or_update(&conn).unwrap();
+    }
+
+    let mut req = ::req(app, Method::Get, &format!("/api/v1/users/{}/stats", u.id));
+    let mut response = ok_resp!(middle.call(&mut req));
+
+    #[derive(Deserialize)]
+    struct Response {
+        total_downloads: i64,
+    }
+    let response: Response = ::json(&mut response);
+    assert_eq!(response.total_downloads, 0);
+}
+
+#[test]
 fn updating_existing_user_doesnt_change_api_token() {
     let (_b, app, _middle) = ::app();
     let conn = t!(app.diesel_database.get());

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -430,7 +430,8 @@ pub fn stats(req: &mut Request) -> CargoResult<Response> {
             crate_owners::owner_kind.eq(OwnerKind::User as i32),
         ))
         .select(sum(crates::downloads))
-        .first::<i64>(&*conn)?;
+        .first::<Option<i64>>(&*conn)?
+        .unwrap_or(0);
 
     #[derive(Serialize)]
     struct R {


### PR DESCRIPTION
0.13.1 was a bugfix release that changed `sum` and `avg` to properly reflect their return type. Previously, this endpoint would error if the query was being performed on an empty table.

Fixes #866 