### PR TITLE
Fixup some fallout from the revert of #865

### DIFF
--- a/migrations/20170711193021_rerename_gitlab/down.sql
+++ b/migrations/20170711193021_rerename_gitlab/down.sql
@@ -1,0 +1,1 @@
+UPDATE badges SET badge_type = replace(badge_type, 'gitlab', 'git-lab');

--- a/migrations/20170711193021_rerename_gitlab/up.sql
+++ b/migrations/20170711193021_rerename_gitlab/up.sql
@@ -1,0 +1,1 @@
+UPDATE badges SET badge_type = replace(badge_type, 'git-lab', 'gitlab');

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -58,18 +58,6 @@ impl Badge {
         serde_json::from_value(serde_json::to_value(self).unwrap()).unwrap()
     }
 
-    pub fn badge_type(&self) -> &'static str {
-        match *self {
-            Badge::TravisCi { .. } => "travis-ci",
-            Badge::Appveyor { .. } => "appveyor",
-            Badge::GitLab { .. } => "gitlab",
-            Badge::IsItMaintainedIssueResolution { .. } => "is-it-maintained-issue-resolution",
-            Badge::IsItMaintainedOpenIssues { .. } => "is-it-maintained-open-issues",
-            Badge::Codecov { .. } => "codecov",
-            Badge::Coveralls { .. } => "coveralls",
-        }
-    }
-
     pub fn update_crate<'a>(
         conn: &PgConnection,
         krate: &Crate,


### PR DESCRIPTION
Sooo I have already deployed #865 to production, but not the revert. This means the migration got run, which means we need to undo it, so I've added it back here with the up/down swapped. It shouldn't affect anyone who hasn't run the reverted migration.

I also cherry-picked the commit from #865 that removes `badge_type`-- that method is indeed still not being used since we switched to serde, so that commit is fine. In fact, not having this is causing small problems because #807 was made between #865 and the revert, and it adds a new badge, so if I merge in #807 that variant isn't in `badge_type`.