### PR TITLE
Don't list crates that teams/users used to own

### DIFF
--- a/src/krate.rs
+++ b/src/krate.rs
@@ -673,6 +673,7 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
                 crate_owners::table
                     .select(crate_owners::crate_id)
                     .filter(crate_owners::owner_id.eq(user_id))
+                    .filter(crate_owners::deleted.eq(false))
                     .filter(crate_owners::owner_kind.eq(OwnerKind::User as i32)),
             ),
         );
@@ -682,6 +683,7 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
                 crate_owners::table
                     .select(crate_owners::crate_id)
                     .filter(crate_owners::owner_id.eq(team_id))
+                    .filter(crate_owners::deleted.eq(false))
                     .filter(crate_owners::owner_kind.eq(OwnerKind::Team as i32)),
             ),
         );


### PR DESCRIPTION
I noticed that the cargo-canoe crate was still listed under my crates on /dashboard, even though alex changed all the ownership records except one to `deleted=true`. Turns out we didn't have that condition on here!

The new tests with the ownership records changed to deleted failed before these changes and pass after.