### PR TITLE
Rename structs in `krate_publish` with prefix `Encodable`

### DIFF
--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -304,7 +304,7 @@ fn logout(req: &mut Request) {
     req.mut_extensions().pop::<User>();
 }
 
-fn new_crate_to_body_with_tarball(new_crate: &u::NewCrate, tarball: &[u8]) -> Vec<u8> {
+fn new_crate_to_body_with_tarball(new_crate: &u::EncodableCrateUpload, tarball: &[u8]) -> Vec<u8> {
     let json = serde_json::to_string(&new_crate).unwrap();
     let mut body = Vec::new();
     body.extend(

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -13,8 +13,7 @@ use tar;
 
 use cargo_registry::util::CargoResult;
 
-use models::{Crate, CrateDownload, Keyword, Version};
-use models::{NewCrate, NewVersion};
+use models::{Crate, CrateDownload, Keyword, NewCrate, NewVersion, Version};
 use schema::*;
 use views::krate_publish as u;
 
@@ -315,7 +314,7 @@ pub struct PublishBuilder {
     pub krate_name: String,
     version: semver::Version,
     tarball: Vec<u8>,
-    deps: Vec<u::CrateDependency>,
+    deps: Vec<u::EncodableCrateDependency>,
     desc: Option<String>,
     readme: Option<String>,
     doc_url: Option<String>,
@@ -469,9 +468,9 @@ impl PublishBuilder {
 
     /// Consume this builder to make the Put request body
     pub fn body(self) -> Vec<u8> {
-        let new_crate = u::NewCrate {
-            name: u::CrateName(self.krate_name.clone()),
-            vers: u::CrateVersion(self.version),
+        let new_crate = u::EncodableCrateUpload {
+            name: u::EncodableCrateName(self.krate_name.clone()),
+            vers: u::EncodableCrateVersion(self.version),
             features: HashMap::new(),
             deps: self.deps,
             authors: self.authors,
@@ -480,11 +479,14 @@ impl PublishBuilder {
             documentation: self.doc_url,
             readme: self.readme,
             readme_file: None,
-            keywords: Some(u::KeywordList(
-                self.keywords.into_iter().map(u::Keyword).collect(),
+            keywords: Some(u::EncodableKeywordList(
+                self.keywords.into_iter().map(u::EncodableKeyword).collect(),
             )),
-            categories: Some(u::CategoryList(
-                self.categories.into_iter().map(u::Category).collect(),
+            categories: Some(u::EncodableCategoryList(
+                self.categories
+                    .into_iter()
+                    .map(u::EncodableCategory)
+                    .collect(),
             )),
             license: self.license,
             license_file: self.license_file,
@@ -500,8 +502,8 @@ impl PublishBuilder {
 /// A builder for constructing a dependency of another crate.
 pub struct DependencyBuilder {
     name: String,
-    explicit_name_in_toml: Option<u::CrateName>,
-    version_req: u::CrateVersionReq,
+    explicit_name_in_toml: Option<u::EncodableCrateName>,
+    version_req: u::EncodableCrateVersionReq,
 }
 
 impl DependencyBuilder {
@@ -510,13 +512,13 @@ impl DependencyBuilder {
         DependencyBuilder {
             name: name.to_string(),
             explicit_name_in_toml: None,
-            version_req: u::CrateVersionReq(semver::VersionReq::parse(">= 0").unwrap()),
+            version_req: u::EncodableCrateVersionReq(semver::VersionReq::parse(">= 0").unwrap()),
         }
     }
 
     /// Rename this dependency.
     pub fn rename(mut self, new_name: &str) -> Self {
-        self.explicit_name_in_toml = Some(u::CrateName(new_name.to_string()));
+        self.explicit_name_in_toml = Some(u::EncodableCrateName(new_name.to_string()));
         self
     }
 
@@ -526,7 +528,7 @@ impl DependencyBuilder {
     ///
     /// Panics if the `version_req` string specified isn't a valid `semver::VersionReq`.
     pub fn version_req(mut self, version_req: &str) -> Self {
-        self.version_req = u::CrateVersionReq(
+        self.version_req = u::EncodableCrateVersionReq(
             semver::VersionReq::parse(version_req)
                 .expect("version req isn't a valid semver::VersionReq"),
         );
@@ -535,9 +537,9 @@ impl DependencyBuilder {
 
     /// Consume this builder to create a `u::CrateDependency`. If the dependent crate doesn't
     /// already exist, publishing a crate with this dependency will fail.
-    fn build(self) -> u::CrateDependency {
-        u::CrateDependency {
-            name: u::CrateName(self.name),
+    fn build(self) -> u::EncodableCrateDependency {
+        u::EncodableCrateDependency {
+            name: u::EncodableCrateName(self.name),
             optional: false,
             default_features: true,
             features: Vec::new(),

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -14,19 +14,19 @@ use models::DependencyKind;
 use models::Keyword as CrateKeyword;
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct NewCrate {
-    pub name: CrateName,
-    pub vers: CrateVersion,
-    pub deps: Vec<CrateDependency>,
-    pub features: HashMap<FeatureName, Vec<Feature>>,
+pub struct EncodableCrateUpload {
+    pub name: EncodableCrateName,
+    pub vers: EncodableCrateVersion,
+    pub deps: Vec<EncodableCrateDependency>,
+    pub features: HashMap<EncodableFeatureName, Vec<EncodableFeature>>,
     pub authors: Vec<String>,
     pub description: Option<String>,
     pub homepage: Option<String>,
     pub documentation: Option<String>,
     pub readme: Option<String>,
     pub readme_file: Option<String>,
-    pub keywords: Option<KeywordList>,
-    pub categories: Option<CategoryList>,
+    pub keywords: Option<EncodableKeywordList>,
+    pub categories: Option<EncodableCategoryList>,
     pub license: Option<String>,
     pub license_file: Option<String>,
     pub repository: Option<String>,
@@ -36,38 +36,38 @@ pub struct NewCrate {
 }
 
 #[derive(PartialEq, Eq, Hash, Serialize, Debug, Deref)]
-pub struct CrateName(pub String);
+pub struct EncodableCrateName(pub String);
 #[derive(Debug, Deref)]
-pub struct CrateVersion(pub semver::Version);
+pub struct EncodableCrateVersion(pub semver::Version);
 #[derive(Debug, Deref)]
-pub struct CrateVersionReq(pub semver::VersionReq);
+pub struct EncodableCrateVersionReq(pub semver::VersionReq);
 #[derive(Serialize, Debug, Deref)]
-pub struct KeywordList(pub Vec<Keyword>);
+pub struct EncodableKeywordList(pub Vec<EncodableKeyword>);
 #[derive(Serialize, Debug, Deref)]
-pub struct Keyword(pub String);
+pub struct EncodableKeyword(pub String);
 #[derive(Serialize, Debug, Deref)]
-pub struct CategoryList(pub Vec<Category>);
+pub struct EncodableCategoryList(pub Vec<EncodableCategory>);
 #[derive(Serialize, Deserialize, Debug, Deref)]
-pub struct Category(pub String);
+pub struct EncodableCategory(pub String);
 #[derive(Serialize, Debug, Deref)]
-pub struct Feature(pub String);
+pub struct EncodableFeature(pub String);
 #[derive(PartialEq, Eq, Hash, Serialize, Debug, Deref)]
-pub struct FeatureName(pub String);
+pub struct EncodableFeatureName(pub String);
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct CrateDependency {
+pub struct EncodableCrateDependency {
     pub optional: bool,
     pub default_features: bool,
-    pub name: CrateName,
-    pub features: Vec<Feature>,
-    pub version_req: CrateVersionReq,
+    pub name: EncodableCrateName,
+    pub features: Vec<EncodableFeature>,
+    pub version_req: EncodableCrateVersionReq,
     pub target: Option<String>,
     pub kind: Option<DependencyKind>,
-    pub explicit_name_in_toml: Option<CrateName>,
+    pub explicit_name_in_toml: Option<EncodableCrateName>,
 }
 
-impl<'de> Deserialize<'de> for CrateName {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<CrateName, D::Error> {
+impl<'de> Deserialize<'de> for EncodableCrateName {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableCrateName, D::Error> {
         let s = String::deserialize(d)?;
         if !Crate::valid_name(&s) {
             let value = de::Unexpected::Str(&s);
@@ -78,12 +78,12 @@ impl<'de> Deserialize<'de> for CrateName {
             );
             Err(de::Error::invalid_value(value, &expected.as_ref()))
         } else {
-            Ok(CrateName(s))
+            Ok(EncodableCrateName(s))
         }
     }
 }
 
-impl<T: ?Sized> PartialEq<T> for CrateName
+impl<T: ?Sized> PartialEq<T> for EncodableCrateName
 where
     String: PartialEq<T>,
 {
@@ -92,20 +92,20 @@ where
     }
 }
 
-impl<'de> Deserialize<'de> for Keyword {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Keyword, D::Error> {
+impl<'de> Deserialize<'de> for EncodableKeyword {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableKeyword, D::Error> {
         let s = String::deserialize(d)?;
         if !CrateKeyword::valid_name(&s) {
             let value = de::Unexpected::Str(&s);
             let expected = "a valid keyword specifier";
             Err(de::Error::invalid_value(value, &expected))
         } else {
-            Ok(Keyword(s))
+            Ok(EncodableKeyword(s))
         }
     }
 }
 
-impl<'de> Deserialize<'de> for FeatureName {
+impl<'de> Deserialize<'de> for EncodableFeatureName {
     fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
         let s = String::deserialize(d)?;
         if !Crate::valid_feature_name(&s) {
@@ -114,29 +114,29 @@ impl<'de> Deserialize<'de> for FeatureName {
                             numbers, hyphens, or underscores";
             Err(de::Error::invalid_value(value, &expected))
         } else {
-            Ok(FeatureName(s))
+            Ok(EncodableFeatureName(s))
         }
     }
 }
 
-impl<'de> Deserialize<'de> for Feature {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Feature, D::Error> {
+impl<'de> Deserialize<'de> for EncodableFeature {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableFeature, D::Error> {
         let s = String::deserialize(d)?;
         if !Crate::valid_feature(&s) {
             let value = de::Unexpected::Str(&s);
             let expected = "a valid feature name";
             Err(de::Error::invalid_value(value, &expected))
         } else {
-            Ok(Feature(s))
+            Ok(EncodableFeature(s))
         }
     }
 }
 
-impl<'de> Deserialize<'de> for CrateVersion {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<CrateVersion, D::Error> {
+impl<'de> Deserialize<'de> for EncodableCrateVersion {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableCrateVersion, D::Error> {
         let s = String::deserialize(d)?;
         match semver::Version::parse(&s) {
-            Ok(v) => Ok(CrateVersion(v)),
+            Ok(v) => Ok(EncodableCrateVersion(v)),
             Err(..) => {
                 let value = de::Unexpected::Str(&s);
                 let expected = "a valid semver";
@@ -146,11 +146,11 @@ impl<'de> Deserialize<'de> for CrateVersion {
     }
 }
 
-impl<'de> Deserialize<'de> for CrateVersionReq {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<CrateVersionReq, D::Error> {
+impl<'de> Deserialize<'de> for EncodableCrateVersionReq {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableCrateVersionReq, D::Error> {
         let s = String::deserialize(d)?;
         match semver::VersionReq::parse(&s) {
-            Ok(v) => Ok(CrateVersionReq(v)),
+            Ok(v) => Ok(EncodableCrateVersionReq(v)),
             Err(..) => {
                 let value = de::Unexpected::Str(&s);
                 let expected = "a valid version req";
@@ -160,7 +160,7 @@ impl<'de> Deserialize<'de> for CrateVersionReq {
     }
 }
 
-impl<T: ?Sized> PartialEq<T> for CrateVersionReq
+impl<T: ?Sized> PartialEq<T> for EncodableCrateVersionReq
 where
     semver::VersionReq: PartialEq<T>,
 {
@@ -169,9 +169,9 @@ where
     }
 }
 
-impl<'de> Deserialize<'de> for KeywordList {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<KeywordList, D::Error> {
-        let inner = <Vec<Keyword> as Deserialize<'de>>::deserialize(d)?;
+impl<'de> Deserialize<'de> for EncodableKeywordList {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableKeywordList, D::Error> {
+        let inner = <Vec<EncodableKeyword> as Deserialize<'de>>::deserialize(d)?;
         if inner.len() > 5 {
             let expected = "at most 5 keywords per crate";
             return Err(de::Error::invalid_length(inner.len(), &expected));
@@ -182,23 +182,23 @@ impl<'de> Deserialize<'de> for KeywordList {
                 return Err(de::Error::invalid_length(val.len(), &expected));
             }
         }
-        Ok(KeywordList(inner))
+        Ok(EncodableKeywordList(inner))
     }
 }
 
-impl<'de> Deserialize<'de> for CategoryList {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<CategoryList, D::Error> {
-        let inner = <Vec<Category> as Deserialize<'de>>::deserialize(d)?;
+impl<'de> Deserialize<'de> for EncodableCategoryList {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableCategoryList, D::Error> {
+        let inner = <Vec<EncodableCategory> as Deserialize<'de>>::deserialize(d)?;
         if inner.len() > 5 {
             let expected = "at most 5 categories per crate";
             Err(de::Error::invalid_length(inner.len(), &expected))
         } else {
-            Ok(CategoryList(inner))
+            Ok(EncodableCategoryList(inner))
         }
     }
 }
 
-impl Serialize for CrateVersion {
+impl Serialize for EncodableCrateVersion {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -207,7 +207,7 @@ impl Serialize for CrateVersion {
     }
 }
 
-impl Serialize for CrateVersionReq {
+impl Serialize for EncodableCrateVersionReq {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -221,7 +221,7 @@ use diesel::serialize::{self, Output, ToSql};
 use diesel::sql_types::Text;
 use std::io::Write;
 
-impl ToSql<Text, Pg> for Feature {
+impl ToSql<Text, Pg> for EncodableFeature {
     fn to_sql<W: Write>(&self, out: &mut Output<'_, W, Pg>) -> serialize::Result {
         ToSql::<Text, Pg>::to_sql(&**self, out)
     }
@@ -231,10 +231,10 @@ impl ToSql<Text, Pg> for Feature {
 fn feature_deserializes_for_valid_features() {
     use serde_json as json;
 
-    assert!(json::from_str::<Feature>("\"foo\"").is_ok());
-    assert!(json::from_str::<Feature>("\"\"").is_err());
-    assert!(json::from_str::<Feature>("\"/\"").is_err());
-    assert!(json::from_str::<Feature>("\"%/%\"").is_err());
-    assert!(json::from_str::<Feature>("\"a/a\"").is_ok());
-    assert!(json::from_str::<Feature>("\"32-column-tables\"").is_ok());
+    assert!(json::from_str::<EncodableFeature>("\"foo\"").is_ok());
+    assert!(json::from_str::<EncodableFeature>("\"\"").is_err());
+    assert!(json::from_str::<EncodableFeature>("\"/\"").is_err());
+    assert!(json::from_str::<EncodableFeature>("\"%/%\"").is_err());
+    assert!(json::from_str::<EncodableFeature>("\"a/a\"").is_ok());
+    assert!(json::from_str::<EncodableFeature>("\"32-column-tables\"").is_ok());
 }

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -210,10 +210,8 @@ pub struct EncodableVersionLinks {
     pub authors: String,
 }
 
-// TODO: Prefix many of these with `Encodable` then clean up the reexports
 pub mod krate_publish;
-pub use self::krate_publish::CrateDependency as EncodableCrateDependency;
-pub use self::krate_publish::NewCrate as EncodableCrateUpload;
+pub use self::krate_publish::{EncodableCrateDependency, EncodableCrateUpload};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This PR renames the structs in `views/krate_publish` to have the prefix `Encodable`, as per a `TODO` that was present.