### PR TITLE
Fixes errors on "not found" pages

### DIFF
--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -6,7 +6,7 @@ export default Route.extend({
 
     model(params) {
         return this.store.find('category', params.category_id).catch(e => {
-            if (e.errors.any(e => e.detail === 'Not Found')) {
+            if (e.errors.some(e => e.detail === 'Not Found')) {
                 this.get('flashMessages').show(`Category '${params.category_id}' does not exist`);
             }
         });

--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -7,7 +7,8 @@ export default Route.extend({
     model(params) {
         return this.store.find('category', params.category_id).catch(e => {
             if (e.errors.some(e => e.detail === 'Not Found')) {
-                this.get('flashMessages').show(`Category '${params.category_id}' does not exist`);
+                this.get('flashMessages').queue(`Category '${params.category_id}' does not exist`);
+                return this.replaceWith('index');
             }
         });
     }

--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -6,7 +6,7 @@ export default Route.extend({
 
     model(params) {
         return this.store.find('crate', params.crate_id).catch(e => {
-            if (e.errors.any(e => e.detail === 'Not Found')) {
+            if (e.errors.some(e => e.detail === 'Not Found')) {
                 this.get('flashMessages').show(`Crate '${params.crate_id}' does not exist`);
                 return;
             }

--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -7,7 +7,8 @@ export default Route.extend({
     model({ keyword_id }) {
         return this.store.find('keyword', keyword_id).catch(e => {
             if (e.errors.some(e => e.detail === 'Not Found')) {
-                this.get('flashMessages').show(`Keyword '${keyword_id}' does not exist`);
+                this.get('flashMessages').queue(`Keyword '${keyword_id}' does not exist`);
+                return this.replaceWith('index');
             }
         });
     }

--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -6,7 +6,7 @@ export default Route.extend({
 
     model({ keyword_id }) {
         return this.store.find('keyword', keyword_id).catch(e => {
-            if (e.errors.any(e => e.detail === 'Not Found')) {
+            if (e.errors.some(e => e.detail === 'Not Found')) {
                 this.get('flashMessages').show(`Keyword '${keyword_id}' does not exist`);
             }
         });

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -31,7 +31,7 @@ export default Route.extend({
             },
             (e) => {
                 if (e.errors.some(e => e.detail === 'Not Found')) {
-                    this.get('flashMessages').queue(`User '${params.team_id}' does not exist`);
+                    this.get('flashMessages').queue(`Team '${params.team_id}' does not exist`);
                     return this.replaceWith('index');
                 }
             }

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -30,7 +30,7 @@ export default Route.extend({
                 });
             },
             (e) => {
-                if (e.errors.any(e => e.detail === 'Not Found')) {
+                if (e.errors.some(e => e.detail === 'Not Found')) {
                     this.get('flashMessages').queue(`User '${params.team_id}' does not exist`);
                     return this.replaceWith('index');
                 }

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -23,7 +23,7 @@ export default Route.extend({
                 });
             },
             (e) => {
-                if (e.errors.any(e => e.detail === 'Not Found')) {
+                if (e.errors.some(e => e.detail === 'Not Found')) {
                     this.get('flashMessages').queue(`User '${params.user_id}' does not exist`);
                     return this.replaceWith('index');
                 }


### PR DESCRIPTION
Turns out when we were checking for crate/category/etc not being found, we were using `any` from the ember prototype extensions. This PR changes those spots to use `some` instead, and cleans up a few other inconsistencies I noticed.

I tried to write tests for "not found" pages, but that's proving to be a bit more.... interesting... so I decided to open this up to fix production first.

r? @Turbo87 