### PR TITLE
Add bors-ng configuration file

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,1 @@
+status = ["continuous-integration/travis-ci/push"]


### PR DESCRIPTION
We're gonna try out [bors-ng](https://bors.tech/)! I've got an instance running at https://bors-voyager.herokuapp.com/ but the repo needs this file :)