### PR TITLE
Resolves #1031 - Branding updates for crates.io

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,5 +1,5 @@
 <div id='title-header'>
-    <h1>The Rust community&rsquo;s crate host</h1>
+    <h1>The Rust community&rsquo;s crate registry</h1>
 
     <div class='links'>
         {{#link-to "install" class='yellow-button'}}


### PR DESCRIPTION
Modified the `<h1>` header inside `app/templates/index.hbs` from "The Rust community’s crate **host**" to "The Rust community’s crate **registry**".