### PR TITLE
Add Vary header to prevent caching routes with different content types

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -47,6 +47,7 @@ http {
 
 		location / {
 			add_header Strict-Transport-Security "max-age=31536000" always;
+            add_header Vary 'Accept, Accept-Encoding, Cookie';
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header Host $http_host;
 			proxy_redirect off;


### PR DESCRIPTION
Such as the /me route, which can be requested by the browser for its
frontend HTML or its backend JSON, but the browser should not cache
either and return it for the other one.

Fixes #888.

I was able to reproduce the problem with reloading locally when, instead of using `ember serve`, I ran `npm run build -- --environment production` and then served the files in `dist` using nginx. This change fixed the problem! 

@sgrif @jtgeibel do yinz see any reason NOT to set this header for literally any non-asset route? 