### PR TITLE
[categories] Add internationalization and localization

### DIFF
--- a/src/categories.toml
+++ b/src/categories.toml
@@ -245,6 +245,20 @@ description = """
 Crates to interface with specific CPU or other hardware features.\
 """
 
+[internationalization]
+name = "Internationalization (i18n)"
+description = """
+Crates to help develop software capable of adapting to various \
+languages and regions.\
+"""
+
+[localization]
+name = "Localization (L10n)"
+description = """
+Crates to help adapting internationalized software to specific \
+languages and regions.\
+"""
+
 [memory-management]
 name = "Memory management"
 description = """


### PR DESCRIPTION
Background: https://github.com/rust-lang/cargo/issues/4368

# References
* <https://en.wikipedia.org/wiki/Internationalization_and_localization>
* <http://www.i18n.ca/publications/GILT.pdf>
* <http://philip.pristine.net/glit/en/>

# Example Crates

## Category: `internationalizaion`
Almost all libraries that implement Unicode-related functionalities (<https://crates.io/search?q=unicode>), like:
* `unicode-normalization`
* `unicode-bidi`
* `unicode-segmentation`
* `unicode-width`
* `unicode-script`
* `unic`, which covers/will-be-covering all of the above.
* `cldr`
* `accept-language`
* `language-tags`
* `locate-locale`
* `locale`
* `precis`
* `idna`
* https://github.com/servo/rust-icu

## Category: `localization`
There are fewer crates in this category, but still enough to start the category:
* `gettext-rs`
* `litelocale`
* `crowbook-localize`
* `locale`
* `l20n`