### PR TITLE
Rename maintenance struct key from value to status

### DIFF
--- a/src/badge.rs
+++ b/src/badge.rs
@@ -39,12 +39,12 @@ pub enum Badge {
         branch: Option<String>,
         service: Option<String>,
     },
-    Maintenance { value: MaintenanceValue },
+    Maintenance { status: MaintenanceStatus },
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum MaintenanceValue {
+pub enum MaintenanceStatus {
     ActivelyDeveloped,
     PassivelyMaintained,
     AsIs,

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,5 +1,5 @@
 use cargo_registry::app::App;
-use cargo_registry::badge::{Badge, MaintenanceValue};
+use cargo_registry::badge::{Badge, MaintenanceStatus};
 use cargo_registry::krate::Crate;
 
 use std::collections::HashMap;
@@ -108,10 +108,10 @@ fn set_up() -> (Arc<App>, Crate, BadgeRef) {
     badge_attributes_circle_ci.insert(String::from("branch"), String::from("beta"));
     badge_attributes_circle_ci.insert(String::from("repository"), String::from("rust-lang/rust"));
 
-    let maintenance = Badge::Maintenance { value: MaintenanceValue::LookingForMaintainer };
+    let maintenance = Badge::Maintenance { status: MaintenanceStatus::LookingForMaintainer };
     let mut maintenance_attributes = HashMap::new();
     maintenance_attributes.insert(
-        String::from("value"),
+        String::from("status"),
         String::from("looking-for-maintainer"),
     );
 
@@ -514,8 +514,8 @@ fn maintenance_required_keys() {
 
     let mut badges = HashMap::new();
 
-    // Value is a required key
-    test_badges.maintenance_attributes.remove("value");
+    // Status is a required key
+    test_badges.maintenance_attributes.remove("status");
     badges.insert(
         String::from("maintenance"),
         test_badges.maintenance_attributes,
@@ -537,7 +537,7 @@ fn maintenance_invalid_values() {
 
     // "totes broken" is not a recognized value
     test_badges.maintenance_attributes.insert(
-        String::from("value"),
+        String::from("status"),
         String::from(
             "totes broken",
         ),


### PR DESCRIPTION
Feel status is a better name for the `Maintenance` struct key than value. I also renamed the `MaintenanceValue` enum to `MaintenanceStatus`. 