### PR TITLE
Improve code display

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -313,6 +313,13 @@
         pre {
             overflow-x: auto;
         }
+
+        p {
+            code {
+                background-color: #fff;
+                padding: 0 2px;
+            }
+        }
     }
     .last-update {
         color: $main-color-light;


### PR DESCRIPTION
A little screenshot with the new style:

<img width="1440" alt="screen shot 2017-08-22 at 23 13 55" src="https://user-images.githubusercontent.com/3050060/29587877-a2e1503a-878f-11e7-95d3-03ad7be32ea5.png">

As you can see, the `code` elements inside the texts are now easier to spot and I find it more attractive when reading.