### PR TITLE
Fix appveyor badge display and link.

### DIFF
--- a/app/components/badge-appveyor.js
+++ b/app/components/badge-appveyor.js
@@ -26,6 +26,11 @@ export default Component.extend({
         return this.get('badge.attributes.branch') || 'master';
     }),
 
+    projectName: computed('badge.attributes.project_name', function() {
+        return this.get('badge.attributes.project_name') ||
+            this.get('badge.attributes.repository').replace(/_/g, '-');
+    }),
+
     service: computed('badge.attributes.service', function() {
         return this.get('badge.attributes.service') || 'github';
     }),

--- a/app/templates/components/badge-appveyor.hbs
+++ b/app/templates/components/badge-appveyor.hbs
@@ -1,4 +1,4 @@
-<a href="https://ci.appveyor.com/project/{{ repository }}">
+<a href="https://ci.appveyor.com/project/{{ projectName }}">
     <img
         src="{{ imageUrl }}"
         alt="{{ text }}"

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -17,6 +17,7 @@ pub enum Badge {
         repository: String,
         id: Option<String>,
         branch: Option<String>,
+        project_name: Option<String>,
         service: Option<String>,
     },
     #[serde(rename = "gitlab")]

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -39,6 +39,7 @@ fn set_up() -> (Arc<App>, Crate, BadgeRef) {
         service: Some(String::from("github")),
         id: None,
         branch: None,
+        project_name: None,
         repository: String::from("rust-lang/cargo"),
     };
     let mut badge_attributes_appveyor = HashMap::new();


### PR DESCRIPTION
This fixes an issue with appveyor badges where if your repository name included an underscore, the link generated would not work because appveyor urls use dashes.

You can now specify an optional `project_name` for the appveyor badge in your `Cargo.toml`
```
[badges]
appveyor = { repository = "example/test_crate", service = "github", project_name = "example/test-crate" }
```

If the optional `project_name` attribute is present, we will use that for the link URL, otherwise we default to the required `repository` attribute and replace the underscores with dashes.

The reason to provide the `project_name` option is that if you change the repository name appveyor doesn't track the change.

Let me know if I missed anything!  I did create a test crate and set it up with appveyor to confirm.

Closes #587 