### PR TITLE
Add the ability to log request headers in production.

### DIFF
--- a/src/middleware/debug.rs
+++ b/src/middleware/debug.rs
@@ -7,18 +7,9 @@ pub struct Debug;
 
 impl Middleware for Debug {
     fn before(&self, req: &mut Request) -> Result<(), Box<Error + Send>> {
-        println!("  version: {}", req.http_version());
-        println!("  method: {:?}", req.method());
-        println!("  scheme: {:?}", req.scheme());
-        println!("  host: {:?}", req.host());
-        println!("  path: {}", req.path());
-        println!("  query_string: {:?}", req.query_string());
-        println!("  remote_addr: {:?}", req.remote_addr());
-        for &(k, ref v) in &req.headers().all() {
-            println!("  hdr: {}={:?}", k, v);
-        }
-        Ok(())
+        DebugRequest.before(req)
     }
+
     fn after(
         &self,
         _req: &mut Request,
@@ -31,5 +22,24 @@ impl Middleware for Debug {
             }
             res
         })
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct DebugRequest;
+
+impl Middleware for DebugRequest{
+    fn before(&self, req: &mut Request) -> Result<(), Box<Error + Send>> {
+        println!("  version: {}", req.http_version());
+        println!("  method: {:?}", req.method());
+        println!("  scheme: {:?}", req.scheme());
+        println!("  host: {:?}", req.host());
+        println!("  path: {}", req.path());
+        println!("  query_string: {:?}", req.query_string());
+        println!("  remote_addr: {:?}", req.remote_addr());
+        for &(k, ref v) in &req.headers().all() {
+            println!("  hdr: {}={:?}", k, v);
+        }
+        Ok(())
     }
 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -6,7 +6,7 @@ mod prelude {
 
 pub use self::app::AppMiddleware;
 pub use self::current_user::CurrentUser;
-pub use self::debug::Debug;
+pub use self::debug::*;
 pub use self::ember_index_rewrite::EmberIndexRewrite;
 pub use self::head::Head;
 pub use self::security_headers::SecurityHeaders;
@@ -25,6 +25,7 @@ use conduit_conditional_get::ConditionalGet;
 use conduit_cookie::{Middleware as Cookie, SessionMiddleware};
 use conduit_log_requests::LogRequests;
 
+use std::env;
 use std::sync::Arc;
 use cookie;
 use log;
@@ -41,6 +42,10 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
         m.add(Debug);
         // Locally serve crates and readmes
         m.around(StaticOrContinue::new("local_uploads"));
+    }
+
+    if env::var_os("DEBUG_REQUESTS").is_some() {
+        m.add(DebugRequest);
     }
 
     if env != Env::Test {


### PR DESCRIPTION
There are enough different IPs requesting large number of crate details
endpoints at the same time that I think we have a page making more API
calls than it should be. I'd also like the see the UA header for a
crawler hitting us a lot. This enables me to do both.