### PR TITLE
Quit cloning Arc<App> unnecessarily in tests

### DIFF
--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -194,7 +194,7 @@ fn env(s: &str) -> String {
     env_result
 }
 
-fn req(_: Arc<App>, method: conduit::Method, path: &str) -> MockRequest {
+fn req(method: conduit::Method, path: &str) -> MockRequest {
     MockRequest::new(method, path)
 }
 
@@ -588,28 +588,18 @@ fn logout(req: &mut Request) {
     req.mut_extensions().pop::<User>();
 }
 
-fn new_req(app: Arc<App>, krate: &str, version: &str) -> MockRequest {
-    new_req_full(app, ::krate(krate), version, Vec::new())
+fn new_req(krate: &str, version: &str) -> MockRequest {
+    new_req_full(::krate(krate), version, Vec::new())
 }
 
-fn new_req_with_documentation(
-    app: Arc<App>,
-    krate: &str,
-    version: &str,
-    documentation: &str,
-) -> MockRequest {
+fn new_req_with_documentation(krate: &str, version: &str, documentation: &str) -> MockRequest {
     let mut krate = ::krate(krate);
     krate.documentation = Some(documentation.into());
-    new_req_full(app, krate, version, Vec::new())
+    new_req_full(krate, version, Vec::new())
 }
 
-fn new_req_full(
-    app: Arc<App>,
-    krate: Crate,
-    version: &str,
-    deps: Vec<u::CrateDependency>,
-) -> MockRequest {
-    let mut req = req(app, Method::Put, "/api/v1/crates/new");
+fn new_req_full(krate: Crate, version: &str, deps: Vec<u::CrateDependency>) -> MockRequest {
+    let mut req = req(Method::Put, "/api/v1/crates/new");
     req.with_body(&new_req_body(
         krate,
         version,
@@ -621,13 +611,8 @@ fn new_req_full(
     req
 }
 
-fn new_req_with_keywords(
-    app: Arc<App>,
-    krate: Crate,
-    version: &str,
-    kws: Vec<String>,
-) -> MockRequest {
-    let mut req = req(app, Method::Put, "/api/v1/crates/new");
+fn new_req_with_keywords(krate: Crate, version: &str, kws: Vec<String>) -> MockRequest {
+    let mut req = req(Method::Put, "/api/v1/crates/new");
     req.with_body(&new_req_body(
         krate,
         version,
@@ -639,13 +624,8 @@ fn new_req_with_keywords(
     req
 }
 
-fn new_req_with_categories(
-    app: Arc<App>,
-    krate: Crate,
-    version: &str,
-    cats: Vec<String>,
-) -> MockRequest {
-    let mut req = req(app, Method::Put, "/api/v1/crates/new");
+fn new_req_with_categories(krate: Crate, version: &str, cats: Vec<String>) -> MockRequest {
+    let mut req = req(Method::Put, "/api/v1/crates/new");
     req.with_body(&new_req_body(
         krate,
         version,
@@ -658,12 +638,11 @@ fn new_req_with_categories(
 }
 
 fn new_req_with_badges(
-    app: Arc<App>,
     krate: Crate,
     version: &str,
     badges: HashMap<String, HashMap<String, String>>,
 ) -> MockRequest {
-    let mut req = req(app, Method::Put, "/api/v1/crates/new");
+    let mut req = req(Method::Put, "/api/v1/crates/new");
     req.with_body(&new_req_body(
         krate,
         version,

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -22,13 +22,10 @@ struct CategoryWithSubcategories {
     category: EncodableCategoryWithSubcategories,
 }
 
-#[cfg(test)]
-use std::sync::Arc;
-
 #[test]
 fn index() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/categories");
+    let mut req = req(Method::Get, "/api/v1/categories");
 
     // List 0 categories if none exist
     let mut response = ok_resp!(middle.call(&mut req));
@@ -61,7 +58,7 @@ fn show() {
     let (_b, app, middle) = app();
 
     // Return not found if a category doesn't exist
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/categories/foo-bar");
+    let mut req = req(Method::Get, "/api/v1/categories/foo-bar");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
@@ -85,7 +82,7 @@ fn show() {
 #[test]
 fn update_crate() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/categories/foo");
+    let mut req = req(Method::Get, "/api/v1/categories/foo");
     macro_rules! cnt {
         ($req:expr, $cat:expr) => {{
             $req.with_path(&format!("/api/v1/categories/{}", $cat));
@@ -183,7 +180,7 @@ fn category_slugs_returns_all_slugs_in_alphabetical_order() {
             .unwrap();
     }
 
-    let mut req = req(app, Method::Get, "/api/v1/category_slugs");
+    let mut req = req(Method::Get, "/api/v1/category_slugs");
 
     #[derive(Deserialize, Debug, PartialEq)]
     struct Slug {

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use conduit::{Handler, Method};
 use conduit_test::MockRequest;
 
@@ -24,7 +22,7 @@ struct GoodKeyword {
 #[test]
 fn index() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/keywords");
+    let mut req = req(Method::Get, "/api/v1/keywords");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: KeywordList = ::json(&mut response);
     assert_eq!(json.keywords.len(), 0);
@@ -44,7 +42,7 @@ fn index() {
 #[test]
 fn show() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/keywords/foo");
+    let mut req = req(Method::Get, "/api/v1/keywords/foo");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
@@ -60,7 +58,7 @@ fn show() {
 #[test]
 fn uppercase() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/keywords/UPPER");
+    let mut req = req(Method::Get, "/api/v1/keywords/UPPER");
     {
         let conn = app.diesel_database.get().unwrap();
         Keyword::find_or_create_all(&conn, &["UPPER"]).unwrap();
@@ -74,7 +72,7 @@ fn uppercase() {
 #[test]
 fn update_crate() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/keywords/foo");
+    let mut req = req(Method::Get, "/api/v1/keywords/foo");
     let cnt = |req: &mut MockRequest, kw: &str| {
         req.with_path(&format!("/api/v1/keywords/{}", kw));
         let mut response = ok_resp!(middle.call(req));

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use conduit::{Handler, Method};
 use diesel;
 use diesel::prelude::*;
@@ -68,11 +66,7 @@ fn owners_can_remove_self() {
     }
 
     let (_b, app, middle) = app();
-    let mut req = req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/crates/owners_selfremove/owners",
-    );
+    let mut req = req(Method::Get, "/api/v1/crates/owners_selfremove/owners");
     let (first_owner, second_owner) = {
         let conn = app.diesel_database.get().unwrap();
         let user = new_user("firstowner").create_or_update(&conn).unwrap();
@@ -193,7 +187,7 @@ fn check_ownership_two_crates() {
         (::CrateBuilder::new("bar", u.id).expect_build(&conn), u)
     };
 
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/crates");
+    let mut req = req(Method::Get, "/api/v1/crates");
 
     let query = format!("user_id={}", user.id);
     let mut response = ok_resp!(middle.call(req.with_query(&query)));
@@ -233,22 +227,14 @@ fn check_ownership_one_crate() {
         (t, u)
     };
 
-    let mut req = req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/crates/best_crate/owner_team",
-    );
+    let mut req = req(Method::Get, "/api/v1/crates/best_crate/owner_team");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: TeamResponse = ::json(&mut response);
 
     assert_eq!(json.teams[0].kind, "team");
     assert_eq!(json.teams[0].name, team.name);
 
-    let mut req = ::req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/crates/best_crate/owner_user",
-    );
+    let mut req = ::req(Method::Get, "/api/v1/crates/best_crate/owner_user");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: UserResponse = ::json(&mut response);
 
@@ -264,11 +250,7 @@ fn invitations_are_empty_by_default() {
     }
 
     let (_b, app, middle) = app();
-    let mut req = req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/me/crate_owner_invitations",
-    );
+    let mut req = req(Method::Get, "/api/v1/me/crate_owner_invitations");
 
     let user = {
         let conn = app.diesel_database.get().unwrap();
@@ -290,11 +272,7 @@ fn invitations_list() {
     }
 
     let (_b, app, middle) = app();
-    let mut req = req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/me/crate_owner_invitations",
-    );
+    let mut req = req(Method::Get, "/api/v1/me/crate_owner_invitations");
     let (krate, user) = {
         let conn = app.diesel_database.get().unwrap();
         let owner = new_user("inviting_user").create_or_update(&conn).unwrap();
@@ -350,11 +328,7 @@ fn test_accept_invitation() {
     }
 
     let (_b, app, middle) = app();
-    let mut req = req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/me/crate_owner_invitations",
-    );
+    let mut req = req(Method::Get, "/api/v1/me/crate_owner_invitations");
     let (krate, user) = {
         let conn = app.diesel_database.get().unwrap();
         let owner = new_user("inviting_user").create_or_update(&conn).unwrap();
@@ -444,11 +418,7 @@ fn test_decline_invitation() {
     }
 
     let (_b, app, middle) = app();
-    let mut req = req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/me/crate_owner_invitations",
-    );
+    let mut req = req(Method::Get, "/api/v1/me/crate_owner_invitations");
     let (krate, user) = {
         let conn = app.diesel_database.get().unwrap();
         let owner = new_user("inviting_user").create_or_update(&conn).unwrap();

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -48,7 +48,7 @@ fn request_with_user_and_mock_crate(
     user: &NewUser<'_>,
     krate: &str,
 ) -> MockRequest {
-    let mut req = new_req(Arc::clone(app), krate, "1.0.0");
+    let mut req = new_req(krate, "1.0.0");
     {
         let conn = app.diesel_database.get().unwrap();
         let user = user.create_or_update(&conn).unwrap();
@@ -479,7 +479,7 @@ fn crates_by_team_id() {
         t
     };
 
-    let mut req = req(app, Method::Get, "/api/v1/crates");
+    let mut req = req(Method::Get, "/api/v1/crates");
     req.with_query(&format!("team_id={}", team.id));
     let mut response = ok_resp!(middle.call(&mut req));
 
@@ -507,7 +507,7 @@ fn crates_by_team_id_not_including_deleted_owners() {
         t
     };
 
-    let mut req = req(app, Method::Get, "/api/v1/crates");
+    let mut req = req(Method::Get, "/api/v1/crates");
     req.with_query(&format!("team_id={}", team.id));
     let mut response = ok_resp!(middle.call(&mut req));
 

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -34,8 +34,8 @@ macro_rules! assert_contains {
 
 #[test]
 fn list_logged_out() {
-    let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/me/tokens");
+    let (_b, _, middle) = app();
+    let mut req = req(Method::Get, "/api/v1/me/tokens");
 
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
@@ -44,7 +44,7 @@ fn list_logged_out() {
 #[test]
 fn list_empty() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/me/tokens");
+    let mut req = req(Method::Get, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -61,7 +61,7 @@ fn list_empty() {
 #[test]
 fn list_tokens() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/me/tokens");
+    let mut req = req(Method::Get, "/api/v1/me/tokens");
 
     let (user, tokens);
     {
@@ -89,8 +89,8 @@ fn list_tokens() {
 
 #[test]
 fn create_token_logged_out() {
-    let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+    let (_b, _, middle) = app();
+    let mut req = req(Method::Put, "/api/v1/me/tokens");
 
     req.with_body(br#"{ "api_token": { "name": "bar" } }"#);
 
@@ -101,7 +101,7 @@ fn create_token_logged_out() {
 #[test]
 fn create_token_invalid_request() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+    let mut req = req(Method::Put, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -120,7 +120,7 @@ fn create_token_invalid_request() {
 #[test]
 fn create_token_no_name() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+    let mut req = req(Method::Put, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -139,7 +139,7 @@ fn create_token_no_name() {
 #[test]
 fn create_token_long_body() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+    let mut req = req(Method::Put, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -158,7 +158,7 @@ fn create_token_long_body() {
 #[test]
 fn create_token_exceeded_tokens_per_user() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+    let mut req = req(Method::Put, "/api/v1/me/tokens");
 
     let user;
     {
@@ -181,7 +181,7 @@ fn create_token_exceeded_tokens_per_user() {
 #[test]
 fn create_token_success() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+    let mut req = req(Method::Put, "/api/v1/me/tokens");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -214,14 +214,14 @@ fn create_token_multiple_have_different_values() {
     };
 
     let first = {
-        let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+        let mut req = req(Method::Put, "/api/v1/me/tokens");
         sign_in_as(&mut req, &user);
         req.with_body(br#"{ "api_token": { "name": "bar" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
     };
 
     let second = {
-        let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+        let mut req = req(Method::Put, "/api/v1/me/tokens");
         sign_in_as(&mut req, &user);
         req.with_body(br#"{ "api_token": { "name": "bar" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
@@ -245,14 +245,14 @@ fn create_token_multiple_users_have_different_values() {
     };
 
     let first_token = {
-        let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+        let mut req = req(Method::Put, "/api/v1/me/tokens");
         sign_in_as(&mut req, &first_user);
         req.with_body(br#"{ "api_token": { "name": "baz" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
     };
 
     let second_token = {
-        let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+        let mut req = req(Method::Put, "/api/v1/me/tokens");
         sign_in_as(&mut req, &second_user);
         req.with_body(br#"{ "api_token": { "name": "baz" } }"#);
         ::json::<NewResponse>(&mut ok_resp!(middle.call(&mut req)))
@@ -264,7 +264,7 @@ fn create_token_multiple_users_have_different_values() {
 #[test]
 fn create_token_with_token() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Put, "/api/v1/me/tokens");
+    let mut req = req(Method::Put, "/api/v1/me/tokens");
 
     let (user, token);
     {
@@ -288,7 +288,7 @@ fn create_token_with_token() {
 #[test]
 fn revoke_token_non_existing() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Delete, "/api/v1/me/tokens/5");
+    let mut req = req(Method::Delete, "/api/v1/me/tokens/5");
 
     let user = {
         let conn = t!(app.diesel_database.get());
@@ -303,7 +303,7 @@ fn revoke_token_non_existing() {
 #[test]
 fn revoke_token_doesnt_revoke_other_users_token() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Delete, "/api/v1/me/tokens");
+    let mut req = req(Method::Delete, "/api/v1/me/tokens");
 
     // Create one user with a token and sign in with a different user
     let (user1, token, user2);
@@ -343,7 +343,7 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 #[test]
 fn revoke_token_success() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Delete, "/api/v1/me/tokens");
+    let mut req = req(Method::Delete, "/api/v1/me/tokens");
 
     let (user, token);
     {
@@ -380,7 +380,7 @@ fn revoke_token_success() {
 #[test]
 fn token_gives_access_to_me() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/me");
+    let mut req = req(Method::Get, "/api/v1/me");
 
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
@@ -402,7 +402,7 @@ fn token_gives_access_to_me() {
 #[test]
 fn using_token_updates_last_used_at() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/me");
+    let mut req = req(Method::Get, "/api/v1/me");
     let response = t_resp!(middle.call(&mut req));
     assert_eq!(response.status.0, 403);
 

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 extern crate conduit_middleware;
 extern crate diesel;
 extern crate serde_json;
@@ -27,7 +25,7 @@ struct VersionResponse {
 #[test]
 fn index() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/versions");
+    let mut req = req(Method::Get, "/api/v1/versions");
     let mut response = ok_resp!(middle.call(&mut req));
     let json: VersionList = ::json(&mut response);
     assert_eq!(json.versions.len(), 0);
@@ -62,7 +60,7 @@ fn index() {
 #[test]
 fn show() {
     let (_b, app, middle) = app();
-    let mut req = req(Arc::clone(&app), Method::Get, "/api/v1/versions");
+    let mut req = req(Method::Get, "/api/v1/versions");
     let v = {
         let conn = app.diesel_database.get().unwrap();
         let user = new_user("foo").create_or_update(&conn).unwrap();
@@ -81,11 +79,7 @@ fn show() {
 #[test]
 fn authors() {
     let (_b, app, middle) = app();
-    let mut req = req(
-        Arc::clone(&app),
-        Method::Get,
-        "/api/v1/crates/foo_authors/1.0.0/authors",
-    );
+    let mut req = req(Method::Get, "/api/v1/crates/foo_authors/1.0.0/authors");
     {
         let conn = app.diesel_database.get().unwrap();
         let u = new_user("foo").create_or_update(&conn).unwrap();


### PR DESCRIPTION
The `Arc<App>` is passed around a lot in the tests, but it isn't needed in many cases.