### PR TITLE
Move backend routes under api/v1

### DIFF
--- a/app/adapters/api-token.js
+++ b/app/adapters/api-token.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 
 export default DS.RESTAdapter.extend({
-    namespace: 'me',
+    namespace: 'api/v1/me',
     pathForType() {
         return 'tokens';
     }

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -45,7 +45,7 @@ export default Controller.extend({
             this.set('loadingMore', true);
             let page = (this.get('myFeed').length / 10) + 1;
 
-            this.get('ajax').request(`/me/updates?page=${page}`).then((data) => {
+            this.get('ajax').request(`/api/v1/me/updates?page=${page}`).then((data) => {
                 let versions = data.versions.map(version =>
                     this.store.push(this.store.normalize('version', version)));
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -11,7 +11,7 @@ export default Route.extend({
     beforeModel() {
         if (this.session.get('isLoggedIn') &&
             this.session.get('currentUser') === null) {
-            this.get('ajax').request('/me').then((response) => {
+            this.get('ajax').request('/api/v1/me').then((response) => {
                 this.session.set('currentUser', this.store.push(this.store.normalize('user', response.user)));
             }).catch(() => this.session.logoutUser()).finally(() => {
                 window.currentUserDetected = true;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -20,7 +20,7 @@ export default Route.extend({
             }
         }
 
-        return this.get('ajax').request('/summary').then((data) => {
+        return this.get('ajax').request('/api/v1/summary').then((data) => {
             addCrates(this.store, data.new_crates);
             addCrates(this.store, data.most_downloaded);
             addCrates(this.store, data.just_updated);

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,6 +1,8 @@
 import Response from 'ember-cli-mirage/response';
 
 export default function() {
+    this.namespace = '/api/v1';
+
     this.get('/summary', function(schema) {
         let crates = schema.crates.all();
 
@@ -27,8 +29,6 @@ export default function() {
             popular_keywords: this.serialize(popular_keywords).keywords,
         };
     });
-
-    this.namespace = '/api/v1';
 
     this.get('/crates', function(schema, request) {
         const { start, end } = pageParams(request);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,12 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     api_router.put("/users/:user_id", C(user::update_user));
     api_router.get("/users/:user_id/stats", C(user::stats));
     api_router.get("/teams/:team_id", C(user::show_team));
+    api_router.get("/me", C(user::me));
+    api_router.get("/me/updates", C(user::updates));
+    api_router.get("/me/tokens", C(token::list));
+    api_router.post("/me/tokens", C(token::new));
+    api_router.delete("/me/tokens/:id", C(token::revoke));
+    api_router.get("/summary", C(krate::summary));
     let api_router = Arc::new(R404(api_router));
 
     let mut router = RouteBuilder::new();
@@ -195,12 +201,6 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     router.get("/authorize_url", C(user::github_authorize));
     router.get("/authorize", C(user::github_access_token));
     router.delete("/logout", C(user::logout));
-    router.get("/me", C(user::me));
-    router.get("/me/updates", C(user::updates));
-    router.get("/me/tokens", C(token::list));
-    router.post("/me/tokens", C(token::new));
-    router.delete("/me/tokens/:id", C(token::revoke));
-    router.get("/summary", C(krate::summary));
 
     // Only serve the local checkout of the git index in development mode.
     // In production, for crates.io, cargo gets the index from

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1054,7 +1054,7 @@ fn new_krate_with_readme() {
 #[test]
 fn summary_doesnt_die() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app, Method::Get, "/summary");
+    let mut req = ::req(app, Method::Get, "/api/v1/summary");
     ok_resp!(middle.call(&mut req));
 }
 

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -26,7 +26,7 @@ macro_rules! assert_contains {
 #[test]
 fn list_logged_out() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me/tokens");
 
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
@@ -35,7 +35,7 @@ fn list_logged_out() {
 #[test]
 fn list_empty() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -52,7 +52,7 @@ fn list_empty() {
 #[test]
 fn list_tokens() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me/tokens");
 
     let (user, tokens);
     {
@@ -81,7 +81,7 @@ fn list_tokens() {
 #[test]
 fn create_token_logged_out() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
 
     req.with_body(br#"{ "api_token": { "name": "bar" } }"#);
 
@@ -92,7 +92,7 @@ fn create_token_logged_out() {
 #[test]
 fn create_token_invalid_request() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -111,7 +111,7 @@ fn create_token_invalid_request() {
 #[test]
 fn create_token_no_name() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -130,7 +130,7 @@ fn create_token_no_name() {
 #[test]
 fn create_token_long_body() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -149,7 +149,7 @@ fn create_token_long_body() {
 #[test]
 fn create_token_exceeded_tokens_per_user() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
 
     let user;
     {
@@ -172,7 +172,7 @@ fn create_token_exceeded_tokens_per_user() {
 #[test]
 fn create_token_success() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -205,14 +205,14 @@ fn create_token_multiple_have_different_values() {
     };
 
     let first = {
-        let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+        let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
         ::sign_in_as(&mut req, &user);
         req.with_body(br#"{ "api_token": { "name": "bar" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
     };
 
     let second = {
-        let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+        let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
         ::sign_in_as(&mut req, &user);
         req.with_body(br#"{ "api_token": { "name": "bar" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
@@ -236,14 +236,14 @@ fn create_token_multiple_users_have_different_values() {
     };
 
     let first_token = {
-        let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+        let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
         ::sign_in_as(&mut req, &first_user);
         req.with_body(br#"{ "api_token": { "name": "baz" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
     };
 
     let second_token = {
-        let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+        let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
         ::sign_in_as(&mut req, &second_user);
         req.with_body(br#"{ "api_token": { "name": "baz" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
@@ -255,7 +255,7 @@ fn create_token_multiple_users_have_different_values() {
 #[test]
 fn create_token_with_token() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Post, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Post, "/api/v1/me/tokens");
 
     let (user, token);
     {
@@ -279,7 +279,7 @@ fn create_token_with_token() {
 #[test]
 fn revoke_token_non_existing() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Delete, "/me/tokens/5");
+    let mut req = ::req(app.clone(), Method::Delete, "/api/v1/me/tokens/5");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -294,7 +294,7 @@ fn revoke_token_non_existing() {
 #[test]
 fn revoke_token_doesnt_revoke_other_users_token() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Delete, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Delete, "/api/v1/me/tokens");
 
     // Create one user with a token and sign in with a different user
     let (user1, token, user2);
@@ -316,7 +316,7 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 
     // Try revoke the token as second user
     {
-        req.with_path(&format!("/me/tokens/{}", token.id));
+        req.with_path(&format!("/api/v1/me/tokens/{}", token.id));
 
         let mut response = ok_resp!(middle.call(&mut req));
         ::json::<RevokedResponse>(&mut response);
@@ -334,7 +334,7 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 #[test]
 fn revoke_token_success() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Delete, "/me/tokens");
+    let mut req = ::req(app.clone(), Method::Delete, "/api/v1/me/tokens");
 
     let (user, token);
     {
@@ -354,7 +354,7 @@ fn revoke_token_success() {
 
     // Revoke the token
     {
-        req.with_path(&format!("/me/tokens/{}", token.id));
+        req.with_path(&format!("/api/v1/me/tokens/{}", token.id));
 
         let mut response = ok_resp!(middle.call(&mut req));
         ::json::<RevokedResponse>(&mut response);
@@ -371,7 +371,7 @@ fn revoke_token_success() {
 #[test]
 fn token_gives_access_to_me() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
 
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
@@ -393,7 +393,7 @@ fn token_gives_access_to_me() {
 #[test]
 fn using_token_updates_last_used_at() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
 
@@ -422,7 +422,7 @@ fn using_token_updates_last_used_at() {
 #[test]
 fn deleted_token_does_not_give_access_to_me() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
 
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -41,7 +41,7 @@ fn access_token_needs_data() {
 #[test]
 fn me() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
 
@@ -129,7 +129,9 @@ fn following() {
     }
 
     let mut response = ok_resp!(middle.call(
-        req.with_path("/me/updates").with_method(Method::Get),
+        req.with_path("/api/v1/me/updates").with_method(
+            Method::Get,
+        ),
     ));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.versions.len(), 0);
@@ -149,7 +151,9 @@ fn following() {
     );
 
     let mut response = ok_resp!(middle.call(
-        req.with_path("/me/updates").with_method(Method::Get),
+        req.with_path("/api/v1/me/updates").with_method(
+            Method::Get,
+        ),
     ));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.versions.len(), 2);
@@ -157,7 +161,7 @@ fn following() {
 
     let mut response = ok_resp!(
         middle.call(
-            req.with_path("/me/updates")
+            req.with_path("/api/v1/me/updates")
                 .with_method(Method::Get)
                 .with_query("per_page=1"),
         )
@@ -174,7 +178,7 @@ fn following() {
     );
     let mut response = ok_resp!(
         middle.call(
-            req.with_path("/me/updates")
+            req.with_path("/api/v1/me/updates")
                 .with_method(Method::Get)
                 .with_query("page=2&per_page=1"),
         )
@@ -290,7 +294,7 @@ fn test_github_login_does_not_overwrite_email() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = NewUser {
@@ -303,7 +307,9 @@ fn test_github_login_does_not_overwrite_email() {
         user
     };
 
-    let mut response = ok_resp!(middle.call(req.with_path("/me").with_method(Method::Get)));
+    let mut response = ok_resp!(middle.call(
+        req.with_path("/api/v1/me").with_method(Method::Get),
+    ));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email, None);
     assert_eq!(r.user.login, "apricot");
@@ -331,7 +337,9 @@ fn test_github_login_does_not_overwrite_email() {
         ::sign_in_as(&mut req, &user);
     }
 
-    let mut response = ok_resp!(middle.call(req.with_path("/me").with_method(Method::Get)));
+    let mut response = ok_resp!(middle.call(
+        req.with_path("/api/v1/me").with_method(Method::Get),
+    ));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "apricot@apricots.apricot");
     assert_eq!(r.user.login, "apricot");
@@ -354,7 +362,7 @@ fn test_email_get_and_put() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = ::new_user("mango").create_or_update(&conn).unwrap();
@@ -362,7 +370,9 @@ fn test_email_get_and_put() {
         user
     };
 
-    let mut response = ok_resp!(middle.call(req.with_path("/me").with_method(Method::Get)));
+    let mut response = ok_resp!(middle.call(
+        req.with_path("/api/v1/me").with_method(Method::Get),
+    ));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email, None);
     assert_eq!(r.user.login, "mango");
@@ -377,7 +387,9 @@ fn test_email_get_and_put() {
     );
     assert!(::json::<S>(&mut response).ok);
 
-    let mut response = ok_resp!(middle.call(req.with_path("/me").with_method(Method::Get)));
+    let mut response = ok_resp!(middle.call(
+        req.with_path("/api/v1/me").with_method(Method::Get),
+    ));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "mango@mangos.mango");
     assert_eq!(r.user.login, "mango");
@@ -396,7 +408,7 @@ fn test_email_get_and_put() {
 #[test]
 fn test_empty_email_not_added() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = ::new_user("papaya").create_or_update(&conn).unwrap();
@@ -446,7 +458,7 @@ fn test_empty_email_not_added() {
 #[test]
 fn test_this_user_cannot_change_that_user_email() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
 
     let not_signed_in_user = {
         let conn = app.diesel_database.get().unwrap();


### PR DESCRIPTION
For consistency, to avoid the clash with the frontend /me route that
caused problems with staying logged in, to make it clear that these
routes are part of the public HTTP API provided by crates.io, and to
let us evolve these routes in the future.

This would make me feel comfortable about adding a cargo command that uses the info from the backend me route (see #1012).

We could do this more conservatively by leaving the old routes here and only adding the new routes... but we haven't made any guarantees about the stability of these routes, so...

See discussion: https://github.com/rust-lang/crates.io/pull/910#issuecomment-318250109

@jtgeibel wdyt?