### PR TITLE
Add default link for documentation to https://docs.rs/{{crate.name}}

### DIFF
--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -30,6 +30,8 @@
         {{/if}}
         {{#if crate.documentation}}
           <li><a href="{{crate.documentation}}">Documentation</a></li>
+        {{else}}
+          <li><a href="https://docs.rs/{{crate.name}}">Documentation</a></li>
         {{/if}}
         {{#if crate.repository}}
           <li><a href="{{crate.repository}}">Repository</a></li>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -40,6 +40,8 @@
         {{/if}}
         {{#if crate.documentation}}
           <li><a href="{{crate.documentation}}">Documentation</a></li>
+        {{else}}
+          <li><a href="https://docs.rs/{{crate.name}}">Documentation</a></li>
         {{/if}}
         {{#if crate.repository}}
           <li><a href="{{crate.repository}}">Repository</a></li>


### PR DESCRIPTION
I made the default for crates that did not specify a path documentation.