### PR TITLE
Added a vagrant environment for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ yarn-error.log
 testem.log
 .env
 docker-compose.override.yml
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ testem.log
 .env
 docker-compose.override.yml
 .vagrant
+*.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,74 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provision :shell, path: "vagrant_provision.sh"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest:8888, host: 8888
+  config.vm.network "forwarded_port", guest:4200, host: 4200
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -48,6 +48,8 @@ Vagrant.configure("2") do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync",
+	  rsync__exclude: [".env", "tmp/", ".git/", "target/"]
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -561,18 +561,26 @@ A number of names volumes are created, as can be seen in the `volumes` section
 of the `docker-compose.yml` file.
 
 ### Running crates.io with Vagrant
+
 A vagrantfile is also provided for quickly setting up an environment for
 crates.io.
 
 #### Dependencies
-The only dependency is Vagrant! Look for the appropriate package from your
-package manager or download the latest version of Vagrant from their
-[website](https://www.vagrantup.com/downloads.html).
+
+Rsync and Vagrant must be installed on the host machine. Rsync should be
+installed by default on most distributions. For Vagrant look for the
+appropriate package from your package manager or download the latest version of
+Vagrant from their [website](https://www.vagrantup.com/downloads.html).
 
   - Ubuntu: `sudo apt-get install vagrant`
   - Fedora: `sudo dnf install vagrant`
 
+#### Configuration
+
+If you want to set values in the `.env` file such as Session key, gh_client id and secret, Mailgun credentials, or S3 credentials you can do so by copying `.env.sample` to `.env.vagrant` and setting the values there. Database URL and Git_repo values will be set to sane values during provisioning.
+
 #### Running Vagrant
+
 The vm can be started by running `vagrant up`. This will run the provisioning
 script `vagrant_provision.sh`, synchronize the crates.io directory on the host
 with /vagrant on the vm, and bind ports from the vm to the host machine. In
@@ -589,29 +597,29 @@ Once logged in, you can start the backend and frontend normally and access them
 on port 4200 or 8888 respectively.
 
 #### Publishing to Vagrant's crates.io
-Publishing to the local crates.io can be done from the vm's shell by running:
+
+You can publish to this crates.io instance from within the Vagrant box or from
+the host machine, although the index endpoints will be different as seen below.
 
 ```
+#Inside the vagrant box
 cargo publish --index file:///vagrant/tmp/index-co
+
+#From the host machine
+cargo publish --index http://localhost:4200/git/index
 ```
 
 #### Synchronized files
-`/vagrant` on the vm and the crates.io directory on the host are synchronized.
-Any changes that occur on one will show up on the other. If you wish to edit
-with a program not installed on the vm, you can go ahead and do so in your host
-environment.
+`/vagrant` on the vm is generated from the `crates.io` directory when `vagrant
+up`, `vagrant reload`, or `vagrant rsync` is run. If you want to keep the
+`/vagrant` directory updated, you can run `vagrant rsync-auto` to monitor the
+`crates.io` directory. It's likely that you'll need to [increase the number of
+inotify
+watchers](https://github.com/guard/listen/wiki/Increasing-the-amount-of-inotify-watchers)
+to use rsync-auto.
 
-#### Environment variables
-Currently the Vagrant setup relies on certain values in `.env`. These are:
-
-```sh
-export DATABASE_URL=postgres://postgres@localhost/cargo_registry
-export GIT_REPO_URL=./tmp/index-bare
-export GIT_REPO_CHECKOUT=./tmp/index-co
-```
-
-Since the `.env` file is synchronized between the host and vm, these values
-should be changed by hand.
+Since the rsync operation is one-way, it is strongly recommended that you don't
+develop inside the vagrant box.
 
 #### Ports
 The vm upon loading will bind itself to three ports on the host machine. These are:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -559,3 +559,65 @@ docker-compose up -d
 
 A number of names volumes are created, as can be seen in the `volumes` section
 of the `docker-compose.yml` file.
+
+### Running crates.io with Vagrant
+A vagrantfile is also provided for quickly setting up an environment for
+crates.io.
+
+#### Dependencies
+The only dependency is Vagrant! Look for the appropriate package from your
+package manager or download the latest version of Vagrant from their
+[website](https://www.vagrantup.com/downloads.html).
+
+  - Ubuntu: `sudo apt-get install vagrant`
+  - Fedora: `sudo dnf install vagrant`
+
+#### Running Vagrant
+The vm can be started by running `vagrant up`. This will run the provisioning
+script `vagrant_provision.sh`, synchronize the crates.io directory on the host
+with /vagrant on the vm, and bind ports from the vm to the host machine. In
+order to access the vm, run `vagrant ssh`.
+
+```sh
+vagrant up
+#When run the first time the provision script will run
+vagrant ssh
+cd /vagrant
+```
+
+Once logged in, you can start the backend and frontend normally and access them
+on port 4200 or 8888 respectively.
+
+#### Publishing to Vagrant's crates.io
+Publishing to the local crates.io can be done from the vm's shell by running:
+
+```
+cargo publish --index file:///vagrant/tmp/index-co
+```
+
+#### Synchronized files
+`/vagrant` on the vm and the crates.io directory on the host are synchronized.
+Any changes that occur on one will show up on the other. If you wish to edit
+with a program not installed on the vm, you can go ahead and do so in your host
+environment.
+
+#### Environment variables
+Currently the Vagrant setup relies on certain values in `.env`. These are:
+
+```sh
+export DATABASE_URL=postgres://postgres@localhost/cargo_registry
+export GIT_REPO_URL=./tmp/index-bare
+export GIT_REPO_CHECKOUT=./tmp/index-co
+```
+
+Since the `.env` file is synchronized between the host and vm, these values
+should be changed by hand.
+
+#### Ports
+The vm upon loading will bind itself to three ports on the host machine. These are:
+
+| Host port | Vm port | Purpose     |
+|-----------|---------|-------------|
+| 2222      | 22      | Vagrant ssh |
+| 4200      | 4200    | Frontend    |
+| 8888      | 8888    | Backend     |

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -1,0 +1,86 @@
+export DEBIAN_FRONTEND=noninteractive
+#Update the local package database
+apt-get update
+
+#Install node
+su vagrant -c 'curl -s -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash'
+su vagrant -c 'export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"; nvm install node'
+
+#Install everything for the frontend with 'npm install'
+su vagrant -c 'cd /vagrant; export NVM_DIR="$HOME/.nvm"; [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"; nvm use node; npm install'
+
+#Install Rust
+su vagrant -c 'curl -s https://sh.rustup.rs -sSf > tmp.sh'
+su vagrant -c 'chmod 775 tmp.sh'
+su vagrant -c './tmp.sh -y'
+rm tmp.sh
+
+#Add .cargo/bin to path
+grep 'export PATH=$PATH:.cargo/bin' /home/vagrant/.bashrc || echo 'export PATH=$PATH:.cargo/bin' | tee -a /home/vagrant/.bashrc
+
+#Install Postgres
+apt-get install -y postgresql postgresql-contrib libpq-dev pkg-config
+
+#Make root a postgres superuser
+if [ ! $(su postgres -c 'psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='"'"'root'"'"'"') ]
+then
+	echo "making root a PSQL user"
+	su postgres -c 'createuser --superuser root'
+fi
+
+#Make vagrant a postgres superuser
+if [ ! $(psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='vagrant'") ]
+then
+	echo "creating PSQL user 'vagrant'"
+	su postgres -c 'createuser --superuser vagrant'
+	su postgres -c 'createdb vagrant'
+else
+	echo "PSQL user 'vagrant' already exists"
+fi
+
+#Give psql user 'vagrant' a database
+if [ ! $(psql postgres -tAc "select 1 from pg_database where datname='vagrant'") ]
+then
+	echo "creating PSQL database 'vagrant'"
+	su postgres -c 'createdb vagrant'
+else
+	echo "PSQL database 'vagrant' already exists"
+fi
+
+#trust all local connections to psql.
+#FIXME This is a security risk making this vagrant file only suitable
+#for development.
+#FIXME This will break when postgresql updates and this path changes.
+sed -i 's/\(local\s*all.*\)peer/\1trust/' /etc/postgresql/9.5/main/pg_hba.conf
+sed -i 's/\(host\s*all\s*all\s*.*\s*\)md5/\1trust/' /etc/postgresql/9.5/main/pg_hba.conf
+
+#reload psql to load the above changes
+/etc/init.d/postgresql reload
+
+#Install cmake and libssl dependencies
+apt-get install -y cmake
+apt-get install -y libssl-dev pkg-config
+
+#Install diesel-cli
+if [ ! -e /home/vagrant/.cargo/bin/diesel ]
+then
+	echo "installing diesel: this may take a while"
+	su - vagrant -c 'cargo install --quiet diesel_cli --no-default-features --features postgres'
+else
+	echo "diesel already installed"
+fi
+
+#Make the cargo_registry database
+if [ ! $(psql postgres -tAc "select 1 from pg_database where datname='cargo_registry'") ]
+then
+	echo "creating PSQL DB 'cargo_registry'"
+	su vagrant -c 'createdb cargo_registry'
+else
+	echo "PSQL database 'cargo_registry' already exists"
+fi
+
+#Run the diesel migrations and init the repos in ./tmp
+echo "DEBUG: running migrations"
+su - vagrant -c 'cd /vagrant; diesel migration run'
+echo "DEBUG: initting local indices"
+su - vagrant -c 'cd /vagrant; ./script/init-local-index.sh'

--- a/vagrant_provision.sh
+++ b/vagrant_provision.sh
@@ -79,6 +79,39 @@ else
 	echo "PSQL database 'cargo_registry' already exists"
 fi
 
+#Set necessary git variables
+su - vagrant -c 'git config --global user.email "you@example.com"'
+su - vagrant -c 'git config --global user.name "Your Name"'
+
+#Make the .env file by either copying .env.vagrant to .env or by building it from .env.sample
+if [ -e /vagrant/.env ]
+then
+	echo "Env file already exists"
+elif [ -e /vagrant/.env.vagrant ]
+then
+	echo "Creating env from vagrant env"
+	cp /vagrant/.env.vagrant /vagrant/.env
+elif [ -e /vagrant/.env.sample ]
+then
+	echo "Creating env from env.sample"
+	cp /vagrant/.env.sample /vagrant/.env
+else
+	echo "ERROR: No .env file could be made"
+fi
+
+if [ -e /vagrant/.env ]
+then
+	echo "ERROR: No .env file. Build will fail"
+	sed -i '/export DATABASE_URL/d' /vagrant/.env
+	sed -i '/export TEST_DATABASE_URL/d' /vagrant/.env
+	sed -i '/export GIT_REPO_URL/d' /vagrant/.env
+	sed -i '/export GIT_REPO_CHECKOUT/d' /vagrant/.env
+	echo 'export DATABASE_URL=postgres://postgres@localhost/cargo_registry' >> /vagrant/.env
+	echo 'export TEST_DATABASE_URL=postgres://postgres@localhost/cargo_registry_test' >> /vagrant/.env
+	echo 'export GIT_REPO_URL=./tmp/index-bare' >> /vagrant/.env
+	echo 'export GIT_REPO_CHECKOUT=./tmp/index-co' >> /vagrant/.env
+fi
+
 #Run the diesel migrations and init the repos in ./tmp
 echo "DEBUG: running migrations"
 su - vagrant -c 'cd /vagrant; diesel migration run'


### PR DESCRIPTION
I made a Vagrant environment for this repo after Docker failed to work for me, and I ran into errors in my local environment. I figured that I might as well make a PR for it in case it helps others. I'd also like to point out a few problems with it. If this PR is merged, I'll move the list below into an issue.

- **security** All local connections to Postgres are trusted currently. This should be restricted to only what is necessary. This means either trusting only root, postgres, and vagrant users and/or using some other method such as a password. As such this should only be used in development currently.
- Currently all files are synchronized, and `.env` has to match the values that Vagrant expects to find. This includes database_url, git_repo_url, and git_repo_checkout. `.env` should probably not be synchronized, but we want to keep track of other variables from the host such as gh_client info
- The path to pg_hba.conf in the provisioning file could change when Ubuntu updates their repos for postgres. This potential technical debt should be avoided.
- The provisioning file should be idempotent. It isn't. This is mainly due to the installation of packages.