### PR TITLE
Load search results in the background

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -13,8 +13,11 @@ export default Controller.extend(EKMixin, {
         if (event.ctrlKey || event.altKey || event.metaKey) {
             return;
         }
-        event.preventDefault();
-        document.querySelector('#cargo-desktop-search').focus();
+
+        if (document.activeElement === document.body) {
+            event.preventDefault();
+            document.querySelector('#cargo-desktop-search').focus();
+        }
     }),
 
     actions: {

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -8,10 +8,12 @@ export default Route.extend({
     },
 
     model(params) {
-        if (params.q !== null) {
-            params.q = params.q.trim();
-        }
+        // we need a model() implementation that changes, otherwise the setupController() hook
+        // is not called and we won't reload the results if a new query string is used
+        return params;
+    },
 
-        return this.store.query('crate', params);
+    setupController(controller, params) {
+        controller.get('dataTask').perform(params);
     },
 });

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -46,6 +46,10 @@
     }
 }
 
+.crate-search .loading-spinner {
+    margin: 0 15px;
+}
+
 #selection {
     width: 100%;
     @include display-flex;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -18,13 +18,14 @@
     {{/link-to}}
 
     <form class='search' action='/search' {{ action "search" on="submit" }} data-test-search-form>
-        {{input type="text" class="search" name="q" id="cargo-desktop-search"
+        <input type="text" class="search" name="q" id="cargo-desktop-search"
                 placeholder="Click or press 'S' to search..."
-                value=searchQuery
+                value={{searchQuery}}
+                oninput={{action (mut searchQuery) value="target.value"}}
                 autofocus="autofocus"
                 tabindex="1"
-                required=true
-                data-test-search-input=true}}
+                required
+                data-test-search-input>
     </form>
 
     <div class='nav'>
@@ -102,12 +103,13 @@
 </div>
 
 <form id='mobile-search' class='search' action='/search' {{ action "search" on="submit" }} >
-    {{input type="text" class="search" name="q"
+    <input type="text" class="search" name="q"
             placeholder="Search"
-            value=searchQuery
+            value={{searchQuery}}
+            oninput={{action (mut searchQuery) value="target.value"}}
             autocorrect="off"
             tabindex="1"
-            required=true}}
+            required>
 </form>
 
 <div id="main" class='inner-content'>

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -8,9 +8,15 @@
     {{#if q}}
         <h2>for '{{ q }}'</h2>
     {{/if}}
+
+    {{#if dataTask.isRunning}}<img src="/assets/ajax-loader.gif" class="loading-spinner">{{/if}}
 </div>
 
-{{#if hasItems}}
+{{#if firstResultPending}}
+    <div id="no-results">
+        <h2>Loading search results...</h2>
+    </div>
+{{else if hasItems}}
     <div id='results'>
         <div class='nav' data-test-search-nav>
             <span class='amt'>

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "2.1.1",
     "ember-cli-uglify": "^2.0.0",
+    "ember-concurrency": "^0.8.12",
     "ember-data": "~2.12.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",


### PR DESCRIPTION
Similar to https://github.com/rust-lang/crates.io/pull/1186 this PR changes the "Search" page to load and reload data in the background

![crates-search](https://user-images.githubusercontent.com/141300/33519943-70a2145c-d7b1-11e7-9e5d-a78503adecdb.gif)
