### PR TITLE
Add /policies page

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -44,6 +44,7 @@ Router.map(function() {
     this.route('category_slugs');
     this.route('catchAll', { path: '*path' });
     this.route('team', { path: '/teams/:team_id' });
+    this.route('policies');
 });
 
 export default Router;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -50,7 +50,7 @@
                 <li><a href='http://doc.crates.io/environment-variables.html'>Environment Variables</a></li>
                 <li><a href='http://doc.crates.io/source-replacement.html'>Source Replacement</a></li>
                 <li><a href='http://doc.crates.io/external-tools.html'>External Tools</a></li>
-                <li><a href='http://doc.crates.io/policies.html'>Policies</a></li>
+                <li>{{#link-to 'policies'}}Policies{{/link-to}}</li>
             {{/rl-dropdown}}
         {{/rl-dropdown-container}}
         <span class="sep">|</span>
@@ -123,5 +123,5 @@
     <span class="sep">|</span>
     <a href='mailto:help@crates.io'>Send us an email</a>
     <span class="sep">|</span>
-    <a href='http://doc.crates.io/policies.html'>Policies</a>
+    {{#link-to 'policies'}}Policies{{/link-to}}
 </div>

--- a/app/templates/policies.hbs
+++ b/app/templates/policies.hbs
@@ -1,0 +1,103 @@
+<div id='crates-heading'>
+    {{svg-jar 'circle-with-i'}}
+    <h1>Crates.io Package Policies</h1>
+</div>
+
+<p>
+In general, these policies are guidelines. Problems are often contextual, and
+exceptional circumstances sometimes require exceptional measures. We plan to
+continue to clarify and expand these rules over time as new circumstances
+arise. If your problem is not described below, consider <a
+href='mailto:help@crates.io'>sending us an email</a>.
+</p>
+
+<h2 id='package-ownership'><a href='#package-ownership'>Package Ownership</a></h2>
+
+<p>
+We have a first-come, first-served policy on crate names. Upon publishing a
+package, the publisher will be made owner of the package on Crates.io.
+</p>
+
+<p>
+If someone wants to take over a package, and the previous owner agrees, the
+existing maintainer can add them as an owner, and the new maintainer can remove
+them. If necessary, the team may reach out to inactive maintainers and help
+mediate the process of ownership transfer.
+</p>
+
+<h2 id='removal'><a href='#removal'>Removal</a></h2>
+
+<p>
+Many questions are specialized instances of a more general form: “Under what
+circumstances can a package be removed from Crates.io?”
+</p>
+
+<p>
+The short version is that packages are first-come, first-served, and we won’t
+attempt to get into policing what exactly makes a legitimate package. We will
+do what the law requires us to do, and address flagrant violations of the Rust
+Code of Conduct.
+</p>
+
+<h3 id='squatting'><a href='#squatting'>Squatting</a></h3>
+
+<p>
+We do not have any policies to define 'squatting', and so will not hand over
+ownership of a package for that reason.
+</p>
+
+<h3 id='the-law'><a href='#the-law'>The Law</a></h3>
+
+<p>
+For issues such as DMCA violations, trademark and copyright infringement,
+Crates.io will respect Mozilla Legal’s decisions with regards to content that
+is hosted.
+</p>
+
+<h3 id='code-of-conduct'><a href='#code-of-conduct'>Code of Conduct</a></h3>
+
+<p>
+The Rust project has a <a href='https://www.rust-lang.org/conduct.html'>Code
+of Conduct</a> which governs appropriate conduct for the Rust community. In
+general, any content on Crates.io that violates the Code of Conduct may be
+removed. Here, content can refer to but is not limited to:
+</p>
+
+<ul>
+    <li>Package Name</li>
+    <li>Package Metadata</li>
+    <li>Documentation</li>
+    <li>Code</li>
+</ul>
+
+<p>
+There are two important, related aspects:
+</p>
+
+<ul>
+    <li>
+    We will not be pro-actively monitoring the site for these kinds of
+    violations, but relying on the community to draw them to our attention.
+    </li>
+
+    <li>
+    “Does this violate the Code of Conduct” is a contextual question that
+    cannot be directly answered in the hypothetical sense. All of the details
+    must be taken into consideration in these kinds of situations.
+    </li>
+</ul>
+
+<h2 id='security'><a href='#security'>Security</a></h2>
+
+<p>
+Cargo and crates.io are projects that are governed by the Rust Programming
+Language Team. Safety is one of the core principles of Rust, and to that end,
+we would like to ensure that cargo and crates.io have secure implementations.
+To learn more about disclosing security vulnerabilities, please reference the
+<a href='https://www.rust-lang.org/security.html'>Rust Security policy</a> for
+more details.
+</p>
+
+<p>
+Thank you for taking the time to responsibly disclose any issues you find.
+</p>


### PR DESCRIPTION
Moving the "Crates.io Package Policies" page from
<http://doc.crates.io/policies.html>, which is hosted in `cargo` repo,
here, as this is a website-related content and not related to the
build-system.

First step for <https://github.com/rust-lang/crates.io/issues/1030>

Next step will be to redirect the old URL to this new page.