### PR TITLE
opensearch.xml not served if Accept header is text/html

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -75,6 +75,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
     if env != Env::Test {
         m.around(StaticOrContinue::new("dist"));
         m.around(EmberIndexRewrite::default());
+        m.around(StaticOrContinue::new("dist"));
         // Note: around middleware is run from bottom to top, so the rewrite occurs first
     }
 


### PR DESCRIPTION
According to #1358 Firefox incorrectly sends a Accept: text/html header when requesting
the opensearch.xml.

This fixes the bug, but I am not sure if it is the most ideal.

edit by JTG: Fixes #1358