### PR TITLE
Don't use shields.io's crate badges

### DIFF
--- a/app/components/crate-badge.js
+++ b/app/components/crate-badge.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+
+export default Component.extend({
+    classNames: ['vers'],
+
+    tagName: 'span',
+
+    color: computed('crate.max_version', function() {
+        if (this.get('crate.max_version')[0] == '0') {
+            return 'orange';
+        } else {
+            return 'blue';
+        }
+    }),
+});

--- a/app/templates/components/crate-badge.hbs
+++ b/app/templates/components/crate-badge.hbs
@@ -1,0 +1,5 @@
+<img
+    src="https://img.shields.io/badge/crates.io-v{{ crate.max_version }}-{{ color }}.svg?longCache=true"
+    alt="{{ crate.max_version }}"
+    title="{{ crate.name }}’s current version badge"
+    data-test-version-badge>

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -1,13 +1,7 @@
 <div class='desc'>
     <div class='info'>
         {{#link-to 'crate' crate.id data-test-crate-link}}{{ crate.name }}{{/link-to}}
-        <span class='vers'>
-            <img
-                src="https://img.shields.io/crates/v/{{ crate.name }}.svg"
-                alt="{{ crate.max_version }}"
-                title="{{ crate.name }}’s current version badge"
-                data-test-version-badge>
-        </span>
+        {{crate-badge crate=crate}}
         {{#each crate.annotated_badges as |badge|}}
             {{component badge.component_name badge=badge data-test-badge=badge.badge_type}}
         {{/each}}

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -109,13 +109,6 @@
             <div>
                 <div class='last-update'><span class='small'>Last Updated</span></div>
                 <div class='date'>{{moment-from-now crate.updated_at}}</div>
-                <p>
-                    <img
-                        src="https://img.shields.io/crates/v/{{ crate.name }}.svg"
-                        alt="{{ crate.name }}’s current version badge"
-                        title="{{ crate.name }}’s current version badge">
-                </p>
-
                 {{#each crate.annotated_badges as |badge|}}
                     <p>
                         {{component badge.component_name badge=badge}}


### PR DESCRIPTION
Every single time someone loads a crates.io badge from shields.io, they
make a separate API call to our servers for each one, with no caching.
This means that right now when you go to the search page, you're going
to make 11 API calls when you should be making 1. The result is that shields.io
accounts for an unreasonably large amount of traffic to our systems.

We have all the information we need for this badge when we load the page,
so let's just do that and use their "badge with these words" API instead.

I've just removed it from the version show page since we already display
that info elsewhere on the page, and it's especially confusing when the
numbers don't match.