### PR TITLE
Never serve HTML for paths starting with `/api`

### DIFF
--- a/src/dist.rs
+++ b/src/dist.rs
@@ -41,7 +41,10 @@ impl Handler for Middleware {
             .find("Accept")
             .map(|accept| accept.iter().any(|s| s.contains("html")))
             .unwrap_or(false);
-        if wants_html {
+        // If the route starts with /api, just assume they want the API
+        // response. Someone is either debugging or trying to download a crate.
+        let is_api_path = req.path().starts_with("/api");
+        if wants_html && !is_api_path {
             self.dist.call(&mut RequestProxy {
                 other: req,
                 path: Some("/index.html"),


### PR DESCRIPTION
We have several routes (notably the download route) which assume they
will be receiving the request regardless of if a JSON accept header was
specified or not. Ultimately if someone is typing `/api/...` into their
browser, they're probably debugging or doing something else for which
they don't want Ember rendering a 404 page.