### PR TITLE
Apply formatting changes from rustfmt-preview on 1.28

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ matrix:
     - rust: stable
       script:
         - rustup component add rustfmt-preview
-        - cargo fmt -- --write-mode=diff
+        - cargo fmt -- --check
         - cargo build
         - cargo test
         - npm install

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -40,7 +40,8 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
     let cat = categories::table
         .filter(categories::slug.eq(::lower(slug)))
         .first::<Category>(&*conn)?;
-    let subcats = cat.subcategories(&conn)?
+    let subcats = cat
+        .subcategories(&conn)?
         .into_iter()
         .map(Category::encodable)
         .collect();

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -25,7 +25,8 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
         .paginate(limit, offset)
         .load::<(Keyword, i64)>(&*conn)?;
     let total = data.get(0).map(|&(_, t)| t).unwrap_or(0);
-    let kws = data.into_iter()
+    let kws = data
+        .into_iter()
         .map(|(k, _)| k.encodable())
         .collect::<Vec<_>>();
 

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -160,7 +160,8 @@ pub fn readme(req: &mut dyn Request) -> CargoResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let version = &req.params()["version"];
 
-    let redirect_url = req.app()
+    let redirect_url = req
+        .app()
         .config
         .uploader
         .readme_location(crate_name, version)

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -88,7 +88,8 @@ pub fn publish(req: &mut dyn Request) -> CargoResult<Response> {
             )));
         }
 
-        let length = req.content_length()
+        let length = req
+            .content_length()
             .chain_error(|| human("missing header: Content-Length"))?;
         let max = krate
             .max_upload_size
@@ -134,7 +135,8 @@ pub fn publish(req: &mut dyn Request) -> CargoResult<Response> {
         // If the git commands fail below, we shouldn't keep the crate on the
         // server.
         let max_unpack = cmp::max(app.config.max_unpack_size, max);
-        let (cksum, mut crate_bomb, mut readme_bomb) = app.config
+        let (cksum, mut crate_bomb, mut readme_bomb) = app
+            .config
             .uploader
             .upload_crate(req, &krate, readme, max, max_unpack, vers)?;
         version.record_readme_rendering(&conn)?;

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -156,7 +156,8 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
         .load::<((Crate, bool, Option<i64>), i64)>(&*conn)?;
     let total = data.first().map(|&(_, t)| t).unwrap_or(0);
     let perfect_matches = data.iter().map(|&((_, b, _), _)| b).collect::<Vec<_>>();
-    let recent_downloads = data.iter()
+    let recent_downloads = data
+        .iter()
         .map(|&((_, _, s), _)| s.unwrap_or(0))
         .collect::<Vec<_>>();
     let crates = data.into_iter().map(|((c, _, _), _)| c).collect::<Vec<_>>();

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -42,7 +42,8 @@ pub fn new(req: &mut dyn Request) -> CargoResult<Response> {
     }
 
     let max_size = 2000;
-    let length = req.content_length()
+    let length = req
+        .content_length()
         .chain_error(|| bad_request("missing header: Content-Length"))?;
 
     if length > max_size {

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -67,11 +67,13 @@ pub fn updates(req: &mut dyn Request) -> CargoResult<Response> {
         .paginate(limit, offset)
         .load::<((Version, String), i64)>(&*conn)?;
 
-    let more = data.get(0)
+    let more = data
+        .get(0)
         .map(|&(_, count)| count > offset + limit)
         .unwrap_or(false);
 
-    let versions = data.into_iter()
+    let versions = data
+        .into_iter()
         .map(|((version, crate_name), _)| version.encodable(&crate_name))
         .collect();
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -94,7 +94,8 @@ pub fn github_access_token(req: &mut dyn Request) -> CargoResult<Response> {
     }
 
     // Fetch the access token from github using the code we just got
-    let token = req.app()
+    let token = req
+        .app()
         .github
         .exchange(code.clone())
         .map_err(|s| human(&s))?;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -30,7 +30,8 @@ pub fn download(req: &mut dyn Request) -> CargoResult<Response> {
         increment_download_counts(req, crate_name, version)?;
     }
 
-    let redirect_url = req.app()
+    let redirect_url = req
+        .app()
         .config
         .uploader
         .crate_location(crate_name, version)
@@ -69,7 +70,8 @@ fn increment_download_counts(
 pub fn downloads(req: &mut dyn Request) -> CargoResult<Response> {
     let (version, _) = version_and_crate(req)?;
     let conn = req.db_conn()?;
-    let cutoff_end_date = req.query()
+    let cutoff_end_date = req
+        .query()
         .get("before_date")
         .and_then(|d| NaiveDate::parse_from_str(d, "%F").ok())
         .unwrap_or_else(|| Utc::today().naive_utc());

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -22,7 +22,8 @@ pub fn dependencies(req: &mut dyn Request) -> CargoResult<Response> {
     let (version, _) = version_and_crate(req)?;
     let conn = req.db_conn()?;
     let deps = version.dependencies(&*conn)?;
-    let deps = deps.into_iter()
+    let deps = deps
+        .into_iter()
         .map(|(dep, crate_name)| dep.encodable(&crate_name, None))
         .collect();
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -5,9 +5,9 @@ use dotenv::dotenv;
 use util::{bad_request, CargoResult};
 
 use lettre::file::FileEmailTransport;
-use lettre::EmailTransport;
-use lettre::smtp::SmtpTransport;
 use lettre::smtp::authentication::{Credentials, Mechanism};
+use lettre::smtp::SmtpTransport;
+use lettre::EmailTransport;
 
 use lettre_email::{Email, EmailBuilder};
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -37,7 +37,8 @@ pub struct Dependency {
 }
 
 fn index_file(base: &Path, name: &str) -> PathBuf {
-    let name = name.chars()
+    let name = name
+        .chars()
         .flat_map(|c| c.to_lowercase())
         .collect::<String>();
     match name.len() {
@@ -86,7 +87,8 @@ pub fn yank(app: &App, krate: &str, version: &semver::Version, yanked: bool) -> 
     commit_and_push(&repo, || {
         let mut prev = String::new();
         File::open(&dst).and_then(|mut f| f.read_to_string(&mut prev))?;
-        let new = prev.lines()
+        let new = prev
+            .lines()
             .map(|line| {
                 let mut git_crate = serde_json::from_str::<Crate>(line)
                     .map_err(|_| internal(&format_args!("couldn't decode: `{}`", line)))?;
@@ -146,7 +148,8 @@ where
         // git add $file
         let mut index = repo.index()?;
         let mut repo_path = repo_path.iter();
-        let dst = dst.iter()
+        let dst = dst
+            .iter()
             .skip_while(|s| Some(*s) == repo_path.next())
             .collect::<PathBuf>();
         index.add_path(&dst)?;

--- a/src/middleware/blacklist_ips.rs
+++ b/src/middleware/blacklist_ips.rs
@@ -27,7 +27,8 @@ impl AroundMiddleware for BlockIps {
 
 impl Handler for BlockIps {
     fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
-        let has_blacklisted_ip = req.headers()
+        let has_blacklisted_ip = req
+            .headers()
             .find("X-Forwarded-For")
             .unwrap()
             .iter()

--- a/src/middleware/ember_index_rewrite.rs
+++ b/src/middleware/ember_index_rewrite.rs
@@ -27,7 +27,8 @@ impl Handler for EmberIndexRewrite {
     fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
         // If the client is requesting html, then we've only got one page so
         // rewrite the request.
-        let wants_html = req.headers()
+        let wants_html = req
+            .headers()
             .find("Accept")
             .map(|accept| accept.iter().any(|s| s.contains("html")))
             .unwrap_or(false);

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -81,7 +81,8 @@ pub fn add_dependencies(
     use self::dependencies::dsl::*;
     use diesel::insert_into;
 
-    let git_and_new_dependencies = deps.iter()
+    let git_and_new_dependencies = deps
+        .iter()
         .map(|dep| {
             let krate = Crate::by_name(&dep.name)
                 .first::<Crate>(&*conn)

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -55,7 +55,8 @@ impl Keyword {
             return false;
         }
         name.chars().next().unwrap().is_alphanumeric()
-            && name.chars()
+            && name
+                .chars()
                 .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
             && name.chars().all(|c| c.is_ascii())
     }

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -255,7 +255,8 @@ impl Crate {
 
     fn valid_ident(name: &str) -> bool {
         Self::valid_feature_name(name)
-            && name.chars()
+            && name
+                .chars()
                 .nth(0)
                 .map(char::is_alphabetic)
                 .unwrap_or(false)
@@ -263,7 +264,8 @@ impl Crate {
 
     pub fn valid_feature_name(name: &str) -> bool {
         !name.is_empty()
-            && name.chars()
+            && name
+                .chars()
                 .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
             && name.chars().all(|c| c.is_ascii())
     }
@@ -390,7 +392,8 @@ impl Crate {
     pub fn max_version(&self, conn: &PgConnection) -> CargoResult<semver::Version> {
         use schema::versions::dsl::*;
 
-        let vs = self.versions()
+        let vs = self
+            .versions()
             .select(num)
             .load::<String>(conn)?
             .into_iter()

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -329,7 +329,8 @@ impl<'a> VersionBuilder<'a> {
                 .get_result(connection)?;
         }
 
-        let new_deps = self.dependencies
+        let new_deps = self
+            .dependencies
             .into_iter()
             .map(|(crate_id, target)| {
                 (
@@ -429,7 +430,8 @@ impl<'a> CrateBuilder<'a> {
     fn build(mut self, connection: &PgConnection) -> CargoResult<Crate> {
         use diesel::{insert_into, select, update};
 
-        let mut krate = self.krate
+        let mut krate = self
+            .krate
             .create_or_update(connection, None, self.owner_id)?;
 
         // Since we are using `NewCrate`, we can't set all the
@@ -732,10 +734,7 @@ fn new_crate_to_body_with_io(
     new_crate_to_body_with_tarball(new_crate, &tarball)
 }
 
-fn new_crate_to_body_with_tarball(
-    new_crate: &u::NewCrate,
-    tarball: &[u8],
-) -> Vec<u8> {
+fn new_crate_to_body_with_tarball(new_crate: &u::NewCrate, tarball: &[u8]) -> Vec<u8> {
     let json = serde_json::to_string(&new_crate).unwrap();
     let mut body = Vec::new();
     body.extend(

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -6,14 +6,14 @@ use std::io;
 use std::io::prelude::*;
 use std::sync::Arc;
 
+use self::diesel::prelude::*;
 use chrono::Utc;
 use conduit::{Handler, Method};
 use diesel::dsl::*;
 use diesel::update;
-use flate2::Compression;
 use flate2::write::GzEncoder;
+use flate2::Compression;
 use git2;
-use self::diesel::prelude::*;
 use semver;
 use serde_json;
 use tar;

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -717,10 +717,12 @@ fn test_confirm_user_email() {
             .unwrap()
     };
 
-    let mut response = ok_resp!(middle.call(req.with_path(&format!(
-        "/api/v1/confirm/{}",
-        email_token
-    )).with_method(Method::Put),));
+    let mut response = ok_resp!(
+        middle.call(
+            req.with_path(&format!("/api/v1/confirm/{}", email_token))
+                .with_method(Method::Put),
+        )
+    );
     assert!(::json::<S>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));


### PR DESCRIPTION
This will fail on stable until the 1.28 release on Thursday.  At that point, bors should be able to merge this.

The command run on CI is now `cargo fmt -- --check`.