### PR TITLE
Need to rerender readmes that haven't been recorded

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -79,9 +79,11 @@ fn main() {
     println!("Rendering readmes older than: {}", older_than);
 
     let mut query = versions::table
-        .inner_join(readme_rendering::table)
         .inner_join(crates::table)
-        .filter(readme_rendering::rendered_at.lt(older_than))
+        .left_join(readme_rendering::table)
+        .filter(readme_rendering::rendered_at.lt(older_than).or(
+            readme_rendering::rendered_at.is_null(),
+        ))
         .select(versions::id)
         .into_boxed();
 


### PR DESCRIPTION
To pick up the readmes that have been rendered before the change to
record the time a readme is rendered went out.