### PR TITLE
[styles] Make header subtitle fit in one line

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -330,7 +330,7 @@ ul.dropdown {
 h1 {
   span.subtitle {
     display: block;
-    font-size: small;
+    font-size: x-small;
   }
 }
 


### PR DESCRIPTION
After shipping the update to header title/subtitle and testing it with
logged-in user, the subtitle was broken into two lines, breaking the
layout. Making the subtitle a bit smaller fixes the problem.

See <https://github.com/rust-lang/crates.io/issues/1031>