### PR TITLE
CI: Use latest Node 8 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - JOBS=1
 
 before_install:
-  - nvm install 8.1.3
+  - nvm install 8
 
 install:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
Pinning Node to v8.1.3 does not seem useful 🤔 