### PR TITLE
Display doc comments for private types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ doctest = false
 name = "all"
 path = "src/tests/all.rs"
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--no-defaults --passes collapse-docs --passes unindent-comments"] 
+
 [dependencies]
 cargo-registry-s3 = { path = "src/s3", version = "0.1.0" }
 rand = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 name = "all"
 path = "src/tests/all.rs"
 
-[package.metadata.docs.rs]
+[project.metadata.docs.rs]
 rustdoc-args = ["--no-defaults --passes collapse-docs --passes unindent-comments"] 
 
 [dependencies]


### PR DESCRIPTION
Fixes #911

- Adds a [package.metadata.docs.rs] to Cargo.toml
- Sets the rustdoc-args key to [ "--no-defaults --passes collapse-docs --passes unindent-comments" ]