### PR TITLE
Remove Google Analytics domains from our Content Security Policy headers

### DIFF
--- a/src/middleware/security_headers.rs
+++ b/src/middleware/security_headers.rs
@@ -46,8 +46,7 @@ impl SecurityHeaders {
                 format!(
                     "default-src 'self'; \
                      connect-src 'self' https://docs.rs https://{}; \
-                     script-src 'self' 'unsafe-eval' \
-                     https://www.google-analytics.com https://www.google.com; \
+                     script-src 'self' 'unsafe-eval' https://www.google.com; \
                      style-src 'self' https://www.google.com https://ajax.googleapis.com; \
                      img-src *; \
                      object-src 'none'",


### PR DESCRIPTION
This removes `https://www.google-analytics.com` from `script-src` in our CSP headers now that GA was removed in #1306.