### PR TITLE
Add crate(s) URL shorthand which redirects to full URL

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -26,6 +26,8 @@ Router.map(function() {
         this.route('docs');
         this.route('repo');
     });
+    this.route('c');
+    this.route('c', { path: '/c/:crate_id' });
     this.route('me', function() {
         this.route('crates');
         this.route('following');

--- a/app/routes/c.js
+++ b/app/routes/c.js
@@ -1,0 +1,8 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+    afterModel(crate) {
+        if (crate === undefined) this.transitionTo('crates');
+        else this.transitionTo('crate', crate);
+    },
+});


### PR DESCRIPTION
Implements #1523 

This PR implements shorthand URLs for crates, to make them easier to type. These shorthand URLs are redirected to their long variant respectively.

The following redirects have been implemented:
- `/c` => `/crates`
- `/c/:crate_id` => `/crates/:crate_id`

I hope the implementation is correct and follows convention. I'm new to `ember`.