### PR TITLE
Add a `dry_run` flag to `/crates/new`

### DIFF
--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -2361,3 +2361,14 @@ fn new_krate_hard_links() {
     let body = new_crate_to_body_with_tarball(&new_crate("foo", "1.1.0"), &tarball);
     bad_resp!(middle.call(req.with_body(&body)));
 }
+
+#[test]
+fn new_krate_dry_run() {
+    let (_b, app, middle) = app();
+    let mut req = new_req("new_crate_dry_run", "1.0.0");
+    req.with_query("dry_run=1");
+    sign_in(&mut req, &app);
+    ok_resp!(middle.call(&mut req));
+    // We know that nothing tried to talk to S3 or Github since there is no
+    // http-data file for this test.
+}

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -1,4 +1,4 @@
-use std::any::Any;
+use std::any::{Any, TypeId};
 use std::error::Error;
 use std::fmt;
 
@@ -38,6 +38,26 @@ pub trait CargoError: Send + fmt::Display + 'static {
     }
     fn human(&self) -> bool {
         false
+    }
+
+    fn get_type_id(&self) -> TypeId {
+        TypeId::of::<Self>()
+    }
+}
+
+impl dyn CargoError {
+    pub fn is<T: Any>(&self) -> bool {
+        self.get_type_id() == TypeId::of::<T>()
+    }
+
+    pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
+        if self.is::<T>() {
+            unsafe {
+                Some(&*(self as *const Self as *const T))
+            }
+        } else {
+            None
+        }
     }
 }
 


### PR DESCRIPTION
Note: Includes #1516

There is interest from Cargo in having the ability to make `cargo
publish --dry-run` hit crates.io to see if there are any checks that we
perform which Cargo does not. This looks for a `dry_run` query param in
the publish function, and will roll back the database transaction before
attempting to upload to S3 or update the index, but after all other
checks are complete.

The code is fairly straightforward, the only hard part here is actually
being able to check why we rolled back the transaction in the first
place. We have to re-implement the inherent methods from `Any` here,
since we can't call inherent methods from `dyn Any` on `dyn CargoError`
even though all `CargoError`s implement `Any`.

Fixes #1515