### PR TITLE
Ensure only exact name matches are added to the index

### DIFF
--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -81,7 +81,8 @@ pub fn add_dependencies(
     let git_and_new_dependencies = deps
         .iter()
         .map(|dep| {
-            let krate = Crate::by_name(&dep.name)
+            // Match only identical names to ensure the index always references the original crate name
+            let krate = Crate::by_exact_name(&dep.name)
                 .first::<Crate>(&*conn)
                 .map_err(|_| human(&format_args!("no known crate named `{}`", &*dep.name)))?;
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -91,6 +91,7 @@ type CanonCrateName<T> = self::canon_crate_name::HelperType<T>;
 type All = diesel::dsl::Select<crates::table, AllColumns>;
 type WithName<'a> = diesel::dsl::Eq<CanonCrateName<crates::name>, CanonCrateName<&'a str>>;
 type ByName<'a> = diesel::dsl::Filter<All, WithName<'a>>;
+type ByExactName<'a> = diesel::dsl::Filter<All, diesel::dsl::Eq<crates::name, &'a str>>;
 
 #[derive(Insertable, AsChangeset, Default, Debug)]
 #[table_name = "crates"]
@@ -242,6 +243,10 @@ impl Crate {
 
     pub fn by_name(name: &str) -> ByName<'_> {
         Crate::all().filter(Self::with_name(name))
+    }
+
+    pub fn by_exact_name(name: &str) -> ByExactName<'_> {
+        Crate::all().filter(crates::name.eq(name))
     }
 
     pub fn all() -> All {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -651,6 +651,23 @@ fn new_krate_with_dependency() {
 }
 
 #[test]
+fn reject_new_krate_with_non_exact_dependency() {
+    let (app, _, user, token) = TestApp::init().with_token();
+
+    app.db(|conn| {
+        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&conn);
+    });
+
+    // Use non-exact name for the dependency
+    let dependency = DependencyBuilder::new("foo_dep");
+
+    let crate_to_publish = PublishBuilder::new("new_dep")
+        .version("1.0.0")
+        .dependency(dependency);
+    token.publish(crate_to_publish).bad_with_status(200);
+}
+
+#[test]
 fn new_krate_with_wildcard_dependency() {
     let (app, _, user, token) = TestApp::init().with_token();
 


### PR DESCRIPTION
On the client side cargo checks dependency names against the index and
requires an exact match.  For instance, a user cannot depend on
`diesel-migrations` or `Diesel_migrations` as cargo generates an error
directing them to use the correct name `diesel_migrations`.

This check for an exact name match is now repeated on the server when a
crate is published.  This ensures that bugs in cargo or third-party
tooling cannot result in a dependency name that cargo is unable to
locate in the index.