### PR TITLE
[header] Replace CARGO with crates.io

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,8 +12,8 @@
     {{/link-to}}
     {{#link-to "index"}}
       <h1>
-        CARGO
-        <span class="subtitle">packages for Rust</span>
+        crates.io
+        <span class="subtitle">Rust Package Registry</span>
       </h1>
     {{/link-to}}
 


### PR DESCRIPTION
As Cargo documentation is being moved to <doc.rust-lang.org>, and to
emphasis the difference between `crates.io` and `cargo`, we better not
title the website as *CARGO* anymore.

This is a quick fix for this, until we redirect `docs.crates.io`
completely and fix the menus and links here.

See <https://github.com/rust-lang/crates.io/issues/1031>