### PR TITLE
Fixes #962 Backend: add "most_recently_downloaded" to 'summary' endpoint

### DIFF
--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -756,9 +756,9 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
 /// Handles the `GET /summary` route.
 pub fn summary(req: &mut Request) -> CargoResult<Response> {
     use schema::crates::dsl::*;
-    use diesel::expression::{DayAndMonthIntervalDsl};
+    use diesel::expression::DayAndMonthIntervalDsl;
     use diesel::types::{BigInt, Nullable};
-    use diesel::expression::functions::date_and_time::{now, date};
+    use diesel::expression::functions::date_and_time::{date, now};
     use diesel::expression::sql_literal::sql;
 
     let conn = req.db_conn()?;
@@ -800,11 +800,12 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
 
     let recent_downloads = sql::<Nullable<BigInt>>("SUM(crate_downloads.downloads)");
     let most_recently_downloaded = crates
-        .left_join(crate_downloads::table.on(
-            id.eq(crate_downloads::crate_id).and(
-                crate_downloads::date.gt(date(now - 90.days())),
+        .left_join(
+            crate_downloads::table.on(
+                id.eq(crate_downloads::crate_id)
+                    .and(crate_downloads::date.gt(date(now - 90.days()))),
             ),
-        ))
+        )
         .group_by(id)
         .order(recent_downloads.clone().desc().nulls_last())
         .limit(10)

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -755,11 +755,9 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
 
 /// Handles the `GET /summary` route.
 pub fn summary(req: &mut Request) -> CargoResult<Response> {
-    use schema::crates::dsl::*;
-    use diesel::expression::DayAndMonthIntervalDsl;
+    use diesel::expression::{date, now, sql, DayAndMonthIntervalDsl};
     use diesel::types::{BigInt, Nullable};
-    use diesel::expression::functions::date_and_time::{date, now};
-    use diesel::expression::sql_literal::sql;
+    use schema::crates::dsl::*;
 
     let conn = req.db_conn()?;
     let num_crates = crates.count().get_result(&*conn)?;
@@ -807,7 +805,7 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
             ),
         )
         .group_by(id)
-        .order(recent_downloads.clone().desc().nulls_last())
+        .order(recent_downloads.desc().nulls_last())
         .limit(10)
         .select(ALL_COLUMNS)
         .load::<Crate>(&*conn)?;

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -756,6 +756,10 @@ pub fn index(req: &mut Request) -> CargoResult<Response> {
 /// Handles the `GET /summary` route.
 pub fn summary(req: &mut Request) -> CargoResult<Response> {
     use schema::crates::dsl::*;
+    use diesel::expression::{DayAndMonthIntervalDsl};
+    use diesel::types::{BigInt, Nullable};
+    use diesel::expression::functions::date_and_time::{now, date};
+    use diesel::expression::sql_literal::sql;
 
     let conn = req.db_conn()?;
     let num_crates = crates.count().get_result(&*conn)?;
@@ -794,6 +798,19 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
         .limit(10)
         .load(&*conn)?;
 
+    let recent_downloads = sql::<Nullable<BigInt>>("SUM(crate_downloads.downloads)");
+    let most_recently_downloaded = crates
+        .left_join(crate_downloads::table.on(
+            id.eq(crate_downloads::crate_id).and(
+                crate_downloads::date.gt(date(now - 90.days())),
+            ),
+        ))
+        .group_by(id)
+        .order(recent_downloads.clone().desc().nulls_last())
+        .limit(10)
+        .select(ALL_COLUMNS)
+        .load::<Crate>(&*conn)?;
+
     let popular_keywords = keywords::table
         .order(keywords::crates_cnt.desc())
         .limit(10)
@@ -813,6 +830,7 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
         num_crates: i64,
         new_crates: Vec<EncodableCrate>,
         most_downloaded: Vec<EncodableCrate>,
+        most_recently_downloaded: Vec<EncodableCrate>,
         just_updated: Vec<EncodableCrate>,
         popular_keywords: Vec<EncodableKeyword>,
         popular_categories: Vec<EncodableCategory>,
@@ -822,6 +840,7 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
         num_crates: num_crates,
         new_crates: encode_crates(new_crates)?,
         most_downloaded: encode_crates(most_downloaded)?,
+        most_recently_downloaded: encode_crates(most_recently_downloaded)?,
         just_updated: encode_crates(just_updated)?,
         popular_keywords: popular_keywords,
         popular_categories: popular_categories,

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1040,12 +1040,15 @@ fn summary_new_crates() {
     let json: SummaryResponse = ::json(&mut response);
 
     assert_eq!(json.num_crates, 4);
-    assert_eq!(json.num_downloads, 0);  // need to add a record to metadata
+    assert_eq!(json.num_downloads, 0); // need to add a record to metadata
     assert_eq!(json.most_downloaded[0].name, "most_recent_downloads");
-    assert_eq!(json.most_recently_downloaded[0].name, "most_recent_downloads");
+    assert_eq!(
+        json.most_recently_downloaded[0].name,
+        "most_recent_downloads"
+    );
     assert_eq!(json.popular_keywords[0].keyword, "popular");
     assert_eq!(json.popular_categories[0].category, "Category 1");
-    assert_eq!(json.just_updated.len(), 0);  // update a couple before running this request...
+    assert_eq!(json.just_updated.len(), 0); // update a couple before running this request...
     assert_eq!(json.new_crates.len(), 4);
 }
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -22,7 +22,7 @@ use cargo_registry::schema::{crates, versions};
 
 use cargo_registry::upload as u;
 use cargo_registry::version::EncodableVersion;
-use cargo_registry::category::Category;
+use cargo_registry::category::{Category, EncodableCategory};
 
 use {CrateList, CrateMeta, GoodCrate};
 
@@ -49,6 +49,18 @@ struct RevDeps {
 #[derive(Deserialize)]
 struct Downloads {
     version_downloads: Vec<EncodableVersionDownload>,
+}
+
+#[derive(Deserialize)]
+struct SummaryResponse {
+    num_downloads: i64,
+    num_crates: i64,
+    new_crates: Vec<EncodableCrate>,
+    most_downloaded: Vec<EncodableCrate>,
+    most_recently_downloaded: Vec<EncodableCrate>,
+    just_updated: Vec<EncodableCrate>,
+    popular_keywords: Vec<EncodableKeyword>,
+    popular_categories: Vec<EncodableCategory>,
 }
 
 fn new_crate(name: &str) -> u::NewCrate {
@@ -980,6 +992,65 @@ fn summary_doesnt_die() {
     let (_b, app, middle) = ::app();
     let mut req = ::req(app, Method::Get, "/api/v1/summary");
     ok_resp!(middle.call(&mut req));
+}
+
+#[test]
+fn summary_new_crates() {
+    let (_b, app, middle) = ::app();
+    let u;
+    let krate;
+    let krate2;
+    let krate3;
+    let krate4;
+    {
+        let conn = app.diesel_database.get().unwrap();
+        u = ::new_user("foo").create_or_update(&conn).unwrap();
+
+        krate = ::CrateBuilder::new("some_downloads", u.id)
+            .version(::VersionBuilder::new("0.1.0"))
+            .description("description")
+            .keyword("popular")
+            .downloads(20)
+            .recent_downloads(10)
+            .expect_build(&conn);
+
+        krate2 = ::CrateBuilder::new("most_recent_downloads", u.id)
+            .version(::VersionBuilder::new("0.2.0"))
+            .keyword("popular")
+            .downloads(5000)
+            .recent_downloads(50)
+            .expect_build(&conn);
+
+        krate3 = ::CrateBuilder::new("with_downloads", u.id)
+            .version(::VersionBuilder::new("0.3.0"))
+            .keyword("popular")
+            .downloads(1000)
+            .expect_build(&conn);
+        krate4 = ::CrateBuilder::new("just_updated", u.id)
+            .version(::VersionBuilder::new("0.4.0"))
+            .expect_build(&conn);
+
+        ::new_category("Category 1", "cat1")
+            .create_or_update(&conn)
+            .unwrap();
+        Category::update_crate(&conn, &krate, &["cat1"]).unwrap();
+        Category::update_crate(&conn, &krate2, &["cat1"]).unwrap();
+    }
+    let mut req = ::req(app.clone(), Method::Get, "/api/v1/summary");
+    let mut response = ok_resp!(middle.call(&mut req));
+    let json: SummaryResponse = ::json(&mut response);
+
+    assert_eq!(json.num_crates, 4);
+    assert_eq!(json.num_downloads, 6020);
+    assert_eq!(json.new_crates[0].name, krate4.name);
+    assert_eq!(json.just_updated[0].name, krate4.name);
+    assert_eq!(json.most_downloaded[0].name, krate2.name);
+    assert_eq!(json.most_downloaded[1].name, krate3.name);
+    assert_eq!(json.most_recently_downloaded[0].name, krate2.name);
+    assert_eq!(json.most_recently_downloaded[1].name, krate.name);
+    assert_eq!(json.popular_keywords[0].keyword, "popular");
+    assert_eq!(json.popular_categories[0].category, "cat1");
+
 }
 
 #[test]


### PR DESCRIPTION
## Description

- Adds "most_recently_downloaded" property to JSON response returned from `api/v1/summary`

- Adds tests for `api/v1/summary` endpoint