### PR TITLE
Create a smaller index to be used on the summary page

### DIFF
--- a/migrations/2018-04-05-192744_create_refresh_todays_recent_crate_downloads/down.sql
+++ b/migrations/2018-04-05-192744_create_refresh_todays_recent_crate_downloads/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION refresh_todays_recent_crate_downloads();

--- a/migrations/2018-04-05-192744_create_refresh_todays_recent_crate_downloads/up.sql
+++ b/migrations/2018-04-05-192744_create_refresh_todays_recent_crate_downloads/up.sql
@@ -1,0 +1,9 @@
+CREATE FUNCTION refresh_todays_recent_crate_downloads() RETURNS void AS $$
+BEGIN
+  DROP INDEX IF EXISTS todays_recent_crate_downloads;
+  EXECUTE 'CREATE INDEX todays_recent_crate_downloads
+   ON crate_downloads (date)
+   WHERE date > date(''' || CURRENT_DATE::text || '''::date - INTERVAL ''90 days'')';
+  ANALYZE crate_downloads;
+END;
+$$ LANGUAGE plpgsql;

--- a/src/bin/update-daily-indices.rs
+++ b/src/bin/update-daily-indices.rs
@@ -1,0 +1,23 @@
+// Creates any partial indexes that need to be updated daily
+//
+// Should be run at just after midnight UTC on a daily basis
+
+#![deny(warnings)]
+
+extern crate cargo_registry;
+#[macro_use]
+extern crate diesel;
+
+use diesel::prelude::*;
+use diesel::select;
+
+fn main() {
+    let conn = cargo_registry::db::connect_now().unwrap();
+    make_indices(&conn).unwrap();
+}
+
+no_arg_sql_function!(refresh_todays_recent_crate_downloads, ());
+fn make_indices(conn: &PgConnection) -> QueryResult<()> {
+    select(refresh_todays_recent_crate_downloads).execute(conn)?;
+    Ok(())
+}


### PR DESCRIPTION
While #1312 improved that query a lot, we can shave off even more time
by giving it an index containing only the data it's going to need. This
index would need to be refreshed daily by a heroku scheduler task at
00:01 UTC.

I don't have a large enough dataset locally to get a great perf
comparison, so it'd be great to have a test comparison on prod before we
merge this.

The funkiness in how we go about creating/dropping the index is due to
the fact that we can't use bind parameters to create indices, nor can we
use `CURRENT_DATE` directly. If we want to create the index concurrently
(I don't think we need to), then we will have to do string concatenation
in Rust.