### PR TITLE
Tweak a few things on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: rust
 sudo: required
 dist: trusty
 
+# Ignore this branch per bors-ng documentation
 branches:
   except:
     - staging.tmp
@@ -22,9 +23,6 @@ env:
     # on community-submitted PRs
     - PERCY_TOKEN=0d8707a02b19aebbec79bb0bf302b8d2fa95edb33169cfe41b084289596670b1
     - PERCY_PROJECT=crates-io/crates.io
-
-before_install:
-  - nvm install 10
 
 install:
   - cargo install --force diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
@@ -54,8 +52,10 @@ matrix:
         - cargo install --force clippy --vers 0.0.210
         - cargo clippy
     - rust: stable
-      script:
+      before_install:
+        - nvm install 10
         - rustup component add rustfmt-preview
+      script:
         - cargo fmt -- --check
         - cargo build
         - cargo test
@@ -69,6 +69,9 @@ matrix:
       script:
         - cargo build
         - cargo test
+      # This portion of the cache is quickly invalidated anyway
+      before_cache:
+        - cargo clean
 
 notifications:
   email:


### PR DESCRIPTION
* Only install node on the stable branch
* Move rustfmt-preview installation to the before_install step
* Clear target directory on nightly (downloaded crates and the index will still be cached)