### PR TITLE
Add support for a CDN in front of crates/readmes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -66,6 +66,7 @@ impl Default for Config {
                         env("S3_SECRET_KEY"),
                         &api_protocol,
                     ),
+                    cdn: env::var("S3_CDN").ok(),
                     proxy: None,
                 }
             }
@@ -86,6 +87,7 @@ impl Default for Config {
                         env::var("S3_SECRET_KEY").unwrap_or_default(),
                         &api_protocol,
                     ),
+                    cdn: env::var("S3_CDN").ok(),
                     proxy: None,
                 }
             }
@@ -105,6 +107,7 @@ impl Default for Config {
                             env::var("S3_SECRET_KEY").unwrap_or_default(),
                             &api_protocol,
                         ),
+                        cdn: env::var("S3_CDN").ok(),
                         proxy: None,
                     }
                 } else {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -142,6 +142,7 @@ fn app() -> (
             &api_protocol,
         ),
         proxy: Some(proxy),
+        cdn: None,
     };
 
     let config = cargo_registry::Config {

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -46,7 +46,11 @@ impl Uploader {
     /// It returns `None` if the current `Uploader` is `NoOp`.
     pub fn crate_location(&self, crate_name: &str, version: &str) -> Option<String> {
         match *self {
-            Uploader::S3 { ref bucket, ref cdn, .. } => {
+            Uploader::S3 {
+                ref bucket,
+                ref cdn,
+                ..
+            } => {
                 let host = match *cdn {
                     Some(ref s) => s.clone(),
                     None => bucket.host(),
@@ -65,7 +69,11 @@ impl Uploader {
     /// It returns `None` if the current `Uploader` is `NoOp`.
     pub fn readme_location(&self, crate_name: &str, version: &str) -> Option<String> {
         match *self {
-            Uploader::S3 { ref bucket, ref cdn, .. } => {
+            Uploader::S3 {
+                ref bucket,
+                ref cdn,
+                ..
+            } => {
                 let host = match *cdn {
                     Some(ref s) => s.clone(),
                     None => bucket.host(),

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -20,6 +20,7 @@ pub enum Uploader {
     /// For test usage with a proxy.
     S3 {
         bucket: s3::Bucket,
+        cdn: Option<String>,
         proxy: Option<String>,
     },
 
@@ -45,11 +46,14 @@ impl Uploader {
     /// It returns `None` if the current `Uploader` is `NoOp`.
     pub fn crate_location(&self, crate_name: &str, version: &str) -> Option<String> {
         match *self {
-            Uploader::S3 { ref bucket, .. } => Some(format!(
-                "https://{}/{}",
-                bucket.host(),
-                Uploader::crate_path(crate_name, version)
-            )),
+            Uploader::S3 { ref bucket, ref cdn, .. } => {
+                let host = match *cdn {
+                    Some(ref s) => s.clone(),
+                    None => bucket.host(),
+                };
+                let path = Uploader::crate_path(crate_name, version);
+                Some(format!("https://{}/{}", host, path))
+            }
             Uploader::Local => Some(format!("/{}", Uploader::crate_path(crate_name, version))),
             Uploader::NoOp => None,
         }
@@ -61,11 +65,14 @@ impl Uploader {
     /// It returns `None` if the current `Uploader` is `NoOp`.
     pub fn readme_location(&self, crate_name: &str, version: &str) -> Option<String> {
         match *self {
-            Uploader::S3 { ref bucket, .. } => Some(format!(
-                "https://{}/{}",
-                bucket.host(),
-                Uploader::readme_path(crate_name, version)
-            )),
+            Uploader::S3 { ref bucket, ref cdn, .. } => {
+                let host = match *cdn {
+                    Some(ref s) => s.clone(),
+                    None => bucket.host(),
+                };
+                let path = Uploader::readme_path(crate_name, version);
+                Some(format!("https://{}/{}", host, path))
+            }
             Uploader::Local => Some(format!("/{}", Uploader::readme_path(crate_name, version))),
             Uploader::NoOp => None,
         }


### PR DESCRIPTION
This should hopefully allow us to configure a CDN on Heroku (namely CloudFront)
to distribute crates/readmes through.