### PR TITLE
Remove obsolete `ember-cli-shims` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5062,37 +5062,6 @@
         }
       }
     },
-    "ember-cli-shims": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-shims/-/ember-cli-shims-1.2.0.tgz",
-      "integrity": "sha1-D1Ov8Kq4C18p2jqXMbrFYWndlB8=",
-      "dev": true,
-      "requires": {
-        "broccoli-file-creator": "1.1.1",
-        "broccoli-merge-trees": "2.0.0",
-        "ember-cli-version-checker": "2.0.0",
-        "ember-rfc176-data": "0.3.1",
-        "silent-error": "1.1.0"
-      },
-      "dependencies": {
-        "broccoli-merge-trees": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
-          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "1.3.0",
-            "merge-trees": "1.0.1"
-          }
-        },
-        "ember-rfc176-data": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.1.tgz",
-          "integrity": "sha512-u+W5rUvYO7xyKJjiPuCM7bIAvFyPwPTJ66fOZz1xuCv3AyReI9Oev5oOADOO6YJZk+vEn0xWiZ9N6zSf8WU7Fg==",
-          "dev": true
-        }
-      }
-    },
     "ember-cli-sri": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ember-cli-sri/-/ember-cli-sri-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-cli-moment-shim": "^3.5.0",
     "ember-cli-qunit": "^4.3.2",
     "ember-cli-sass": "^7.1.7",
-    "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "2.1.1",
     "ember-cli-template-lint": "^0.7.0",
     "ember-cli-uglify": "^2.0.0",


### PR DESCRIPTION
This is no longer needed as all dependencies use Babel 6+ now :)