### PR TITLE
Build on the new test infrastructure and convert more tests

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -8,7 +8,7 @@ use util::bad_request;
 
 use models::{Email, Follow, NewEmail, User, Version};
 use schema::{crates, emails, follows, users, versions};
-use views::{EncodablePrivateUser, EncodableVersion};
+use views::{EncodableMe, EncodableVersion};
 
 /// Handles the `GET /me` route.
 pub fn me(req: &mut dyn Request) -> CargoResult<Response> {
@@ -40,11 +40,7 @@ pub fn me(req: &mut dyn Request) -> CargoResult<Response> {
     let verification_sent = verified || verification_sent;
     let user = User { email, ..user };
 
-    #[derive(Serialize)]
-    struct R {
-        user: EncodablePrivateUser,
-    }
-    Ok(req.json(&R {
+    Ok(req.json(&EncodableMe {
         user: user.encodable_private(verified, verification_sent),
     }))
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -36,6 +36,7 @@ pub trait RequestTransaction {
     /// Return the lazily initialized postgres connection for this request.
     ///
     /// The connection will live for the lifetime of the request.
+    // FIXME: This description does not match the implementation below.
     fn db_conn(&self) -> CargoResult<DieselPooledConn>;
 }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -136,7 +136,8 @@ where
         good
     }
 
-    pub fn bad(&mut self) -> Bad {
+    pub fn bad_with_status(&mut self, code: u32) -> Bad {
+        assert_eq!(self.response.status.0, code);
         match ::bad_resp(&mut self.response) {
             None => panic!("ok response: {:?}", self.response.status),
             Some(b) => b,
@@ -873,7 +874,7 @@ impl MockUserSession {
         request
     }
 
-    /// Issue a GET request
+    /// Issue a GET request as the current user
     pub fn get<T>(&self, path: &str) -> Response<T>
     where
         for<'de> T: serde::Deserialize<'de>,
@@ -882,7 +883,7 @@ impl MockUserSession {
         Response::new(self.middle.call(&mut request))
     }
 
-    /// Issue a PUT request
+    /// Issue a PUT request as the current user
     pub fn put<T>(&self, path: &str, body: &[u8]) -> Response<T>
     where
         for<'de> T: serde::Deserialize<'de>,
@@ -890,6 +891,15 @@ impl MockUserSession {
         let mut builder = self.request_builder(Method::Put, path);
         let request = builder.with_body(body);
         Response::new(self.middle.call(request))
+    }
+
+    /// Issue a DELETE request as the current user
+    pub fn delete<T>(&self, path: &str) -> Response<T>
+    where
+        for<'de> T: serde::Deserialize<'de>,
+    {
+        let mut request = self.request_builder(Method::Delete, path);
+        Response::new(self.middle.call(&mut request))
     }
 
     /// Log out the currently logged in user.

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -142,9 +142,11 @@ where
             Some(b) => b,
         }
     }
+}
 
-    pub fn assert_status(&self, status: u32) {
-        assert_eq!(self.response.status.0, status);
+impl Response<()> {
+    pub fn assert_not_found(&self) {
+        assert_eq!((404, "Not Found"), self.response.status);
     }
 }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -148,6 +148,10 @@ impl Response<()> {
     pub fn assert_not_found(&self) {
         assert_eq!((404, "Not Found"), self.response.status);
     }
+
+    pub fn assert_forbidden(&self) {
+        assert_eq!((403, "Forbidden"), self.response.status);
+    }
 }
 
 mod badge;
@@ -878,6 +882,16 @@ impl MockUserSession {
         Response::new(self.middle.call(&mut request))
     }
 
+    /// Issue a PUT request
+    pub fn put<T>(&self, path: &str, body: &[u8]) -> Response<T>
+    where
+        for<'de> T: serde::Deserialize<'de>,
+    {
+        let mut builder = self.request_builder(Method::Put, path);
+        let request = builder.with_body(body);
+        Response::new(self.middle.call(request))
+    }
+
     /// Log out the currently logged in user.
     pub fn logout(&mut self) {
         self.user = None;
@@ -886,6 +900,15 @@ impl MockUserSession {
     /// Using the same session, log in as a different user.
     pub fn log_in_as(&mut self, user: User) {
         self.user = Some(user);
+    }
+
+    /// Return a reference to the current user
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is no current user.
+    pub fn user(&self) -> &User {
+        self.user.as_ref().unwrap()
     }
 
     /// Publish the crate as specified by the given builder

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -190,7 +190,7 @@ pub struct CrateResponse {
     keywords: Vec<EncodableKeyword>,
 }
 #[derive(Deserialize)]
-struct Ok {
+struct OkBool {
     ok: bool,
 }
 
@@ -882,8 +882,8 @@ impl MockUserSession {
     }
 
     /// Using the same session, log in as a different user.
-    pub fn log_in_as(&mut self, user: &User) {
-        self.user = Some(user.clone());
+    pub fn log_in_as(&mut self, user: User) {
+        self.user = Some(user);
     }
 
     /// Publish the crate as specified by the given builder
@@ -903,7 +903,7 @@ impl MockUserSession {
     }
 
     /// Yank the specified version of the specified crate.
-    pub fn yank(&mut self, krate_name: &str, version: &str) -> Response<Ok> {
+    pub fn yank(&mut self, krate_name: &str, version: &str) -> Response<OkBool> {
         let url = format!("/api/v1/crates/{}/{}/yank", krate_name, version);
         let mut request = self.request_builder(Method::Delete, &url);
         Response::new(self.middle.call(&mut request))
@@ -916,7 +916,7 @@ impl MockUserSession {
         let mut builder = self.request_builder(Method::Put, &url);
         let request = builder.with_body(body.as_bytes());
 
-        let response: Ok = Response::new(self.middle.call(request)).good();
+        let response: OkBool = Response::new(self.middle.call(request)).good();
         assert!(response.ok);
     }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -97,6 +97,8 @@ struct Bad {
     errors: Vec<Error>,
 }
 
+type DieselConnection =
+    diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 type ResponseResult = Result<conduit::Response, Box<std::error::Error + Send>>;
 
 #[must_use]
@@ -865,9 +867,7 @@ impl MockUserSession {
     // }
 
     /// Obtain the database connection
-    pub fn db_conn(
-        &self,
-    ) -> diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>> {
+    pub fn db_conn(&self) -> DieselConnection {
         self.app.diesel_database.get().unwrap()
     }
 
@@ -949,7 +949,7 @@ impl MockUserSession {
         use views::InvitationResponse;
 
         let krate_id = {
-            let conn = self.app.diesel_database.get().unwrap();
+            let conn = self.db_conn();
             Crate::by_name(krate_name)
                 .first::<Crate>(&*conn)
                 .unwrap()

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use models::{Badge, Crate, MaintenanceStatus};
-use {app, new_user, CrateBuilder, DieselConnection};
+use {app, new_user, util::DieselConnection, CrateBuilder};
 
 struct BadgeRef {
     appveyor: Badge,

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use models::{Badge, Crate, MaintenanceStatus};
-use {app, new_user, App, CrateBuilder};
+use {app, new_user, CrateBuilder, DieselConnection};
 
 struct BadgeRef {
     appveyor: Badge,
@@ -25,7 +24,7 @@ struct BadgeRef {
     maintenance_attributes: HashMap<String, String>,
 }
 
-fn set_up() -> (Arc<App>, Crate, BadgeRef) {
+fn set_up() -> (DieselConnection, Crate, BadgeRef) {
     let (_b, app, _middle) = app();
 
     let krate = {
@@ -133,14 +132,14 @@ fn set_up() -> (Arc<App>, Crate, BadgeRef) {
         maintenance,
         maintenance_attributes,
     };
-    (app, krate, badges)
+    let conn = app.diesel_database.get().unwrap();
+    (conn, krate, badges)
 }
 
 #[test]
 fn update_no_badges() {
     // Add no badges
-    let (app, krate, _) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, _) = set_up();
 
     // Updating with no badges has no effect
     Badge::update_crate(&conn, &krate, None).unwrap();
@@ -150,8 +149,7 @@ fn update_no_badges() {
 #[test]
 fn update_add_appveyor() {
     // Add an appveyor badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(String::from("appveyor"), test_badges.appveyor_attributes);
@@ -162,8 +160,7 @@ fn update_add_appveyor() {
 #[test]
 fn update_add_travis_ci() {
     // Add a travis ci badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(String::from("travis-ci"), test_badges.travis_ci_attributes);
@@ -174,8 +171,7 @@ fn update_add_travis_ci() {
 #[test]
 fn update_add_gitlab() {
     // Add a gitlab badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(String::from("gitlab"), test_badges.gitlab_attributes);
@@ -186,8 +182,7 @@ fn update_add_gitlab() {
 #[test]
 fn update_add_isitmaintained_issue_resolution() {
     // Add a isitmaintained_issue_resolution badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(
@@ -204,8 +199,7 @@ fn update_add_isitmaintained_issue_resolution() {
 #[test]
 fn update_add_isitmaintained_open_issues() {
     // Add a isitmaintained_open_issues badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(
@@ -222,8 +216,7 @@ fn update_add_isitmaintained_open_issues() {
 #[test]
 fn update_add_codecov() {
     // Add a codecov badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(String::from("codecov"), test_badges.codecov_attributes);
@@ -234,8 +227,7 @@ fn update_add_codecov() {
 #[test]
 fn update_add_coveralls() {
     // Add a coveralls badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(String::from("coveralls"), test_badges.coveralls_attributes);
@@ -246,8 +238,7 @@ fn update_add_coveralls() {
 #[test]
 fn update_add_circle_ci() {
     // Add a CircleCI badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(String::from("circle-ci"), test_badges.circle_ci_attributes);
@@ -258,8 +249,7 @@ fn update_add_circle_ci() {
 #[test]
 fn update_add_maintenance() {
     // Add a maintenance badge
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(
@@ -273,8 +263,7 @@ fn update_add_maintenance() {
 #[test]
 fn replace_badge() {
     // Replacing one badge with another
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     // Add a badge
     let mut badges = HashMap::new();
@@ -295,8 +284,7 @@ fn replace_badge() {
 #[test]
 fn update_attributes() {
     // Update badge attributes
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     // Add a travis-ci badge
     let mut badges = HashMap::new();
@@ -327,8 +315,7 @@ fn update_attributes() {
 #[test]
 fn clear_badges() {
     // Add 3 badges and then remove them
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -353,8 +340,7 @@ fn clear_badges() {
 #[test]
 fn appveyor_extra_keys() {
     // Add a badge with extra invalid keys
-    let (app, krate, test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -370,8 +356,7 @@ fn appveyor_extra_keys() {
 #[test]
 fn travis_ci_required_keys() {
     // Add a travis ci badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -388,8 +373,7 @@ fn travis_ci_required_keys() {
 #[test]
 fn gitlab_required_keys() {
     // Add a gitlab badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -406,8 +390,7 @@ fn gitlab_required_keys() {
 #[test]
 fn isitmaintained_issue_resolution_required_keys() {
     // Add a isitmaintained_issue_resolution badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -429,8 +412,7 @@ fn isitmaintained_issue_resolution_required_keys() {
 #[test]
 fn isitmaintained_open_issues_required_keys() {
     // Add a isitmaintained_open_issues badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -452,8 +434,7 @@ fn isitmaintained_open_issues_required_keys() {
 #[test]
 fn codecov_required_keys() {
     // Add a codecov badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -470,8 +451,7 @@ fn codecov_required_keys() {
 #[test]
 fn coveralls_required_keys() {
     // Add a coveralls badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -488,8 +468,7 @@ fn coveralls_required_keys() {
 #[test]
 fn circle_ci_required_keys() {
     // Add a CircleCI badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -506,8 +485,7 @@ fn circle_ci_required_keys() {
 #[test]
 fn maintenance_required_keys() {
     // Add a maintenance badge missing a required field
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -527,8 +505,7 @@ fn maintenance_required_keys() {
 #[test]
 fn maintenance_invalid_values() {
     // Add a maintenance badge with an invalid value
-    let (app, krate, mut test_badges) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -550,8 +527,7 @@ fn maintenance_invalid_values() {
 #[test]
 fn unknown_badge() {
     // Add an unknown badge
-    let (app, krate, _) = set_up();
-    let conn = app.diesel_database.get().unwrap();
+    let (conn, krate, _) = set_up();
 
     let mut badges = HashMap::new();
 

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -59,7 +59,7 @@ fn show() {
 
     // Return not found if a category doesn't exist
     let mut req = req(Method::Get, "/api/v1/categories/foo-bar");
-    let response = t_resp!(middle.call(&mut req));
+    let response = t!(middle.call(&mut req));
     assert_eq!(response.status.0, 404);
 
     // Create a category and a subcategory

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,6 +1,6 @@
 use models::Keyword;
 use views::EncodableKeyword;
-use {new_user, CrateBuilder, MockUserSession};
+use {new_user, CrateBuilder, RequestHelper, TestApp};
 
 #[derive(Deserialize)]
 struct KeywordList {
@@ -19,16 +19,16 @@ struct GoodKeyword {
 #[test]
 fn index() {
     let url = "/api/v1/keywords";
-    let session = MockUserSession::anonymous();
-    let json: KeywordList = session.get(url).good();
+    let (app, anon) = TestApp::empty();
+    let json: KeywordList = anon.get(url).good();
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
     });
 
-    let json: KeywordList = session.get(url).good();
+    let json: KeywordList = anon.get(url).good();
     assert_eq!(json.keywords.len(), 1);
     assert_eq!(json.meta.total, 1);
     assert_eq!(json.keywords[0].keyword.as_str(), "foo");
@@ -37,74 +37,74 @@ fn index() {
 #[test]
 fn show() {
     let url = "/api/v1/keywords/foo";
-    let session = MockUserSession::anonymous();
-    session.get(url).assert_not_found();
+    let (app, anon) = TestApp::empty();
+    anon.get(url).assert_not_found();
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
     });
-    let json: GoodKeyword = session.get(url).good();
+    let json: GoodKeyword = anon.get(url).good();
     assert_eq!(json.keyword.keyword.as_str(), "foo");
 }
 
 #[test]
 fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
-    let session = MockUserSession::anonymous();
-    session.get(url).assert_not_found();
+    let (app, anon) = TestApp::empty();
+    anon.get(url).assert_not_found();
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();
     });
-    let json: GoodKeyword = session.get(url).good();
+    let json: GoodKeyword = anon.get(url).good();
     assert_eq!(json.keyword.keyword.as_str(), "upper");
 }
 
 #[test]
 fn update_crate() {
-    let session = MockUserSession::anonymous();
+    let (app, anon) = TestApp::empty();
     let cnt = |kw: &str| {
-        let json: GoodKeyword = session.get(&format!("/api/v1/keywords/{}", kw)).good();
+        let json: GoodKeyword = anon.get(&format!("/api/v1/keywords/{}", kw)).good();
         json.keyword.crates_cnt as usize
     };
 
-    let krate = session.db(|conn| {
+    let krate = app.db(|conn| {
         let u = new_user("foo").create_or_update(&conn).unwrap();
         Keyword::find_or_create_all(&conn, &["kw1", "kw2"]).unwrap();
         CrateBuilder::new("fookey", u.id).expect_build(&conn)
     });
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::update_crate(&conn, &krate, &[]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);
     assert_eq!(cnt("kw2"), 0);
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::update_crate(&conn, &krate, &["kw1"]).unwrap();
     });
     assert_eq!(cnt("kw1"), 1);
     assert_eq!(cnt("kw2"), 0);
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::update_crate(&conn, &krate, &["kw2"]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);
     assert_eq!(cnt("kw2"), 1);
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::update_crate(&conn, &krate, &[]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);
     assert_eq!(cnt("kw2"), 0);
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::update_crate(&conn, &krate, &["kw1", "kw2"]).unwrap();
     });
     assert_eq!(cnt("kw1"), 1);
     assert_eq!(cnt("kw2"), 1);
 
-    session.db(|conn| {
+    app.db(|conn| {
         Keyword::update_crate(&conn, &krate, &[]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -27,10 +27,10 @@ fn index() {
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
 
-    {
-        let conn = session.db_conn();
-        Keyword::find_or_create_all(&conn, &["foo"]).unwrap();
-    }
+    session.db(|conn| {
+        Keyword::find_or_create_all(conn, &["foo"]).unwrap();
+    });
+
     let json: KeywordList = session.get(url).good();
     assert_eq!(json.keywords.len(), 1);
     assert_eq!(json.meta.total, 1);
@@ -43,10 +43,9 @@ fn show() {
     let mut session = MockUserSession::anonymous();
     session.get::<()>(url).assert_status(404);
 
-    {
-        let conn = session.db_conn();
-        Keyword::find_or_create_all(&conn, &["foo"]).unwrap();
-    }
+    session.db(|conn| {
+        Keyword::find_or_create_all(conn, &["foo"]).unwrap();
+    });
     let json: GoodKeyword = session.get(url).good();
     assert_eq!(json.keyword.keyword, "foo".to_string());
 }
@@ -57,10 +56,9 @@ fn uppercase() {
     let mut session = MockUserSession::anonymous();
     session.get::<()>(url).assert_status(404);
 
-    {
-        let conn = session.db_conn();
-        Keyword::find_or_create_all(&conn, &["UPPER"]).unwrap();
-    }
+    session.db(|conn| {
+        Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();
+    });
     let json: GoodKeyword = session.get(url).good();
     assert_eq!(json.keyword.keyword, "upper".to_string());
 }

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -31,7 +31,7 @@ fn index() {
     let json: KeywordList = session.get(url).good();
     assert_eq!(json.keywords.len(), 1);
     assert_eq!(json.meta.total, 1);
-    assert_eq!(json.keywords[0].keyword, "foo".to_string());
+    assert_eq!(json.keywords[0].keyword.as_str(), "foo");
 }
 
 #[test]
@@ -44,7 +44,7 @@ fn show() {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
     });
     let json: GoodKeyword = session.get(url).good();
-    assert_eq!(json.keyword.keyword, "foo".to_string());
+    assert_eq!(json.keyword.keyword.as_str(), "foo");
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn uppercase() {
         Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();
     });
     let json: GoodKeyword = session.get(url).good();
-    assert_eq!(json.keyword.keyword, "upper".to_string());
+    assert_eq!(json.keyword.keyword.as_str(), "upper");
 }
 
 #[test]

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -38,7 +38,7 @@ fn index() {
 fn show() {
     let url = "/api/v1/keywords/foo";
     let session = MockUserSession::anonymous();
-    session.get::<()>(url).assert_status(404);
+    session.get(url).assert_not_found();
 
     session.db(|conn| {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
@@ -51,7 +51,7 @@ fn show() {
 fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
     let session = MockUserSession::anonymous();
-    session.get::<()>(url).assert_status(404);
+    session.get(url).assert_not_found();
 
     session.db(|conn| {
         Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,9 +1,6 @@
-use conduit::{Handler, Method};
-use conduit_test::MockRequest;
-
 use models::Keyword;
 use views::EncodableKeyword;
-use {app, new_user, req, CrateBuilder, MockUserSession};
+use {new_user, CrateBuilder, MockUserSession};
 
 #[derive(Deserialize)]
 struct KeywordList {
@@ -22,7 +19,7 @@ struct GoodKeyword {
 #[test]
 fn index() {
     let url = "/api/v1/keywords";
-    let mut session = MockUserSession::anonymous();
+    let session = MockUserSession::anonymous();
     let json: KeywordList = session.get(url).good();
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
@@ -40,7 +37,7 @@ fn index() {
 #[test]
 fn show() {
     let url = "/api/v1/keywords/foo";
-    let mut session = MockUserSession::anonymous();
+    let session = MockUserSession::anonymous();
     session.get::<()>(url).assert_status(404);
 
     session.db(|conn| {
@@ -53,7 +50,7 @@ fn show() {
 #[test]
 fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
-    let mut session = MockUserSession::anonymous();
+    let session = MockUserSession::anonymous();
     session.get::<()>(url).assert_status(404);
 
     session.db(|conn| {
@@ -65,60 +62,51 @@ fn uppercase() {
 
 #[test]
 fn update_crate() {
-    let (_b, app, middle) = app();
-    let mut req = req(Method::Get, "/api/v1/keywords/foo");
-    let cnt = |req: &mut MockRequest, kw: &str| {
-        req.with_path(&format!("/api/v1/keywords/{}", kw));
-        let mut response = ok_resp!(middle.call(req));
-        ::json::<GoodKeyword>(&mut response).keyword.crates_cnt as usize
+    let session = MockUserSession::anonymous();
+    let cnt = |kw: &str| {
+        let json: GoodKeyword = session.get(&format!("/api/v1/keywords/{}", kw)).good();
+        json.keyword.crates_cnt as usize
     };
 
-    let krate = {
-        let conn = app.diesel_database.get().unwrap();
+    let krate = session.db(|conn| {
         let u = new_user("foo").create_or_update(&conn).unwrap();
         Keyword::find_or_create_all(&conn, &["kw1", "kw2"]).unwrap();
         CrateBuilder::new("fookey", u.id).expect_build(&conn)
-    };
+    });
 
-    {
-        let conn = app.diesel_database.get().unwrap();
+    session.db(|conn| {
         Keyword::update_crate(&conn, &krate, &[]).unwrap();
-    }
-    assert_eq!(cnt(&mut req, "kw1"), 0);
-    assert_eq!(cnt(&mut req, "kw2"), 0);
+    });
+    assert_eq!(cnt("kw1"), 0);
+    assert_eq!(cnt("kw2"), 0);
 
-    {
-        let conn = app.diesel_database.get().unwrap();
+    session.db(|conn| {
         Keyword::update_crate(&conn, &krate, &["kw1"]).unwrap();
-    }
-    assert_eq!(cnt(&mut req, "kw1"), 1);
-    assert_eq!(cnt(&mut req, "kw2"), 0);
+    });
+    assert_eq!(cnt("kw1"), 1);
+    assert_eq!(cnt("kw2"), 0);
 
-    {
-        let conn = app.diesel_database.get().unwrap();
+    session.db(|conn| {
         Keyword::update_crate(&conn, &krate, &["kw2"]).unwrap();
-    }
-    assert_eq!(cnt(&mut req, "kw1"), 0);
-    assert_eq!(cnt(&mut req, "kw2"), 1);
+    });
+    assert_eq!(cnt("kw1"), 0);
+    assert_eq!(cnt("kw2"), 1);
 
-    {
-        let conn = app.diesel_database.get().unwrap();
+    session.db(|conn| {
         Keyword::update_crate(&conn, &krate, &[]).unwrap();
-    }
-    assert_eq!(cnt(&mut req, "kw1"), 0);
-    assert_eq!(cnt(&mut req, "kw2"), 0);
+    });
+    assert_eq!(cnt("kw1"), 0);
+    assert_eq!(cnt("kw2"), 0);
 
-    {
-        let conn = app.diesel_database.get().unwrap();
+    session.db(|conn| {
         Keyword::update_crate(&conn, &krate, &["kw1", "kw2"]).unwrap();
-    }
-    assert_eq!(cnt(&mut req, "kw1"), 1);
-    assert_eq!(cnt(&mut req, "kw2"), 1);
+    });
+    assert_eq!(cnt("kw1"), 1);
+    assert_eq!(cnt("kw2"), 1);
 
-    {
-        let conn = app.diesel_database.get().unwrap();
+    session.db(|conn| {
         Keyword::update_crate(&conn, &krate, &[]).unwrap();
-    }
-    assert_eq!(cnt(&mut req, "kw1"), 0);
-    assert_eq!(cnt(&mut req, "kw2"), 0);
+    });
+    assert_eq!(cnt("kw1"), 0);
+    assert_eq!(cnt("kw2"), 0);
 }

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1509,7 +1509,7 @@ fn yank() {
 fn yank_not_owner() {
     let mut session = MockUserSession::logged_in();
     {
-        let conn = session.app.diesel_database.get().unwrap();
+        let conn = session.db_conn();
         let another_user = new_user("bar").create_or_update(&conn).unwrap();
         CrateBuilder::new("foo_not", another_user.id).expect_build(&conn);
     }

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -70,7 +70,7 @@ struct SummaryResponse {
 #[test]
 fn index() {
     let url = "/api/v1/crates";
-    let mut session = MockUserSession::anonymous();
+    let session = MockUserSession::anonymous();
     let json: CrateList = session.get(url).good();
     assert_eq!(json.crates.len(), 0);
     assert_eq!(json.meta.total, 0);
@@ -543,7 +543,7 @@ fn yanked_versions_are_not_considered_for_max_version() {
 
 #[test]
 fn versions() {
-    let mut session = MockUserSession::anonymous();
+    let session = MockUserSession::anonymous();
     session.db(|conn| {
         let u = new_user("foo").create_or_update(conn).unwrap();
         CrateBuilder::new("foo_versions", u.id)
@@ -1511,9 +1511,11 @@ fn yank_not_owner() {
         CrateBuilder::new("foo_not", another_user.id).expect_build(conn);
     });
 
-    let mut response = session.yank("foo_not", "1.0.0");
-
-    ::json::<Bad>(&mut response);
+    let json = session.yank("foo_not", "1.0.0").bad();
+    assert_eq!(
+        json.errors[0].detail,
+        "crate `foo_not` does not have a version `1.0.0`"
+    );
 }
 
 #[test]

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1348,17 +1348,11 @@ fn dependencies() {
 
 #[test]
 fn diesel_not_found_results_in_404() {
-    let (_b, app, middle) = app();
-    let mut req = req(Method::Get, "/api/v1/crates/foo_following/following");
+    let session = MockUserSession::logged_in();
 
-    {
-        let conn = app.diesel_database.get().unwrap();
-        let user = new_user("foo").create_or_update(&conn).unwrap();
-        sign_in_as(&mut req, &user);
-    }
-
-    let response = middle.call(&mut req).unwrap();
-    assert_eq!((404, "Not Found"), response.status);
+    session
+        .get("/api/v1/crates/foo_following/following")
+        .assert_not_found();
 }
 
 #[test]

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -31,8 +31,8 @@ use {
     app, krate, logout, new_category, new_crate, new_crate_to_body, new_crate_to_body_with_io,
     new_crate_to_body_with_tarball, new_dependency, new_req, new_req_body_version_2, new_req_full,
     new_req_with_badges, new_req_with_categories, new_req_with_documentation,
-    new_req_with_keywords, new_user, new_version, req, sign_in, sign_in_as, user, Bad,
-    CrateBuilder, CrateList, CrateMeta, CrateResponse, GoodCrate, MockUserSession, PublishBuilder,
+    new_req_with_keywords, new_user, new_version, req, sign_in, sign_in_as, Bad, CrateBuilder,
+    CrateList, CrateMeta, CrateResponse, GoodCrate, MockUserSession, PublishBuilder,
     VersionBuilder,
 };
 
@@ -2083,7 +2083,6 @@ fn yanked_versions_not_included_in_reverse_dependencies() {
 #[test]
 fn author_license_and_description_required() {
     let (_b, _, middle) = app();
-    user("foo");
 
     let mut req = req(Method::Put, "/api/v1/crates/new");
     let mut new_crate = new_crate("foo_metadata", "1.1.0");

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -771,7 +771,7 @@ fn new_renamed_crate() {
     assert_eq!(p.vers, "1.0.0");
     assert_eq!(p.deps.len(), 1);
     assert_eq!(p.deps[0].name, "my-name");
-    assert_eq!(p.deps[0].package, Some("package-name".to_string()));
+    assert_eq!(p.deps[0].package.as_ref().unwrap(), "package-name");
 }
 
 #[test]
@@ -1821,7 +1821,7 @@ fn ignored_categories() {
     let json: GoodCrate = ::json(&mut response);
     assert_eq!(json.krate.name, "foo_ignored_cat");
     assert_eq!(json.krate.max_version, "1.0.0");
-    assert_eq!(json.warnings.invalid_categories, vec!["bar".to_string()]);
+    assert_eq!(json.warnings.invalid_categories, vec!["bar"]);
 }
 
 #[test]

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -32,7 +32,7 @@ use {
     new_crate_to_body_with_tarball, new_dependency, new_req, new_req_body_version_2, new_req_full,
     new_req_with_badges, new_req_with_categories, new_req_with_documentation,
     new_req_with_keywords, new_user, new_version, req, sign_in, sign_in_as, Bad, CrateBuilder,
-    CrateList, CrateMeta, CrateResponse, GoodCrate, MockUserSession, PublishBuilder,
+    CrateList, CrateMeta, CrateResponse, GoodCrate, MockUserSession, OkBool, PublishBuilder,
     VersionBuilder,
 };
 
@@ -1367,10 +1367,6 @@ fn following() {
     struct F {
         following: bool,
     }
-    #[derive(Deserialize)]
-    struct O {
-        ok: bool,
-    }
 
     let (_b, app, middle) = app();
     let mut req = req(Method::Get, "/api/v1/crates/foo_following/following");
@@ -1389,9 +1385,9 @@ fn following() {
     req.with_path("/api/v1/crates/foo_following/follow")
         .with_method(Method::Put);
     let mut response = ok_resp!(middle.call(&mut req));
-    assert!(::json::<O>(&mut response).ok);
+    assert!(::json::<OkBool>(&mut response).ok);
     let mut response = ok_resp!(middle.call(&mut req));
-    assert!(::json::<O>(&mut response).ok);
+    assert!(::json::<OkBool>(&mut response).ok);
 
     req.with_path("/api/v1/crates/foo_following/following")
         .with_method(Method::Get);
@@ -1408,9 +1404,9 @@ fn following() {
     req.with_path("/api/v1/crates/foo_following/follow")
         .with_method(Method::Delete);
     let mut response = ok_resp!(middle.call(&mut req));
-    assert!(::json::<O>(&mut response).ok);
+    assert!(::json::<OkBool>(&mut response).ok);
     let mut response = ok_resp!(middle.call(&mut req));
-    assert!(::json::<O>(&mut response).ok);
+    assert!(::json::<OkBool>(&mut response).ok);
 
     req.with_path("/api/v1/crates/foo_following/following")
         .with_method(Method::Get);
@@ -1426,10 +1422,6 @@ fn following() {
 
 #[test]
 fn yank() {
-    #[derive(Deserialize)]
-    struct O {
-        ok: bool,
-    }
     #[derive(Deserialize)]
     struct V {
         version: EncodableVersion,
@@ -1465,7 +1457,7 @@ fn yank() {
                 .with_path("/api/v1/crates/fyk/1.0.0/yank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut contents = String::new();
     File::open(&path)
         .unwrap()
@@ -1487,7 +1479,7 @@ fn yank() {
                 .with_path("/api/v1/crates/fyk/1.0.0/unyank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut contents = String::new();
     File::open(&path)
         .unwrap()
@@ -1520,10 +1512,6 @@ fn yank_not_owner() {
 
 #[test]
 fn yank_max_version() {
-    #[derive(Deserialize)]
-    struct O {
-        ok: bool,
-    }
     let (_b, app, middle) = app();
 
     // Upload a new crate
@@ -1554,7 +1542,7 @@ fn yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/1.0.0/yank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)
@@ -1571,7 +1559,7 @@ fn yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/1.0.0/unyank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)
@@ -1588,7 +1576,7 @@ fn yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/2.0.0/yank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)
@@ -1605,7 +1593,7 @@ fn yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/1.0.0/yank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)
@@ -1622,7 +1610,7 @@ fn yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/2.0.0/unyank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)
@@ -1639,7 +1627,7 @@ fn yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/1.0.0/unyank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)
@@ -1652,10 +1640,6 @@ fn yank_max_version() {
 
 #[test]
 fn publish_after_yank_max_version() {
-    #[derive(Deserialize)]
-    struct O {
-        ok: bool,
-    }
     let (_b, app, middle) = app();
 
     // Upload a new crate
@@ -1674,7 +1658,7 @@ fn publish_after_yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/1.0.0/yank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)
@@ -1703,7 +1687,7 @@ fn publish_after_yank_max_version() {
                 .with_path("/api/v1/crates/fyk_max/1.0.0/unyank",),
         )
     );
-    assert!(::json::<O>(&mut r).ok);
+    assert!(::json::<OkBool>(&mut r).ok);
     let mut response = ok_resp!(
         middle.call(
             req.with_method(Method::Get,)

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -917,7 +917,9 @@ fn valid_feature_names() {
 fn new_krate_too_big() {
     let files = [("foo_big-1.0.0/big", &[b'a'; 2000] as &[_])];
     let builder = PublishBuilder::new("foo_big").files(&files);
-    let json = MockUserSession::logged_in().publish(builder).bad();
+    let json = MockUserSession::logged_in()
+        .publish(builder)
+        .bad_with_status(200);
     assert!(
         json.errors[0]
             .detail
@@ -1497,7 +1499,7 @@ fn yank_not_owner() {
         CrateBuilder::new("foo_not", another_user.id).expect_build(conn);
     });
 
-    let json = session.yank("foo_not", "1.0.0").bad();
+    let json = session.yank("foo_not", "1.0.0").bad_with_status(200);
     assert_eq!(
         json.errors[0].detail,
         "crate `foo_not` does not have a version `1.0.0`"

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -26,7 +26,7 @@ fn new_crate_owner() {
     // Create a crate under one user
     let mut session = MockUserSession::logged_in();
     let crate_to_publish = PublishBuilder::new("foo_owner").version("1.0.0");
-    session.publish(crate_to_publish);
+    session.publish(crate_to_publish).good();
 
     let u2;
     {
@@ -49,7 +49,7 @@ fn new_crate_owner() {
 
     // And upload a new crate as the second user
     let crate_to_publish = PublishBuilder::new("foo_owner").version("2.0.0");
-    session.publish(crate_to_publish);
+    session.publish(crate_to_publish).good();
 }
 
 // Ensures that so long as at least one owner remains associated with the crate,

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -146,8 +146,7 @@ fn create_token_multiple_users_have_different_values() {
     let mut session = MockUserSession::logged_in();
     let first_token: NewResponse = session.put(URL, NEW_BAR).good();
 
-    let second_user = session.db(|conn| t!(new_user("bar").create_or_update(conn)));
-    session.log_in_as(second_user);
+    session.log_in_as_new("bar");
     let second_token: NewResponse = session.put(URL, NEW_BAR).good();
 
     assert_ne!(first_token.api_token.token, second_token.api_token.token);
@@ -189,13 +188,8 @@ fn revoke_token_doesnt_revoke_other_users_token() {
     let user1 = session.user().clone();
 
     // Create one user with a token and sign in with a different user
-    let (token, user2) = session.db(|conn| {
-        (
-            t!(ApiToken::insert(conn, user1.id, "bar")),
-            t!(new_user("baz").create_or_update(conn)),
-        )
-    });
-    session.log_in_as(user2);
+    let token = session.db(|conn| t!(ApiToken::insert(conn, user1.id, "bar")));
+    session.log_in_as_new("baz");
 
     // List tokens for first user contains the token
     session.db(|conn| {

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -5,7 +5,9 @@ use diesel::prelude::*;
 
 use models::{ApiToken, Email, NewUser, User};
 use views::{EncodableCrate, EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
-use {app, logout, new_user, req, sign_in, sign_in_as, Bad, CrateBuilder, VersionBuilder, NEXT_ID};
+use {
+    app, logout, new_user, req, sign_in, sign_in_as, Bad, CrateBuilder, VersionBuilder, NEXT_GH_ID,
+};
 
 #[derive(Deserialize)]
 struct AuthResponse {
@@ -321,7 +323,7 @@ fn updating_existing_user_doesnt_change_api_token() {
     let (_b, app, _middle) = app();
     let conn = t!(app.diesel_database.get());
 
-    let gh_user_id = NEXT_ID.fetch_add(1, Ordering::SeqCst) as i32;
+    let gh_user_id = NEXT_GH_ID.fetch_add(1, Ordering::SeqCst) as i32;
 
     let original_user =
         t!(NewUser::new(gh_user_id, "foo", None, None, None, "foo_token").create_or_update(&conn));

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -5,10 +5,10 @@ use diesel::prelude::*;
 
 use models::{ApiToken, Email, NewUser, User};
 use util::RequestHelper;
-use views::{EncodableCrate, EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
+use views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
 use {
-    app, logout, new_user, req, sign_in_as, CrateBuilder, OkBool, TestApp, VersionBuilder,
-    NEXT_GH_ID,
+    app, logout, new_user, req, sign_in_as, CrateBuilder, CrateList, OkBool, TestApp,
+    VersionBuilder, NEXT_GH_ID,
 };
 
 #[derive(Deserialize)]
@@ -25,11 +25,6 @@ pub struct UserShowPublicResponse {
 #[derive(Deserialize)]
 pub struct UserShowPrivateResponse {
     pub user: EncodablePrivateUser,
-}
-
-#[derive(Deserialize)]
-struct CrateList {
-    crates: Vec<EncodableCrate>,
 }
 
 #[test]

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -1,0 +1,311 @@
+/// This module provides utility types and traits for managing a test session
+///
+/// Tests start by using one of the `TestApp` constructors.  All constrcutors return at least a
+/// `TestApp` and `MockAnonymousUser`.  The `MockAnonymousUser` can be used to issue requests
+/// in an unauthenticated session.
+///
+/// A `TestApp` value provides raw access to the database through the `db` function and can
+/// construct new users via the `db_new_user` function.  This function returns a
+/// `MockCookieUser`, which can be used to generate one or more tokens via its `db_new_token`
+/// function, which in turn returns a `MockTokenUser`.
+///
+/// All three user types implement the `RequestHelper` trait which provides convenience methods for
+/// constructing requests.  Some of these methods, such as `publish` are expected to fail for an
+/// unauthenticated user (or for other reasons) and return a `Response<T>`.  The `Response<T>`
+/// provides several functions to check the response status and deserialize the JSON response.
+///
+/// `MockCookieUser` and `MockTokenUser` provide an `as_model` function which returns a reference
+/// to the underlying database model value (`User` and `ApiToken` respectively).
+use std::{self, rc::Rc, sync::Arc};
+
+use {conduit, conduit_middleware, diesel, serde};
+
+use conduit::{Handler, Method, Request};
+use conduit_test::MockRequest;
+
+use cargo_registry::app::App;
+use cargo_registry::middleware::current_user::AuthenticationSource;
+use models::{ApiToken, User};
+
+use super::{app, record, CrateList, CrateResponse, GoodCrate, PublishBuilder};
+
+struct TestAppInner {
+    app: Arc<App>,
+    // The bomb needs to be held in scope until the end of the test.
+    _bomb: record::Bomb,
+    middle: conduit_middleware::MiddlewareBuilder,
+}
+
+/// A representation of the app and its database transaction
+pub struct TestApp(Rc<TestAppInner>);
+
+impl TestApp {
+    /// Create a `TestApp` with an empty database
+    pub fn empty() -> (Self, MockAnonymousUser) {
+        let (_bomb, app, middle) = app();
+        let inner = Rc::new(TestAppInner { app, _bomb, middle });
+        let anon = MockAnonymousUser {
+            inner: TestApp(Rc::clone(&inner)),
+        };
+        (TestApp(inner), anon)
+    }
+
+    // Create a `TestApp` with a database including a default user
+    pub fn with_user() -> (Self, MockAnonymousUser, MockCookieUser) {
+        let (app, anon) = TestApp::empty();
+        let user = app.db_new_user("foo");
+        (app, anon, user)
+    }
+
+    /// Create a `TestApp` with a database including a default user and its token
+    pub fn with_token() -> (Self, MockAnonymousUser, MockCookieUser, MockTokenUser) {
+        let (app, anon) = TestApp::empty();
+        let user = app.db_new_user("foo");
+        let token = user.db_new_token("bar");
+        (app, anon, user, token)
+    }
+
+    /// Obtain the database connection and pass it to the closure
+    ///
+    /// Within each test, the connection pool only has 1 connection so it is necessary to drop the
+    /// connection before making any API calls.  Once the closure returns, the connection is
+    /// dropped, ensuring it is returned to the pool and available for any future API calls.
+    pub fn db<T, F: FnOnce(&DieselConnection) -> T>(&self, f: F) -> T {
+        let conn = self.0.app.diesel_database.get().unwrap();
+        f(&conn)
+    }
+
+    /// Create a new user in the database and return a mock user session
+    pub fn db_new_user(&self, user: &str) -> MockCookieUser {
+        let user = self.db(|conn| ::new_user(user).create_or_update(conn).unwrap());
+        MockCookieUser {
+            inner: TestApp(Rc::clone(&self.0)),
+            user,
+        }
+    }
+}
+
+/// A colleciton of helper methods for the 3 authentication types
+///
+/// Helper methods go through public APIs, and should not modify the database directly
+pub trait RequestHelper {
+    fn request_builder(&self, method: Method, path: &str) -> MockRequest;
+    fn app(&self) -> &TestApp;
+
+    /// Issue a GET request
+    fn get<T>(&self, path: &str) -> Response<T>
+    where
+        for<'de> T: serde::Deserialize<'de>,
+    {
+        let mut request = self.request_builder(Method::Get, path);
+        Response::new(self.app().0.middle.call(&mut request))
+    }
+
+    /// Issue a GET request that includes query parameters
+    fn get_with_query<T>(&self, path: &str, query: &str) -> Response<T>
+    where
+        for<'de> T: serde::Deserialize<'de>,
+    {
+        let mut request = self.request_builder(Method::Get, path);
+        request.with_query(query);
+        Response::new(self.app().0.middle.call(&mut request))
+    }
+
+    /// Issue a PUT request
+    fn put<T>(&self, path: &str, body: &[u8]) -> Response<T>
+    where
+        for<'de> T: serde::Deserialize<'de>,
+    {
+        let mut builder = self.request_builder(Method::Put, path);
+        let request = builder.with_body(body);
+        Response::new(self.app().0.middle.call(request))
+    }
+
+    /// Issue a DELETE request
+    fn delete<T>(&self, path: &str) -> Response<T>
+    where
+        for<'de> T: serde::Deserialize<'de>,
+    {
+        let mut request = self.request_builder(Method::Delete, path);
+        Response::new(self.app().0.middle.call(&mut request))
+    }
+
+    /// Get the crates owned by the specified user.
+    fn crates_owned_by_user_id(&self, id: i32) -> CrateList {
+        let query = format!("user_id={}", id);
+        self.get_with_query("/api/v1/crates", &query).good()
+    }
+
+    /// Publish a crate
+    fn publish(&self, publish_builder: PublishBuilder) -> Response<GoodCrate> {
+        let krate_name = publish_builder.krate_name.clone();
+        let response = self.put("/api/v1/crates/new", &publish_builder.body());
+        let callback_on_good = move |json: &GoodCrate| assert_eq!(json.krate.name, krate_name);
+        response.with_callback(Box::new(callback_on_good))
+    }
+
+    /// Request the JSON used for a crate's page
+    fn show_crate(&self, krate_name: &str) -> CrateResponse {
+        let url = format!("/api/v1/crates/{}", krate_name);
+        self.get(&url).good()
+    }
+}
+
+/// A type that can generate unauthenticated requests
+pub struct MockAnonymousUser {
+    inner: TestApp,
+}
+
+impl RequestHelper for MockAnonymousUser {
+    fn request_builder(&self, method: Method, path: &str) -> MockRequest {
+        MockRequest::new(method, path)
+    }
+
+    fn app(&self) -> &TestApp {
+        &self.inner
+    }
+}
+
+/// A type that can generate cookie authenticated requests
+///
+/// The `User` is directly injected into middleware extensions and thus the cookie logic is not
+/// exercised.
+pub struct MockCookieUser {
+    inner: TestApp,
+    user: User,
+}
+
+impl RequestHelper for MockCookieUser {
+    fn request_builder(&self, method: Method, path: &str) -> MockRequest {
+        let mut request = MockRequest::new(method, path);
+        request.mut_extensions().insert(self.user.clone());
+        request
+            .mut_extensions()
+            .insert(AuthenticationSource::SessionCookie);
+        request
+    }
+
+    fn app(&self) -> &TestApp {
+        &self.inner
+    }
+}
+
+impl MockCookieUser {
+    /// Returns a reference to the database `User` model
+    pub fn as_model(&self) -> &User {
+        &self.user
+    }
+
+    /// Creates a token and wraps it in a helper struct
+    ///
+    /// This method updates the database directly
+    pub fn db_new_token(&self, name: &str) -> MockTokenUser {
+        let token = self
+            .inner
+            .db(|conn| ApiToken::insert(conn, self.user.id, name).unwrap());
+        MockTokenUser {
+            inner: TestApp(Rc::clone(&self.inner.0)),
+            token,
+        }
+    }
+}
+
+/// A type that can generate token authenticated requests
+pub struct MockTokenUser {
+    inner: TestApp,
+    token: ApiToken,
+}
+
+impl RequestHelper for MockTokenUser {
+    fn request_builder(&self, method: Method, path: &str) -> MockRequest {
+        let mut request = MockRequest::new(method, path);
+        request.header("Authorization", &self.token.token);
+        request
+    }
+
+    fn app(&self) -> &TestApp {
+        &self.inner
+    }
+}
+
+impl MockTokenUser {
+    /// Returns a reference to the database `ApiToken` model
+    pub fn as_model(&self) -> &ApiToken {
+        &self.token
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Error {
+    pub detail: String,
+}
+
+#[derive(Deserialize)]
+pub struct Bad {
+    pub errors: Vec<Error>,
+}
+
+pub type DieselConnection =
+    diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
+type ResponseResult = Result<conduit::Response, Box<std::error::Error + Send>>;
+
+/// A type providing helper methods for working with responses
+#[must_use]
+pub struct Response<T> {
+    response: conduit::Response,
+    callback_on_good: Option<Box<Fn(&T)>>,
+}
+
+impl<T> Response<T>
+where
+    for<'de> T: serde::Deserialize<'de>,
+{
+    fn new(response: ResponseResult) -> Self {
+        Self {
+            response: t!(response),
+            callback_on_good: None,
+        }
+    }
+
+    fn with_callback(self, callback_on_good: Box<Fn(&T)>) -> Self {
+        Self {
+            response: self.response,
+            callback_on_good: Some(callback_on_good),
+        }
+    }
+
+    /// Assert that the response is good and deserialize the message
+    pub fn good(mut self) -> T {
+        if !::ok_resp(&self.response) {
+            panic!("bad response: {:?}", self.response.status);
+        }
+        let good = ::json(&mut self.response);
+        if let Some(callback) = self.callback_on_good {
+            callback(&good)
+        }
+        good
+    }
+
+    /// Assert the response status code and deserialze into a list of errors
+    ///
+    /// Cargo endpoints return a status 200 on error instead of 400.
+    pub fn bad_with_status(&mut self, code: u32) -> Bad {
+        assert_eq!(self.response.status.0, code);
+        match ::bad_resp(&mut self.response) {
+            None => panic!("ok response: {:?}", self.response.status),
+            Some(b) => b,
+        }
+    }
+}
+
+impl Response<()> {
+    /// Assert that the status code is 404
+    pub fn assert_not_found(&self) {
+        assert_eq!((404, "Not Found"), self.response.status);
+    }
+
+    /// Assert that the status code is 403
+    pub fn assert_forbidden(&self) {
+        assert_eq!((403, "Forbidden"), self.response.status);
+    }
+}

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -10,7 +10,8 @@ use conduit::{Handler, Method};
 use schema::versions;
 use views::EncodableVersion;
 use {
-    app, new_user, new_version, req, CrateBuilder, MockUserSession, PublishBuilder, VersionBuilder,
+    app, new_user, new_version, req, CrateBuilder, PublishBuilder, RequestHelper, TestApp,
+    VersionBuilder,
 };
 
 #[derive(Deserialize)]
@@ -113,18 +114,18 @@ fn record_rerendered_readme_time() {
 
 #[test]
 fn version_size() {
-    let mut session = MockUserSession::logged_in();
+    let (_, _, user) = TestApp::with_user();
     let crate_to_publish = PublishBuilder::new("foo_version_size").version("1.0.0");
-    session.publish(crate_to_publish).good();
+    user.publish(crate_to_publish).good();
 
     // Add a file to version 2 so that it's a different size than version 1
     let files = [("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_])];
     let crate_to_publish = PublishBuilder::new("foo_version_size")
         .version("2.0.0")
         .files(&files);
-    session.publish(crate_to_publish).good();
+    user.publish(crate_to_publish).good();
 
-    let crate_json = session.show_crate("foo_version_size");
+    let crate_json = user.show_crate("foo_version_size");
 
     let version1 = crate_json
         .versions

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -115,14 +115,14 @@ fn record_rerendered_readme_time() {
 fn version_size() {
     let mut session = MockUserSession::logged_in();
     let crate_to_publish = PublishBuilder::new("foo_version_size").version("1.0.0");
-    session.publish(crate_to_publish);
+    session.publish(crate_to_publish).good();
 
     // Add a file to version 2 so that it's a different size than version 1
     let files = [("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_])];
     let crate_to_publish = PublishBuilder::new("foo_version_size")
         .version("2.0.0")
         .files(&files);
-    session.publish(crate_to_publish);
+    session.publish(crate_to_publish).good();
 
     let crate_json = session.show_crate("foo_version_size");
 

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -92,7 +92,7 @@ fn authors() {
     let s = ::std::str::from_utf8(&data).unwrap();
     let json: Value = serde_json::from_str(s).unwrap();
     let json = json.as_object().unwrap();
-    assert!(json.contains_key(&"users".to_string()));
+    assert!(json.contains_key("users"));
 }
 
 #[test]

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -150,6 +150,11 @@ pub struct EncodableApiTokenWithToken {
     pub last_used_at: Option<NaiveDateTime>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EncodableMe {
+    pub user: EncodablePrivateUser,
+}
+
 /// The serialization format for the `User` model.
 /// Same as public user, except for addition of
 /// email field


### PR DESCRIPTION
This builds on the test infrastructure improvements made by @carols10cents.  In particular, it adds a `Response<T>` type that wraps the `conduit::Response` and a callback.  Tests can use the `good()` method which asserts that the response status is good and returns the deserialized `T`.  It is the equivalent of `::json(&mut ok_resp!(...))`. The `bad()` method is equivalent to `bad_resp!`.

The callback is called if the test calls `good()` on the response.  This allows helper methods to return a `Response<T>` with attached assertions that are run if the test expects the response to deserialize correctly, but are not run if the test expects an error response.