### PR TITLE
Disallow trivial casts

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -780,7 +780,6 @@ impl Model for Crate {
 }
 
 /// Handles the `GET /crates` route.
-#[allow(trivial_casts)]
 pub fn index(req: &mut Request) -> CargoResult<Response> {
     use diesel::expression::AsExpression;
     use diesel::types::Bool;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -105,7 +105,6 @@ where
 }
 
 impl<T, E: CargoError> ChainError<T> for Result<T, E> {
-    #[allow(trivial_casts)]
     fn chain_error<E2, C>(self, callback: C) -> CargoResult<T>
     where
         E2: CargoError,


### PR DESCRIPTION
Trivial casts were allowed in two places but the code compiles and
passes tests without this attribute.