### PR TITLE
[UI UPDATE]: Based on issue #1148, widen main to prevent icon overflow

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -212,7 +212,7 @@
     border-bottom: 5px solid $gray-border;
     margin-bottom: 20px;
 
-    @media only screen and (min-width: 820px) {
+    @media only screen and (min-width: 890px) {
         @include flex-direction(row);
 
         .docs {


### PR DESCRIPTION
Slight widening to the `main` section of a given crates page based on issue #1148, overflow now prevented