### PR TITLE
Don't query `reverse_dependencies` on crates/show

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,4 +1,4 @@
-import { alias, readOnly, gt, or } from '@ember/object/computed';
+import { alias, readOnly, gt } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
@@ -41,8 +41,6 @@ export default Controller.extend({
     }),
 
     hasMoreVersions: gt('sortedVersions.length', NUM_VERSIONS),
-
-    anyLinks: or('crate.{homepage,wiki,mailing_list,documentation,repository,reverse_dependencies}'),
 
     displayedAuthors: computed('currentVersion.authors.[]', function() {
         return PromiseArray.create({

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -42,15 +42,11 @@
         {{#if crate.repository}}
             <li><a href="{{crate.repository}}">Repository</a></li>
         {{/if}}
-        {{#if crate.reverse_dependencies}}
-            <li>
-              {{#link-to 'crate.reverse-dependencies' (query-params dependency=crate.crate_id) data-test-reverse-deps-link=true}}
-                Dependent crates
-              {{/link-to}}
-            </li>
-        {{else}}
-            <li>No dependent crates</li>
-        {{/if}}
+        <li>
+          {{#link-to 'crate.reverse-dependencies' (query-params dependency=crate.crate_id) data-test-reverse-deps-link=true}}
+            Dependent crates
+          {{/link-to}}
+        </li>
     </ul>
     </div>
 </div>


### PR DESCRIPTION
This endpoint is one of our slowest, we don't need to hit it every time
someone visits this page.