### PR TITLE
Bump clippy & rustfmt to latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,11 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: stable
+  - rust: nightly-2017-09-20
     env: RUSTFMT=YESPLEASE
     script:
-    - cargo install --force rustfmt
+    - cargo install --force rustfmt-nightly --vers 0.2.7
+    - export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
     - rustfmt --version
     - cargo fmt -- --write-mode=diff
   - rust: stable
@@ -50,7 +51,7 @@ matrix:
     - cargo build
     - cargo test
     - npm test
-  - rust: nightly-2017-07-04
+  - rust: nightly-2017-09-20
     env: CLIPPY=YESPLEASE
     script:
     - cargo rustc --lib --features "lint" -- -Zno-trans

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
  "cargo-registry-s3 0.2.0",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.142 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.162 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -225,21 +225,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clippy"
-version = "0.0.142"
+version = "0.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.142 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.162 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.142"
+version = "0.0.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itertools 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -702,6 +703,11 @@ dependencies = [
 [[package]]
 name = "gcc"
 version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "getopts"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1173,6 +1179,15 @@ dependencies = [
 name = "precomputed-hash"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "quine-mc_cluskey"
@@ -1825,8 +1840,8 @@ dependencies = [
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6263e7af767a5bf9e4d3d0a6c3ceb5f3940ec85cf2fbfee59024b8a264be180f"
 "checksum civet-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "958d15372bf28b7983cb35e1d4bf36dd843b0d42e507c1c73aad7150372c5936"
-"checksum clippy 0.0.142 (registry+https://github.com/rust-lang/crates.io-index)" = "e82a66cfefcffef361a3ba150954563c5a1e151467e8bf4e28551f931200c7e3"
-"checksum clippy_lints 0.0.142 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f0b1f90db91953dd03b115148df31427f006cf6d8958fa7582c4f9f2037df5"
+"checksum clippy 0.0.162 (registry+https://github.com/rust-lang/crates.io-index)" = "fcdb42cab913b8eb5d390ba612400ec581813fb59af29afd39333d7a550f332c"
+"checksum clippy_lints 0.0.162 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c0da7936c88883ac09bc3b29584c275551eff961b2d0d87a22b60205088e55"
 "checksum cmake 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8a6541a55bcd72d3de4faee2d101a5a66df29790282c7f797082a7228a9b3d"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum comrak 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "8b2d07f7b7e1fd35e70300a9fc5397636650477887dc7b6ad6d29ba7d82e3349"
@@ -1878,6 +1893,7 @@ dependencies = [
 "checksum futures 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "05a23db7bd162d4e8265968602930c476f688f0c180b44bdaf55e0cb2c687558"
 "checksum futures-cpupool 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "77d49e7de8b91b20d6fda43eea906637eff18b96702eb6b2872df8bfab1ad2b5"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1c0203d653f4140241da0c1375a404f0a397249ec818cd2076c6280c50f6fa"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum html5ever 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba0806f17ce2ea657c67cd28d03941166638c05153fb644aac6d5156b3033d0"
@@ -1931,6 +1947,7 @@ dependencies = [
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dfb5e575ef93a1b7b2a381d47ba7c5d4e4f73bff37cee932195de769aad9a54"
 "checksum precomputed-hash 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf1fc3616b3ef726a847f2cd2388c646ef6a1f1ba4835c2629004da48184150"
+"checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2c8284508b38df440f8f3527395e23c4780b22f74226b270daf58fee38e4bcce"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ diesel_full_text_search = "0.16.0"
 serde_json = "1.0.0"
 serde_derive = "1.0.0"
 serde = "1.0.0"
-clippy = { version = "=0.0.142", optional = true }
+clippy = { version = "=0.0.162", optional = true }
 chrono = "0.4.0"
 comrak = { version = "0.1.9", default-features = false }
 ammonia = "0.7.0"

--- a/build.rs
+++ b/build.rs
@@ -13,9 +13,8 @@ fn main() {
     if env::var("PROFILE") == Ok("debug".into()) {
         let _ = dotenv();
         if let Ok(database_url) = env::var("TEST_DATABASE_URL") {
-            let connection = PgConnection::establish(&database_url).expect(
-                "Could not connect to TEST_DATABASE_URL",
-            );
+            let connection = PgConnection::establish(&database_url)
+                .expect("Could not connect to TEST_DATABASE_URL");
             run_pending_migrations(&connection).expect("Error running migrations");
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -120,7 +120,7 @@ impl AppMiddleware {
 
 impl Middleware for AppMiddleware {
     fn before(&self, req: &mut Request) -> Result<(), Box<Error + Send>> {
-        req.mut_extensions().insert(self.app.clone());
+        req.mut_extensions().insert(Arc::clone(&self.app));
         Ok(())
     }
 

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -80,7 +80,7 @@ impl Badge {
         krate: &Crate,
         badges: Option<&'a HashMap<String, HashMap<String, String>>>,
     ) -> QueryResult<Vec<&'a str>> {
-        use diesel::{insert, delete};
+        use diesel::{delete, insert};
 
         #[derive(Insertable, Debug)]
         #[table_name = "badges"]
@@ -111,8 +111,7 @@ impl Badge {
         }
 
         conn.transaction(|| {
-            delete(badges::table.filter(badges::crate_id.eq(krate.id)))
-                .execute(conn)?;
+            delete(badges::table.filter(badges::crate_id.eq(krate.id))).execute(conn)?;
             insert(&new_badges).into(badges::table).execute(conn)?;
             Ok(invalid_badges)
         })

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -14,9 +14,9 @@ extern crate diesel;
 extern crate diesel_codegen;
 extern crate rand;
 
-use chrono::{Utc, NaiveDate, Duration};
+use chrono::{Duration, NaiveDate, Utc};
 use diesel::prelude::*;
-use rand::{StdRng, Rng};
+use rand::{Rng, StdRng};
 use std::env;
 
 use cargo_registry::schema::version_downloads;
@@ -27,9 +27,9 @@ fn main() {
 }
 
 fn update(conn: &PgConnection) -> QueryResult<()> {
-    let ids = env::args().skip(1).filter_map(
-        |arg| arg.parse::<i32>().ok(),
-    );
+    let ids = env::args()
+        .skip(1)
+        .filter_map(|arg| arg.parse::<i32>().ok());
     for id in ids {
         let mut rng = StdRng::new().unwrap();
         let mut dls = rng.gen_range(5000i32, 10000);

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -21,7 +21,7 @@ extern crate toml;
 extern crate url;
 
 use curl::easy::{Easy, List};
-use chrono::{Utc, TimeZone};
+use chrono::{TimeZone, Utc};
 use diesel::prelude::*;
 use diesel::expression::any;
 use docopt::Docopt;
@@ -66,9 +66,8 @@ fn main() {
     let start_time = Utc::now();
 
     let older_than = if let Some(ref time) = args.flag_older_than {
-        Utc.datetime_from_str(&time, "%Y-%m-%d %H:%M:%S").expect(
-            "Could not parse --older-than argument as a time",
-        )
+        Utc.datetime_from_str(&time, "%Y-%m-%d %H:%M:%S")
+            .expect("Could not parse --older-than argument as a time")
     } else {
         start_time
     };
@@ -80,9 +79,11 @@ fn main() {
     let mut query = versions::table
         .inner_join(crates::table)
         .left_join(readme_rendering::table)
-        .filter(readme_rendering::rendered_at.lt(older_than).or(
-            readme_rendering::rendered_at.is_null(),
-        ))
+        .filter(
+            readme_rendering::rendered_at
+                .lt(older_than)
+                .or(readme_rendering::rendered_at.is_null()),
+        )
         .select(versions::id)
         .into_boxed();
 
@@ -91,9 +92,9 @@ fn main() {
         query = query.filter(crates::name.eq(crate_name));
     }
 
-    let version_ids = query.load::<(i32)>(&conn).expect(
-        "error loading version ids",
-    );
+    let version_ids = query
+        .load::<(i32)>(&conn)
+        .expect("error loading version ids");
 
     let total_versions = version_ids.len();
     println!("Rendering {} versions", total_versions);
@@ -107,12 +108,11 @@ fn main() {
         total_pages + 1
     };
 
-    for (page_num, version_ids_chunk) in
-        version_ids
-            .into_iter()
-            .chunks(page_size)
-            .into_iter()
-            .enumerate()
+    for (page_num, version_ids_chunk) in version_ids
+        .into_iter()
+        .chunks(page_size)
+        .into_iter()
+        .enumerate()
     {
         println!(
             "= Page {} of {} ==================================",
@@ -174,10 +174,10 @@ fn main() {
 /// Renders the readme of an uploaded crate version.
 fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<String> {
     let mut handle = Easy::new();
-    let location = match config.uploader.crate_location(
-        &krate_name,
-        &version.num.to_string(),
-    ) {
+    let location = match config
+        .uploader
+        .crate_location(&krate_name, &version.num.to_string())
+    {
         Some(l) => l,
         None => return None,
     };

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -2,8 +2,8 @@
 
 extern crate cargo_registry;
 extern crate civet;
-extern crate git2;
 extern crate env_logger;
+extern crate git2;
 
 use cargo_registry::{env, Env};
 use civet::Server;

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -73,9 +73,7 @@ fn transfer(conn: &PgConnection) {
         .filter(crate_owners::owner_id.eq(from.id))
         .filter(crate_owners::owner_kind.eq(OwnerKind::User as i32));
     let crates = Crate::all()
-        .filter(crates::id.eq_any(
-            crate_owners.select(crate_owners::crate_id),
-        ))
+        .filter(crates::id.eq_any(crate_owners.select(crate_owners::crate_id)))
         .load::<Crate>(conn)
         .unwrap();
 

--- a/src/categories.rs
+++ b/src/categories.rs
@@ -7,7 +7,7 @@ use toml;
 
 use db;
 use schema::categories;
-use util::errors::{CargoResult, ChainError, internal};
+use util::errors::{internal, CargoResult, ChainError};
 
 #[derive(Debug)]
 struct Category {
@@ -24,20 +24,16 @@ impl Category {
         parent: Option<&Category>,
     ) -> Category {
         match parent {
-            Some(parent) => {
-                Category {
-                    slug: format!("{}::{}", parent.slug, slug),
-                    name: format!("{}::{}", parent.name, name),
-                    description: description.into(),
-                }
-            }
-            None => {
-                Category {
-                    slug: slug.into(),
-                    name: name.into(),
-                    description: description.into(),
-                }
-            }
+            Some(parent) => Category {
+                slug: format!("{}::{}", parent.slug, slug),
+                name: format!("{}::{}", parent.name, name),
+                description: description.into(),
+            },
+            None => Category {
+                slug: slug.into(),
+                name: name.into(),
+                description: description.into(),
+            },
         }
     }
 }
@@ -126,9 +122,7 @@ pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<
         categories::slug,
         do_update().set((
             categories::category.eq(excluded(categories::category)),
-            categories::description.eq(
-                excluded(categories::description),
-            ),
+            categories::description.eq(excluded(categories::description)),
         )),
     );
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -7,7 +7,7 @@ use diesel::*;
 use Crate;
 use db::RequestTransaction;
 use schema::*;
-use util::{RequestUtils, CargoResult};
+use util::{CargoResult, RequestUtils};
 
 #[derive(Clone, Identifiable, Queryable, Debug)]
 #[table_name = "categories"]
@@ -150,15 +150,15 @@ impl Category {
 
         sql(
             "SELECT c.id, c.category, c.slug, c.description, \
-            COALESCE (( \
-                SELECT sum(c2.crates_cnt)::int \
-                FROM categories as c2 \
-                WHERE c2.slug = c.slug \
-                OR c2.slug LIKE c.slug || '::%' \
-            ), 0) as crates_cnt, c.created_at \
-            FROM categories as c \
-            WHERE c.category ILIKE $1 || '::%' \
-            AND c.category NOT ILIKE $1 || '::%::%'",
+             COALESCE (( \
+             SELECT sum(c2.crates_cnt)::int \
+             FROM categories as c2 \
+             WHERE c2.slug = c.slug \
+             OR c2.slug LIKE c.slug || '::%' \
+             ), 0) as crates_cnt, c.created_at \
+             FROM categories as c \
+             WHERE c.category ILIKE $1 || '::%' \
+             AND c.category NOT ILIKE $1 || '::%::%'",
         ).bind::<Text, _>(&self.category)
             .load(conn)
     }
@@ -240,7 +240,9 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
     struct R {
         category: EncodableCategoryWithSubcategories,
     }
-    Ok(req.json(&R { category: cat_with_subcats }))
+    Ok(req.json(&R {
+        category: cat_with_subcats,
+    }))
 }
 
 /// Handles the `GET /category_slugs` route.
@@ -261,7 +263,9 @@ pub fn slugs(req: &mut Request) -> CargoResult<Response> {
     struct R {
         category_slugs: Vec<Slug>,
     }
-    Ok(req.json(&R { category_slugs: slugs }))
+    Ok(req.json(&R {
+        category_slugs: slugs,
+    }))
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use s3;
 use std::env;
 use std::path::PathBuf;
 
-use {Env, env, Uploader, Replica};
+use {env, Env, Replica, Uploader};
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/src/crate_owner_invitation.rs
+++ b/src/crate_owner_invitation.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use time::Timespec;
 
 use db::RequestTransaction;
-use schema::{crate_owner_invitations, users, crates};
+use schema::{crate_owner_invitations, crates, users};
 use user::RequestUser;
 use util::errors::CargoResult;
 use util::RequestUtils;
@@ -78,5 +78,7 @@ pub fn list(req: &mut Request) -> CargoResult<Response> {
     struct R {
         crate_owner_invitations: Vec<EncodableCrateOwnerInvitation>,
     }
-    Ok(req.json(&R { crate_owner_invitations }))
+    Ok(req.json(&R {
+        crate_owner_invitations,
+    }))
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use conduit::Request;
-use diesel::prelude::{PgConnection, ConnectionResult};
+use diesel::prelude::{ConnectionResult, PgConnection};
 use r2d2;
 use r2d2_diesel::{self, ConnectionManager};
 use url::Url;

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -6,7 +6,7 @@ use semver;
 use git;
 use krate::Crate;
 use schema::*;
-use util::{CargoResult, human};
+use util::{human, CargoResult};
 use version::Version;
 
 #[derive(Identifiable, Associations, Debug)]
@@ -88,10 +88,8 @@ impl Dependency {
 
 impl ReverseDependency {
     pub fn encodable(self, crate_name: &str) -> EncodableDependency {
-        self.dependency.encodable(
-            crate_name,
-            Some(self.crate_downloads),
-        )
+        self.dependency
+            .encodable(crate_name, Some(self.crate_downloads))
     }
 }
 
@@ -104,11 +102,11 @@ pub fn add_dependencies(
 
     let git_and_new_dependencies = deps.iter()
         .map(|dep| {
-            let krate = Crate::by_name(&dep.name).first::<Crate>(&*conn).map_err(
-                |_| {
+            let krate = Crate::by_name(&dep.name)
+                .first::<Crate>(&*conn)
+                .map_err(|_| {
                     human(&format_args!("no known crate named `{}`", &*dep.name))
-                },
-            )?;
+                })?;
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {
                 return Err(human(
                     "wildcard (`*`) dependency constraints are not allowed \
@@ -154,7 +152,17 @@ pub fn add_dependencies(
 }
 
 impl Queryable<dependencies::SqlType, Pg> for Dependency {
-    type Row = (i32, i32, i32, String, bool, bool, Vec<String>, Option<String>, i32);
+    type Row = (
+        i32,
+        i32,
+        i32,
+        String,
+        bool,
+        bool,
+        Vec<String>,
+        Option<String>,
+        i32,
+    );
 
     fn build(row: Self::Row) -> Self {
         Dependency {
@@ -178,7 +186,11 @@ impl Queryable<dependencies::SqlType, Pg> for Dependency {
 
 // FIXME: We can derive this in the next release of Diesel
 impl Queryable<(dependencies::SqlType, Integer, Text), Pg> for ReverseDependency {
-    type Row = (<Dependency as Queryable<dependencies::SqlType, Pg>>::Row, i32, String);
+    type Row = (
+        <Dependency as Queryable<dependencies::SqlType, Pg>>::Row,
+        i32,
+        String,
+    );
 
     fn build((dep_row, downloads, _name): Self::Row) -> Self {
         ReverseDependency {

--- a/src/dist.rs
+++ b/src/dist.rs
@@ -2,7 +2,7 @@
 //! frontend
 use std::error::Error;
 
-use conduit::{Request, Response, Handler};
+use conduit::{Handler, Request, Response};
 use conduit_static::Static;
 use conduit_middleware::AroundMiddleware;
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -18,10 +18,7 @@ pub struct VersionDownload {
 
 #[derive(Insertable, Debug, Clone, Copy)]
 #[table_name = "version_downloads"]
-struct NewVersionDownload(
-    #[column_name(version_id)]
-    i32
-);
+struct NewVersionDownload(#[column_name(version_id)] i32);
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct EncodableVersionDownload {

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,8 +1,8 @@
 use dotenv::dotenv;
 use std::env;
 use std::path::Path;
-use util::{CargoResult, bad_request};
-use lettre::email::{EmailBuilder, Email};
+use util::{bad_request, CargoResult};
+use lettre::email::{Email, EmailBuilder};
 use lettre::transport::file::FileEmailTransport;
 use lettre::transport::EmailTransport;
 use lettre::transport::smtp::{SecurityLevel, SmtpTransportBuilder};
@@ -24,13 +24,11 @@ pub fn init_config_vars() -> Option<MailgunConfigVars> {
         env::var("MAILGUN_SMTP_PASSWORD"),
         env::var("MAILGUN_SMTP_SERVER"),
     ) {
-        (Ok(login), Ok(password), Ok(server)) => {
-            Some(MailgunConfigVars {
-                smtp_login: login,
-                smtp_password: password,
-                smtp_server: server,
-            })
-        }
+        (Ok(login), Ok(password), Ok(server)) => Some(MailgunConfigVars {
+            smtp_login: login,
+            smtp_password: password,
+            smtp_server: server,
+        }),
         _ => None,
     }
 }
@@ -76,9 +74,7 @@ pub fn send_email(recipient: &str, subject: &str, body: &str) -> CargoResult<()>
         None => {
             let mut sender = FileEmailTransport::new(Path::new("/tmp"));
             let result = sender.send(email.clone());
-            result.map_err(
-                |_| bad_request("Email file could not be generated"),
-            )?;
+            result.map_err(|_| bad_request("Email file could not be generated"))?;
         }
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -10,7 +10,7 @@ use serde_json;
 
 use app::App;
 use dependency::Kind;
-use util::{CargoResult, internal};
+use util::{internal, CargoResult};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Crate {
@@ -56,9 +56,7 @@ pub fn add_crate(app: &App, krate: &Crate) -> CargoResult<()> {
         fs::create_dir_all(dst.parent().unwrap())?;
         let mut prev = String::new();
         if fs::metadata(&dst).is_ok() {
-            File::open(&dst).and_then(
-                |mut f| f.read_to_string(&mut prev),
-            )?;
+            File::open(&dst).and_then(|mut f| f.read_to_string(&mut prev))?;
         }
         let s = serde_json::to_string(krate).unwrap();
         let new = prev + &s;
@@ -84,14 +82,11 @@ pub fn yank(app: &App, krate: &str, version: &semver::Version, yanked: bool) -> 
 
     commit_and_push(&repo, || {
         let mut prev = String::new();
-        File::open(&dst).and_then(
-            |mut f| f.read_to_string(&mut prev),
-        )?;
+        File::open(&dst).and_then(|mut f| f.read_to_string(&mut prev))?;
         let new = prev.lines()
             .map(|line| {
-                let mut git_crate = serde_json::from_str::<Crate>(line).map_err(|_| {
-                    internal(&format_args!("couldn't decode: `{}`", line))
-                })?;
+                let mut git_crate = serde_json::from_str::<Crate>(line)
+                    .map_err(|_| internal(&format_args!("couldn't decode: `{}`", line)))?;
                 if git_crate.name != krate || git_crate.vers != version.to_string() {
                     return Ok(line.to_string());
                 }
@@ -160,14 +155,7 @@ where
         let head = repo.head()?;
         let parent = repo.find_commit(head.target().unwrap())?;
         let sig = repo.signature()?;
-        repo.commit(
-            Some("HEAD"),
-            &sig,
-            &sig,
-            &msg,
-            &tree,
-            &[&parent],
-        )?;
+        repo.commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[&parent])?;
 
         // git push
         let mut ref_status = None;

--- a/src/http.rs
+++ b/src/http.rs
@@ -14,7 +14,7 @@ use std::error::Error;
 use std::collections::HashMap;
 
 use app::App;
-use util::{CargoResult, internal, ChainError, human};
+use util::{human, internal, CargoResult, ChainError};
 use Uploader;
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
@@ -58,7 +58,8 @@ pub fn parse_github_response<'de, 'a: 'de, T: Deserialize<'de>>(
     data: &'a [u8],
 ) -> CargoResult<T> {
     match resp.response_code().unwrap() {
-        200 => {} // Ok!
+        200 => {}
+        // Ok!
         403 => {
             return Err(human(
                 "It looks like you don't have permission \
@@ -81,9 +82,9 @@ pub fn parse_github_response<'de, 'a: 'de, T: Deserialize<'de>>(
         }
     }
 
-    let json = str::from_utf8(data).ok().chain_error(|| {
-        internal("github didn't send a utf8-response")
-    })?;
+    let json = str::from_utf8(data)
+        .ok()
+        .chain_error(|| internal("github didn't send a utf8-response"))?;
 
     serde_json::from_str(json).chain_error(|| internal("github didn't send a valid json response"))
 }
@@ -115,12 +116,10 @@ impl SecurityHeadersMiddleware {
 
         let s3_host = match *uploader {
             Uploader::S3 { ref bucket, .. } => bucket.host(),
-            _ => {
-                unreachable!(
-                    "This middleware should only be used in the production environment, \
-                               which should also require an S3 uploader, QED"
-                )
-            }
+            _ => unreachable!(
+                "This middleware should only be used in the production environment, \
+                 which should also require an S3 uploader, QED"
+            ),
         };
 
         // It would be better if we didn't have to have 'unsafe-eval' in the `script-src`
@@ -133,12 +132,12 @@ impl SecurityHeadersMiddleware {
             vec![
                 format!(
                     "default-src 'self'; \
-                  connect-src 'self' https://docs.rs https://{}; \
-                  script-src 'self' 'unsafe-eval' \
-                             https://www.google-analytics.com https://www.google.com; \
-                  style-src 'self' https://www.google.com https://ajax.googleapis.com; \
-                  img-src *; \
-                  object-src 'none'",
+                     connect-src 'self' https://docs.rs https://{}; \
+                     script-src 'self' 'unsafe-eval' \
+                     https://www.google-analytics.com https://www.google.com; \
+                     style-src 'self' https://www.google.com https://ajax.googleapis.com; \
+                     img-src *; \
+                     object-src 'none'",
                     s3_host
                 ),
             ],

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -10,7 +10,7 @@ use Crate;
 use db::RequestTransaction;
 use pagination::Paginate;
 use schema::*;
-use util::{RequestUtils, CargoResult};
+use util::{CargoResult, RequestUtils};
 
 #[derive(Clone, Identifiable, Queryable, Debug)]
 pub struct Keyword {
@@ -77,10 +77,10 @@ impl Keyword {
         if name.is_empty() {
             return false;
         }
-        name.chars().next().unwrap().is_alphanumeric() &&
-            name.chars().all(
-                |c| c.is_alphanumeric() || c == '_' || c == '-',
-            ) && name.chars().all(|c| c.is_ascii())
+        name.chars().next().unwrap().is_alphanumeric()
+            && name.chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+            && name.chars().all(|c| c.is_ascii())
     }
 
     pub fn encodable(self) -> EncodableKeyword {
@@ -101,9 +101,7 @@ impl Keyword {
     pub fn update_crate(conn: &PgConnection, krate: &Crate, keywords: &[&str]) -> QueryResult<()> {
         conn.transaction(|| {
             let keywords = Keyword::find_or_create_all(conn, keywords)?;
-            diesel::delete(CrateKeyword::belonging_to(krate)).execute(
-                conn,
-            )?;
+            diesel::delete(CrateKeyword::belonging_to(krate)).execute(conn)?;
             let crate_keywords = keywords
                 .into_iter()
                 .map(|kw| {
@@ -171,7 +169,9 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
     struct R {
         keyword: EncodableKeyword,
     }
-    Ok(req.json(&R { keyword: kw.encodable() }))
+    Ok(req.json(&R {
+        keyword: kw.encodable(),
+    }))
 }
 
 #[cfg(test)]

--- a/src/krate.rs
+++ b/src/krate.rs
@@ -1,6 +1,7 @@
 use std::ascii::AsciiExt;
 use std::cmp;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
@@ -21,22 +22,22 @@ use chrono::NaiveDate;
 
 use app::{App, RequestApp};
 use badge::EncodableBadge;
-use category::{EncodableCategory, CrateCategory};
+use category::{CrateCategory, EncodableCategory};
 use db::RequestTransaction;
-use dependency::{self, ReverseDependency, EncodableDependency};
-use download::{VersionDownload, EncodableVersionDownload};
+use dependency::{self, EncodableDependency, ReverseDependency};
+use download::{EncodableVersionDownload, VersionDownload};
 use git;
-use keyword::{EncodableKeyword, CrateKeyword};
-use owner::{EncodableOwner, Owner, Rights, OwnerKind, Team, rights, CrateOwner};
+use keyword::{CrateKeyword, EncodableKeyword};
+use owner::{rights, CrateOwner, EncodableOwner, Owner, OwnerKind, Rights, Team};
 use pagination::Paginate;
 use render;
 use schema::*;
 use upload;
 use user::RequestUser;
-use util::{read_le_u32, read_fill};
-use util::{RequestUtils, CargoResult, internal, ChainError, human};
+use util::{read_fill, read_le_u32};
+use util::{human, internal, CargoResult, ChainError, RequestUtils};
 use version::{EncodableVersion, NewVersion};
-use {User, Keyword, Version, Category, Badge, Replica};
+use {Badge, Category, Keyword, Replica, User, Version};
 
 /// Hosts in this blacklist are known to not be hosting documentation,
 /// and are possibly of malicious intent e.g. ad tracking networks, etc.
@@ -70,18 +71,20 @@ pub struct Crate {
 
 /// We literally never want to select `textsearchable_index_col`
 /// so we provide this type and constant to pass to `.select`
-type AllColumns = (crates::id,
-                   crates::name,
-                   crates::updated_at,
-                   crates::created_at,
-                   crates::downloads,
-                   crates::description,
-                   crates::homepage,
-                   crates::documentation,
-                   crates::readme,
-                   crates::license,
-                   crates::repository,
-                   crates::max_upload_size);
+type AllColumns = (
+    crates::id,
+    crates::name,
+    crates::updated_at,
+    crates::created_at,
+    crates::downloads,
+    crates::description,
+    crates::homepage,
+    crates::documentation,
+    crates::readme,
+    crates::license,
+    crates::repository,
+    crates::max_upload_size,
+);
 
 pub const ALL_COLUMNS: AllColumns = (
     crates::id,
@@ -166,9 +169,8 @@ impl<'a> NewCrate<'a> {
                 return Ok(krate);
             }
 
-            let target = crates::table.filter(canon_crate_name(crates::name).eq(
-                canon_crate_name(self.name),
-            ));
+            let target = crates::table
+                .filter(canon_crate_name(crates::name).eq(canon_crate_name(self.name)));
             update(target)
                 .set(&self)
                 .returning(ALL_COLUMNS)
@@ -242,11 +244,7 @@ impl<'a> NewCrate<'a> {
         use diesel::expression::dsl::exists;
 
         let reserved_name = select(exists(
-            reserved_crate_names.filter(canon_crate_name(name).eq(
-                canon_crate_name(
-                    self.name,
-                ),
-            )),
+            reserved_crate_names.filter(canon_crate_name(name).eq(canon_crate_name(self.name))),
         )).get_result::<bool>(conn)?;
         if reserved_name {
             Err(human("cannot upload a crate with a reserved name"))
@@ -301,10 +299,10 @@ impl Crate {
         if name.is_empty() {
             return false;
         }
-        name.chars().next().unwrap().is_alphabetic() &&
-            name.chars().all(
-                |c| c.is_alphanumeric() || c == '_' || c == '-',
-            ) && name.chars().all(|c| c.is_ascii())
+        name.chars().next().unwrap().is_alphabetic()
+            && name.chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+            && name.chars().all(|c| c.is_ascii())
     }
 
     pub fn valid_feature_name(name: &str) -> bool {
@@ -467,24 +465,20 @@ impl Crate {
     ) -> CargoResult<()> {
         let owner = match Owner::find_by_login(conn, login) {
             Ok(owner @ Owner::User(_)) => owner,
-            Ok(Owner::Team(team)) => {
-                if team.contains_user(app, req_user)? {
-                    Owner::Team(team)
-                } else {
-                    return Err(human(&format_args!(
-                        "only members of {} can add it as \
-                         an owner",
-                        login
-                    )));
-                }
-            }
-            Err(err) => {
-                if login.contains(':') {
-                    Owner::Team(Team::create(app, conn, login, req_user)?)
-                } else {
-                    return Err(err);
-                }
-            }
+            Ok(Owner::Team(team)) => if team.contains_user(app, req_user)? {
+                Owner::Team(team)
+            } else {
+                return Err(human(&format_args!(
+                    "only members of {} can add it as \
+                     an owner",
+                    login
+                )));
+            },
+            Err(err) => if login.contains(':') {
+                Owner::Team(Team::create(app, conn, login, req_user)?)
+            } else {
+                return Err(err);
+            },
         };
 
         let crate_owner = CrateOwner {
@@ -519,9 +513,9 @@ impl Crate {
     }
 
     pub fn badges(&self, conn: &PgConnection) -> QueryResult<Vec<Badge>> {
-        badges::table.filter(badges::crate_id.eq(self.id)).load(
-            conn,
-        )
+        badges::table
+            .filter(badges::crate_id.eq(self.id))
+            .load(conn)
     }
 
     /// Returns (dependency, dependent crate name, dependent crate downloads)
@@ -532,7 +526,7 @@ impl Crate {
         limit: i64,
     ) -> QueryResult<(Vec<ReverseDependency>, i64)> {
         use diesel::expression::dsl::sql;
-        use diesel::types::{Integer, Text, BigInt};
+        use diesel::types::{BigInt, Integer, Text};
 
         type SqlType = ((dependencies::SqlType, Integer, Text), BigInt);
         let rows = sql::<SqlType>(include_str!("krate_reverse_dependencies.sql"))
@@ -570,25 +564,28 @@ impl Crate {
 /// for them.
 pub fn index(req: &mut Request) -> CargoResult<Response> {
     use diesel::expression::{AsExpression, DayAndMonthIntervalDsl};
-    use diesel::types::{Bool, BigInt, Nullable};
-    use diesel::expression::functions::date_and_time::{now, date};
+    use diesel::types::{BigInt, Bool, Nullable};
+    use diesel::expression::functions::date_and_time::{date, now};
     use diesel::expression::sql_literal::sql;
 
     let conn = req.db_conn()?;
     let (offset, limit) = req.pagination(10, 100)?;
     let params = req.query();
-    let sort = params.get("sort").map(|s| &**s).unwrap_or(
-        "recent-downloads",
-    );
+    let sort = params
+        .get("sort")
+        .map(|s| &**s)
+        .unwrap_or("recent-downloads");
 
     let recent_downloads = sql::<Nullable<BigInt>>("SUM(crate_downloads.downloads)");
 
     let mut query = crates::table
-        .left_join(crate_downloads::table.on(
-            crates::id.eq(crate_downloads::crate_id).and(
-                crate_downloads::date.gt(date(now - 90.days())),
+        .left_join(
+            crate_downloads::table.on(
+                crates::id
+                    .eq(crate_downloads::crate_id)
+                    .and(crate_downloads::date.gt(date(now - 90.days()))),
             ),
-        ))
+        )
         .group_by(crates::id)
         .select((
             ALL_COLUMNS,
@@ -608,11 +605,10 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
     if let Some(q_string) = params.get("q") {
         let sort = params.get("sort").map(|s| &**s).unwrap_or("relevance");
         let q = plainto_tsquery(q_string);
-        query = query.filter(q.matches(crates::textsearchable_index_col).or(
-            crates::name.eq(
-                q_string,
-            ),
-        ));
+        query = query.filter(
+            q.matches(crates::textsearchable_index_col)
+                .or(crates::name.eq(q_string)),
+        );
 
         query = query.select((
             ALL_COLUMNS,
@@ -639,10 +635,11 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
                 crates_categories::table
                     .select(crates_categories::crate_id)
                     .inner_join(categories::table)
-                    .filter(categories::slug.eq(cat).or(categories::slug.like(format!(
-                        "{}::%",
-                        cat
-                    )))),
+                    .filter(
+                        categories::slug
+                            .eq(cat)
+                            .or(categories::slug.like(format!("{}::%", cat))),
+                    ),
             ),
         );
     }
@@ -688,11 +685,13 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
             ),
         );
     } else if params.get("following").is_some() {
-        query = query.filter(crates::id.eq_any(
-            follows::table.select(follows::crate_id).filter(
-                follows::user_id.eq(req.user()?.id),
+        query = query.filter(
+            crates::id.eq_any(
+                follows::table
+                    .select(follows::crate_id)
+                    .filter(follows::user_id.eq(req.user()?.id)),
             ),
-        ));
+        );
     }
 
     // The database query returns a tuple within a tuple , with the root
@@ -723,20 +722,21 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
         .zip(crates)
         .zip(perfect_matches)
         .zip(recent_downloads)
-        .map(|(((max_version, krate), perfect_match),
-          recent_downloads)| {
-            // FIXME: If we add crate_id to the Badge enum we can eliminate
-            // this N+1
-            let badges = badges::table
-                .filter(badges::crate_id.eq(krate.id))
-                .load::<Badge>(&*conn)?;
-            Ok(krate.minimal_encodable(
-                max_version,
-                Some(badges),
-                perfect_match,
-                Some(recent_downloads),
-            ))
-        })
+        .map(
+            |(((max_version, krate), perfect_match), recent_downloads)| {
+                // FIXME: If we add crate_id to the Badge enum we can eliminate
+                // this N+1
+                let badges = badges::table
+                    .filter(badges::crate_id.eq(krate.id))
+                    .load::<Badge>(&*conn)?;
+                Ok(krate.minimal_encodable(
+                    max_version,
+                    Some(badges),
+                    perfect_match,
+                    Some(recent_downloads),
+                ))
+            },
+        )
         .collect::<Result<_, ::diesel::result::Error>>()?;
 
     #[derive(Serialize)]
@@ -855,15 +855,14 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
         .select(sum(crate_downloads::downloads))
         .get_result(&*conn)?;
 
-    let badges = badges::table.filter(badges::crate_id.eq(krate.id)).load(
-        &*conn,
-    )?;
+    let badges = badges::table
+        .filter(badges::crate_id.eq(krate.id))
+        .load(&*conn)?;
     let max_version = krate.max_version(&conn)?;
 
     #[derive(Serialize)]
     struct R {
-        #[serde(rename = "crate")]
-        krate: EncodableCrate,
+        #[serde(rename = "crate")] krate: EncodableCrate,
         versions: Vec<EncodableVersion>,
         keywords: Vec<EncodableKeyword>,
         categories: Vec<EncodableCategory>,
@@ -897,7 +896,7 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
 pub fn new(req: &mut Request) -> CargoResult<Response> {
-    let app = req.app().clone();
+    let app = Arc::clone(req.app());
     let (new_crate, user) = parse_new_headers(req)?;
 
     let name = &*new_crate.name;
@@ -954,13 +953,12 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
             ));
         }
 
-        let length = req.content_length().chain_error(|| {
-            human("missing header: Content-Length")
-        })?;
-        let max = krate.max_upload_size.map(|m| m as u64).unwrap_or(
-            app.config
-                .max_upload_size,
-        );
+        let length = req.content_length()
+            .chain_error(|| human("missing header: Content-Length"))?;
+        let max = krate
+            .max_upload_size
+            .map(|m| m as u64)
+            .unwrap_or(app.config.max_upload_size);
         if length > max {
             return Err(human(&format_args!("max upload size is: {}", max)));
         }
@@ -996,13 +994,10 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
         // Upload the crate, return way to delete the crate from the server
         // If the git commands fail below, we shouldn't keep the crate on the
         // server.
-        let (cksum, mut crate_bomb, mut readme_bomb) = app.config.uploader.upload_crate(
-            req,
-            &krate,
-            readme,
-            max,
-            vers,
-        )?;
+        let (cksum, mut crate_bomb, mut readme_bomb) =
+            app.config
+                .uploader
+                .upload_crate(req, &krate, readme, max, vers)?;
         version.record_readme_rendering(&conn)?;
 
         // Register this crate in our local git repo.
@@ -1037,8 +1032,7 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
 
         #[derive(Serialize)]
         struct R<'a> {
-            #[serde(rename = "crate")]
-            krate: EncodableCrate,
+            #[serde(rename = "crate")] krate: EncodableCrate,
             warnings: Warnings<'a>,
         }
         Ok(req.json(&R {
@@ -1055,19 +1049,16 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
 /// information.
 fn parse_new_headers(req: &mut Request) -> CargoResult<(upload::NewCrate, User)> {
     // Read the json upload request
-    let amt = read_le_u32(req.body())? as u64;
+    let amt = u64::from(read_le_u32(req.body())?);
     let max = req.app().config.max_upload_size;
     if amt > max {
         return Err(human(&format_args!("max upload size is: {}", max)));
     }
     let mut json = vec![0; amt as usize];
     read_fill(req.body(), &mut json)?;
-    let json = String::from_utf8(json).map_err(|_| {
-        human("json body was not valid utf-8")
-    })?;
-    let new: upload::NewCrate = serde_json::from_str(&json).map_err(|e| {
-        human(&format_args!("invalid upload request: {}", e))
-    })?;
+    let json = String::from_utf8(json).map_err(|_| human("json body was not valid utf-8"))?;
+    let new: upload::NewCrate = serde_json::from_str(&json)
+        .map_err(|e| human(&format_args!("invalid upload request: {}", e)))?;
 
     // Make sure required fields are provided
     fn empty(s: Option<&String>) -> bool {
@@ -1158,9 +1149,7 @@ fn increment_download_counts(req: &Request, crate_name: &str, version: &str) -> 
     let conn = req.db_conn()?;
     let version_id = versions
         .select(id)
-        .filter(crate_id.eq_any(
-            Crate::by_name(crate_name).select(crates::id),
-        ))
+        .filter(crate_id.eq_any(Crate::by_name(crate_name).select(crates::id)))
         .filter(num.eq(version))
         .first(&*conn)?;
 
@@ -1214,7 +1203,9 @@ pub fn downloads(req: &mut Request) -> CargoResult<Response> {
     struct Meta {
         extra_downloads: Vec<ExtraDownload>,
     }
-    let meta = Meta { extra_downloads: extra };
+    let meta = Meta {
+        extra_downloads: extra,
+    };
     Ok(req.json(&R {
         version_downloads: downloads,
         meta: meta,
@@ -1273,13 +1264,14 @@ pub fn following(req: &mut Request) -> CargoResult<Response> {
 
     let follow = follow_target(req)?;
     let conn = req.db_conn()?;
-    let following = diesel::select(exists(follows::table.find(follow.id())))
-        .get_result(&*conn)?;
+    let following = diesel::select(exists(follows::table.find(follow.id()))).get_result(&*conn)?;
     #[derive(Serialize)]
     struct R {
         following: bool,
     }
-    Ok(req.json(&R { following: following }))
+    Ok(req.json(&R {
+        following: following,
+    }))
 }
 
 /// Handles the `GET /crates/:crate_id/versions` route.
@@ -1370,13 +1362,12 @@ fn modify_owners(req: &mut Request, add: bool) -> CargoResult<Response> {
     req.body().read_to_string(&mut body)?;
     let user = req.user()?;
     let conn = req.db_conn()?;
-    let krate = Crate::by_name(&req.params()["crate_id"]).first::<Crate>(
-        &*conn,
-    )?;
+    let krate = Crate::by_name(&req.params()["crate_id"]).first::<Crate>(&*conn)?;
     let owners = krate.owners(&conn)?;
 
     match rights(req.app(), &owners, user)? {
-        Rights::Full => {} // Yes!
+        Rights::Full => {}
+        // Yes!
         Rights::Publish => {
             return Err(human("team members don't have permission to modify owners"));
         }
@@ -1392,13 +1383,12 @@ fn modify_owners(req: &mut Request, add: bool) -> CargoResult<Response> {
         owners: Option<Vec<String>>,
     }
 
-    let request: Request = serde_json::from_str(&body).map_err(
-        |_| human("invalid json request"),
-    )?;
+    let request: Request = serde_json::from_str(&body).map_err(|_| human("invalid json request"))?;
 
-    let logins = request.owners.or(request.users).ok_or_else(|| {
-        human("invalid json request")
-    })?;
+    let logins = request
+        .owners
+        .or(request.users)
+        .ok_or_else(|| human("invalid json request"))?;
 
     for login in &logins {
         if add {
@@ -1465,7 +1455,7 @@ pub fn reverse_dependencies(req: &mut Request) -> CargoResult<Response> {
     }))
 }
 
-use diesel::types::{Text, Date};
+use diesel::types::{Date, Text};
 sql_function!(canon_crate_name, canon_crate_name_t, (x: Text) -> Text);
 sql_function!(to_char, to_char_t, (a: Date, b: Text) -> Text);
 
@@ -1501,7 +1491,7 @@ mod tests {
         assert_eq!(
             Crate::remove_blacklisted_documentation_urls(Some(String::from(
                 "http://rust-ci.org/crate/crate-0.1/doc/crate-0.1",
-            ))),
+            ),),),
             None
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,28 +7,25 @@
 #![deny(missing_debug_implementations, missing_copy_implementations)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
-#![recursion_limit="128"]
+#![recursion_limit = "128"]
 
-#[macro_use]
-extern crate diesel;
-#[macro_use]
-extern crate diesel_codegen;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
 extern crate ammonia;
 extern crate chrono;
 extern crate comrak;
 extern crate curl;
+#[macro_use]
+extern crate diesel;
+#[macro_use]
+extern crate diesel_codegen;
 extern crate diesel_full_text_search;
 extern crate dotenv;
 extern crate flate2;
 extern crate git2;
 extern crate hex;
+extern crate lettre;
 extern crate license_exprs;
+#[macro_use]
+extern crate log;
 extern crate oauth2;
 extern crate openssl;
 extern crate r2d2;
@@ -37,21 +34,24 @@ extern crate rand;
 extern crate s3;
 extern crate semver;
 extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
 extern crate tar;
 extern crate time;
 extern crate toml;
 extern crate url;
-extern crate lettre;
 
 extern crate conduit;
 extern crate conduit_conditional_get;
 extern crate conduit_cookie;
-extern crate cookie;
 extern crate conduit_git_http_backend;
 extern crate conduit_log_requests;
 extern crate conduit_middleware;
 extern crate conduit_router;
 extern crate conduit_static;
+extern crate cookie;
 
 pub use app::App;
 pub use self::badge::Badge;
@@ -63,7 +63,7 @@ pub use self::keyword::Keyword;
 pub use self::krate::Crate;
 pub use self::user::User;
 pub use self::version::Version;
-pub use self::uploaders::{Uploader, Bomb};
+pub use self::uploaders::{Bomb, Uploader};
 
 use std::sync::Arc;
 use std::error::Error;
@@ -71,7 +71,7 @@ use std::error::Error;
 use conduit_router::RouteBuilder;
 use conduit_middleware::MiddlewareBuilder;
 
-use util::{C, R, R404};
+use util::{R404, C, R};
 
 pub mod app;
 pub mod badge;
@@ -200,10 +200,10 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
 
     // Mount the router under the /api/v1 path so we're at least somewhat at the
     // liberty to change things in the future!
-    router.get("/api/v1/*path", R(api_router.clone()));
-    router.put("/api/v1/*path", R(api_router.clone()));
-    router.post("/api/v1/*path", R(api_router.clone()));
-    router.head("/api/v1/*path", R(api_router.clone()));
+    router.get("/api/v1/*path", R(Arc::clone(&api_router)));
+    router.put("/api/v1/*path", R(Arc::clone(&api_router)));
+    router.post("/api/v1/*path", R(Arc::clone(&api_router)));
+    router.head("/api/v1/*path", R(Arc::clone(&api_router)));
     router.delete("/api/v1/*path", R(api_router));
 
     router.get("/authorize_url", C(user::github_authorize));
@@ -217,7 +217,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     if env == Env::Development {
         let s = conduit_git_http_backend::Serve(app.git_repo_checkout.clone());
         let s = Arc::new(s);
-        router.get("/git/index/*path", R(s.clone()));
+        router.get("/git/index/*path", R(Arc::clone(&s)));
         router.post("/git/index/*path", R(s));
     }
 

--- a/src/local_upload.rs
+++ b/src/local_upload.rs
@@ -3,7 +3,7 @@
 //! development environments.
 use std::error::Error;
 
-use conduit::{Request, Response, Handler};
+use conduit::{Handler, Request, Response};
 use conduit_static::Static;
 use conduit_middleware::AroundMiddleware;
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -102,7 +102,9 @@ impl<'a> MarkdownRenderer<'a> {
             allowed_classes: allowed_classes,
             ..Ammonia::default()
         };
-        MarkdownRenderer { html_sanitizer: html_sanitizer }
+        MarkdownRenderer {
+            html_sanitizer: html_sanitizer,
+        }
     }
 
     /// Renders the given markdown to HTML using the current settings.

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,46 +1,46 @@
 #![deny(warnings)]
 
-#[macro_use]
-extern crate serde_derive;
-extern crate diesel;
-#[macro_use]
-extern crate diesel_codegen;
 extern crate cargo_registry;
 extern crate chrono;
 extern crate conduit;
 extern crate conduit_middleware;
 extern crate conduit_test;
 extern crate curl;
+extern crate diesel;
+#[macro_use]
+extern crate diesel_codegen;
 extern crate dotenv;
+extern crate flate2;
 extern crate git2;
+extern crate s3;
 extern crate semver;
 extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
+extern crate tar;
 extern crate time;
 extern crate url;
-extern crate s3;
-extern crate tar;
-extern crate flate2;
 
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::sync::Arc;
 
 use cargo_registry::app::App;
 use cargo_registry::category::NewCategory;
 use cargo_registry::dependency::NewDependency;
 use cargo_registry::keyword::Keyword;
-use cargo_registry::krate::{NewCrate, CrateDownload, EncodableCrate};
+use cargo_registry::krate::{CrateDownload, EncodableCrate, NewCrate};
 use cargo_registry::schema::*;
 use cargo_registry::upload as u;
 use cargo_registry::user::NewUser;
 use cargo_registry::owner::{CrateOwner, NewTeam, Team};
 use cargo_registry::version::NewVersion;
 use cargo_registry::user::AuthenticationSource;
-use cargo_registry::{User, Crate, Version, Dependency, Replica};
-use conduit::{Request, Method};
+use cargo_registry::{Crate, Dependency, Replica, User, Version};
+use conduit::{Method, Request};
 use conduit_test::MockRequest;
 use diesel::prelude::*;
 use diesel::pg::upsert::*;
@@ -101,8 +101,7 @@ mod version;
 
 #[derive(Deserialize)]
 struct GoodCrate {
-    #[serde(rename = "crate")]
-    krate: EncodableCrate,
+    #[serde(rename = "crate")] krate: EncodableCrate,
     warnings: Warnings,
 }
 #[derive(Deserialize)]
@@ -120,7 +119,11 @@ struct CrateMeta {
     total: i32,
 }
 
-fn app() -> (record::Bomb, Arc<App>, conduit_middleware::MiddlewareBuilder) {
+fn app() -> (
+    record::Bomb,
+    Arc<App>,
+    conduit_middleware::MiddlewareBuilder,
+) {
     dotenv::dotenv().ok();
     git::init();
 
@@ -302,8 +305,7 @@ impl<'a> VersionBuilder<'a> {
             &self.features,
             license,
             self.license_file,
-        )?
-            .save(connection, &[])?;
+        )?.save(connection, &[])?;
 
         let new_deps = self.dependencies
             .into_iter()
@@ -317,9 +319,9 @@ impl<'a> VersionBuilder<'a> {
                 }
             })
             .collect::<Vec<_>>();
-        insert(&new_deps).into(dependencies::table).execute(
-            connection,
-        )?;
+        insert(&new_deps)
+            .into(dependencies::table)
+            .execute(connection)?;
 
         Ok(vers)
     }
@@ -485,9 +487,8 @@ fn krate(name: &str) -> Crate {
 
 fn sign_in_as(req: &mut Request, user: &User) {
     req.mut_extensions().insert(user.clone());
-    req.mut_extensions().insert(
-        AuthenticationSource::SessionCookie,
-    );
+    req.mut_extensions()
+        .insert(AuthenticationSource::SessionCookie);
 }
 
 fn sign_in(req: &mut Request, app: &App) -> User {
@@ -682,14 +683,12 @@ fn new_crate_to_body(new_crate: &u::NewCrate, files: &[(&str, &[u8])]) -> Vec<u8
             .cloned(),
     );
     body.extend(json.as_bytes().iter().cloned());
-    body.extend(
-        &[
-            (tarball.len() >> 0) as u8,
-            (tarball.len() >> 8) as u8,
-            (tarball.len() >> 16) as u8,
-            (tarball.len() >> 24) as u8,
-        ],
-    );
+    body.extend(&[
+        (tarball.len() >> 0) as u8,
+        (tarball.len() >> 8) as u8,
+        (tarball.len() >> 16) as u8,
+        (tarball.len() >> 24) as u8,
+    ]);
     body.extend(tarball);
     body
 }

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -61,25 +61,19 @@ fn set_up() -> (Arc<App>, Crate, BadgeRef) {
     badge_attributes_gitlab.insert(String::from("branch"), String::from("beta"));
     badge_attributes_gitlab.insert(String::from("repository"), String::from("rust-lang/rust"));
 
-    let isitmaintained_issue_resolution =
-        Badge::IsItMaintainedIssueResolution { repository: String::from("rust-lang/rust") };
+    let isitmaintained_issue_resolution = Badge::IsItMaintainedIssueResolution {
+        repository: String::from("rust-lang/rust"),
+    };
     let mut badge_attributes_isitmaintained_issue_resolution = HashMap::new();
-    badge_attributes_isitmaintained_issue_resolution.insert(
-        String::from("repository"),
-        String::from("rust-lang/rust"),
-    );
+    badge_attributes_isitmaintained_issue_resolution
+        .insert(String::from("repository"), String::from("rust-lang/rust"));
 
-    let isitmaintained_open_issues =
-        Badge::IsItMaintainedOpenIssues { repository: String::from("rust-lang/rust") };
+    let isitmaintained_open_issues = Badge::IsItMaintainedOpenIssues {
+        repository: String::from("rust-lang/rust"),
+    };
     let mut badge_attributes_isitmaintained_open_issues = HashMap::new();
-    badge_attributes_isitmaintained_open_issues.insert(
-        String::from(
-            "repository",
-        ),
-        String::from(
-            "rust-lang/rust",
-        ),
-    );
+    badge_attributes_isitmaintained_open_issues
+        .insert(String::from("repository"), String::from("rust-lang/rust"));
 
     let codecov = Badge::Codecov {
         service: Some(String::from("github")),
@@ -109,7 +103,9 @@ fn set_up() -> (Arc<App>, Crate, BadgeRef) {
     badge_attributes_circle_ci.insert(String::from("branch"), String::from("beta"));
     badge_attributes_circle_ci.insert(String::from("repository"), String::from("rust-lang/rust"));
 
-    let maintenance = Badge::Maintenance { status: MaintenanceStatus::LookingForMaintainer };
+    let maintenance = Badge::Maintenance {
+        status: MaintenanceStatus::LookingForMaintainer,
+    };
     let mut maintenance_attributes = HashMap::new();
     maintenance_attributes.insert(
         String::from("status"),
@@ -439,9 +435,9 @@ fn isitmaintained_open_issues_required_keys() {
     let mut badges = HashMap::new();
 
     // Repository is a required key
-    test_badges.isitmaintained_open_issues_attributes.remove(
-        "repository",
-    );
+    test_badges
+        .isitmaintained_open_issues_attributes
+        .remove("repository");
     badges.insert(
         String::from("isitmaintained_open_issues"),
         test_badges.isitmaintained_open_issues_attributes,
@@ -537,12 +533,9 @@ fn maintenance_invalid_values() {
     let mut badges = HashMap::new();
 
     // "totes broken" is not a recognized value
-    test_badges.maintenance_attributes.insert(
-        String::from("status"),
-        String::from(
-            "totes broken",
-        ),
-    );
+    test_badges
+        .maintenance_attributes
+        .insert(String::from("status"), String::from("totes broken"));
     badges.insert(
         String::from("maintenance"),
         test_badges.maintenance_attributes,

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -157,9 +157,7 @@ fn update_crate() {
     // Add a category and its subcategory
     {
         let conn = t!(app.diesel_database.get());
-        t!(::new_category("cat1::bar", "cat1::bar").create_or_update(
-            &conn,
-        ));
+        t!(::new_category("cat1::bar", "cat1::bar").create_or_update(&conn,));
         Category::update_crate(&conn, &krate, &["cat1", "cat1::bar"]).unwrap();
     }
     assert_eq!(cnt!(&mut req, "cat1"), 1);

--- a/src/tests/git.rs
+++ b/src/tests/git.rs
@@ -8,11 +8,10 @@ use git2;
 use url::Url;
 
 fn root() -> PathBuf {
-    env::current_dir().unwrap().join("tmp").join(
-        thread::current()
-            .name()
-            .unwrap(),
-    )
+    env::current_dir()
+        .unwrap()
+        .join("tmp")
+        .join(thread::current().name().unwrap())
 }
 
 pub fn checkout() -> PathBuf {

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,7 +1,7 @@
 use conduit::{Handler, Method};
 use conduit_test::MockRequest;
 
-use cargo_registry::keyword::{Keyword, EncodableKeyword};
+use cargo_registry::keyword::{EncodableKeyword, Keyword};
 
 #[derive(Deserialize)]
 struct KeywordList {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -114,36 +114,36 @@ fn owners_can_remove_self() {
 
     // Deleting yourself when you're the only owner isn't allowed.
     let body = r#"{"users":["firstowner"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Delete).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Delete,).with_body(body.as_bytes(),),));
     let json = ::json::<::Bad>(&mut response);
-    assert!(json.errors[0].detail.contains(
-        "cannot remove the sole owner of a crate",
-    ));
+    assert!(
+        json.errors[0]
+            .detail
+            .contains("cannot remove the sole owner of a crate",)
+    );
 
     let body = r#"{"users":["secondowner"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Put).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Put,).with_body(body.as_bytes(),),));
     assert!(::json::<O>(&mut response).ok);
 
     // Deleting yourself when there are other owners is allowed.
     let body = r#"{"users":["firstowner"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Delete).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Delete,).with_body(body.as_bytes(),),));
     assert!(::json::<O>(&mut response).ok);
 
     // After you delete yourself, you no longer have permisions to manage the crate.
     let body = r#"{"users":["secondowner"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Delete).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Delete,).with_body(body.as_bytes(),),));
     let json = ::json::<::Bad>(&mut response);
-    assert!(json.errors[0].detail.contains(
-        "only owners have permission to modify owners",
-    ));
+    assert!(
+        json.errors[0]
+            .detail
+            .contains("only owners have permission to modify owners",)
+    );
 }
 
 #[test]
@@ -176,9 +176,8 @@ fn owners() {
     assert_eq!(r.users.len(), 1);
 
     let body = r#"{"users":["foobar"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Put).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Put,).with_body(body.as_bytes(),),));
     assert!(::json::<O>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_method(Method::Get)));
@@ -186,9 +185,8 @@ fn owners() {
     assert_eq!(r.users.len(), 2);
 
     let body = r#"{"users":["foobar"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Delete).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Delete,).with_body(body.as_bytes(),),));
     assert!(::json::<O>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_method(Method::Get)));
@@ -196,15 +194,13 @@ fn owners() {
     assert_eq!(r.users.len(), 1);
 
     let body = r#"{"users":["foo"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Delete).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Delete,).with_body(body.as_bytes(),),));
     ::json::<::Bad>(&mut response);
 
     let body = r#"{"users":["foobar"]}"#;
-    let mut response = ok_resp!(middle.call(req.with_method(Method::Put).with_body(
-        body.as_bytes(),
-    )));
+    let mut response =
+        ok_resp!(middle.call(req.with_method(Method::Put,).with_body(body.as_bytes(),),));
     assert!(::json::<O>(&mut response).ok);
 }
 

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -63,11 +63,9 @@ impl Drop for Bomb {
             .to_string();
         match res {
             Err(..) if !thread::panicking() => panic!("server subtask failed: {}", stderr),
-            Err(e) => {
-                if stderr.len() > 0 {
-                    println!("server subtask failed ({:?}): {}", e, stderr)
-                }
-            }
+            Err(e) => if stderr.len() > 0 {
+                println!("server subtask failed ({:?}): {}", e, stderr)
+            },
             Ok(_) if thread::panicking() => {}
             Ok(None) => {}
             Ok(Some((data, file))) => {
@@ -310,9 +308,7 @@ fn replay_http(
     });
 
     let mut response = hyper::Response::new();
-    response.set_status(
-        hyper::StatusCode::try_from(exchange.response.status).unwrap(),
-    );
+    response.set_status(hyper::StatusCode::try_from(exchange.response.status).unwrap());
     for (key, value) in exchange.response.headers.into_iter() {
         response.headers_mut().append_raw(key, value);
     }

--- a/src/tests/schema_details.rs
+++ b/src/tests/schema_details.rs
@@ -5,17 +5,15 @@ fn all_columns_called_crate_id_have_a_cascading_foreign_key() {
     for (table_name, constraint) in get_fk_constraint_definitions("crate_id") {
         let constraint = match constraint {
             Some(c) => c,
-            None => {
-                panic!(
-                    "Column called crate_id on {} has no foreign key",
-                    table_name
-                )
-            }
+            None => panic!(
+                "Column called crate_id on {} has no foreign key",
+                table_name
+            ),
         };
         if !constraint.definition.contains("ON DELETE CASCADE") {
             panic!(
                 "Foreign key {} on table {} should have `ON DELETE CASCADE` \
-            but it doesn't.",
+                 but it doesn't.",
                 constraint.name,
                 table_name
             );
@@ -28,17 +26,15 @@ fn all_columns_called_version_id_have_a_cascading_foreign_key() {
     for (table_name, constraint) in get_fk_constraint_definitions("version_id") {
         let constraint = match constraint {
             Some(c) => c,
-            None => {
-                panic!(
-                    "Column called version_id on {} has no foreign key",
-                    table_name
-                )
-            }
+            None => panic!(
+                "Column called version_id on {} has no foreign key",
+                table_name
+            ),
         };
         if !constraint.definition.contains("ON DELETE CASCADE") {
             panic!(
                 "Foreign key {} on table {} should have `ON DELETE CASCADE` \
-            but it doesn't.",
+                 but it doesn't.",
                 constraint.name,
                 table_name
             );

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -71,9 +71,9 @@ fn weird_name() {
         )
     );
     assert!(
-        json.errors[0].detail.contains(
-            "organization cannot contain",
-        ),
+        json.errors[0]
+            .detail
+            .contains("organization cannot contain",),
         "{:?}",
         json.errors
     );
@@ -115,9 +115,9 @@ fn nonexistent_team() {
         )
     );
     assert!(
-        json.errors[0].detail.contains(
-            "don't have permission to query a necessary property",
-        ),
+        json.errors[0]
+            .detail
+            .contains("don't have permission to query a necessary property",),
         "{:?}",
         json.errors
     );
@@ -236,9 +236,9 @@ fn remove_team_as_team_owner() {
     );
 
     assert!(
-        json.errors[0].detail.contains(
-            "only owners have permission",
-        ),
+        json.errors[0]
+            .detail
+            .contains("only owners have permission",),
         "{:?}",
         json.errors
     );
@@ -349,9 +349,9 @@ fn add_owners_as_team_owner() {
         )
     );
     assert!(
-        json.errors[0].detail.contains(
-            "only owners have permission",
-        ),
+        json.errors[0]
+            .detail
+            .contains("only owners have permission",),
         "{:?}",
         json.errors
     );

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -4,8 +4,8 @@ use conduit::{Handler, Method};
 
 use cargo_registry::token::ApiToken;
 use cargo_registry::krate::EncodableCrate;
-use cargo_registry::user::{User, NewUser, EncodablePrivateUser, EncodablePublicUser, Email,
-                           NewEmail, Token};
+use cargo_registry::user::{Email, EncodablePrivateUser, EncodablePublicUser, NewEmail, NewUser,
+                           Token, User};
 use cargo_registry::version::EncodableVersion;
 
 use diesel::prelude::*;
@@ -153,11 +153,12 @@ fn following() {
             .expect_build(&conn);
     }
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me/updates").with_method(
-            Method::Get,
-        ),
-    ));
+    let mut response = ok_resp!(
+        middle.call(
+            req.with_path("/api/v1/me/updates",)
+                .with_method(Method::Get,),
+        )
+    );
     let r = ::json::<R>(&mut response);
     assert_eq!(r.versions.len(), 0);
     assert_eq!(r.meta.more, false);
@@ -175,11 +176,12 @@ fn following() {
         )
     );
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me/updates").with_method(
-            Method::Get,
-        ),
-    ));
+    let mut response = ok_resp!(
+        middle.call(
+            req.with_path("/api/v1/me/updates",)
+                .with_method(Method::Get,),
+        )
+    );
     let r = ::json::<R>(&mut response);
     assert_eq!(r.versions.len(), 2);
     assert_eq!(r.meta.more, false);
@@ -236,8 +238,8 @@ fn user_total_downloads() {
 
         let another_user = ::new_user("bar").create_or_update(&conn).unwrap();
 
-        let mut another_krate = ::CrateBuilder::new("bar_krate1", another_user.id)
-            .expect_build(&conn);
+        let mut another_krate =
+            ::CrateBuilder::new("bar_krate1", another_user.id).expect_build(&conn);
         another_krate.downloads = 2;
         update(&another_krate)
             .set(&another_krate)
@@ -332,9 +334,7 @@ fn test_github_login_does_not_overwrite_email() {
         user
     };
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email, None);
     assert_eq!(r.user.login, "apricot");
@@ -362,9 +362,7 @@ fn test_github_login_does_not_overwrite_email() {
         ::sign_in_as(&mut req, &user);
     }
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "apricot@apricots.apricot");
     assert_eq!(r.user.login, "apricot");
@@ -395,9 +393,7 @@ fn test_email_get_and_put() {
         user
     };
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email, None);
     assert_eq!(r.user.login, "mango");
@@ -412,9 +408,7 @@ fn test_email_get_and_put() {
     );
     assert!(::json::<S>(&mut response).ok);
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "mango@mangos.mango");
     assert_eq!(r.user.login, "mango");
@@ -506,13 +500,12 @@ fn test_this_user_cannot_change_that_user_email() {
     );
 
     assert!(
-        json.errors[0].detail.contains(
-            "current user does not match requested user",
-        ),
+        json.errors[0]
+            .detail
+            .contains("current user does not match requested user",),
         "{:?}",
         json.errors
     );
-
 }
 
 /* Given a new user, test that if they sign in with
@@ -542,9 +535,7 @@ fn test_insert_into_email_table() {
         ::sign_in_as(&mut req, &user);
     }
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "potato@example.com");
     assert_eq!(r.user.login, "potato");
@@ -564,9 +555,7 @@ fn test_insert_into_email_table() {
         ::sign_in_as(&mut req, &user);
     }
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "potato@example.com");
     assert_eq!(r.user.login, "potato");
@@ -604,9 +593,7 @@ fn test_insert_into_email_table_with_email_change() {
         user
     };
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "potato@example.com");
     assert_eq!(r.user.login, "potato");
@@ -638,9 +625,7 @@ fn test_insert_into_email_table_with_email_change() {
         ::sign_in_as(&mut req, &user);
     }
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "apricot@apricots.apricot");
     assert!(!r.user.email_verified);
@@ -703,9 +688,7 @@ fn test_confirm_user_email() {
     );
     assert!(::json::<S>(&mut response).ok);
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "potato@example.com");
     assert_eq!(r.user.login, "potato");
@@ -754,9 +737,7 @@ fn test_existing_user_email() {
         ::sign_in_as(&mut req, &user);
     }
 
-    let mut response = ok_resp!(middle.call(
-        req.with_path("/api/v1/me").with_method(Method::Get),
-    ));
+    let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
     let r = ::json::<R>(&mut response);
     assert_eq!(r.user.email.unwrap(), "potahto@example.com");
     assert!(!r.user.email_verified);

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -31,9 +31,7 @@ fn index() {
         let u = ::new_user("foo").create_or_update(&conn).unwrap();
         ::CrateBuilder::new("foo_vers_index", u.id)
             .version(::VersionBuilder::new("2.0.0").license(Some("MIT")))
-            .version(::VersionBuilder::new("2.0.1").license(
-                Some("MIT/Apache-2.0"),
-            ))
+            .version(::VersionBuilder::new("2.0.1").license(Some("MIT/Apache-2.0")))
             .expect_build(&conn);
         let ids = versions::table
             .select(versions::id)

--- a/src/user/middleware.rs
+++ b/src/user/middleware.rs
@@ -8,7 +8,7 @@ use diesel::prelude::*;
 use db::RequestTransaction;
 use schema::users;
 use super::User;
-use util::errors::{CargoResult, Unauthorized, ChainError, std_error};
+use util::errors::{std_error, CargoResult, ChainError, Unauthorized};
 
 #[derive(Debug, Clone, Copy)]
 pub struct Middleware;
@@ -23,9 +23,9 @@ impl conduit_middleware::Middleware for Middleware {
     fn before(&self, req: &mut Request) -> Result<(), Box<Error + Send>> {
         // Check if the request has a session cookie with a `user_id` property inside
         let id = {
-            req.session().get("user_id").and_then(
-                |s| s.parse::<i32>().ok(),
-            )
+            req.session()
+                .get("user_id")
+                .and_then(|s| s.parse::<i32>().ok())
         };
 
         let conn = req.db_conn().map_err(std_error)?;
@@ -36,9 +36,8 @@ impl conduit_middleware::Middleware for Middleware {
             if let Ok(user) = maybe_user {
                 // Attach the `User` model from the database to the request
                 req.mut_extensions().insert(user);
-                req.mut_extensions().insert(
-                    AuthenticationSource::SessionCookie,
-                );
+                req.mut_extensions()
+                    .insert(AuthenticationSource::SessionCookie);
             }
         } else {
             // Otherwise, look for an `Authorization` header on the request
@@ -66,9 +65,9 @@ pub trait RequestUser {
 
 impl<'a> RequestUser for Request + 'a {
     fn user(&self) -> CargoResult<&User> {
-        self.extensions().find::<User>().chain_error(
-            || Unauthorized,
-        )
+        self.extensions()
+            .find::<User>()
+            .chain_error(|| Unauthorized)
     }
 
     fn authentication_source(&self) -> CargoResult<AuthenticationSource> {

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -28,7 +28,11 @@ pub trait CargoError: Send + fmt::Display + 'static {
     fn response(&self) -> Option<Response> {
         if self.human() {
             Some(json_response(&Bad {
-                errors: vec![StringError { detail: self.description().to_string() }],
+                errors: vec![
+                    StringError {
+                        detail: self.description().to_string(),
+                    },
+                ],
             }))
         } else {
             self.cause().and_then(|cause| cause.response())
@@ -233,7 +237,11 @@ impl CargoError for NotFound {
 
     fn response(&self) -> Option<Response> {
         let mut response = json_response(&Bad {
-            errors: vec![StringError { detail: "Not Found".to_string() }],
+            errors: vec![
+                StringError {
+                    detail: "Not Found".to_string(),
+                },
+            ],
         });
         response.status = (404, "Not Found");
         Some(response)
@@ -282,7 +290,11 @@ impl CargoError for BadRequest {
 
     fn response(&self) -> Option<Response> {
         let mut response = json_response(&Bad {
-            errors: vec![StringError { detail: self.0.clone() }],
+            errors: vec![
+                StringError {
+                    detail: self.0.clone(),
+                },
+            ],
         });
         response.status = (400, "Bad Request");
         Some(response)

--- a/src/util/head.rs
+++ b/src/util/head.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::error::Error;
 
-use conduit::{Request, Response, Handler, Method};
+use conduit::{Handler, Method, Request, Response};
 use conduit_middleware::AroundMiddleware;
 
 use util::RequestProxy;

--- a/src/util/io_util.rs
+++ b/src/util/io_util.rs
@@ -9,19 +9,19 @@ pub struct LimitErrorReader<R> {
 
 impl<R: Read> LimitErrorReader<R> {
     pub fn new(r: R, limit: u64) -> LimitErrorReader<R> {
-        LimitErrorReader { inner: r.take(limit) }
+        LimitErrorReader {
+            inner: r.take(limit),
+        }
     }
 }
 
 impl<R: Read> Read for LimitErrorReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self.inner.read(buf) {
-            Ok(0) if self.inner.limit() == 0 => {
-                Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "maximum limit reached when reading",
-                ))
-            }
+            Ok(0) if self.inner.limit() == 0 => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "maximum limit reached when reading",
+            )),
             e => e,
         }
     }
@@ -31,7 +31,8 @@ pub fn read_le_u32<R: Read + ?Sized>(r: &mut R) -> io::Result<u32> {
     let mut b = [0; 4];
     read_fill(r, &mut b)?;
     Ok(
-        (b[0] as u32) | ((b[1] as u32) << 8) | ((b[2] as u32) << 16) | ((b[3] as u32) << 24),
+        u32::from(b[0]) | (u32::from(b[1]) << 8) | (u32::from(b[2]) << 16)
+            | (u32::from(b[3]) << 24),
     )
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,15 +7,15 @@ use serde_json;
 use serde::Serialize;
 use url;
 
-use conduit::{Request, Response, Handler};
-use conduit_router::{RouteBuilder, RequestParams};
+use conduit::{Handler, Request, Response};
+use conduit_router::{RequestParams, RouteBuilder};
 use self::errors::NotFound;
 
-pub use self::errors::{CargoError, CargoResult, internal, human, bad_request, internal_error};
-pub use self::errors::{ChainError, std_error};
-pub use self::hasher::{HashingReader, hash};
+pub use self::errors::{bad_request, human, internal, internal_error, CargoError, CargoResult};
+pub use self::errors::{std_error, ChainError};
+pub use self::hasher::{hash, HashingReader};
 pub use self::head::Head;
-pub use self::io_util::{LimitErrorReader, read_le_u32, read_fill};
+pub use self::io_util::{read_fill, LimitErrorReader, read_le_u32};
 pub use self::request_proxy::RequestProxy;
 
 pub mod errors;
@@ -108,12 +108,10 @@ impl Handler for C {
         let C(f) = *self;
         match f(req) {
             Ok(resp) => Ok(resp),
-            Err(e) => {
-                match e.response() {
-                    Some(response) => Ok(response),
-                    None => Err(std_error(e)),
-                }
-            }
+            Err(e) => match e.response() {
+                Some(response) => Ok(response),
+                None => Err(std_error(e)),
+            },
         }
     }
 }

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -21,9 +21,9 @@ impl<'a> Request for RequestProxy<'a> {
         self.other.conduit_version()
     }
     fn method(&self) -> conduit::Method {
-        self.method.clone().unwrap_or_else(
-            || self.other.method().clone(),
-        )
+        self.method
+            .clone()
+            .unwrap_or_else(|| self.other.method().clone())
     }
     fn scheme(&self) -> conduit::Scheme {
         self.other.scheme()


### PR DESCRIPTION
The only new lints that clippy wanted were `Arc::clone(&x)` instead of `x.clone()`, and `u64::from(x)` instead of `x as u64`. The rest of these changes are just from the new rustfmt version