### PR TITLE
Remove explicit use of PgConnection as this is now in the prelude

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,6 @@ extern crate diesel;
 extern crate dotenv;
 
 use diesel::migrations::run_pending_migrations;
-use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use dotenv::dotenv;
 use std::env;

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -1,7 +1,7 @@
 use krate::Crate;
 use schema::badges;
 
-use diesel::pg::{Pg, PgConnection};
+use diesel::pg::Pg;
 use diesel::prelude::*;
 use serde_json;
 use std::collections::HashMap;

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -12,7 +12,6 @@ extern crate diesel;
 extern crate time;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use std::env;
 use std::io;
 use std::io::prelude::*;

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -13,7 +13,6 @@ extern crate time;
 extern crate semver;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use std::env;
 use std::io;
 use std::io::prelude::*;

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -15,7 +15,6 @@ extern crate diesel_codegen;
 extern crate rand;
 
 use chrono::{Utc, NaiveDate, Duration};
-use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use rand::{StdRng, Rng};
 use std::env;

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -10,7 +10,6 @@ extern crate diesel;
 extern crate semver;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use std::env;
 use std::io;
 use std::io::prelude::*;

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -12,7 +12,6 @@ extern crate time;
 
 use chrono::NaiveDate;
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use diesel::pg::upsert::*;
 use std::env;
 use std::time::Duration;

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -3,7 +3,6 @@
 
 use diesel;
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use toml;
 
 use db;

--- a/src/category.rs
+++ b/src/category.rs
@@ -3,7 +3,6 @@ use time::Timespec;
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use diesel::*;
-use diesel::pg::PgConnection;
 
 use Crate;
 use db::RequestTransaction;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,7 @@
 use std::env;
 
 use conduit::Request;
-use diesel::pg::PgConnection;
-use diesel::prelude::ConnectionResult;
+use diesel::prelude::{PgConnection, ConnectionResult};
 use r2d2;
 use r2d2_diesel::{self, ConnectionManager};
 use url::Url;

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel::pg::{Pg, PgConnection};
+use diesel::pg::Pg;
 use diesel::types::{Integer, Text};
 use semver;
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,7 +1,6 @@
 use chrono::NaiveDate;
 use diesel;
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 
 use schema::version_downloads;
 use version::Version;

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -3,7 +3,6 @@ use time::Timespec;
 
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
-use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel;
 

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -7,7 +7,7 @@ use conduit_router::RequestParams;
 use diesel::associations::Identifiable;
 use diesel::helper_types::Select;
 use diesel::pg::upsert::*;
-use diesel::pg::{Pg, PgConnection};
+use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel;
 use diesel_full_text_search::*;

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -1,5 +1,4 @@
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 
 use app::App;
 use http;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -41,7 +41,6 @@ use cargo_registry::user::AuthenticationSource;
 use cargo_registry::{User, Crate, Version, Dependency, Replica};
 use conduit::{Request, Method};
 use conduit_test::MockRequest;
-use diesel::pg::PgConnection;
 use diesel::prelude::*;
 use diesel::pg::upsert::*;
 use cargo_registry::schema::*;

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -1,6 +1,5 @@
 use cargo_registry::schema::categories;
 use diesel::*;
-use diesel::pg::PgConnection;
 use dotenv::dotenv;
 
 use std::env;

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,6 +1,5 @@
 use diesel;
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use conduit::{Request, Response};
 use time::Timespec;
 use conduit_router::RequestParams;

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -2,7 +2,6 @@ use conduit::{Request, Response};
 use conduit_cookie::RequestSession;
 use conduit_router::RequestParams;
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
 use rand::{thread_rng, Rng};
 use std::borrow::Cow;
 use serde_json;

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use diesel;
-use diesel::pg::{Pg, PgConnection};
+use diesel::pg::Pg;
 use diesel::pg::upsert::*;
 use diesel::prelude::*;
 use semver;


### PR DESCRIPTION
As of diesel 0.16.0 `diesel::pg::PgConnection` is now also exported
from `diesel::prelude`.