### PR TITLE
[do not merge] Attempt to write a test that sends a request with two slashes

### DIFF
--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -2381,3 +2381,15 @@ fn new_krate_hard_links() {
     let body = ::new_crate_to_body_with_tarball(&::new_crate("foo", "1.1.0"), &tarball);
     bad_resp!(middle.call(req.with_body(&body)));
 }
+
+#[test]
+fn double_slash_in_publish_urls() {
+    // Turns out `cargo publish` actually makes a request to `crates.io//api/v1/crates/new`,
+    // so we should be testing that.
+    let (_b, app, middle) = ::app();
+    let mut req = ::req(app, Method::Put, "//api/v1/crates/new");
+    let new_crate = ::new_crate("foo_double_slash", "1.0.0");
+    req.with_body(&::new_crate_to_body(&new_crate, &[]));
+    let mut response = ok_resp!(middle.call(&mut req));
+    ::json::<GoodCrate>(&mut response);
+}


### PR DESCRIPTION
@jtgeibel I tried to write a test that publishes to `//api/v1/crates/new` because that's what cargo does, but it fails even without your switch to hyper??? I don't know if our test infrastructure is different than the real stack or if I messed something up or what, but I wanted to give this to you in case it was useful at all.