### PR TITLE
Add UI for sorting my crates by recent downloads

### DIFF
--- a/app/controllers/me/crates.js
+++ b/app/controllers/me/crates.js
@@ -15,6 +15,12 @@ export default Controller.extend(PaginationMixin, {
     totalItems: readOnly('model.meta.total'),
 
     currentSortBy: computed('sort', function() {
-        return (this.get('sort') === 'downloads') ? 'Downloads' : 'Alphabetical';
+        if (this.get('sort') === 'downloads') {
+            return 'All-Time Downloads';
+        } else if (this.get('sort') === 'recent-downloads') {
+            return 'Recent Downloads';
+        } else {
+            return 'Alphabetical';
+        }
     }),
 });

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -33,7 +33,12 @@
                 </li>
                 <li>
                     {{#link-to (query-params sort="downloads")}}
-                        Downloads
+                        All-Time Downloads
+                    {{/link-to}}
+                </li>
+                <li>
+                    {{#link-to (query-params sort="recent-downloads")}}
+                        Recent Downloads
                     {{/link-to}}
                 </li>
             {{/rl-dropdown}}


### PR DESCRIPTION
This fixes #1231, and renames "Downloads" to "All-Time Downloads" to be consistent with the sort dropdowns on other listings.