### PR TITLE
Give tables in readmes a bit of padding and a border

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -320,6 +320,15 @@
                 padding: 0 2px;
             }
         }
+
+        table {
+            border-collapse: collapse;
+
+            th, td {
+                border: 1px solid #dfe2e5;
+                padding: 6px 13px;
+            }
+        }
     }
     .last-update {
         color: $main-color-light;


### PR DESCRIPTION
Before:

<img width="253" alt="before" src="https://user-images.githubusercontent.com/193874/29745854-40021ae6-8a94-11e7-868c-80e5e350b6f2.png">

After:

<img width="278" alt="after" src="https://user-images.githubusercontent.com/193874/29745855-43dfb466-8a94-11e7-8e0e-e3fc5cb12b48.png">
