### PR TITLE
Don't re-index crates search all the time

### DIFF
--- a/migrations/2018-04-13-203856_trigger_search_reindex_less/down.sql
+++ b/migrations/2018-04-13-203856_trigger_search_reindex_less/down.sql
@@ -1,0 +1,4 @@
+DROP TRIGGER trigger_crates_tsvector_update ON crates;
+CREATE TRIGGER trigger_crates_tsvector_update BEFORE INSERT OR UPDATE
+ON crates
+FOR EACH ROW EXECUTE PROCEDURE trigger_crates_name_search();

--- a/migrations/2018-04-13-203856_trigger_search_reindex_less/up.sql
+++ b/migrations/2018-04-13-203856_trigger_search_reindex_less/up.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER trigger_crates_tsvector_update ON crates;
+
+CREATE TRIGGER trigger_crates_tsvector_update BEFORE INSERT OR UPDATE OF updated_at
+ON crates
+FOR EACH ROW EXECUTE PROCEDURE trigger_crates_name_search();


### PR DESCRIPTION
I'm seeing a lot of this in the logs:

> Words longer than 2047 characters are ignored.
>  PL/pgSQL function trigger_crates_name_search() line 8 at assignment

It looks like the update-downloads script is causing this trigger to run
when it increments the download count. This restricts the trigger so it
only runs when the `updated_at` column is changed (which does not happen
when only the downloads column is touched)