### PR TITLE
Make `CargoError` implement debug

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -19,7 +19,7 @@ struct Bad {
 // =============================================================================
 // CargoError trait
 
-pub trait CargoError: Send + fmt::Display + 'static {
+pub trait CargoError: Send + fmt::Display + fmt::Debug + 'static {
     fn description(&self) -> &str;
     fn cause(&self) -> Option<&(dyn CargoError)> {
         None
@@ -38,12 +38,6 @@ pub trait CargoError: Send + fmt::Display + 'static {
     }
     fn human(&self) -> bool {
         false
-    }
-}
-
-impl fmt::Debug for Box<dyn CargoError> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
     }
 }
 
@@ -88,6 +82,7 @@ pub trait ChainError<T> {
         F: FnOnce() -> E;
 }
 
+#[derive(Debug)]
 struct ChainedError<E> {
     error: E,
     cause: Box<dyn CargoError>,
@@ -166,6 +161,7 @@ impl<E: Any + Error + Send + 'static> From<E> for Box<dyn CargoError> {
             }
         }
 
+        #[derive(Debug)]
         struct Shim<E>(E);
         impl<E: Error + Send + 'static> CargoError for Shim<E> {
             fn description(&self) -> &str {
@@ -202,6 +198,7 @@ impl CargoError for ::std::io::Error {
 // =============================================================================
 // Concrete errors
 
+#[derive(Debug)]
 struct ConcreteCargoError {
     description: String,
     detail: Option<String>,
@@ -281,6 +278,7 @@ impl fmt::Display for Unauthorized {
     }
 }
 
+#[derive(Debug)]
 struct BadRequest(String);
 
 impl CargoError for BadRequest {


### PR DESCRIPTION
If you don't have the concrete error type you expect, or aren't sure
what you even have, figuring out the answer is incredibly frustrating
without this impl. We do not ever use the debug implementation outside
of tests.