### PR TITLE
Add missed wrap to fix view on small screens

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -168,6 +168,7 @@
     ul {
         @include display-flex;
         @include flex-direction(row);
+        @include flex-wrap(wrap);
 
         font-size: 80%;
         list-style-type: none;


### PR DESCRIPTION
Before: ![before](https://user-images.githubusercontent.com/6342851/39496654-108b97ec-4da8-11e8-94ee-6d44ac6d7c12.png)
After: ![after](https://user-images.githubusercontent.com/6342851/39496659-139bd24e-4da8-11e8-9e93-4a099f3716ae.png)
