### PR TITLE
Center stats on homepage for smaller/mobile screen

### DIFF
--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -96,7 +96,10 @@ button.small {
 
     @media only screen and (max-width: 530px) {
         @include flex-direction(column);
-        #stats { border: none; }
+        #stats {
+            border: none;
+            margin: auto;
+        }
         .crates, .downloads {
             @include justify-content(center);
         }


### PR DESCRIPTION
> before
![before_home](https://user-images.githubusercontent.com/17413539/35761709-8989bc30-0840-11e8-82db-31db03a288e8.png)

> after
![after_home](https://user-images.githubusercontent.com/17413539/35761712-8f8ae352-0840-11e8-9ccc-533b09f77187.png)

