### PR TITLE
Use the new rustfmt-preview component when on CI

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,1 @@
-combine_control_expr = true
 max_width = 100
-error_on_line_overflow = false
-write_mode = "Overwrite"
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,12 @@ matrix:
   include:
     - rust: nightly-2018-02-13
       script:
-        - cargo install --force rustfmt-nightly --vers 0.3.6
-        - cargo fmt -- --write-mode=diff
         - cargo install --force clippy --vers 0.0.186
         - cargo clippy
     - rust: stable
       script:
+        - rustup component add rustfmt-preview
+        - cargo fmt -- --write-mode=diff
         - cargo build
         - cargo test
         - npm install

--- a/config/manifest.js
+++ b/config/manifest.js
@@ -3,22 +3,22 @@
 
 module.exports = function(/* environment, appConfig */) {
     return {
-        name: "Cargo: packages for Rust",
-        short_name: "Cargo",
-        description: "Cargo is the package manager and crate host for Rust.",
-        start_url: "/",
-        display: "standalone",
-        background_color: "#3b6837",
-        theme_color: "#f9f7ec",
+        name: 'Cargo: packages for Rust',
+        short_name: 'Cargo',
+        description: 'Cargo is the package manager and crate host for Rust.',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#3b6837',
+        theme_color: '#f9f7ec',
         icons: [
             {
-                src: "cargo.png",
-                sizes: "227x227",
-                type: "image/png"
+                src: 'cargo.png',
+                sizes: '227x227',
+                type: 'image/png'
             }
         ],
         ms: {
-            tileColor: "#3b6837"
+            tileColor: '#3b6837'
         }
     };
-}
+};

--- a/config/targets.js
+++ b/config/targets.js
@@ -1,13 +1,13 @@
 /* eslint-env node */
 module.exports = {
-  browsers: [
-    // These are the browsers we actually are attempting to support:
-    'last 2 Chrome versions',
-    'last 1 Firefox version',
-    'Firefox ESR',
-    'last 1 Safari version',
-    'last 1 iOS version',
-    'last 1 Edge version',
-    'last 1 UCAndroid version'
-  ]
+    browsers: [
+        // These are the browsers we actually are attempting to support:
+        'last 2 Chrome versions',
+        'last 1 Firefox version',
+        'Firefox ESR',
+        'last 1 Safari version',
+        'last 1 iOS version',
+        'last 1 Edge version',
+        'last 1 UCAndroid version'
+    ]
 };


### PR DESCRIPTION
Use the `rustfmt-preview` component on the `stable` channel when checking formatting on CI.   When developing, proper formatting is now just a `cargo +stable fmt` away!