### PR TITLE
Change Version::max to take an Iterator

### DIFF
--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -116,10 +116,9 @@ impl Version {
 
     pub fn max<T>(versions: T) -> semver::Version
     where
-        T: IntoIterator<Item = semver::Version>,
+        T: Iterator<Item = semver::Version>,
     {
         versions
-            .into_iter()
             .max()
             .unwrap_or_else(|| semver::Version {
                 major: 0,


### PR DESCRIPTION
`Version::max` takes an `IntoIterator` as it's argument. This seems overly restrictive. If I want to use the max function, I now have to pass ownership of what ever data-structure I'm using into the `max` function (either that, or clone it and then pass the clone into `max`). What if I still want to keep using that data-structure? I was taking a stab at #1058 and ran into this exact case. I have a vector of versions that I need to do multiple operations on (get all the version ids in the vector, get the length of the vector, as well as get the max version in the vector). It seemed weird that I had to give up ownership of the vector to get it's max version.

Instead, let's just have `Version::max` take an `Iterator` instead. This is more permissive and actually doesn't break any existing code.