### PR TITLE
Only install rustfmt when we need it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ install:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
   - npm install
   - cargo install --force diesel_cli --vers 0.14.0 --debug --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
-  - cargo install --force rustfmt
-  - rustfmt --version
 
 before_script:
   - diesel database setup
@@ -40,6 +38,8 @@ matrix:
   - rust: stable
     env: RUSTFMT=YESPLEASE
     script:
+    - cargo install --force rustfmt
+    - rustfmt --version
     - cargo fmt -- --write-mode=diff
   - rust: stable
     script:


### PR DESCRIPTION
Travis is timing out (because of no output for 10 min) trying to install rustfmt (with syntex_syntax) when we're using rustc 1.20.0-nightly (734c83642 2017-07-03) for clippy... but we don't need rustfmt installed when we're running clippy, soooooo let's not