### PR TITLE
Refactor code that generates JSON error messages for standard HTTP error responses

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -277,15 +277,6 @@ impl fmt::Display for BadRequest {
     }
 }
 
-pub fn internal_error(error: &str, detail: &str) -> Box<CargoError> {
-    Box::new(ConcreteCargoError {
-        description: error.to_string(),
-        detail: Some(detail.to_string()),
-        cause: None,
-        human: false,
-    })
-}
-
 pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<CargoError> {
     Box::new(ConcreteCargoError {
         description: error.to_string(),

--- a/src/util/json.rs
+++ b/src/util/json.rs
@@ -1,0 +1,44 @@
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use serde_json;
+use serde::Serialize;
+
+use conduit::Response;
+
+pub fn json_response<T: Serialize>(t: &T) -> Response {
+    let json = serde_json::to_string(t).unwrap();
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Content-Type".to_string(),
+        vec!["application/json; charset=utf-8".to_string()],
+    );
+    headers.insert("Content-Length".to_string(), vec![json.len().to_string()]);
+    Response {
+        status: (200, "OK"),
+        headers,
+        body: Box::new(Cursor::new(json.into_bytes())),
+    }
+}
+
+#[derive(Serialize)]
+struct StringError<'a> {
+    detail: &'a str,
+}
+
+#[derive(Serialize)]
+struct Bad<'a> {
+    errors: Vec<StringError<'a>>,
+}
+
+pub fn json_error(status: (u32, &'static str), detail: &str) -> Response {
+    let mut response = json_error_200(detail);
+    response.status = status;
+    response
+}
+
+pub fn json_error_200(detail: &str) -> Response {
+    json_response(&Bad {
+        errors: vec![StringError { detail }],
+    })
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,32 +1,11 @@
-use std::collections::HashMap;
-use std::io::Cursor;
-
-use serde_json;
-use serde::Serialize;
-
-use conduit::Response;
-
 pub use self::errors::{bad_request, human, internal, internal_error, CargoError, CargoResult};
 pub use self::errors::{std_error, ChainError};
 pub use self::io_util::{read_fill, LimitErrorReader, read_le_u32};
+pub use self::json::{json_error, json_response, json_error_200};
 pub use self::request_proxy::RequestProxy;
 
 pub mod errors;
 pub mod rfc3339;
 mod io_util;
+mod json;
 mod request_proxy;
-
-pub fn json_response<T: Serialize>(t: &T) -> Response {
-    let json = serde_json::to_string(t).unwrap();
-    let mut headers = HashMap::new();
-    headers.insert(
-        "Content-Type".to_string(),
-        vec!["application/json; charset=utf-8".to_string()],
-    );
-    headers.insert("Content-Length".to_string(), vec![json.len().to_string()]);
-    Response {
-        status: (200, "OK"),
-        headers,
-        body: Box::new(Cursor::new(json.into_bytes())),
-    }
-}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,4 +1,4 @@
-pub use self::errors::{bad_request, human, internal, internal_error, CargoError, CargoResult};
+pub use self::errors::{bad_request, human, internal, CargoError, CargoResult};
 pub use self::errors::{std_error, ChainError};
 pub use self::io_util::{read_fill, LimitErrorReader, read_le_u32};
 pub use self::json::{json_error, json_response, json_error_200};


### PR DESCRIPTION
This is a light refactoring of the logic that generates JSON responses for typical HTTP status codes: 400, 403, and 404.  An unused function is also removed.