### PR TITLE
Update the documentation links to point directly to the new domain

### DIFF
--- a/app/routes/install.js
+++ b/app/routes/install.js
@@ -2,6 +2,6 @@ import Route from '@ember/routing/route';
 
 export default Route.extend({
     redirect() {
-        window.location = 'http://doc.crates.io/';
+        window.location = 'https://doc.rust-lang.org/cargo/getting-started/installation.html';
     },
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -38,18 +38,18 @@
             {{/rl-dropdown-toggle}}
 
             {{#rl-dropdown tagName="ul" id="doc-links" class="dropdown" closeOnChildClick="a:link"}}
-                <li><a href='http://doc.crates.io/index.html'>Getting Started</a></li>
-                <li><a href='http://doc.crates.io/guide.html'>Guide</a></li>
-                <li><a href='http://doc.crates.io/specifying-dependencies.html'>Specifying Dependencies</a></li>
-                <li><a href='http://doc.crates.io/crates-io.html'>Publishing on crates.io</a></li>
-                <li><a href='http://doc.crates.io/faq.html'>FAQ</a></li>
-                <li><a href='http://doc.crates.io/manifest.html'>Cargo.toml Format</a></li>
-                <li><a href='http://doc.crates.io/build-script.html'>Build Scripts</a></li>
-                <li><a href='http://doc.crates.io/config.html'>Configuration</a></li>
-                <li><a href='http://doc.crates.io/pkgid-spec.html'>Package ID specs</a></li>
-                <li><a href='http://doc.crates.io/environment-variables.html'>Environment Variables</a></li>
-                <li><a href='http://doc.crates.io/source-replacement.html'>Source Replacement</a></li>
-                <li><a href='http://doc.crates.io/external-tools.html'>External Tools</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/getting-started/'>Getting Started</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html'>Specifying Dependencies</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/publishing.html'>Publishing on crates.io</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/faq.html'>FAQ</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/manifest.html'>Cargo.toml Format</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/build-scripts.html'>Build Scripts</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/config.html'>Configuration</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/pkgid-spec.html'>Package ID specs</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/environment-variables.html'>Environment Variables</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/source-replacement.html'>Source Replacement</a></li>
+                <li><a href='https://doc.rust-lang.org/cargo/reference/external-tools.html'>External Tools</a></li>
                 <li>{{#link-to 'policies'}}Policies{{/link-to}}</li>
             {{/rl-dropdown}}
         {{/rl-dropdown-container}}
@@ -119,9 +119,9 @@
 <footer class='after-main-links'>
     {{#link-to 'install'}}Install{{/link-to}}
     <span class="sep">|</span>
-    <a href='http://doc.crates.io'>Getting Started</a>
+    <a href='https://doc.rust-lang.org/cargo/'>Getting Started</a>
     <span class="sep">|</span>
-    <a href='http://doc.crates.io/guide.html'>Guide</a>
+    <a href='https://doc.rust-lang.org/cargo/guide.html'>Guide</a>
     <span class="sep">|</span>
     <a href='mailto:help@crates.io'>Send us an email</a>
     <span class="sep">|</span>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -7,7 +7,7 @@
             Install Cargo
         {{/link-to}}
 
-        <a href='http://doc.crates.io/guide.html' class='yellow-button'>
+        <a href='https://doc.rust-lang.org/cargo/guide.html' class='yellow-button'>
             {{svg-jar "flag"}}
             Getting Started
         </a>

--- a/app/templates/install.hbs
+++ b/app/templates/install.hbs
@@ -4,5 +4,5 @@
 </div>
 
 <p>
-    Redirecting you to <code>http://doc.crates.io/</code>&#8230;
+    Redirecting you to <code>https://doc.rust-lang.org/cargo/getting-started/installation.html</code>&#8230;
 </p>

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -87,6 +87,6 @@
     </div>
 {{else}}
     <div id="no-results">
-        <h2>0 crates found. <a href='http://doc.crates.io/index.html'>Get started</a> and create your own.</h2>
+        <h2>0 crates found. <a href='https://doc.rust-lang.org/cargo/getting-started/'>Get started</a> and create your own.</h2>
     </div>
 {{/if}}

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -223,7 +223,7 @@ fn parse_new_headers(req: &mut Request) -> CargoResult<(EncodableCrateUpload, Us
     if !missing.is_empty() {
         return Err(human(&format_args!(
             "missing or empty metadata fields: {}. Please \
-             see http://doc.crates.io/manifest.html#package-metadata for \
+             see https://doc.rust-lang.org/cargo/reference/manifest.html for \
              how to upload metadata",
             missing.join(", ")
         )));

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -89,7 +89,7 @@ pub fn add_dependencies(
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {
                 return Err(human(
                     "wildcard (`*`) dependency constraints are not allowed \
-                     on crates.io. See http://doc.crates.io/faq.html#can-\
+                     on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-\
                      libraries-use--as-a-version-for-their-dependencies for more \
                      information",
                 ));


### PR DESCRIPTION
This updates the links to point directly to the new documentation on rlo, rather than going through the redirect at doc.crates.io.

I know there was a previous discussion of adding `includeSubDomains` to our `Strict-Transport-Security` header but this was blocked by the old documentation (served via github pages I believe).  I'm assuming that is no longer blocked as the redirect works for me over `https://`.  However, this PR does not change the STS header at this time.