### PR TITLE
Temporarily disable the test requiring a user agent too

### DIFF
--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -88,7 +88,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
     }
     // Note: Temporarily disabled because cargo-vendor doesn't include a
     // User-Agent header and Rust's CI broke. If this is still commented out
-    // by Nov 7, 2018 we need to ping some folks
+    // by Nov 7, 2018 ping the crates.io team.
     // m.around(require_user_agent::RequireUserAgent::default());
 
     if env != Env::Test {

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -1,13 +1,18 @@
-use conduit::{Handler, Method};
+// Note: Temporarily disabled because cargo-vendor doesn't include a
+// User-Agent header and Rust's CI broke. If this is still commented out
+// by Nov 7, 2018 ping the crates.io team.
 
-use {app, req};
-
-#[test]
-fn user_agent_is_required() {
-    let (_b, _app, middle) = app();
-
-    let mut req = req(Method::Get, "/api/v1/crates");
-    req.header("User-Agent", "");
-    let resp = t!(middle.call(&mut req));
-    assert_eq!(resp.status.0, 403);
-}
+// use conduit::{Handler, Method};
+//
+// use {app, req};
+//
+//
+// #[test]
+// fn user_agent_is_required() {
+//     let (_b, _app, middle) = app();
+//
+//     let mut req = req(Method::Get, "/api/v1/crates");
+//     req.header("User-Agent", "");
+//     let resp = t!(middle.call(&mut req));
+//     assert_eq!(resp.status.0, 403);
+// }


### PR DESCRIPTION
And clarify who should be pinging whom (readers of the code should ping
the crates.io team)

CI is currently broken; this should fix it.

r? @sgrif 