### PR TITLE
repository URLs sometimes end in .git in real-world usage

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -310,11 +310,12 @@ mod tests {
         let relative = "[there](there)";
 
         for host in &["github.com", "gitlab.com", "bitbucket.org"] {
-            for &extra_slash in &[true, false] {
+            for (&extra_slash, &dot_git) in [true, false].iter().zip(&[true, false]) {
                 let url = format!(
-                    "https://{}/rust-lang/test{}",
+                    "https://{}/rust-lang/test{}{}",
                     host,
-                    if extra_slash { "/" } else { "" }
+                    if dot_git { ".git" } else { "" },
+                    if extra_slash { "/" } else { "" },
                 );
 
                 let result = markdown_to_html(absolute, Some(&url)).unwrap();

--- a/src/render.rs
+++ b/src/render.rs
@@ -129,6 +129,10 @@ impl<'a> MarkdownRenderer<'a> {
             if !new_url.ends_with('/') {
                 new_url.push('/');
             }
+            if new_url.ends_with(".git/") {
+                let offset = new_url.len() - 5;
+                new_url.drain(offset..offset + 4);
+            }
             new_url += "blob/master";
             if !url.starts_with('/') {
                 new_url.push('/');


### PR DESCRIPTION
And this is okay, because the major sites (BitBucket, GitHub, GitLab) all either directly support visiting the `.git`-suffixed URL of any repo, or redirect from it to the non-suffixed version. These all work fine as-is.

What they don't universally work for is letting you append any path onto that. (Which is to say, from my testing BitBucket doesn't mind, but GitHub and GitLab both 404.)  So we trim the suffix when manipulating relative paths.

See https://github.com/kbknapp/clap-rs/issues/1106 for where this came up with `clap`.