### PR TITLE
Add a missing index on crates

### DIFF
--- a/migrations/2018-10-17-203221_index_crates_name/down.sql
+++ b/migrations/2018-10-17-203221_index_crates_name/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX index_crates_name_ordering;

--- a/migrations/2018-10-17-203221_index_crates_name/up.sql
+++ b/migrations/2018-10-17-203221_index_crates_name/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX index_crates_name_ordering ON crates (name);


### PR DESCRIPTION
Our most time consuming query is coming from crawlers on /crates ordered
by name. It turns out this query was not using any indexes, as the only
index we have on `crates.name` is `canon_crate_name(name)`. An
alternative would be to order by `canon_crate_name(name)` instead, but
that shouldn't actually be able to change the order. This is a low write
table, so the extra index isn't a major cost. Adding an index instead of changing
the query means the effects of this change will be easier to see.

The weird index name is because we already have an index called `index_crates_name`.