### PR TITLE
Bump semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,11 +195,12 @@ dependencies = [
  "license-exprs 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "old_semver 0.1.0",
  "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (git+https://github.com/steveklabnik/semver.git)",
  "serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1452,6 +1453,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "old_semver"
+version = "0.1.0"
+dependencies = [
+ "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl"
 version = "0.9.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1914,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "git+https://github.com/steveklabnik/semver.git#27c2b066cc0d3818f8b2047388ce29be2e4c97e1"
+dependencies = [
+ "diesel 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2812,6 +2830,7 @@ dependencies = [
 "checksum security-framework-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab01dfbe5756785b5b4d46e0289e5a18071dfa9a7c2b24213ea00b9ef9b665bf"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
+"checksum semver 0.9.0 (git+https://github.com/steveklabnik/semver.git)" = "<none>"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fff3c9c5a54636ab95acd8c1349926e04cb1eb8cd70b5adced8a1d1f703a67"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,11 @@ rustdoc-args = [
 
 [dependencies]
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
+old_semver = { path = "src/old_semver", version = "0.1.0" }
 rand = "0.3"
 git2 = "0.6.4"
 flate2 = "1.0"
-semver = "0.5"
+semver = { version = "0.9", git = "https://github.com/steveklabnik/semver.git", features = ["diesel", "serde"] }
 url = "1.2.1"
 tar = "0.4.13"
 base64 = "0.9"

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use chrono::NaiveDateTime;
 use diesel;
-use diesel::pg::Pg;
 use diesel::prelude::*;
 use semver;
 use serde_json;
@@ -15,7 +14,7 @@ use schema::*;
 use views::{EncodableVersion, EncodableVersionLinks};
 
 // Queryable has a custom implementation below
-#[derive(Clone, Identifiable, Associations, Debug)]
+#[derive(Clone, Identifiable, Associations, Debug, Queryable)]
 #[belongs_to(Crate)]
 pub struct Version {
     pub id: i32,
@@ -191,36 +190,5 @@ impl NewVersion {
             self.license = Some(String::from("non-standard"));
         }
         Ok(())
-    }
-}
-
-impl Queryable<versions::SqlType, Pg> for Version {
-    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
-    type Row = (
-        i32,
-        i32,
-        String,
-        NaiveDateTime,
-        NaiveDateTime,
-        i32,
-        serde_json::Value,
-        bool,
-        Option<String>,
-        Option<i32>,
-    );
-
-    fn build(row: Self::Row) -> Self {
-        Version {
-            id: row.0,
-            crate_id: row.1,
-            num: semver::Version::parse(&row.2).unwrap(),
-            updated_at: row.3,
-            created_at: row.4,
-            downloads: row.5,
-            features: row.6,
-            yanked: row.7,
-            license: row.8,
-            crate_size: row.9,
-        }
     }
 }

--- a/src/old_semver/Cargo.toml
+++ b/src/old_semver/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "old_semver"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+
+[dependencies]
+semver = "0.5.0"

--- a/src/old_semver/src/lib.rs
+++ b/src/old_semver/src/lib.rs
@@ -1,4 +1,3 @@
 /// We need semver 0.5.0 for conduit, but we want to use newer versions.
 /// This is a silly workaround.
-
 pub extern crate semver;

--- a/src/old_semver/src/lib.rs
+++ b/src/old_semver/src/lib.rs
@@ -1,0 +1,4 @@
+/// We need semver 0.5.0 for conduit, but we want to use newer versions.
+/// This is a silly workaround.
+
+pub extern crate semver;

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -3,9 +3,9 @@ extern crate old_semver;
 use std::io::Read;
 use std::net::SocketAddr;
 
+use self::old_semver::semver;
 use conduit;
 use conduit::Request;
-use self::old_semver::semver;
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -1,9 +1,11 @@
+extern crate old_semver;
+
 use std::io::Read;
 use std::net::SocketAddr;
 
 use conduit;
 use conduit::Request;
-use semver;
+use self::old_semver::semver;
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
The amount of manual serialization/deserialization of semver stuff is
really starting to get in the way of refactoring. Semver supports both
Serde and Diesel on master (only serde in the released version, hence
the git dependency).

Conduit still expects an older version though. That project is
unmaintained and I've been having trouble getting added as an owner to
publish a new version (Alex is in Europe right now, not worth bothering
him) so we've got a little hacky workaround in the meantime.