### PR TITLE
Ensure the build script is run when migrations are added

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,7 @@ use std::env;
 fn main() {
     println!("cargo:rerun-if-env-changed=TEST_DATABASE_URL");
     println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=migrations/");
     if env::var("PROFILE") == Ok("debug".into()) {
         let _ = dotenv();
         if let Ok(database_url) = env::var("TEST_DATABASE_URL") {


### PR DESCRIPTION
When the timestamp on the migrations/ directory changes the build script will be run so that any pending migrations are run.

I've tested this on Linux, but management of timestamps on directories may be platform specific.