### PR TITLE
Issue #680 : Crate owners can now remove themselves as owner 

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1404,8 +1404,8 @@ fn modify_owners(req: &mut Request, add: bool) -> CargoResult<Response> {
         } else {
             // Removing the team that gives you rights is prevented because
             // team members only have Rights::Publish
-            if *login == user.gh_login {
-                return Err(human("cannot remove yourself as an owner"));
+            if owners.len() == 1 {
+                return Err(human("cannot remove the sole owner of a crate"));
             }
             krate.owner_remove(&conn, user, login)?;
         }

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1294,10 +1294,6 @@ fn owners_can_remove_self() {
     let r: R = ::json(&mut response);
     assert_eq!(r.users.len(), 1);
 
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Get)));
-    let r: R = ::json(&mut response);
-    assert_eq!(r.users.len(), 1);
-
     let body = r#"{"users":["secondowner"]}"#;
     let mut response = ok_resp!(middle.call(req.with_method(Method::Put).with_body(
         body.as_bytes(),


### PR DESCRIPTION
If there is at least one other owner remaining, then an owner can remove themselves from a crate.