### PR TITLE
Ensure we return a well formed 500 on errors

### DIFF
--- a/src/middleware/ensure_well_formed_500.rs
+++ b/src/middleware/ensure_well_formed_500.rs
@@ -1,0 +1,29 @@
+//! Ensures that we returned a well formed response when we error, because civet vomits
+
+use super::prelude::*;
+
+use std::collections::HashMap;
+
+// Can't derive debug because of Handler.
+#[allow(missing_debug_implementations)]
+#[derive(Default)]
+pub struct EnsureWellFormed500;
+
+impl Middleware for EnsureWellFormed500 {
+    fn after(
+        &self,
+        _: &mut Request,
+        res: Result<Response, Box<Error + Send>>,
+    ) -> Result<Response, Box<Error + Send>> {
+        res.or_else(|_| {
+            let body = "Internal Server Error";
+            let mut headers = HashMap::new();
+            headers.insert("Content-Length".to_string(), vec![body.len().to_string()]);
+            Ok(Response {
+                status: (500, "Internal Server Error"),
+                headers,
+                body: Box::new(body.as_bytes()),
+            })
+        })
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -16,6 +16,7 @@ pub mod app;
 mod blacklist_ips;
 pub mod current_user;
 mod debug;
+mod ensure_well_formed_500;
 mod ember_index_rewrite;
 mod head;
 mod security_headers;
@@ -36,6 +37,10 @@ use router::R404;
 
 pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);
+
+    if env != Env::Test {
+        m.add(ensure_well_formed_500::EnsureWellFormed500);
+    }
 
     let env = app.config.env;
     if env == Env::Development {


### PR DESCRIPTION
rust-civet basically vomits if you ever return it an error. The
resulting response would cause nginx to flip out, and then for Heroku to
give us an H13 or otherwise respond with a 502 error.

This ensures that we always return an `Ok` response, no matter what.