### PR TITLE
Make the page wider to give more room for README on desktop

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -35,7 +35,7 @@ body {
 
 .ember-application > div {
     width: 960px;
-    @media only screen and (max-width: 900px) {
+    @media only screen and (max-width: 960px) {
         width: 100%;
     }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -34,7 +34,7 @@ body {
 }
 
 .ember-application > div {
-    width: 900px;
+    width: 960px;
     @media only screen and (max-width: 900px) {
         width: 100%;
     }

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -208,7 +208,7 @@
         .docs {
             @include flex(7);
             padding-right: 40px;
-            max-width: 600px;
+            max-width: 640px;
         }
         .authorship {
             @include flex(3);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/crates.io/issues/970

**Summary**
This is my first PR to this repo, but I saw the Issue above and thought I'd try and tackle it since it's fairly minimal, but is a nice change to help with readability. This is a suggestion to widen the width of the main div to 960px so that the `.crate-info .docs` div can be increased a bit without having to decrease the size of the `.crate-info .authorship` div.

**Reasoning**
I mainly chose 960px since it's a fairly widely accepted standard for content of this type. This allows the documentation to be 640px, which increases the line-length of the `pre` elements to 65 to help minimize horizontal scrolling.

**Before/After**
![screenflow](https://user-images.githubusercontent.com/13207348/30617484-440b40ee-9d64-11e7-9d8a-9c0c9e74a4ac.gif)

**Other Changes**
I also changed the responsive screen width option to match the 960px width. The only major side effect here is the authorship div gets a little narrow until it switches to 100% at 900px, but that was already happening at 1040px and it's still readable. The other option is to leave it at 960px and just let the whole page horizontally scroll from 900-960px.

_Example of the narrow authorship div @ 915px_
![image](https://user-images.githubusercontent.com/13207348/30618133-17211a2e-9d67-11e7-9cef-ac13b2b8306a.png)

**Docs Updates**
If the team wants to accept this change, for the docs to be consistent, [this line](https://github.com/rust-lang/cargo/blob/73eb8c424dc3732cea23769982d0e4e261d5399e/stylesheets/all.css#L6) in the [GitHub pages branch](https://github.com/rust-lang/cargo/tree/gh-pages) of the Cargo repo will also need to be updated.

I saw there were some discussions about a much bigger redesign, but I thought this may help in the interim since it's a fairly minimal change. I'm open to any feedback! 😄 