### PR TITLE
[WIP] Listing Crate Owner Invitations

### DIFF
--- a/migrations/20170812041508_crate_owner_invitations/down.sql
+++ b/migrations/20170812041508_crate_owner_invitations/down.sql
@@ -1,0 +1,3 @@
+DROP TRIGGER trigger_ensure_single_crate_owner_invitation ON crate_owner_invitations;
+DROP FUNCTION ensure_single_crate_owner_invitation();
+DROP TABLE crate_owner_invitations;

--- a/migrations/20170812041508_crate_owner_invitations/up.sql
+++ b/migrations/20170812041508_crate_owner_invitations/up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE crate_owner_invitations (
+    id SERIAL PRIMARY KEY,
+    invited_user_id INTEGER NOT NULL REFERENCES users (id),
+    invited_by INTEGER NOT NULL REFERENCES users (id),
+    crate_id INTEGER NOT NULL REFERENCES crates (id) ON DELETE CASCADE,
+    status TEXT NOT NULL,
+    created TIMESTAMP NOT NULL DEFAULT now()
+);
+
+CREATE FUNCTION ensure_single_crate_owner_invitation() RETURNS trigger AS $$
+DECLARE
+    old_id INTEGER;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        old_id = OLD.id;
+    ELSE
+        old_id = -1;
+    END IF;
+
+    -- If a pending invitation already exists for this same invited user and crate
+    IF EXISTS (
+        SELECT 1 FROM crate_owner_invitations
+            WHERE id != old_id AND
+                  invited_user_id = NEW.invited_user_id AND
+                  crate_id = NEW.crate_id AND
+                  status = 'pending'
+    ) THEN
+        RAISE EXCEPTION 'cannot invite a user to the same crate more than once';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_ensure_single_crate_owner_invitation
+BEFORE INSERT OR UPDATE ON crate_owner_invitations
+FOR EACH ROW EXECUTE PROCEDURE ensure_single_crate_owner_invitation();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -40,6 +40,17 @@ table! {
 }
 
 table! {
+    crate_owner_invitations (id) {
+        id -> Int4,
+        invited_user_id -> Int4,
+        invited_by -> Int4,
+        crate_id -> Int4,
+        status -> Text,
+        created -> Timestamp,
+    }
+}
+
+table! {
     crate_owners (crate_id, owner_id, owner_kind) {
         crate_id -> Int4,
         owner_id -> Int4,


### PR DESCRIPTION
**DO NOT MERGE YET**

This is the first deployable chunk of #924: Listing Invitations

I'm only going to be working on the backend stuff for each of these chunks. Anyone else is welcome to take on the frontend work. :smile: I will go through and finish as much of the backend in each deployable chunk as I can, one chunk at a time.

So far I've just got the migration for the table in which every invitation will be stored. I followed the examples of other migrations in order to create this. The trigger is based on the one we have for reserved crate names and ensures the integrity of our data by making sure you can't invite the same user to the same crate more than once.

I've manually tested this in postgres and it works very well. You can update the same row but you cannot have more than once pending invitation for the same user and crate. Multiple declined invitations are fine, but only a single pending one will validate.

@carols10cents Could you skim this over and let me know if it's alright? I don't want to take too much of your time. We'll do a full review once I've made more progress. I want to know if I'm on the right track so far since I've never added a migration for this codebase before. 

## To Do

- [x] Migration for `crate_owner_invitations` table
- [ ] Make an API route that can list all of the currently logged in user's pending invitations (and perhaps the declined ones too, if we want to support "undecline"?)