### PR TITLE
Use /raw/ rather than /blob/ URLs for images

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -144,7 +144,7 @@ impl<'a> MarkdownRenderer<'a> {
                 let offset = new_url.len() - 5;
                 new_url.drain(offset..offset + 4);
             }
-            // Assumes GitHub's URL scheme. GitHub renders text and markdown
+            // Assumes GitHub’s URL scheme. GitHub renders text and markdown
             // better in the "blob" view, but images need to be served raw.
             new_url += if is_media_url(url) {
                 "raw/master"
@@ -360,7 +360,7 @@ mod tests {
                 assert_eq!(
                     result,
                     format!(
-                        "<p><img src=\"https://{}/rust-lang/test/raw/master/img.png\" alt=\"alt\"></p>\n",
+                 "<p><img src=\"https://{}/rust-lang/test/raw/master/img.png\" alt=\"alt\"></p>\n",
                         host
                     )
                 );


### PR DESCRIPTION
Images in READMEs don't render ([example](https://crates.io/crates/imgref)), because relative image URLs are converted to a URL to an HTML page about the image, rather than to the image data.

This fixes image embedding by changing `/blob/` to `/raw/` part of the URL for image URLs. The images are detected by file extension in the URL, because I haven't found a way to distinguish when URLs are generated for `<img>` markup and other URLs.

