### PR TITLE
Cleanup `session` service code

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -30,7 +30,7 @@ export default Controller.extend({
     keywords: alias('crate.keywords'),
     categories: alias('crate.categories'),
     badges: alias('crate.badges'),
-    isOwner: computed('crate.owner_user', function() {
+    isOwner: computed('crate.owner_user', 'session.currentUser.login', function() {
         return this.get('crate.owner_user').findBy('login', this.get('session.currentUser.login'));
     }),
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,4 +1,5 @@
 import { alias, readOnly, gt, or } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
@@ -12,6 +13,8 @@ const NUM_VERSIONS = 5;
 const PromiseArray = ArrayProxy.extend(PromiseProxyMixin);
 
 export default Controller.extend({
+    session: service(),
+
     isDownloading: false,
 
     downloadsContext: computed('requestedVersion', 'model', 'crate', function() {
@@ -28,7 +31,7 @@ export default Controller.extend({
     categories: alias('crate.categories'),
     badges: alias('crate.badges'),
     isOwner: computed('crate.owner_user', function() {
-        return this.get('crate.owner_user').findBy('login', this.session.get('currentUser.login'));
+        return this.get('crate.owner_user').findBy('login', this.get('session.currentUser.login'));
     }),
 
     sortedVersions: readOnly('crate.versions'),

--- a/app/initializers/session.js
+++ b/app/initializers/session.js
@@ -1,5 +1,4 @@
 export function initialize(application) {
-    application.inject('route', 'session', 'service:session');
 }
 
 export default {

--- a/app/initializers/session.js
+++ b/app/initializers/session.js
@@ -1,7 +1,0 @@
-export function initialize(application) {
-}
-
-export default {
-    name: 'app.session',
-    initialize
-};

--- a/app/initializers/session.js
+++ b/app/initializers/session.js
@@ -1,5 +1,4 @@
 export function initialize(application) {
-    application.inject('controller', 'session', 'service:session');
     application.inject('route', 'session', 'service:session');
 }
 

--- a/app/mixins/authenticated-route.js
+++ b/app/mixins/authenticated-route.js
@@ -3,9 +3,10 @@ import { inject as service } from '@ember/service';
 
 export default Mixin.create({
     flashMessages: service(),
+    session: service(),
 
     beforeModel(transition) {
-        return this.session.checkCurrentUser(transition, () => {
+        return this.get('session').checkCurrentUser(transition, () => {
             this.get('flashMessages').queue('Please log in to proceed');
         });
     },

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -3,9 +3,10 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
     flashMessages: service(),
+    session: service(),
 
     beforeModel() {
-        this.session.loadUser();
+        this.get('session').loadUser();
     },
 
     actions: {

--- a/app/routes/confirm.js
+++ b/app/routes/confirm.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 export default Route.extend({
     flashMessages: service(),
     ajax: service(),
+    session: service(),
 
     async model(params) {
         try {
@@ -19,9 +20,9 @@ export default Route.extend({
 
                 Suggestions of a more ideomatic way to fix/test this are welcome!
             */
-            if (this.session.get('isLoggedIn')) {
+            if (this.get('session.isLoggedIn')) {
                 this.get('ajax').request('/api/v1/me').then((response) => {
-                    this.session.set('currentUser', this.store.push(this.store.normalize('user', response.user)));
+                    this.get('session').set('currentUser', this.store.push(this.store.normalize('user', response.user)));
                 });
             }
 

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -3,8 +3,8 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default Route.extend({
-
     ajax: service(),
+    session: service(),
 
     flashMessages: service(),
 
@@ -84,7 +84,7 @@ export default Route.extend({
         controller.set('requestedVersion', requestedVersion);
         controller.set('fetchingFollowing', true);
 
-        if (this.session.get('currentUser')) {
+        if (this.get('session.currentUser')) {
             this.get('ajax').request(`/api/v1/crates/${crate.get('name')}/following`)
                 .then((d) => controller.set('following', d.following))
                 .finally(() => controller.set('fetchingFollowing', false));

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -22,7 +22,7 @@ export default Route.extend(AuthenticatedRoute, {
     },
 
     model() {
-        return this.session.get('currentUser');
+        return this.get('session.currentUser');
     },
 
     async afterModel(user) {

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -10,6 +10,7 @@ import { inject as service } from '@ember/service';
  */
 export default Route.extend({
     flashMessages: service(),
+    session: service(),
 
     beforeModel(transition) {
         try {
@@ -68,8 +69,8 @@ export default Route.extend({
             }
 
             let user = this.store.push(this.store.normalize('user', data.user));
-            let transition = this.session.get('savedTransition');
-            this.session.loginUser(user);
+            let transition = this.get('session.savedTransition');
+            this.get('session').loginUser(user);
             if (transition) {
                 transition.retry();
             }

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -3,13 +3,13 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default Route.extend({
-
     ajax: service(),
+    session: service(),
 
     async activate() {
         await this.get('ajax').delete(`/logout`);
         run(() => {
-            this.session.logoutUser();
+            this.get('session').logoutUser();
             this.transitionTo('index');
         });
     }

--- a/app/routes/me/crates.js
+++ b/app/routes/me/crates.js
@@ -9,7 +9,7 @@ export default Route.extend(AuthenticatedRoute, {
     },
 
     model(params) {
-        params.user_id = this.session.get('currentUser.id');
+        params.user_id = this.get('session.currentUser.id');
         return this.store.query('crate', params);
     },
 });

--- a/app/routes/me/index.js
+++ b/app/routes/me/index.js
@@ -5,7 +5,7 @@ import AuthenticatedRoute from '../../mixins/authenticated-route';
 export default Route.extend(AuthenticatedRoute, {
     model() {
         return {
-            user: this.session.get('currentUser'),
+            user: this.get('session.currentUser'),
             api_tokens: this.get('store').findAll('api-token'),
         };
     },

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -83,6 +83,10 @@ export default function() {
         };
     });
 
+    this.get('/crates/:crate_id/following', (/* schema, request */) => {
+        // TODO
+    });
+
     this.get('/crates/:crate_id/versions', (schema, request) => {
         let crate = request.params.crate_id;
         return schema.versions.where({ crate }).sort((a, b) => compareIsoDates(b.created_at, a.created_at));

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -182,13 +182,12 @@ test('navigating to the owners page when not logged in', async function(assert) 
 test('navigating to the owners page when not an owner', async function(assert) {
     server.loadFixtures();
 
-    this.application.register('service:session-b', Service.extend({
+    this.application.__deprecatedInstance__.register('service:session', Service.extend({
         currentUser: {
             login: 'iain8'
-        }
+        },
+        loadUser() {},
     }));
-
-    this.application.inject('controller', 'session', 'service:session-b');
 
     await visit('/crates/nanomsg');
 
@@ -198,13 +197,12 @@ test('navigating to the owners page when not an owner', async function(assert) {
 test('navigating to the owners page', async function(assert) {
     server.loadFixtures();
 
-    this.application.register('service:session-b', Service.extend({
+    this.application.__deprecatedInstance__.register('service:session', Service.extend({
         currentUser: {
             login: 'thehydroimpulse'
-        }
+        },
+        loadUser() {},
     }));
-
-    this.application.inject('controller', 'session', 'service:session-b');
 
     await visit('/crates/nanomsg');
     await click('#crate-owners p a');


### PR DESCRIPTION
This PR cleans up the `session` service. It is generally recommended to inject services only into those modules that actually need them. Injecting them unconditionally in an initializer makes them much harder to mock at the same time and causes unnecessary injections.

Partly extracted from https://github.com/rust-lang/crates.io/pull/1279, thanks @CvX!