### PR TITLE
Format dashboard total downloads count

### DIFF
--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -6,7 +6,7 @@
     <div id="stats">
         <div class='downloads'>
             <img class="download" src="/assets/download.svg" />
-            <span class='num'>{{visibleStats.total_downloads}}</span>
+            <span class='num'>{{format-num visibleStats.total_downloads}}</span>
             <span class='desc small'>Total Downloads</span>
         </div>
     </div>


### PR DESCRIPTION
Use the format-num helper to properly comma-seperate the "Total Downloads" count
on the Dashboard page.

Fixes #855

<img width="993" alt="screen shot 2017-07-12 at 8 43 40 pm" src="https://user-images.githubusercontent.com/5692947/28146932-d7932942-6742-11e7-949d-e80f3df62cab.png">