### PR TITLE
Load summary data in the background

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,0 +1,33 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+import { task } from 'ember-concurrency';
+
+export default Controller.extend({
+    ajax: service(),
+
+    model: readOnly('dataTask.lastSuccessful.value'),
+
+    hasData: computed('dataTask.lastSuccessful', 'dataTask.isRunning', function() {
+        return this.get('dataTask.lastSuccessful') || !this.get('dataTask.isRunning');
+    }),
+
+    dataTask: task(function* () {
+        let data = yield this.get('ajax').request('/api/v1/summary');
+
+        addCrates(this.store, data.new_crates);
+        addCrates(this.store, data.most_downloaded);
+        addCrates(this.store, data.just_updated);
+        addCrates(this.store, data.most_recently_downloaded);
+
+        return data;
+    }).drop(),
+});
+
+function addCrates(store, crates) {
+    for (let i = 0; i < crates.length; i++) {
+        crates[i] = store.push(store.normalize('crate', crates[i]));
+    }
+}

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,10 +1,6 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
 
 export default Route.extend({
-
-    ajax: service(),
-
     headTags: [{
         type: 'meta',
         attrs: {
@@ -13,20 +9,7 @@ export default Route.extend({
         }
     }],
 
-    model() {
-        function addCrates(store, crates) {
-            for (let i = 0; i < crates.length; i++) {
-                crates[i] = store.push(store.normalize('crate', crates[i]));
-            }
-        }
-
-        return this.get('ajax').request('/api/v1/summary').then((data) => {
-            addCrates(this.store, data.new_crates);
-            addCrates(this.store, data.most_downloaded);
-            addCrates(this.store, data.just_updated);
-            addCrates(this.store, data.most_recently_downloaded);
-
-            return data;
-        });
-    }
+    setupController(controller) {
+        controller.get('dataTask').perform();
+    },
 });

--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -106,7 +106,11 @@ button.small {
 .crate-lists {
     @include display-flex;
 
-    h2 { font-size: 105%; }
+    h2 {
+        font-size: 105%;
+        line-height: 20px;
+    }
+
     > div { margin: 0 15px; }
 
     ul { list-style: none; padding: 0; }

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -24,12 +24,12 @@
     <div id='stats'>
         <div class='downloads'>
             {{svg-jar "download"}}
-            <span class='num' data-test-total-downloads>{{format-num model.num_downloads}}</span>
+            <span class='num' data-test-total-downloads>{{if hasData (format-num model.num_downloads) "---,---,---"}}</span>
             <span class='desc small'>Downloads</span>
         </div>
         <div class='crates'>
             {{svg-jar "crate"}}
-            <span class='num' data-test-total-crates>{{format-num model.num_crates}}</span>
+            <span class='num' data-test-total-crates>{{if hasData (format-num model.num_crates) "---,---"}}</span>
             <span class='desc small'>Crates in stock</span>
         </div>
     </div>
@@ -37,27 +37,27 @@
 
 <div id='home-crates' class='crate-lists'>
     <div id='new-crates' data-test-new-crates>
-        <h2>New Crates</h2>
+        <h2>New Crates {{#if dataTask.isRunning}}<img src="/assets/ajax-loader.gif">{{/if}}</h2>
         {{crate-list crates=model.new_crates}}
     </div>
     <div id='most-downloaded' data-test-most-downloaded>
-        <h2>Most Downloaded</h2>
+        <h2>Most Downloaded {{#if dataTask.isRunning}}<img src="/assets/ajax-loader.gif">{{/if}}</h2>
         {{crate-list crates=model.most_downloaded}}
     </div>
     <div id='just-updated' data-test-just-updated>
-        <h2>Just Updated</h2>
+        <h2>Just Updated {{#if dataTask.isRunning}}<img src="/assets/ajax-loader.gif">{{/if}}</h2>
         {{crate-list crates=model.just_updated}}
     </div>
     <div id='most-recently-downloaded' data-test-most-recently-downloaded>
-        <h2>Most Recent Downloads</h2>
+        <h2>Most Recent Downloads {{#if dataTask.isRunning}}<img src="/assets/ajax-loader.gif">{{/if}}</h2>
         {{crate-list crates=model.most_recently_downloaded}}
     </div>
     <div id='keywords' data-test-keywords>
-        <h2>Popular Keywords {{#link-to 'keywords'}}(see all){{/link-to}}</h2>
+        <h2>Popular Keywords {{#link-to 'keywords'}}(see all){{/link-to}} {{#if dataTask.isRunning}}<img src="/assets/ajax-loader.gif">{{/if}}</h2>
         {{keyword-list keywords=model.popular_keywords}}
     </div>
     <div id='categories' data-test-categories>
-        <h2>Popular Categories {{#link-to 'categories'}}(see all){{/link-to}}</h2>
+        <h2>Popular Categories {{#link-to 'categories'}}(see all){{/link-to}} {{#if dataTask.isRunning}}<img src="/assets/ajax-loader.gif">{{/if}}</h2>
         {{category-list categories=model.popular_categories}}
     </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "2.1.1",
     "ember-cli-uglify": "^2.0.0",
+    "ember-concurrency": "^0.8.12",
     "ember-data": "~2.12.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",


### PR DESCRIPTION
This PR improves the perceived frontpage performance experience by loading the summary data in the background while already displaying the "data" that is available.

![crates](https://user-images.githubusercontent.com/141300/33473893-88aff27e-d678-11e7-9e73-eb0596208297.gif)

We can probably use the same pattern for some other routes too to get rid of the "Loading..." screen.

/cc @carols10cents @tchak 