### PR TITLE
Update to Diesel 1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
  "conduit-test 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_full_text_search 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_migrations 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_migrations 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -147,8 +147,6 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2-diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -446,20 +444,21 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "diesel_derives 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel_derives 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pq-sys 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "r2d2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel_derives"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -471,16 +470,16 @@ name = "diesel_full_text_search"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "diesel_migrations"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "migrations_internals 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "migrations_macros 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "migrations_internals 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "migrations_macros 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -932,18 +931,18 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "migrations_macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "migrations_internals 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "migrations_internals 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1174,15 +1173,6 @@ dependencies = [
  "antidote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "r2d2-diesel"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "r2d2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1838,10 +1828,10 @@ dependencies = [
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
-"checksum diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de51f2e2321a7db9bdfd7e3457c6ce11dce5009cad7ff9ac25a04879239e5fe6"
-"checksum diesel_derives 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "274aeed033dcd9e40f472cd282a3692512fef153283ec4c745873517d0e67f3f"
+"checksum diesel 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "432f5bcbee154114f4ba4d2a09153498f3195e6e0551ed0dbc9964e0e4d5f5e8"
+"checksum diesel_derives 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "28e2b2605ac6a3b9a586383f5f8b2b5f1108f07a421ade965b266289d2805e79"
 "checksum diesel_full_text_search 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6bb76b26499ddcd4672f4a47fa6cdf97b5dfbedf688c4e2f386ba576585b4ae"
-"checksum diesel_migrations 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "45efc922686673614d4aee6ddd47ebef2d5c789a0a0b34e0df5efaaedac51d09"
+"checksum diesel_migrations 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0928a7d6f27c849954185416bd59439837de55fbc89e2985b0e46e756ae4e3da"
 "checksum docopt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3b5b93718f8b3e5544fcc914c43de828ca6c6ace23e0332c6080a2977b49787a"
 "checksum dotenv 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d6f0e2bb24d163428d8031d3ebd2d2bd903ad933205a97d0f18c7c1aade380f3"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
@@ -1895,8 +1885,8 @@ dependencies = [
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e01e64d9017d18e7fc09d8e4fe0e28ff6931019e979fb8019319db7ca827f8a6"
-"checksum migrations_internals 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd5248cbbe4f45d5b4e6cf13a9f37aa587d31c41d2d8b80a0bf0aaf2e30c862d"
-"checksum migrations_macros 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06b25945741aeb3a00bb37eb142d03480e96230fff5569327ab4ac2082449df2"
+"checksum migrations_internals 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd916de6df9ac7e811e7e1ac28e0abfebe5205f3b29a7bda9ec8a41ee980a4eb"
+"checksum migrations_macros 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a550cfd76f6cfdf15a7b541893d7c79b68277b0b309f12179211a373a56e617"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
@@ -1923,7 +1913,6 @@ dependencies = [
 "checksum precomputed-hash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum r2d2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "59611202bee496c586ecd84e3ed149b4ec75981b0fc10d7f60e878fa23ae16e9"
-"checksum r2d2-diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9c29bad92da76d02bc2c020452ebc3a3fe6fa74cfab91e711c43116e4fb1a3"
 "checksum rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)" = "6475140dfd8655aeb72e1fd4b7a1cc1c202be65d71669476e392fe62532b9edd"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7febc28567082c345f10cddc3612c6ea020fc3297a1977d472cf9fdb73e6e493"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ semver = "0.5"
 url = "1.2.1"
 tar = "0.4.13"
 
-r2d2 = "0.8.0"
 openssl = "0.9.14"
 curl = "0.4"
 oauth2 = "0.3"
@@ -46,8 +45,7 @@ htmlescape = "0.3.1"
 license-exprs = "^1.3"
 dotenv = "0.10.0"
 toml = "0.4"
-diesel = { version = "1.0.0", features = ["postgres", "serde_json", "chrono"] }
-r2d2-diesel = "1.0.0"
+diesel = { version = "1.1.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
 diesel_full_text_search = "1.0.0"
 serde_json = "1.0.0"
 serde_derive = "1.0.0"
@@ -82,8 +80,8 @@ tokio-service = "0.1"
 
 [build-dependencies]
 dotenv = "0.10"
-diesel = { version = "1.0.0", features = ["postgres"] }
-diesel_migrations = { version = "1.0.0", features = ["postgres"] }
+diesel = { version = "1.1.0", features = ["postgres"] }
+diesel_migrations = { version = "1.1.0", features = ["postgres"] }
 
 # Remove once cookie depends on ring >= 0.13.0
 [patch.crates-io]

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,9 +7,9 @@ use std::sync::{Arc, Mutex};
 
 use conduit::{Request, Response};
 use conduit_middleware::Middleware;
+use diesel::r2d2;
 use git2;
 use oauth2;
-use r2d2;
 use curl::easy::Easy;
 use scheduled_thread_pool::ScheduledThreadPool;
 

--- a/src/category.rs
+++ b/src/category.rs
@@ -140,7 +140,7 @@ impl Category {
     }
 
     pub fn subcategories(&self, conn: &PgConnection) -> QueryResult<Vec<Category>> {
-        use diesel::types::Text;
+        use diesel::sql_types::Text;
 
         sql_query(
             "SELECT c.id, c.category, c.slug, c.description, \

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,8 +2,7 @@ use std::env;
 
 use conduit::Request;
 use diesel::prelude::{ConnectionResult, PgConnection};
-use r2d2;
-use r2d2_diesel::ConnectionManager;
+use diesel::r2d2::{self, ConnectionManager};
 use url::Url;
 
 use app::RequestApp;

--- a/src/krate/downloads.rs
+++ b/src/krate/downloads.rs
@@ -20,7 +20,7 @@ use super::{to_char, Crate};
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub fn downloads(req: &mut Request) -> CargoResult<Response> {
     use diesel::dsl::*;
-    use diesel::types::BigInt;
+    use diesel::sql_types::BigInt;
 
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;

--- a/src/krate/metadata.rs
+++ b/src/krate/metadata.rs
@@ -23,7 +23,7 @@ use super::{Crate, CrateDownload, EncodableCrate, ALL_COLUMNS};
 /// Handles the `GET /summary` route.
 pub fn summary(req: &mut Request) -> CargoResult<Response> {
     use diesel::dsl::*;
-    use diesel::types::{BigInt, Nullable};
+    use diesel::sql_types::{BigInt, Nullable};
     use schema::crates::dsl::*;
 
     let conn = req.db_conn()?;

--- a/src/krate/mod.rs
+++ b/src/krate/mod.rs
@@ -530,7 +530,7 @@ impl Crate {
         limit: i64,
     ) -> QueryResult<(Vec<ReverseDependency>, i64)> {
         use diesel::sql_query;
-        use diesel::types::{BigInt, Integer};
+        use diesel::sql_types::{BigInt, Integer};
 
         let rows = sql_query(include_str!("krate_reverse_dependencies.sql"))
             .bind::<Integer, _>(self.id)
@@ -551,7 +551,7 @@ pub struct Follow {
     crate_id: i32,
 }
 
-use diesel::types::{Date, Text};
+use diesel::sql_types::{Date, Text};
 sql_function!(canon_crate_name, canon_crate_name_t, (x: Text) -> Text);
 sql_function!(to_char, to_char_t, (a: Date, b: Text) -> Text);
 

--- a/src/krate/search.rs
+++ b/src/krate/search.rs
@@ -37,7 +37,7 @@ use super::{canon_crate_name, Crate, EncodableCrate, ALL_COLUMNS};
 /// for them.
 pub fn search(req: &mut Request) -> CargoResult<Response> {
     use diesel::dsl::*;
-    use diesel::types::{BigInt, Bool, Nullable};
+    use diesel::sql_types::{BigInt, Bool, Nullable};
 
     let conn = req.db_conn()?;
     let (offset, limit) = req.pagination(10, 100)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,8 +25,6 @@ extern crate license_exprs;
 extern crate log;
 extern crate oauth2;
 extern crate openssl;
-extern crate r2d2;
-extern crate r2d2_diesel;
 extern crate rand;
 extern crate s3;
 extern crate scheduled_thread_pool;
@@ -327,4 +325,4 @@ pub fn env(s: &str) -> String {
     ::std::env::var(s).unwrap_or_else(|_| panic!("must have `{}` defined", s))
 }
 
-sql_function!(lower, lower_t, (x: ::diesel::types::Text) -> ::diesel::types::Text);
+sql_function!(lower, lower_t, (x: ::diesel::sql_types::Text) -> ::diesel::sql_types::Text);

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -1,6 +1,6 @@
 use diesel::prelude::*;
 use diesel::query_builder::*;
-use diesel::types::BigInt;
+use diesel::sql_types::BigInt;
 use diesel::pg::Pg;
 
 pub struct Paginated<T> {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -222,7 +222,7 @@ table! {
 
 table! {
     use diesel_full_text_search::{TsVector as Tsvector};
-    use diesel::types::*;
+    use diesel::sql_types::*;
 
     /// Representation of the `crates` table.
     ///

--- a/src/tests/schema_details.rs
+++ b/src/tests/schema_details.rs
@@ -1,5 +1,5 @@
 use diesel::prelude::*;
-use diesel::types::Text;
+use diesel::sql_types::Text;
 
 #[test]
 fn all_columns_called_crate_id_have_a_cascading_foreign_key() {
@@ -44,7 +44,7 @@ fn all_columns_called_version_id_have_a_cascading_foreign_key() {
 #[derive(QueryableByName)]
 struct FkConstraint {
     #[sql_type = "Text"]
-    #[column_name(conname)]
+    #[column_name = "conname"]
     name: String,
     #[sql_type = "Text"] definition: String,
 }
@@ -52,7 +52,7 @@ struct FkConstraint {
 #[derive(QueryableByName)]
 struct TableNameAndConstraint {
     #[sql_type = "Text"]
-    #[column_name(relname)]
+    #[column_name = "relname"]
     table_name: String,
     #[diesel(embed)] constraint: Option<FkConstraint>,
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -252,15 +252,12 @@ impl Deref for CategoryList {
 }
 
 use diesel::pg::Pg;
-use diesel::types::{IsNull, Text, ToSql, ToSqlOutput};
-use std::error::Error;
+use diesel::serialize::{self, Output, ToSql};
+use diesel::sql_types::Text;
 use std::io::Write;
 
 impl ToSql<Text, Pg> for Feature {
-    fn to_sql<W: Write>(
-        &self,
-        out: &mut ToSqlOutput<W, Pg>,
-    ) -> Result<IsNull, Box<Error + Send + Sync>> {
+    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         ToSql::<Text, Pg>::to_sql(&**self, out)
     }
 }

--- a/src/user/mod.rs
+++ b/src/user/mod.rs
@@ -88,7 +88,7 @@ impl<'a> NewUser<'a> {
     pub fn create_or_update(&self, conn: &PgConnection) -> QueryResult<User> {
         use diesel::insert_into;
         use diesel::dsl::sql;
-        use diesel::types::Integer;
+        use diesel::sql_types::Integer;
         use diesel::pg::upsert::excluded;
         use diesel::NotFound;
         use schema::users::dsl::*;

--- a/src/with_count.rs
+++ b/src/with_count.rs
@@ -1,6 +1,6 @@
 #[derive(QueryableByName)]
 pub struct WithCount<T> {
-    #[sql_type = "::diesel::types::BigInt"] total: i64,
+    #[sql_type = "::diesel::sql_types::BigInt"] total: i64,
     #[diesel(embed)] record: T,
 }
 


### PR DESCRIPTION
This is the minimum changes required to fix any deprecation warnings.
There's a lot of additional stuff we could do that I wanted to keep
separate. After updating to Diesel 1.1, we can remove virtually anywhere
that we're doing an explicit `&*`. Additionally, there are probably a
lot of places that we should be using custom types but aren't. We can
remove a lot of code once
https://github.com/steveklabnik/semver/pull/169 is merged/released as well.