### PR TITLE
Update formatting for rustfmt-preview as of 1.26.1

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -32,8 +32,8 @@ use std::thread;
 use tar::Archive;
 use url::Url;
 
-use cargo_registry::Config;
 use cargo_registry::render::readme_to_html;
+use cargo_registry::Config;
 
 use cargo_registry::models::Version;
 use cargo_registry::schema::*;

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -9,8 +9,8 @@ use cargo_registry::{env, Env};
 use civet::Server;
 use std::env;
 use std::fs::{self, File};
-use std::sync::Arc;
 use std::sync::mpsc::channel;
+use std::sync::Arc;
 
 fn main() {
     // Initialize logging

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -134,10 +134,9 @@ pub fn publish(req: &mut Request) -> CargoResult<Response> {
         // If the git commands fail below, we shouldn't keep the crate on the
         // server.
         let max_unpack = cmp::max(app.config.max_unpack_size, max);
-        let (cksum, mut crate_bomb, mut readme_bomb) =
-            app.config
-                .uploader
-                .upload_crate(req, &krate, readme, max, max_unpack, vers)?;
+        let (cksum, mut crate_bomb, mut readme_bomb) = app.config
+            .uploader
+            .upload_crate(req, &krate, readme, max, max_unpack, vers)?;
         version.record_readme_rendering(&conn)?;
 
         // Register this crate in our local git repo.

--- a/src/email.rs
+++ b/src/email.rs
@@ -3,11 +3,11 @@ use std::path::Path;
 
 use dotenv::dotenv;
 use lettre::email::{Email, EmailBuilder};
-use lettre::transport::EmailTransport;
 use lettre::transport::file::FileEmailTransport;
-use lettre::transport::smtp::SUBMISSION_PORT;
 use lettre::transport::smtp::authentication::Mechanism;
+use lettre::transport::smtp::SUBMISSION_PORT;
 use lettre::transport::smtp::{SecurityLevel, SmtpTransportBuilder};
+use lettre::transport::EmailTransport;
 use util::{bad_request, CargoResult};
 
 #[derive(Debug)]

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 
-use App;
 use std::sync::Arc;
+use App;
 
 /// Middleware that injects the `App` instance into the `Request` extensions
 // Can't derive Debug because `App` can't.

--- a/src/middleware/security_headers.rs
+++ b/src/middleware/security_headers.rs
@@ -42,17 +42,15 @@ impl SecurityHeaders {
         // or if we switch to a different graph generation library.
         headers.insert(
             "Content-Security-Policy".into(),
-            vec![
-                format!(
-                    "default-src 'self'; \
-                     connect-src 'self' https://docs.rs https://{}; \
-                     script-src 'self' 'unsafe-eval' https://www.google.com; \
-                     style-src 'self' https://www.google.com https://ajax.googleapis.com; \
-                     img-src *; \
-                     object-src 'none'",
-                    s3_host
-                ),
-            ],
+            vec![format!(
+                "default-src 'self'; \
+                 connect-src 'self' https://docs.rs https://{}; \
+                 script-src 'self' 'unsafe-eval' https://www.google.com; \
+                 style-src 'self' https://www.google.com https://ajax.googleapis.com; \
+                 img-src *; \
+                 object-src 'none'",
+                s3_host
+            )],
         );
 
         SecurityHeaders { headers }

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -50,10 +50,7 @@ impl Owner {
     ) -> CargoResult<Owner> {
         if name.contains(':') {
             Ok(Owner::Team(Team::create_or_update(
-                app,
-                conn,
-                name,
-                req_user,
+                app, conn, name, req_user,
             )?))
         } else {
             users::table

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -53,11 +53,11 @@ impl<'a> NewUser<'a> {
 
     /// Inserts the user into the database, or updates an existing one.
     pub fn create_or_update(&self, conn: &PgConnection) -> QueryResult<User> {
-        use diesel::NotFound;
         use diesel::dsl::sql;
         use diesel::insert_into;
         use diesel::pg::upsert::excluded;
         use diesel::sql_types::Integer;
+        use diesel::NotFound;
         use schema::users::dsl::*;
 
         conn.transaction(|| {

--- a/src/render.rs
+++ b/src/render.rs
@@ -75,29 +75,27 @@ impl<'a> MarkdownRenderer<'a> {
         ].iter()
             .cloned()
             .collect();
-        let allowed_classes = [
-            (
-                "code",
-                [
-                    "language-bash",
-                    "language-clike",
-                    "language-glsl",
-                    "language-go",
-                    "language-ini",
-                    "language-javascript",
-                    "language-json",
-                    "language-markup",
-                    "language-protobuf",
-                    "language-ruby",
-                    "language-rust",
-                    "language-scss",
-                    "language-sql",
-                    "yaml",
-                ].iter()
-                    .cloned()
-                    .collect(),
-            ),
-        ].iter()
+        let allowed_classes = [(
+            "code",
+            [
+                "language-bash",
+                "language-clike",
+                "language-glsl",
+                "language-go",
+                "language-ini",
+                "language-javascript",
+                "language-json",
+                "language-markup",
+                "language-protobuf",
+                "language-ruby",
+                "language-rust",
+                "language-scss",
+                "language-sql",
+                "yaml",
+            ].iter()
+                .cloned()
+                .collect(),
+        )].iter()
             .cloned()
             .collect();
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -6,8 +6,8 @@ use conduit_git_http_backend;
 use conduit_router::{RequestParams, RouteBuilder};
 
 use controllers::*;
-use util::RequestProxy;
 use util::errors::{std_error, CargoError, CargoResult, NotFound};
+use util::RequestProxy;
 use {App, Env};
 
 pub fn build_router(app: &App) -> R404 {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -25,26 +25,26 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::env;
 use std::io::Read;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
+use std::sync::Arc;
 
-use cargo_registry::Replica;
 use cargo_registry::app::App;
 use cargo_registry::middleware::current_user::AuthenticationSource;
+use cargo_registry::Replica;
 use chrono::Utc;
 use conduit::{Method, Request};
 use conduit_test::MockRequest;
 use diesel::prelude::*;
-use flate2::Compression;
 use flate2::write::GzEncoder;
+use flate2::Compression;
 
 pub use cargo_registry::{models, schema, views};
 
 use models::{Crate, CrateDownload, CrateOwner, Dependency, Keyword, Team, User, Version};
 use models::{NewCategory, NewCrate, NewTeam, NewUser, NewVersion};
 use schema::*;
-use views::EncodableCrate;
 use views::krate_publish as u;
+use views::EncodableCrate;
 
 macro_rules! t {
     ($e:expr) => {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -625,17 +625,15 @@ fn new_krate_with_dependency() {
 #[test]
 fn new_krate_non_canon_crate_name_dependencies() {
     let (_b, app, middle) = ::app();
-    let deps = vec![
-        u::CrateDependency {
-            name: u::CrateName("foo-dep".to_string()),
-            optional: false,
-            default_features: true,
-            features: Vec::new(),
-            version_req: u::CrateVersionReq(semver::VersionReq::parse(">= 0").unwrap()),
-            target: None,
-            kind: None,
-        },
-    ];
+    let deps = vec![u::CrateDependency {
+        name: u::CrateName("foo-dep".to_string()),
+        optional: false,
+        default_features: true,
+        features: Vec::new(),
+        version_req: u::CrateVersionReq(semver::VersionReq::parse(">= 0").unwrap()),
+        target: None,
+        kind: None,
+    }];
     let mut req = ::new_req_full(Arc::clone(&app), ::krate("new_dep"), "1.0.0", deps);
     {
         let conn = app.diesel_database.get().unwrap();

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use conduit::{Handler, Method};
 use diesel::prelude::*;

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -7,7 +7,7 @@ use semver;
 use tar;
 
 use util::{human, internal, CargoResult, ChainError};
-use util::{LimitErrorReader, read_le_u32};
+use util::{read_le_u32, LimitErrorReader};
 
 use std::env;
 use std::fs::{self, File};

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -28,11 +28,9 @@ pub trait CargoError: Send + fmt::Display + 'static {
     fn response(&self) -> Option<Response> {
         if self.human() {
             Some(json_response(&Bad {
-                errors: vec![
-                    StringError {
-                        detail: self.description().to_string(),
-                    },
-                ],
+                errors: vec![StringError {
+                    detail: self.description().to_string(),
+                }],
             }))
         } else {
             self.cause().and_then(|cause| cause.response())
@@ -243,11 +241,9 @@ impl CargoError for NotFound {
 
     fn response(&self) -> Option<Response> {
         let mut response = json_response(&Bad {
-            errors: vec![
-                StringError {
-                    detail: "Not Found".to_string(),
-                },
-            ],
+            errors: vec![StringError {
+                detail: "Not Found".to_string(),
+            }],
         });
         response.status = (404, "Not Found");
         Some(response)
@@ -270,11 +266,9 @@ impl CargoError for Unauthorized {
 
     fn response(&self) -> Option<Response> {
         let mut response = json_response(&Bad {
-            errors: vec![
-                StringError {
-                    detail: "must be logged in to perform that action".to_string(),
-                },
-            ],
+            errors: vec![StringError {
+                detail: "must be logged in to perform that action".to_string(),
+            }],
         });
         response.status = (403, "Forbidden");
         Some(response)
@@ -296,11 +290,9 @@ impl CargoError for BadRequest {
 
     fn response(&self) -> Option<Response> {
         let mut response = json_response(&Bad {
-            errors: vec![
-                StringError {
-                    detail: self.0.clone(),
-                },
-            ],
+            errors: vec![StringError {
+                detail: self.0.clone(),
+            }],
         });
         response.status = (400, "Bad Request");
         Some(response)

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,7 +8,7 @@ use conduit::Response;
 
 pub use self::errors::{bad_request, human, internal, internal_error, CargoError, CargoResult};
 pub use self::errors::{std_error, ChainError};
-pub use self::io_util::{read_fill, LimitErrorReader, read_le_u32};
+pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
 pub use self::request_proxy::RequestProxy;
 


### PR DESCRIPTION
Running `cargo +stable fmt` because CI is failing on master now that
1.26.1 has been released.