### PR TITLE
Fix badges for crates with prerelease versions

### DIFF
--- a/app/components/crate-badge.js
+++ b/app/components/crate-badge.js
@@ -6,6 +6,10 @@ export default Component.extend({
 
     tagName: 'span',
 
+    version: computed('crate.max_version', function() {
+        return this.get('crate.max_version').replace('-', '--');
+    }),
+
     color: computed('crate.max_version', function() {
         if (this.get('crate.max_version')[0] == '0') {
             return 'orange';

--- a/app/templates/components/crate-badge.hbs
+++ b/app/templates/components/crate-badge.hbs
@@ -1,5 +1,5 @@
 <img
-    src="https://img.shields.io/badge/crates.io-v{{ crate.max_version }}-{{ color }}.svg?longCache=true"
+    src="https://img.shields.io/badge/crates.io-v{{ version }}-{{ color }}.svg?longCache=true"
     alt="{{ crate.max_version }}"
     title="{{ crate.name }}’s current version badge"
     data-test-version-badge>


### PR DESCRIPTION
Dashes are used to separate sections, and need to be escaped. I had
thought that `crate.max_version` never included prereleases, but I was
wrong.