### PR TITLE
Minor documentation fix

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,10 +24,12 @@ impl Default for Config {
     /// Returns a default value for the application's config
     ///
     /// Sets the following default values:
+    ///
     /// - `Config::max_upload_size`: 10MiB
     /// - `Config::api_protocol`: `https`
     ///
     /// Pulls values from the following environment variables:
+    ///
     /// - `GIT_REPO_CHECKOUT`: The directory where the registry index was cloned.
     /// - `MIRROR`: Is this instance of cargo_registry a mirror of crates.io.
     /// - `HEROKU`: Is this instance of cargo_registry currently running on Heroku.


### PR DESCRIPTION
Working my way through the codebase I came across this markdown issue.

## Before:
<img width="1030" alt="screen shot 2017-11-06 at 14 24 37" src="https://user-images.githubusercontent.com/5019938/32462216-40ccfdf4-c2fe-11e7-8341-6a83f1409f61.png">

## After:
<img width="1044" alt="screen shot 2017-11-06 at 14 27 04" src="https://user-images.githubusercontent.com/5019938/32462320-97a616d8-c2fe-11e7-9347-b68509fc7e1b.png">

