### PR TITLE
Disable `conduit_log_requests` in production

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -48,7 +48,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
         m.add(DebugRequest);
     }
 
-    if env != Env::Test {
+    if env == Env::Development {
         m.add(LogRequests(log::LogLevel::Info));
     }
 


### PR DESCRIPTION
Everything it outputs is redundant with heroku's router logging. We're
hitting our usage limits for log storage, so let's cut them down by
half.