### PR TITLE
Better mobile styling for the /crates page

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -127,21 +127,23 @@
 }
 
 @media only screen and (max-width: 639px) {
-    .white-rows div {
-        margin: auto auto 0.2rem auto;
-        text-align: center;
-    }
-    .white-rows > div .row {
-        flex-flow: column wrap;
-    }
-    .row > div.stats {
-        width: 100%;
-        display: flex;
-        margin: auto;
-    }
-    .crate-link {
-        text-align: center;
-        display: block;
+    #crates {
+        .white-rows div {
+            margin: auto auto 0.2rem auto;
+            text-align: center;
+        }
+        .white-rows > div .row {
+            flex-flow: column wrap;
+        }
+        .row > div.stats {
+            width: 100%;
+            display: flex;
+            margin: auto;
+        }
+        .crate-link {
+            text-align: center;
+            display: block;
+        }
     }
 }
 

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -25,6 +25,10 @@
         .team-info {
             @include flex-direction(column);
         }
+        h1 {
+            position: relative;
+            bottom: 0.3rem;
+        }
     }
     h1 {
         padding-left: 10px;
@@ -118,12 +122,35 @@
     }
 }
 
+.crate-link {
+    display: inline-block;
+}
+
+@media only screen and (max-width: 639px) {
+    .white-rows div {
+        margin: auto auto 0.2rem auto;
+        text-align: center;
+    }
+    .white-rows > div .row {
+        flex-flow: column wrap;
+    }
+    .row > div.stats {
+        width: 100%;
+        display: flex;
+        margin: auto;
+    }
+    .crate-link {
+        text-align: center;
+        display: block;
+    }
+}
+
 .crate {
     .desc {
         padding-top: 5px;
         @include display-flex;
         @include flex-direction(column);
-        width: 75%;
+        @media screen and (min-width: 640px){ width: 75%; }
     }
 
     .info a {
@@ -143,7 +170,7 @@
     .downloads {
         @include display-flex;
         @include align-items(center);
-        padding-bottom: 5px;
+        @media screen and (min-width: 640px) { padding-bottom: 5px; }
     }
     .recent-downloads {
         @include display-flex;

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -25,10 +25,6 @@
         .team-info {
             @include flex-direction(column);
         }
-        h1 {
-            position: relative;
-            bottom: 0.3rem;
-        }
     }
     h1 {
         padding-left: 10px;

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -1,6 +1,8 @@
 <div class='desc'>
     <div class='info'>
-        {{#link-to 'crate' crate.id data-test-crate-link}}{{ crate.name }}{{/link-to}}
+        <div class='crate-link'>
+            {{#link-to 'crate' crate.id data-test-crate-link}}{{ crate.name }}{{/link-to}}
+        </div>
         {{crate-badge crate=crate}}
         {{#each crate.annotated_badges as |badge|}}
             {{component badge.component_name badge=badge data-test-badge=badge.badge_type}}


### PR DESCRIPTION
It's a little more space per crate in the vertical, but I think it's a bit easier to read when you're on a smaller screen (phone).

> Before
![before_mobile](https://user-images.githubusercontent.com/17413539/35762833-7be90866-0853-11e8-8fb9-302e611d81e2.png)

> After
![after_mobile](https://user-images.githubusercontent.com/17413539/35762835-8a6dc534-0853-11e8-85bb-12d048dd7ab1.png)
