### PR TITLE
Add query to display recent_downloads on krates::show

### DIFF
--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -404,6 +404,8 @@ fn show() {
             .version(::VersionBuilder::new("0.5.0"))
             .version(::VersionBuilder::new("0.5.1"))
             .keyword("kw1")
+            .downloads(20)
+            .recent_downloads(10)
             .expect_build(&conn);
     }
 
@@ -415,6 +417,7 @@ fn show() {
     assert_eq!(json.krate.homepage, krate.homepage);
     assert_eq!(json.krate.documentation, krate.documentation);
     assert_eq!(json.krate.keywords, Some(vec!["kw1".into()]));
+    assert_eq!(json.krate.recent_downloads, Some(10));
     let versions = json.krate.versions.as_ref().unwrap();
     assert_eq!(versions.len(), 3);
     assert_eq!(json.versions.len(), 3);


### PR DESCRIPTION
Additionally, we've updated the join for this data on krate::index to
use the new public API Diesel added for this in the most recent version,
and made sure that any other endpoints which *don't* include this data
are returning NULL instead of 0

/cc @natboehm 