### PR TITLE
Only use session tokens for auth for `GET` requests

### DIFF
--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
 
+use conduit::Method;
 use conduit_cookie::RequestSession;
 use diesel::prelude::*;
 
@@ -29,7 +30,7 @@ impl Middleware for CurrentUser {
 
         let conn = req.db_conn().map_err(std_error)?;
 
-        if let Some(id) = id {
+        if let (Some(id), Method::Get) = (id, req.method()) {
             // If it did, look for a user in the database with the given `user_id`
             let maybe_user = users::table.find(id).first::<User>(&*conn);
             if let Ok(user) = maybe_user {


### PR DESCRIPTION
Since we do not have any form of CSRF protection in place, we should not
be allowing session tokens to be used for non-get requests. We don't
currently have any CSRF vulnerabilities, as there are no `POST` requests
in our router today.

In the event that one does get added in the future, this will prevent
a CSRF vulnerability from appearing, without us having to remember this
detail in the future. It will also force us to properly add some form of
protection if we want to accept a POST request sent by an HTML form in
the future.