### PR TITLE
ESLint: fix “ember/new-module-imports” error.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,5 @@ module.exports = {
         'ember/no-on-calls-in-components': 'off',
         'ember/avoid-leaking-state-in-ember-objects': 'off',
         'ember/no-capital-letters-in-routes': 'off',
-        'ember/new-module-imports': 'off',
     },
 };

--- a/mirage/factories/category.js
+++ b/mirage/factories/category.js
@@ -1,5 +1,5 @@
 import { Factory, faker } from 'ember-cli-mirage';
-import Ember from 'ember';
+import { dasherize } from '@ember/string';
 
 export default Factory.extend({
     category(i) {
@@ -7,11 +7,11 @@ export default Factory.extend({
     },
 
     id() {
-        return Ember.String.dasherize(this.category);
+        return dasherize(this.category);
     },
 
     slug() {
-        return Ember.String.dasherize(this.category);
+        return dasherize(this.category);
     },
 
     description: () => faker.lorem.sentence(),


### PR DESCRIPTION
“Use import { dasherize } from '@ember/string'; instead of using Ember.String.dasherize”

cc: @Turbo87 