### PR TITLE
Improve build times by caching `cargo install` artifacts for diesel, clippy, and rustfmt

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,11 +1,4 @@
-fn_args_layout = "Block"
-array_layout = "Block"
-control_style = "Rfc"
-where_style = "Rfc"
-generics_indent = "Block"
-fn_call_style = "Block"
 combine_control_expr = true
-fn_args_paren_newline = false
 max_width = 100
 error_on_line_overflow = false
 write_mode = "Overwrite"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - nvm install 8
 
 install:
-  - cargo install --force diesel_cli --vers 1.0.0-rc1 --debug --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
+  - cargo install --force diesel_cli --vers 1.0.0 --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
 
 before_script:
   - diesel database setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ before_install:
   - nvm install 8
 
 install:
-  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
-  - npm install
-  - cargo install --force diesel_cli --vers 0.16.0 --debug --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
+  - cargo install --force diesel_cli --vers 1.0.0-rc1 --debug --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
 
 before_script:
   - diesel database setup
@@ -44,16 +42,17 @@ matrix:
   allow_failures:
     - rust: nightly
   include:
-  - rust: nightly-2017-11-07
+  - rust: nightly-2017-12-28
     script:
-    - cargo install --force rustfmt-nightly --vers 0.2.15
-    - cargo install --force clippy --vers 0.0.169
+    - cargo install --force rustfmt-nightly --vers 0.3.4
     - cargo fmt -- --write-mode=diff
+    - cargo install --force clippy --vers 0.0.177
     - cargo clippy
   - rust: stable
     script:
     - cargo build
     - cargo test
+    - npm install
     - npm test
   - rust: beta
     script:
@@ -68,6 +67,7 @@ env:
   global:
     - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
     - TEST_DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
+    - CARGO_TARGET_DIR=target
 
 notifications:
   email:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.11.1 (git+https://github.com/SergioBenitez/ring?branch=v0.11)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1264,10 +1264,10 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.11.1"
+source = "git+https://github.com/SergioBenitez/ring?branch=v0.11#ca9fe986137a2dd494c1cd318ae0a04797aac4b0"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1933,7 +1933,7 @@ dependencies = [
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum relay 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f301bafeb60867c85170031bdb2fcf24c8041f33aee09e7b116a58d4e9f781c5"
-"checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
+"checksum ring 0.11.1 (git+https://github.com/SergioBenitez/ring?branch=v0.11)" = "<none>"
 "checksum route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3255338088df8146ba63d60a9b8e3556f1146ce2973bc05a75181a42ce2256"
 "checksum rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f76d05d3993fd5f4af9434e8e436db163a12a9d40e1a58a726f27a01dfd12a2a"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,7 @@ tokio-service = "0.1"
 dotenv = "0.10"
 diesel = { version = "1.0.0-beta1", features = ["postgres"] }
 diesel_migrations = { version = "1.0.0-beta1", features = ["postgres"] }
+
+# Remove once cookie depends on ring >= 0.13.0
+[patch.crates-io]
+ring = { git = "https://github.com/SergioBenitez/ring", branch = "v0.11" }

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -29,8 +29,12 @@ pub enum Badge {
         repository: String,
         branch: Option<String>,
     },
-    IsItMaintainedIssueResolution { repository: String },
-    IsItMaintainedOpenIssues { repository: String },
+    IsItMaintainedIssueResolution {
+        repository: String,
+    },
+    IsItMaintainedOpenIssues {
+        repository: String,
+    },
     Codecov {
         repository: String,
         branch: Option<String>,
@@ -41,7 +45,9 @@ pub enum Badge {
         branch: Option<String>,
         service: Option<String>,
     },
-    Maintenance { status: MaintenanceStatus },
+    Maintenance {
+        status: MaintenanceStatus,
+    },
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Deserialize, Serialize)]

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -39,8 +39,7 @@ fn delete(conn: &PgConnection) {
     let krate = Crate::by_name(&name).first::<Crate>(conn).unwrap();
     print!(
         "Are you sure you want to delete {} ({}) [y/N]: ",
-        name,
-        krate.id
+        name, krate.id
     );
     io::stdout().flush().unwrap();
     let mut line = String::new();

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -50,9 +50,7 @@ fn delete(conn: &PgConnection) {
         .unwrap();
     print!(
         "Are you sure you want to delete {}#{} ({}) [y/N]: ",
-        name,
-        version,
-        v.id
+        name, version, v.id
     );
     io::stdout().flush().unwrap();
     let mut line = String::new();

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -132,8 +132,7 @@ fn main() {
             let config = config.clone();
             version.record_readme_rendering(&conn).expect(&format!(
                 "[{}-{}] Couldn't record rendering time",
-                krate_name,
-                version.num
+                krate_name, version.num
             ));
             let handle = thread::spawn(move || {
                 println!("[{}-{}] Rendering README...", krate_name, version.num);
@@ -155,8 +154,7 @@ fn main() {
                     )
                     .expect(&format!(
                         "[{}-{}] Couldn't upload file to S3",
-                        krate_name,
-                        version.num
+                        krate_name, version.num
                     ));
             });
             tasks.push(handle);
@@ -182,8 +180,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
     let date = Utc::now().to_rfc2822();
     let url = Url::parse(&location).expect(&format!(
         "[{}-{}] Couldn't parse crate URL",
-        krate_name,
-        version.num
+        krate_name, version.num
     ));
 
     let mut headers = List::new();
@@ -206,9 +203,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
         if let Err(err) = req.perform() {
             println!(
                 "[{}-{}] Unable to fetch crate: {}",
-                krate_name,
-                version.num,
-                err
+                krate_name, version.num, err
             );
             return None;
         }
@@ -217,31 +212,26 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
         let response = String::from_utf8_lossy(&response);
         println!(
             "[{}-{}] Failed to get a 200 response: {}",
-            krate_name,
-            version.num,
-            response
+            krate_name, version.num, response
         );
         return None;
     }
     let reader = Cursor::new(response);
     let reader = GzDecoder::new(reader).expect(&format!(
         "[{}-{}] Invalid gzip header",
-        krate_name,
-        version.num
+        krate_name, version.num
     ));
     let mut archive = Archive::new(reader);
     let mut entries = archive.entries().expect(&format!(
         "[{}-{}] Invalid tar archive entries",
-        krate_name,
-        version.num
+        krate_name, version.num
     ));
     let manifest: Manifest = {
         let path = format!("{}-{}/Cargo.toml", krate_name, version.num);
         let contents = find_file_by_path(&mut entries, Path::new(&path), version, krate_name);
         toml::from_str(&contents).expect(&format!(
             "[{}-{}] Syntax error in manifest file",
-            krate_name,
-            version.num
+            krate_name, version.num
         ))
     };
     if manifest.package.readme.is_none() {
@@ -265,8 +255,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
             manifest.package.repository.as_ref().map(|e| &**e),
         ).expect(&format!(
             "[{}-{}] Couldn't render README",
-            krate_name,
-            version.num
+            krate_name, version.num
         ))
     };
     return Some(rendered);
@@ -315,8 +304,7 @@ fn find_file_by_path<R: Read>(
     let mut contents = String::new();
     file.read_to_string(&mut contents).expect(&format!(
         "[{}-{}] Couldn't read file contents",
-        krate_name,
-        version.num
+        krate_name, version.num
     ));
     contents
 }

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -64,8 +64,7 @@ fn transfer(conn: &PgConnection) {
 
     println!(
         "Are you sure you want to transfer crates from {} to {}",
-        from.gh_login,
-        to.gh_login
+        from.gh_login, to.gh_login
     );
     get_confirm("continue");
 

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -57,9 +57,9 @@ fn categories_from_toml(
     let mut result = vec![];
 
     for (slug, details) in categories {
-        let details = details.as_table().chain_error(|| {
-            internal(&format_args!("category {} was not a TOML table", slug))
-        })?;
+        let details = details
+            .as_table()
+            .chain_error(|| internal(&format_args!("category {} was not a TOML table", slug)))?;
 
         let category = Category::from_parent(
             slug,

--- a/src/category.rs
+++ b/src/category.rs
@@ -88,11 +88,9 @@ impl Category {
                 .collect();
             let crate_categories = categories
                 .iter()
-                .map(|c| {
-                    CrateCategory {
-                        category_id: c.id,
-                        crate_id: krate.id,
-                    }
+                .map(|c| CrateCategory {
+                    category_id: c.id,
+                    crate_id: krate.id,
                 })
                 .collect::<Vec<_>>();
 
@@ -137,9 +135,7 @@ impl Category {
              WHERE split_part(c.slug, '::', 1) = c.slug
              GROUP BY c.id
              {} LIMIT {} OFFSET {}",
-            sort_sql,
-            limit,
-            offset
+            sort_sql, limit, offset
         ))).load(conn)
     }
 

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -109,9 +109,7 @@ pub fn add_dependencies(
         .map(|dep| {
             let krate = Crate::by_name(&dep.name)
                 .first::<Crate>(&*conn)
-                .map_err(|_| {
-                    human(&format_args!("no known crate named `{}`", &*dep.name))
-                })?;
+                .map_err(|_| human(&format_args!("no known crate named `{}`", &*dep.name)))?;
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {
                 return Err(human(
                     "wildcard (`*`) dependency constraints are not allowed \

--- a/src/github.rs
+++ b/src/github.rs
@@ -72,8 +72,7 @@ pub fn parse_github_response<'de, 'a: 'de, T: Deserialize<'de>>(
             return Err(internal(&format_args!(
                 "didn't get a 200 result from \
                  github, got {} with: {}",
-                n,
-                resp
+                n, resp
             )));
         }
     }

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -96,11 +96,9 @@ impl Keyword {
             diesel::delete(CrateKeyword::belonging_to(krate)).execute(conn)?;
             let crate_keywords = keywords
                 .into_iter()
-                .map(|kw| {
-                    CrateKeyword {
-                        crate_id: krate.id,
-                        keyword_id: kw.id,
-                    }
+                .map(|kw| CrateKeyword {
+                    crate_id: krate.id,
+                    keyword_id: kw.id,
                 })
                 .collect::<Vec<_>>();
             diesel::insert_into(crates_keywords::table)

--- a/src/krate/metadata.rs
+++ b/src/krate/metadata.rs
@@ -66,10 +66,8 @@ pub fn summary(req: &mut Request) -> CargoResult<Response> {
     let recent_downloads = sql::<Nullable<BigInt>>("SUM(crate_downloads.downloads)");
     let most_recently_downloaded = crates
         .left_join(
-            crate_downloads::table.on(
-                id.eq(crate_downloads::crate_id)
-                    .and(crate_downloads::date.gt(date(now - 90.days()))),
-            ),
+            crate_downloads::table.on(id.eq(crate_downloads::crate_id)
+                .and(crate_downloads::date.gt(date(now - 90.days())))),
         )
         .group_by(id)
         .order(recent_downloads.desc().nulls_last())
@@ -150,25 +148,23 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
         keywords: Vec<EncodableKeyword>,
         categories: Vec<EncodableCategory>,
     }
-    Ok(
-        req.json(&R {
-            krate: krate.clone().encodable(
-                &max_version,
-                Some(ids),
-                Some(&kws),
-                Some(&cats),
-                Some(badges),
-                false,
-                recent_downloads,
-            ),
-            versions: versions
-                .into_iter()
-                .map(|v| v.encodable(&krate.name))
-                .collect(),
-            keywords: kws.into_iter().map(|k| k.encodable()).collect(),
-            categories: cats.into_iter().map(|k| k.encodable()).collect(),
-        }),
-    )
+    Ok(req.json(&R {
+        krate: krate.clone().encodable(
+            &max_version,
+            Some(ids),
+            Some(&kws),
+            Some(&cats),
+            Some(badges),
+            false,
+            recent_downloads,
+        ),
+        versions: versions
+            .into_iter()
+            .map(|v| v.encodable(&krate.name))
+            .collect(),
+        keywords: kws.into_iter().map(|k| k.encodable()).collect(),
+        categories: cats.into_iter().map(|k| k.encodable()).collect(),
+    }))
 }
 
 /// Handles the `GET /crates/:crate_id/:version/readme` route.

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -177,17 +177,15 @@ impl<'a> NewCrate<'a> {
                 Some(s) => s,
                 None => return Ok(()),
             };
-            let url = Url::parse(url).map_err(|_| {
-                human(&format_args!("`{}` is not a valid url: `{}`", field, url))
-            })?;
+            let url = Url::parse(url)
+                .map_err(|_| human(&format_args!("`{}` is not a valid url: `{}`", field, url)))?;
             match &url.scheme()[..] {
                 "http" | "https" => {}
                 s => {
                     return Err(human(&format_args!(
                         "`{}` has an invalid url \
                          scheme: `{}`",
-                        field,
-                        s
+                        field, s
                     )))
                 }
             }
@@ -195,8 +193,7 @@ impl<'a> NewCrate<'a> {
                 return Err(human(&format_args!(
                     "`{}` must have relative scheme \
                      data: {}",
-                    field,
-                    url
+                    field, url
                 )));
             }
             Ok(())
@@ -578,9 +575,9 @@ mod tests {
     #[test]
     fn documentation_blacklist_url_contains_partial_match() {
         assert_eq!(
-            Crate::remove_blacklisted_documentation_urls(
-                Some(String::from("http://rust-ci.organists.com")),
-            ),
+            Crate::remove_blacklisted_documentation_urls(Some(String::from(
+                "http://rust-ci.organists.com"
+            )),),
             Some(String::from("http://rust-ci.organists.com"))
         );
     }

--- a/src/krate/publish.rs
+++ b/src/krate/publish.rs
@@ -88,9 +88,10 @@ pub fn publish(req: &mut Request) -> CargoResult<Response> {
         }
 
         if krate.name != name {
-            return Err(human(
-                &format_args!("crate was previously named `{}`", krate.name),
-            ));
+            return Err(human(&format_args!(
+                "crate was previously named `{}`",
+                krate.name
+            )));
         }
 
         let length = req.content_length()

--- a/src/krate/search.rs
+++ b/src/krate/search.rs
@@ -51,11 +51,9 @@ pub fn search(req: &mut Request) -> CargoResult<Response> {
 
     let mut query = crates::table
         .left_join(
-            crate_downloads::table.on(
-                crates::id
-                    .eq(crate_downloads::crate_id)
-                    .and(crate_downloads::date.gt(date(now - 90.days()))),
-            ),
+            crate_downloads::table.on(crates::id
+                .eq(crate_downloads::crate_id)
+                .and(crate_downloads::date.gt(date(now - 90.days())))),
         )
         .group_by(crates::id)
         .select((
@@ -90,10 +88,7 @@ pub fn search(req: &mut Request) -> CargoResult<Response> {
         if sort == "downloads" {
             query = query.order((perfect_match, crates::downloads.desc()));
         } else if sort == "recent-downloads" {
-            query = query.order((
-                perfect_match,
-                recent_downloads.clone().desc().nulls_last(),
-            ));
+            query = query.order((perfect_match, recent_downloads.clone().desc().nulls_last()));
         } else {
             let rank = ts_rank_cd(crates::textsearchable_index_col, q);
             query = query.order((perfect_match, rank.desc()))

--- a/src/owner.rs
+++ b/src/owner.rs
@@ -197,8 +197,7 @@ impl Team {
             .ok_or_else(|| {
                 human(&format_args!(
                     "could not find the github team {}/{}",
-                    org_name,
-                    team_name
+                    org_name, team_name
                 ))
             })?;
 
@@ -310,17 +309,18 @@ impl Owner {
         name: &str,
     ) -> CargoResult<Owner> {
         if name.contains(':') {
-            Ok(Owner::Team(
-                Team::create_or_update(app, conn, name, req_user)?,
-            ))
+            Ok(Owner::Team(Team::create_or_update(
+                app,
+                conn,
+                name,
+                req_user,
+            )?))
         } else {
             users::table
                 .filter(users::gh_login.eq(name))
                 .first(conn)
                 .map(Owner::User)
-                .map_err(|_| {
-                    human(&format_args!("could not find user with login `{}`", name))
-                })
+                .map_err(|_| human(&format_args!("could not find user with login `{}`", name)))
         }
     }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -312,14 +312,12 @@ impl<'a> VersionBuilder<'a> {
 
         let new_deps = self.dependencies
             .into_iter()
-            .map(|(crate_id, target)| {
-                NewDependency {
-                    version_id: vers.id,
-                    req: ">= 0".into(),
-                    crate_id,
-                    target,
-                    ..Default::default()
-                }
+            .map(|(crate_id, target)| NewDependency {
+                version_id: vers.id,
+                req: ">= 0".into(),
+                crate_id,
+                target,
+                ..Default::default()
             })
             .collect::<Vec<_>>();
         insert_into(dependencies::table)

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -650,7 +650,6 @@ fn new_krate_non_canon_crate_name_dependencies() {
     ::json::<GoodCrate>(&mut response);
 }
 
-
 #[test]
 fn new_krate_with_wildcard_dependency() {
     let (_b, app, middle) = ::app();

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -499,7 +499,6 @@ fn test_accept_invitation() {
     assert_eq!(json.users.len(), 2);
 }
 
-
 /*  Given a user inviting a different user to be a crate
     owner, check that the user invited can decline their
     invitation and the invitation will be deleted from
@@ -571,7 +570,6 @@ fn test_decline_invitation() {
     let json: T = ::json(&mut response);
     assert_eq!(json.crate_owner_invitation.accepted, false);
     assert_eq!(json.crate_owner_invitation.crate_id, krate.id);
-
 
     // then check to make sure that decline_invite did what it
     // was supposed to

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -121,7 +121,6 @@ pub fn proxy() -> (String, Bomb) {
             .connector(hyper_tls::HttpsConnector::new(4, &handle).unwrap())
             .build(&handle);
 
-
         let record = Rc::new(RefCell::new(record));
         let srv = listener.incoming().for_each(|(socket, addr)| {
             Http::new().bind_connection(
@@ -174,14 +173,14 @@ impl Service for Proxy {
         match *self.record.borrow_mut() {
             Record::Capture(_, _) => {
                 let record = Rc::clone(&self.record);
-                Box::new(record_http(req, &self.client).map(
-                    move |(response, exchange)| {
+                Box::new(
+                    record_http(req, &self.client).map(move |(response, exchange)| {
                         if let Record::Capture(ref mut d, _) = *record.borrow_mut() {
                             d.push(exchange);
                         }
                         response
-                    },
-                ))
+                    }),
+                )
             }
             Record::Replay(ref mut exchanges) => {
                 replay_http(req, exchanges.remove(0), &mut &self.sink)

--- a/src/tests/schema_details.rs
+++ b/src/tests/schema_details.rs
@@ -15,8 +15,7 @@ fn all_columns_called_crate_id_have_a_cascading_foreign_key() {
             panic!(
                 "Foreign key {} on table {} should have `ON DELETE CASCADE` \
                  but it doesn't.",
-                constraint.name,
-                row.table_name
+                constraint.name, row.table_name
             );
         }
     }
@@ -36,8 +35,7 @@ fn all_columns_called_version_id_have_a_cascading_foreign_key() {
             panic!(
                 "Foreign key {} on table {} should have `ON DELETE CASCADE` \
                  but it doesn't.",
-                constraint.name,
-                row.table_name
+                constraint.name, row.table_name
             );
         }
     }

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -93,26 +93,22 @@ fn show_latest_user_case_insensitively() {
         // should be used for uniquely identifying GitHub accounts whenever possible. For the
         // crates.io/user/:username pages, the best we can do is show the last crates.io account
         // created with that username.
-        t!(
-            NewUser::new(
-                1,
-                "foobar",
-                Some("foo@bar.com"),
-                Some("I was first then deleted my github account"),
-                None,
-                "bar"
-            ).create_or_update(&conn)
-        );
-        t!(
-            NewUser::new(
-                2,
-                "FOOBAR",
-                Some("later-foo@bar.com"),
-                Some("I was second, I took the foobar username on github"),
-                None,
-                "bar"
-            ).create_or_update(&conn)
-        );
+        t!(NewUser::new(
+            1,
+            "foobar",
+            Some("foo@bar.com"),
+            Some("I was first then deleted my github account"),
+            None,
+            "bar"
+        ).create_or_update(&conn));
+        t!(NewUser::new(
+            2,
+            "FOOBAR",
+            Some("later-foo@bar.com"),
+            Some("I was second, I took the foobar username on github"),
+            None,
+            "bar"
+        ).create_or_update(&conn));
     }
     let mut req = ::req(Arc::clone(&app), Method::Get, "api/v1/users/fOObAr");
     let mut response = ok_resp!(middle.call(&mut req));
@@ -724,12 +720,10 @@ fn test_confirm_user_email() {
             .unwrap()
     };
 
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/confirm/{}", email_token))
-                .with_method(Method::Put),
-        )
-    );
+    let mut response = ok_resp!(middle.call(req.with_path(&format!(
+        "/api/v1/confirm/{}",
+        email_token
+    )).with_method(Method::Put),));
     assert!(::json::<S>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));

--- a/src/token.rs
+++ b/src/token.rs
@@ -102,9 +102,8 @@ pub fn new(req: &mut Request) -> CargoResult<Response> {
 
     let json = String::from_utf8(json).map_err(|_| bad_request(&"json body was not valid utf-8"))?;
 
-    let new: NewApiTokenRequest = json::from_str(&json).map_err(|e| {
-        bad_request(&format!("invalid new token request: {:?}", e))
-    })?;
+    let new: NewApiTokenRequest = json::from_str(&json)
+        .map_err(|e| bad_request(&format!("invalid new token request: {:?}", e)))?;
 
     let name = &new.api_token.name;
     if name.len() < 1 {

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -256,9 +256,8 @@ fn verify_tarball(
     let mut archive = tar::Archive::new(decoder);
     let prefix = format!("{}-{}", krate.name, vers);
     for entry in archive.entries()? {
-        let entry = entry.chain_error(|| {
-            human("uploaded tarball is malformed or too large when decompressed")
-        })?;
+        let entry = entry
+            .chain_error(|| human("uploaded tarball is malformed or too large when decompressed"))?;
 
         // Verify that all entries actually start with `$name-$vers/`.
         // Historically Cargo didn't verify this on extraction so you could

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -585,8 +585,7 @@ fn send_user_confirm_email(email: &str, user_name: &str, token: &str) -> CargoRe
         "Hello {}! Welcome to Crates.io. Please click the
 link below to verify your email address. Thank you!\n
 https://crates.io/confirm/{}",
-        user_name,
-        token
+        user_name, token
     );
 
     email::send_email(email, subject, &body)

--- a/src/util/head.rs
+++ b/src/util/head.rs
@@ -27,12 +27,14 @@ impl Handler for Head {
                 path: None,
                 method: Some(Method::Get),
             };
-            self.handler.as_ref().unwrap().call(&mut req).map(|r| {
-                Response {
+            self.handler
+                .as_ref()
+                .unwrap()
+                .call(&mut req)
+                .map(|r| Response {
                     body: Box::new(io::empty()),
                     ..r
-                }
-            })
+                })
         } else {
             self.handler.as_ref().unwrap().call(req)
         }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -49,7 +49,6 @@ pub fn json_response<T: Serialize>(t: &T) -> Response {
     }
 }
 
-
 impl<'a> RequestUtils for Request + 'a {
     fn json<T: Serialize>(&self, t: &T) -> Response {
         json_response(t)
@@ -89,9 +88,10 @@ impl<'a> RequestUtils for Request + 'a {
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(default);
         if limit > max {
-            return Err(human(
-                &format_args!("cannot request more than {} items", max),
-            ));
+            return Err(human(&format_args!(
+                "cannot request more than {} items",
+                max
+            )));
         }
         if page == 0 {
             return Err(human("page indexing starts from 1, page 0 is invalid"));

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -115,15 +115,16 @@ impl Version {
     where
         T: IntoIterator<Item = semver::Version>,
     {
-        versions.into_iter().max().unwrap_or_else(|| {
-            semver::Version {
+        versions
+            .into_iter()
+            .max()
+            .unwrap_or_else(|| semver::Version {
                 major: 0,
                 minor: 0,
                 patch: 0,
                 pre: vec![],
                 build: vec![],
-            }
-        })
+            })
     }
 
     pub fn record_readme_rendering(&self, conn: &PgConnection) -> QueryResult<usize> {
@@ -261,8 +262,7 @@ fn version_and_crate(req: &mut Request) -> CargoResult<(Version, Crate)> {
         .map_err(|_| {
             human(&format_args!(
                 "crate `{}` does not have a version `{}`",
-                crate_name,
-                semver
+                crate_name, semver
             ))
         })?;
     Ok((version, krate))


### PR DESCRIPTION
The primary change is to set `CARGO_TARGET_DIR=target` which instructs `cargo install` to use the target/ directory which is cached between builds on travis.  This is only available on recent nightlies so I've bumped clippy and rustfmt versions.

Unfortunately, `ring v0.11.0` does not compile on recent nightlies and upstream provides no support for older versions.  Therefore I've added a patch section to use a git repo that incorporates the fix and a few other cleanups.  This issue would have broken the build soon anyway when rust 1.24 goes into beta.

A few other changes:

* only `npm install` on the stable job
* removed travis-cargo which appears to be unused
* removed rustfmt configuration options that were removed upstream
