### PR TITLE
crate.scss: When rendering code in README, don't show scrollbar unless necessary

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -307,7 +307,7 @@
         line-height: 1.5;
 
         pre {
-            overflow-x: scroll;
+            overflow-x: auto;
         }
     }
     .last-update {


### PR DESCRIPTION
The current `overflow-x: scroll` shows a scrollbar all the time, even
for code blocks that don't need them. Switch to `overflow-x: auto`, to
only show the scrollbar when needed.