### PR TITLE
Serve locally uploaded crates from a different folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /.sass-cache
 /connect.lock
 /coverage/*
+/local_uploads
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,6 +93,8 @@ These files are mostly only relevant when running crates.io's code in developmen
 * `.env.sample` - Example environment file checked into the repository
 * `.git/` - The git repository; not available in all deployments (e.g. Heroku)
 * `.gitignore` - Configures git to ignore certain files and folders
+* `local_uploads/` - Serves crates and readmes that are published to the
+local development environment
 * `script/init-local-index.sh` - Creates registry repositories used during development
 * `tmp/` - Temporary files created during development; when deployed on Heroku this is the only
   writable directory - (ignored in `.gitignore`)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -402,10 +402,10 @@ sense as a name for this flag](https://github.com/rust-lang/cargo/issues/3797).
 
 Note that when you're running crates.io in development mode without the S3
 variables set (which is what we've done in these setup steps), the crate files
-will be stored in `dist/local_uploads/crates` and served from there when a
-crate is downloaded. This directory gets cleared out if you stop and restart
-the frontend. If you try to install a crate from your local crates.io and
-`cargo` can't find the crate files, that's probably why.
+will be stored in `local_uploads/crates` and served from there when a
+crate is downloaded.  If you try to install a crate from your local crates.io and
+`cargo` can't find the crate files, it is probably because this directory does not
+exist.
 
 ##### Downloading a crate from your local crates.io
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,9 @@ impl Default for Config {
                     // If we don't set the `S3_BUCKET` variable, we'll use a development-only
                     // uploader that makes it possible to run and publish to a locally-running
                     // crates.io instance without needing to set up an account and a bucket in S3.
-                    println!("Using local uploader, crate files will be in the local_uploads directory");
+                    println!(
+                        "Using local uploader, crate files will be in the local_uploads directory"
+                    );
                     Uploader::Local
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ impl Default for Config {
                     // If we don't set the `S3_BUCKET` variable, we'll use a development-only
                     // uploader that makes it possible to run and publish to a locally-running
                     // crates.io instance without needing to set up an account and a bucket in S3.
-                    println!("Using local uploader, crate files will be in the dist directory");
+                    println!("Using local uploader, crate files will be in the local_uploads directory");
                     Uploader::Local
                 }
             }

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -1,3 +1,5 @@
+//! This module implements middleware to serve the compiled emberjs
+//! frontend
 use std::error::Error;
 
 use conduit::{Request, Response, Handler};

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1092,6 +1092,7 @@ fn parse_new_headers(req: &mut Request) -> CargoResult<(upload::NewCrate, User)>
 }
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
+/// This returns a URL to the location where the crate is stored.
 pub fn download(req: &mut Request) -> CargoResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let version = &req.params()["version"];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@ pub mod user;
 pub mod util;
 pub mod version;
 
+mod local_upload;
 mod pagination;
 
 /// Used for setting different values depending on whether the app is being run in production,
@@ -217,6 +218,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     if env == Env::Development {
         // DebugMiddleware is defined below to print logs for each request.
         m.add(DebugMiddleware);
+        m.around(local_upload::Middleware::default());
     }
 
     if env != Env::Test {

--- a/src/local_upload.rs
+++ b/src/local_upload.rs
@@ -1,0 +1,41 @@
+//! This module implements middleware to serve crates and readmes
+//! from the `local_uploads/` directory. This is only used in
+//! development environments.
+use std::error::Error;
+
+use conduit::{Request, Response, Handler};
+use conduit_static::Static;
+use conduit_middleware::AroundMiddleware;
+
+// Can't derive debug because of Handler and Static.
+#[allow(missing_debug_implementations)]
+pub struct Middleware {
+    handler: Option<Box<Handler>>,
+    local_uploads: Static,
+}
+
+impl Default for Middleware {
+    fn default() -> Middleware {
+        Middleware {
+            handler: None,
+            local_uploads: Static::new("local_uploads"),
+        }
+    }
+}
+
+impl AroundMiddleware for Middleware {
+    fn with_handler(&mut self, handler: Box<Handler>) {
+        self.handler = Some(handler);
+    }
+}
+
+impl Handler for Middleware {
+    fn call(&self, req: &mut Request) -> Result<Response, Box<Error + Send>> {
+        match self.local_uploads.call(req) {
+            Ok(ref resp) if resp.status.0 == 404 => {}
+            ret => return ret,
+        }
+
+        self.handler.as_ref().unwrap().call(req)
+    }
+}

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -52,7 +52,7 @@ impl Uploader {
             }
             Uploader::Local => {
                 Some(format!(
-                    "/local_uploads/{}",
+                    "/{}",
                     Uploader::crate_path(crate_name, version)
                 ))
             }
@@ -75,7 +75,7 @@ impl Uploader {
             }
             Uploader::Local => {
                 Some(format!(
-                    "/local_uploads/{}",
+                    "/{}",
                     Uploader::readme_path(crate_name, version)
                 ))
             }
@@ -138,7 +138,6 @@ impl Uploader {
             Uploader::Local => {
                 let filename = env::current_dir()
                     .unwrap()
-                    .join("dist")
                     .join("local_uploads")
                     .join(path);
                 let dir = filename.parent().unwrap();

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -50,12 +50,7 @@ impl Uploader {
                     Uploader::crate_path(crate_name, version)
                 ))
             }
-            Uploader::Local => {
-                Some(format!(
-                    "/{}",
-                    Uploader::crate_path(crate_name, version)
-                ))
-            }
+            Uploader::Local => Some(format!("/{}", Uploader::crate_path(crate_name, version))),
             Uploader::NoOp => None,
         }
     }
@@ -73,12 +68,7 @@ impl Uploader {
                     Uploader::readme_path(crate_name, version)
                 ))
             }
-            Uploader::Local => {
-                Some(format!(
-                    "/{}",
-                    Uploader::readme_path(crate_name, version)
-                ))
-            }
+            Uploader::Local => Some(format!("/{}", Uploader::readme_path(crate_name, version))),
             Uploader::NoOp => None,
         }
     }
@@ -136,10 +126,7 @@ impl Uploader {
                 Ok((Some(String::from(path)), cksum))
             }
             Uploader::Local => {
-                let filename = env::current_dir()
-                    .unwrap()
-                    .join("local_uploads")
-                    .join(path);
+                let filename = env::current_dir().unwrap().join("local_uploads").join(path);
                 let dir = filename.parent().unwrap();
                 fs::create_dir_all(dir)?;
                 let mut file = File::create(&filename)?;


### PR DESCRIPTION
Fix #934, serve locally uploaded crates from a different location since `dist/` gets recreated each time the front end restarts.