### PR TITLE
Show download graph as a stacked area chart

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -137,7 +137,7 @@ export default Component.extend({
                 pointShape: 'square'
             };
             seriesOption[i * 2 + 1] = {
-                type: 'line',
+                type: 'area',
                 color: COLORS[i % COLORS.length],
                 lineWidth: 2,
                 curveType: 'function',
@@ -156,7 +156,7 @@ export default Component.extend({
                 minorGridlines: { count: 5 },
                 viewWindow: { min: 0, },
             },
-            isStacked: false,
+            isStacked: true,
             focusTarget: 'category',
             seriesType: 'scatter',
             series: seriesOption


### PR DESCRIPTION
The purpose of this PR is to change the download chart such that it shows how the absolute number of downloads compares from version to version. Instead of having lots of different lines that might be hard to compare to each other, we show the 7-day average as an area. Additionally, the areas are stacked, so you can see the total and compare between versions.

Here's an example of how it might look (that's the libc crate):

![graph](https://user-images.githubusercontent.com/230613/31327539-475d502c-acd0-11e7-9ba2-f47053756d12.png)

This PR intends to close #393, although I realize it doesn't do exactly what was proposed. I think this is a simple fix that improves the readability of the graph, but I'm prepared to change it to more closely mimic the proposal in #393 if need be.