### PR TITLE
Blacklist reserved keywords as crates name

### DIFF
--- a/migrations/2018-09-04-151653_delete_crates_with_blacklisted_names/down.sql
+++ b/migrations/2018-09-04-151653_delete_crates_with_blacklisted_names/down.sql
@@ -1,0 +1,1 @@
+-- Nothing to do

--- a/migrations/2018-09-04-151653_delete_crates_with_blacklisted_names/up.sql
+++ b/migrations/2018-09-04-151653_delete_crates_with_blacklisted_names/up.sql
@@ -1,0 +1,7 @@
+DELETE FROM crates WHERE name IN (
+    'abstract', 'alignof', 'as', 'become', 'box', 'break', 'const', 'continue', 'crate', 'do',
+    'else', 'enum', 'extern', 'false', 'final', 'fn', 'for', 'if', 'impl', 'in', 'let', 'loop',
+    'macro', 'match', 'mod', 'move', 'mut', 'offsetof', 'override', 'priv', 'proc', 'pub',
+    'pure', 'ref', 'return', 'self', 'sizeof', 'static', 'struct', 'super', 'test', 'trait',
+    'true', 'type', 'typeof', 'unsafe', 'unsized', 'use', 'virtual', 'where', 'while', 'yield'
+)

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -249,8 +249,19 @@ impl Crate {
     }
 
     pub fn valid_name(name: &str) -> bool {
+        // This is the same blacklist as Cargo
+        // https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_new.rs#L131
+        let blacklist = [
+            "abstract", "alignof", "as", "become", "box", "break", "const", "continue", "crate",
+            "do", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl", "in",
+            "let", "loop", "macro", "match", "mod", "move", "mut", "offsetof", "override", "priv",
+            "proc", "pub", "pure", "ref", "return", "self", "sizeof", "static", "struct", "super",
+            "test", "trait", "true", "type", "typeof", "unsafe", "unsized", "use", "virtual",
+            "where", "while", "yield",
+        ];
+
         let under_max_length = name.chars().take(MAX_NAME_LENGTH + 1).count() <= MAX_NAME_LENGTH;
-        Crate::valid_ident(name) && under_max_length
+        !blacklist.contains(&name) && Crate::valid_ident(name) && under_max_length
     }
 
     fn valid_ident(name: &str) -> bool {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -878,6 +878,18 @@ fn new_krate_bad_name() {
 }
 
 #[test]
+fn valid_crate_name() {
+    // Bad names
+    // Reserved keywords are blacklisted
+    assert!(!Crate::valid_name("if"));
+    assert!(!Crate::valid_name("bête"));
+    assert!(!Crate::valid_name("test"));
+    // Good names
+    assert!(Crate::valid_name("ok"));
+    assert!(Crate::valid_name("a-good-test-1"));
+}
+
+#[test]
 fn valid_feature_names() {
     assert!(Crate::valid_feature("foo"));
     assert!(!Crate::valid_feature(""));

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -72,7 +72,8 @@ impl<'de> Deserialize<'de> for CrateName {
             let value = de::Unexpected::Str(&s);
             let expected = format!(
                 "a valid crate name to start with a letter, contain only letters, \
-                 numbers, hyphens, or underscores and have at most {} characters",
+                 numbers, hyphens, or underscores, have at most {} characters \
+                 and not a reserved keyword",
                 MAX_NAME_LENGTH
             );
             Err(de::Error::invalid_value(value, &expected.as_ref()))


### PR DESCRIPTION
Adresses #1480 

I'm not sure about the migration though, is there associated records to be manually deleted ? Do the foreign keys have a cascade delete thing ?