### PR TITLE
Don't consider yanked versions for `max_version` on Search

### DIFF
--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -7,7 +7,7 @@ use std::cmp;
 
 use controllers::prelude::*;
 
-use models::{Crate, Version, VersionDownload};
+use models::{Crate, CrateVersions, Version, VersionDownload};
 use schema::version_downloads;
 use views::EncodableVersionDownload;
 
@@ -22,7 +22,7 @@ pub fn downloads(req: &mut Request) -> CargoResult<Response> {
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
 
-    let mut versions = Version::belonging_to(&krate).load::<Version>(&*conn)?;
+    let mut versions = krate.all_versions().load::<Version>(&*conn)?;
     versions.sort_by(|a, b| b.num.cmp(&a.num));
     let (latest_five, rest) = versions.split_at(cmp::min(5, versions.len()));
 

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -4,7 +4,7 @@ use diesel_full_text_search::*;
 
 use controllers::helpers::Paginate;
 use controllers::prelude::*;
-use models::{Crate, CrateBadge, OwnerKind, Version};
+use models::{Crate, CrateBadge, CrateVersions, OwnerKind, Version};
 use schema::*;
 use views::EncodableCrate;
 
@@ -159,7 +159,8 @@ pub fn search(req: &mut Request) -> CargoResult<Response> {
         .collect::<Vec<_>>();
     let crates = data.into_iter().map(|((c, _, _), _)| c).collect::<Vec<_>>();
 
-    let versions = Version::belonging_to(&crates)
+    let versions = crates
+        .versions()
         .load::<Version>(&*conn)?
         .grouped_by(&crates)
         .into_iter()

--- a/src/controllers/version/mod.rs
+++ b/src/controllers/version/mod.rs
@@ -6,7 +6,7 @@ pub mod yank;
 use super::prelude::*;
 use semver;
 
-use models::{Crate, Version};
+use models::{Crate, CrateVersions, Version};
 use schema::versions;
 
 fn version_and_crate(req: &mut Request) -> CargoResult<(Version, Crate)> {
@@ -17,7 +17,8 @@ fn version_and_crate(req: &mut Request) -> CargoResult<(Version, Crate)> {
     };
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
-    let version = Version::belonging_to(&krate)
+    let version = krate
+        .all_versions()
         .filter(versions::num.eq(semver))
         .first(&*conn)
         .map_err(|_| {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -6,7 +6,7 @@ pub use self::download::VersionDownload;
 pub use self::email::{Email, NewEmail};
 pub use self::follow::Follow;
 pub use self::keyword::{CrateKeyword, Keyword};
-pub use self::krate::{Crate, CrateDownload, NewCrate};
+pub use self::krate::{Crate, CrateDownload, CrateVersions, NewCrate};
 pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::rights::Rights;
 pub use self::team::{NewTeam, Team};

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -420,6 +420,28 @@ fn show() {
 }
 
 #[test]
+fn yanked_versions_are_not_considered_for_max_version() {
+    let (_b, app, middle) = ::app();
+
+    {
+        let conn = app.diesel_database.get().unwrap();
+        let user = ::new_user("foo").create_or_update(&conn).unwrap();
+
+        ::CrateBuilder::new("foo_yanked_version", user.id)
+            .description("foo")
+            .version("1.0.0")
+            .version(::VersionBuilder::new("1.1.0").yanked(true))
+            .expect_build(&conn);
+    }
+
+    let mut req = ::req(app, Method::Get, "/api/v1/crates");
+    let mut response = ok_resp!(middle.call(req.with_query("q=foo")));
+    let json: CrateList = ::json(&mut response);
+    assert_eq!(json.meta.total, 1);
+    assert_eq!(json.crates[0].max_version, "1.0.0");
+}
+
+#[test]
 fn versions() {
     let (_b, app, middle) = ::app();
 


### PR DESCRIPTION
Since this seems likely to creep up again, I've added a canonical
`versions` method to both `Crate` and `Vec<Crate>` which filters out
yanked versions, and a separate `all_versions` which includes yanked
versions. I've gone through all uses of `Version::belonging_to` to make
sure that these methods are used instead.

I'm tempted to remove the association entirely to force this function to
be used instead, but if I did that we'd lose the ability to use
`grouped_by`, which is a lot of code to replace.

In one case, this required adding an additional temporary, since the
trait appears to be confusing the borrow checker (I'm not sure why the
temporary is required now, but wasn't before -- the same lifetime is
appearing on a type in the same positions. I suspect it's a borrow
checker bug that would fall under the blanket of "fixed by MIR borrowck"
bugs)

Fixes #1452.