### PR TITLE
Disable prototype extensions

### DIFF
--- a/app/helpers/format-email.js
+++ b/app/helpers/format-email.js
@@ -1,4 +1,5 @@
 import { helper } from '@ember/component/helper';
+import { htmlSafe } from '@ember/string';
 import Ember from 'ember';
 
 const escape = Ember.Handlebars.Utils.escapeExpression;
@@ -13,7 +14,7 @@ export function formatEmail(email) {
         ret = `<a href='mailto:${escape(formatted[2])}'>${ret}</a>`;
     }
 
-    return ret.htmlSafe();
+    return htmlSafe(ret);
 }
 
 export default helper(params => formatEmail(params[0]));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4965,6 +4965,12 @@
         }
       }
     },
+    "ember-disable-prototype-extensions": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz",
+      "integrity": "sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=",
+      "dev": true
+    },
     "ember-export-application-global": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-cli-sri": "2.1.1",
     "ember-cli-uglify": "1.2.0",
     "ember-data": "~2.12.1",
+    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",


### PR DESCRIPTION
Prototype extensions are unfortunately not supported by fastboot so we will need to disable them to prepare for server-side rendering.

(see https://github.com/ember-fastboot/ember-cli-fastboot#prototype-extensions)