### PR TITLE
Update Ember to v3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6036,9 +6036,9 @@
       }
     },
     "ember-source": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.18.2.tgz",
-      "integrity": "sha1-ddAO71SIv+UEBEsCXHUrqSTq+H8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.0.0.tgz",
+      "integrity": "sha1-UYEcrpjSzuxTvPuqh20CsrWyFZ8=",
       "dev": true,
       "requires": {
         "broccoli-funnel": "2.0.1",
@@ -6048,7 +6048,6 @@
         "ember-cli-normalize-entity-name": "1.0.0",
         "ember-cli-path-utils": "1.0.0",
         "ember-cli-string-utils": "1.1.0",
-        "ember-cli-test-info": "1.0.0",
         "ember-cli-valid-component-name": "1.0.0",
         "ember-cli-version-checker": "2.1.2",
         "ember-router-generator": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6036,12 +6036,12 @@
       }
     },
     "ember-source": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.17.0.tgz",
-      "integrity": "sha1-t4hx3Um9jWQrgBdt9Pr3/X0Fnaw=",
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-2.18.2.tgz",
+      "integrity": "sha1-ddAO71SIv+UEBEsCXHUrqSTq+H8=",
       "dev": true,
       "requires": {
-        "broccoli-funnel": "1.2.0",
+        "broccoli-funnel": "2.0.1",
         "broccoli-merge-trees": "2.0.0",
         "ember-cli-get-component-path-option": "1.0.0",
         "ember-cli-is-package-missing": "1.0.0",
@@ -6050,14 +6050,34 @@
         "ember-cli-string-utils": "1.1.0",
         "ember-cli-test-info": "1.0.0",
         "ember-cli-valid-component-name": "1.0.0",
-        "ember-cli-version-checker": "2.1.0",
+        "ember-cli-version-checker": "2.1.2",
         "ember-router-generator": "1.2.3",
-        "fs-extra": "4.0.2",
         "inflection": "1.12.0",
-        "jquery": "3.2.1",
+        "jquery": "3.3.1",
         "resolve": "1.3.3"
       },
       "dependencies": {
+        "broccoli-funnel": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "dev": true,
+          "requires": {
+            "array-equal": "1.0.0",
+            "blank-object": "1.0.2",
+            "broccoli-plugin": "1.3.0",
+            "debug": "2.6.8",
+            "fast-ordered-set": "1.0.3",
+            "fs-tree-diff": "0.5.6",
+            "heimdalljs": "0.2.5",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "path-posix": "1.0.0",
+            "rimraf": "2.6.1",
+            "symlink-or-copy": "1.1.8",
+            "walk-sync": "0.3.2"
+          }
+        },
         "broccoli-merge-trees": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
@@ -6069,33 +6089,13 @@
           }
         },
         "ember-cli-version-checker": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz",
-          "integrity": "sha512-ssiNyVTp+PphroFum8guHX9py4xU1PCxkRYgb25NxumgjpKTPjhkgTfpRRKXlIQe+/wVMmhf+Uv6w9vSLZKWKQ==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
+          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
           "dev": true,
           "requires": {
             "resolve": "1.3.3",
             "semver": "5.3.0"
-          }
-        },
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "4.0.0",
-            "universalify": "0.1.0"
-          }
-        },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
           }
         }
       }
@@ -9976,9 +9976,9 @@
       }
     },
     "jquery": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
-      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
       "dev": true
     },
     "js-base64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6036,9 +6036,9 @@
       }
     },
     "ember-source": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.0.0.tgz",
-      "integrity": "sha1-UYEcrpjSzuxTvPuqh20CsrWyFZ8=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.1.2.tgz",
+      "integrity": "sha512-qnVaI3GEZxTQtJVft7xKWJky4e2FJ4dBrAPlDKWVFXkqHfgWdvV1CWpPai0etNI/ANy1MDEnaNXbfY4X00LZQg==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "2.0.1",
@@ -6053,7 +6053,7 @@
         "ember-router-generator": "1.2.3",
         "inflection": "1.12.0",
         "jquery": "3.3.1",
-        "resolve": "1.3.3"
+        "resolve": "1.7.1"
       },
       "dependencies": {
         "broccoli-funnel": {
@@ -6093,8 +6093,17 @@
           "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
           "dev": true,
           "requires": {
-            "resolve": "1.3.3",
+            "resolve": "1.7.1",
             "semver": "5.3.0"
+          }
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-prism": "^0.2.0",
     "ember-resolver": "^4.1.0",
     "ember-router-scroll": "^0.4.0",
-    "ember-source": "~2.17.0",
+    "ember-source": "~2.18.0",
     "ember-svg-jar": "^1.1.1",
     "ember-test-selectors": "^0.3.7",
     "ember-web-app": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-prism": "^0.2.0",
     "ember-resolver": "^4.1.0",
     "ember-router-scroll": "^0.4.0",
-    "ember-source": "~3.0.0",
+    "ember-source": "~3.1.0",
     "ember-svg-jar": "^1.1.1",
     "ember-test-selectors": "^0.3.7",
     "ember-web-app": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ember-prism": "^0.2.0",
     "ember-resolver": "^4.1.0",
     "ember-router-scroll": "^0.4.0",
-    "ember-source": "~2.18.0",
+    "ember-source": "~3.0.0",
     "ember-svg-jar": "^1.1.1",
     "ember-test-selectors": "^0.3.7",
     "ember-web-app": "^2.2.0",


### PR DESCRIPTION
This PR updates `ember-source` to v3.1.2. Since all previous deprecation warnings had been addressed already, this should work without any changes, but will allow us to take advantage of newer features soon. :)