### PR TITLE
Use diesel from inside the users middleware

### DIFF
--- a/src/user/middleware.rs
+++ b/src/user/middleware.rs
@@ -3,9 +3,10 @@ use std::error::Error;
 use conduit_middleware;
 use conduit::Request;
 use conduit_cookie::RequestSession;
+use diesel::prelude::*;
 
-use Model;
 use db::RequestTransaction;
+use schema::users;
 use super::User;
 use util::errors::{CargoResult, Unauthorized, ChainError, std_error};
 
@@ -22,12 +23,17 @@ impl conduit_middleware::Middleware for Middleware {
     fn before(&self, req: &mut Request) -> Result<(), Box<Error + Send>> {
         // Check if the request has a session cookie with a `user_id` property inside
         let id = {
-            req.session().get("user_id").and_then(|s| s.parse().ok())
+            req.session().get("user_id").and_then(
+                |s| s.parse::<i32>().ok(),
+            )
         };
+
+        let conn = req.db_conn().map_err(std_error)?;
 
         if let Some(id) = id {
             // If it did, look for a user in the database with the given `user_id`
-            if let Ok(user) = User::find(req.tx().map_err(std_error)?, id) {
+            let maybe_user = users::table.find(id).first::<User>(&*conn);
+            if let Ok(user) = maybe_user {
                 // Attach the `User` model from the database to the request
                 req.mut_extensions().insert(user);
                 req.mut_extensions().insert(
@@ -38,7 +44,7 @@ impl conduit_middleware::Middleware for Middleware {
             // Otherwise, look for an `Authorization` header on the request
             // and try to find a user in the database with a matching API token
             let user = if let Some(headers) = req.headers().find("Authorization") {
-                User::find_by_api_token(&*req.db_conn().map_err(std_error)?, headers[0]).ok()
+                User::find_by_api_token(&conn, headers[0]).ok()
             } else {
                 None
             };


### PR DESCRIPTION
I'm a bit worried about the fact that there were not tests which needed
to be updated. It seems like we never actually test the authentication
directly, we always just stub the user into the request.