### PR TITLE
Add `TestApp::init()` for tests that don't need HTTP recording

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -103,8 +103,8 @@ impl App {
     /// Returns a client for making HTTP requests to upload crate files.
     ///
     /// The handle will go through a proxy if the uploader being used has specified one, which
-    /// is only done in test mode in order to be able to record and inspect the HTTP requests
-    /// that tests make.
+    /// is only done in tests with `TestApp::with_proxy()` in order to be able to record and
+    /// inspect the HTTP requests that tests make.
     pub fn http_client(&self) -> CargoResult<reqwest::Client> {
         let mut builder = reqwest::Client::builder();
         if let Some(proxy) = self.config.uploader.proxy() {

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -24,7 +24,7 @@ struct CategoryWithSubcategories {
 
 #[test]
 fn index() {
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     let url = "/api/v1/categories";
 
     // List 0 categories if none exist
@@ -51,7 +51,7 @@ fn index() {
 
 #[test]
 fn show() {
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     let url = "/api/v1/categories/foo-bar";
 
     // Return not found if a category doesn't exist
@@ -161,7 +161,7 @@ fn update_crate() {
 
 #[test]
 fn category_slugs_returns_all_slugs_in_alphabetical_order() {
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     app.db(|conn| {
         new_category("Foo", "foo", "For crates that foo")
             .create_or_update(&conn)

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -19,7 +19,7 @@ struct GoodKeyword {
 #[test]
 fn index() {
     let url = "/api/v1/keywords";
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     let json: KeywordList = anon.get(url).good();
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
@@ -37,7 +37,7 @@ fn index() {
 #[test]
 fn show() {
     let url = "/api/v1/keywords/foo";
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     anon.get(url).assert_not_found();
 
     app.db(|conn| {
@@ -50,7 +50,7 @@ fn show() {
 #[test]
 fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     anon.get(url).assert_not_found();
 
     app.db(|conn| {
@@ -62,7 +62,7 @@ fn uppercase() {
 
 #[test]
 fn update_crate() {
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     let cnt = |kw: &str| {
         let json: GoodKeyword = anon.get(&format!("/api/v1/keywords/{}", kw)).good();
         json.keyword.crates_cnt as usize

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -79,7 +79,7 @@ impl ::util::MockTokenUser {
 
 #[test]
 fn index() {
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     let json = anon.search("");
     assert_eq!(json.crates.len(), 0);
     assert_eq!(json.meta.total, 0);
@@ -98,7 +98,7 @@ fn index() {
 
 #[test]
 fn index_queries() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     let (krate, krate2) = app.db(|conn| {
@@ -179,7 +179,7 @@ fn index_queries() {
 
 #[test]
 fn search_includes_crates_where_name_is_stopword() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
     app.db(|conn| {
         CrateBuilder::new("which", user.id).expect_build(conn);
@@ -194,7 +194,7 @@ fn search_includes_crates_where_name_is_stopword() {
 
 #[test]
 fn exact_match_first_on_queries() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -236,7 +236,7 @@ fn exact_match_first_on_queries() {
 
 #[test]
 fn index_sorting() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -318,7 +318,7 @@ fn index_sorting() {
 
 #[test]
 fn exact_match_on_queries_with_sort() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -416,7 +416,7 @@ fn exact_match_on_queries_with_sort() {
 
 #[test]
 fn show() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     let krate = app.db(|conn| {
@@ -463,7 +463,7 @@ fn show() {
 
 #[test]
 fn yanked_versions_are_not_considered_for_max_version() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -481,7 +481,7 @@ fn yanked_versions_are_not_considered_for_max_version() {
 
 #[test]
 fn versions() {
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     app.db(|conn| {
         let u = new_user("foo").create_or_update(conn).unwrap();
         CrateBuilder::new("foo_versions", u.id)
@@ -854,7 +854,7 @@ fn valid_feature_names() {
 
 #[test]
 fn new_krate_too_big() {
-    let (_, _, user) = TestApp::with_user();
+    let (_, _, user) = TestApp::init().with_user();
     let files = [("foo_big-1.0.0/big", &[b'a'; 2000] as &[_])];
     let builder = PublishBuilder::new("foo_big").files(&files);
 
@@ -1103,13 +1103,13 @@ fn new_krate_with_readme() {
 
 #[test]
 fn summary_doesnt_die() {
-    let (_, anon) = TestApp::empty();
+    let (_, anon) = TestApp::init().empty();
     anon.get::<SummaryResponse>("/api/v1/summary").good();
 }
 
 #[test]
 fn summary_new_crates() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
     app.db(|conn| {
         let krate = CrateBuilder::new("some_downloads", user.id)
@@ -1176,7 +1176,7 @@ fn summary_new_crates() {
 #[test]
 fn download() {
     use chrono::{Duration, Utc};
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::with_proxy().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -1260,7 +1260,7 @@ fn dependencies() {
 
 #[test]
 fn diesel_not_found_results_in_404() {
-    let (_, _, user) = TestApp::with_user();
+    let (_, _, user) = TestApp::init().with_user();
 
     user.get("/api/v1/crates/foo_following/following")
         .assert_not_found();
@@ -1269,7 +1269,7 @@ fn diesel_not_found_results_in_404() {
 #[test]
 fn following() {
     // TODO: Test anon requests as well?
-    let (app, _, user) = TestApp::with_user();
+    let (app, _, user) = TestApp::init().with_user();
 
     app.db(|conn| {
         CrateBuilder::new("foo_following", user.as_model().id).expect_build(&conn);
@@ -1399,7 +1399,7 @@ fn yank() {
 
 #[test]
 fn yank_not_owner() {
-    let (app, _, _, token) = TestApp::with_token();
+    let (app, _, _, token) = TestApp::init().with_token();
     app.db(|conn| {
         let another_user = new_user("bar").create_or_update(conn).unwrap();
         CrateBuilder::new("foo_not", another_user.id).expect_build(conn);
@@ -2019,7 +2019,7 @@ fn author_license_and_description_required() {
 */
 #[test]
 fn test_recent_download_count() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -2057,7 +2057,7 @@ fn test_recent_download_count() {
  */
 #[test]
 fn test_zero_downloads() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -2082,7 +2082,7 @@ fn test_zero_downloads() {
 */
 #[test]
 fn test_default_sort_recent() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     let (green_crate, potato_crate) = app.db(|conn| {
@@ -2145,7 +2145,7 @@ fn test_default_sort_recent() {
 
 #[test]
 fn block_bad_documentation_url() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {
@@ -2163,7 +2163,7 @@ fn block_bad_documentation_url() {
 // which call the `PUT /crates/:crate_id/owners` route
 #[test]
 fn test_cargo_invite_owners() {
-    let (app, _, owner) = TestApp::with_user();
+    let (app, _, owner) = TestApp::init().with_user();
 
     let new_user = app.db_new_user("cilantro");
     app.db(|conn| {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -63,7 +63,7 @@ impl ::util::MockCookieUser {
 
 #[test]
 fn new_crate_owner() {
-    let (app, _, user1, token) = TestApp::with_token();
+    let (app, _, user1, token) = TestApp::with_proxy().with_token();
 
     // Create a crate under one user
     let crate_to_publish = PublishBuilder::new("foo_owner").version("1.0.0");
@@ -203,7 +203,7 @@ fn owners_can_remove_self() {
 */
 #[test]
 fn check_ownership_two_crates() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     let (krate_owned_by_team, team) = app.db(|conn| {

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -29,14 +29,14 @@ pub struct UserShowPrivateResponse {
 
 #[test]
 fn auth_gives_a_token() {
-    let (_, anon) = TestApp::empty();
+    let (_, anon) = TestApp::init().empty();
     let json: AuthResponse = anon.get("/authorize_url").good();
     assert!(json.url.contains(&json.state));
 }
 
 #[test]
 fn access_token_needs_data() {
-    let (_, anon) = TestApp::empty();
+    let (_, anon) = TestApp::init().empty();
     let json = anon.get::<()>("/authorize").bad_with_status(200); // Change endpoint to 400?
     assert!(json.errors[0].detail.contains("invalid state"));
 }
@@ -44,7 +44,7 @@ fn access_token_needs_data() {
 #[test]
 fn me() {
     let url = "/api/v1/me";
-    let (app, anon) = TestApp::empty();
+    let (app, anon) = TestApp::init().empty();
     anon.get(url).assert_forbidden();
 
     let user = app.db_new_user("foo");
@@ -115,7 +115,7 @@ fn show_latest_user_case_insensitively() {
 
 #[test]
 fn crates_by_user_id() {
-    let (app, _, user) = TestApp::with_user();
+    let (app, _, user) = TestApp::init().with_user();
     let id = user.as_model().id;
     app.db(|conn| {
         CrateBuilder::new("foo_my_packages", id).expect_build(conn);
@@ -127,7 +127,7 @@ fn crates_by_user_id() {
 
 #[test]
 fn crates_by_user_id_not_including_deleted_owners() {
-    let (app, anon, user) = TestApp::with_user();
+    let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
     app.db(|conn| {

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -114,7 +114,7 @@ fn record_rerendered_readme_time() {
 
 #[test]
 fn version_size() {
-    let (_, _, user) = TestApp::with_user();
+    let (_, _, user) = TestApp::with_proxy().with_user();
     let crate_to_publish = PublishBuilder::new("foo_version_size").version("1.0.0");
     user.publish(crate_to_publish).good();
 


### PR DESCRIPTION
The unused `Uploader::NoOp` option is now `Uploader::Panic` which
panics on any usage.  The panic message directs users to initialize the
app with `TestApp::with_proxy()`.

While this adds more panics to the main lib, the application
configuration isn't dynamic and it should be obvious that
`Uploader::Panic` is not to be used to configure a production
application.