### PR TITLE
Try out the nginx realip module

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,5 +1,5 @@
 https://github.com/Starkast/heroku-buildpack-cmake#a243c67
 https://github.com/emk/heroku-buildpack-rust#578d630
 https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
-https://github.com/travis-ci/nginx-buildpack.git#2fbde35
+https://github.com/heroku/heroku-buildpack-nginx.git#fbc49cd
 https://github.com/sgrif/heroku-buildpack-diesel#f605edd

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -2,6 +2,10 @@ daemon off;
 #Heroku dynos have at least 4 cores.
 worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
 
+set_real_ip_from 127.0.0.1;
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+
 events {
 	use epoll;
 	accept_mutex on;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -2,9 +2,8 @@ daemon off;
 #Heroku dynos have at least 4 cores.
 worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
 
-set_real_ip_from 127.0.0.1;
+set_real_ip_from 10.0.0.0/24;
 real_ip_header X-Forwarded-For;
-real_ip_recursive on;
 
 events {
 	use epoll;
@@ -53,6 +52,7 @@ http {
 			add_header Strict-Transport-Security "max-age=31536000" always;
             add_header Vary 'Accept, Accept-Encoding, Cookie';
 			proxy_set_header Host $http_host;
+			proxy_set_header X-Real-Ip $remote_addr;
 			proxy_redirect off;
 			if ($http_x_forwarded_proto != 'https') {
 				rewrite ^ https://$host$request_uri? permanent;

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -33,12 +33,13 @@ impl Handler for LogRequests {
 
         print!(
             "at={level} method={method} path=\"{path}\" \
-             request_id={request_id} fwd=\"{ip}\" service={time_ms}ms \
+             request_id={request_id} fwd=\"{ip}\" real_ip=\"{real_ip}\" service={time_ms}ms \
              status={status} user_agent=\"{user_agent}\" referer=\"{referer}\"",
             level = level,
             method = req.method(),
             path = FullPath(req),
             ip = request_header(req, "X-Forwarded-For"),
+            real_ip = req.remote_addr(),
             time_ms = response_time,
             user_agent = request_header(req, "User-Agent"),
             referer = request_header(req, "Referer"), // sic

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -39,7 +39,7 @@ impl Handler for LogRequests {
             method = req.method(),
             path = FullPath(req),
             ip = request_header(req, "X-Forwarded-For"),
-            real_ip = req.remote_addr(),
+            real_ip = request_header(req, "X-Real-Ip"),
             time_ms = response_time,
             user_agent = request_header(req, "User-Agent"),
             referer = request_header(req, "Referer"), // sic


### PR DESCRIPTION
On Heroku and any system that involves proxies, the remote_addr of the
request becomes useless, as it will be the proxy forwarding your request
rather than the client itself. Most proxies will set or append an
`X-Forwarded-For` header, putting whatever remote_addr it received at
the end of the the header. So if there are 3 proxies, the header will
look like

real_ip, proxy1, proxy2

However, if we're not careful this makes us vulnerable to IP spoofing. A
lot of implementations just look at the first value in the header. All
the proxies just append the header though (they don't know if they're
getting traffic from the origin or a proxy), so you end up with

spoofed_ip, real_ip, proxy1, proxy2

nginx, Rails, and many other implementations avoid this by requiring an
allowlist of trusted IPs. With this configuration, the realip only kicks
in if remote_addr is a trusted proxy, and then it will replace it with
the last non-trusted IP from the header.

This will simplify our own codebase, where we either have to do this
logic over and over, or in a few places we've forgotten and have bugs
(mostly logging related).

I haven't switched any code to use this yet, because I want to see our
logs saying I got this right before I do that.