### PR TITLE
Enable HSTS headers on all responses

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,5 +1,5 @@
 https://github.com/rcaught/heroku-buildpack-cmake#e4e2c9e
 https://github.com/emk/heroku-buildpack-rust#578d630
 https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
-https://github.com/ryandotsmith/nginx-buildpack.git#af813ba
+https://github.com/travis-ci/nginx-buildpack.git#2fbde35
 https://github.com/sgrif/heroku-buildpack-diesel#f605edd

--- a/app.json
+++ b/app.json
@@ -65,7 +65,7 @@
         "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz"
       },
       {
-        "url": "https://github.com/ryandotsmith/nginx-buildpack.git#af813ba"
+        "url": "https://github.com/travis-ci/nginx-buildpack.git#2fbde35"
       },
       {
         "url": "https://github.com/sgrif/heroku-buildpack-diesel.git#f605edd"

--- a/app.json
+++ b/app.json
@@ -56,19 +56,19 @@
   ],
   "buildpacks": [
       {
-        "url": "https://github.com/rcaught/heroku-buildpack-cmake.git#e4e2c9e"
+        "url": "https://github.com/rcaught/heroku-buildpack-cmake"
       },
       {
-        "url": "https://github.com/emk/heroku-buildpack-rust.git#578d630"
+        "url": "https://github.com/emk/heroku-buildpack-rust"
       },
       {
         "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz"
       },
       {
-        "url": "https://github.com/travis-ci/nginx-buildpack.git#2fbde35"
+        "url": "https://github.com/travis-ci/nginx-buildpack"
       },
       {
-        "url": "https://github.com/sgrif/heroku-buildpack-diesel.git#f605edd"
+        "url": "https://github.com/sgrif/heroku-buildpack-diesel"
       }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -56,19 +56,7 @@
   ],
   "buildpacks": [
       {
-        "url": "https://github.com/rcaught/heroku-buildpack-cmake"
+        "url": "https://github.com/heroku/heroku-buildpack-multi"
       },
-      {
-        "url": "https://github.com/emk/heroku-buildpack-rust"
-      },
-      {
-        "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz"
-      },
-      {
-        "url": "https://github.com/travis-ci/nginx-buildpack"
-      },
-      {
-        "url": "https://github.com/sgrif/heroku-buildpack-diesel"
-      }
   ]
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -39,6 +39,7 @@ http {
 
 		location ~ ^/assets/ {
 			add_header Strict-Transport-Security "max-age=31536000" always;
+			add_header X-Content-Type-Options nosniff;
 			add_header Cache-Control public;
 			root dist;
 			expires max;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -36,15 +36,16 @@ http {
 		listen <%= ENV["PORT"] %>;
 		server_name _;
 		keepalive_timeout 5;
-		add_header Strict-Transport-Security "max-age=31536000";
 
 		location ~ ^/assets/ {
+			add_header Strict-Transport-Security "max-age=31536000" always;
 			add_header Cache-Control public;
 			root dist;
 			expires max;
 		}
 
 		location / {
+			add_header Strict-Transport-Security "max-age=31536000" always;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_redirect off;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -9,11 +9,11 @@ events {
 }
 
 http {
-        gzip on;
-        gzip_comp_level 2;
-        gzip_proxied any;
-        gzip_min_length 512;
-        gzip_types text/plain text/css application/json application/javascript application/x-javascript text/javascript text/xml application/xml application/rss+xml application/atom+xml application/rdf+xml image/svg+xml;
+	gzip on;
+	gzip_comp_level 2;
+	gzip_proxied any;
+	gzip_min_length 512;
+	gzip_types text/plain text/css application/json application/javascript application/x-javascript text/javascript text/xml application/xml application/rss+xml application/atom+xml application/rdf+xml image/svg+xml;
 
 	server_tokens off;
 
@@ -26,7 +26,7 @@ http {
 	sendfile on;
 
 	client_body_timeout 30;
-        client_max_body_size 50m;
+	client_max_body_size 50m;
 
 	upstream app_server {
 		server localhost:8888 fail_timeout=0;
@@ -36,20 +36,21 @@ http {
 		listen <%= ENV["PORT"] %>;
 		server_name _;
 		keepalive_timeout 5;
-                add_header Strict-Transport-Security "max-age=31536000";
+		add_header Strict-Transport-Security "max-age=31536000";
 
-                location ~ ^/assets/ {
-                        add_header Cache-Control public;
-                        root dist;
-                        expires max;
-                }
+		location ~ ^/assets/ {
+			add_header Cache-Control public;
+			root dist;
+			expires max;
+		}
+
 		location / {
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_redirect off;
-                        if ($http_x_forwarded_proto != 'https') {
-                            rewrite ^ https://$host$request_uri? permanent;
-                        }
+			if ($http_x_forwarded_proto != 'https') {
+				rewrite ^ https://$host$request_uri? permanent;
+			}
 			proxy_pass http://app_server;
 		}
 	}


### PR DESCRIPTION
**Deployment Warning:** This pull request uses a configuration syntax added in nginx-1.7.5 and requires switching to a new buildpack.  ~~If this pull request is merged the buildpack configuration on *staging* and *production* will need to be changed on Heroku.~~  (This is no longer a concern with the updated PR as this is specified in `.buildpacks`.)  It is unclear if there are any existing mirror deployments on Heroku or otherwise depending on our `nginx.conf.erb` template.

This pull request enables HSTS headers for all responses.  My tests show an upgrade from an F to a D on the Mozilla Observatory.  (Out of 100 points, this scores 35 instead of 15.)  Please also see the discussion in #597 which is what prompted my review.

This pull request also fixes the buildpack URLs defined in `app.json` so that the Heroku deploy button works.

# Nginx buildpack upgrade

The previous buildpack was based on nginx-1.5.7 which was released in November of 2013.  Fortunately for us, it looks like travis-ci recently cloned this buildpack and upgraded it to the latest release of 1.13.3.

Note that the odd minor version number represents that this (as well as our previous release) is from the development branch.  The stable release of 1.12.1 may be preferable, but I expect that the travis-ci clone is our best bet for a responsive upstream at this time.

# Nginx configuration change

Two changes to the nginx configuration file where necessary.  See http://nginx.org/en/docs/http/ngx_http_headers_module.html for more details on both of these.

## Use the always parameter

The `always` parameter was introduced in nginx-1.7.5.  The HSTS header is now included for all response codes.

## Duplicate header declaration in both blocks

This surprised me, but the documentation states:

> There could be several add_header directives. These directives are inherited from the previous level **if and only if** there are no add_header directives defined on the current level.

I figured it was best to explicitly duplicate the declaration rather than rely on inheritance at all.

# Fix the Deploy to Heroku button

This pull request also fixes the Deploy to Heroku button in `docs/MIRROR.md` by updating the `app.json` file.  ~~It appears that Heroku does not support URLs with the #SHA fragment.  If we want to fix ourselves to specific commits for the buildpacks it may be possible to do so with `archive/*.tar.gz` links, but I suspect that we are currently targeting the master branches for these in production anyway.~~  The PR now sets up `app.json` to use heroku-buildpack-multi which will pull in the other buildpacks from `.buildpacks`.  New mirror deployments should now match our staging and production environments.