### PR TITLE
Adds a title to elaborate on how we count recent downloads.

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -350,3 +350,8 @@ h1 {
 a.arrow svg {
     background: #EEECDD;
 }
+
+abbr[title] {
+    text-decoration: none;
+    border-bottom: 1px dotted;
+}

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -24,7 +24,7 @@
     </div>
     <div class="recent-downloads">
         {{svg-jar "download"}}
-        <span class='num'>Recent: {{ format-num crate.recent_downloads }}</span>
+        <span class='num'><abbr title="Downloads in the last 90 days">Recent:</abbr> {{ format-num crate.recent_downloads }}</span>
     </div>
 </div>
 <div class="quick-links">


### PR DESCRIPTION
On http://crates.io/categories/no-std, we list "All time downloads" and "Recent downloads" without explaining how recent the recent downloads are. This diff just adds an `<abbr>` element with a title to explain:

![image](https://user-images.githubusercontent.com/80639/29497273-54792342-85b3-11e7-96ee-16dcd71f99f6.png)

The default `<abbr>` styles on my browser made this illegible (Brave on OS X) so I replaced the default abbr style with a border-bottom, but it could potentially be changed to use a newer CSS property (text-decoration-position).