### PR TITLE
Update `ember-fetch` to v5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -257,6 +257,12 @@
       "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
       "dev": true
     },
+    "abortcontroller-polyfill": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.1.9.tgz",
+      "integrity": "sha512-omvG7zOHIs3BphdH62Kh3xy8nlftAsTyp7PDa9EmC3Jz9pa6sZFYk7UhNgu9Y4sIBhj6jF0RgeFZYvPnsP5sBw==",
+      "dev": true
+    },
     "accepts": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
@@ -2486,91 +2492,74 @@
       }
     },
     "broccoli-templater": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/broccoli-templater/-/broccoli-templater-1.0.0.tgz",
-      "integrity": "sha1-fAVKrPWW0YaNGkQpH57HuQfTDs8=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/broccoli-templater/-/broccoli-templater-2.0.1.tgz",
+      "integrity": "sha1-LgAeRa66f6LrmxmlTJxht0GTV5k=",
       "dev": true,
       "requires": {
-        "broccoli-filter": "0.1.14",
-        "broccoli-stew": "1.5.0",
-        "lodash.template": "3.6.2"
+        "broccoli-persistent-filter": "1.4.3",
+        "broccoli-plugin": "1.3.0",
+        "fs-tree-diff": "0.5.7",
+        "lodash.template": "4.4.0",
+        "rimraf": "2.6.2",
+        "walk-sync": "0.3.2"
       },
       "dependencies": {
-        "broccoli-filter": {
-          "version": "0.1.14",
-          "resolved": "https://registry.npmjs.org/broccoli-filter/-/broccoli-filter-0.1.14.tgz",
-          "integrity": "sha1-I8rjiR/567e019sAxtzwNTXa960=",
+        "broccoli-persistent-filter": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz",
+          "integrity": "sha512-JwNLDvvXJlhUmr+CHcbVhCyp33NbCIAITjQZmJY9e8QzANXh3jpFWlhSFvkWghwKA8rTAKcXkW12agtiZjxr4g==",
           "dev": true,
           "requires": {
-            "broccoli-kitchen-sink-helpers": "0.2.9",
-            "broccoli-writer": "0.1.1",
-            "mkdirp": "0.3.5",
+            "async-disk-cache": "1.3.2",
+            "async-promise-queue": "1.0.3",
+            "broccoli-plugin": "1.3.0",
+            "fs-tree-diff": "0.5.7",
+            "hash-for-dep": "1.1.2",
+            "heimdalljs": "0.2.5",
+            "heimdalljs-logger": "0.1.9",
+            "mkdirp": "0.5.1",
             "promise-map-series": "0.2.3",
-            "quick-temp": "0.1.8",
+            "rimraf": "2.6.2",
             "rsvp": "3.6.1",
             "symlink-or-copy": "1.1.8",
-            "walk-sync": "0.1.3"
+            "walk-sync": "0.3.2"
           }
         },
-        "broccoli-kitchen-sink-helpers": {
-          "version": "0.2.9",
-          "resolved": "https://registry.npmjs.org/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz",
-          "integrity": "sha1-peCYbtjXb7WYS2jD8EUNOpbjbsw=",
+        "fs-tree-diff": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.7.tgz",
+          "integrity": "sha512-dJwDX6NBH7IfdfFjZAdHCZ6fIKc8LwR7kzqUhYRFJuX4g9ctG/7cuqJuwegGQsyLEykp6Z4krq+yIFMQlt7d9Q==",
           "dev": true,
           "requires": {
-            "glob": "5.0.15",
-            "mkdirp": "0.5.1"
-          },
-          "dependencies": {
-            "mkdirp": {
-              "version": "0.5.1",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-              "dev": true,
-              "requires": {
-                "minimist": "0.0.8"
-              }
-            }
+            "heimdalljs-logger": "0.1.9",
+            "object-assign": "4.1.1",
+            "path-posix": "1.0.0",
+            "symlink-or-copy": "1.1.8"
           }
         },
-        "lodash.template": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash._basetostring": "3.0.1",
-            "lodash._basevalues": "3.0.0",
-            "lodash._isiterateecall": "3.0.9",
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0",
-            "lodash.keys": "3.1.2",
-            "lodash.restparam": "3.6.1",
-            "lodash.templatesettings": "3.1.1"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
-        "lodash.templatesettings": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0"
+            "glob": "7.1.2"
           }
-        },
-        "mkdirp": {
-          "version": "0.3.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
-          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc=",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.1.3.tgz",
-          "integrity": "sha1-igcmGgC9ps+xviXp8QD61XVG9YM=",
-          "dev": true
         }
       }
     },
@@ -5410,19 +5399,31 @@
       }
     },
     "ember-fetch": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-3.4.4.tgz",
-      "integrity": "sha512-N81LZl/NEaQiK4KnLHuibrIZ7goxuIarrQ+A6ZBE/aQCI2x23IISL/YgX0U4bL2F+9I6Kg9ZO2gI+4tszGQSEQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ember-fetch/-/ember-fetch-5.0.0.tgz",
+      "integrity": "sha1-/FiYABDWJenYbSOMuqvngD/d3Po=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
+        "abortcontroller-polyfill": "1.1.9",
+        "broccoli-concat": "3.2.2",
+        "broccoli-merge-trees": "2.0.0",
         "broccoli-stew": "1.5.0",
-        "broccoli-templater": "1.0.0",
+        "broccoli-templater": "2.0.1",
         "ember-cli-babel": "6.8.2",
         "node-fetch": "2.1.2",
-        "whatwg-fetch": "2.0.3"
+        "yetch": "0.0.1"
       },
       "dependencies": {
+        "broccoli-merge-trees": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
+          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "1.3.0",
+            "merge-trees": "1.0.1"
+          }
+        },
         "node-fetch": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
@@ -10185,18 +10186,6 @@
         "lodash.isarray": "3.0.4"
       }
     },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
-    },
     "lodash._bindcallback": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
@@ -10230,12 +10219,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
     "lodash.assign": {
@@ -10287,15 +10270,6 @@
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",
       "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
       "dev": true
-    },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "3.0.1"
-      }
     },
     "lodash.find": {
       "version": "4.6.0",
@@ -17781,12 +17755,6 @@
       "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
       "dev": true
     },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ=",
-      "dev": true
-    },
     "whatwg-url-compat": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
@@ -18003,6 +17971,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
+    },
+    "yetch": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/yetch/-/yetch-0.0.1.tgz",
+      "integrity": "sha512-Zl5SG98t7zLphqFAFsgXeyQF6i7MvsErop0Kb6CSyjQLR5qNXcvvwwBDKuF4X2m9/HWXgmHX/HPaZuMU1isXaQ==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-exam": "^1.0.0",
     "ember-export-application-global": "^2.0.0",
-    "ember-fetch": "^3.4.3",
+    "ember-fetch": "^5.0.0",
     "ember-keyboard": "^3.0.2",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",


### PR DESCRIPTION
This update gets rid of a broccoli deprecation warning.

see https://github.com/ember-cli/ember-fetch/blob/master/CHANGELOG.md