### PR TITLE
Avoid content jumps on front page

### DIFF
--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -28,6 +28,11 @@
     }
 }
 
+@keyframes fadein {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
 .yellow-button {
     @include button(#fede9e, #fdc452);
     vertical-align: middle;
@@ -147,11 +152,16 @@ button.small {
       margin: 0;
       padding: 0 15px;
       width: 33.33%;
+      min-height: 788.283px;
       @media only screen and (max-width: 750px) {
         width: 50%;
       }
       @media only screen and (max-width: 550px) {
         width: 100%;
+      }
+
+      li {
+        animation: fadein 400ms;
       }
     }
 }


### PR DESCRIPTION
Currently, the crate lists are collapsed while the data is fetched (increasing in size when the data arrives). This makes the headers jump on the screen ([it's a common problem](https://css-tricks.com/content-jumping-avoid/)). This attempts to fix this by setting `min-height` on the lists (and adding a quick fade-in animation for when the crates arrive).