### PR TITLE
Prepare for clippy and rustfmt in rust-2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,7 @@ matrix:
         - rustup component add clippy-preview
       script:
         - cargo fmt -- --check
-        # TODO: Once clippy:: lint syntax is stable, remove everything after the -- below
-        - cargo clippy --all-targets -- -A renamed_and_removed_lints
+        - cargo clippy --all-targets --all-features --all
         - cargo build
         - cargo test
         - npm install

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -23,7 +23,8 @@ fn main() {
     conn.transaction::<_, diesel::result::Error, _>(|| {
         delete(&conn);
         Ok(())
-    }).unwrap()
+    })
+    .unwrap()
 }
 
 fn delete(conn: &PgConnection) {

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -23,7 +23,8 @@ fn main() {
     conn.transaction::<_, diesel::result::Error, _>(|| {
         delete(&conn);
         Ok(())
-    }).unwrap()
+    })
+    .unwrap()
 }
 
 fn delete(conn: &PgConnection) {

--- a/src/bin/on_call/mod.rs
+++ b/src/bin/on_call/mod.rs
@@ -39,7 +39,8 @@ impl Event {
             .json(&FullEvent {
                 service_key,
                 event: self,
-            }).send()?;
+            })
+            .send()?;
 
         match response.status() {
             s if s.is_success() => Ok(()),

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -39,7 +39,8 @@ fn update(conn: &PgConnection) -> QueryResult<()> {
                     version_downloads::version_id.eq(id),
                     version_downloads::downloads.eq(dls),
                     version_downloads::date.eq(date(now - day.days())),
-                )).execute(conn)?;
+                ))
+                .execute(conn)?;
         }
     }
     Ok(())

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -81,7 +81,8 @@ fn main() {
             readme_renderings::rendered_at
                 .lt(older_than)
                 .or(readme_renderings::version_id.is_null()),
-        ).select(versions::id)
+        )
+        .select(versions::id)
         .into_boxed();
 
     if let Some(crate_name) = args.flag_crate {
@@ -150,7 +151,8 @@ fn main() {
                         &readme_path,
                         readme.into_bytes(),
                         "text/html",
-                    ).unwrap_or_else(|_| {
+                    )
+                    .unwrap_or_else(|_| {
                         panic!(
                             "[{}-{}] Couldn't upload file to S3",
                             krate_name, version.num
@@ -227,7 +229,8 @@ fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<St
                 .as_ref()
                 .map_or("README.md", |e| &**e),
             manifest.package.repository.as_ref().map(|e| &**e),
-        ).unwrap_or_else(|_| panic!("[{}-{}] Couldn't render README", krate_name, version.num))
+        )
+        .unwrap_or_else(|_| panic!("[{}-{}] Couldn't render README", krate_name, version.num))
     };
     return Some(rendered);
 
@@ -261,14 +264,16 @@ fn find_file_by_path<R: Read>(
                 };
                 filepath == path
             }
-        }).unwrap_or_else(|| {
+        })
+        .unwrap_or_else(|| {
             panic!(
                 "[{}-{}] couldn't open file: {}",
                 krate_name,
                 version.num,
                 path.display()
             )
-        }).unwrap_or_else(|_| {
+        })
+        .unwrap_or_else(|_| {
             panic!(
                 "[{}-{}] file is not present: {}",
                 krate_name,

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -21,7 +21,8 @@ fn main() {
     conn.transaction::<_, diesel::result::Error, _>(|| {
         transfer(&conn);
         Ok(())
-    }).unwrap()
+    })
+    .unwrap()
 }
 
 fn transfer(conn: &PgConnection) {

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -92,7 +92,8 @@ fn collect(conn: &PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
                     crate_downloads::crate_id.eq(crate_id),
                     crate_downloads::downloads.eq(amt),
                     crate_downloads::date.eq(download.date),
-                )).on_conflict(crate_downloads::table.primary_key())
+                ))
+                .on_conflict(crate_downloads::table.primary_key())
                 .do_update()
                 .set(crate_downloads::downloads.eq(crate_downloads::downloads + amt))
                 .execute(conn)?;
@@ -136,7 +137,8 @@ mod test {
         let krate = NewCrate {
             name: "foo",
             ..Default::default()
-        }.create_or_update(&conn, None, user_id)
+        }
+        .create_or_update(&conn, None, user_id)
         .unwrap();
         let version = NewVersion::new(
             krate.id,
@@ -145,7 +147,8 @@ mod test {
             None,
             None,
             0,
-        ).unwrap();
+        )
+        .unwrap();
         let version = version.save(&conn, &[]).unwrap();
         (krate, version)
     }
@@ -176,7 +179,8 @@ mod test {
                 version_downloads::version_id.eq(version.id),
                 version_downloads::date.eq(date(now - 1.day())),
                 version_downloads::processed.eq(true),
-            )).execute(&conn)
+            ))
+            .execute(&conn)
             .unwrap();
 
         ::update(&conn).unwrap();
@@ -213,7 +217,8 @@ mod test {
                 version_downloads::counted.eq(2),
                 version_downloads::date.eq(date(now - 2.days())),
                 version_downloads::processed.eq(false),
-            )).execute(&conn)
+            ))
+            .execute(&conn)
             .unwrap();
         ::update(&conn).unwrap();
         let processed = version_downloads::table
@@ -236,7 +241,8 @@ mod test {
                 version_downloads::counted.eq(2),
                 version_downloads::date.eq(date(now)),
                 version_downloads::processed.eq(false),
-            )).execute(&conn)
+            ))
+            .execute(&conn)
             .unwrap();
         ::update(&conn).unwrap();
         let processed = version_downloads::table
@@ -269,13 +275,15 @@ mod test {
                 version_downloads::counted.eq(1),
                 version_downloads::date.eq(date(now)),
                 version_downloads::processed.eq(false),
-            )).execute(&conn)
+            ))
+            .execute(&conn)
             .unwrap();
         insert_into(version_downloads::table)
             .values((
                 version_downloads::version_id.eq(version.id),
                 version_downloads::date.eq(date(now - 1.day())),
-            )).execute(&conn)
+            ))
+            .execute(&conn)
             .unwrap();
 
         let version_before = versions::table
@@ -331,7 +339,8 @@ mod test {
                 version_downloads::counted.eq(2),
                 version_downloads::date.eq(date(now - 2.days())),
                 version_downloads::processed.eq(false),
-            )).execute(&conn)
+            ))
+            .execute(&conn)
             .unwrap();
 
         ::update(&conn).unwrap();

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -107,7 +107,8 @@ pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<
                 category.eq(c.name),
                 description.eq(c.description),
             )
-        }).collect::<Vec<_>>();
+        })
+        .collect::<Vec<_>>();
 
     conn.transaction(|| {
         let slugs = diesel::insert_into(categories)
@@ -117,7 +118,8 @@ pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<
             .set((
                 category.eq(excluded(category)),
                 description.eq(excluded(description)),
-            )).returning(slug)
+            ))
+            .returning(slug)
             .get_results::<String>(&*conn)?;
 
         diesel::delete(categories)

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -71,7 +71,8 @@ fn accept_invite(
                 owner_id: user_id,
                 created_by: pending_crate_owner.invited_by_user_id,
                 owner_kind: OwnerKind::User as i32,
-            }).on_conflict(crate_owners::table.primary_key())
+            })
+            .on_conflict(crate_owners::table.primary_key())
             .do_update()
             .set(crate_owners::deleted.eq(false))
             .execute(conn)?;

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -39,7 +39,8 @@ pub fn downloads(req: &mut dyn Request) -> CargoResult<Response> {
         .select((
             to_char(version_downloads::date, "YYYY-MM-DD"),
             sum_downloads,
-        )).filter(version_downloads::date.gt(date(now - 90.days())))
+        ))
+        .filter(version_downloads::date.gt(date(now - 90.days())))
         .group_by(version_downloads::date)
         .order(version_downloads::date.asc())
         .load::<ExtraDownload>(&*conn)?;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -34,7 +34,8 @@ pub fn summary(req: &mut dyn Request) -> CargoResult<Response> {
             .zip(krates)
             .map(|(max_version, krate)| {
                 Ok(krate.minimal_encodable(&max_version, None, false, None))
-            }).collect()
+            })
+            .collect()
     };
 
     let new_crates = crates

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -53,7 +53,8 @@ pub fn publish(req: &mut dyn Request) -> CargoResult<Response> {
                 k[..].to_string(),
                 v.iter().map(|v| v[..].to_string()).collect(),
             )
-        }).collect::<HashMap<String, Vec<String>>>();
+        })
+        .collect::<HashMap<String, Vec<String>>>();
     let keywords = new_crate
         .keywords
         .as_ref()
@@ -146,7 +147,8 @@ pub fn publish(req: &mut dyn Request) -> CargoResult<Response> {
             // Downcast is okay because the file length must be less than the max upload size
             // to get here, and max upload sizes are way less than i32 max
             file_length as i32,
-        )?.save(&conn, &new_crate.authors)?;
+        )?
+        .save(&conn, &new_crate.authors)?;
 
         // Link this new version to all dependencies
         let git_deps = dependency::add_dependencies(&conn, &new_crate.deps, version.id)?;

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -48,7 +48,8 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
             ALL_COLUMNS,
             false.into_sql::<Bool>(),
             recent_crate_downloads::downloads.nullable(),
-        )).into_boxed();
+        ))
+        .into_boxed();
 
     if let Some(q_string) = params.get("q") {
         if !q_string.is_empty() {
@@ -189,7 +190,8 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
                     Some(recent_downloads),
                 )
             },
-        ).collect();
+        )
+        .collect();
 
     #[derive(Serialize)]
     struct R {

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -34,7 +34,8 @@ pub fn me(req: &mut dyn Request) -> CargoResult<Response> {
             emails::verified.nullable(),
             emails::email.nullable(),
             emails::token_generated_at.nullable().is_not_null(),
-        )).first::<(User, Option<bool>, Option<String>, bool)>(&*conn)?;
+        ))
+        .first::<(User, Option<bool>, Option<String>, bool)>(&*conn)?;
 
     let verified = verified.unwrap_or(false);
     let verification_sent = verified || verification_sent;

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -37,7 +37,8 @@ pub fn stats(req: &mut dyn Request) -> CargoResult<Response> {
             crate_owners::owner_id
                 .eq(user_id)
                 .and(crate_owners::owner_kind.eq(OwnerKind::User as i32)),
-        ).select(sum(crates::downloads))
+        )
+        .select(sum(crates::downloads))
         .first::<Option<i64>>(&*conn)?
         .unwrap_or(0);
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -109,7 +109,8 @@ pub fn github_access_token(req: &mut dyn Request) -> CargoResult<Response> {
         ghuser.name.as_ref().map(|s| &s[..]),
         ghuser.avatar_url.as_ref().map(|s| &s[..]),
         &token.access_token,
-    ).create_or_update(&*req.db_conn()?)?;
+    )
+    .create_or_update(&*req.db_conn()?)?;
     req.session()
         .insert("user_id".to_string(), user.id.to_string());
     req.mut_extensions().insert(user);

--- a/src/email.rs
+++ b/src/email.rs
@@ -82,7 +82,8 @@ fn send_email(recipient: &str, subject: &str, body: &str) -> CargoResult<()> {
                 .credentials(Credentials::new(
                     mailgun_config.smtp_login,
                     mailgun_config.smtp_password,
-                )).smtp_utf8(true)
+                ))
+                .smtp_utf8(true)
                 .authentication_mechanism(Mechanism::Plain)
                 .build();
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -99,7 +99,8 @@ pub fn yank(app: &App, krate: &str, version: &semver::Version, yanked: bool) -> 
                 }
                 git_crate.yanked = Some(yanked);
                 Ok(serde_json::to_string(&git_crate).unwrap())
-            }).collect::<CargoResult<Vec<String>>>();
+            })
+            .collect::<CargoResult<Vec<String>>>();
         let new = new?.join("\n");
         let mut f = File::create(&dst)?;
         f.write_all(new.as_bytes())?;

--- a/src/github.rs
+++ b/src/github.rs
@@ -27,7 +27,8 @@ where
         .header(
             header::AUTHORIZATION,
             format!("token {}", auth.access_token),
-        ).send()?
+        )
+        .send()?
         .error_for_status()
         .map_err(|e| handle_error_response(&e))?
         .json()

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -22,11 +22,7 @@ pub struct CrateBadge {
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(
-    rename_all = "kebab-case",
-    tag = "badge_type",
-    content = "attributes"
-)]
+#[serde(rename_all = "kebab-case", tag = "badge_type", content = "attributes")]
 pub enum Badge {
     TravisCi {
         repository: String,

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -119,7 +119,8 @@ impl Category {
                 .map(|c| CrateCategory {
                     category_id: c.id,
                     crate_id: krate.id,
-                }).collect::<Vec<_>>();
+                })
+                .collect::<Vec<_>>();
 
             delete(CrateCategory::belonging_to(krate)).execute(conn)?;
             insert_into(crates_categories::table)
@@ -232,7 +233,8 @@ mod tests {
                 (category.eq("Cat 2"), slug.eq("cat2")),
                 (category.eq("Cat 1"), slug.eq("cat1")),
                 (category.eq("Cat 1::sub"), slug.eq("cat1::sub")),
-            ]).execute(&conn)
+            ])
+            .execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "", 10, 0)
@@ -253,7 +255,8 @@ mod tests {
                 (category.eq("Cat 1"), slug.eq("cat1"), crates_cnt.eq(0)),
                 (category.eq("Cat 2"), slug.eq("cat2"), crates_cnt.eq(2)),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(1)),
-            ]).execute(&conn)
+            ])
+            .execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "crates", 10, 0)
@@ -277,7 +280,8 @@ mod tests {
             .values(&vec![
                 (category.eq("Cat 1"), slug.eq("cat1")),
                 (category.eq("Cat 2"), slug.eq("cat2")),
-            ]).execute(&conn)
+            ])
+            .execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "", 1, 0)
@@ -321,7 +325,8 @@ mod tests {
                     crates_cnt.eq(5),
                 ),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(6)),
-            ]).execute(&conn)
+            ])
+            .execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "crates", 10, 0)
@@ -361,7 +366,8 @@ mod tests {
                     crates_cnt.eq(5),
                 ),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(6)),
-            ]).execute(&conn)
+            ])
+            .execute(&conn)
             .unwrap();
 
         let cats = Category::toplevel(&conn, "crates", 2, 0)
@@ -415,7 +421,8 @@ mod tests {
                     crates_cnt.eq(5),
                 ),
                 (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(200)),
-            ]).execute(&conn)
+            ])
+            .execute(&conn)
             .unwrap();
 
         let cat = Category::by_slug("cat1::sub1")

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -126,7 +126,8 @@ pub fn add_dependencies(
                     target.eq(dep.target.as_ref().map(|s| &**s)),
                 ),
             ))
-        }).collect::<Result<Vec<_>, _>>()?;
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     let (git_deps, new_dependencies): (Vec<_>, Vec<_>) =
         git_and_new_dependencies.into_iter().unzip();

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -85,7 +85,8 @@ impl Keyword {
                 .map(|kw| CrateKeyword {
                     crate_id: krate.id,
                     keyword_id: kw.id,
-                }).collect::<Vec<_>>();
+                })
+                .collect::<Vec<_>>();
             diesel::insert_into(crates_keywords::table)
                 .values(&crate_keywords)
                 .execute(conn)?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -152,7 +152,7 @@ impl<'a> NewCrate<'a> {
                         "`{}` has an invalid url \
                          scheme: `{}`",
                         field, s
-                    )))
+                    )));
                 }
             }
             if url.cannot_be_a_base() {
@@ -200,7 +200,8 @@ impl<'a> NewCrate<'a> {
 
         let reserved_name = select(exists(
             reserved_crate_names.filter(canon_crate_name(name).eq(canon_crate_name(self.name))),
-        )).get_result::<bool>(conn)?;
+        ))
+        .get_result::<bool>(conn)?;
         if reserved_name {
             Err(human("cannot upload a crate with a reserved name"))
         } else {
@@ -259,11 +260,12 @@ impl Crate {
     }
 
     fn valid_ident(name: &str) -> bool {
-        Self::valid_feature_name(name) && name
-            .chars()
-            .nth(0)
-            .map(char::is_alphabetic)
-            .unwrap_or(false)
+        Self::valid_feature_name(name)
+            && name
+                .chars()
+                .nth(0)
+                .map(char::is_alphabetic)
+                .unwrap_or(false)
     }
 
     pub fn valid_feature_name(name: &str) -> bool {
@@ -444,7 +446,8 @@ impl Crate {
                         invited_user_id: owner.id(),
                         invited_by_user_id: req_user.id,
                         crate_id: self.id,
-                    }).on_conflict_do_nothing()
+                    })
+                    .on_conflict_do_nothing()
                     .execute(conn)?;
                 Ok(format!(
                     "user {} has been invited to be an owner of crate {}",
@@ -460,7 +463,8 @@ impl Crate {
                         owner_id: owner.id(),
                         created_by: req_user.id,
                         owner_kind: OwnerKind::Team as i32,
-                    }).on_conflict(crate_owners::table.primary_key())
+                    })
+                    .on_conflict(crate_owners::table.primary_key())
                     .do_update()
                     .set(crate_owners::deleted.eq(false))
                     .execute(conn)?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -306,7 +306,7 @@ impl Crate {
         )
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]
+    #[allow(clippy::too_many_arguments)]
     pub fn encodable(
         self,
         max_version: &semver::Version,

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -67,16 +67,14 @@ mod tests {
             last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
         };
         let json = serde_json::to_string(&tok).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
-        assert!(
-            json.as_str()
-                .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
+        assert!(json
+            .as_str()
+            .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
+            .is_some());
     }
 
     #[test]
@@ -90,16 +88,14 @@ mod tests {
             last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
         };
         let json = serde_json::to_string(&tok).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
-        assert!(
-            json.as_str()
-                .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
+        assert!(json
+            .as_str()
+            .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
+            .is_some());
     }
 
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -78,7 +78,8 @@ impl<'a> NewUser<'a> {
                     name.eq(excluded(name)),
                     gh_avatar.eq(excluded(gh_avatar)),
                     gh_access_token.eq(excluded(gh_access_token)),
-                )).get_result::<User>(conn)?;
+                ))
+                .get_result::<User>(conn)?;
 
             // To send the user an account verification email...
             if let Some(user_email) = user.email.as_ref() {
@@ -146,12 +147,16 @@ impl User {
         let mut best = Rights::None;
         for owner in owners {
             match *owner {
-                Owner::User(ref other_user) => if other_user.id == self.id {
-                    return Ok(Rights::Full);
-                },
-                Owner::Team(ref team) => if team.contains_user(app, self)? {
-                    best = Rights::Publish;
-                },
+                Owner::User(ref other_user) => {
+                    if other_user.id == self.id {
+                        return Ok(Rights::Full);
+                    }
+                }
+                Owner::Team(ref team) => {
+                    if team.contains_user(app, self)? {
+                        best = Rights::Publish;
+                    }
+                }
             }
         }
         Ok(best)
@@ -163,7 +168,8 @@ impl User {
             emails::table
                 .filter(emails::user_id.eq(self.id))
                 .filter(emails::verified.eq(true)),
-        )).get_result(&*conn)?;
+        ))
+        .get_result(&*conn)?;
         Ok(email_exists)
     }
 

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -114,6 +114,7 @@ impl Version {
 }
 
 impl NewVersion {
+    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         crate_id: i32,
         num: &semver::Version,

--- a/src/render.rs
+++ b/src/render.rs
@@ -57,9 +57,9 @@ impl<'a> MarkdownRenderer<'a> {
             "hr",
             "span",
         ]
-            .iter()
-            .cloned()
-            .collect();
+        .iter()
+        .cloned()
+        .collect();
         let tag_attributes = [
             ("a", ["href", "id", "target"].iter().cloned().collect()),
             (
@@ -74,9 +74,9 @@ impl<'a> MarkdownRenderer<'a> {
                 ["checked", "disabled", "type"].iter().cloned().collect(),
             ),
         ]
-            .iter()
-            .cloned()
-            .collect();
+        .iter()
+        .cloned()
+        .collect();
         let allowed_classes = [(
             "code",
             [
@@ -95,13 +95,13 @@ impl<'a> MarkdownRenderer<'a> {
                 "language-sql",
                 "yaml",
             ]
-                .iter()
-                .cloned()
-                .collect(),
-        )]
             .iter()
             .cloned()
-            .collect();
+            .collect(),
+        )]
+        .iter()
+        .cloned()
+        .collect();
 
         let sanitizer_base_url = base_url.map(|s| s.to_string());
 
@@ -182,7 +182,8 @@ impl<'a> MarkdownRenderer<'a> {
                 UrlRelative::Custom(Box::new(relative_url_sanitizer))
             } else {
                 UrlRelative::Custom(Box::new(unrelative_url_sanitizer))
-            }).id_prefix(Some("user-content-"));
+            })
+            .id_prefix(Some("user-content-"));
 
         MarkdownRenderer { html_sanitizer }
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -213,14 +213,13 @@ mod tests {
 
         // All other error types are propogated up the middleware, eventually becoming status 500
         assert!(C(|_| Err(internal(""))).call(&mut req).is_err());
-        assert!(
-            C(|_| err(::serde_json::Error::syntax(
-                ::serde_json::error::ErrorCode::ExpectedColon,
-                0,
-                0
-            ))).call(&mut req)
-            .is_err()
-        );
+        assert!(C(|_| err(::serde_json::Error::syntax(
+            ::serde_json::error::ErrorCode::ExpectedColon,
+            0,
+            0
+        )))
+        .call(&mut req)
+        .is_err());
         assert!(
             C(|_| err(::std::io::Error::new(::std::io::ErrorKind::Other, "")))
                 .call(&mut req)

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,9 +1,6 @@
 #![deny(warnings)]
 #![allow(unknown_lints, proc_macro_derive_resolution_fallback)] // TODO: This can be removed after diesel-1.4
 
-// Several test methods trip this clippy lint
-#![cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
-
 extern crate cargo_registry;
 extern crate chrono;
 extern crate conduit;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -273,7 +273,8 @@ fn new_dependency(conn: &PgConnection, version: &Version, krate: &Crate) -> Depe
             optional.eq(false),
             default_features.eq(false),
             features.eq(Vec::<String>::new()),
-        )).get_result(conn)
+        ))
+        .get_result(conn)
         .unwrap()
 }
 

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -88,7 +88,8 @@ impl<'a> VersionBuilder<'a> {
             license,
             self.license_file,
             self.size,
-        )?.save(connection, &[])?;
+        )?
+        .save(connection, &[])?;
 
         if self.yanked {
             vers = update(&vers)
@@ -109,7 +110,8 @@ impl<'a> VersionBuilder<'a> {
                     dependencies::default_features.eq(false),
                     dependencies::features.eq(Vec::<String>::new()),
                 )
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
         insert_into(dependencies::table)
             .values(&new_deps)
             .execute(connection)?;
@@ -362,7 +364,8 @@ impl PublishBuilder {
             .map(|(&(name, _), data)| {
                 let len = data.len() as u64;
                 (name, data as &mut Read, len)
-            }).collect::<Vec<_>>();
+            })
+            .collect::<Vec<_>>();
 
         self.files_with_io(&mut files)
     }
@@ -504,8 +507,8 @@ impl PublishBuilder {
                 (json.len() >> 16) as u8,
                 (json.len() >> 24) as u8,
             ]
-                .iter()
-                .cloned(),
+            .iter()
+            .cloned(),
         );
         body.extend(json.as_bytes().iter().cloned());
 

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -118,7 +118,8 @@ fn update_crate() {
         &app.diesel_database.get().unwrap(),
         &krate,
         &["cat1", "category-2"],
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(cnt!(&mut req, "cat1"), 1);
     assert_eq!(cnt!(&mut req, "category-2"), 1);
 
@@ -132,7 +133,8 @@ fn update_crate() {
         &app.diesel_database.get().unwrap(),
         &krate,
         &["cat1", "catnope"],
-    ).unwrap();
+    )
+    .unwrap();
     assert_eq!(invalid_categories, vec!["catnope"]);
     assert_eq!(cnt!(&mut req, "cat1"), 1);
     assert_eq!(cnt!(&mut req, "category-2"), 0);

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -73,6 +73,7 @@ fn show() {
 }
 
 #[test]
+#[allow(clippy::cyclomatic_complexity)]
 fn update_crate() {
     let (_b, app, middle) = app();
     let mut req = req(Method::Get, "/api/v1/categories/foo");

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -104,6 +104,7 @@ fn index() {
 }
 
 #[test]
+#[allow(clippy::cyclomatic_complexity)]
 fn index_queries() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
@@ -324,6 +325,7 @@ fn index_sorting() {
 }
 
 #[test]
+#[allow(clippy::cyclomatic_complexity)]
 fn exact_match_on_queries_with_sort() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
@@ -1368,6 +1370,7 @@ fn yank_not_owner() {
 }
 
 #[test]
+#[allow(clippy::cyclomatic_complexity)]
 fn yank_max_version() {
     let (_, anon, _, token) = TestApp::with_proxy().with_token();
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1049,7 +1049,8 @@ fn new_krate_with_unverified_email_warns() {
             .values((
                 emails::user_id.eq(user.id),
                 emails::email.eq("something@example.com"),
-            )).execute(conn)
+            ))
+            .execute(conn)
             .unwrap();
     });
 
@@ -1076,7 +1077,8 @@ fn new_krate_with_verified_email_doesnt_warn() {
                 emails::user_id.eq(user.id),
                 emails::email.eq("something@example.com"),
                 emails::verified.eq(true),
-            )).execute(conn)
+            ))
+            .execute(conn)
             .unwrap();
     });
 
@@ -1586,16 +1588,14 @@ fn ignored_badges() {
     assert_eq!(json.krate.name, "foo_ignored_badge");
     assert_eq!(json.krate.max_version, "1.0.0");
     assert_eq!(json.warnings.invalid_badges.len(), 2);
-    assert!(
-        json.warnings
-            .invalid_badges
-            .contains(&"travis-ci".to_string(),)
-    );
-    assert!(
-        json.warnings
-            .invalid_badges
-            .contains(&"not-a-badge".to_string(),)
-    );
+    assert!(json
+        .warnings
+        .invalid_badges
+        .contains(&"travis-ci".to_string(),));
+    assert!(json
+        .warnings
+        .invalid_badges
+        .contains(&"not-a-badge".to_string(),));
 
     let json = anon.show_crate("foo_ignored_badge");
     let badges = json.krate.badges.unwrap();
@@ -1615,7 +1615,8 @@ fn reverse_dependencies() {
                 VersionBuilder::new("1.1.0")
                     .dependency(&c1, None)
                     .dependency(&c1, Some("foo")),
-            ).expect_build(conn);
+            )
+            .expect_build(conn);
     });
 
     let deps = anon.reverse_dependencies("c1");
@@ -1821,9 +1822,9 @@ fn test_recent_download_count() {
 }
 
 /*  Given one crate with zero downloads, check that the crate
-    still shows up in index results, but that it displays 0
-    for both recent downloads and downloads.
- */
+   still shows up in index results, but that it displays 0
+   for both recent downloads and downloads.
+*/
 #[test]
 fn test_zero_downloads() {
     let (app, anon, user) = TestApp::init().with_user();

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -95,11 +95,9 @@ fn owners_can_remove_self() {
     let json = token
         .remove_named_owner("owners_selfremove", &user.as_model().gh_login)
         .bad_with_status(200);
-    assert!(
-        json.errors[0]
-            .detail
-            .contains("cannot remove the sole owner of a crate")
-    );
+    assert!(json.errors[0]
+        .detail
+        .contains("cannot remove the sole owner of a crate"));
 
     let user2 = app.db_new_user("secondowner");
     token.add_user_owner("owners_selfremove", user2.as_model());
@@ -116,11 +114,9 @@ fn owners_can_remove_self() {
         .remove_named_owner("owners_selfremove", &user2.as_model().gh_login)
         .bad_with_status(200);
 
-    assert!(
-        json.errors[0]
-            .detail
-            .contains("only owners have permission to modify owners",)
-    );
+    assert!(json.errors[0]
+        .detail
+        .contains("only owners have permission to modify owners",));
 }
 
 /*  Testing the crate ownership between two crates and one team.
@@ -249,7 +245,8 @@ fn test_accept_invitation() {
                 invited_by_user_id: owner.id,
                 invited_user_id: user.id,
                 crate_id: krate.id,
-            }).execute(&*conn)
+            })
+            .execute(&*conn)
             .unwrap();
         (krate, user)
     };
@@ -267,13 +264,11 @@ fn test_accept_invitation() {
 
     // first check that response from inserting new crate owner
     // and deleting crate_owner_invitation is okay
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path(&format!("api/v1/me/crate_owner_invitations/{}", krate.id))
-                .with_method(Method::Put)
-                .with_body(body.to_string().as_bytes()),
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path(&format!("api/v1/me/crate_owner_invitations/{}", krate.id))
+            .with_method(Method::Put)
+            .with_body(body.to_string().as_bytes()),
+    ));
 
     let json: T = ::json(&mut response);
     assert_eq!(json.crate_owner_invitation.accepted, true);
@@ -282,22 +277,18 @@ fn test_accept_invitation() {
     // then check to make sure that accept_invite did what it
     // was supposed to
     // crate_owner_invitation was deleted
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path("api/v1/me/crate_owner_invitations")
-                .with_method(Method::Get)
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path("api/v1/me/crate_owner_invitations")
+            .with_method(Method::Get)
+    ));
     let json: InvitationListResponse = ::json(&mut response);
     assert_eq!(json.crate_owner_invitations.len(), 0);
 
     // new crate owner was inserted
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path("/api/v1/crates/invited_crate/owners")
-                .with_method(Method::Get)
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path("/api/v1/crates/invited_crate/owners")
+            .with_method(Method::Get)
+    ));
     let json: Q = ::json(&mut response);
     assert_eq!(json.users.len(), 2);
 }
@@ -334,7 +325,8 @@ fn test_decline_invitation() {
                 invited_by_user_id: owner.id,
                 invited_user_id: user.id,
                 crate_id: krate.id,
-            }).execute(&*conn)
+            })
+            .execute(&*conn)
             .unwrap();
         (krate, user)
     };
@@ -352,13 +344,11 @@ fn test_decline_invitation() {
 
     // first check that response from deleting
     // crate_owner_invitation is okay
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path(&format!("api/v1/me/crate_owner_invitations/{}", krate.id))
-                .with_method(Method::Put)
-                .with_body(body.to_string().as_bytes()),
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path(&format!("api/v1/me/crate_owner_invitations/{}", krate.id))
+            .with_method(Method::Put)
+            .with_body(body.to_string().as_bytes()),
+    ));
 
     let json: T = ::json(&mut response);
     assert_eq!(json.crate_owner_invitation.accepted, false);
@@ -367,22 +357,18 @@ fn test_decline_invitation() {
     // then check to make sure that decline_invite did what it
     // was supposed to
     // crate_owner_invitation was deleted
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path("api/v1/me/crate_owner_invitations")
-                .with_method(Method::Get)
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path("api/v1/me/crate_owner_invitations")
+            .with_method(Method::Get)
+    ));
     let json: InvitationListResponse = ::json(&mut response);
     assert_eq!(json.crate_owner_invitations.len(), 0);
 
     // new crate owner was not inserted
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path("/api/v1/crates/invited_crate/owners")
-                .with_method(Method::Get)
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path("/api/v1/crates/invited_crate/owners")
+            .with_method(Method::Get)
+    ));
     let json: Q = ::json(&mut response);
     assert_eq!(json.users.len(), 1);
 }

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -32,7 +32,7 @@ use new_user;
 pub struct Bomb {
     iorx: Sink,
     quittx: Option<oneshot::Sender<()>>,
-    #[cfg_attr(feature = "cargo-clippy", allow(type_complexity))]
+    #[allow(clippy::type_complexity)]
     thread: Option<thread::JoinHandle<Option<(Vec<u8>, PathBuf)>>>,
 }
 

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -62,9 +62,11 @@ impl Drop for Bomb {
             .to_string();
         match res {
             Err(..) if !thread::panicking() => panic!("server subtask failed: {}", stderr),
-            Err(e) => if !stderr.is_empty() {
-                println!("server subtask failed ({:?}): {}", e, stderr)
-            },
+            Err(e) => {
+                if !stderr.is_empty() {
+                    println!("server subtask failed ({:?}): {}", e, stderr)
+                }
+            }
             Ok(_) if thread::panicking() => {}
             Ok(None) => {}
             Ok(Some((data, file))) => {
@@ -123,7 +125,8 @@ pub fn proxy() -> (String, Bomb) {
                 sink: sink2,
                 record: Arc::clone(&record),
                 client,
-            }).map_err(|e| eprintln!("server connection error: {}", e));
+            })
+            .map_err(|e| eprintln!("server connection error: {}", e));
 
         drop(core.run(srv.select2(quitrx)));
 
@@ -363,7 +366,8 @@ impl GhUser {
                 note: "crates.io test".to_string(),
                 client_id: ::env("GH_CLIENT_ID"),
                 client_secret: ::env("GH_CLIENT_SECRET"),
-            }).basic_auth(self.login, Some(password));
+            })
+            .basic_auth(self.login, Some(password));
 
         let mut response = t!(req.send().and_then(|r| r.error_for_status()));
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -109,7 +109,8 @@ fn nonexistent_team() {
         .add_named_owner(
             "foo_nonexistent",
             "github:crates-test-org:this-does-not-exist",
-        ).bad_with_status(200);
+        )
+        .bad_with_status(200);
 
     assert!(
         json.errors[0]
@@ -165,7 +166,8 @@ fn add_team_as_non_member() {
         .add_named_owner(
             "foo_team_non_member",
             "github:crates-test-org:just-for-crates-2",
-        ).bad_with_status(200);
+        )
+        .bad_with_status(200);
 
     assert!(
         json.errors[0]

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -93,12 +93,11 @@ fn list_tokens_exclude_revoked() {
     // Check that we now have one less token being listed.
     let json: ListResponse = user.get(URL).good();
     assert_eq!(json.api_tokens.len(), tokens.len() - 1);
-    assert!(
-        json.api_tokens
-            .iter()
-            .find(|token| token.name == tokens[0].name)
-            .is_none()
-    );
+    assert!(json
+        .api_tokens
+        .iter()
+        .find(|token| token.name == tokens[0].name)
+        .is_none());
 }
 
 #[test]
@@ -191,7 +190,8 @@ fn cannot_create_token_with_token() {
         .put::<()>(
             "/api/v1/me/tokens",
             br#"{ "api_token": { "name": "baz" } }"#,
-        ).bad_with_status(400);
+        )
+        .bad_with_status(400);
 
     assert_contains!(
         json.errors[0].detail,

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -86,7 +86,8 @@ fn show_latest_user_case_insensitively() {
             Some("I was first then deleted my github account"),
             None,
             "bar"
-        ).create_or_update(&conn));
+        )
+        .create_or_update(&conn));
         t!(NewUser::new(
             2,
             "FOOBAR",
@@ -94,7 +95,8 @@ fn show_latest_user_case_insensitively() {
             Some("I was second, I took the foobar username on github"),
             None,
             "bar"
-        ).create_or_update(&conn));
+        )
+        .create_or_update(&conn));
     });
 
     let json: UserShowPublicResponse = anon.get("api/v1/users/fOObAr").good();
@@ -279,13 +281,11 @@ fn test_github_login_does_not_overwrite_email() {
 
     let body =
         r#"{"user":{"email":"apricot@apricots.apricot","name":"Apricot Apricoto","login":"apricot","avatar":"https://avatars0.githubusercontent.com","url":"https://github.com/apricot","kind":null}}"#;
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/users/{}", user.id))
-                .with_method(Method::Put)
-                .with_body(body.as_bytes()),
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path(&format!("/api/v1/users/{}", user.id))
+            .with_method(Method::Put)
+            .with_body(body.as_bytes()),
+    ));
     assert!(::json::<OkBool>(&mut response).ok);
 
     logout(&mut req);
@@ -329,13 +329,11 @@ fn test_email_get_and_put() {
 
     let body =
         r#"{"user":{"email":"mango@mangos.mango","name":"Mango McMangoface","login":"mango","avatar":"https://avatars0.githubusercontent.com","url":"https://github.com/mango","kind":null}}"#;
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/users/{}", user.id))
-                .with_method(Method::Put)
-                .with_body(body.as_bytes()),
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path(&format!("/api/v1/users/{}", user.id))
+            .with_method(Method::Put)
+            .with_body(body.as_bytes()),
+    ));
     assert!(::json::<OkBool>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
@@ -369,13 +367,11 @@ fn test_empty_email_not_added() {
 
     let body =
         r#"{"user":{"email":"","name":"Papayo Papaya","login":"papaya","avatar":"https://avatars0.githubusercontent.com","url":"https://github.com/papaya","kind":null}}"#;
-    let json = bad_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/users/{}", user.id))
-                .with_method(Method::Put)
-                .with_body(body.as_bytes()),
-        )
-    );
+    let json = bad_resp!(middle.call(
+        req.with_path(&format!("/api/v1/users/{}", user.id))
+            .with_method(Method::Put)
+            .with_body(body.as_bytes()),
+    ));
 
     assert!(
         json.errors[0].detail.contains("empty email rejected"),
@@ -385,13 +381,11 @@ fn test_empty_email_not_added() {
 
     let body =
         r#"{"user":{"email":null,"name":"Papayo Papaya","login":"papaya","avatar":"https://avatars0.githubusercontent.com","url":"https://github.com/papaya","kind":null}}"#;
-    let json = bad_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/users/{}", user.id))
-                .with_method(Method::Put)
-                .with_body(body.as_bytes()),
-        )
-    );
+    let json = bad_resp!(middle.call(
+        req.with_path(&format!("/api/v1/users/{}", user.id))
+            .with_method(Method::Put)
+            .with_body(body.as_bytes()),
+    ));
 
     assert!(
         json.errors[0].detail.contains("empty email rejected"),
@@ -424,13 +418,11 @@ fn test_this_user_cannot_change_that_user_email() {
     let body =
         r#"{"user":{"email":"pineapple@pineapples.pineapple","name":"Pine Apple","login":"pineapple","avatar":"https://avatars0.githubusercontent.com","url":"https://github.com/pineapple","kind":null}}"#;
 
-    let json = bad_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/users/{}", not_signed_in_user.id))
-                .with_method(Method::Put)
-                .with_body(body.as_bytes()),
-        )
-    );
+    let json = bad_resp!(middle.call(
+        req.with_path(&format!("/api/v1/users/{}", not_signed_in_user.id))
+            .with_method(Method::Put)
+            .with_body(body.as_bytes()),
+    ));
 
     assert!(
         json.errors[0]
@@ -520,13 +512,11 @@ fn test_insert_into_email_table_with_email_change() {
 
     let body =
         r#"{"user":{"email":"apricot@apricots.apricot","name":"potato","login":"potato","avatar":"https://avatars0.githubusercontent.com","url":"https://github.com/potato","kind":null}}"#;
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/users/{}", user.id))
-                .with_method(Method::Put)
-                .with_body(body.as_bytes()),
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path(&format!("/api/v1/users/{}", user.id))
+            .with_method(Method::Put)
+            .with_body(body.as_bytes()),
+    ));
     assert!(::json::<OkBool>(&mut response).ok);
 
     logout(&mut req);
@@ -584,12 +574,10 @@ fn test_confirm_user_email() {
             .unwrap()
     };
 
-    let mut response = ok_resp!(
-        middle.call(
-            req.with_path(&format!("/api/v1/confirm/{}", email_token))
-                .with_method(Method::Put),
-        )
-    );
+    let mut response = ok_resp!(middle.call(
+        req.with_path(&format!("/api/v1/confirm/{}", email_token))
+            .with_method(Method::Put),
+    ));
     assert!(::json::<OkBool>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -13,6 +13,6 @@ use conduit::Request;
 pub fn request_header<'a>(req: &'a dyn Request, header_name: &str) -> &'a str {
     req.headers()
         .find(header_name)
-        .and_then(|x| x.first().map(|&s| s))
+        .and_then(|x| x.first().cloned())
         .unwrap_or_default()
 }

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -245,11 +245,10 @@ mod tests {
             created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
         };
         let json = serde_json::to_string(&cat).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
     }
 
     #[test]
@@ -265,11 +264,10 @@ mod tests {
             parent_categories: vec![],
         };
         let json = serde_json::to_string(&cat).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
     }
 
     #[test]
@@ -281,11 +279,10 @@ mod tests {
             crates_cnt: 0,
         };
         let json = serde_json::to_string(&key).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
     }
 
     #[test]
@@ -310,16 +307,14 @@ mod tests {
             crate_size: Some(1234),
         };
         let json = serde_json::to_string(&ver).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
+            .is_some());
     }
 
     #[test]
@@ -351,16 +346,14 @@ mod tests {
             exact_match: false,
         };
         let json = serde_json::to_string(&crt).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
+            .is_some());
     }
 
     #[test]
@@ -372,10 +365,9 @@ mod tests {
             created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
         };
         let json = serde_json::to_string(&inv).unwrap();
-        assert!(
-            json.as_str()
-                .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-                .is_some()
-        );
+        assert!(json
+            .as_str()
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
+            .is_some());
     }
 }


### PR DESCRIPTION
The first commit includes minor updates recommended by the clippy version which will be released with rust stable tomorrow.  In particular it uses the new lint attribute syntax like `#[allow(clippy::too_many_arguments)]`.  The second commit applies rustfmt changes.

This PR will fail on CI for now, but can be merged after the new stable release is published.