### PR TITLE
Add endpoint to display deployed git sha.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub mod user;
 pub mod util;
 pub mod version;
 pub mod email;
+pub mod site_metadata;
 
 mod local_upload;
 mod pagination;
@@ -202,6 +203,7 @@ pub fn middleware(app: Arc<App>) -> MiddlewareBuilder {
     api_router.get("/summary", C(krate::summary));
     api_router.put("/confirm/:email_token", C(user::confirm_user_email));
     api_router.put("/users/:user_id/resend", C(user::regenerate_token_and_send));
+    api_router.get("/site_metadata", C(site_metadata::show_deployed_sha));
     let api_router = Arc::new(R404(api_router));
 
     let mut router = RouteBuilder::new();

--- a/src/site_metadata.rs
+++ b/src/site_metadata.rs
@@ -1,0 +1,20 @@
+use conduit::{Request, Response};
+use util::RequestUtils;
+use util::errors::CargoResult;
+
+/// Returns the JSON representation of the current deployed commit sha.
+///
+/// The sha is contained within the `HEROKU_SLUG_COMMIT` environment variable.
+/// If `HEROKU_SLUG_COMMIT` is not set, returns `"unknown"`.
+pub fn show_deployed_sha(req: &mut Request) -> CargoResult<Response> {
+    let deployed_sha =
+        ::std::env::var("HEROKU_SLUG_COMMIT").unwrap_or_else(|_| String::from("unknown"));
+
+    #[derive(Serialize)]
+    struct R {
+        deployed_sha: String,
+    }
+    Ok(req.json(&R {
+        deployed_sha: deployed_sha,
+    }))
+}


### PR DESCRIPTION
This PR adds an api endpoint `/deployed_sha`, which returns a JSON response containing that sha `{ "sha": "abc" }` or if it's unavailable returns `{ "sha": "unknown" }`.

Closes #879