### PR TITLE
Fix path in api-token-row.hbs

### DIFF
--- a/app/templates/components/api-token-row.hbs
+++ b/app/templates/components/api-token-row.hbs
@@ -65,7 +65,7 @@
     <div class='row new-token'>
         <div>
             Please record this token somewhere, you cannot retrieve
-            its value again. For use on the command line you can save it to <code>~/.cargo/config</code>
+            its value again. For use on the command line you can save it to <code>~/.cargo/credentials</code>
             with:
 
             <pre>cargo login {{ api_token.token }}</pre>


### PR DESCRIPTION
Tokens now go in ~/.cargo/credentials, not ~/.cargo/config