### PR TITLE
Update comrak to 0.2.3, use ext_header_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.162 (registry+https://github.com/rust-lang/crates.io-index)",
- "comrak 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "comrak 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-cookie 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -269,12 +269,13 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.1.9"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "entities 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "twoway 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode_categories 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1689,6 +1690,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "twoway"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typed-arena"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1843,7 +1852,7 @@ dependencies = [
 "checksum clippy_lints 0.0.162 (registry+https://github.com/rust-lang/crates.io-index)" = "b1c0da7936c88883ac09bc3b29584c275551eff961b2d0d87a22b60205088e55"
 "checksum cmake 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "0c8a6541a55bcd72d3de4faee2d101a5a66df29790282c7f797082a7228a9b3d"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
-"checksum comrak 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "8b2d07f7b7e1fd35e70300a9fc5397636650477887dc7b6ad6d29ba7d82e3349"
+"checksum comrak 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d6e2837c1814c4dc781f73697fdaaf9d5e2f2b137735dda2baad3d73dc684980"
 "checksum conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "db0caa30f78c207dc14c071b62512253ece5c4459897815682786aff1028bc82"
 "checksum conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "614f67083e437fd0b8fb9f13067203f358f1c6f52989eb6539292fde007fc6d6"
 "checksum conduit-cookie 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2ed0c16befdfbb983fa822470af5480a150401824ed9f2fb928df440781f7e35"
@@ -2006,6 +2015,7 @@ dependencies = [
 "checksum tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24da22d077e0f15f55162bdbdc661228c1581892f52074fb242678d015b45162"
 "checksum tokio-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d88e411cac1c87e405e4090be004493c5d8072a370661033b1a64ea205ec2e13"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
+"checksum twoway 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e267e178055eb3b081224bbef62d4f508ae3c9f000b6ae6ccdb04a0d9c34b77f"
 "checksum typed-arena 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5934776c3ac1bea4a9d56620d6bf2d483b20d394e49581db40f187e1118ff667"
 "checksum unicase 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e01da42520092d0cd2d6ac3ae69eb21a22ad43ff195676b86f8c37f487d6b80"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,12 +35,13 @@ dependencies = [
 
 [[package]]
 name = "ammonia"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.0-rc1"
+source = "git+https://github.com/notriddle/ammonia#00f39f4fdbf7bf0540f58bd92d2dddddb2e63f4d"
 dependencies = [
- "html5ever 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "html5ever 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendril 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -123,7 +124,7 @@ dependencies = [
 name = "cargo-registry"
 version = "0.2.1"
 dependencies = [
- "ammonia 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ammonia 1.0.0-rc1 (git+https://github.com/notriddle/ammonia)",
  "cargo-registry-s3 0.2.0",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -730,12 +731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "html5ever"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "markup5ever 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "markup5ever 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -935,7 +936,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "markup5ever"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "phf 0.7.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1831,7 +1832,7 @@ dependencies = [
 "checksum advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e06588080cb19d0acb6739808aafa5f26bfb2ca015b2b6370028b44cf7cb8a9a"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
-"checksum ammonia 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "768ad3bb5c582f19377a00ea9355d9c4f1b8349939da74949b1983312e7a2c0b"
+"checksum ammonia 1.0.0-rc1 (git+https://github.com/notriddle/ammonia)" = "<none>"
 "checksum antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
 "checksum backtrace-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "afccc5772ba333abccdf60d55200fa3406f8c59dcf54d5f7998c9107d3799c7c"
@@ -1904,7 +1905,7 @@ dependencies = [
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1c0203d653f4140241da0c1375a404f0a397249ec818cd2076c6280c50f6fa"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
-"checksum html5ever 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba0806f17ce2ea657c67cd28d03941166638c05153fb644aac6d5156b3033d0"
+"checksum html5ever 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5bfb46978eb757a603b7dfe2dafb1c62cb4dee3428d8ac1de734d83d6b022d06"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "641abc3e3fcf0de41165595f801376e01106bca1fd876dda937730e477ca004c"
 "checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
@@ -1927,7 +1928,7 @@ dependencies = [
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
 "checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum maplit 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "be384c560e0c3ad868b590ffb88d2c0a1effde6f59885234e4ea811c1202bfea"
-"checksum markup5ever 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8c787ec52b50a2ee0f15db7c18e628528964f71e113ceb864177abe866d169c9"
+"checksum markup5ever 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "047150a0e03b57e638fc45af33a0b63a0362305d5b9f92ecef81df472a4cceb0"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ serde = "1.0.0"
 clippy = { version = "=0.0.162", optional = true }
 chrono = { version = "0.4.0", features = ["serde"] }
 comrak = { version = "0.2.3", default-features = false }
-ammonia = "0.7.0"
+ammonia = { git = "https://github.com/notriddle/ammonia" }
 docopt = "0.8.1"
 itertools = "0.6.0"
 lettre = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde_derive = "1.0.0"
 serde = "1.0.0"
 clippy = { version = "=0.0.162", optional = true }
 chrono = { version = "0.4.0", features = ["serde"] }
-comrak = { version = "0.1.9", default-features = false }
+comrak = { version = "0.2.3", default-features = false }
 ammonia = "0.7.0"
 docopt = "0.8.1"
 itertools = "0.6.0"

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,8 +1,9 @@
 import Controller from '@ember/controller';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
-import { computed } from '@ember/object';
+import { computed, observer } from '@ember/object';
 import { later } from '@ember/runloop';
+import $ from 'jquery';
 import moment from 'moment';
 
 const NUM_VERSIONS = 5;
@@ -173,7 +174,7 @@ export default Controller.extend({
         },
     },
 
-    report: Ember.observer('crate.readme', function() {
+    report: observer('crate.readme', function() {
         setTimeout(() => $(window).trigger('hashchange'));
     }),
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -173,4 +173,8 @@ export default Controller.extend({
         },
     },
 
+    report: Ember.observer('crate.readme', function() {
+        setTimeout(() => $(window).trigger('hashchange'));
+    }),
+
 });

--- a/app/initializers/hashchange.js
+++ b/app/initializers/hashchange.js
@@ -1,7 +1,9 @@
+import $ from 'jquery';
+
 function decodeFragmentValue(hash) {
     try {
         return decodeURIComponent(hash.slice(1));
-    } catch (_) {
+    } catch(_) {
         return '';
     }
 }
@@ -26,7 +28,7 @@ function hashchange() {
     }
 }
 
-export function initialize(application) {
+export function initialize() {
     $(window).on('hashchange', hashchange);
 
     // If clicking on a link to the same fragment as currently in the address bar,

--- a/app/initializers/hashchange.js
+++ b/app/initializers/hashchange.js
@@ -1,0 +1,48 @@
+function decodeFragmentValue(hash) {
+    try {
+        return decodeURIComponent(hash.slice(1));
+    } catch (_) {
+        return '';
+    }
+}
+
+function findElementByFragmentName(document, name) {
+    if (name === '') {
+        return;
+    }
+
+    return document.getElementById(name) || document.getElementsByName(name)[0];
+}
+
+function hashchange() {
+    if (document.querySelector(':target')) {
+        return;
+    }
+
+    const hash = decodeFragmentValue(location.hash);
+    const target = findElementByFragmentName(document, `user-content-${hash}`);
+    if (target) {
+        target.scrollIntoView();
+    }
+}
+
+export function initialize(application) {
+    $(window).on('hashchange', hashchange);
+
+    // If clicking on a link to the same fragment as currently in the address bar,
+    // hashchange won't be fired, so we need to manually trigger rescroll.
+    $(document).on('a[href]', 'click', function(event) {
+        if (this.href === location.href && location.hash.length > 1) {
+            setTimeout(function() {
+                if (!event.defaultPrevented) {
+                    hashchange();
+                }
+            });
+        }
+    });
+}
+
+export default {
+    name: 'app.hashchange',
+    initialize
+};

--- a/src/render.rs
+++ b/src/render.rs
@@ -115,6 +115,7 @@ impl<'a> MarkdownRenderer<'a> {
             ext_table: true,
             ext_tagfilter: true,
             ext_tasklist: true,
+            ext_header_ids: Some("user-content-".to_string()),
             ..comrak::ComrakOptions::default()
         };
         let rendered = comrak::markdown_to_html(text, &options);

--- a/src/render.rs
+++ b/src/render.rs
@@ -94,7 +94,8 @@ impl<'a> MarkdownRenderer<'a> {
             .cloned()
             .collect();
         let mut html_sanitizer = Builder::new();
-        html_sanitizer.link_rel(Some("nofollow noopener noreferrer"))
+        html_sanitizer
+            .link_rel(Some("nofollow noopener noreferrer"))
             .tags(tags)
             .tag_attributes(tag_attributes)
             .allowed_classes(allowed_classes)
@@ -221,13 +222,19 @@ mod tests {
     fn header_has_tags() {
         let text = "# My crate\n\nHello, world!\n";
         let result = markdown_to_html(text).unwrap();
-        assert_eq!(result, "<h1><a href=\"#my-crate\" id=\"user-content-my-crate\" rel=\"nofollow noopener noreferrer\"></a>My crate</h1>\n<p>Hello, world!</p>\n");
+        assert_eq!(
+            result,
+            "<h1><a href=\"#my-crate\" id=\"user-content-my-crate\" rel=\"nofollow noopener noreferrer\"></a>My crate</h1>\n<p>Hello, world!</p>\n"
+        );
     }
 
     #[test]
     fn manual_anchor_is_sanitized() {
         let text = "<h1><a href=\"#my-crate\" id=\"my-crate\"></a>My crate</h1>\n<p>Hello, world!</p>\n";
         let result = markdown_to_html(text).unwrap();
-        assert_eq!(result, "<h1><a href=\"#my-crate\" id=\"user-content-my-crate\" rel=\"nofollow noopener noreferrer\"></a>My crate</h1>\n<p>Hello, world!</p>\n");
+        assert_eq!(
+            result,
+            "<h1><a href=\"#my-crate\" id=\"user-content-my-crate\" rel=\"nofollow noopener noreferrer\"></a>My crate</h1>\n<p>Hello, world!</p>\n"
+        );
     }
 }


### PR DESCRIPTION
Fixes #1037. Use latest comrak, and use the header IDs extension to generate GitHub-compatible anchors.

/cc @kejadlen @treiff