### PR TITLE
Make `entries` binding immutable for &mut type

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -212,7 +212,7 @@ fn get_readme(config: &Config, version: &EncodableVersion) -> Option<String> {
 
 /// Search an entry by its path in a Tar archive.
 fn find_file_by_path<R: Read>(
-    mut entries: &mut tar::Entries<R>,
+    entries: &mut tar::Entries<R>,
     path: &Path,
     version: &EncodableVersion,
 ) -> String {


### PR DESCRIPTION
It appears that the lint on nightly is more aggressive and it correctly
identifies that the entries binding itself is not mutated even though
the type is (and needs to be) &mut.

This will ensure that our builds don't break when nightly becomes
the new beta.