### PR TITLE
Allow database timeouts to be configured

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,8 @@
 use std::env;
 
 use conduit::Request;
-use diesel::prelude::{ConnectionResult, PgConnection};
-use diesel::r2d2::{self, ConnectionManager};
+use diesel::prelude::*;
+use diesel::r2d2::{self, ConnectionManager, CustomizeConnection};
 use url::Url;
 
 use middleware::app::RequestApp;
@@ -42,5 +42,19 @@ pub trait RequestTransaction {
 impl<T: Request + ?Sized> RequestTransaction for T {
     fn db_conn(&self) -> CargoResult<DieselPooledConn> {
         self.app().diesel_database.get().map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SetStatementTimeout(pub u64);
+
+impl CustomizeConnection<PgConnection, r2d2::Error> for SetStatementTimeout {
+    fn on_acquire(&self, conn: &mut PgConnection) -> Result<(), r2d2::Error> {
+        use diesel::sql_query;
+
+        sql_query(format!("SET statement_timeout = {}", self.0 * 1000))
+            .execute(conn)
+            .map_err(r2d2::Error::QueryError)?;
+        Ok(())
     }
 }


### PR DESCRIPTION
We're consistently seeing the endpoint for crate downloads H12. The logs
are showing that we are *eventually* finishing without error, it's just
taking >30s, so Heroku is killing the connection.

Unfortunately, this means that we don't have visibility into *why* it's
timing out. It's either waiting for a long time for a DB connection,
updating the `version_downloads` table (my guess), or talking to S3. If
it's database related, this will turn those requests into actual errors.

This setting will increase our error rates, as we're seeing the 99th
percentile push up to 5s at some points, and we do have requests that
take 15s to complete (but are completing). Eventually I think we should
be able to consider 10s response times unacceptable, but for now I'm
only going to leave this at 10s for long enough for me to see *what* is
failing, at which point I will set it back to 30s until we no longer see
requests pushing 10s regularly.