### PR TITLE
Use latest Rust in backend Docker image.

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.20-stretch
+FROM rust:latest
 
 RUN apt-get update \
     && apt-get install -y postgresql cmake \


### PR DESCRIPTION
The `pest` crate (a dependency of `comrak`) requires at least Rust 1.23 (https://github.com/pest-parser/pest#usage).

Currently we test crates.io on Travis using latest stable Rust (and newer).
I don't think there's any reason to pin the Docker image to a specific (and outdated) Rust version.