### PR TITLE
Fix Guide link in footer

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -121,7 +121,7 @@
     <span class="sep">|</span>
     <a href='https://doc.rust-lang.org/cargo/'>Getting Started</a>
     <span class="sep">|</span>
-    <a href='https://doc.rust-lang.org/cargo/guide.html'>Guide</a>
+    <a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a>
     <span class="sep">|</span>
     <a href='mailto:help@crates.io'>Send us an email</a>
     <span class="sep">|</span>


### PR DESCRIPTION
The [Guide link in the footer](https://doc.rust-lang.org/cargo/guide.html) is currently not found.