### PR TITLE
Better error messages for empty string ENV variables

### DIFF
--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -138,11 +138,17 @@ fn app() -> (record::Bomb, Arc<App>, conduit_middleware::MiddlewareBuilder) {
     return (bomb, app, middleware);
 }
 
+// Return the environment variable only if it has been defined
 fn env(s: &str) -> String {
-    match env::var(s).ok() {
-        Some(s) => s,
-        None => panic!("must have `{}` defined", s),
+    // Handles both the `None` and empty string cases e.g. VAR=
+    // by converting `None` to an empty string
+    let env_result = env::var(s).ok().unwrap_or(String::new());
+
+    if env_result == "" {
+        panic!("must have `{}` defined", s);
     }
+
+    env_result
 }
 
 fn req(app: Arc<App>, method: conduit::Method, path: &str) -> MockRequest {


### PR DESCRIPTION
Fixes up #937, which was caused by me not having the `TEST_DATABASE_URL` set i.e. it was `TEST_DATABASE_URL=`. Thanks to Arnavion on the #rust channel for pointing out I could use unwrap_or() to cover both the `None` and `""` cases at once :).