### PR TITLE
Use semver's built-in Diesel support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ dependencies = [
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-cookie 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -150,7 +150,7 @@ dependencies = [
  "openssl 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (git+https://github.com/sgrif/semver?branch=sg-diesel-support)",
  "serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -197,7 +197,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "civet-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -240,7 +240,7 @@ dependencies = [
 [[package]]
 name = "conduit"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/sgrif/conduit?branch=sg-public-semver#e77a516d9929ace361efd687ada7792c565d7361"
 dependencies = [
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -250,7 +250,7 @@ name = "conduit-conditional-get"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -261,7 +261,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -271,7 +271,7 @@ name = "conduit-git-http-backend"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -280,7 +280,7 @@ name = "conduit-json-parser"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-utils 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -292,7 +292,7 @@ name = "conduit-log-requests"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -303,7 +303,7 @@ name = "conduit-middleware"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -320,7 +320,7 @@ name = "conduit-router"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "route-recognizer 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -330,7 +330,7 @@ name = "conduit-static"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -341,7 +341,7 @@ name = "conduit-test"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -350,7 +350,7 @@ name = "conduit-utils"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1389,6 +1389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.9.0"
+source = "git+https://github.com/sgrif/semver?branch=sg-diesel-support#6690cc16e25d165aedcec36229cb94c0c15c9d65"
+dependencies = [
+ "diesel 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,6 +1405,11 @@ dependencies = [
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
@@ -1817,7 +1831,7 @@ dependencies = [
 "checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
 "checksum coco 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c06169f5beb7e31c7c67ebf5540b8b472d23e3eade3b2ec7d1f5b504a85f91bd"
 "checksum comrak 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d6e2837c1814c4dc781f73697fdaaf9d5e2f2b137735dda2baad3d73dc684980"
-"checksum conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "db0caa30f78c207dc14c071b62512253ece5c4459897815682786aff1028bc82"
+"checksum conduit 0.8.1 (git+https://github.com/sgrif/conduit?branch=sg-public-semver)" = "<none>"
 "checksum conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "614f67083e437fd0b8fb9f13067203f358f1c6f52989eb6539292fde007fc6d6"
 "checksum conduit-cookie 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2ed0c16befdfbb983fa822470af5480a150401824ed9f2fb928df440781f7e35"
 "checksum conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "027a1900afd70becd52b5061afc85a24de6af0d9199f39d4e1af8b7ac55fbe6e"
@@ -1949,7 +1963,9 @@ dependencies = [
 "checksum security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "5421621e836278a0b139268f36eee0dc7e389b784dc3f79d8f11aabadf41bead"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
+"checksum semver 0.9.0 (git+https://github.com/sgrif/semver?branch=sg-diesel-support)" = "<none>"
 "checksum semver-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fff3c9c5a54636ab95acd8c1349926e04cb1eb8cd70b5adced8a1d1f703a67"
+"checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "0c9cab69e16835717c9b8bd13c29f92b6aa34fe32ce2866b1ab481cf2da8442a"
 "checksum serde_derive 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3bdafe3e71710131a919735916caa5b18c2754ad0d33d8ae5d586ccc804a403e"
 "checksum serde_derive_internals 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "32f1926285523b2db55df263d2aa4eb69ddcfa7a7eade6430323637866b513ab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 rand = "0.3"
 git2 = "0.6.4"
 flate2 = "0.2"
-semver = "0.5"
+semver = { version = "0.9", features = ["diesel"] }
 url = "1.2.1"
 tar = "0.4.13"
 
@@ -87,3 +87,5 @@ diesel_migrations = { version = "1.1.0", features = ["postgres"] }
 # Remove once cookie depends on ring >= 0.13.0
 [patch.crates-io]
 ring = { git = "https://github.com/SergioBenitez/ring", branch = "v0.11" }
+semver = { git = "https://github.com/sgrif/semver", branch = "sg-diesel-support" }
+conduit = { git = "https://github.com/sgrif/conduit", branch = "sg-public-semver" }

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -2,8 +2,7 @@ use std::io::Read;
 use std::net::SocketAddr;
 
 use conduit;
-use conduit::Request;
-use semver;
+use conduit::{Request, semver};
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 use std::net::SocketAddr;
 
 use conduit;
-use conduit::{Request, semver};
+use conduit::{semver, Request};
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
This is still a PR and hasn't been released yet, but Steve's said he's
fine with the feature and it'll likely be released soon. I also had to
patch conduit so we don't get a mismatch between semver versions there.