### PR TITLE
`cargo +nightly fmt` to prepare for the next stable release

### DIFF
--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -39,8 +39,7 @@ fn update(conn: &PgConnection) -> QueryResult<()> {
                     version_downloads::version_id.eq(id),
                     version_downloads::downloads.eq(dls),
                     version_downloads::date.eq(date(now - day.days())),
-                ))
-                .execute(conn)?;
+                )).execute(conn)?;
         }
     }
     Ok(())

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -84,8 +84,7 @@ fn main() {
             readme_renderings::rendered_at
                 .lt(older_than)
                 .or(readme_renderings::version_id.is_null()),
-        )
-        .select(versions::id)
+        ).select(versions::id)
         .into_boxed();
 
     if let Some(crate_name) = args.flag_crate {
@@ -156,8 +155,7 @@ fn main() {
                         readme.as_bytes(),
                         "text/html",
                         readme_len as u64,
-                    )
-                    .unwrap_or_else(|_| {
+                    ).unwrap_or_else(|_| {
                         panic!(
                             "[{}-{}] Couldn't upload file to S3",
                             krate_name, version.num
@@ -289,16 +287,14 @@ fn find_file_by_path<R: Read>(
                 };
                 filepath == path
             }
-        })
-        .unwrap_or_else(|| {
+        }).unwrap_or_else(|| {
             panic!(
                 "[{}-{}] couldn't open file: {}",
                 krate_name,
                 version.num,
                 path.display()
             )
-        })
-        .unwrap_or_else(|_| {
+        }).unwrap_or_else(|_| {
             panic!(
                 "[{}-{}] file is not present: {}",
                 krate_name,

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -92,8 +92,7 @@ fn collect(conn: &PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
                     crate_downloads::crate_id.eq(crate_id),
                     crate_downloads::downloads.eq(amt),
                     crate_downloads::date.eq(download.date),
-                ))
-                .on_conflict(crate_downloads::table.primary_key())
+                )).on_conflict(crate_downloads::table.primary_key())
                 .do_update()
                 .set(crate_downloads::downloads.eq(crate_downloads::downloads + amt))
                 .execute(conn)?;
@@ -138,7 +137,7 @@ mod test {
             name: "foo",
             ..Default::default()
         }.create_or_update(&conn, None, user_id)
-            .unwrap();
+        .unwrap();
         let version = NewVersion::new(
             krate.id,
             &semver::Version::parse("1.0.0").unwrap(),
@@ -177,8 +176,7 @@ mod test {
                 version_downloads::version_id.eq(version.id),
                 version_downloads::date.eq(date(now - 1.day())),
                 version_downloads::processed.eq(true),
-            ))
-            .execute(&conn)
+            )).execute(&conn)
             .unwrap();
 
         ::update(&conn).unwrap();
@@ -215,8 +213,7 @@ mod test {
                 version_downloads::counted.eq(2),
                 version_downloads::date.eq(date(now - 2.days())),
                 version_downloads::processed.eq(false),
-            ))
-            .execute(&conn)
+            )).execute(&conn)
             .unwrap();
         ::update(&conn).unwrap();
         let processed = version_downloads::table
@@ -239,8 +236,7 @@ mod test {
                 version_downloads::counted.eq(2),
                 version_downloads::date.eq(date(now)),
                 version_downloads::processed.eq(false),
-            ))
-            .execute(&conn)
+            )).execute(&conn)
             .unwrap();
         ::update(&conn).unwrap();
         let processed = version_downloads::table
@@ -273,15 +269,13 @@ mod test {
                 version_downloads::counted.eq(1),
                 version_downloads::date.eq(date(now)),
                 version_downloads::processed.eq(false),
-            ))
-            .execute(&conn)
+            )).execute(&conn)
             .unwrap();
         insert_into(version_downloads::table)
             .values((
                 version_downloads::version_id.eq(version.id),
                 version_downloads::date.eq(date(now - 1.day())),
-            ))
-            .execute(&conn)
+            )).execute(&conn)
             .unwrap();
 
         let version_before = versions::table
@@ -337,8 +331,7 @@ mod test {
                 version_downloads::counted.eq(2),
                 version_downloads::date.eq(date(now - 2.days())),
                 version_downloads::processed.eq(false),
-            ))
-            .execute(&conn)
+            )).execute(&conn)
             .unwrap();
 
         ::update(&conn).unwrap();

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -107,8 +107,7 @@ pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<
                 category.eq(c.name),
                 description.eq(c.description),
             )
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
 
     conn.transaction(|| {
         let slugs = diesel::insert_into(categories)
@@ -118,8 +117,7 @@ pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<
             .set((
                 category.eq(excluded(category)),
                 description.eq(excluded(description)),
-            ))
-            .returning(slug)
+            )).returning(slug)
             .get_results::<String>(&*conn)?;
 
         diesel::delete(categories)

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -71,8 +71,7 @@ fn accept_invite(
                 owner_id: user_id,
                 created_by: pending_crate_owner.invited_by_user_id,
                 owner_kind: OwnerKind::User as i32,
-            })
-            .on_conflict(crate_owners::table.primary_key())
+            }).on_conflict(crate_owners::table.primary_key())
             .do_update()
             .set(crate_owners::deleted.eq(false))
             .execute(conn)?;

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -39,8 +39,7 @@ pub fn downloads(req: &mut dyn Request) -> CargoResult<Response> {
         .select((
             to_char(version_downloads::date, "YYYY-MM-DD"),
             sum_downloads,
-        ))
-        .filter(version_downloads::date.gt(date(now - 90.days())))
+        )).filter(version_downloads::date.gt(date(now - 90.days())))
         .group_by(version_downloads::date)
         .order(version_downloads::date.asc())
         .load::<ExtraDownload>(&*conn)?;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -11,7 +11,9 @@ fn follow_target(req: &mut dyn Request) -> CargoResult<Follow> {
     let user = req.user()?;
     let conn = req.db_conn()?;
     let crate_name = &req.params()["crate_id"];
-    let crate_id = Crate::by_name(crate_name).select(crates::id).first(&*conn)?;
+    let crate_id = Crate::by_name(crate_name)
+        .select(crates::id)
+        .first(&*conn)?;
     Ok(Follow {
         user_id: user.id,
         crate_id,

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -34,8 +34,7 @@ pub fn summary(req: &mut dyn Request) -> CargoResult<Response> {
             .zip(krates)
             .map(|(max_version, krate)| {
                 Ok(krate.minimal_encodable(&max_version, None, false, None))
-            })
-            .collect()
+            }).collect()
     };
 
     let new_crates = crates

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -95,7 +95,8 @@ fn modify_owners(req: &mut dyn Request, add: bool) -> CargoResult<Response> {
         owners: Option<Vec<String>>,
     }
 
-    let request: Request = serde_json::from_str(&body).map_err(|_| human("invalid json request"))?;
+    let request: Request =
+        serde_json::from_str(&body).map_err(|_| human("invalid json request"))?;
 
     let logins = request
         .owners

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -53,8 +53,7 @@ pub fn publish(req: &mut dyn Request) -> CargoResult<Response> {
                 k[..].to_string(),
                 v.iter().map(|v| v[..].to_string()).collect(),
             )
-        })
-        .collect::<HashMap<String, Vec<String>>>();
+        }).collect::<HashMap<String, Vec<String>>>();
     let keywords = new_crate
         .keywords
         .as_ref()

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -48,8 +48,7 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
             ALL_COLUMNS,
             false.into_sql::<Bool>(),
             recent_crate_downloads::downloads.nullable(),
-        ))
-        .into_boxed();
+        )).into_boxed();
 
     if let Some(q_string) = params.get("q") {
         if !q_string.is_empty() {
@@ -190,8 +189,7 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
                     Some(recent_downloads),
                 )
             },
-        )
-        .collect();
+        ).collect();
 
     #[derive(Serialize)]
     struct R {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -53,7 +53,8 @@ pub fn new(req: &mut dyn Request) -> CargoResult<Response> {
     let mut json = vec![0; length as usize];
     read_fill(req.body(), &mut json)?;
 
-    let json = String::from_utf8(json).map_err(|_| bad_request(&"json body was not valid utf-8"))?;
+    let json =
+        String::from_utf8(json).map_err(|_| bad_request(&"json body was not valid utf-8"))?;
 
     let new: NewApiTokenRequest = json::from_str(&json)
         .map_err(|e| bad_request(&format!("invalid new token request: {:?}", e)))?;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -34,8 +34,7 @@ pub fn me(req: &mut dyn Request) -> CargoResult<Response> {
             emails::verified.nullable(),
             emails::email.nullable(),
             emails::token_generated_at.nullable().is_not_null(),
-        ))
-        .first::<(User, Option<bool>, Option<String>, bool)>(&*conn)?;
+        )).first::<(User, Option<bool>, Option<String>, bool)>(&*conn)?;
 
     let verified = verified.unwrap_or(false);
     let verification_sent = verified || verification_sent;

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -37,8 +37,7 @@ pub fn stats(req: &mut dyn Request) -> CargoResult<Response> {
             crate_owners::owner_id
                 .eq(user_id)
                 .and(crate_owners::owner_kind.eq(OwnerKind::User as i32)),
-        )
-        .select(sum(crates::downloads))
+        ).select(sum(crates::downloads))
         .first::<Option<i64>>(&*conn)?
         .unwrap_or(0);
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -82,8 +82,7 @@ fn send_email(recipient: &str, subject: &str, body: &str) -> CargoResult<()> {
                 .credentials(Credentials::new(
                     mailgun_config.smtp_login,
                     mailgun_config.smtp_password,
-                ))
-                .smtp_utf8(true)
+                )).smtp_utf8(true)
                 .authentication_mechanism(Mechanism::Plain)
                 .build();
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -97,8 +97,7 @@ pub fn yank(app: &App, krate: &str, version: &semver::Version, yanked: bool) -> 
                 }
                 git_crate.yanked = Some(yanked);
                 Ok(serde_json::to_string(&git_crate).unwrap())
-            })
-            .collect::<CargoResult<Vec<String>>>();
+            }).collect::<CargoResult<Vec<String>>>();
         let new = new?.join("\n");
         let mut f = File::create(&dst)?;
         f.write_all(new.as_bytes())?;

--- a/src/github.rs
+++ b/src/github.rs
@@ -41,8 +41,7 @@ pub fn github(app: &App, url: &str, auth: &Token) -> Result<(Easy, Vec<u8>), cur
             .write_function(|buf| {
                 data.extend_from_slice(buf);
                 Ok(buf.len())
-            })
-            .unwrap();
+            }).unwrap();
         transfer.perform()?;
     }
     Ok((handle, data))

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -22,7 +22,11 @@ pub struct CrateBadge {
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case", tag = "badge_type", content = "attributes")]
+#[serde(
+    rename_all = "kebab-case",
+    tag = "badge_type",
+    content = "attributes"
+)]
 pub enum Badge {
     TravisCi {
         repository: String,

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -118,8 +118,7 @@ impl Category {
                 .map(|c| CrateCategory {
                     category_id: c.id,
                     crate_id: krate.id,
-                })
-                .collect::<Vec<_>>();
+                }).collect::<Vec<_>>();
 
             delete(CrateCategory::belonging_to(krate)).execute(conn)?;
             insert_into(crates_categories::table)
@@ -232,8 +231,7 @@ mod tests {
                 (category.eq("Cat 2"), slug.eq("cat2")),
                 (category.eq("Cat 1"), slug.eq("cat1")),
                 (category.eq("Cat 1::sub"), slug.eq("cat1::sub")),
-            ])
-            .execute(&conn)
+            ]).execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "", 10, 0)
@@ -254,8 +252,7 @@ mod tests {
                 (category.eq("Cat 1"), slug.eq("cat1"), crates_cnt.eq(0)),
                 (category.eq("Cat 2"), slug.eq("cat2"), crates_cnt.eq(2)),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(1)),
-            ])
-            .execute(&conn)
+            ]).execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "crates", 10, 0)
@@ -279,8 +276,7 @@ mod tests {
             .values(&vec![
                 (category.eq("Cat 1"), slug.eq("cat1")),
                 (category.eq("Cat 2"), slug.eq("cat2")),
-            ])
-            .execute(&conn)
+            ]).execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "", 1, 0)
@@ -324,8 +320,7 @@ mod tests {
                     crates_cnt.eq(5),
                 ),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(6)),
-            ])
-            .execute(&conn)
+            ]).execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "crates", 10, 0)
@@ -365,8 +360,7 @@ mod tests {
                     crates_cnt.eq(5),
                 ),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(6)),
-            ])
-            .execute(&conn)
+            ]).execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "crates", 2, 0)
@@ -420,8 +414,7 @@ mod tests {
                     crates_cnt.eq(5),
                 ),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(200)),
-            ])
-            .execute(&conn)
+            ]).execute(&conn)
             .unwrap();
 
         let cat = Category::by_slug("cat1::sub1")

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -117,8 +117,7 @@ pub fn add_dependencies(
                     target.eq(dep.target.as_ref().map(|s| &**s)),
                 ),
             ))
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+        }).collect::<Result<Vec<_>, _>>()?;
 
     let (git_deps, new_dependencies): (Vec<_>, Vec<_>) =
         git_and_new_dependencies.into_iter().unzip();

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -85,8 +85,7 @@ impl Keyword {
                 .map(|kw| CrateKeyword {
                     crate_id: krate.id,
                     keyword_id: kw.id,
-                })
-                .collect::<Vec<_>>();
+                }).collect::<Vec<_>>();
             diesel::insert_into(crates_keywords::table)
                 .values(&crate_keywords)
                 .execute(conn)?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -254,12 +254,11 @@ impl Crate {
     }
 
     fn valid_ident(name: &str) -> bool {
-        Self::valid_feature_name(name)
-            && name
-                .chars()
-                .nth(0)
-                .map(char::is_alphabetic)
-                .unwrap_or(false)
+        Self::valid_feature_name(name) && name
+            .chars()
+            .nth(0)
+            .map(char::is_alphabetic)
+            .unwrap_or(false)
     }
 
     pub fn valid_feature_name(name: &str) -> bool {
@@ -440,8 +439,7 @@ impl Crate {
                         invited_user_id: owner.id(),
                         invited_by_user_id: req_user.id,
                         crate_id: self.id,
-                    })
-                    .on_conflict_do_nothing()
+                    }).on_conflict_do_nothing()
                     .execute(conn)?;
                 Ok(format!(
                     "user {} has been invited to be an owner of crate {}",
@@ -457,8 +455,7 @@ impl Crate {
                         owner_id: owner.id(),
                         created_by: req_user.id,
                         owner_kind: OwnerKind::Team as i32,
-                    })
-                    .on_conflict(crate_owners::table.primary_key())
+                    }).on_conflict(crate_owners::table.primary_key())
                     .do_update()
                     .set(crate_owners::deleted.eq(false))
                     .execute(conn)?;

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -78,8 +78,7 @@ impl<'a> NewUser<'a> {
                     name.eq(excluded(name)),
                     gh_avatar.eq(excluded(gh_avatar)),
                     gh_access_token.eq(excluded(gh_access_token)),
-                ))
-                .get_result::<User>(conn)?;
+                )).get_result::<User>(conn)?;
 
             // To send the user an account verification email...
             if let Some(user_email) = user.email.as_ref() {

--- a/src/render.rs
+++ b/src/render.rs
@@ -56,7 +56,8 @@ impl<'a> MarkdownRenderer<'a> {
             "ul",
             "hr",
             "span",
-        ].iter()
+        ]
+            .iter()
             .cloned()
             .collect();
         let tag_attributes = [
@@ -72,7 +73,8 @@ impl<'a> MarkdownRenderer<'a> {
                 "input",
                 ["checked", "disabled", "type"].iter().cloned().collect(),
             ),
-        ].iter()
+        ]
+            .iter()
             .cloned()
             .collect();
         let allowed_classes = [(
@@ -92,10 +94,12 @@ impl<'a> MarkdownRenderer<'a> {
                 "language-scss",
                 "language-sql",
                 "yaml",
-            ].iter()
+            ]
+                .iter()
                 .cloned()
                 .collect(),
-        )].iter()
+        )]
+            .iter()
             .cloned()
             .collect();
 
@@ -178,8 +182,7 @@ impl<'a> MarkdownRenderer<'a> {
                 UrlRelative::Custom(Box::new(relative_url_sanitizer))
             } else {
                 UrlRelative::Custom(Box::new(unrelative_url_sanitizer))
-            })
-            .id_prefix(Some("user-content-"));
+            }).id_prefix(Some("user-content-"));
 
         MarkdownRenderer { html_sanitizer }
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -220,7 +220,7 @@ mod tests {
                 0,
                 0
             ))).call(&mut req)
-                .is_err()
+            .is_err()
         );
         assert!(
             C(|_| err(::std::io::Error::new(::std::io::ErrorKind::Other, "")))

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -350,8 +350,7 @@ impl<'a> VersionBuilder<'a> {
                     dependencies::default_features.eq(false),
                     dependencies::features.eq(Vec::<String>::new()),
                 )
-            })
-            .collect::<Vec<_>>();
+            }).collect::<Vec<_>>();
         insert_into(dependencies::table)
             .values(&new_deps)
             .execute(connection)?;
@@ -571,8 +570,7 @@ fn new_dependency(conn: &PgConnection, version: &Version, krate: &Crate) -> Depe
             optional.eq(false),
             default_features.eq(false),
             features.eq(Vec::<String>::new()),
-        ))
-        .get_result(conn)
+        )).get_result(conn)
         .unwrap()
 }
 
@@ -744,8 +742,7 @@ fn new_crate_to_body(new_crate: &u::NewCrate, files: &[(&str, &[u8])]) -> Vec<u8
         .map(|(&(name, _), data)| {
             let len = data.len() as u64;
             (name, data as &mut Read, len)
-        })
-        .collect::<Vec<_>>();
+        }).collect::<Vec<_>>();
     new_crate_to_body_with_io(new_crate, &mut files)
 }
 
@@ -777,7 +774,8 @@ fn new_crate_to_body_with_tarball(new_crate: &u::NewCrate, tarball: &[u8]) -> Ve
             (json.len() >> 8) as u8,
             (json.len() >> 16) as u8,
             (json.len() >> 24) as u8,
-        ].iter()
+        ]
+            .iter()
             .cloned(),
     );
     body.extend(json.as_bytes().iter().cloned());

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1057,8 +1057,7 @@ fn new_krate_git_upload_appends() {
         .write_all(
             br#"{"name":"FPP","vers":"0.0.1","deps":[],"features":{},"cksum":"3j3"}
 "#,
-        )
-        .unwrap();
+        ).unwrap();
 
     let mut req = new_req(Arc::clone(&app), "FPP", "1.0.0");
     sign_in(&mut req, &app);
@@ -1943,8 +1942,7 @@ fn reverse_dependencies() {
                 VersionBuilder::new("1.1.0")
                     .dependency(&c1, None)
                     .dependency(&c1, Some("foo")),
-            )
-            .expect_build(&conn);
+            ).expect_build(&conn);
     }
 
     let mut response = ok_resp!(middle.call(&mut req));

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -371,8 +371,7 @@ fn invitations_list() {
                 invited_by_user_id: owner.id,
                 invited_user_id: user.id,
                 crate_id: krate.id,
-            })
-            .execute(&*conn)
+            }).execute(&*conn)
             .unwrap();
         (krate, user)
     };
@@ -432,8 +431,7 @@ fn test_accept_invitation() {
                 invited_by_user_id: owner.id,
                 invited_user_id: user.id,
                 crate_id: krate.id,
-            })
-            .execute(&*conn)
+            }).execute(&*conn)
             .unwrap();
         (krate, user)
     };
@@ -527,8 +525,7 @@ fn test_decline_invitation() {
                 invited_by_user_id: owner.id,
                 invited_user_id: user.id,
                 crate_id: krate.id,
-            })
-            .execute(&*conn)
+            }).execute(&*conn)
             .unwrap();
         (krate, user)
     };

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -122,8 +122,7 @@ pub fn proxy() -> (String, Bomb) {
                 sink: sink2,
                 record: Arc::clone(&record),
                 client,
-            })
-            .map_err(|e| eprintln!("server connection error: {}", e));
+            }).map_err(|e| eprintln!("server connection error: {}", e));
 
         drop(core.run(srv.select2(quitrx)));
 

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -125,8 +125,7 @@ impl Uploader {
                             .write_function(|data| {
                                 response.extend(data);
                                 Ok(data.len())
-                            })
-                            .unwrap();
+                            }).unwrap();
                         s3req.perform().chain_error(|| {
                             internal(&format_args!("failed to upload to S3: `{}`", path))
                         })?;
@@ -259,8 +258,9 @@ fn verify_tarball(
     let mut archive = tar::Archive::new(decoder);
     let prefix = format!("{}-{}", krate.name, vers);
     for entry in archive.entries()? {
-        let entry = entry
-            .chain_error(|| human("uploaded tarball is malformed or too large when decompressed"))?;
+        let entry = entry.chain_error(|| {
+            human("uploaded tarball is malformed or too large when decompressed")
+        })?;
 
         // Verify that all entries actually start with `$name-$vers/`.
         // Historically Cargo didn't verify this on extraction so you could


### PR DESCRIPTION
This diff was created from the latest nightly and passes checks on beta
(which will soon be stable).  As I understand it, Rust 1.29 will
include the rustfmt release candidate and we can expect stable
formatting from this point forward!

Bors should be able to merge this cleanly after the release tomorrow.  It will fail on CI for now.