### PR TITLE
Remove the `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,6 @@ dependencies = [
  "serde_derive 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -508,7 +507,6 @@ dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ rustdoc-args = [
 [dependencies]
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 rand = "0.3"
-time = "0.1"
 git2 = "0.6.4"
 flate2 = "0.2"
 semver = "0.5"
@@ -46,7 +45,7 @@ hex = "0.2"
 license-exprs = "^1.3"
 dotenv = "0.10.0"
 toml = "0.4"
-diesel = { version = "0.16.0", features = ["postgres", "serde_json", "deprecated-time", "chrono"] }
+diesel = { version = "0.16.0", features = ["postgres", "serde_json", "chrono"] }
 diesel_codegen = "0.16.0"
 r2d2-diesel = "0.16.0"
 diesel_full_text_search = "0.16.0"

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -16,7 +16,6 @@ extern crate docopt;
 extern crate flate2;
 extern crate itertools;
 extern crate tar;
-extern crate time;
 extern crate toml;
 extern crate url;
 
@@ -180,7 +179,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
         Some(l) => l,
         None => return None,
     };
-    let date = time::now().rfc822z().to_string();
+    let date = Utc::now().to_rfc2822();
     let url = Url::parse(&location).expect(&format!(
         "[{}-{}] Couldn't parse crate URL",
         krate_name,

--- a/src/category.rs
+++ b/src/category.rs
@@ -1,5 +1,4 @@
-use time::Timespec;
-
+use chrono::NaiveDateTime;
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use diesel::*;
@@ -17,7 +16,7 @@ pub struct Category {
     pub slug: String,
     pub description: String,
     pub crates_cnt: i32,
-    pub created_at: Timespec,
+    pub created_at: NaiveDateTime,
 }
 
 #[derive(Associations, Insertable, Identifiable, Debug, Clone, Copy)]
@@ -36,7 +35,7 @@ pub struct EncodableCategory {
     pub category: String,
     pub slug: String,
     pub description: String,
-    pub created_at: String,
+    pub created_at: NaiveDateTime,
     pub crates_cnt: i32,
 }
 
@@ -46,7 +45,7 @@ pub struct EncodableCategoryWithSubcategories {
     pub category: String,
     pub slug: String,
     pub description: String,
-    pub created_at: String,
+    pub created_at: NaiveDateTime,
     pub crates_cnt: i32,
     pub subcategories: Vec<EncodableCategory>,
 }
@@ -65,7 +64,7 @@ impl Category {
             id: slug.clone(),
             slug: slug.clone(),
             description: description.clone(),
-            created_at: ::encode_time(created_at),
+            created_at: created_at,
             crates_cnt: crates_cnt,
             category: category,
         }
@@ -148,7 +147,7 @@ impl Category {
         use diesel::expression::dsl::*;
         use diesel::types::Text;
 
-        sql(
+        sql::<categories::SqlType>(
             "SELECT c.id, c.category, c.slug, c.description, \
              COALESCE (( \
              SELECT sum(c2.crates_cnt)::int \

--- a/src/crate_owner_invitation.rs
+++ b/src/crate_owner_invitation.rs
@@ -1,6 +1,6 @@
+use chrono::NaiveDateTime;
 use conduit::{Request, Response};
 use diesel::prelude::*;
-use time::Timespec;
 use serde_json;
 
 use db::RequestTransaction;
@@ -17,7 +17,7 @@ pub struct CrateOwnerInvitation {
     pub invited_user_id: i32,
     pub invited_by_user_id: i32,
     pub crate_id: i32,
-    pub created_at: Timespec,
+    pub created_at: NaiveDateTime,
 }
 
 #[derive(Insertable, Clone, Copy, Debug)]
@@ -50,7 +50,7 @@ impl CrateOwnerInvitation {
             invited_by_username: self.invited_by_username(conn),
             crate_name: self.crate_name(conn),
             crate_id: self.crate_id,
-            created_at: ::encode_time(self.created_at),
+            created_at: self.created_at,
         }
     }
 }
@@ -61,7 +61,7 @@ pub struct EncodableCrateOwnerInvitation {
     pub invited_by_username: String,
     pub crate_name: String,
     pub crate_id: i32,
-    pub created_at: String,
+    pub created_at: NaiveDateTime,
 }
 
 /// Handles the `GET /me/crate_owner_invitations` route.

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -1,6 +1,6 @@
 use std::ascii::AsciiExt;
-use time::Timespec;
 
+use chrono::NaiveDateTime;
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use diesel::prelude::*;
@@ -17,7 +17,7 @@ pub struct Keyword {
     pub id: i32,
     pub keyword: String,
     pub crates_cnt: i32,
-    pub created_at: Timespec,
+    pub created_at: NaiveDateTime,
 }
 
 #[derive(Associations, Insertable, Identifiable, Debug, Clone, Copy)]
@@ -34,7 +34,7 @@ pub struct CrateKeyword {
 pub struct EncodableKeyword {
     pub id: String,
     pub keyword: String,
-    pub created_at: String,
+    pub created_at: NaiveDateTime,
     pub crates_cnt: i32,
 }
 
@@ -92,7 +92,7 @@ impl Keyword {
         } = self;
         EncodableKeyword {
             id: keyword.clone(),
-            created_at: ::encode_time(created_at),
+            created_at: created_at,
             crates_cnt: crates_cnt,
             keyword: keyword,
         }

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -2,6 +2,7 @@ use std::ascii::AsciiExt;
 use std::cmp;
 use std::collections::HashMap;
 
+use chrono::{NaiveDate, NaiveDateTime};
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use diesel::associations::Identifiable;
@@ -15,9 +16,7 @@ use license_exprs;
 use hex::ToHex;
 use serde_json;
 use semver;
-use time::Timespec;
 use url::Url;
-use chrono::NaiveDate;
 
 use app::{App, RequestApp};
 use badge::EncodableBadge;
@@ -56,8 +55,8 @@ pub struct CrateDownload {
 pub struct Crate {
     pub id: i32,
     pub name: String,
-    pub updated_at: Timespec,
-    pub created_at: Timespec,
+    pub updated_at: NaiveDateTime,
+    pub created_at: NaiveDateTime,
     pub downloads: i32,
     pub description: Option<String>,
     pub homepage: Option<String>,
@@ -108,12 +107,12 @@ type CrateQuery<'a> = crates::BoxedQuery<'a, Pg, <AllColumns as Expression>::Sql
 pub struct EncodableCrate {
     pub id: String,
     pub name: String,
-    pub updated_at: String,
+    pub updated_at: NaiveDateTime,
     pub versions: Option<Vec<i32>>,
     pub keywords: Option<Vec<String>>,
     pub categories: Option<Vec<String>>,
     pub badges: Option<Vec<EncodableBadge>>,
-    pub created_at: String,
+    pub created_at: NaiveDateTime,
     pub downloads: i32,
     pub recent_downloads: Option<i64>,
     pub max_version: String,
@@ -370,8 +369,8 @@ impl Crate {
         EncodableCrate {
             id: name.clone(),
             name: name.clone(),
-            updated_at: ::encode_time(updated_at),
-            created_at: ::encode_time(created_at),
+            updated_at: updated_at,
+            created_at: created_at,
             downloads: downloads,
             recent_downloads: recent_downloads,
             versions: versions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 extern crate tar;
-extern crate time;
 extern crate toml;
 extern crate url;
 
@@ -296,18 +295,6 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
             })
         }
     }
-}
-
-/// Convenience function for getting the current server time in UTC.
-pub fn now() -> time::Timespec {
-    time::now_utc().to_timespec()
-}
-
-/// Convenience function for getting a time in RFC 3339 format.
-///
-/// Example: `2012-02-22T14:53:18Z`. Used for returning time values in JSON API responses.
-pub fn encode_time(ts: time::Timespec) -> String {
-    time::at_utc(ts).rfc3339().to_string()
 }
 
 /// Convenience function requiring that an environment variable is set.

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -20,7 +20,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
 extern crate tar;
-extern crate time;
 extern crate url;
 
 use std::borrow::Cow;
@@ -41,6 +40,7 @@ use cargo_registry::owner::{CrateOwner, NewTeam, Team};
 use cargo_registry::version::NewVersion;
 use cargo_registry::user::AuthenticationSource;
 use cargo_registry::{Crate, Dependency, Replica, User, Version};
+use chrono::Utc;
 use conduit::{Method, Request};
 use conduit_test::MockRequest;
 use diesel::prelude::*;
@@ -412,7 +412,7 @@ impl<'a> CrateBuilder<'a> {
         // crate properties in a single DB call.
 
         let old_downloads = self.downloads.unwrap_or(0) - self.recent_downloads.unwrap_or(0);
-        let now = chrono::Utc::now();
+        let now = Utc::now();
         let old_date = now.naive_utc().date() - chrono::Duration::days(91);
 
         if let Some(downloads) = self.downloads {
@@ -473,8 +473,8 @@ fn krate(name: &str) -> Crate {
     cargo_registry::krate::Crate {
         id: NEXT_ID.fetch_add(1, Ordering::SeqCst) as i32,
         name: name.to_string(),
-        updated_at: time::now().to_timespec(),
-        created_at: time::now().to_timespec(),
+        updated_at: Utc::now().naive_utc(),
+        created_at: Utc::now().naive_utc(),
         downloads: 10,
         documentation: None,
         homepage: None,

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -984,7 +984,7 @@ fn summary_doesnt_die() {
 
 #[test]
 fn download() {
-    use time::{now_utc, strftime, Duration};
+    use chrono::{Duration, Utc};
     let (_b, app, middle) = ::app();
     let mut req = ::req(
         app.clone(),
@@ -1023,27 +1023,27 @@ fn download() {
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 1);
 
-    let yesterday = now_utc() + Duration::days(-1);
+    let yesterday = Utc::today() + Duration::days(-1);
     req.with_path("/api/v1/crates/FOO_DOWNLOAD/1.0.0/downloads");
-    req.with_query(&("before_date=".to_string() + &strftime("%Y-%m-%d", &yesterday).unwrap()));
+    req.with_query(&format!("before_date={}", yesterday.format("%F")));
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 0);
     req.with_path("/api/v1/crates/FOO_DOWNLOAD/downloads");
-    req.with_query(&("before_date=".to_string() + &strftime("%Y-%m-%d", &yesterday).unwrap()));
+    req.with_query(&format!("before_date={}", yesterday.format("%F")));
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     // crate/downloads always returns the last 90 days and ignores date params
     assert_eq!(downloads.version_downloads.len(), 1);
 
-    let tomorrow = now_utc() + Duration::days(1);
+    let tomorrow = Utc::today() + Duration::days(1);
     req.with_path("/api/v1/crates/FOO_DOWNLOAD/1.0.0/downloads");
-    req.with_query(&("before_date=".to_string() + &strftime("%Y-%m-%d", &tomorrow).unwrap()));
+    req.with_query(&format!("before_date={}", tomorrow.format("%F")));
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 1);
     req.with_path("/api/v1/crates/FOO_DOWNLOAD/downloads");
-    req.with_query(&("before_date=".to_string() + &strftime("%Y-%m-%d", &tomorrow).unwrap()));
+    req.with_query(&format!("before_date={}", tomorrow.format("%F")));
     let mut resp = ok_resp!(middle.call(&mut req));
     let downloads = ::json::<Downloads>(&mut resp);
     assert_eq!(downloads.version_downloads.len(), 1);

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,8 +1,8 @@
-use diesel;
-use diesel::prelude::*;
 use chrono::NaiveDateTime;
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
+use diesel::prelude::*;
+use diesel;
 use serde_json as json;
 
 use db::RequestTransaction;

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -1,11 +1,12 @@
+use chrono::NaiveDateTime;
 use conduit::{Request, Response};
 use conduit_cookie::RequestSession;
 use conduit_router::RequestParams;
+use diesel::expression::now;
 use diesel::prelude::*;
 use rand::{thread_rng, Rng};
 use std::borrow::Cow;
 use serde_json;
-use time::Timespec;
 
 use app::RequestApp;
 use db::RequestTransaction;
@@ -69,7 +70,7 @@ pub struct Token {
     pub id: i32,
     pub email_id: i32,
     pub token: String,
-    pub created_at: Timespec,
+    pub created_at: NaiveDateTime,
 }
 
 #[derive(Debug, Insertable, AsChangeset)]
@@ -212,7 +213,6 @@ impl User {
     /// Queries the database for a user with a certain `api_token` value.
     pub fn find_by_api_token(conn: &PgConnection, token_: &str) -> CargoResult<User> {
         use diesel::update;
-        use diesel::expression::now;
         use schema::api_tokens::dsl::{api_tokens, last_used_at, token, user_id};
         use schema::users::dsl::{id, users};
         let user_id_ = update(api_tokens.filter(token.eq(token_)))


### PR DESCRIPTION
This replaces all remaining usage of the deprecated `time` crate with
the `chrono` crate instead.