### PR TITLE
Policies: Document policy on maintainer-requested removals

### DIFF
--- a/app/templates/policies.hbs
+++ b/app/templates/policies.hbs
@@ -39,6 +39,20 @@ do what the law requires us to do, and address flagrant violations of the Rust
 Code of Conduct.
 </p>
 
+<h3 id='the-maintainer'><a href='#the-maintainer'>Upon Maintainer Request</a></h3>
+
+<p>
+If you uploaded a package by accident and it needs to be removed, contact
+<a href='mailto:help@crates.io'>help@crates.io</a> and request removal.
+</p>
+
+<p>
+Please note that this option is not intended for package versions which
+merely should not be used for some technical reason, and can remain published.
+For that, use
+<a href='https://doc.rust-lang.org/cargo/reference/publishing.html#cargo-yank'><code>cargo yank</code></a> instead.
+</p>
+
 <h3 id='squatting'><a href='#squatting'>Squatting</a></h3>
 
 <p>


### PR DESCRIPTION
Under the current removal policy, maintainers can only request removal
through Mozilla Legal or by introducing a deliberate Code of  Conduct
violation.  This is not a desirable situation, so this change adds
some language which suggest contacting help@crates.io.