### PR TITLE
Update test in the update-downloads binary to work at all hours

### DIFF
--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -236,7 +236,7 @@ mod test {
                 version_downloads::version_id.eq(version.id),
                 version_downloads::downloads.eq(2),
                 version_downloads::counted.eq(2),
-                version_downloads::date.eq(date(now - 2.hours())),
+                version_downloads::date.eq(date(now)),
                 version_downloads::processed.eq(false),
             ))
             .execute(&conn)


### PR DESCRIPTION
The existing 2 hour offset causes tests failures between 0:00 and 2:00
UTC.  During this time period, the generated row is given a date of
"yesterday" and the new processing logic marks the row as processed.