### PR TITLE
Update `ember-svg-jar` to v1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7047,9 +7047,9 @@
       }
     },
     "ember-svg-jar": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/ember-svg-jar/-/ember-svg-jar-0.11.1.tgz",
-      "integrity": "sha512-8oyHCxRYEkWO4eAZoj1OmoS6i36z1ze0rMTnBaSyaay1hIqtLRUnDXkmDKTx+dPZoL4hBpLrWabNFTpSFMrAgg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ember-svg-jar/-/ember-svg-jar-1.1.1.tgz",
+      "integrity": "sha512-389sabirEDNd+rbzm0SszWyS6LEvW1t8NHh6Ry5X719bfVJuQ4pZp+M8OHlM7Ks0buewXl0mpuFXySSzBCb4Hw==",
       "dev": true,
       "requires": {
         "broccoli-caching-writer": "2.3.1",
@@ -7473,9 +7473,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -7483,7 +7483,16 @@
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.5.6"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "eslint": {
@@ -10504,8 +10513,8 @@
         "acorn-globals": "1.0.9",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
-        "escodegen": "1.9.0",
-        "nwmatcher": "1.4.3",
+        "escodegen": "1.9.1",
+        "nwmatcher": "1.4.4",
         "parse5": "1.5.1",
         "request": "2.81.0",
         "sax": "1.2.4",
@@ -11906,9 +11915,9 @@
       "dev": true
     },
     "nwmatcher": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
       "dev": true,
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "ember-resolver": "^4.1.0",
     "ember-router-scroll": "^0.4.0",
     "ember-source": "~2.17.0",
-    "ember-svg-jar": "^0.11.1",
+    "ember-svg-jar": "^1.1.1",
     "ember-test-selectors": "^0.3.7",
     "ember-web-app": "^2.2.0",
     "emberx-select": "^3.1.1",


### PR DESCRIPTION
This should allow us to drop `ember-cli-shims` from the dependencies