### PR TITLE
Add support for Azure DevOps badge

### DIFF
--- a/app/components/badge-azure-devops.js
+++ b/app/components/badge-azure-devops.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+
+export default Component.extend({
+    tagName: 'span',
+    classNames: ['badge'],
+    project: alias('badge.attributes.project'),
+    pipeline: alias('badge.attributes.pipeline'),
+    build: computed('badge.attributes.build', function() {
+        return this.get('badge.attributes.build') || '1';
+    }),
+    text: computed('pipeline', function() {
+        return `Azure Devops build status for the ${this.pipeline} pipeline`;
+    }),
+});

--- a/app/templates/components/badge-azure-devops.hbs
+++ b/app/templates/components/badge-azure-devops.hbs
@@ -1,0 +1,3 @@
+<a href="https://dev.azure.com/{{ project }}/_build/latest?definitionId={{ build }}">
+    <img src="https://dev.azure.com/{{ project }}/_apis/build/status/{{ pipeline }}" alt="{{ text }}" title="{{ text }}">
+</a>

--- a/mirage/fixtures/crates.js
+++ b/mirage/fixtures/crates.js
@@ -54,6 +54,14 @@ export default [
         badges: [
             {
                 attributes: {
+                    project: 'robertohuertasm/github-oss',
+                    pipeline: 'microserver',
+                    build: '2',
+                },
+                badge_type: 'azure-devops',
+            },
+            {
+                attributes: {
                     repository: 'huonw/external_mixin',
                 },
                 badge_type: 'appveyor',

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -34,6 +34,11 @@ pub enum Badge {
         project_name: Option<String>,
         service: Option<String>,
     },
+    AzureDevops {
+        project: String,
+        pipeline: String,
+        build: Option<String>,
+    },
     #[serde(rename = "gitlab")]
     GitLab {
         repository: String,

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -21,7 +21,11 @@ pub struct CrateBadge {
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "kebab-case", tag = "badge_type", content = "attributes")]
+#[serde(
+    rename_all = "kebab-case",
+    tag = "badge_type",
+    content = "attributes"
+)]
 pub enum Badge {
     TravisCi {
         repository: String,

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -21,11 +21,7 @@ pub struct CrateBadge {
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(
-    rename_all = "kebab-case",
-    tag = "badge_type",
-    content = "attributes"
-)]
+#[serde(rename_all = "kebab-case", tag = "badge_type", content = "attributes")]
 pub enum Badge {
     TravisCi {
         repository: String,

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -215,15 +215,15 @@ fn update_add_gitlab() {
 #[test]
 fn update_add_azure_devops() {
     // Add a azure devops badge
-    let (conn, krate, test_badges) = set_up();
+    let (krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
     badges.insert(
         String::from("azure-devops"),
         test_badges.azure_devops_attributes,
     );
-    Badge::update_crate(&conn, &krate, Some(&badges)).unwrap();
-    assert_eq!(krate.badges(&conn).unwrap(), vec![test_badges.azure_devops]);
+    krate.update(&badges);
+    assert_eq!(krate.badges(), vec![test_badges.azure_devops]);
 }
 
 #[test]
@@ -429,7 +429,7 @@ fn gitlab_required_keys() {
 #[test]
 fn azure_devops_required_keys() {
     // Add a azure devops badge missing a required field
-    let (conn, krate, mut test_badges) = set_up();
+    let (krate, mut test_badges) = set_up();
 
     let mut badges = HashMap::new();
 
@@ -440,10 +440,10 @@ fn azure_devops_required_keys() {
         test_badges.azure_devops_attributes,
     );
 
-    let invalid_badges = Badge::update_crate(&conn, &krate, Some(&badges)).unwrap();
+    let invalid_badges = krate.update(&badges);
     assert_eq!(invalid_badges.len(), 1);
-    assert!(invalid_badges.contains(&"azure-devops"));
-    assert_eq!(krate.badges(&conn).unwrap(), vec![]);
+    assert_eq!(invalid_badges.first().unwrap(), "azure-devops");
+    assert_eq!(krate.badges(), vec![]);
 }
 
 #[test]

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -9,6 +9,8 @@ struct BadgeRef {
     travis_ci_attributes: HashMap<String, String>,
     gitlab: Badge,
     gitlab_attributes: HashMap<String, String>,
+    azure_devops: Badge,
+    azure_devops_attributes: HashMap<String, String>,
     isitmaintained_issue_resolution: Badge,
     isitmaintained_issue_resolution_attributes: HashMap<String, String>,
     isitmaintained_open_issues: Badge,
@@ -80,6 +82,16 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
     badge_attributes_gitlab.insert(String::from("branch"), String::from("beta"));
     badge_attributes_gitlab.insert(String::from("repository"), String::from("rust-lang/rust"));
 
+    let azure_devops = Badge::AzureDevops {
+        project: String::from("rust-lang"),
+        pipeline: String::from("rust"),
+        build: Some(String::from("2")),
+    };
+    let mut badge_attributes_azure_devops = HashMap::new();
+    badge_attributes_azure_devops.insert(String::from("project"), String::from("rust-lang"));
+    badge_attributes_azure_devops.insert(String::from("pipeline"), String::from("rust"));
+    badge_attributes_azure_devops.insert(String::from("build"), String::from("2"));
+
     let isitmaintained_issue_resolution = Badge::IsItMaintainedIssueResolution {
         repository: String::from("rust-lang/rust"),
     };
@@ -138,6 +150,8 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
         travis_ci_attributes: badge_attributes_travis_ci,
         gitlab,
         gitlab_attributes: badge_attributes_gitlab,
+        azure_devops,
+        azure_devops_attributes: badge_attributes_azure_devops,
         isitmaintained_issue_resolution,
         isitmaintained_issue_resolution_attributes:
             badge_attributes_isitmaintained_issue_resolution,
@@ -196,6 +210,20 @@ fn update_add_gitlab() {
     badges.insert(String::from("gitlab"), test_badges.gitlab_attributes);
     krate.update(&badges);
     assert_eq!(krate.badges(), vec![test_badges.gitlab]);
+}
+
+#[test]
+fn update_add_azure_devops() {
+    // Add a azure devops badge
+    let (conn, krate, test_badges) = set_up();
+
+    let mut badges = HashMap::new();
+    badges.insert(
+        String::from("azure-devops"),
+        test_badges.azure_devops_attributes,
+    );
+    Badge::update_crate(&conn, &krate, Some(&badges)).unwrap();
+    assert_eq!(krate.badges(&conn).unwrap(), vec![test_badges.azure_devops]);
 }
 
 #[test]
@@ -396,6 +424,26 @@ fn gitlab_required_keys() {
     assert_eq!(invalid_badges.len(), 1);
     assert_eq!(invalid_badges.first().unwrap(), "gitlab");
     assert_eq!(krate.badges(), vec![]);
+}
+
+#[test]
+fn azure_devops_required_keys() {
+    // Add a azure devops badge missing a required field
+    let (conn, krate, mut test_badges) = set_up();
+
+    let mut badges = HashMap::new();
+
+    // project is a required key
+    test_badges.gitlab_attributes.remove("project");
+    badges.insert(
+        String::from("azure-devops"),
+        test_badges.azure_devops_attributes,
+    );
+
+    let invalid_badges = Badge::update_crate(&conn, &krate, Some(&badges)).unwrap();
+    assert_eq!(invalid_badges.len(), 1);
+    assert!(invalid_badges.contains(&"azure-devops"));
+    assert_eq!(krate.badges(&conn).unwrap(), vec![]);
 }
 
 #[test]

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -434,7 +434,7 @@ fn azure_devops_required_keys() {
     let mut badges = HashMap::new();
 
     // project is a required key
-    test_badges.gitlab_attributes.remove("project");
+    test_badges.azure_devops_attributes.remove("project");
     badges.insert(
         String::from("azure-devops"),
         test_badges.azure_devops_attributes,


### PR DESCRIPTION
I added a project of mine that is already using `Azure Devops` into `fixtures/crates.js`. Let me know if that's an inconvenience and I'll remove it. I just put it there to easily see that everything was working as expected.

I also added some tests by following the existing code example.

See also rust-lang/cargo#6264