### PR TITLE
Add list of category slugs to docs menu

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -51,6 +51,7 @@
                 <li><a href='https://doc.rust-lang.org/cargo/reference/source-replacement.html'>Source Replacement</a></li>
                 <li><a href='https://doc.rust-lang.org/cargo/reference/external-tools.html'>External Tools</a></li>
                 <li>{{#link-to 'policies'}}Policies{{/link-to}}</li>
+                <li>{{#link-to 'category-slugs'}}List of category slugs{{/link-to}}</li>
             {{/rl-dropdown}}
         {{/rl-dropdown-container}}
         <span class="sep">|</span>


### PR DESCRIPTION
Previously the category slug list wasn't linked from anywhere on
crates.io.