### PR TITLE
Prepare for new rustfmt in 1.27 release

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -7,8 +7,9 @@
 use controllers::prelude::*;
 use models::{Category, Crate, CrateCategory, CrateDownload, CrateKeyword, Keyword, Version};
 use schema::*;
-use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
-            EncodableVersion};
+use views::{
+    EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
+};
 
 use models::krate::ALL_COLUMNS;
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -9,8 +9,10 @@ use url::Url;
 use app::App;
 use util::{human, CargoResult};
 
-use models::{Badge, Category, CrateOwner, Keyword, NewCrateOwnerInvitation, Owner, OwnerKind,
-             ReverseDependency, User, Version};
+use models::{
+    Badge, Category, CrateOwner, Keyword, NewCrateOwnerInvitation, Owner, OwnerKind,
+    ReverseDependency, User, Version,
+};
 use views::{EncodableCrate, EncodableCrateLinks};
 
 use models::helpers::with_count::*;

--- a/src/render.rs
+++ b/src/render.rs
@@ -158,7 +158,8 @@ impl<'a> MarkdownRenderer<'a> {
 
         let use_relative = if let Some(base_url) = base_url {
             if let Ok(url) = Url::parse(base_url) {
-                url.host_str() == Some("github.com") || url.host_str() == Some("gitlab.com")
+                url.host_str() == Some("github.com")
+                    || url.host_str() == Some("gitlab.com")
                     || url.host_str() == Some("bitbucket.org")
             } else {
                 false

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -22,8 +22,10 @@ use {CrateList, CrateMeta, GoodCrate};
 use models::{ApiToken, Category, Crate};
 use schema::{crates, metadata, versions};
 use views::krate_publish as u;
-use views::{EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword,
-            EncodableVersion, EncodableVersionDownload};
+use views::{
+    EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
+    EncodableVersionDownload,
+};
 
 #[derive(Deserialize)]
 struct VersionsList {
@@ -1972,7 +1974,8 @@ fn author_license_and_description_required() {
     req.with_body(&::new_crate_to_body(&new_crate, &[]));
     let json = bad_resp!(middle.call(&mut req));
     assert!(
-        json.errors[0].detail.contains("author") && json.errors[0].detail.contains("description")
+        json.errors[0].detail.contains("author")
+            && json.errors[0].detail.contains("description")
             && json.errors[0].detail.contains("license"),
         "{:?}",
         json.errors
@@ -1983,7 +1986,8 @@ fn author_license_and_description_required() {
     req.with_body(&::new_crate_to_body(&new_crate, &[]));
     let json = bad_resp!(middle.call(&mut req));
     assert!(
-        json.errors[0].detail.contains("author") && json.errors[0].detail.contains("description")
+        json.errors[0].detail.contains("author")
+            && json.errors[0].detail.contains("description")
             && !json.errors[0].detail.contains("license"),
         "{:?}",
         json.errors
@@ -1995,7 +1999,8 @@ fn author_license_and_description_required() {
     req.with_body(&::new_crate_to_body(&new_crate, &[]));
     let json = bad_resp!(middle.call(&mut req));
     assert!(
-        !json.errors[0].detail.contains("author") && json.errors[0].detail.contains("description")
+        !json.errors[0].detail.contains("author")
+            && json.errors[0].detail.contains("description")
             && !json.errors[0].detail.contains("license"),
         "{:?}",
         json.errors

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -8,7 +8,9 @@ use diesel::prelude::*;
 
 use models::{Crate, NewCrateOwnerInvitation};
 use schema::crate_owner_invitations;
-use views::{EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse};
+use views::{
+    EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse,
+};
 
 #[derive(Deserialize)]
 struct TeamResponse {

--- a/src/util/io_util.rs
+++ b/src/util/io_util.rs
@@ -31,7 +31,9 @@ pub fn read_le_u32<R: Read + ?Sized>(r: &mut R) -> io::Result<u32> {
     let mut b = [0; 4];
     read_fill(r, &mut b)?;
     Ok(
-        u32::from(b[0]) | (u32::from(b[1]) << 8) | (u32::from(b[2]) << 16)
+        u32::from(b[0])
+            | (u32::from(b[1]) << 8)
+            | (u32::from(b[2]) << 16)
             | (u32::from(b[3]) << 24),
     )
 }


### PR DESCRIPTION
This is the diff that results from `cargo +beta fmt`.  It will not pass
CI today, but should be mergable via bors after the release tomorrow.