### PR TITLE
Rate limit the crate publish endpoint

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -28,6 +28,8 @@ http {
 	client_body_timeout 30;
 	client_max_body_size 50m;
 
+	limit_req_zone $binary_remote_addr zone=publish:1m rate=1r/s;
+
 	upstream app_server {
 		server localhost:8888 fail_timeout=0;
  	}
@@ -54,6 +56,11 @@ http {
 				rewrite ^ https://$host$request_uri? permanent;
 			}
 			proxy_pass http://app_server;
+		}
+
+		location ~ ^/api/v./crates/new$ {
+			limit_req zone=publish burst=10 nodelay;
+			limit_req_status 429;
 		}
 	}
 }


### PR DESCRIPTION
This adds a restriction to the number of crates that can be published
from a single IP address in a single time period. This is done per IP
instead of per-user, since that's what we can do with nginx alone. We
may want to do additional rate limiting per token to force spammers to
register additional accounts, and not just change their IP.

This will use what's called the "leaky bucket" strategy for rate
limiting. Basically every user has a bucket of tokens they use to
publish crates. They start with 10 tokens available. Every time they hit
this endpoint, they use one of the tokens. We give them a new token each
minute.

What this means is that you can upload 1 crate per minute, but we allow
you to upload up to 10 in a short period of time before we start
enforcing the rate limit.

When someone does hit the rate limit, they will receive a 429 response
(which is `TOO MANY REQUESTS` but since it's a newer status code I'm not
sure if nginx actually knows that's the text description). We could also
allow it to instead just slow down the requests, refusing to process
them until a token is available (queueing a max of 10 requests).

This reserves 1 megabyte of memory for the IP table, which means we can
hold about 16000 IPs. When the table is full, it will attempt to drop
the oldest record, and if that doesn't give enough space, it'll give a
503. Keep in mind this is all in memory, not shared between our servers.
This means that it is possible (but not guaranteed) that someone can
upload 20 crates, and then send 2 requests per second.