### PR TITLE
Fix Wrong AppVeyor badge

### DIFF
--- a/app/components/badge-appveyor.js
+++ b/app/components/badge-appveyor.js
@@ -12,7 +12,7 @@ export default Component.extend({
     imageUrl: computed('badge.attributes.id', function() {
         let id = this.get('badge.attributes.id');
         let branch = this.get('branch');
-        if (id === undefined || id === null) {
+        if (id !== undefined || id !== null) {
             return `https://ci.appveyor.com/api/projects/status/${id}/branch/${branch}?svg=true`;
         } else {
             let service = this.get('service');

--- a/app/components/badge-appveyor.js
+++ b/app/components/badge-appveyor.js
@@ -6,7 +6,21 @@ export default Component.extend({
     tagName: 'span',
     classNames: ['badge'],
 
+    id: alias('badge.attributes.id'),
     repository: alias('badge.attributes.repository'),
+
+    imageUrl: computed('badge.attributes.id', function() {
+        let id = this.get('badge.attributes.id');
+        let branch = this.get('branch');
+        if (id === undefined || id === null) {
+            return `https://ci.appveyor.com/api/projects/status/${id}/branch/${branch}?svg=true`;
+        } else {
+            let service = this.get('service');
+            let repository = this.get('repository');
+
+            return `https://ci.appveyor.com/api/projects/status/${service}/${repository}?svg=true&branch=${branch}`;
+        }
+    }),
 
     branch: computed('badge.attributes.branch', function() {
         return this.get('badge.attributes.branch') || 'master';

--- a/app/components/badge-appveyor.js
+++ b/app/components/badge-appveyor.js
@@ -12,7 +12,7 @@ export default Component.extend({
     imageUrl: computed('badge.attributes.id', function() {
         let id = this.get('badge.attributes.id');
         let branch = this.get('branch');
-        if (id !== undefined || id !== null) {
+        if (id !== undefined && id !== null) {
             return `https://ci.appveyor.com/api/projects/status/${id}/branch/${branch}?svg=true`;
         } else {
             let service = this.get('service');

--- a/app/templates/components/badge-appveyor.hbs
+++ b/app/templates/components/badge-appveyor.hbs
@@ -1,6 +1,6 @@
 <a href="https://ci.appveyor.com/project/{{ repository }}">
     <img
-        src="https://ci.appveyor.com/api/projects/status/{{ service }}/{{ repository }}?svg=true&branch={{ branch }}"
+        src="{{ imageUrl }}"
         alt="{{ text }}"
         width="106"
         height="20"

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -15,6 +15,7 @@ pub enum Badge {
     },
     Appveyor {
         repository: String,
+        id: Option<String>,
         branch: Option<String>,
         service: Option<String>,
     },

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -37,6 +37,7 @@ fn set_up() -> (Arc<App>, Crate, BadgeRef) {
 
     let appveyor = Badge::Appveyor {
         service: Some(String::from("github")),
+        id: None,
         branch: None,
         repository: String::from("rust-lang/cargo"),
     };


### PR DESCRIPTION
this is part of fixing issue #693

- [x] Add an id field with type Option<String> to the Appveyor badge enum variant

- [x]  Add id: alias('badge.attributes.id') to the appveyor badge component

- [x]  Add an image-url attribute, computed from the id to the appveyor badge component that checks to see if id is defined. (I've used `imageUrl` as attribute)

- [x]  Change the appveyor badge template to use the image-url attribute for the img src instead

- [x]  Publish a crate to your local instance that has the URLs dtolnay has listed for serde and manually verify the badge is displayed correctly.

- [x]  Send a pull request to cargo to update the badge documentation to indicate you can specify the appveyor project id if you want to use that instead. (_https://github.com/rust-lang/cargo/pull/4489_)