### PR TITLE
[UI UPDATE]: Slight alignment tweak for the stats numbers on the

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -369,6 +369,10 @@
             font-size: 160%;
             font-weight: bold;
             margin-bottom: 4px;
+            &__align {
+                position: relative;
+                bottom: 0.4rem;
+            }
         }
     }
 

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -252,14 +252,14 @@
         <div class='stat'>
             <span class='num'>
                 {{svg-jar "download"}}
-                {{format-num downloadsContext.downloads}}
+                <span class="num__align">{{ format-num downloadsContext.downloads }}</span>
             </span>
             <span class='desc small'>Downloads all time</span>
         </div>
         <div class='stat'>
             <span class="{{if crate.versions.isPending 'loading'}} num">
                 {{svg-jar "crate"}}
-                {{crate.versions.length}}
+            <span class="num__align">{{ crate.versions.length }}</span>
             </span>
             <span class='desc small'>Versions published</span>
         </div>


### PR DESCRIPTION
`/crates/<some-crate>` pages

> Before
![cargo_before](https://user-images.githubusercontent.com/17413539/35181137-44a167be-fd71-11e7-9afc-2daface800d5.png)

> After
![cargo_after](https://user-images.githubusercontent.com/17413539/35181141-55b76a9e-fd71-11e7-907e-baeda4f25c40.png)


