### PR TITLE
Running ember tests in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5155,6 +5155,109 @@
       "integrity": "sha1-GWkTUhdlS14nj5/i2dTkm1cgMp4=",
       "dev": true
     },
+    "ember-exam": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-exam/-/ember-exam-1.0.0.tgz",
+      "integrity": "sha512-5E7FiG9zJSkYiJC88JRW4sT9xt51bj1yflF4b+YS9HXhKV1g4NpeH3gdWMExTNdTaY7eKvXfecdbnsc6kTlSBg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.2",
+        "cli-table2": "0.2.0",
+        "debug": "3.1.0",
+        "ember-cli-babel": "6.8.2",
+        "fs-extra": "4.0.3",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
+      }
+    },
     "ember-export-application-global": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "start:live": "ember serve --proxy https://crates.io",
     "start:local": "ember serve --proxy http://127.0.0.1:8888",
     "start:staging": "ember serve --proxy https://staging-crates-io.herokuapp.com",
-    "test": "ember test"
+    "test": "ember exam --split=2 --parallel"
   },
   "devDependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
@@ -49,6 +49,7 @@
     "ember-concurrency": "^0.8.12",
     "ember-data": "~2.12.1",
     "ember-disable-prototype-extensions": "^1.1.3",
+    "ember-exam": "^1.0.0",
     "ember-export-application-global": "^2.0.0",
     "ember-keyboard": "^2.3.0",
     "ember-load-initializers": "^1.0.0",

--- a/testem.js
+++ b/testem.js
@@ -5,6 +5,7 @@
 module.exports = {
     test_page: 'tests/index.html?hidepassed',
     disable_watching: true,
+    parallel: -1,
     launch_in_ci: [
         'Chrome'
     ],

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,9 @@
 import Application from '../app';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import loadEmberExam from 'ember-exam/test-support/load';
 
 setApplication(Application.create({ autoboot: false }));
 
+loadEmberExam();
 start();


### PR DESCRIPTION
These changes:

1. Install a frontend dependency called [ember-exam](https://github.com/trentmwillis/ember-exam)
2. Alter the command to run frontend tests in order to use ember-exam parallelism feature. It will split randomly the frontend tests into four partitions and run them all in parallel. 

A simple further step to improve performance would be to detect how many core are available on the running machine and split by exactly this number - so it can be fully used.