### PR TITLE
Tag slow requests in our logs

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -49,6 +49,10 @@ impl Handler for LogRequests {
             print!(" error=\"{}\"", e.description());
         }
 
+        if response_time > 1000 {
+            print!(" SLOW REQUEST");
+        }
+
         println!();
 
         res


### PR DESCRIPTION
We occasionally see max response time spike to 10s or greater. I want to
be able to know exactly what that request was. Unfortunately, the time
that gets logged appears to be slightly different from what appears in
our metrics. I'd like to be able to find these requests in the logs more
easily.