### PR TITLE
Propose new MVC module layout

### DIFF
--- a/src/badge.rs
+++ b/src/badge.rs
@@ -1,10 +1,10 @@
-use krate::Crate;
-use schema::badges;
-
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use serde_json;
 use std::collections::HashMap;
+
+use models::Crate;
+use schema::badges;
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", tag = "badge_type", content = "attributes")]

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -15,7 +15,7 @@ use std::env;
 use std::io;
 use std::io::prelude::*;
 
-use cargo_registry::Crate;
+use cargo_registry::models::Crate;
 use cargo_registry::schema::crates;
 
 #[allow(dead_code)]

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -15,7 +15,7 @@ use std::env;
 use std::io;
 use std::io::prelude::*;
 
-use cargo_registry::{Crate, Version};
+use cargo_registry::models::{Crate, Version};
 use cargo_registry::schema::versions;
 
 #[allow(dead_code)]

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -32,9 +32,11 @@ use std::thread;
 use tar::Archive;
 use url::Url;
 
-use cargo_registry::{Config, Version};
-use cargo_registry::schema::*;
+use cargo_registry::Config;
 use cargo_registry::render::readme_to_html;
+
+use cargo_registry::models::Version;
+use cargo_registry::schema::*;
 
 const DEFAULT_PAGE_SIZE: usize = 25;
 const USAGE: &str = "

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -13,8 +13,7 @@ use std::env;
 use std::io;
 use std::io::prelude::*;
 
-use cargo_registry::{Crate, User};
-use cargo_registry::owner::OwnerKind;
+use cargo_registry::models::{Crate, OwnerKind, User};
 use cargo_registry::schema::*;
 
 fn main() {

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -8,7 +8,7 @@ use diesel::prelude::*;
 use std::env;
 use std::time::Duration;
 
-use cargo_registry::VersionDownload;
+use cargo_registry::models::VersionDownload;
 use cargo_registry::schema::*;
 
 static LIMIT: i64 = 1000;
@@ -118,9 +118,7 @@ mod test {
     use diesel::insert_into;
     use super::*;
     use cargo_registry::env;
-    use cargo_registry::krate::{Crate, NewCrate};
-    use cargo_registry::user::{NewUser, User};
-    use cargo_registry::version::{NewVersion, Version};
+    use cargo_registry::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
 
     fn conn() -> PgConnection {
         let conn = PgConnection::establish(&env("TEST_DATABASE_URL")).unwrap();

--- a/src/category.rs
+++ b/src/category.rs
@@ -3,10 +3,11 @@ use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use diesel::*;
 
-use Crate;
 use db::RequestTransaction;
-use schema::*;
 use util::{CargoResult, RequestUtils};
+
+use models::Crate;
+use schema::*;
 
 #[derive(Clone, Identifiable, Queryable, QueryableByName, Debug)]
 #[table_name = "categories"]

--- a/src/controllers/helpers/mod.rs
+++ b/src/controllers/helpers/mod.rs
@@ -1,0 +1,3 @@
+pub mod pagination;
+
+pub use self::pagination::Paginate;

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -3,6 +3,7 @@ use diesel::query_builder::*;
 use diesel::sql_types::BigInt;
 use diesel::pg::Pg;
 
+#[derive(Debug)]
 pub struct Paginated<T> {
     query: T,
     limit: i64,

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,1 +1,3 @@
 // TODO: All endpoints would be moved to submodules here
+
+pub mod helpers;

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,0 +1,1 @@
+// TODO: All endpoints would be moved to submodules here

--- a/src/crate_owner_invitation.rs
+++ b/src/crate_owner_invitation.rs
@@ -4,11 +4,12 @@ use diesel::prelude::*;
 use serde_json;
 
 use db::RequestTransaction;
-use schema::{crate_owner_invitations, crate_owners, crates, users};
 use user::RequestUser;
 use util::errors::{human, CargoResult};
 use util::RequestUtils;
-use owner::{CrateOwner, OwnerKind};
+
+use models::{CrateOwner, OwnerKind};
+use schema::{crate_owner_invitations, crate_owners, crates, users};
 
 /// The model representing a row in the `crate_owner_invitations` database table.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Identifiable, Queryable)]

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -5,10 +5,10 @@ use diesel::row::NamedRow;
 use semver;
 
 use git;
-use krate::Crate;
-use schema::*;
 use util::{human, CargoResult};
-use version::Version;
+
+use models::{Crate, Version};
+use schema::*;
 
 #[derive(Identifiable, Associations, Debug)]
 #[belongs_to(Version)]
@@ -86,7 +86,7 @@ impl ReverseDependency {
 
 pub fn add_dependencies(
     conn: &PgConnection,
-    deps: &[::upload::CrateDependency],
+    deps: &[::views::EncodableCrateDependency],
     target_version_id: i32,
 ) -> CargoResult<Vec<git::Dependency>> {
     use diesel::insert_into;

--- a/src/download.rs
+++ b/src/download.rs
@@ -2,8 +2,8 @@ use chrono::NaiveDate;
 use diesel;
 use diesel::prelude::*;
 
+use models::Version;
 use schema::version_downloads;
-use version::Version;
 
 #[derive(Queryable, Identifiable, Associations, Debug, Clone, Copy)]
 #[belongs_to(Version)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -9,8 +9,9 @@ use git2;
 use serde_json;
 
 use app::App;
-use dependency::Kind;
 use util::{internal, CargoResult};
+
+use models::Kind;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Crate {

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -5,7 +5,7 @@ use diesel::prelude::*;
 use diesel;
 
 use db::RequestTransaction;
-use pagination::Paginate;
+use controllers::helpers::Paginate;
 use util::{CargoResult, RequestUtils};
 
 use models::Crate;

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -1,17 +1,15 @@
-#[allow(unused_imports)] // TODO: Remove when rustc 1.23 is stable
-use std::ascii::AsciiExt;
-
 use chrono::NaiveDateTime;
 use conduit::{Request, Response};
 use conduit_router::RequestParams;
 use diesel::prelude::*;
 use diesel;
 
-use Crate;
 use db::RequestTransaction;
 use pagination::Paginate;
-use schema::*;
 use util::{CargoResult, RequestUtils};
+
+use models::Crate;
+use schema::*;
 
 #[derive(Clone, Identifiable, Queryable, Debug)]
 pub struct Keyword {

--- a/src/krate/downloads.rs
+++ b/src/krate/downloads.rs
@@ -10,12 +10,13 @@ use conduit_router::RequestParams;
 use diesel::prelude::*;
 
 use db::RequestTransaction;
-use download::{EncodableVersionDownload, VersionDownload};
-use schema::*;
 use util::{CargoResult, RequestUtils};
-use Version;
 
-use super::{to_char, Crate};
+use views::EncodableVersionDownload;
+use models::{Crate, Version, VersionDownload};
+use schema::*;
+
+use super::to_char;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub fn downloads(req: &mut Request) -> CargoResult<Response> {

--- a/src/krate/follow.rs
+++ b/src/krate/follow.rs
@@ -7,11 +7,11 @@ use diesel::prelude::*;
 use diesel;
 
 use db::RequestTransaction;
-use schema::*;
 use user::RequestUser;
 use util::{CargoResult, RequestUtils};
 
-use super::{Crate, Follow};
+use models::{Crate, Follow};
+use schema::*;
 
 fn follow_target(req: &mut Request) -> CargoResult<Follow> {
     let user = req.user()?;

--- a/src/krate/metadata.rs
+++ b/src/krate/metadata.rs
@@ -9,16 +9,15 @@ use conduit_router::RequestParams;
 use diesel::prelude::*;
 
 use app::RequestApp;
-use category::{CrateCategory, EncodableCategory};
 use db::RequestTransaction;
-use dependency::EncodableDependency;
-use keyword::{CrateKeyword, EncodableKeyword};
-use schema::*;
 use util::{human, CargoResult, RequestUtils};
-use version::EncodableVersion;
-use {Category, Keyword, Version};
 
-use super::{Crate, CrateDownload, EncodableCrate, ALL_COLUMNS};
+use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
+            EncodableVersion};
+use models::{Category, Crate, CrateCategory, CrateDownload, CrateKeyword, Keyword, Version};
+use schema::*;
+
+use super::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
 pub fn summary(req: &mut Request) -> CargoResult<Response> {

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -1,6 +1,3 @@
-#[allow(unused_imports)] // TODO: Remove when rustc 1.23 is stable
-use std::ascii::AsciiExt;
-
 use chrono::{NaiveDate, NaiveDateTime};
 use diesel::associations::Identifiable;
 use diesel::prelude::*;
@@ -10,14 +7,14 @@ use semver;
 use url::Url;
 
 use app::App;
-use badge::EncodableBadge;
-use crate_owner_invitation::NewCrateOwnerInvitation;
-use dependency::ReverseDependency;
-use owner::{CrateOwner, Owner, OwnerKind};
-use schema::*;
 use util::{human, CargoResult};
+
+use views::EncodableBadge;
+use models::{Badge, Category, CrateOwner, Keyword, NewCrateOwnerInvitation, Owner, OwnerKind,
+             ReverseDependency, User, Version};
+
+use schema::*;
 use with_count::*;
-use {Badge, Category, Keyword, User, Version};
 
 pub mod search;
 pub mod publish;
@@ -560,6 +557,7 @@ mod tests {
     use super::*;
     use chrono::NaiveDate;
     use serde_json;
+    use models::Crate;
 
     #[test]
     fn documentation_blacklist_no_url_provided() {

--- a/src/krate/owners.rs
+++ b/src/krate/owners.rs
@@ -7,12 +7,12 @@ use serde_json;
 
 use app::RequestApp;
 use db::RequestTransaction;
-use owner::{rights, EncodableOwner, Owner, Rights, Team};
+use owner::rights;
 use user::RequestUser;
 use util::{human, CargoResult, RequestUtils};
-use User;
 
-use super::Crate;
+use views::EncodableOwner;
+use models::{Crate, Owner, Rights, Team, User};
 
 /// Handles the `GET /crates/:crate_id/owners` route.
 pub fn owners(req: &mut Request) -> CargoResult<Response> {

--- a/src/krate/search.rs
+++ b/src/krate/search.rs
@@ -5,7 +5,7 @@ use diesel::prelude::*;
 use diesel_full_text_search::*;
 
 use db::RequestTransaction;
-use pagination::Paginate;
+use controllers::helpers::Paginate;
 use user::RequestUser;
 use util::{CargoResult, RequestUtils};
 

--- a/src/krate/search.rs
+++ b/src/krate/search.rs
@@ -5,14 +5,15 @@ use diesel::prelude::*;
 use diesel_full_text_search::*;
 
 use db::RequestTransaction;
-use owner::OwnerKind;
 use pagination::Paginate;
-use schema::*;
 use user::RequestUser;
 use util::{CargoResult, RequestUtils};
-use {Badge, Version};
 
-use super::{canon_crate_name, Crate, EncodableCrate, ALL_COLUMNS};
+use views::EncodableCrate;
+use models::{Badge, Crate, OwnerKind, Version};
+use schema::*;
+
+use super::{canon_crate_name, ALL_COLUMNS};
 
 /// Handles the `GET /crates` route.
 /// Returns a list of crates. Called in a variety of scenarios in the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,15 +51,7 @@ extern crate conduit_static;
 extern crate cookie;
 
 pub use app::App;
-pub use self::badge::Badge;
-pub use self::category::Category;
 pub use config::Config;
-pub use self::dependency::Dependency;
-pub use self::download::VersionDownload;
-pub use self::keyword::Keyword;
-pub use self::krate::Crate;
-pub use self::user::User;
-pub use self::version::Version;
 pub use self::uploaders::{Bomb, Uploader};
 
 use std::sync::Arc;
@@ -89,13 +81,16 @@ pub mod owner;
 pub mod render;
 pub mod schema;
 pub mod token;
-pub mod upload;
 pub mod uploaders;
 pub mod user;
 pub mod util;
 pub mod version;
 pub mod email;
 pub mod site_metadata;
+
+pub mod controllers;
+pub mod models;
+pub mod views;
 
 mod local_upload;
 mod pagination;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,6 @@ pub mod models;
 pub mod views;
 
 mod local_upload;
-mod pagination;
 mod with_count;
 
 /// Used for setting different values depending on whether the app is being run in production,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,11 @@
+pub use badge::{Badge, MaintenanceStatus};
+pub use category::{Category, CrateCategory, NewCategory};
+pub use crate_owner_invitation::NewCrateOwnerInvitation;
+pub use dependency::{Dependency, Kind, ReverseDependency};
+pub use download::VersionDownload;
+pub use keyword::{CrateKeyword, Keyword};
+pub use krate::{Crate, CrateDownload, Follow, NewCrate};
+pub use owner::{CrateOwner, NewTeam, Owner, OwnerKind, Rights, Team};
+pub use user::{Email, NewUser, User};
+pub use token::ApiToken;
+pub use version::{NewVersion, Version};

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -2,9 +2,10 @@ use diesel::prelude::*;
 
 use app::App;
 use github;
-use schema::*;
 use util::{human, CargoResult};
-use {Crate, User};
+
+use models::{Crate, User};
+use schema::*;
 
 #[derive(Insertable, Associations, Identifiable, Debug, Clone, Copy)]
 #[belongs_to(Crate)]

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -29,22 +29,22 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
 use cargo_registry::app::App;
-use cargo_registry::category::NewCategory;
-use cargo_registry::keyword::Keyword;
-use cargo_registry::krate::{CrateDownload, EncodableCrate, NewCrate};
-use cargo_registry::schema::*;
-use cargo_registry::upload as u;
-use cargo_registry::user::NewUser;
-use cargo_registry::owner::{CrateOwner, NewTeam, Team};
-use cargo_registry::version::NewVersion;
 use cargo_registry::user::AuthenticationSource;
-use cargo_registry::{Crate, Dependency, Replica, User, Version};
+use cargo_registry::Replica;
 use chrono::Utc;
 use conduit::{Method, Request};
 use conduit_test::MockRequest;
 use diesel::prelude::*;
 use flate2::Compression;
 use flate2::write::GzEncoder;
+
+pub use cargo_registry::{models, schema, views};
+
+use views::EncodableCrate;
+use views::krate_publish as u;
+use models::{Crate, CrateDownload, CrateOwner, Dependency, Keyword, Team, User, Version};
+use models::{NewCategory, NewCrate, NewTeam, NewUser, NewVersion};
+use schema::*;
 
 macro_rules! t {
     ($e:expr) => (
@@ -474,7 +474,7 @@ fn new_version(crate_id: i32, num: &str) -> NewVersion {
 }
 
 fn krate(name: &str) -> Crate {
-    cargo_registry::krate::Crate {
+    Crate {
         id: NEXT_ID.fetch_add(1, Ordering::SeqCst) as i32,
         name: name.to_string(),
         updated_at: Utc::now().naive_utc(),

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,9 +1,9 @@
-use cargo_registry::app::App;
-use cargo_registry::badge::{Badge, MaintenanceStatus};
-use cargo_registry::krate::Crate;
-
 use std::collections::HashMap;
 use std::sync::Arc;
+
+use App;
+
+use models::{Badge, Crate, MaintenanceStatus};
 
 struct BadgeRef {
     appveyor: Badge,

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -1,8 +1,9 @@
 use std::env;
 
-use cargo_registry::schema::categories;
 use diesel::*;
 use dotenv::dotenv;
+
+use schema::categories;
 
 const ALGORITHMS: &str = r#"
 [algorithms]

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,6 +1,7 @@
 use conduit::{Handler, Method};
 
-use cargo_registry::category::{Category, EncodableCategory, EncodableCategoryWithSubcategories};
+use views::{EncodableCategory, EncodableCategoryWithSubcategories};
+use models::Category;
 
 #[derive(Deserialize)]
 struct CategoryList {

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use conduit::{Handler, Method};
 use conduit_test::MockRequest;
 
-use cargo_registry::keyword::{EncodableKeyword, Keyword};
+use views::EncodableKeyword;
+use models::Keyword;
 
 #[derive(Deserialize)]
 struct KeywordList {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -14,20 +14,16 @@ use git2;
 use semver;
 use serde_json;
 
-use cargo_registry::dependency::EncodableDependency;
-use cargo_registry::download::EncodableVersionDownload;
 use cargo_registry::git;
-use cargo_registry::keyword::EncodableKeyword;
-use cargo_registry::krate::{Crate, EncodableCrate, MAX_NAME_LENGTH};
-
-use cargo_registry::token::ApiToken;
-use cargo_registry::schema::{crates, metadata, versions};
-
-use cargo_registry::upload as u;
-use cargo_registry::version::EncodableVersion;
-use cargo_registry::category::{Category, EncodableCategory};
+use cargo_registry::krate::MAX_NAME_LENGTH;
 
 use {CrateList, CrateMeta, GoodCrate};
+
+use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
+            EncodableVersion, EncodableVersionDownload};
+use views::krate_publish as u;
+use models::{ApiToken, Category, Crate};
+use schema::{crates, metadata, versions};
 
 #[derive(Deserialize)]
 struct VersionsList {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -2,16 +2,13 @@ use std::sync::Arc;
 
 use {CrateList, GoodCrate};
 
-use cargo_registry::owner::EncodableOwner;
-use cargo_registry::user::EncodablePublicUser;
-use cargo_registry::crate_owner_invitation::{EncodableCrateOwnerInvitation, InvitationResponse,
-                                             NewCrateOwnerInvitation};
-use cargo_registry::schema::crate_owner_invitations;
-use cargo_registry::krate::Crate;
-
 use conduit::{Handler, Method};
 use diesel;
 use diesel::prelude::*;
+
+use views::{EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse};
+use models::{Crate, NewCrateOwnerInvitation};
+use schema::crate_owner_invitations;
 
 #[derive(Deserialize)]
 struct TeamResponse {

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -8,8 +8,7 @@ use std::borrow::Cow;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::env;
-use std::fs::File;
-use std::fs;
+use std::fs::{self, File};
 use std::io::prelude::*;
 use std::io;
 use std::net;
@@ -19,7 +18,6 @@ use std::str;
 use std::sync::{Arc, Mutex, Once};
 use std::thread;
 
-use cargo_registry::user::NewUser;
 use curl::easy::{Easy, List};
 use self::futures::{Future, Stream};
 use self::futures::sync::oneshot;
@@ -28,6 +26,8 @@ use self::tokio_core::net::TcpListener;
 use self::tokio_core::reactor::Core;
 use self::tokio_service::Service;
 use serde_json;
+
+use models::NewUser;
 
 // A "bomb" so when the test task exists we know when to shut down
 // the server and fail if the subtask failed.

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -1,10 +1,10 @@
 use std::sync::ONCE_INIT;
 use conduit::{Handler, Method};
 use diesel::*;
-
-use cargo_registry::user::NewUser;
-use cargo_registry::krate::{Crate, EncodableCrate};
 use record::GhUser;
+
+use views::EncodableCrate;
+use models::{Crate, NewUser};
 
 // Users: `crates-tester-1` and `crates-tester-2`
 // Passwords: ask acrichto or gankro

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use diesel::prelude::*;
 use conduit::{Handler, Method};
 
-use cargo_registry::token::{ApiToken, EncodableApiTokenWithToken};
+use views::EncodableApiTokenWithToken;
+use models::ApiToken;
 
 #[derive(Deserialize)]
 struct DecodableApiToken {

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -2,13 +2,10 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use conduit::{Handler, Method};
-
-use cargo_registry::token::ApiToken;
-use cargo_registry::krate::EncodableCrate;
-use cargo_registry::user::{Email, EncodablePrivateUser, EncodablePublicUser, NewUser, User};
-use cargo_registry::version::EncodableVersion;
-
 use diesel::prelude::*;
+
+use views::{EncodableCrate, EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
+use models::{ApiToken, Email, NewUser, User};
 
 #[derive(Deserialize)]
 struct AuthResponse {

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -8,8 +8,8 @@ use serde_json::Value;
 use conduit::{Handler, Method};
 use self::diesel::prelude::*;
 
-use cargo_registry::version::EncodableVersion;
-use cargo_registry::schema::versions;
+use views::EncodableVersion;
+use schema::versions;
 
 #[derive(Deserialize)]
 struct VersionList {

--- a/src/token.rs
+++ b/src/token.rs
@@ -6,8 +6,10 @@ use diesel;
 use serde_json as json;
 
 use db::RequestTransaction;
-use user::{AuthenticationSource, RequestUser, User};
+use user::{AuthenticationSource, RequestUser};
 use util::{bad_request, read_fill, CargoResult, ChainError, RequestUtils};
+
+use models::User;
 use schema::api_tokens;
 
 /// The model representing a row in the `api_tokens` database table.

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -1,7 +1,6 @@
 use conduit::Request;
 use curl::easy::Easy;
 use flate2::read::GzDecoder;
-use krate::Crate;
 use s3;
 use semver;
 use tar;
@@ -13,6 +12,8 @@ use std::sync::Arc;
 use std::fs::{self, File};
 use std::env;
 use std::io::{Read, Write};
+
+use models::Crate;
 
 #[derive(Clone, Debug)]
 pub enum Uploader {

--- a/src/user/middleware.rs
+++ b/src/user/middleware.rs
@@ -6,9 +6,10 @@ use conduit_cookie::RequestSession;
 use diesel::prelude::*;
 
 use db::RequestTransaction;
-use schema::users;
-use super::User;
 use util::errors::{std_error, CargoResult, ChainError, Unauthorized};
+
+use models::User;
+use schema::users;
 
 #[derive(Debug, Clone, Copy)]
 pub struct Middleware;

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -10,7 +10,7 @@ use serde_json;
 
 use app::RequestApp;
 use db::RequestTransaction;
-use pagination::Paginate;
+use controllers::helpers::Paginate;
 use util::{bad_request, human, CargoResult, RequestUtils};
 use github;
 use email;

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -10,19 +10,18 @@ use serde_json;
 
 use app::RequestApp;
 use db::RequestTransaction;
-use krate::Follow;
 use pagination::Paginate;
-use schema::*;
 use util::{bad_request, human, CargoResult, RequestUtils};
-use version::EncodableVersion;
-use {github, Version};
-use owner::{CrateOwner, Owner, OwnerKind};
-use krate::Crate;
+use github;
 use email;
 
 pub use self::middleware::{AuthenticationSource, Middleware, RequestUser};
 
 pub mod middleware;
+
+use views::{EncodableTeam, EncodableVersion};
+use models::{Crate, CrateOwner, Follow, Owner, OwnerKind, Team, Version};
+use schema::*;
 
 /// The model representing a row in the `users` database table.
 #[derive(Clone, Debug, PartialEq, Eq, Queryable, Identifiable, AsChangeset, Associations)]
@@ -420,8 +419,6 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
 /// Handles the `GET /teams/:team_id` route.
 pub fn show_team(req: &mut Request) -> CargoResult<Response> {
     use self::teams::dsl::{login, teams};
-    use owner::Team;
-    use owner::EncodableTeam;
 
     let name = &req.params()["team_id"];
     let conn = req.db_conn()?;
@@ -479,7 +476,6 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
 /// Handles the `GET /users/:user_id/stats` route.
 pub fn stats(req: &mut Request) -> CargoResult<Response> {
     use diesel::dsl::sum;
-    use owner::OwnerKind;
 
     let user_id = &req.params()["user_id"].parse::<i32>().ok().unwrap();
     let conn = req.db_conn()?;

--- a/src/version/deprecated.rs
+++ b/src/version/deprecated.rs
@@ -11,10 +11,13 @@ use diesel::prelude::*;
 use url;
 
 use db::RequestTransaction;
-use schema::*;
 use util::{CargoResult, RequestUtils};
 
-use super::{version_and_crate, EncodableVersion, Version};
+use views::EncodableVersion;
+use models::Version;
+use schema::*;
+
+use super::version_and_crate;
 
 /// Handles the `GET /versions` route.
 pub fn index(req: &mut Request) -> CargoResult<Response> {

--- a/src/version/downloads.rs
+++ b/src/version/downloads.rs
@@ -9,10 +9,12 @@ use diesel::prelude::*;
 
 use app::RequestApp;
 use db::RequestTransaction;
-use download::{EncodableVersionDownload, VersionDownload};
-use schema::*;
 use util::{human, CargoResult, RequestUtils};
-use {Crate, Replica};
+use Replica;
+
+use views::EncodableVersionDownload;
+use schema::*;
+use models::{Crate, VersionDownload};
 
 use super::version_and_crate;
 

--- a/src/version/metadata.rs
+++ b/src/version/metadata.rs
@@ -8,9 +8,10 @@ use conduit::{Request, Response};
 
 use diesel::prelude::*;
 use db::RequestTransaction;
-use dependency::EncodableDependency;
-use schema::*;
 use util::{CargoResult, RequestUtils};
+
+use views::{EncodableDependency, EncodablePublicUser};
+use schema::*;
 
 use super::version_and_crate;
 
@@ -51,7 +52,7 @@ pub fn authors(req: &mut Request) -> CargoResult<Response> {
     // is all that is left, hear for backwards compatibility.
     #[derive(Serialize)]
     struct R {
-        users: Vec<::user::EncodablePublicUser>,
+        users: Vec<EncodablePublicUser>,
         meta: Meta,
     }
     #[derive(Serialize)]

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -9,10 +9,7 @@ use diesel::prelude::*;
 use semver;
 use serde_json;
 
-use Crate;
 use db::RequestTransaction;
-use dependency::Dependency;
-use schema::*;
 use util::{human, CargoResult};
 use license_exprs;
 
@@ -20,6 +17,9 @@ pub mod deprecated;
 pub mod downloads;
 pub mod metadata;
 pub mod yank;
+
+use models::{Crate, Dependency};
+use schema::*;
 
 // Queryable has a custom implementation below
 #[derive(Clone, Identifiable, Associations, Debug)]

--- a/src/version/yank.rs
+++ b/src/version/yank.rs
@@ -7,11 +7,13 @@ use diesel::prelude::*;
 use app::RequestApp;
 use db::RequestTransaction;
 use git;
-use owner::{rights, Rights};
-use schema::*;
+use owner::rights;
 use user::RequestUser;
 use util::errors::CargoError;
 use util::{human, CargoResult, RequestUtils};
+
+use models::Rights;
+use schema::*;
 
 use super::version_and_crate;
 

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -6,10 +6,12 @@ use std::collections::HashMap;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use semver;
-use dependency::Kind as DependencyKind;
 
-use keyword::Keyword as CrateKeyword;
-use krate::{Crate, MAX_NAME_LENGTH};
+use krate::MAX_NAME_LENGTH;
+
+use models::Keyword as CrateKeyword;
+use models::Kind as DependencyKind;
+use models::Crate;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct NewCrate {

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,0 +1,19 @@
+// TODO: Move all encodable types here
+// For now, just reexport
+
+pub use badge::EncodableBadge;
+pub use category::{EncodableCategory, EncodableCategoryWithSubcategories};
+pub use crate_owner_invitation::{EncodableCrateOwnerInvitation, InvitationResponse};
+pub use dependency::EncodableDependency;
+pub use download::EncodableVersionDownload;
+pub use keyword::EncodableKeyword;
+pub use krate::EncodableCrate;
+pub use owner::{EncodableOwner, EncodableTeam};
+pub use token::EncodableApiTokenWithToken;
+pub use user::{EncodablePrivateUser, EncodablePublicUser};
+pub use version::EncodableVersion;
+
+// TODO: Prefix many of these with `Encodable` then clean up the reexports
+pub mod krate_publish;
+pub use self::krate_publish::CrateDependency as EncodableCrateDependency;
+pub use self::krate_publish::NewCrate as EncodableCrateUpload;


### PR DESCRIPTION
This pull request proposes a new module layout following a model-view-controller style.  For now, the functionality is re-exported from the new locations and the `use` statements have been updated to use the new locations.    If we define where things should be moved to now, it should be easier to split future changes into small, reviewable PRs.

## Controllers - `src/api/*`

For now, this is an empty placeholder, but the api route declarations and endpoints would be moved here.  (In a [separate branch](https://github.com/jtgeibel/crates.io/compare/master...mvc-example) I have some examples where the existing logic is moved.)

## Views - `src/views/*`

Currently this is JSON only and most existing types are prefixed with `Encodable`.  The major exception to this is the types from the `cargo publish` endpoint, which has been moved to `views::krate_publish`.

## Models - `src/models/*`

All of the Diesel types would move to here.  Many of these were previously reexported from the crate root.

Going forward, I think many of the `New*` structs can go away using the new syntax as shown in: https://github.com/rust-lang/crates.io/blob/e0e57b9843c2fb244997a2e47d8cedc40fa9b516/src/boot/categories.rs#L105-L109

# Future work

We can consider additional top level modules.  For instance, the outgoing email and github_auth functionality could be moved to a module for `external` services.  Additionally, `src/pagination.rs` could be moved into `src/api/mod.rs` and a few more things could probably move to `util`.  I'm not sure yet where something like the README rendering would fit in.