### PR TITLE
Remove unused code for download button

### DIFF
--- a/app/adapters/version.js
+++ b/app/adapters/version.js
@@ -1,7 +1,0 @@
-import ApplicationAdapter from './application';
-
-export default ApplicationAdapter.extend({
-    getDownloadUrl(dlPath) {
-        return this.ajax(dlPath, 'GET').then(response => response.url);
-    },
-});

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -3,7 +3,6 @@ import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
 import { computed } from '@ember/object';
 import { later } from '@ember/runloop';
-import $ from 'jquery';
 import moment from 'moment';
 
 const NUM_VERSIONS = 5;
@@ -161,16 +160,6 @@ export default Controller.extend({
 
         copyError() {
             this.toggleClipboardProps(false);
-        },
-
-        download(version) {
-            this.set('isDownloading', true);
-
-            version.getDownloadUrl().then(url => {
-                this.incrementProperty('crate.downloads');
-                this.incrementProperty('currentVersion.downloads');
-                $('#download-frame').attr('src', url);
-            }).finally(() => this.set('isDownloading', false));
         },
 
         toggleFollow() {

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -20,8 +20,4 @@ export default DS.Model.extend({
     crateName: computed('crate', function() {
         return this.belongsTo('crate').id();
     }),
-
-    getDownloadUrl() {
-        return this.store.adapterFor('version').getDownloadUrl(this.get('dl_path'));
-    },
 });

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -22,14 +22,6 @@
                     {{/if}}
                 </button>
             {{/if}}
-            {{!--
-                <a class='yellow-button' download
-                   {{action 'download' currentVersion}}
-                   href='{{currentVersion.dl_path}}'>
-                    <img class="button-download" src="/assets/button-download.png"/>
-                    Download
-                </a>
-            --}}
         </div>
     </div>
 


### PR DESCRIPTION
The download button has not been available since pre rust-1.0.  The button was originally commented out in #15 and #18.