### PR TITLE
`cargo +beta fmt`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,8 @@ extern crate diesel;
 extern crate diesel_migrations;
 extern crate dotenv;
 
-use diesel_migrations::run_pending_migrations;
 use diesel::prelude::*;
+use diesel_migrations::run_pending_migrations;
 use dotenv::dotenv;
 use std::env;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,10 +5,10 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use curl::easy::Easy;
 use diesel::r2d2;
 use git2;
 use oauth2;
-use curl::easy::Easy;
 use scheduled_thread_pool::ScheduledThreadPool;
 
 use {db, Config};

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -19,10 +19,10 @@ extern crate tar;
 extern crate toml;
 extern crate url;
 
-use curl::easy::{Easy, List};
 use chrono::{TimeZone, Utc};
-use diesel::prelude::*;
+use curl::easy::{Easy, List};
 use diesel::dsl::any;
+use diesel::prelude::*;
 use docopt::Docopt;
 use flate2::read::GzDecoder;
 use itertools::Itertools;

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -116,10 +116,10 @@ mod test {
 
     use std::collections::HashMap;
 
-    use diesel::insert_into;
     use super::*;
     use cargo_registry::env;
     use cargo_registry::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
+    use diesel::insert_into;
 
     fn conn() -> PgConnection {
         let conn = PgConnection::establish(&env("TEST_DATABASE_URL")).unwrap();
@@ -151,13 +151,13 @@ mod test {
     }
 
     macro_rules! crate_downloads {
-        ($conn: expr, $id: expr, $expected: expr) => {
+        ($conn:expr, $id:expr, $expected:expr) => {
             let dl = crate_downloads::table
                 .filter(crate_downloads::crate_id.eq($id))
                 .select(crate_downloads::downloads)
                 .first($conn);
             assert_eq!(Ok($expected as i32), dl);
-        }
+        };
     }
 
     #[test]
@@ -315,8 +315,8 @@ mod test {
 
     #[test]
     fn set_processed_no_set_updated_at() {
-        use diesel::update;
         use diesel::dsl::*;
+        use diesel::update;
 
         let conn = conn();
         let user = user(&conn);

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -91,8 +91,8 @@ pub fn sync(toml_str: &str) -> CargoResult<()> {
 }
 
 pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<()> {
-    use diesel::pg::upsert::excluded;
     use diesel::dsl::all;
+    use diesel::pg::upsert::excluded;
     use schema::categories::dsl::*;
 
     let toml: toml::value::Table =

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -1,7 +1,7 @@
+use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::query_builder::*;
 use diesel::sql_types::BigInt;
-use diesel::pg::Pg;
 
 #[derive(Debug)]
 pub struct Paginated<T> {

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -4,11 +4,12 @@
 //! download counts are located in `krate::downloads`.
 
 use std::cmp;
+
 use controllers::prelude::*;
 
-use views::EncodableVersionDownload;
 use models::{Crate, Version, VersionDownload};
 use schema::version_downloads;
+use views::EncodableVersionDownload;
 
 use models::krate::to_char;
 

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -1,7 +1,7 @@
 //! Endpoints for managing a per user list of followed crates
 
-use diesel::associations::Identifiable;
 use diesel;
+use diesel::associations::Identifiable;
 
 use controllers::prelude::*;
 use models::{Crate, Follow};

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -5,10 +5,10 @@
 //! `Cargo.toml` file.
 
 use controllers::prelude::*;
-use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
-            EncodableVersion};
 use models::{Category, Crate, CrateCategory, CrateDownload, CrateKeyword, Keyword, Version};
 use schema::*;
+use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
+            EncodableVersion};
 
 use models::krate::ALL_COLUMNS;
 

--- a/src/controllers/krate/mod.rs
+++ b/src/controllers/krate/mod.rs
@@ -1,6 +1,6 @@
-pub mod search;
-pub mod publish;
-pub mod owners;
-pub mod follow;
 pub mod downloads;
+pub mod follow;
 pub mod metadata;
+pub mod owners;
+pub mod publish;
+pub mod search;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -3,8 +3,8 @@
 use serde_json;
 
 use controllers::prelude::*;
-use views::EncodableOwner;
 use models::{Crate, Owner, Rights, Team, User};
+use views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
 pub fn owners(req: &mut Request) -> CargoResult<Response> {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -9,13 +9,13 @@ use serde_json;
 
 use git;
 use render;
-use util::{read_fill, read_le_u32};
 use util::{internal, ChainError};
+use util::{read_fill, read_le_u32};
 
 use controllers::prelude::*;
-use views::{EncodableCrate, EncodableCrateUpload};
-use models::{Badge, Category, Keyword, NewCrate, NewVersion, Rights, User};
 use models::dependency;
+use models::{Badge, Category, Keyword, NewCrate, NewVersion, Rights, User};
+use views::{EncodableCrate, EncodableCrateUpload};
 
 /// Handles the `PUT /crates/new` route.
 /// Used by `cargo publish` to publish a new crate or to publish a new version of an

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -4,9 +4,9 @@ use diesel_full_text_search::*;
 
 use controllers::helpers::Paginate;
 use controllers::prelude::*;
-use views::EncodableCrate;
 use models::{Crate, CrateBadge, OwnerKind, Version};
 use schema::*;
+use views::EncodableCrate;
 
 use models::krate::{canon_crate_name, ALL_COLUMNS};
 

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,6 +1,6 @@
 mod prelude {
-    pub use diesel::prelude::*;
     pub use super::helpers::ok_true;
+    pub use diesel::prelude::*;
 
     pub use conduit::{Request, Response};
     pub use conduit_router::RequestParams;
@@ -11,10 +11,11 @@ mod prelude {
     pub use middleware::app::RequestApp;
     pub use middleware::current_user::RequestUser;
 
-    use std::io;
-    use url;
     use std::collections::HashMap;
+    use std::io;
+
     use serde::Serialize;
+    use url;
 
     pub trait RequestUtils {
         fn redirect(&self, url: String) -> Response;
@@ -86,5 +87,5 @@ pub mod krate;
 pub mod site_metadata;
 pub mod team;
 pub mod token;
-pub mod version;
 pub mod user;
+pub mod version;

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
 
 use diesel;
-use serde_json as json;
 use middleware::current_user::AuthenticationSource;
+use serde_json as json;
 use util::{bad_request, read_fill, ChainError};
 
 use models::ApiToken;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -3,12 +3,12 @@ use controllers::prelude::*;
 use serde_json;
 
 use controllers::helpers::Paginate;
-use util::bad_request;
 use email;
+use util::bad_request;
 
-use views::{EncodablePrivateUser, EncodableVersion};
 use models::{Email, Follow, NewEmail, User, Version};
 use schema::{crates, emails, follows, users, versions};
+use views::{EncodablePrivateUser, EncodableVersion};
 
 /// Handles the `GET /me` route.
 pub fn me(req: &mut Request) -> CargoResult<Response> {
@@ -92,9 +92,9 @@ pub fn updates(req: &mut Request) -> CargoResult<Response> {
 
 /// Handles the `PUT /user/:user_id` route.
 pub fn update_user(req: &mut Request) -> CargoResult<Response> {
-    use diesel::{insert_into, update};
     use self::emails::user_id;
     use self::users::dsl::{email, gh_login, users};
+    use diesel::{insert_into, update};
 
     let mut body = String::new();
     req.body().read_to_string(&mut body)?;
@@ -185,8 +185,8 @@ pub fn confirm_user_email(req: &mut Request) -> CargoResult<Response> {
 
 /// Handles `PUT /user/:user_id/resend` route
 pub fn regenerate_token_and_send(req: &mut Request) -> CargoResult<Response> {
-    use diesel::update;
     use diesel::dsl::sql;
+    use diesel::update;
 
     let user = req.user()?;
     let name = &req.params()["user_id"].parse::<i32>().ok().unwrap();

--- a/src/controllers/user/mod.rs
+++ b/src/controllers/user/mod.rs
@@ -1,3 +1,3 @@
 pub mod me;
-pub mod session;
 pub mod other;
+pub mod session;

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -1,8 +1,8 @@
 use controllers::prelude::*;
 
 use conduit_cookie::RequestSession;
-use rand::{thread_rng, Rng};
 use github;
+use rand::{thread_rng, Rng};
 
 use models::NewUser;
 

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -9,9 +9,9 @@ use controllers::prelude::*;
 
 use url;
 
-use views::EncodableVersion;
 use models::Version;
 use schema::*;
+use views::EncodableVersion;
 
 use super::version_and_crate;
 

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -8,9 +8,9 @@ use chrono::{Duration, NaiveDate, Utc};
 
 use Replica;
 
-use views::EncodableVersionDownload;
-use schema::*;
 use models::{Crate, VersionDownload};
+use schema::*;
+use views::EncodableVersionDownload;
 
 use super::version_and_crate;
 

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -6,8 +6,8 @@
 
 use controllers::prelude::*;
 
-use views::{EncodableDependency, EncodablePublicUser};
 use schema::*;
+use views::{EncodableDependency, EncodablePublicUser};
 
 use super::version_and_crate;
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,13 +1,14 @@
-use dotenv::dotenv;
 use std::env;
 use std::path::Path;
-use util::{bad_request, CargoResult};
+
+use dotenv::dotenv;
 use lettre::email::{Email, EmailBuilder};
-use lettre::transport::file::FileEmailTransport;
 use lettre::transport::EmailTransport;
-use lettre::transport::smtp::{SecurityLevel, SmtpTransportBuilder};
+use lettre::transport::file::FileEmailTransport;
 use lettre::transport::smtp::SUBMISSION_PORT;
 use lettre::transport::smtp::authentication::Mechanism;
+use lettre::transport::smtp::{SecurityLevel, SmtpTransportBuilder};
+use util::{bad_request, CargoResult};
 
 #[derive(Debug)]
 pub struct MailgunConfigVars {

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,8 +4,8 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
-use semver;
 use git2;
+use semver;
 use serde_json;
 
 use app::App;

--- a/src/github.rs
+++ b/src/github.rs
@@ -5,8 +5,8 @@ use curl::easy::{Easy, List};
 
 use oauth2::*;
 
-use serde_json;
 use serde::Deserialize;
+use serde_json;
 
 use std::str;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@ extern crate conduit_router;
 extern crate conduit_static;
 extern crate cookie;
 
+pub use self::uploaders::{Bomb, Uploader};
 pub use app::App;
 pub use config::Config;
-pub use self::uploaders::{Bomb, Uploader};
 
 use std::sync::Arc;
 
@@ -61,6 +61,7 @@ pub mod app;
 pub mod boot;
 pub mod config;
 pub mod db;
+pub mod email;
 pub mod git;
 pub mod github;
 pub mod middleware;
@@ -68,7 +69,6 @@ pub mod render;
 pub mod schema;
 pub mod uploaders;
 pub mod util;
-pub mod email;
 
 pub mod controllers;
 pub mod models;

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 
-use std::sync::Arc;
 use App;
+use std::sync::Arc;
 
 /// Middleware that injects the `App` instance into the `Request` extensions
 // Can't derive Debug because `App` can't.

--- a/src/middleware/blacklist_ips.rs
+++ b/src/middleware/blacklist_ips.rs
@@ -2,8 +2,8 @@
 
 use super::prelude::*;
 
-use std::io::Cursor;
 use std::collections::HashMap;
+use std::io::Cursor;
 
 // Can't derive debug because of Handler.
 #[allow(missing_debug_implementations)]

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -2,8 +2,8 @@
 
 use super::prelude::*;
 
-use std::io;
 use conduit::Method;
+use std::io;
 use util::RequestProxy;
 
 // Can't derive debug because of Handler.

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -1,10 +1,10 @@
 //! Log all requests in a format similar to Heroku's router, but with additional
 //! information that we care about like User-Agent and Referer
 
+use super::prelude::*;
 use conduit::Request;
 use std::fmt;
 use std::time::Instant;
-use super::prelude::*;
 use util::request_header;
 
 #[allow(missing_debug_implementations)] // We can't

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -1,7 +1,7 @@
 mod prelude {
-    pub use std::error::Error;
     pub use conduit::{Handler, Request, Response};
     pub use conduit_middleware::{AroundMiddleware, Middleware};
+    pub use std::error::Error;
 }
 
 pub use self::app::AppMiddleware;
@@ -16,23 +16,23 @@ pub mod app;
 mod blacklist_ips;
 pub mod current_user;
 mod debug;
-mod ensure_well_formed_500;
 mod ember_index_rewrite;
-mod log_request;
+mod ensure_well_formed_500;
 mod head;
+mod log_request;
 mod security_headers;
 mod static_or_continue;
 
-use conduit_middleware::MiddlewareBuilder;
 use conduit_conditional_get::ConditionalGet;
 use conduit_cookie::{Middleware as Cookie, SessionMiddleware};
+use conduit_middleware::MiddlewareBuilder;
 
+use cookie;
 use std::env;
 use std::sync::Arc;
-use cookie;
 
-use {App, Env};
 use router::R404;
+use {App, Env};
 
 pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -93,8 +93,8 @@ impl Category {
         limit: i64,
         offset: i64,
     ) -> QueryResult<Vec<Category>> {
-        use diesel::select;
         use diesel::dsl::*;
+        use diesel::select;
 
         let sort_sql = match sort {
             "crates" => "ORDER BY crates_cnt DESC",

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -78,8 +78,8 @@ pub fn add_dependencies(
     deps: &[::views::EncodableCrateDependency],
     target_version_id: i32,
 ) -> CargoResult<Vec<git::Dependency>> {
-    use diesel::insert_into;
     use self::dependencies::dsl::*;
+    use diesel::insert_into;
 
     let git_and_new_dependencies = deps.iter()
         .map(|dep| {
@@ -173,8 +173,8 @@ impl Queryable<dependencies::SqlType, Pg> for Dependency {
 
 impl QueryableByName<Pg> for Dependency {
     fn build<R: NamedRow<Pg>>(row: &R) -> deserialize::Result<Self> {
-        use schema::dependencies::*;
         use diesel::dsl::SqlTypeOf;
+        use schema::dependencies::*;
 
         let req_str = row.get::<SqlTypeOf<req>, String>("req")?;
         Ok(Dependency {

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use diesel;
+use diesel::prelude::*;
 
 use models::Crate;
 use schema::*;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -1,7 +1,7 @@
 use chrono::{NaiveDate, NaiveDateTime};
+use diesel;
 use diesel::associations::Identifiable;
 use diesel::prelude::*;
-use diesel;
 use license_exprs;
 use semver;
 use url::Url;
@@ -9,12 +9,12 @@ use url::Url;
 use app::App;
 use util::{human, CargoResult};
 
-use views::{EncodableCrate, EncodableCrateLinks};
 use models::{Badge, Category, CrateOwner, Keyword, NewCrateOwnerInvitation, Owner, OwnerKind,
              ReverseDependency, User, Version};
+use views::{EncodableCrate, EncodableCrateLinks};
 
-use schema::*;
 use models::helpers::with_count::*;
+use schema::*;
 
 /// Hosts in this blacklist are known to not be hosting documentation,
 /// and are possibly of malicious intent e.g. ad tracking networks, etc.
@@ -189,9 +189,9 @@ impl<'a> NewCrate<'a> {
     }
 
     fn ensure_name_not_reserved(&self, conn: &PgConnection) -> CargoResult<()> {
-        use schema::reserved_crate_names::dsl::*;
-        use diesel::select;
         use diesel::dsl::exists;
+        use diesel::select;
+        use schema::reserved_crate_names::dsl::*;
 
         let reserved_name = select(exists(
             reserved_crate_names.filter(canon_crate_name(name).eq(canon_crate_name(self.name))),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -10,8 +10,8 @@ pub use self::krate::{Crate, CrateDownload, NewCrate};
 pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::rights::Rights;
 pub use self::team::{NewTeam, Team};
-pub use self::user::{NewUser, User};
 pub use self::token::ApiToken;
+pub use self::user::{NewUser, User};
 pub use self::version::{NewVersion, Version};
 
 pub mod helpers;

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 use diesel;
+use diesel::prelude::*;
 
 use models::User;
 use schema::api_tokens;

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -53,11 +53,11 @@ impl<'a> NewUser<'a> {
 
     /// Inserts the user into the database, or updates an existing one.
     pub fn create_or_update(&self, conn: &PgConnection) -> QueryResult<User> {
-        use diesel::insert_into;
-        use diesel::dsl::sql;
-        use diesel::sql_types::Integer;
-        use diesel::pg::upsert::excluded;
         use diesel::NotFound;
+        use diesel::dsl::sql;
+        use diesel::insert_into;
+        use diesel::pg::upsert::excluded;
+        use diesel::sql_types::Integer;
         use schema::users::dsl::*;
 
         conn.transaction(|| {

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -7,8 +7,8 @@ use diesel::prelude::*;
 use semver;
 use serde_json;
 
-use util::{human, CargoResult};
 use license_exprs;
+use util::{human, CargoResult};
 
 use models::{Crate, Dependency};
 use schema::*;
@@ -98,8 +98,8 @@ impl Version {
     }
 
     pub fn record_readme_rendering(&self, conn: &PgConnection) -> QueryResult<usize> {
-        use schema::readme_renderings::dsl::*;
         use diesel::dsl::now;
+        use schema::readme_renderings::dsl::*;
 
         diesel::insert_into(readme_renderings)
             .values(version_id.eq(self.id))
@@ -133,10 +133,10 @@ impl NewVersion {
     }
 
     pub fn save(&self, conn: &PgConnection, authors: &[String]) -> CargoResult<Version> {
-        use diesel::{insert_into, select};
         use diesel::dsl::exists;
-        use schema::versions::dsl::*;
+        use diesel::{insert_into, select};
         use schema::version_authors::{name, version_id};
+        use schema::versions::dsl::*;
 
         conn.transaction(|| {
             let already_uploaded = versions

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,10 +5,10 @@ use conduit::{Handler, Request, Response};
 use conduit_git_http_backend;
 use conduit_router::{RequestParams, RouteBuilder};
 
-use util::errors::{std_error, CargoError, CargoResult, NotFound};
-use util::RequestProxy;
-use {App, Env};
 use controllers::*;
+use util::RequestProxy;
+use util::errors::{std_error, CargoError, CargoResult, NotFound};
+use {App, Env};
 
 pub fn build_router(app: &App) -> R404 {
     let mut api_router = RouteBuilder::new();

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -7,12 +7,12 @@ extern crate openssl;
 
 use std::io::prelude::*;
 
+use base64::encode;
 use chrono::prelude::Utc;
 use curl::easy::{Easy, List, ReadError, Transfer};
 use openssl::hash::MessageDigest;
-use openssl::sign::Signer;
 use openssl::pkey::PKey;
-use base64::encode;
+use openssl::sign::Signer;
 
 #[derive(Clone, Debug)]
 pub struct Bucket {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -28,9 +28,9 @@ use std::io::Read;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 
+use cargo_registry::Replica;
 use cargo_registry::app::App;
 use cargo_registry::middleware::current_user::AuthenticationSource;
-use cargo_registry::Replica;
 use chrono::Utc;
 use conduit::{Method, Request};
 use conduit_test::MockRequest;
@@ -40,39 +40,45 @@ use flate2::write::GzEncoder;
 
 pub use cargo_registry::{models, schema, views};
 
-use views::EncodableCrate;
-use views::krate_publish as u;
 use models::{Crate, CrateDownload, CrateOwner, Dependency, Keyword, Team, User, Version};
 use models::{NewCategory, NewCrate, NewTeam, NewUser, NewVersion};
 use schema::*;
+use views::EncodableCrate;
+use views::krate_publish as u;
 
 macro_rules! t {
-    ($e:expr) => (
+    ($e:expr) => {
         match $e {
             Ok(e) => e,
             Err(m) => panic!("{} failed with: {}", stringify!($e), m),
         }
-    )
+    };
 }
 
-macro_rules! t_resp { ($e:expr) => (t!($e)) }
+macro_rules! t_resp {
+    ($e:expr) => {
+        t!($e)
+    };
+}
 
 macro_rules! ok_resp {
-    ($e:expr) => ({
+    ($e:expr) => {{
         let resp = t_resp!($e);
-        if !::ok_resp(&resp) { panic!("bad response: {:?}", resp.status); }
+        if !::ok_resp(&resp) {
+            panic!("bad response: {:?}", resp.status);
+        }
         resp
-    })
+    }};
 }
 
 macro_rules! bad_resp {
-    ($e:expr) => ({
+    ($e:expr) => {{
         let mut resp = t_resp!($e);
         match ::bad_resp(&mut resp) {
             None => panic!("ok response: {:?}", resp.status),
             Some(b) => b,
         }
-    })
+    }};
 }
 
 #[derive(Deserialize, Debug)]
@@ -509,8 +515,8 @@ fn sign_in(req: &mut Request, app: &App) -> User {
 }
 
 fn new_dependency(conn: &PgConnection, version: &Version, krate: &Crate) -> Dependency {
-    use diesel::insert_into;
     use cargo_registry::schema::dependencies::dsl::*;
+    use diesel::insert_into;
 
     insert_into(dependencies)
         .values((

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,7 +1,7 @@
 use conduit::{Handler, Method};
 
-use views::{EncodableCategory, EncodableCategoryWithSubcategories};
 use models::Category;
+use views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 #[derive(Deserialize)]
 struct CategoryList {
@@ -86,11 +86,11 @@ fn update_crate() {
     let (_b, app, middle) = ::app();
     let mut req = ::req(Arc::clone(&app), Method::Get, "/api/v1/categories/foo");
     macro_rules! cnt {
-        ($req: expr, $cat: expr) => {{
+        ($req:expr, $cat:expr) => {{
             $req.with_path(&format!("/api/v1/categories/{}", $cat));
             let mut response = ok_resp!(middle.call($req));
             ::json::<GoodCategory>(&mut response).category.crates_cnt as usize
-        }}
+        }};
     }
 
     let krate = {

--- a/src/tests/git.rs
+++ b/src/tests/git.rs
@@ -1,8 +1,8 @@
-use std::fs;
 use std::env;
-use std::thread;
+use std::fs;
 use std::path::PathBuf;
 use std::sync::{Once, ONCE_INIT};
+use std::thread;
 
 use git2;
 use url::Url;

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use conduit::{Handler, Method};
 use conduit_test::MockRequest;
 
-use views::EncodableKeyword;
 use models::Keyword;
+use views::EncodableKeyword;
 
 #[derive(Deserialize)]
 struct KeywordList {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -2,14 +2,14 @@ extern crate diesel;
 
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 use std::sync::Arc;
 
+use self::diesel::prelude::*;
 use chrono::Utc;
 use conduit::{Handler, Method};
 use diesel::update;
-use self::diesel::prelude::*;
 use git2;
 use semver;
 use serde_json;
@@ -19,11 +19,11 @@ use cargo_registry::models::krate::MAX_NAME_LENGTH;
 
 use {CrateList, CrateMeta, GoodCrate};
 
-use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
-            EncodableVersion, EncodableVersionDownload};
-use views::krate_publish as u;
 use models::{ApiToken, Category, Crate};
 use schema::{crates, metadata, versions};
+use views::krate_publish as u;
+use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
+            EncodableVersion, EncodableVersionDownload};
 
 #[derive(Deserialize)]
 struct VersionsList {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -6,9 +6,9 @@ use conduit::{Handler, Method};
 use diesel;
 use diesel::prelude::*;
 
-use views::{EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse};
 use models::{Crate, NewCrateOwnerInvitation};
 use schema::crate_owner_invitations;
+use views::{EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse};
 
 #[derive(Deserialize)]
 struct TeamResponse {
@@ -187,7 +187,7 @@ fn owners_can_remove_self() {
         middle.call(
             req.with_path(&format!("/api/v1/me/crate_owner_invitations/{}", krate_id))
                 .with_method(Method::Put)
-                .with_body(body.to_string().as_bytes())
+                .with_body(body.to_string().as_bytes()),
         )
     );
 

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -9,8 +9,8 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::env;
 use std::fs::{self, File};
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 use std::net;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -18,13 +18,13 @@ use std::str;
 use std::sync::{Arc, Mutex, Once};
 use std::thread;
 
-use curl::easy::{Easy, List};
-use self::futures::{Future, Stream};
 use self::futures::sync::oneshot;
+use self::futures::{Future, Stream};
 use self::hyper::server::Http;
 use self::tokio_core::net::TcpListener;
 use self::tokio_core::reactor::Core;
 use self::tokio_service::Service;
+use curl::easy::{Easy, List};
 use serde_json;
 
 use models::NewUser;

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -1,10 +1,10 @@
-use std::sync::ONCE_INIT;
 use conduit::{Handler, Method};
 use diesel::*;
 use record::GhUser;
+use std::sync::ONCE_INIT;
 
-use views::EncodableCrate;
 use models::{Crate, NewUser};
+use views::EncodableCrate;
 
 // Users: `crates-tester-1` and `crates-tester-2`
 // Passwords: ask acrichto or gankro

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use diesel::prelude::*;
 use conduit::{Handler, Method};
+use diesel::prelude::*;
 
-use views::EncodableApiTokenWithToken;
 use models::ApiToken;
+use views::EncodableApiTokenWithToken;
 
 #[derive(Deserialize)]
 struct DecodableApiToken {
@@ -28,7 +28,7 @@ macro_rules! assert_contains {
         if !$e.contains($f) {
             panic!(format!("expected '{}' to contain '{}'", $e, $f));
         }
-    }
+    };
 }
 
 #[test]

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,11 +1,11 @@
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use conduit::{Handler, Method};
 use diesel::prelude::*;
 
-use views::{EncodableCrate, EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
 use models::{ApiToken, Email, NewUser, User};
+use views::{EncodableCrate, EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
 
 #[derive(Deserialize)]
 struct AuthResponse {

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -5,11 +5,11 @@ extern crate serde_json;
 
 use serde_json::Value;
 
-use conduit::{Handler, Method};
 use self::diesel::prelude::*;
+use conduit::{Handler, Method};
 
-use views::EncodableVersion;
 use schema::versions;
+use views::EncodableVersion;
 
 #[derive(Deserialize)]
 struct VersionList {

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -9,10 +9,10 @@ use tar;
 use util::{human, internal, CargoResult, ChainError};
 use util::{LimitErrorReader, read_le_u32};
 
-use std::sync::Arc;
-use std::fs::{self, File};
 use std::env;
+use std::fs::{self, File};
 use std::io::{Read, Write};
+use std::sync::Arc;
 
 use app::App;
 use middleware::app::RequestApp;

--- a/src/util/io_util.rs
+++ b/src/util/io_util.rs
@@ -1,5 +1,5 @@
-use std::io::prelude::*;
 use std::io;
+use std::io::prelude::*;
 use std::mem;
 
 #[derive(Debug)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,22 +1,22 @@
 use std::collections::HashMap;
 use std::io::Cursor;
 
-use serde_json;
 use serde::Serialize;
+use serde_json;
 
 use conduit::Response;
 
 pub use self::errors::{bad_request, human, internal, internal_error, CargoError, CargoResult};
 pub use self::errors::{std_error, ChainError};
 pub use self::io_util::{read_fill, LimitErrorReader, read_le_u32};
-pub use self::request_proxy::RequestProxy;
 pub use self::request_helpers::*;
+pub use self::request_proxy::RequestProxy;
 
 pub mod errors;
-pub mod rfc3339;
 mod io_util;
 mod request_helpers;
 mod request_proxy;
+pub mod rfc3339;
 
 pub fn json_response<T: Serialize>(t: &T) -> Response {
     let json = serde_json::to_string(t).unwrap();

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -4,14 +4,14 @@
 //! integration tests.
 use std::collections::HashMap;
 
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use semver;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use models::krate::MAX_NAME_LENGTH;
 
-use models::Keyword as CrateKeyword;
-use models::DependencyKind;
 use models::Crate;
+use models::DependencyKind;
+use models::Keyword as CrateKeyword;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct NewCrate {

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use chrono::NaiveDateTime;
+use std::collections::HashMap;
 
 use models::DependencyKind;
 
@@ -204,10 +204,10 @@ pub use self::krate_publish::NewCrate as EncodableCrateUpload;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use super::*;
     use chrono::NaiveDate;
     use serde_json;
+    use std::collections::HashMap;
 
     #[test]
     fn category_dates_serializes_to_rfc3339() {


### PR DESCRIPTION
This PR prepares us for the next stable release of rust which will pull
in a new version of the rustfmt-preview component.  These changes have
been stable since at least April 11th, so I don't expect any changes
between now and the next release.

The changes consist of sorting use statements in alphabetical order,
and some minor tweaks to the formatting of macro definitions.