### PR TITLE
Fix relevance sorting on search

### DIFF
--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -13,7 +13,6 @@ export default Controller.extend(PaginationMixin, {
     q: alias('search.q'),
     page: '1',
     per_page: 10,
-    sort: null,
 
     model: readOnly('dataTask.lastSuccessful.value'),
 

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -38,7 +38,7 @@
 
                 {{#rl-dropdown tagName="ul" class="dropdown" closeOnChildClick="a:link"}}
                     <li>
-                        {{#link-to (query-params page=1 sort="")}}
+                        {{#link-to (query-params page=1 sort="relevance")}}
                             Relevance
                         {{/link-to}}
                     </li>


### PR DESCRIPTION
To sort by relevence, the backend expects the sort string to either be
not present, or set to the value "relevance". Right now the backend is
either sending the string `null` or an empty string. Neither of these do
what we want.

Fixes #1370