### PR TITLE
Cleanup of the `users` module

### DIFF
--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -741,11 +741,9 @@ fn test_existing_user_email() {
             .get_result::<User>(&*conn)
             .unwrap();
 
-        println!("{:?}", user);
-
         let email = NewEmail {
             user_id: user.id,
-            email: String::from("potahto@example.com"),
+            email: "potahto@example.com",
             verified: false,
         };
 

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -616,7 +616,7 @@ pub fn update_user(req: &mut Request) -> CargoResult<Response> {
             .into(emails::table)
             .returning(emails::id)
             .get_result(&*conn)
-            .map_err(|_| human("Error in creating token"))?;
+            .map_err(|_| human("Error in updating email"))?;
         let token = NewToken::regenerate(email_id, &conn)?;
 
         send_user_confirm_email(user_email, &user.gh_login, &token)


### PR DESCRIPTION
This commit has various cleanup of functions involving `NewToken` and
`NewEmail` in the users module. In particular, the following changes
were made:

- Use the database as the source of truth when possible
- Run non-atomic operations in a transaction
- Avoid extra allocations
- Clean up some oddly structured code