### PR TITLE
Forbid tarballs with hard links being uploaded

### DIFF
--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -271,6 +271,17 @@ fn verify_tarball(
         if !entry.path()?.starts_with(&prefix) {
             return Err(human("invalid tarball uploaded"));
         }
+
+        // Historical versions of the `tar` crate which Cargo uses internally
+        // don't properly prevent hard links from overwriting arbitrary files on
+        // the filesystem.
+        //
+        // As a bit of a hammer we reject any tarball with a hard link. Cargo
+        // doesn't currently ever generate a tarball with a hard link so this
+        // should work for now.
+        if entry.header().entry_type().is_hard_link() {
+            return Err(human("invalid tarball uploaded"));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
It was discovered recently that tarballs with hard links aren't properly handled
in the `tar` crate and can in malicious situations cause any file on the
filesystem to get overwritten during the extraction process. This commit is a
patch for crates.io to simply reject all tarballs which have hard links inside
of them. This is a big hammer of a solution and is step 1 of a fix for this bug.

I've verified that all existing tarballs on crates.io do not contain hard links
and Cargo itself doesn't produce tarballs with hard links inside them. That
means that no legitimate tarball should be rejected as a result of this patch.
After this has been deployed I'll be updating the `tar` crate as well as Cargo
itself, in addition to posting an announcement.