### PR TITLE
Update to use Diesel 0.99.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,11 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "bitflags"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bufstream"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,9 +128,9 @@ dependencies = [
  "conduit-test 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_full_text_search 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_full_text_search 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_migrations 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -142,9 +147,10 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2-diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2-diesel 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -440,45 +446,41 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "0.16.0"
-source = "git+https://github.com/diesel-rs/diesel.git#75ba15a91218ef040e0b379cc3e9c4bbd34f09da"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_derives 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "diesel"
-version = "0.16.0"
+name = "diesel_derives"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "diesel 0.16.0 (git+https://github.com/diesel-rs/diesel.git)"
-
-[[package]]
-name = "diesel_codegen"
-version = "0.16.0"
-source = "git+https://github.com/diesel-rs/diesel.git#846b3f8f9f136123f895df58774ac1f109dd74d3"
 dependencies = [
- "diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "diesel_codegen"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-replace = "diesel_codegen 0.16.0 (git+https://github.com/diesel-rs/diesel.git)"
-
-[[package]]
 name = "diesel_full_text_search"
-version = "0.16.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "diesel_migrations"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "migrations_internals 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "migrations_macros 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -929,6 +931,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "migrations_internals"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "diesel 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "migrations_macros"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "migrations_internals 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1148,21 +1168,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "r2d2"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "scheduled-thread-pool 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "r2d2-diesel"
-version = "0.16.0"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1310,7 +1330,7 @@ dependencies = [
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1785,6 +1805,7 @@ dependencies = [
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
+"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
 "checksum bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f382711e76b9de6c744cc00d0497baba02fb00a787f088c879f01d09468e32"
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d828f97b58cc5de3e40c421d0cf2132d6b2da4ee0e11b8632fa838f0f9333ad6"
@@ -1817,11 +1838,10 @@ dependencies = [
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
-"checksum diesel 0.16.0 (git+https://github.com/diesel-rs/diesel.git)" = "<none>"
-"checksum diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "304226fa7a3982b0405f6bb95dd9c10c3e2000709f194038a60ec2c277150951"
-"checksum diesel_codegen 0.16.0 (git+https://github.com/diesel-rs/diesel.git)" = "<none>"
-"checksum diesel_codegen 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18a42ca5c9b660add51d58bc5a50a87123380e1e458069c5504528a851ed7384"
-"checksum diesel_full_text_search 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ab84b47676bc5344481e066f7a915ce292b4b87f734e397d651b7d085707c4b6"
+"checksum diesel 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0b97bd43f72d4819fac99f24d0030184c64c5ebdee96f94c7a7d4215c50506a7"
+"checksum diesel_derives 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad228b6fd05c86050b95f56e497a8135073ffce28602e2200e63a21047eb474d"
+"checksum diesel_full_text_search 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee6499a77b8a47b6a565117abd4db9dd18095ba20309d09a10f5d5f1337f02af"
+"checksum diesel_migrations 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "745dcfe39e3043c267e46dbe4f2ebbc9917039bdf4d81b108950be61244dfc89"
 "checksum docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b5b93718f8b3e5544fcc914c43de828ca6c6ace23e0332c6080a2977b49787a"
 "checksum dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d6f0e2bb24d163428d8031d3ebd2d2bd903ad933205a97d0f18c7c1aade380f3"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -1875,6 +1895,8 @@ dependencies = [
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e01e64d9017d18e7fc09d8e4fe0e28ff6931019e979fb8019319db7ca827f8a6"
+"checksum migrations_internals 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ac1d17f6f161f4d91cb7e5a72cce5b24a60b80f96580a8ac94351c56b8606a"
+"checksum migrations_macros 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc767420eac6b718cd593aaa09c06a31d4ed228291c8538b274737e28a29939b"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
@@ -1900,8 +1922,8 @@ dependencies = [
 "checksum pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4dfb5e575ef93a1b7b2a381d47ba7c5d4e4f73bff37cee932195de769aad9a54"
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum r2d2 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2c8284508b38df440f8f3527395e23c4780b22f74226b270daf58fee38e4bcce"
-"checksum r2d2-diesel 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6b921696a6c45991296d21b52ed973b9fb56f6c47524fda1f99458c2d6c0478"
+"checksum r2d2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59611202bee496c586ecd84e3ed149b4ec75981b0fc10d7f60e878fa23ae16e9"
+"checksum r2d2-diesel 0.99.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77aaed149a82720f4b664427f359e1b2a34d8787c1bc3fb1d167b104a1ddd866"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"
@@ -1919,7 +1941,7 @@ dependencies = [
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum schannel 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7554288337c1110e34d7a2433518d889374c1de1a45f856b7bcddb03702131fc"
-"checksum scheduled-thread-pool 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d9fbe48ead32343b76f544c85953bf260ed39219a8bbbb62cd85f6a00f9644f"
+"checksum scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a2ff3fc5223829be817806c6441279c676e454cc7da608faf03b0ccc09d3889"
 "checksum scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f417c22df063e9450888a7561788e9bd46d3bb3c1466435b4eccb903807f147d"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum secur32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3f412dfa83308d893101dd59c10d6fda8283465976c28c287c5c855bf8d216bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ semver = "0.5"
 url = "1.2.1"
 tar = "0.4.13"
 
-r2d2 = "0.7.0"
+r2d2 = "0.8.0"
 openssl = "0.9.14"
 curl = "0.4"
 oauth2 = "0.3"
@@ -46,10 +46,9 @@ htmlescape = "0.3.1"
 license-exprs = "^1.3"
 dotenv = "0.10.0"
 toml = "0.4"
-diesel = { version = "0.16.0", features = ["postgres", "serde_json", "chrono"] }
-diesel_codegen = "0.16.0"
-r2d2-diesel = "0.16.0"
-diesel_full_text_search = "0.16.0"
+diesel = { version = "0.99.0", features = ["postgres", "serde_json", "chrono"] }
+r2d2-diesel = "0.99.0"
+diesel_full_text_search = "0.99.0"
 serde_json = "1.0.0"
 serde_derive = "1.0.0"
 serde = "1.0.0"
@@ -59,6 +58,7 @@ ammonia = "1.0.0"
 docopt = "0.8.1"
 itertools = "0.6.0"
 lettre = "0.6"
+scheduled-thread-pool = "0.2.0"
 
 conduit = "0.8"
 conduit-conditional-get = "0.8"
@@ -82,8 +82,5 @@ tokio-service = "0.1"
 
 [build-dependencies]
 dotenv = "0.10"
-diesel = { version = "0.16.0", features = ["postgres"] }
-
-[replace]
-"diesel:0.16.0" = { git = "https://github.com/diesel-rs/diesel.git" }
-"diesel_codegen:0.16.0" = { git = "https://github.com/diesel-rs/diesel.git" }
+diesel = { version = "0.99.0", features = ["postgres"] }
+diesel_migrations = { version = "0.99.0", features = ["postgres"] }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,8 @@
 extern crate diesel;
+extern crate diesel_migrations;
 extern crate dotenv;
 
-use diesel::migrations::run_pending_migrations;
+use diesel_migrations::run_pending_migrations;
 use diesel::prelude::*;
 use dotenv::dotenv;
 use std::env;

--- a/src/category.rs
+++ b/src/category.rs
@@ -8,7 +8,7 @@ use db::RequestTransaction;
 use schema::*;
 use util::{CargoResult, RequestUtils};
 
-#[derive(Clone, Identifiable, Queryable, Debug)]
+#[derive(Clone, Identifiable, Queryable, QueryableByName, Debug)]
 #[table_name = "categories"]
 pub struct Category {
     pub id: i32,
@@ -144,10 +144,9 @@ impl Category {
     }
 
     pub fn subcategories(&self, conn: &PgConnection) -> QueryResult<Vec<Category>> {
-        use diesel::dsl::*;
         use diesel::types::Text;
 
-        sql::<categories::SqlType>(
+        sql_query(
             "SELECT c.id, c.category, c.slug, c.description, \
              COALESCE (( \
              SELECT sum(c2.crates_cnt)::int \

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,7 +3,7 @@ use std::env;
 use conduit::Request;
 use diesel::prelude::{ConnectionResult, PgConnection};
 use r2d2;
-use r2d2_diesel::{self, ConnectionManager};
+use r2d2_diesel::ConnectionManager;
 use url::Url;
 
 use app::RequestApp;
@@ -23,14 +23,14 @@ pub fn connect_now() -> ConnectionResult<PgConnection> {
 
 pub fn diesel_pool(
     url: &str,
-    config: r2d2::Config<PgConnection, r2d2_diesel::Error>,
+    config: r2d2::Builder<ConnectionManager<PgConnection>>,
 ) -> DieselPool {
     let mut url = Url::parse(url).expect("Invalid database URL");
     if env::var("HEROKU").is_ok() && !url.query_pairs().any(|(k, _)| k == "sslmode") {
         url.query_pairs_mut().append_pair("sslmode", "require");
     }
     let manager = ConnectionManager::new(url.into_string());
-    r2d2::Pool::new(config, manager).unwrap()
+    config.build(manager).unwrap()
 }
 
 pub trait RequestTransaction {

--- a/src/krate/krate_reverse_dependencies.sql
+++ b/src/krate/krate_reverse_dependencies.sql
@@ -2,15 +2,7 @@
 SELECT *, COUNT(*) OVER () as total FROM (
     -- Multple dependencies can exist, make it distinct
     SELECT DISTINCT ON (crate_downloads, crate_name)
-    dependencies.id,
-    dependencies.version_id,
-    dependencies.crate_id,
-    dependencies.req,
-    dependencies.optional,
-    dependencies.default_features,
-    dependencies.features,
-    dependencies.target,
-    dependencies.kind,
+    dependencies.*,
     crates.downloads AS crate_downloads,
     crates.name AS crate_name
     FROM dependencies

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@ extern crate comrak;
 extern crate curl;
 #[macro_use]
 extern crate diesel;
-#[macro_use]
-extern crate diesel_codegen;
 extern crate diesel_full_text_search;
 extern crate dotenv;
 extern crate flate2;
@@ -31,6 +29,7 @@ extern crate r2d2;
 extern crate r2d2_diesel;
 extern crate rand;
 extern crate s3;
+extern crate scheduled_thread_pool;
 extern crate semver;
 extern crate serde;
 #[macro_use]
@@ -100,6 +99,7 @@ pub mod site_metadata;
 
 mod local_upload;
 mod pagination;
+mod with_count;
 
 /// Used for setting different values depending on whether the app is being run in production,
 /// in development, or for testing.

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -7,8 +7,6 @@ extern crate conduit_middleware;
 extern crate conduit_test;
 extern crate curl;
 extern crate diesel;
-#[macro_use]
-extern crate diesel_codegen;
 extern crate dotenv;
 extern crate flate2;
 extern crate git2;

--- a/src/tests/load_foreign_key_constraints.sql
+++ b/src/tests/load_foreign_key_constraints.sql
@@ -1,7 +1,6 @@
 -- This can't quite use Diesel's query builder yet, because diesel doesn't
--- support custom ON clauses yet. We need the attnum comparison in the join
--- to make sure that we get NULL if no constraint is present
-SELECT relname, conname, pg_get_constraintdef(pg_constraint.oid, true)
+-- have the `ARRAY[]` constructor
+SELECT relname, conname, pg_get_constraintdef(pg_constraint.oid, true) AS definition
     FROM pg_attribute
     INNER JOIN pg_class ON pg_class.oid = attrelid
     LEFT JOIN pg_constraint ON pg_class.oid = conrelid AND ARRAY[attnum] = conkey

--- a/src/tests/schema_details.rs
+++ b/src/tests/schema_details.rs
@@ -1,13 +1,17 @@
+use diesel::pg::Pg;
 use diesel::prelude::*;
+use diesel::query_source::QueryableByName;
+use diesel::row::NamedRow;
+use std::error::Error;
 
 #[test]
 fn all_columns_called_crate_id_have_a_cascading_foreign_key() {
-    for (table_name, constraint) in get_fk_constraint_definitions("crate_id") {
-        let constraint = match constraint {
+    for row in get_fk_constraint_definitions("crate_id") {
+        let constraint = match row.constraint {
             Some(c) => c,
             None => panic!(
                 "Column called crate_id on {} has no foreign key",
-                table_name
+                row.table_name
             ),
         };
         if !constraint.definition.contains("ON DELETE CASCADE") {
@@ -15,7 +19,7 @@ fn all_columns_called_crate_id_have_a_cascading_foreign_key() {
                 "Foreign key {} on table {} should have `ON DELETE CASCADE` \
                  but it doesn't.",
                 constraint.name,
-                table_name
+                row.table_name
             );
         }
     }
@@ -23,12 +27,12 @@ fn all_columns_called_crate_id_have_a_cascading_foreign_key() {
 
 #[test]
 fn all_columns_called_version_id_have_a_cascading_foreign_key() {
-    for (table_name, constraint) in get_fk_constraint_definitions("version_id") {
-        let constraint = match constraint {
+    for row in get_fk_constraint_definitions("version_id") {
+        let constraint = match row.constraint {
             Some(c) => c,
             None => panic!(
                 "Column called version_id on {} has no foreign key",
-                table_name
+                row.table_name
             ),
         };
         if !constraint.definition.contains("ON DELETE CASCADE") {
@@ -36,26 +40,48 @@ fn all_columns_called_version_id_have_a_cascading_foreign_key() {
                 "Foreign key {} on table {} should have `ON DELETE CASCADE` \
                  but it doesn't.",
                 constraint.name,
-                table_name
+                row.table_name
             );
         }
     }
 }
 
-#[derive(Queryable)]
 struct FkConstraint {
     name: String,
     definition: String,
 }
 
-fn get_fk_constraint_definitions(column_name: &str) -> Vec<(String, Option<FkConstraint>)> {
-    use diesel::dsl::sql;
+struct TableNameAndConstraint {
+    table_name: String,
+    constraint: Option<FkConstraint>,
+}
+
+impl QueryableByName<Pg> for TableNameAndConstraint {
+    fn build<R: NamedRow<Pg>>(row: &R) -> Result<Self, Box<Error + Send + Sync>> {
+        use diesel::types::{Nullable, Text};
+
+        let constraint = match row.get::<Nullable<Text>, _>("conname")? {
+            Some(name) => Some(FkConstraint {
+                definition: row.get::<Text, _>("definition")?,
+                name,
+            }),
+            None => None,
+        };
+        Ok(TableNameAndConstraint {
+            table_name: row.get::<Text, _>("relname")?,
+            constraint,
+        })
+    }
+}
+
+fn get_fk_constraint_definitions(column_name: &str) -> Vec<TableNameAndConstraint> {
+    use diesel::sql_query;
     use diesel::types::Text;
 
     let (_r, app, _) = ::app();
     let conn = app.diesel_database.get().unwrap();
 
-    sql(include_str!("load_foreign_key_constraints.sql"))
+    sql_query(include_str!("load_foreign_key_constraints.sql"))
         .bind::<Text, _>(column_name)
         .load(&*conn)
         .unwrap()

--- a/src/version/downloads.rs
+++ b/src/version/downloads.rs
@@ -74,7 +74,7 @@ pub fn downloads(req: &mut Request) -> CargoResult<Response> {
     let cutoff_start_date = cutoff_end_date - Duration::days(89);
 
     let downloads = VersionDownload::belonging_to(&version)
-        .filter(version_downloads::date.between(cutoff_start_date..cutoff_end_date))
+        .filter(version_downloads::date.between(cutoff_start_date, cutoff_end_date))
         .order(version_downloads::date)
         .load(&*conn)?
         .into_iter()

--- a/src/with_count.rs
+++ b/src/with_count.rs
@@ -1,0 +1,35 @@
+use diesel::pg::Pg;
+use diesel::query_source::QueryableByName;
+use diesel::row::NamedRow;
+use std::error::Error;
+
+pub struct WithCount<T> {
+    total: i64,
+    record: T,
+}
+
+impl<T> QueryableByName<Pg> for WithCount<T>
+where
+    T: QueryableByName<Pg>,
+{
+    fn build<R: NamedRow<Pg>>(row: &R) -> Result<Self, Box<Error + Send + Sync>> {
+        use diesel::types::BigInt;
+
+        Ok(WithCount {
+            total: row.get::<BigInt, _>("total")?,
+            record: T::build(row)?,
+        })
+    }
+}
+
+pub trait WithCountExtension<T> {
+    fn records_and_total(self) -> (Vec<T>, i64);
+}
+
+impl<T> WithCountExtension<T> for Vec<WithCount<T>> {
+    fn records_and_total(self) -> (Vec<T>, i64) {
+        let cnt = self.get(0).map(|row| row.total).unwrap_or(0);
+        let vec = self.into_iter().map(|row| row.record).collect();
+        (vec, cnt)
+    }
+}


### PR DESCRIPTION
Most of the code changes are for us to switch to `sql_query` where
appropriate. `sql` deprecated its API for bind parameters, as it's meant
to be used with fragments of SQL as part of the query builder, not full
queries. `sql_query` does not require the SQL type to be specified, and
it gets the values by name instead of by index. Unfortunately, none of
the places we are using raw SQL were places that
`#[derive(QueryableByName)]` would work, so I had to manually implement
all of them

This also updates to r2d2 0.8, because I couldn't remember the command
to make cargo force r2d2-diesel to resolve to r2d2 0.7