### PR TITLE
Fix "pushObjects is not a function" error

### DIFF
--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,4 +1,5 @@
 import Controller from '@ember/controller';
+import { A } from '@ember/array';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
 
@@ -14,9 +15,9 @@ export default Controller.extend({
         this.fetchingFeed = true;
         this.loadingMore = false;
         this.hasMore = false;
-        this.myCrates = [];
-        this.myFollowing = [];
-        this.myFeed = [];
+        this.myCrates = A();
+        this.myFollowing = A();
+        this.myFeed = A();
         this.myStats = 0;
     },
 

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -1,4 +1,5 @@
 import Route from '@ember/routing/route';
+import { A } from '@ember/array';
 import RSVP from 'rsvp';
 
 import AuthenticatedRoute from '../mixins/authenticated-route';
@@ -15,7 +16,7 @@ export default Route.extend(AuthenticatedRoute, {
         controller.set('myStats', this.get('data.myStats'));
 
         if (!controller.get('loadingMore')) {
-            controller.set('myFeed', []);
+            controller.set('myFeed', A());
             controller.send('loadMore');
         }
     },


### PR DESCRIPTION
This is a bit of a quick patch to address the problem, we should dig some more into why it's happening.

Fixes #1099

[edit] I only checked `config/environment.js` for something disabling prototype extensions, and forgot to check `package.json`, which lists [ember-disable-prototype-extensions](https://github.com/rust-lang/crates.io/blob/master/package.json#L49).