### PR TITLE
Use `derive_deref`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,7 @@ dependencies = [
  "conduit-test 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_deref 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_full_text_search 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel_migrations 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -438,6 +439,15 @@ dependencies = [
 [[package]]
 name = "derive-error-chain"
 version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_deref"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1838,6 +1848,7 @@ dependencies = [
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum debug_unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
 "checksum derive-error-chain 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c9ca9ade651388daad7c993f005d0d20c4f6fe78c1cdc93e95f161c6f5ede4a"
+"checksum derive_deref 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75977fd13de1d8a2b0db58cb124e8f1e63cf233917fea33065e8b214d1eccdb8"
 "checksum diesel 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de51f2e2321a7db9bdfd7e3457c6ce11dce5009cad7ff9ac25a04879239e5fe6"
 "checksum diesel_derives 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "274aeed033dcd9e40f472cd282a3692512fef153283ec4c745873517d0e67f3f"
 "checksum diesel_full_text_search 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6bb76b26499ddcd4672f4a47fa6cdf97b5dfbedf688c4e2f386ba576585b4ae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ docopt = "0.8.1"
 itertools = "0.6.0"
 lettre = "0.6"
 scheduled-thread-pool = "0.2.0"
+derive_deref = "1.0.0"
 
 conduit = "0.8"
 conduit-conditional-get = "0.8"

--- a/src/krate/publish.rs
+++ b/src/krate/publish.rs
@@ -51,11 +51,11 @@ pub fn publish(req: &mut Request) -> CargoResult<Response> {
     let keywords = new_crate
         .keywords
         .as_ref()
-        .map(|kws| kws.iter().map(|kw| &**kw).collect())
+        .map(|kws| kws.iter().map(|kw| &***kw).collect())
         .unwrap_or_else(Vec::new);
 
     let categories = new_crate.categories.as_ref().map(|s| &s[..]).unwrap_or(&[]);
-    let categories: Vec<_> = categories.iter().map(|k| &**k).collect();
+    let categories: Vec<_> = categories.iter().map(|k| &***k).collect();
 
     let conn = req.db_conn()?;
     // Create a transaction on the database, if there are no errors,
@@ -87,7 +87,7 @@ pub fn publish(req: &mut Request) -> CargoResult<Response> {
             ));
         }
 
-        if krate.name != name {
+        if &krate.name != name {
             return Err(human(&format_args!(
                 "crate was previously named `{}`",
                 krate.name

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ extern crate chrono;
 extern crate comrak;
 extern crate curl;
 #[macro_use]
+extern crate derive_deref;
+#[macro_use]
 extern crate diesel;
 extern crate diesel_full_text_search;
 extern crate dotenv;

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -3,7 +3,6 @@
 //! to and from structs. The serlializing is only utilised in
 //! integration tests.
 use std::collections::HashMap;
-use std::ops::Deref;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use semver;
@@ -32,21 +31,21 @@ pub struct NewCrate {
     pub badges: Option<HashMap<String, HashMap<String, String>>>,
 }
 
-#[derive(PartialEq, Eq, Hash, Serialize, Debug)]
+#[derive(PartialEq, Eq, Hash, Serialize, Debug, Deref)]
 pub struct CrateName(pub String);
-#[derive(Debug)]
+#[derive(Debug, Deref)]
 pub struct CrateVersion(pub semver::Version);
-#[derive(Debug)]
+#[derive(Debug, Deref)]
 pub struct CrateVersionReq(pub semver::VersionReq);
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Deref)]
 pub struct KeywordList(pub Vec<Keyword>);
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Deref)]
 pub struct Keyword(pub String);
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Deref)]
 pub struct CategoryList(pub Vec<Category>);
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Deref)]
 pub struct Category(pub String);
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Deref)]
 pub struct Feature(pub String);
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -177,6 +176,7 @@ impl<'de> Deserialize<'de> for CategoryList {
         }
     }
 }
+
 impl Serialize for CrateVersion {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -192,62 +192,6 @@ impl Serialize for CrateVersionReq {
         S: Serializer,
     {
         serializer.serialize_str(&(**self).to_string())
-    }
-}
-
-impl Deref for CrateName {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Deref for Keyword {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Deref for Category {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Deref for Feature {
-    type Target = str;
-    fn deref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Deref for CrateVersion {
-    type Target = semver::Version;
-    fn deref(&self) -> &semver::Version {
-        &self.0
-    }
-}
-
-impl Deref for CrateVersionReq {
-    type Target = semver::VersionReq;
-    fn deref(&self) -> &semver::VersionReq {
-        &self.0
-    }
-}
-
-impl Deref for KeywordList {
-    type Target = [Keyword];
-    fn deref(&self) -> &[Keyword] {
-        &self.0
-    }
-}
-
-impl Deref for CategoryList {
-    type Target = [Category];
-    fn deref(&self) -> &[Category] {
-        &self.0
     }
 }
 


### PR DESCRIPTION
The generated impls from that crate are very slightly different than the
impls we had before. Things will deref to `&String` and `&Vec<T>` rather
than `&str` and `&[T]`. However, this rarely matters, and in the few
places it did, it was just a matter of one extra `*` or `&`