### PR TITLE
Redirect /install to doc.crates.io

### DIFF
--- a/app/routes/install.js
+++ b/app/routes/install.js
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+    redirect() {
+        window.location = 'http://doc.crates.io/';
+    },
+});

--- a/app/templates/install.hbs
+++ b/app/templates/install.hbs
@@ -4,36 +4,5 @@
 </div>
 
 <p>
-Rust comes with Cargo by default, so the easiest way to get Cargo is to
-<a href='http://www.rust-lang.org/install.html'>install Rust</a> via
-the official binary installers.
+    Redirecting you to <code>http://doc.crates.io/</code>&#8230;
 </p>
-
-<h2>Only Cargo</h2>
-
-<p>
-    To install just Cargo, the current recommended installation method is
-    through the official nightly builds. Note that Cargo will also require that
-    <a href='http://www.rust-lang.org/'>Rust</a> is already installed on the
-    system.
-</p>
-
-<div id='install-downloads'>
-    <table>
-        <tr>
-            <td class='label'>Linux binaries (.tar.gz)</td>
-            <td><a href={{linux64}}>64-bit</a></td>
-            <td><a href={{linux32}}>32-bit</a></td>
-        </tr>
-        <tr>
-            <td class='label'>Mac binaries (.tar.gz)</td>
-            <td><a href={{mac64}}>64-bit</a></td>
-            <td><a href={{mac32}}>32-bit</a></td>
-        </tr>
-        <tr>
-            <td class='label'>Windows binaries (.tar.gz)</td>
-            <td><a href={{win64}}>64-bit</a></td>
-            <td><a href={{win32}}>32-bit</a></td>
-        </tr>
-    </table>
-</div>


### PR DESCRIPTION
The content of the `install` page here is duplicate of `cargo`'s
*Installation* page/section. Since it's not *registry*-specific feature,
we better just redirect to the original source.

The content of the page is already merged into <http://doc.crates.io/>
and is live.

See <https://github.com/rust-lang/crates.io/issues/1029>