### PR TITLE
Various minor cleanup of the `token` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde_json = "1.0.0"
 serde_derive = "1.0.0"
 serde = "1.0.0"
 clippy = { version = "=0.0.142", optional = true }
-chrono = "0.4.0"
+chrono = { version = "0.4.0", features = ["serde"] }
 comrak = { version = "0.1.9", default-features = false }
 ammonia = "0.7.0"
 docopt = "0.8.1"


### PR DESCRIPTION
- Inlined functions which were only used once
  - In the case of `find_for_user`, I think that the order should be
    close to where it is relevant.
  - In the case of `delete`, the only test that was calling it was
    literally testing "a deleted row is deleted", which is not needed.
    There are tests for the `revoke` endpoint
  - The direct usage of Diesel is not meaningfully more verbose than
    these functions were
- Removed `EncodableApiToken`, moved the `#[derive(Deserialize)]` struct
  to tests