### PR TITLE
Switch to `DELETE` for /logout route to prevent CSRF

### DIFF
--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -7,7 +7,7 @@ export default Route.extend({
     ajax: service(),
 
     activate() {
-        this.get('ajax').request(`/logout`).then(() => {
+        this.get('ajax').delete(`/logout`).then(() => {
             run(() => {
                 this.session.logoutUser();
                 this.transitionTo('index');

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,6 +87,7 @@ for another platform.
 
 These files are mostly only relevant when running crates.io's code in development mode.
 
+* `bors.toml` - Configure our instance of [bors-ng][] for continous integration
 * `.editorconfig` - Coding style definitions supported by some IDEs // TODO: Reference extensions
   for common editors
 * `.env` - Environment variables loaded by the backend - (ignored in `.gitignore`)
@@ -101,4 +102,5 @@ These files are mostly only relevant when running crates.io's code in developmen
 * `.travis.yml` - Configuration for continous integration at [TravisCI][]
 * `.watchmanconfig` - Use by Ember CLI to efficiently watch for file changes if you install watchman
 
+[bors-ng]: https://github.com/bors-ng/bors-ng
 [TravisCI]: https://travis-ci.org/rust-lang/crates.io

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
 
     router.get("/authorize_url", C(user::github_authorize));
     router.get("/authorize", C(user::github_access_token));
-    router.get("/logout", C(user::logout));
+    router.delete("/logout", C(user::logout));
     router.get("/me", C(user::me));
     router.get("/me/updates", C(user::updates));
     router.get("/me/tokens", C(token::list));


### PR DESCRIPTION
Other sites are allowed to make `GET` requests so switching to `DELETE`
to match the destructive nature of the route.

If the user navigates to `GET /logout` we now fall back to the default
behavior which is to serve up the ember app.  Ember then sends a
`DELETE` request.  Fortunately we already enforce sameorigin for
iframes via the `X-FRAME-OPTIONS` header.

Fixes: #986 