### PR TITLE
Add WebAssembly category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -429,6 +429,12 @@ description = """
 Ways to view data, such as plotting or graphing.\
 """
 
+[wasm]
+name = "WebAssembly"
+description = """
+Crates for use when targeting WebAssembly, or for manipulating WebAssembly.\
+"""
+
 [web-programming]
 name = "Web programming"
 description = """


### PR DESCRIPTION
I did not add this under `web-programming` because there is nothing inherently "Web-y" about wasm: it can be used as a general arch-independent binary format, as parity exemplifies.

Examples crates that would use this category (some of which are not actually published on crates.io yet, but the point stands):

* `parity-wasm`
* `wasmi`
* `wee_alloc`
* `wasm-bindgen`
* `wasm-gc`
* `wasm-nm`
* `wasm-snip`
* `svelte`
* `binaryen`
* `wabt`