### PR TITLE
Pull diesel_cli version from .diesel_version when installing on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - nvm install 8
 
 install:
-  - cargo install --force diesel_cli --vers 1.2.0 --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
+  - cargo install --force diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
 
 before_script:
   - diesel database setup


### PR DESCRIPTION
The Diesel buildpack uses the version defined in `.diesel_version` when
running migrations.  This change ensures that we are also using the
same version on CI any time the version in that file is bumped.