### PR TITLE
Allow a new macro hygiene lint until we get Diesel 1.4

### DIFF
--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![allow(unknown_lints, proc_macro_derive_resolution_fallback)] // This can be removed after diesel-1.4
 
 extern crate cargo_registry;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![deny(missing_debug_implementations, missing_copy_implementations)]
 #![deny(bare_trait_objects)]
 #![recursion_limit = "128"]
+#![allow(unknown_lints, proc_macro_derive_resolution_fallback)] // This can be removed after diesel-1.4
 
 extern crate ammonia;
 extern crate chrono;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![allow(unknown_lints, proc_macro_derive_resolution_fallback)] // This can be removed after diesel-1.4
 
 extern crate cargo_registry;
 extern crate chrono;


### PR DESCRIPTION
Because we deny warnings, this new lint will cause our CI to fail once
it hits beta.  Allowing `unknown_lints` is necessary because
stable-1.28 isn't aware of this lint.

This patch can be reverted as part of upgrading to Diesel 1.4 once that
is released.  See the [upstream PR] for more information.

[upstream PR]: https://github.com/diesel-rs/diesel/pull/1787