### PR TITLE
Recently updated sort

### DIFF
--- a/app/controllers/category/index.js
+++ b/app/controllers/category/index.js
@@ -19,8 +19,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'alpha') {
             return 'Alphabetical';
-        } else if (this.get('sort') === 'recently-updated') {
-            return 'Recently Updated';
+        } else if (this.get('sort') === 'recent-updates') {
+            return 'Recent Updates';
         } else {
             return 'Recent Downloads';
         }

--- a/app/controllers/category/index.js
+++ b/app/controllers/category/index.js
@@ -19,6 +19,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'alpha') {
             return 'Alphabetical';
+        } else if (this.get('sort') === 'recently-updated') {
+            return 'Recently Updated';
         } else {
             return 'Recent Downloads';
         }

--- a/app/controllers/crates.js
+++ b/app/controllers/crates.js
@@ -19,8 +19,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
-        } else if (this.get('sort') === 'recently-updated') {
-            return 'Recently Updated';
+        } else if (this.get('sort') === 'recent-updates') {
+            return 'Recent Updates';
         } else {
             return 'Alphabetical';
         }

--- a/app/controllers/crates.js
+++ b/app/controllers/crates.js
@@ -19,6 +19,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
+        } else if (this.get('sort') === 'recently-updated') {
+            return 'Recently Updated';
         } else {
             return 'Alphabetical';
         }

--- a/app/controllers/keyword/index.js
+++ b/app/controllers/keyword/index.js
@@ -17,8 +17,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'alpha') {
             return 'Alphabetical';
-        } else if (this.get('sort') === 'recently-updated') {
-            return 'Recently Updated';
+        } else if (this.get('sort') === 'recent-updates') {
+            return 'Recent Updates';
         } else {
             return 'Recent Downloads';
         }

--- a/app/controllers/keyword/index.js
+++ b/app/controllers/keyword/index.js
@@ -17,6 +17,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'alpha') {
             return 'Alphabetical';
+        } else if (this.get('sort') === 'recently-updated') {
+            return 'Recently Updated';
         } else {
             return 'Recent Downloads';
         }

--- a/app/controllers/me/crates.js
+++ b/app/controllers/me/crates.js
@@ -19,8 +19,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
-        } else if (this.get('sort') === 'recently-updated') {
-            return 'Recently Updated';
+        } else if (this.get('sort') === 'recent-updates') {
+            return 'Recent Updates';
         } else {
             return 'Alphabetical';
         }

--- a/app/controllers/me/crates.js
+++ b/app/controllers/me/crates.js
@@ -19,6 +19,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
+        } else if (this.get('sort') === 'recently-updated') {
+            return 'Recently Updated';
         } else {
             return 'Alphabetical';
         }

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -31,8 +31,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
-        } else if (this.get('sort') === 'recently-updated') {
-            return 'Recently Updated';
+        } else if (this.get('sort') === 'recent-updates') {
+            return 'Recent Updates';
         } else {
             return 'Relevance';
         }

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -31,6 +31,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
+        } else if (this.get('sort') === 'recently-updated') {
+            return 'Recently Updated';
         } else {
             return 'Relevance';
         }

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -17,6 +17,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
+        } else if (this.get('sort') === 'recently-updated') {
+            return 'Recently Updated';
         } else {
             return 'Alphabetical';
         }

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -17,8 +17,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
-        } else if (this.get('sort') === 'recently-updated') {
-            return 'Recently Updated';
+        } else if (this.get('sort') === 'recent-updates') {
+            return 'Recent Updates';
         } else {
             return 'Alphabetical';
         }

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -18,6 +18,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
+        } else if (this.get('sort') === 'recently-updated') {
+            return 'Recently Updated';
         } else {
             return 'Alphabetical';
         }

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -18,8 +18,8 @@ export default Controller.extend(PaginationMixin, {
             return 'All-Time Downloads';
         } else if (this.sort === 'recent-downloads') {
             return 'Recent Downloads';
-        } else if (this.get('sort') === 'recently-updated') {
-            return 'Recently Updated';
+        } else if (this.get('sort') === 'recent-updates') {
+            return 'Recent Updates';
         } else {
             return 'Alphabetical';
         }

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -69,6 +69,11 @@
                         Recent Downloads
                     {{/link-to}}
                 </li>
+                <li>
+                    {{#link-to (query-params sort="recently-updated")}}
+                        Recently Updated
+                    {{/link-to}}
+                </li>
             {{/rl-dropdown}}
         {{/rl-dropdown-container}}
     </div>

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -70,8 +70,8 @@
                     {{/link-to}}
                 </li>
                 <li>
-                    {{#link-to (query-params sort="recently-updated")}}
-                        Recently Updated
+                    {{#link-to (query-params sort="recent-updates")}}
+                        Recent Updates
                     {{/link-to}}
                 </li>
             {{/rl-dropdown}}

--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -61,8 +61,8 @@
                     {{/link-to}}
                 </li>
                 <li>
-                    {{#link-to (query-params page=1 sort="recently-updated")}}
-                        Recently Updated
+                    {{#link-to (query-params page=1 sort="recent-updates")}}
+                        Recent Updates
                     {{/link-to}}
                 </li>
             {{/rl-dropdown}}

--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -60,6 +60,11 @@
                         Recent Downloads
                     {{/link-to}}
                 </li>
+                <li>
+                    {{#link-to (query-params page=1 sort="recently-updated")}}
+                        Recently Updated
+                    {{/link-to}}
+                </li>
             {{/rl-dropdown}}
         {{/rl-dropdown-container}}
     </div>

--- a/app/templates/keyword/index.hbs
+++ b/app/templates/keyword/index.hbs
@@ -40,6 +40,11 @@
                         Recent Downloads
                     {{/link-to}}
                 </li>
+                <li>
+                    {{#link-to (query-params sort="recently-updated")}}
+                        Recently Updated
+                    {{/link-to}}
+                </li>
             {{/rl-dropdown}}
         {{/rl-dropdown-container}}
     </div>

--- a/app/templates/keyword/index.hbs
+++ b/app/templates/keyword/index.hbs
@@ -41,8 +41,8 @@
                     {{/link-to}}
                 </li>
                 <li>
-                    {{#link-to (query-params sort="recently-updated")}}
-                        Recently Updated
+                    {{#link-to (query-params sort="recent-updates")}}
+                        Recent Updates
                     {{/link-to}}
                 </li>
             {{/rl-dropdown}}

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -42,8 +42,8 @@
                     {{/link-to}}
                 </li>
                 <li>
-                    {{#link-to (query-params sort="recently-updated")}}
-                        Recently Updated
+                    {{#link-to (query-params sort="recent-updates")}}
+                        Recent Updates
                     {{/link-to}}
                 </li>
             {{/rl-dropdown}}

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -41,6 +41,11 @@
                         Recent Downloads
                     {{/link-to}}
                 </li>
+                <li>
+                    {{#link-to (query-params sort="recently-updated")}}
+                        Recently Updated
+                    {{/link-to}}
+                </li>
             {{/rl-dropdown}}
         {{/rl-dropdown-container}}
     </div>

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -52,6 +52,11 @@
                             Recent Downloads
                         {{/link-to}}
                     </li>
+                    <li>
+                        {{#link-to (query-params page=1 sort="recently-updated")}}
+                            Recently Updated
+                        {{/link-to}}
+                    </li>
                 {{/rl-dropdown}}
             {{/rl-dropdown-container}}
         </div>

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -53,8 +53,8 @@
                         {{/link-to}}
                     </li>
                     <li>
-                        {{#link-to (query-params page=1 sort="recently-updated")}}
-                            Recently Updated
+                        {{#link-to (query-params page=1 sort="recent-updates")}}
+                            Recent Updates
                         {{/link-to}}
                     </li>
                 {{/rl-dropdown}}

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -56,8 +56,8 @@
                             {{/link-to}}
                         </li>
                         <li>
-                            {{#link-to (query-params sort="recently-updated")}}
-                                Recently Updated
+                            {{#link-to (query-params sort="recent-updates")}}
+                                Recent Updates
                             {{/link-to}}
                         </li>
                     {{/rl-dropdown}}

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -55,6 +55,11 @@
                                 Recent Downloads
                             {{/link-to}}
                         </li>
+                        <li>
+                            {{#link-to (query-params sort="recently-updated")}}
+                                Recently Updated
+                            {{/link-to}}
+                        </li>
                     {{/rl-dropdown}}
                 {{/rl-dropdown-container}}
             </div>

--- a/app/templates/user.hbs
+++ b/app/templates/user.hbs
@@ -46,6 +46,11 @@
                                 Recent Downloads
                             {{/link-to}}
                         </li>
+                        <li>
+                            {{#link-to (query-params sort="recently-updated")}}
+                                Recently Updated
+                            {{/link-to}}
+                        </li>
                     {{/rl-dropdown}}
                 {{/rl-dropdown-container}}
             </div>

--- a/app/templates/user.hbs
+++ b/app/templates/user.hbs
@@ -47,8 +47,8 @@
                             {{/link-to}}
                         </li>
                         <li>
-                            {{#link-to (query-params sort="recently-updated")}}
-                                Recently Updated
+                            {{#link-to (query-params sort="recent-updates")}}
+                                Recent Updates
                             {{/link-to}}
                         </li>
                     {{/rl-dropdown}}

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -143,7 +143,7 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
         query = query.then_order_by(crates::downloads.desc())
     } else if sort == "recent-downloads" {
         query = query.then_order_by(recent_crate_downloads::downloads.desc().nulls_last())
-    } else if sort == "recently-updated" {
+    } else if sort == "recent-updates" {
         query = query.order(crates::updated_at.desc());
     } else {
         query = query.then_order_by(crates::name.asc())

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -143,6 +143,8 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
         query = query.then_order_by(crates::downloads.desc())
     } else if sort == "recent-downloads" {
         query = query.then_order_by(recent_crate_downloads::downloads.desc().nulls_last())
+    } else if sort == "recently-updated" {
+        query = query.order(crates::updated_at.desc());
     } else {
         query = query.then_order_by(crates::name.asc())
     }

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -362,7 +362,7 @@ fn index_sorting() {
     assert_eq!(json.crates[2].name, "bar_sort");
     assert_eq!(json.crates[3].name, "other_sort");
 
-    //Sort by recent-updates
+    // Sort by recent-updates
     let mut response = ok_resp!(middle.call(req.with_query("sort=recent-updates"),));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 4);
@@ -372,8 +372,7 @@ fn index_sorting() {
     assert_eq!(json.crates[3].name, "foo_sort");
 
     // Test for bug with showing null results first when sorting
-    // by descending
-    // This has nothing to do with querying for exact match I'm sorry
+    // by descending downloads
     let mut response = ok_resp!(middle.call(req.with_query("sort=recent-downloads")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 4);
@@ -477,7 +476,7 @@ fn exact_match_on_queries_with_sort() {
     assert_eq!(json.crates[1].name, "foo_sort");
     assert_eq!(json.crates[2].name, "baz_sort");
 
-    //Sort by recent-updates
+    // Sort by recent-updates
     let mut response = ok_resp!(middle.call(req.with_query("q=bar_sort&sort=recent-updates"),));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
@@ -486,8 +485,7 @@ fn exact_match_on_queries_with_sort() {
     assert_eq!(json.crates[2].name, "foo_sort");
 
     // Test for bug with showing null results first when sorting
-    // by descending
-    // This has nothing to do with querying for exact match I'm sorry
+    // by descending downloads
     let mut response = ok_resp!(middle.call(req.with_query("sort=recent-downloads")));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 4);

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -362,8 +362,8 @@ fn index_sorting() {
     assert_eq!(json.crates[2].name, "bar_sort");
     assert_eq!(json.crates[3].name, "other_sort");
 
-    //Sort by recently-updated
-    let mut response = ok_resp!(middle.call(req.with_query("sort=recently-updated"),));
+    //Sort by recent-updates
+    let mut response = ok_resp!(middle.call(req.with_query("sort=recent-updates"),));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 4);
     assert_eq!(json.crates[0].name, "other_sort");
@@ -477,8 +477,8 @@ fn exact_match_on_queries_with_sort() {
     assert_eq!(json.crates[1].name, "foo_sort");
     assert_eq!(json.crates[2].name, "baz_sort");
 
-    //Sort by recently-updated
-    let mut response = ok_resp!(middle.call(req.with_query("q=bar_sort&sort=recently-updated"),));
+    //Sort by recent-updates
+    let mut response = ok_resp!(middle.call(req.with_query("q=bar_sort&sort=recent-updates"),));
     let json: CrateList = ::json(&mut response);
     assert_eq!(json.meta.total, 3);
     assert_eq!(json.crates[0].name, "baz_sort");

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -36,7 +36,7 @@ module('Acceptance | search', function(hooks) {
         assert.dom('[data-test-search-nav]').hasText('Displaying 1-8 of 8 total results');
         assert
             .dom('[data-test-search-sort]')
-            .hasText('Sort by Relevance Relevance All-Time Downloads Recent Downloads');
+            .hasText('Sort by Relevance Relevance All-Time Downloads Recent Downloads Recent Updates');
         assert.dom('[data-test-crate-row="0"] [data-test-crate-link]').hasText('kinetic-rust');
         assert.dom('[data-test-crate-row="0"] [data-test-version-badge]').hasAttribute('alt', '0.0.16');
 


### PR DESCRIPTION
Allow sorting by which crates were most recently updated as mentioned in #1210. The option is called 'recent-updates' in order to match the naming convention of 'recent-downloads'