### PR TITLE
Add wildcard lifetimes where they were previously elided

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -274,7 +274,7 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
 
 /// Search an entry by its path in a Tar archive.
 fn find_file_by_path<R: Read>(
-    entries: &mut tar::Entries<R>,
+    entries: &mut tar::Entries<'_, R>,
     path: &Path,
     version: &Version,
     krate_name: &str,

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -32,7 +32,7 @@ impl<T> QueryFragment<Pg> for Paginated<T>
 where
     T: QueryFragment<Pg>,
 {
-    fn walk_ast(&self, mut out: AstPass<Pg>) -> QueryResult<()> {
+    fn walk_ast(&self, mut out: AstPass<'_, Pg>) -> QueryResult<()> {
         out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
         self.query.walk_ast(out.reborrow())?;
         out.push_sql(") t LIMIT ");

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -63,7 +63,7 @@ impl Handler for LogRequests {
 struct FullPath<'a>(&'a dyn Request);
 
 impl<'a> fmt::Display for FullPath<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.path())?;
         if let Some(q_string) = self.0.query_string() {
             write!(f, "?{}", q_string)?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -236,11 +236,11 @@ impl<'a> NewCrate<'a> {
 }
 
 impl Crate {
-    pub fn with_name(name: &str) -> WithName {
+    pub fn with_name(name: &str) -> WithName<'_> {
         canon_crate_name(crates::name).eq(canon_crate_name(name))
     }
 
-    pub fn by_name(name: &str) -> ByName {
+    pub fn by_name(name: &str) -> ByName<'_> {
         Crate::all().filter(Self::with_name(name))
     }
 
@@ -557,27 +557,27 @@ mod tests {
 }
 
 pub trait CrateVersions {
-    fn versions(&self) -> versions::BoxedQuery<Pg> {
+    fn versions(&self) -> versions::BoxedQuery<'_, Pg> {
         self.all_versions().filter(versions::yanked.eq(false))
     }
 
-    fn all_versions(&self) -> versions::BoxedQuery<Pg>;
+    fn all_versions(&self) -> versions::BoxedQuery<'_, Pg>;
 }
 
 impl CrateVersions for Crate {
-    fn all_versions(&self) -> versions::BoxedQuery<Pg> {
+    fn all_versions(&self) -> versions::BoxedQuery<'_, Pg> {
         Version::belonging_to(self).into_boxed()
     }
 }
 
 impl CrateVersions for Vec<Crate> {
-    fn all_versions(&self) -> versions::BoxedQuery<Pg> {
+    fn all_versions(&self) -> versions::BoxedQuery<'_, Pg> {
         self.as_slice().all_versions()
     }
 }
 
 impl CrateVersions for [Crate] {
-    fn all_versions(&self) -> versions::BoxedQuery<Pg> {
+    fn all_versions(&self) -> versions::BoxedQuery<'_, Pg> {
         Version::belonging_to(self).into_boxed()
     }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -216,7 +216,7 @@ where
 
 static NEXT_ID: AtomicUsize = ATOMIC_USIZE_INIT;
 
-fn new_user(login: &str) -> NewUser {
+fn new_user(login: &str) -> NewUser<'_> {
     NewUser {
         gh_id: NEXT_ID.fetch_add(1, Ordering::SeqCst) as i32,
         gh_login: login,
@@ -239,7 +239,7 @@ fn user(login: &str) -> User {
     }
 }
 
-fn new_team(login: &str) -> NewTeam {
+fn new_team(login: &str) -> NewTeam<'_> {
     NewTeam {
         github_id: NEXT_ID.fetch_add(1, Ordering::SeqCst) as i32,
         login: login,
@@ -368,7 +368,7 @@ struct CrateBuilder<'a> {
 }
 
 impl<'a> CrateBuilder<'a> {
-    fn new(name: &str, owner_id: i32) -> CrateBuilder {
+    fn new(name: &str, owner_id: i32) -> CrateBuilder<'_> {
         CrateBuilder {
             owner_id: owner_id,
             krate: NewCrate {
@@ -558,7 +558,11 @@ fn logout(req: &mut Request) {
     req.mut_extensions().pop::<User>();
 }
 
-fn request_with_user_and_mock_crate(app: &Arc<App>, user: &NewUser, krate: &str) -> MockRequest {
+fn request_with_user_and_mock_crate(
+    app: &Arc<App>,
+    user: &NewUser<'_>,
+    krate: &str,
+) -> MockRequest {
     let mut req = new_req(Arc::clone(app), krate, "1.0.0");
     {
         let conn = app.diesel_database.get().unwrap();

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -329,7 +329,7 @@ fn replay_http(
 }
 
 impl GhUser {
-    pub fn user(&'static self) -> NewUser {
+    pub fn user(&'static self) -> NewUser<'_> {
         self.init.call_once(|| self.init());
         let mut u = ::new_user(self.login);
         u.gh_access_token = Cow::Owned(self.token());

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -42,7 +42,7 @@ pub trait CargoError: Send + fmt::Display + 'static {
 }
 
 impl fmt::Debug for Box<dyn CargoError> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self, f)
     }
 }
@@ -150,7 +150,7 @@ impl<E: CargoError> CargoError for ChainedError<E> {
 }
 
 impl<E: CargoError> fmt::Display for ChainedError<E> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} caused by {}", self.error, self.cause)
     }
 }
@@ -173,7 +173,7 @@ impl<E: Any + Error + Send + 'static> From<E> for Box<dyn CargoError> {
             }
         }
         impl<E: fmt::Display> fmt::Display for Shim<E> {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 self.0.fmt(f)
             }
         }
@@ -210,7 +210,7 @@ struct ConcreteCargoError {
 }
 
 impl fmt::Display for ConcreteCargoError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description)?;
         if let Some(ref s) = self.detail {
             write!(f, " ({})", s)?;
@@ -251,7 +251,7 @@ impl CargoError for NotFound {
 }
 
 impl fmt::Display for NotFound {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "Not Found".fmt(f)
     }
 }
@@ -276,7 +276,7 @@ impl CargoError for Unauthorized {
 }
 
 impl fmt::Display for Unauthorized {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "must be logged in to perform that action".fmt(f)
     }
 }
@@ -300,7 +300,7 @@ impl CargoError for BadRequest {
 }
 
 impl fmt::Display for BadRequest {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }
@@ -352,7 +352,7 @@ pub fn std_error(e: Box<dyn CargoError>) -> Box<dyn Error + Send> {
         }
     }
     impl fmt::Display for E {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{}", self.0)?;
 
             let mut err = &*self.0;

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -28,7 +28,7 @@ impl<'a> Request for RequestProxy<'a> {
     fn scheme(&self) -> conduit::Scheme {
         self.other.scheme()
     }
-    fn host(&self) -> conduit::Host {
+    fn host(&self) -> conduit::Host<'_> {
         self.other.host()
     }
     fn virtual_root(&self) -> Option<&str> {

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -221,7 +221,7 @@ use diesel::sql_types::Text;
 use std::io::Write;
 
 impl ToSql<Text, Pg> for Feature {
-    fn to_sql<W: Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
+    fn to_sql<W: Write>(&self, out: &mut Output<'_, W, Pg>) -> serialize::Result {
         ToSql::<Text, Pg>::to_sql(&**self, out)
     }
 }


### PR DESCRIPTION
This diff was created with the following commands:

    RUSTFLAGS="-W elided_lifetimes_in_paths" cargo +nightly fix
    cargo +stable fmt