### PR TITLE
Remove some unused indexes

### DIFF
--- a/migrations/2018-04-27-194025_remove_unused_indexes/down.sql
+++ b/migrations/2018-04-27-194025_remove_unused_indexes/down.sql
@@ -1,0 +1,4 @@
+CREATE UNIQUE INDEX reserved_crate_names_canon_crate_name_idx ON reserved_crate_names (canon_crate_name(name));
+CREATE INDEX index_users_gh_id ON users (gh_id);
+CREATE INDEX index_version_downloads_version_id ON version_downloads (version_id);
+CREATE INDEX index_version_downloads_date ON version_downloads (date);

--- a/migrations/2018-04-27-194025_remove_unused_indexes/up.sql
+++ b/migrations/2018-04-27-194025_remove_unused_indexes/up.sql
@@ -1,0 +1,4 @@
+DROP INDEX reserved_crate_names_canon_crate_name_idx;
+DROP INDEX index_users_gh_id;
+DROP INDEX index_version_downloads_version_id;
+DROP INDEX index_version_downloads_date;


### PR DESCRIPTION
The gh_id index has never been read at all. reserved_crate_names is too
small of a table for indexes to be useful. I've manually verified that
every query hitting version_downloads either doesn't use these indexes,
or has the same performance when not using them.