### PR TITLE
Don't use Diesel CLI 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - nvm install 8
 
 install:
-  - cargo install --force diesel_cli --vers 1.0.0 --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
+  - cargo install --force diesel_cli --vers 1.0.1 --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
 
 before_script:
   - diesel database setup


### PR DESCRIPTION
Diesel 1.0.0 was released with overly broad constraints on internal
dependencies. `diesel_cli` relies on internal implementation details of
`diesel` (and other internal crates) which are not bound to semver.
Unfortunately, we didn't anticipate the problems that came from having a
"semver compatible" bound on these dependencies when relying on semver
excempt APIs.

This was fixed in Diesel 1.0.1. We could probably just switch to 1.2.0,
but this is the more conservative change.

Fixes our build