### PR TITLE
Tests to ensure datetime JSON serialization stays the same

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -412,7 +412,11 @@ mod tests {
             created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
         };
         let json = serde_json::to_string(&cat).unwrap();
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
     }
 
     #[test]
@@ -427,7 +431,11 @@ mod tests {
             subcategories: vec![],
         };
         let json = serde_json::to_string(&cat).unwrap();
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
     }
 
 }

--- a/src/category.rs
+++ b/src/category.rs
@@ -266,8 +266,10 @@ pub fn slugs(req: &mut Request) -> CargoResult<Response> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::NaiveDate;
     use diesel::connection::SimpleConnection;
     use dotenv::dotenv;
+    use serde_json;
     use std::env;
 
     fn pg_connection() -> PgConnection {
@@ -398,4 +400,34 @@ mod tests {
         let expected = vec![("Cat 3".to_string(), 6), ("Cat 1".to_string(), 3)];
         assert_eq!(expected, categories);
     }
+
+    #[test]
+    fn category_dates_serializes_to_rfc3339() {
+        let cat = EncodableCategory {
+            id: "".to_string(),
+            category: "".to_string(),
+            slug: "".to_string(),
+            description: "".to_string(),
+            crates_cnt: 1,
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+        };
+        let json = serde_json::to_string(&cat).unwrap();
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+    }
+
+    #[test]
+    fn category_with_sub_dates_serializes_to_rfc3339() {
+        let cat = EncodableCategoryWithSubcategories {
+            id: "".to_string(),
+            category: "".to_string(),
+            slug: "".to_string(),
+            description: "".to_string(),
+            crates_cnt: 1,
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+            subcategories: vec![],
+        };
+        let json = serde_json::to_string(&cat).unwrap();
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+    }
+
 }

--- a/src/crate_owner_invitation.rs
+++ b/src/crate_owner_invitation.rs
@@ -173,3 +173,23 @@ fn decline_invite(
         crate_owner_invitation: crate_invite,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+    use serde_json;
+
+    #[test]
+    fn crate_owner_invitation_serializes_to_rfc3339() {
+        let inv = EncodableCrateOwnerInvitation {
+            invited_by_username: "".to_string(),
+            crate_name: "".to_string(),
+            crate_id: 123,
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+        };
+        let json = serde_json::to_string(&inv).unwrap();
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+    }
+
+}

--- a/src/crate_owner_invitation.rs
+++ b/src/crate_owner_invitation.rs
@@ -189,7 +189,11 @@ mod tests {
             created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
         };
         let json = serde_json::to_string(&inv).unwrap();
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
     }
 
 }

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -211,7 +211,11 @@ mod tests {
             crates_cnt: 0,
         };
         let json = serde_json::to_string(&key).unwrap();
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
     }
 
 }

--- a/src/keyword.rs
+++ b/src/keyword.rs
@@ -169,10 +169,12 @@ pub fn show(req: &mut Request) -> CargoResult<Response> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dotenv::dotenv;
-    use std::env;
+    use chrono::NaiveDate;
     use diesel;
     use diesel::connection::SimpleConnection;
+    use dotenv::dotenv;
+    use serde_json;
+    use std::env;
 
     fn pg_connection() -> PgConnection {
         let _ = dotenv();
@@ -199,4 +201,17 @@ mod tests {
         assert_eq!(associated.len(), 1);
         assert_eq!(associated.first().unwrap().keyword, "no");
     }
+
+    #[test]
+    fn keyword_serializes_to_rfc3339() {
+        let key = EncodableKeyword {
+            id: "".to_string(),
+            keyword: "".to_string(),
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+            crates_cnt: 0,
+        };
+        let json = serde_json::to_string(&key).unwrap();
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+    }
+
 }

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -620,10 +620,18 @@ mod tests {
                 owner_user: None,
                 reverse_dependencies: "".to_string(),
             },
-            exact_match: false
+            exact_match: false,
         };
         let json = serde_json::to_string(&crt).unwrap();
-        assert!(json.as_str().find(r#""updated_at":"2017-01-06T14:23:11+00:00""#).is_some());
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:12+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
+                .is_some()
+        );
     }
 }

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -557,7 +557,9 @@ sql_function!(to_char, to_char_t, (a: Date, b: Text) -> Text);
 
 #[cfg(test)]
 mod tests {
-    use super::Crate;
+    use super::*;
+    use chrono::NaiveDate;
+    use serde_json;
 
     #[test]
     fn documentation_blacklist_no_url_provided() {
@@ -590,5 +592,38 @@ mod tests {
             ),),),
             None
         );
+    }
+
+    #[test]
+    fn crate_serializes_to_rfc3399() {
+        let crt = EncodableCrate {
+            id: "".to_string(),
+            name: "".to_string(),
+            updated_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+            versions: None,
+            keywords: None,
+            categories: None,
+            badges: None,
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12),
+            downloads: 0,
+            recent_downloads: None,
+            max_version: "".to_string(),
+            description: None,
+            homepage: None,
+            documentation: None,
+            repository: None,
+            links: CrateLinks {
+                version_downloads: "".to_string(),
+                versions: None,
+                owners: None,
+                owner_team: None,
+                owner_user: None,
+                reverse_dependencies: "".to_string(),
+            },
+            exact_match: false
+        };
+        let json = serde_json::to_string(&crt).unwrap();
+        assert!(json.as_str().find(r#""updated_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:12+00:00""#).is_some());
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -146,3 +146,40 @@ pub fn revoke(req: &mut Request) -> CargoResult<Response> {
     struct R {}
     Ok(req.json(&R {}))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+    use serde_json;
+
+    #[test]
+    fn api_token_serializes_to_rfc3339() {
+        let tok = ApiToken {
+            id: 12345,
+            user_id: 23456,
+            token: "".to_string(),
+            name: "".to_string(),
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+            last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
+        };
+        let json = serde_json::to_string(&tok).unwrap();
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(json.as_str().find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#).is_some());
+    }
+
+    #[test]
+    fn encodeable_api_token_with_token_serializes_to_rfc3339() {
+        let tok = EncodableApiTokenWithToken {
+            id: 12345,
+            name: "".to_string(),
+            token: "".to_string(),
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+            last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
+        };
+        let json = serde_json::to_string(&tok).unwrap();
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(json.as_str().find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#).is_some());
+    }
+
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -164,8 +164,16 @@ mod tests {
             last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
         };
         let json = serde_json::to_string(&tok).unwrap();
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
-        assert!(json.as_str().find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
+        assert!(
+            json.as_str()
+                .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
+                .is_some()
+        );
     }
 
     #[test]
@@ -178,8 +186,16 @@ mod tests {
             last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
         };
         let json = serde_json::to_string(&tok).unwrap();
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11+00:00""#).is_some());
-        assert!(json.as_str().find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
+        assert!(
+            json.as_str()
+                .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
+                .is_some()
+        );
     }
 
 }

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -295,10 +295,16 @@ mod tests {
             },
         };
         let json = serde_json::to_string(&ver).unwrap();
-        assert!(json.as_str().find(r#""updated_at":"2017-01-06T14:23:11+00:00""#).is_some());
-        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:12+00:00""#).is_some());
+        assert!(
+            json.as_str()
+                .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
+                .is_some()
+        );
+        assert!(
+            json.as_str()
+                .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
+                .is_some()
+        );
     }
 
 }
-
-

--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -267,3 +267,38 @@ fn version_and_crate(req: &mut Request) -> CargoResult<(Version, Crate)> {
         })?;
     Ok((version, krate))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+    use serde_json;
+
+    #[test]
+    fn version_serializes_to_rfc3339() {
+        let ver = EncodableVersion {
+            id: 1,
+            krate: "".to_string(),
+            num: "".to_string(),
+            dl_path: "".to_string(),
+            readme_path: "".to_string(),
+            updated_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+            created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12),
+            downloads: 0,
+            features: HashMap::new(),
+            yanked: false,
+            license: None,
+            links: VersionLinks {
+                dependencies: "".to_string(),
+                version_downloads: "".to_string(),
+                authors: "".to_string(),
+            },
+        };
+        let json = serde_json::to_string(&ver).unwrap();
+        assert!(json.as_str().find(r#""updated_at":"2017-01-06T14:23:11+00:00""#).is_some());
+        assert!(json.as_str().find(r#""created_at":"2017-01-06T14:23:12+00:00""#).is_some());
+    }
+
+}
+
+


### PR DESCRIPTION
99c459bb fixed the serialization to be RFC3339 compliant with the
timezone being represented as `+00:00`. This simply adds tests for the
structs where we use `#[serde(with = "::util::rfc3339")]` to ensure
the JSON representation of those dates stay the same.

Fixes #1164