### PR TITLE
frontend: show descriptions in category list

### DIFF
--- a/app/models/category-slug.js
+++ b/app/models/category-slug.js
@@ -2,4 +2,5 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
     slug: DS.attr('string'),
+    description: DS.attr('string'),
 });

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -444,3 +444,13 @@
         float: right;
     }
 }
+
+#category-slugs {
+    dt {
+        margin-bottom: 5px;
+        font-weight: bold;
+    }
+    dd {
+        margin-bottom: 20px;
+    }
+}

--- a/app/templates/category-slugs.hbs
+++ b/app/templates/category-slugs.hbs
@@ -1,15 +1,17 @@
 {{ title 'Category Slugs' }}
 
-<div id='crates-heading'>
-    {{svg-jar "crate"}}
-    <h1>All Valid Category Slugs</h1>
-</div>
+<div id='category-slugs'>
+    <div id='crates-heading'>
+        {{svg-jar "crate"}}
+        <h1>All Valid Category Slugs</h1>
+    </div>
 
-<div class='white-rows'>
-    <dl>
-      {{#each model as |slug|}}
-          <dt>{{slug.slug}}</dt>
-          <dd>{{slug.description}}</dd>
-      {{/each}}
-    </dl>
+    <div class='white-rows'>
+        <dl>
+          {{#each model as |slug|}}
+              <dt>{{slug.slug}}</dt>
+              <dd>{{slug.description}}</dd>
+          {{/each}}
+        </dl>
+    </div>
 </div>

--- a/app/templates/category-slugs.hbs
+++ b/app/templates/category-slugs.hbs
@@ -6,9 +6,10 @@
 </div>
 
 <div class='white-rows'>
-    <ul>
+    <dl>
       {{#each model as |slug|}}
-          <li>{{slug.slug}}</li>
+          <dt>{{slug.slug}}</dt>
+          <dd>{{slug.description}}</dd>
       {{/each}}
-    </ul>
+    </dl>
 </div>

--- a/app/templates/category-slugs.hbs
+++ b/app/templates/category-slugs.hbs
@@ -8,9 +8,9 @@
 
     <div class='white-rows'>
         <dl>
-          {{#each model as |slug|}}
-              <dt>{{slug.slug}}</dt>
-              <dd>{{slug.description}}</dd>
+          {{#each model as |category|}}
+              <dt data-test-category-slug={{category.slug}}>{{category.slug}}</dt>
+              <dd data-test-category-description={{category.slug}}>{{category.description}}</dd>
           {{/each}}
         </dl>
     </div>

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -193,6 +193,17 @@ export default function() {
         return category ? category : notFound();
     });
 
+    this.get('/category_slugs', function(schema) {
+        let allCategories = schema.categories.all().sort((a, b) => compareStrings(a.category, b.category));
+        return {
+            category_slugs: this.serialize(allCategories).categories.map(cat => ({
+                id: cat.id,
+                slug: cat.slug,
+                description: cat.description,
+            })),
+        };
+    });
+
     this.get('/keywords', function(schema, request) {
         let { start, end } = pageParams(request);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7556,6 +7556,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
@@ -9657,7 +9658,8 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -9793,6 +9795,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -9937,7 +9940,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isbinaryfile": {
       "version": "3.0.2",
@@ -9955,6 +9959,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -10348,6 +10353,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -10996,7 +11002,8 @@
     "math-random": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+      "dev": true
     },
     "md5-hex": {
       "version": "2.0.0",
@@ -15245,9 +15252,9 @@
       }
     },
     "qunit-dom": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/qunit-dom/-/qunit-dom-0.6.3.tgz",
-      "integrity": "sha1-9tdWMhgXnE8O+F+UC7eeEGMcFP8=",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/qunit-dom/-/qunit-dom-0.7.1.tgz",
+      "integrity": "sha512-8mwF7taWSqDrVRYHgp98nJmoTeE2z37K7RmHjV18pX0YoGxaJSYg+y1bRE0h3tsjSMs85W9gL/WR62yfoQN3VA==",
       "dev": true,
       "requires": {
         "broccoli-funnel": "^2.0.0",
@@ -15291,6 +15298,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "dev": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -15300,12 +15308,14 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -15556,12 +15566,14 @@
     "repeat-element": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+      "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "normalize.css": "^7.0.0",
     "nyc": "^11.6.0",
     "prettier": "^1.13.4",
-    "qunit-dom": "^0.6.3",
+    "qunit-dom": "^0.7.1",
     "timekeeper": "^2.1.0"
   },
   "engines": {

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -69,7 +69,7 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
 pub fn slugs(req: &mut dyn Request) -> CargoResult<Response> {
     let conn = req.db_conn()?;
     let slugs = categories::table
-        .select((categories::slug, categories::slug))
+        .select((categories::slug, categories::slug, categories::description))
         .order(categories::slug)
         .load(&*conn)?;
 
@@ -77,6 +77,7 @@ pub fn slugs(req: &mut dyn Request) -> CargoResult<Response> {
     struct Slug {
         id: String,
         slug: String,
+        description: String,
     }
 
     #[derive(Serialize)]

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -134,11 +134,14 @@ impl Category {
     }
 }
 
+/// Struct for inserting categories; only used in tests. Actual categories are inserted
+/// in src/boot/categories.rs.
 #[derive(Insertable, AsChangeset, Default, Debug)]
 #[table_name = "categories"]
 pub struct NewCategory<'a> {
     pub category: &'a str,
     pub slug: &'a str,
+    pub description: &'a str,
 }
 
 impl<'a> NewCategory<'a> {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -531,10 +531,11 @@ fn new_dependency(conn: &PgConnection, version: &Version, krate: &Crate) -> Depe
         .unwrap()
 }
 
-fn new_category<'a>(category: &'a str, slug: &'a str) -> NewCategory<'a> {
+fn new_category<'a>(category: &'a str, slug: &'a str, description: &'a str) -> NewCategory<'a> {
     NewCategory {
-        category: category,
-        slug: slug,
+        category,
+        slug,
+        description,
     }
 }
 

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -38,10 +38,10 @@ fn index() {
     // Create a category and a subcategory
     {
         let conn = t!(app.diesel_database.get());
-        ::new_category("foo", "foo")
+        ::new_category("foo", "foo", "Foo crates")
             .create_or_update(&conn)
             .unwrap();
-        ::new_category("foo::bar", "foo::bar")
+        ::new_category("foo::bar", "foo::bar", "Bar crates")
             .create_or_update(&conn)
             .unwrap();
     }
@@ -68,8 +68,8 @@ fn show() {
     {
         let conn = t!(app.diesel_database.get());
 
-        t!(::new_category("Foo Bar", "foo-bar").create_or_update(&conn));
-        t!(::new_category("Foo Bar::Baz", "foo-bar::baz").create_or_update(&conn));
+        t!(::new_category("Foo Bar", "foo-bar", "Foo Bar crates").create_or_update(&conn));
+        t!(::new_category("Foo Bar::Baz", "foo-bar::baz", "Baz crates").create_or_update(&conn));
     }
 
     // The category and its subcategories should be in the json
@@ -96,8 +96,8 @@ fn update_crate() {
     let krate = {
         let conn = t!(app.diesel_database.get());
         let user = t!(::new_user("foo").create_or_update(&conn));
-        t!(::new_category("cat1", "cat1").create_or_update(&conn));
-        t!(::new_category("Category 2", "category-2").create_or_update(&conn));
+        t!(::new_category("cat1", "cat1", "Category 1 crates").create_or_update(&conn));
+        t!(::new_category("Category 2", "category-2", "Category 2 crates").create_or_update(&conn));
         ::CrateBuilder::new("foo_crate", user.id).expect_build(&conn)
     };
 
@@ -161,7 +161,7 @@ fn update_crate() {
     // Add a category and its subcategory
     {
         let conn = t!(app.diesel_database.get());
-        t!(::new_category("cat1::bar", "cat1::bar").create_or_update(&conn,));
+        t!(::new_category("cat1::bar", "cat1::bar", "bar crates").create_or_update(&conn,));
         Category::update_crate(&conn, &krate, &["cat1", "cat1::bar"]).unwrap();
     }
     assert_eq!(cnt!(&mut req, "cat1"), 1);
@@ -174,10 +174,10 @@ fn category_slugs_returns_all_slugs_in_alphabetical_order() {
     let (_b, app, middle) = ::app();
     {
         let conn = app.diesel_database.get().unwrap();
-        ::new_category("Foo", "foo")
+        ::new_category("Foo", "foo", "For crates that foo")
             .create_or_update(&conn)
             .unwrap();
-        ::new_category("Bar", "bar")
+        ::new_category("Bar", "bar", "For crates that bar")
             .create_or_update(&conn)
             .unwrap();
     }
@@ -188,6 +188,7 @@ fn category_slugs_returns_all_slugs_in_alphabetical_order() {
     struct Slug {
         id: String,
         slug: String,
+        description: String,
     }
 
     #[derive(Deserialize, Debug, PartialEq)]
@@ -201,10 +202,12 @@ fn category_slugs_returns_all_slugs_in_alphabetical_order() {
             Slug {
                 id: "bar".into(),
                 slug: "bar".into(),
+                description: "For crates that bar".into(),
             },
             Slug {
                 id: "foo".into(),
                 slug: "foo".into(),
+                description: "For crates that foo".into(),
             },
         ],
     };

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -182,10 +182,10 @@ fn index_queries() {
 
     {
         let conn = app.diesel_database.get().unwrap();
-        ::new_category("Category 1", "cat1")
+        ::new_category("Category 1", "cat1", "Category 1 crates")
             .create_or_update(&conn)
             .unwrap();
-        ::new_category("Category 1::Ba'r", "cat1::bar")
+        ::new_category("Category 1::Ba'r", "cat1::bar", "Ba'r crates")
             .create_or_update(&conn)
             .unwrap();
         Category::update_crate(&conn, &krate, &["cat1"]).unwrap();
@@ -1056,7 +1056,7 @@ fn summary_new_crates() {
             .downloads(1000)
             .expect_build(&conn);
 
-        ::new_category("Category 1", "cat1")
+        ::new_category("Category 1", "cat1", "Category 1 crates")
             .create_or_update(&conn)
             .unwrap();
         Category::update_crate(&conn, &krate, &["cat1"]).unwrap();
@@ -1685,7 +1685,7 @@ fn good_categories() {
     ::sign_in(&mut req, &app);
     {
         let conn = app.diesel_database.get().unwrap();
-        ::new_category("Category 1", "cat1")
+        ::new_category("Category 1", "cat1", "Category 1 crates")
             .create_or_update(&conn)
             .unwrap();
     }
@@ -2135,7 +2135,7 @@ fn test_default_sort_recent() {
 
     {
         let conn = app.diesel_database.get().unwrap();
-        ::new_category("Animal", "animal")
+        ::new_category("Animal", "animal", "animal crates")
             .create_or_update(&conn)
             .unwrap();
         Category::update_crate(&conn, &green_crate, &["animal"]).unwrap();

--- a/tests/acceptance/categories-test.js
+++ b/tests/acceptance/categories-test.js
@@ -53,4 +53,16 @@ module('Acceptance | categories', function(hooks) {
 
         assert.dom('[data-test-category-sort] [data-test-current-order]').hasText('Recent Downloads');
     });
+
+    test('listing category slugs', async function(assert) {
+        this.server.create('category', { category: 'Algorithms', description: 'Crates for algorithms' });
+        this.server.create('category', { category: 'Asynchronous', description: 'Async crates' });
+
+        await visit('/category_slugs');
+
+        assert.dom('[data-test-category-slug="algorithms"]').hasText('algorithms');
+        assert.dom('[data-test-category-description="algorithms"]').hasText('Crates for algorithms');
+        assert.dom('[data-test-category-slug="asynchronous"]').hasText('asynchronous');
+        assert.dom('[data-test-category-description="asynchronous"]').hasText('Async crates');
+    });
 });


### PR DESCRIPTION
The manifest documentation https://doc.rust-lang.org/cargo/reference/manifest.html
suggests https://crates.io/category_slugs as a list of all categories, but this
is a fairly terse list of nouns presently. The description is useful for making
an informed decision about which categories apply.