### PR TITLE
Switch to `cargo clippy` which also lints the binaries and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,21 +40,16 @@ matrix:
     - rust: nightly
   include:
   - rust: nightly-2017-11-07
-    env: RUSTFMT=YESPLEASE
     script:
     - cargo install --force rustfmt-nightly --vers 0.2.15
-    - export LD_LIBRARY_PATH=$(rustc --print sysroot)/lib:$LD_LIBRARY_PATH
-    - rustfmt --version
+    - cargo install --force clippy --vers 0.0.169
     - cargo fmt -- --write-mode=diff
+    - cargo clippy
   - rust: stable
     script:
     - cargo build
     - cargo test
     - npm test
-  - rust: nightly-2017-11-07
-    env: CLIPPY=YESPLEASE
-    script:
-    - cargo check --features "lint"
   - rust: beta
     script:
     - cargo build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,6 @@ dependencies = [
  "cargo-registry-s3 0.2.0",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.169 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -168,16 +167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo_metadata"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,35 +201,6 @@ dependencies = [
 name = "civet-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "clippy"
-version = "0.0.169"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.169 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "clippy_lints"
-version = "0.0.169"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cmake"
@@ -715,11 +675,6 @@ version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "getopts"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "git2"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,11 +760,6 @@ dependencies = [
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "if_chain"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "iovec"
@@ -1192,20 +1142,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "quine-mc_cluskey"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,14 +1369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "semver-parser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,11 +1376,6 @@ dependencies = [
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -1865,14 +1788,11 @@ dependencies = [
 "checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
-"checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
 "checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6263e7af767a5bf9e4d3d0a6c3ceb5f3940ec85cf2fbfee59024b8a264be180f"
 "checksum civet-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "958d15372bf28b7983cb35e1d4bf36dd843b0d42e507c1c73aad7150372c5936"
-"checksum clippy 0.0.169 (registry+https://github.com/rust-lang/crates.io-index)" = "a4058d4c76590a351844378fd20a8ccfcbf411771957f3d4772d2b1e4a5c5194"
-"checksum clippy_lints 0.0.169 (registry+https://github.com/rust-lang/crates.io-index)" = "768bae4e989596d7aa787fb8578f2c6b2071ac32aeb1cab7e3cb1af906fff50d"
 "checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum comrak 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d6e2837c1814c4dc781f73697fdaaf9d5e2f2b137735dda2baad3d73dc684980"
@@ -1926,7 +1846,6 @@ dependencies = [
 "checksum futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "118b49cac82e04121117cbd3121ede3147e885627d82c4546b87c702debb90c1"
 "checksum futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "e86f49cc0d92fe1b97a5980ec32d56208272cbb00f15044ea9e2799dde766fdf"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
-"checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum git2 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0c1c0203d653f4140241da0c1375a404f0a397249ec818cd2076c6280c50f6fa"
 "checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
 "checksum html5ever 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba3a1fd1857a714d410c191364c5d7bf8a6487c0ab5575146d37dd7eb17ef523"
@@ -1935,7 +1854,6 @@ dependencies = [
 "checksum hyper 0.11.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b45eac8b696d59491b079bd04fcb0f3488c0f6ed62dcb36bcfea8a543e9cdc3"
 "checksum hyper-tls 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c81fa95203e2a6087242c38691a0210f23e9f3f8f944350bd676522132e2985"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
-"checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum iovec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b6e8b9c2247fcf6c6a1151f1156932be5606c9fd6f55a2d7f9fc1cb29386b2f7"
 "checksum itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f2be4da1690a039e9ae5fd575f706a63ad5a2120f161b1d653c9da3930dd21"
 "checksum itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8324a32baf01e2ae060e9de58ed0bc2320c9a2833491ee36cd3b4c414de4db8c"
@@ -1981,8 +1899,6 @@ dependencies = [
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dfb5e575ef93a1b7b2a381d47ba7c5d4e4f73bff37cee932195de769aad9a54"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-"checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
-"checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2c8284508b38df440f8f3527395e23c4780b22f74226b270daf58fee38e4bcce"
 "checksum r2d2-diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6b921696a6c45991296d21b52ed973b9fb56f6c47524fda1f99458c2d6c0478"
@@ -2011,9 +1927,7 @@ dependencies = [
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
-"checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fff3c9c5a54636ab95acd8c1349926e04cb1eb8cd70b5adced8a1d1f703a67"
-"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "0c9cab69e16835717c9b8bd13c29f92b6aa34fe32ce2866b1ab481cf2da8442a"
 "checksum serde_derive 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3bdafe3e71710131a919735916caa5b18c2754ad0d33d8ae5d586ccc804a403e"
 "checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ diesel_full_text_search = "0.16.0"
 serde_json = "1.0.0"
 serde_derive = "1.0.0"
 serde = "1.0.0"
-clippy = { version = "=0.0.169", optional = true }
 chrono = { version = "0.4.0", features = ["serde"] }
 comrak = { version = "0.2.3", default-features = false }
 ammonia = "1.0.0"
@@ -84,10 +83,6 @@ tokio-service = "0.1"
 [build-dependencies]
 dotenv = "0.10"
 diesel = { version = "0.16.0", features = ["postgres"] }
-
-[features]
-unstable = []
-lint = ["clippy"]
 
 [replace]
 "diesel:0.16.0" = { git = "https://github.com/diesel-rs/diesel.git" }

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -40,7 +40,7 @@ installation and running instructions. The logs for recent builds in Travis
 may also be helpful to see which versions of these tools we're currently using.
 
 [jslint]: http://jslint.com/
-[clippy]: https://github.com/Manishearth/rust-clippy
+[clippy]: https://github.com/rust-lang-nursery/rust-clippy
 [rustfmt]: https://github.com/rust-lang-nursery/rustfmt
 
 We will try to review your pull requests as soon as possible!

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -45,7 +45,7 @@ fn delete(conn: &PgConnection) {
     io::stdout().flush().unwrap();
     let mut line = String::new();
     io::stdin().read_line(&mut line).unwrap();
-    if !line.starts_with("y") {
+    if !line.starts_with('y') {
         return;
     }
 
@@ -59,7 +59,7 @@ fn delete(conn: &PgConnection) {
     io::stdout().flush().unwrap();
     let mut line = String::new();
     io::stdin().read_line(&mut line).unwrap();
-    if !line.starts_with("y") {
+    if !line.starts_with('y') {
         panic!("aborting transaction");
     }
 }

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -57,7 +57,7 @@ fn delete(conn: &PgConnection) {
     io::stdout().flush().unwrap();
     let mut line = String::new();
     io::stdin().read_line(&mut line).unwrap();
-    if !line.starts_with("y") {
+    if !line.starts_with('y') {
         return;
     }
 
@@ -70,7 +70,7 @@ fn delete(conn: &PgConnection) {
     io::stdout().flush().unwrap();
     let mut line = String::new();
     io::stdin().read_line(&mut line).unwrap();
-    if !line.starts_with("y") {
+    if !line.starts_with('y') {
         panic!("aborting transaction");
     }
 }

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -29,7 +29,7 @@ fn update(conn: &PgConnection) -> QueryResult<()> {
         .filter_map(|arg| arg.parse::<i32>().ok());
     for id in ids {
         let mut rng = StdRng::new().unwrap();
-        let mut dls = rng.gen_range(5000i32, 10000);
+        let mut dls = rng.gen_range(5_000i32, 10_000);
 
         for day in 0..90 {
             dls += rng.gen_range(-100, 100);

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -37,7 +37,7 @@ use cargo_registry::schema::*;
 use cargo_registry::render::readme_to_html;
 
 const DEFAULT_PAGE_SIZE: usize = 25;
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage: render-readmes [options]
        render-readmes --help
 
@@ -65,7 +65,7 @@ fn main() {
     let start_time = Utc::now();
 
     let older_than = if let Some(ref time) = args.flag_older_than {
-        Utc.datetime_from_str(&time, "%Y-%m-%d %H:%M:%S")
+        Utc.datetime_from_str(time, "%Y-%m-%d %H:%M:%S")
             .expect("Could not parse --older-than argument as a time")
     } else {
         start_time
@@ -174,7 +174,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
     let mut handle = Easy::new();
     let location = match config
         .uploader
-        .crate_location(&krate_name, &version.num.to_string())
+        .crate_location(krate_name, &version.num.to_string())
     {
         Some(l) => l,
         None => return None,
@@ -237,7 +237,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
     ));
     let manifest: Manifest = {
         let path = format!("{}-{}/Cargo.toml", krate_name, version.num);
-        let contents = find_file_by_path(&mut entries, Path::new(&path), &version, &krate_name);
+        let contents = find_file_by_path(&mut entries, Path::new(&path), version, krate_name);
         toml::from_str(&contents).expect(&format!(
             "[{}-{}] Syntax error in manifest file",
             krate_name,
@@ -254,7 +254,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
             version.num,
             manifest.package.readme.unwrap()
         );
-        let contents = find_file_by_path(&mut entries, Path::new(&path), &version, &krate_name);
+        let contents = find_file_by_path(&mut entries, Path::new(&path), version, krate_name);
         readme_to_html(
             &contents,
             manifest
@@ -297,7 +297,7 @@ fn find_file_by_path<R: Read>(
                     Ok(p) => p,
                     Err(_) => return false,
                 };
-                return filepath == path;
+                filepath == path
             }
         })
         .expect(&format!(

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -51,7 +51,7 @@ fn main() {
     // On every server restart, ensure the categories available in the database match
     // the information in *src/categories.toml*.
     let categories_toml = include_str!("../boot/categories.toml");
-    cargo_registry::boot::categories::sync(&categories_toml).unwrap();
+    cargo_registry::boot::categories::sync(categories_toml).unwrap();
 
     let heroku = env::var("HEROKU").is_ok();
     let port = if heroku {

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -53,9 +53,9 @@ fn transfer(conn: &PgConnection) {
     if from.gh_id != to.gh_id {
         println!("====================================================");
         println!("WARNING");
-        println!("");
+        println!();
         println!("this may not be the same github user, different github IDs");
-        println!("");
+        println!();
         println!("from: {:?}", from.gh_id);
         println!("to:   {:?}", to.gh_id);
 
@@ -97,7 +97,7 @@ fn get_confirm(msg: &str) {
     io::stdout().flush().unwrap();
     let mut line = String::new();
     io::stdin().read_line(&mut line).unwrap();
-    if !line.starts_with("y") {
+    if !line.starts_with('y') {
         std::process::exit(0);
     }
 }

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -65,7 +65,7 @@ fn collect(conn: &PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
     let mut total = 0;
     for download in rows {
         let amt = download.downloads - download.counted;
-        total += amt as i64;
+        total += i64::from(amt);
 
         // Flag this row as having been processed if we're passed the cutoff,
         // and unconditionally increment the number of counted downloads.

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -332,7 +332,7 @@ impl Crate {
         )
     }
 
-    #[cfg_attr(feature = "clippy", allow(too_many_arguments))]
+    #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
     pub fn encodable(
         self,
         max_version: &semver::Version,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 #![deny(warnings)]
 #![deny(missing_debug_implementations, missing_copy_implementations)]
-#![cfg_attr(feature = "clippy", feature(plugin))]
-#![cfg_attr(feature = "clippy", plugin(clippy))]
 #![recursion_limit = "128"]
 
 extern crate ammonia;

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -1,10 +1,10 @@
+use std::env;
+
 use cargo_registry::schema::categories;
 use diesel::*;
 use dotenv::dotenv;
 
-use std::env;
-
-const ALGORITHMS: &'static str = r#"
+const ALGORITHMS: &str = r#"
 [algorithms]
 name = "Algorithms"
 description = """
@@ -12,7 +12,7 @@ Rust implementations of core algorithms such as hashing, sorting, \
 searching, and more.\
 """"#;
 
-const ALGORITHMS_AND_SUCH: &'static str = r#"
+const ALGORITHMS_AND_SUCH: &str = r#"
 [algorithms]
 name = "Algorithms"
 description = """
@@ -26,7 +26,7 @@ description = """
 Other stuff
 """"#;
 
-const ALGORITHMS_AND_ANOTHER: &'static str = r#"
+const ALGORITHMS_AND_ANOTHER: &str = r#"
 [algorithms]
 name = "Algorithms"
 description = """

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -20,10 +20,13 @@ struct CategoryWithSubcategories {
     category: EncodableCategoryWithSubcategories,
 }
 
+#[cfg(test)]
+use std::sync::Arc;
+
 #[test]
 fn index() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/categories");
 
     // List 0 categories if none exist
     let mut response = ok_resp!(middle.call(&mut req));
@@ -56,7 +59,7 @@ fn show() {
     let (_b, app, middle) = ::app();
 
     // Return not found if a category doesn't exist
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories/foo-bar");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/categories/foo-bar");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
@@ -80,7 +83,7 @@ fn show() {
 #[test]
 fn update_crate() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/categories/foo");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/categories/foo");
     macro_rules! cnt {
         ($req: expr, $cat: expr) => {{
             $req.with_path(&format!("/api/v1/categories/{}", $cat));

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use conduit::{Handler, Method};
 use conduit_test::MockRequest;
 
@@ -20,7 +22,7 @@ struct GoodKeyword {
 #[test]
 fn index() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/keywords");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/keywords");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: KeywordList = ::json(&mut response);
     assert_eq!(json.keywords.len(), 0);
@@ -40,7 +42,7 @@ fn index() {
 #[test]
 fn show() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/keywords/foo");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/keywords/foo");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
@@ -56,7 +58,7 @@ fn show() {
 #[test]
 fn uppercase() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/keywords/UPPER");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/keywords/UPPER");
     {
         let conn = app.diesel_database.get().unwrap();
         Keyword::find_or_create_all(&conn, &["UPPER"]).unwrap();
@@ -70,7 +72,7 @@ fn uppercase() {
 #[test]
 fn update_crate() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/keywords/foo");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/keywords/foo");
     let cnt = |req: &mut MockRequest, kw: &str| {
         req.with_path(&format!("/api/v1/keywords/{}", kw));
         let mut response = ok_resp!(middle.call(req));

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use {CrateList, GoodCrate};
 
 use cargo_registry::owner::EncodableOwner;
@@ -30,7 +32,7 @@ fn new_crate_owner() {
     let (_b, app, middle) = ::app();
 
     // Create a crate under one user
-    let mut req = ::new_req(app.clone(), "foo_owner", "1.0.0");
+    let mut req = ::new_req(Arc::clone(&app), "foo_owner", "1.0.0");
     ::sign_in(&mut req, &app);
     let u2;
     {
@@ -135,7 +137,7 @@ fn owners_can_remove_self() {
 
     let (_b, app, middle) = ::app();
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/crates/owners_selfremove/owners",
     );
@@ -265,7 +267,7 @@ fn check_ownership_two_crates() {
         (::CrateBuilder::new("bar", u.id).expect_build(&conn), u)
     };
 
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/crates");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/crates");
 
     let query = format!("user_id={}", user.id);
     let mut response = ok_resp!(middle.call(req.with_query(&query)));
@@ -306,7 +308,7 @@ fn check_ownership_one_crate() {
     };
 
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/crates/best_crate/owner_team",
     );
@@ -317,7 +319,7 @@ fn check_ownership_one_crate() {
     assert_eq!(json.teams[0].name, team.name);
 
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/crates/best_crate/owner_user",
     );
@@ -337,7 +339,7 @@ fn invitations_are_empty_by_default() {
 
     let (_b, app, middle) = ::app();
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/me/crate_owner_invitations",
     );
@@ -365,7 +367,7 @@ fn invitations_list() {
 
     let (_b, app, middle) = ::app();
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/me/crate_owner_invitations",
     );
@@ -426,7 +428,7 @@ fn test_accept_invitation() {
 
     let (_b, app, middle) = ::app();
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/me/crate_owner_invitations",
     );
@@ -522,7 +524,7 @@ fn test_decline_invitation() {
 
     let (_b, app, middle) = ::app();
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/me/crate_owner_invitations",
     );

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -40,7 +40,7 @@ fn body_for_team_x() -> &'static str {
 fn not_github() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_not_github");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_not_github");
 
     let body = r#"{"users":["dropbox:foo:foo"]}"#;
     let json = bad_resp!(
@@ -61,7 +61,7 @@ fn not_github() {
 fn weird_name() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_weird_name");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_weird_name");
 
     let body = r#"{"users":["github:foo/../bar:wut"]}"#;
     let json = bad_resp!(
@@ -84,7 +84,8 @@ fn weird_name() {
 #[test]
 fn one_colon() {
     let (_b, app, middle) = ::app();
-    let mut req = ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_one_colon");
+    let mut req =
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_one_colon");
 
     let body = r#"{"users":["github:foo"]}"#;
     let json = bad_resp!(
@@ -105,7 +106,7 @@ fn one_colon() {
 fn nonexistent_team() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_nonexistent");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_nonexistent");
 
     let body = r#"{"users":["github:crates-test-org:this-does-not-exist"]}"#;
     let json = bad_resp!(
@@ -129,7 +130,7 @@ fn nonexistent_team() {
 fn add_team_as_member() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_team_member");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_team_member");
 
     let body = body_for_team_x();
     ok_resp!(
@@ -154,7 +155,7 @@ fn add_team_as_member() {
 fn add_team_as_non_member() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_only_x(), "foo_team_non_member");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_only_x(), "foo_team_non_member");
 
     let body = body_for_team_y();
     let json = bad_resp!(
@@ -177,7 +178,7 @@ fn add_team_as_non_member() {
 fn remove_team_as_named_owner() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_remove_team");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_remove_team");
 
     let body = body_for_team_x();
     ok_resp!(
@@ -231,7 +232,7 @@ fn remove_team_as_named_owner() {
 fn remove_team_as_team_owner() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_remove_team_owner");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_remove_team_owner");
 
     let body = body_for_team_x();
     ok_resp!(
@@ -285,7 +286,8 @@ fn remove_team_as_team_owner() {
 fn publish_not_owned() {
     let (_b, app, middle) = ::app();
 
-    let mut req = ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_not_owned");
+    let mut req =
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_not_owned");
 
     let body = body_for_team_y();
     ok_resp!(
@@ -329,7 +331,7 @@ fn publish_not_owned() {
 fn publish_owned() {
     let (_b, app, middle) = ::app();
     let mut req =
-        ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_team_owned");
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_team_owned");
 
     let body = body_for_team_x();
     ok_resp!(
@@ -365,7 +367,8 @@ fn publish_owned() {
 #[test]
 fn add_owners_as_team_owner() {
     let (_b, app, middle) = ::app();
-    let mut req = ::request_with_user_and_mock_crate(&app, mock_user_on_x_and_y(), "foo_add_owner");
+    let mut req =
+        ::request_with_user_and_mock_crate(&app, &mock_user_on_x_and_y(), "foo_add_owner");
 
     let body = body_for_team_x();
     ok_resp!(

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use conduit::{Handler, Method};
 
@@ -46,7 +47,7 @@ fn access_token_needs_data() {
 #[test]
 fn me() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/me");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
 
@@ -68,7 +69,7 @@ fn show() {
         t!(NewUser::new(2, "bar", Some("bar@baz.com"), None, None, "bar").create_or_update(&conn));
     }
 
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/users/foo");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/users/foo");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: UserShowPublicResponse = ::json(&mut response);
     assert_eq!("foo", json.user.login);
@@ -113,7 +114,7 @@ fn show_latest_user_case_insensitively() {
             ).create_or_update(&conn)
         );
     }
-    let mut req = ::req(app.clone(), Method::Get, "api/v1/users/fOObAr");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "api/v1/users/fOObAr");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: UserShowPublicResponse = ::json(&mut response);
     assert_eq!(
@@ -180,7 +181,7 @@ fn following() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/");
     {
         let conn = app.diesel_database.get().unwrap();
         let user = ::new_user("foo").create_or_update(&conn).unwrap();
@@ -363,7 +364,7 @@ fn test_github_login_does_not_overwrite_email() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = NewUser {
@@ -428,7 +429,7 @@ fn test_email_get_and_put() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = ::new_user("mango").create_or_update(&conn).unwrap();
@@ -473,7 +474,7 @@ fn test_email_get_and_put() {
 #[test]
 fn test_empty_email_not_added() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = ::new_user("papaya").create_or_update(&conn).unwrap();
@@ -525,7 +526,7 @@ fn test_empty_email_not_added() {
 #[test]
 fn test_this_user_cannot_change_that_user_email() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/me");
 
     let not_signed_in_user = {
         let conn = app.diesel_database.get().unwrap();
@@ -569,7 +570,7 @@ fn test_insert_into_email_table() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/me");
     {
         let conn = app.diesel_database.get().unwrap();
         let user = NewUser {
@@ -626,7 +627,7 @@ fn test_insert_into_email_table_with_email_change() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = NewUser {
@@ -702,7 +703,7 @@ fn test_confirm_user_email() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/me");
     let user = {
         let conn = app.diesel_database.get().unwrap();
         let user = NewUser {
@@ -755,7 +756,7 @@ fn test_existing_user_email() {
     }
 
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/me");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/me");
     {
         let conn = app.diesel_database.get().unwrap();
         let new_user = NewUser {

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 extern crate diesel;
 extern crate serde_json;
 
@@ -21,7 +23,7 @@ struct VersionResponse {
 #[test]
 fn index() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/versions");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/versions");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: VersionList = ::json(&mut response);
     assert_eq!(json.versions.len(), 0);
@@ -56,7 +58,7 @@ fn index() {
 #[test]
 fn show() {
     let (_b, app, middle) = ::app();
-    let mut req = ::req(app.clone(), Method::Get, "/api/v1/versions");
+    let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/versions");
     let v = {
         let conn = app.diesel_database.get().unwrap();
         let user = ::new_user("foo").create_or_update(&conn).unwrap();
@@ -73,7 +75,7 @@ fn show() {
 fn authors() {
     let (_b, app, middle) = ::app();
     let mut req = ::req(
-        app.clone(),
+        Arc::clone(&app),
         Method::Get,
         "/api/v1/crates/foo_authors/1.0.0/authors",
     );
@@ -87,7 +89,7 @@ fn authors() {
     let mut data = Vec::new();
     response.body.write_body(&mut data).unwrap();
     let s = ::std::str::from_utf8(&data).unwrap();
-    let json: Value = serde_json::from_str(&s).unwrap();
+    let json: Value = serde_json::from_str(s).unwrap();
     let json = json.as_object().unwrap();
     assert!(json.contains_key(&"users".to_string()));
 }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -215,7 +215,7 @@ impl NewVersion {
 }
 
 impl Queryable<versions::SqlType, Pg> for Version {
-    #[cfg_attr(feature = "clippy", allow(type_complexity))]
+    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
     type Row = (
         i32,
         i32,


### PR DESCRIPTION
This switches our CI to install `clippy` and use the `cargo clippy` command.  Additionally, the tests are now run on CI in the same build as `rustfmt`.  If `cargo fmt` fails, travis will still run `cargo clippy` and report any errors there.

In this configuration, `clippy` is no longer included in the `Cargo.toml` file.

/cc @carols10cents 