### PR TITLE
Enable Rust 2018 Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.2.2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 description = "Backend of crates.io"
+edition = "2018"
 
 [workspace]
 

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,3 @@
-extern crate diesel;
-extern crate diesel_migrations;
-extern crate dotenv;
-
 use diesel::prelude::*;
 use diesel_migrations::run_pending_migrations;
 use dotenv::dotenv;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,18 +1,15 @@
 //! Application-wide components in a struct accessible from each request
 
-use std::env;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use crate::{db, util::CargoResult, Config, Env};
+use std::{
+    env,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use diesel::r2d2;
-use git2;
-use oauth2;
-use reqwest;
 use scheduled_thread_pool::ScheduledThreadPool;
-
-use crate::util::CargoResult;
-use crate::{db, Config, Env};
 
 /// The `App` struct holds the main components of the application like
 /// the database connection pool and configurations

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,8 +11,8 @@ use oauth2;
 use reqwest;
 use scheduled_thread_pool::ScheduledThreadPool;
 
-use util::CargoResult;
-use {db, Config, Env};
+use crate::util::CargoResult;
+use crate::{db, Config, Env};
 
 /// The `App` struct holds the main components of the application like
 /// the database connection pool and configurations

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -7,19 +7,16 @@
 
 #![deny(warnings)]
 
-extern crate cargo_registry;
-extern crate diesel;
+use cargo_registry::{db, models::Crate, schema::crates};
+use std::{
+    env,
+    io::{self, prelude::*},
+};
 
 use diesel::prelude::*;
-use std::env;
-use std::io;
-use std::io::prelude::*;
-
-use cargo_registry::models::Crate;
-use cargo_registry::schema::crates;
 
 fn main() {
-    let conn = cargo_registry::db::connect_now().unwrap();
+    let conn = db::connect_now().unwrap();
     conn.transaction::<_, diesel::result::Error, _>(|| {
         delete(&conn);
         Ok(())

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -7,19 +7,20 @@
 
 #![deny(warnings)]
 
-extern crate cargo_registry;
-extern crate diesel;
+use cargo_registry::{
+    db,
+    models::{Crate, Version},
+    schema::versions,
+};
+use std::{
+    env,
+    io::{self, prelude::*},
+};
 
 use diesel::prelude::*;
-use std::env;
-use std::io;
-use std::io::prelude::*;
-
-use cargo_registry::models::{Crate, Version};
-use cargo_registry::schema::versions;
 
 fn main() {
-    let conn = cargo_registry::db::connect_now().unwrap();
+    let conn = db::connect_now().unwrap();
     conn.transaction::<_, diesel::result::Error, _>(|| {
         delete(&conn);
         Ok(())

--- a/src/bin/on_call/mod.rs
+++ b/src/bin/on_call/mod.rs
@@ -1,10 +1,7 @@
-extern crate cargo_registry;
-extern crate reqwest;
-
-use self::reqwest::{header, StatusCode as Status};
+use cargo_registry::util::{internal, CargoResult};
 use std::env;
 
-use self::cargo_registry::util::*;
+use reqwest::{header, StatusCode as Status};
 
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "snake_case", tag = "event_type")]

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -6,18 +6,14 @@
 
 #![deny(warnings)]
 
-extern crate cargo_registry;
-extern crate diesel;
-extern crate rand;
+use cargo_registry::{db, schema::version_downloads};
+use std::env;
 
 use diesel::prelude::*;
 use rand::{Rng, StdRng};
-use std::env;
-
-use cargo_registry::schema::version_downloads;
 
 fn main() {
-    let conn = cargo_registry::db::connect_now().unwrap();
+    let conn = db::connect_now().unwrap();
     conn.transaction(|| update(&conn)).unwrap();
 }
 

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -8,32 +8,21 @@
 #[macro_use]
 extern crate serde_derive;
 
-extern crate cargo_registry;
-extern crate chrono;
-extern crate diesel;
-extern crate docopt;
-extern crate flate2;
-extern crate itertools;
-extern crate reqwest;
-extern crate tar;
-extern crate toml;
+use cargo_registry::{
+    db,
+    models::Version,
+    render::readme_to_html,
+    schema::{crates, readme_renderings, versions},
+    Config,
+};
+use std::{io::Read, path::Path, thread};
 
 use chrono::{TimeZone, Utc};
-use diesel::dsl::any;
-use diesel::prelude::*;
+use diesel::{dsl::any, prelude::*};
 use docopt::Docopt;
 use flate2::read::GzDecoder;
 use itertools::Itertools;
-use std::io::Read;
-use std::path::Path;
-use std::thread;
-use tar::Archive;
-
-use cargo_registry::render::readme_to_html;
-use cargo_registry::Config;
-
-use cargo_registry::models::Version;
-use cargo_registry::schema::*;
+use tar::{self, Archive};
 
 const DEFAULT_PAGE_SIZE: usize = 25;
 const USAGE: &str = "
@@ -59,7 +48,7 @@ fn main() {
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());
     let config = Config::default();
-    let conn = cargo_registry::db::connect_now().unwrap();
+    let conn = db::connect_now().unwrap();
 
     let start_time = Utc::now();
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,21 +1,18 @@
 #![deny(warnings)]
 
-extern crate cargo_registry;
-extern crate civet;
-extern crate env_logger;
-extern crate git2;
+use cargo_registry::{boot, build_handler, env, git, App, Config, Env};
+use std::{
+    env,
+    fs::{self, File},
+    sync::{mpsc::channel, Arc},
+};
 
-use cargo_registry::{env, Env};
 use civet::Server;
-use std::env;
-use std::fs::{self, File};
-use std::sync::mpsc::channel;
-use std::sync::Arc;
 
 fn main() {
     // Initialize logging
     env_logger::init();
-    let config = cargo_registry::Config::default();
+    let config = Config::default();
 
     // If there isn't a git checkout containing the crate index repo at the path specified
     // by `GIT_REPO_CHECKOUT`, delete that directory and clone the repo specified by `GIT_REPO_URL`
@@ -28,7 +25,7 @@ fn main() {
             let _ = fs::remove_dir_all(&config.git_repo_checkout);
             fs::create_dir_all(&config.git_repo_checkout).unwrap();
             let mut cb = git2::RemoteCallbacks::new();
-            cb.credentials(cargo_registry::git::credentials);
+            cb.credentials(git::credentials);
             let mut opts = git2::FetchOptions::new();
             opts.remote_callbacks(cb);
             git2::build::RepoBuilder::new()
@@ -44,13 +41,13 @@ fn main() {
     cfg.set_str("user.name", "bors").unwrap();
     cfg.set_str("user.email", "bors@rust-lang.org").unwrap();
 
-    let app = cargo_registry::App::new(&config);
-    let app = cargo_registry::build_handler(Arc::new(app));
+    let app = App::new(&config);
+    let app = build_handler(Arc::new(app));
 
     // On every server restart, ensure the categories available in the database match
     // the information in *src/categories.toml*.
     let categories_toml = include_str!("../boot/categories.toml");
-    cargo_registry::boot::categories::sync(categories_toml).unwrap();
+    boot::categories::sync(categories_toml).unwrap();
 
     let heroku = env::var("HEROKU").is_ok();
     let port = if heroku {

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -5,19 +5,21 @@
 
 #![deny(warnings)]
 
-extern crate cargo_registry;
-extern crate diesel;
+use cargo_registry::{
+    db,
+    models::{Crate, OwnerKind, User},
+    schema::{crate_owners, crates, users},
+};
+use std::{
+    env,
+    io::{self, prelude::*},
+    process::exit,
+};
 
 use diesel::prelude::*;
-use std::env;
-use std::io;
-use std::io::prelude::*;
-
-use cargo_registry::models::{Crate, OwnerKind, User};
-use cargo_registry::schema::*;
 
 fn main() {
-    let conn = cargo_registry::db::connect_now().unwrap();
+    let conn = db::connect_now().unwrap();
     conn.transaction::<_, diesel::result::Error, _>(|| {
         transfer(&conn);
         Ok(())
@@ -97,6 +99,6 @@ fn get_confirm(msg: &str) {
     let mut line = String::new();
     io::stdin().read_line(&mut line).unwrap();
     if !line.starts_with('y') {
-        std::process::exit(0);
+        exit(0);
     }
 }

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -30,9 +30,9 @@ fn main() {
 }
 
 fn update(conn: &PgConnection) -> QueryResult<()> {
+    use crate::version_downloads::dsl::*;
     use diesel::dsl::now;
     use diesel::select;
-    use version_downloads::dsl::*;
 
     let mut max = Some(0);
     while let Some(m) = max {
@@ -183,7 +183,7 @@ mod test {
             .execute(&conn)
             .unwrap();
 
-        ::update(&conn).unwrap();
+        crate::update(&conn).unwrap();
         let version_downloads = versions::table
             .find(version.id)
             .select(versions::downloads)
@@ -195,7 +195,7 @@ mod test {
             .first(&conn);
         assert_eq!(Ok(1), crate_downloads);
         crate_downloads!(&conn, krate.id, 1);
-        ::update(&conn).unwrap();
+        crate::update(&conn).unwrap();
         let version_downloads = versions::table
             .find(version.id)
             .select(versions::downloads)
@@ -220,7 +220,7 @@ mod test {
             ))
             .execute(&conn)
             .unwrap();
-        ::update(&conn).unwrap();
+        crate::update(&conn).unwrap();
         let processed = version_downloads::table
             .filter(version_downloads::version_id.eq(version.id))
             .select(version_downloads::processed)
@@ -244,7 +244,7 @@ mod test {
             ))
             .execute(&conn)
             .unwrap();
-        ::update(&conn).unwrap();
+        crate::update(&conn).unwrap();
         let processed = version_downloads::table
             .filter(version_downloads::version_id.eq(version.id))
             .select(version_downloads::processed)
@@ -294,7 +294,7 @@ mod test {
             .filter(crates::id.eq(krate.id))
             .first::<Crate>(&conn)
             .unwrap();
-        ::update(&conn).unwrap();
+        crate::update(&conn).unwrap();
         let version2 = versions::table
             .find(version.id)
             .first::<Version>(&conn)
@@ -308,7 +308,7 @@ mod test {
         assert_eq!(krate2.downloads, 2);
         assert_eq!(krate2.updated_at, krate_before.updated_at);
         crate_downloads!(&conn, krate.id, 1);
-        ::update(&conn).unwrap();
+        crate::update(&conn).unwrap();
         let version3 = versions::table
             .find(version.id)
             .first::<Version>(&conn)
@@ -343,7 +343,7 @@ mod test {
             .execute(&conn)
             .unwrap();
 
-        ::update(&conn).unwrap();
+        crate::update(&conn).unwrap();
         let versions_changed = versions::table
             .select(versions::updated_at.ne(now - 2.days()))
             .get_result(&conn);

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -5,8 +5,8 @@ use diesel;
 use diesel::prelude::*;
 use toml;
 
-use db;
-use util::errors::{internal, CargoResult, ChainError};
+use crate::db;
+use crate::util::errors::{internal, CargoResult, ChainError};
 
 #[derive(Debug)]
 struct Category {
@@ -91,9 +91,9 @@ pub fn sync(toml_str: &str) -> CargoResult<()> {
 }
 
 pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<()> {
+    use crate::schema::categories::dsl::*;
     use diesel::dsl::all;
     use diesel::pg::upsert::excluded;
-    use schema::categories::dsl::*;
 
     let toml: toml::value::Table =
         toml::from_str(toml_str).expect("Could not parse categories toml");

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -1,12 +1,12 @@
 // Sync available crate categories from `src/categories.toml`.
 // Runs when the server is started.
 
-use diesel;
-use diesel::prelude::*;
-use toml;
+use crate::{
+    db,
+    util::errors::{internal, CargoResult, ChainError},
+};
 
-use crate::db;
-use crate::util::errors::{internal, CargoResult, ChainError};
+use diesel::prelude::*;
 
 #[derive(Debug)]
 struct Category {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use s3;
 use std::env;
 use std::path::PathBuf;
 
-use {env, Env, Replica, Uploader};
+use crate::{env, Env, Replica, Uploader};
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,5 @@
-use s3;
-
-use std::env;
-use std::path::PathBuf;
-
-use crate::{env, Env, Replica, Uploader};
+use crate::{env, uploaders::Uploader, Env, Replica};
+use std::{env, path::PathBuf};
 
 #[derive(Clone, Debug)]
 pub struct Config {

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -1,8 +1,8 @@
 use super::prelude::*;
 
-use models::Category;
-use schema::categories;
-use views::{EncodableCategory, EncodableCategoryWithSubcategories};
+use crate::models::Category;
+use crate::schema::categories;
+use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
 pub fn index(req: &mut dyn Request) -> CargoResult<Response> {

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -2,9 +2,9 @@ use super::prelude::*;
 
 use serde_json;
 
-use models::{CrateOwner, CrateOwnerInvitation, OwnerKind};
-use schema::{crate_owner_invitations, crate_owners};
-use views::{EncodableCrateOwnerInvitation, InvitationResponse};
+use crate::models::{CrateOwner, CrateOwnerInvitation, OwnerKind};
+use crate::schema::{crate_owner_invitations, crate_owners};
+use crate::views::{EncodableCrateOwnerInvitation, InvitationResponse};
 
 /// Handles the `GET /me/crate_owner_invitations` route.
 pub fn list(req: &mut dyn Request) -> CargoResult<Response> {

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -1,7 +1,5 @@
 use super::prelude::*;
 
-use serde_json;
-
 use crate::models::{CrateOwner, CrateOwnerInvitation, OwnerKind};
 use crate::schema::{crate_owner_invitations, crate_owners};
 use crate::views::{EncodableCrateOwnerInvitation, InvitationResponse};

--- a/src/controllers/helpers/mod.rs
+++ b/src/controllers/helpers/mod.rs
@@ -1,5 +1,5 @@
+use crate::util::{json_response, CargoResult};
 use conduit::Response;
-use util::{json_response, CargoResult};
 
 pub mod pagination;
 

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -1,12 +1,12 @@
 use super::prelude::*;
 
-use controllers::helpers::Paginate;
-use models::Keyword;
-use views::EncodableKeyword;
+use crate::controllers::helpers::Paginate;
+use crate::models::Keyword;
+use crate::views::EncodableKeyword;
 
 /// Handles the `GET /keywords` route.
 pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
-    use schema::keywords;
+    use crate::schema::keywords;
 
     let conn = req.db_conn()?;
     let (offset, limit) = req.pagination(10, 100)?;

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -5,13 +5,13 @@
 
 use std::cmp;
 
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
-use models::{Crate, CrateVersions, Version, VersionDownload};
-use schema::version_downloads;
-use views::EncodableVersionDownload;
+use crate::models::{Crate, CrateVersions, Version, VersionDownload};
+use crate::schema::version_downloads;
+use crate::views::EncodableVersionDownload;
 
-use models::krate::to_char;
+use crate::models::krate::to_char;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub fn downloads(req: &mut dyn Request) -> CargoResult<Response> {

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -1,6 +1,5 @@
 //! Endpoints for managing a per user list of followed crates
 
-use diesel;
 use diesel::associations::Identifiable;
 
 use crate::controllers::prelude::*;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -3,9 +3,9 @@
 use diesel;
 use diesel::associations::Identifiable;
 
-use controllers::prelude::*;
-use models::{Crate, Follow};
-use schema::*;
+use crate::controllers::prelude::*;
+use crate::models::{Crate, Follow};
+use crate::schema::*;
 
 fn follow_target(req: &mut dyn Request) -> CargoResult<Follow> {
     let user = req.user()?;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -4,20 +4,20 @@
 //! index or cached metadata which was extracted (client side) from the
 //! `Cargo.toml` file.
 
-use controllers::prelude::*;
-use models::{
+use crate::controllers::prelude::*;
+use crate::models::{
     Category, Crate, CrateCategory, CrateDownload, CrateKeyword, CrateVersions, Keyword, Version,
 };
-use schema::*;
-use views::{
+use crate::schema::*;
+use crate::views::{
     EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
 };
 
-use models::krate::ALL_COLUMNS;
+use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
 pub fn summary(req: &mut dyn Request) -> CargoResult<Response> {
-    use schema::crates::dsl::*;
+    use crate::schema::crates::dsl::*;
 
     let conn = req.db_conn()?;
     let num_crates = crates.count().get_result(&*conn)?;
@@ -116,7 +116,7 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
         .load(&*conn)?;
     let cats = CrateCategory::belonging_to(&krate)
         .inner_join(categories::table)
-        .select(::models::category::ALL_COLUMNS)
+        .select(crate::models::category::ALL_COLUMNS)
         .load(&*conn)?;
     let recent_downloads = CrateDownload::belonging_to(&krate)
         .filter(crate_downloads::date.gt(date(now - 90.days())))

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -2,9 +2,9 @@
 
 use serde_json;
 
-use controllers::prelude::*;
-use models::{Crate, Owner, Rights, Team, User};
-use views::EncodableOwner;
+use crate::controllers::prelude::*;
+use crate::models::{Crate, Owner, Rights, Team, User};
+use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
 pub fn owners(req: &mut dyn Request) -> CargoResult<Response> {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -6,15 +6,15 @@ use std::sync::Arc;
 use hex::ToHex;
 use serde_json;
 
-use git;
-use render;
-use util::{internal, ChainError, Maximums};
-use util::{read_fill, read_le_u32};
+use crate::git;
+use crate::render;
+use crate::util::{internal, ChainError, Maximums};
+use crate::util::{read_fill, read_le_u32};
 
-use controllers::prelude::*;
-use models::dependency;
-use models::{Badge, Category, Keyword, NewCrate, NewVersion, Rights, User};
-use views::{EncodableCrateUpload, GoodCrate, PublishWarnings};
+use crate::controllers::prelude::*;
+use crate::models::dependency;
+use crate::models::{Badge, Category, Keyword, NewCrate, NewVersion, Rights, User};
+use crate::views::{EncodableCrateUpload, GoodCrate, PublishWarnings};
 
 /// Handles the `PUT /crates/new` route.
 /// Used by `cargo publish` to publish a new crate or to publish a new version of an

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use hex::ToHex;
-use serde_json;
 
 use crate::git;
 use crate::render;

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -2,13 +2,13 @@
 
 use diesel_full_text_search::*;
 
-use controllers::helpers::Paginate;
-use controllers::prelude::*;
-use models::{Crate, CrateBadge, CrateVersions, OwnerKind, Version};
-use schema::*;
-use views::EncodableCrate;
+use crate::controllers::helpers::Paginate;
+use crate::controllers::prelude::*;
+use crate::models::{Crate, CrateBadge, CrateVersions, OwnerKind, Version};
+use crate::schema::*;
+use crate::views::EncodableCrate;
 
-use models::krate::{canon_crate_name, ALL_COLUMNS};
+use crate::models::krate::{canon_crate_name, ALL_COLUMNS};
 
 /// Handles the `GET /crates` route.
 /// Returns a list of crates. Called in a variety of scenarios in the
@@ -95,7 +95,7 @@ pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
                 crates_keywords::table
                     .select(crates_keywords::crate_id)
                     .inner_join(keywords::table)
-                    .filter(::lower(keywords::keyword).eq(::lower(kw))),
+                    .filter(crate::lower(keywords::keyword).eq(crate::lower(kw))),
             ),
         );
     } else if let Some(letter) = params.get("letter") {

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -5,11 +5,11 @@ mod prelude {
     pub use conduit::{Request, Response};
     pub use conduit_router::RequestParams;
 
-    pub use db::RequestTransaction;
-    pub use util::{human, CargoResult};
+    pub use crate::db::RequestTransaction;
+    pub use crate::util::{human, CargoResult};
 
-    pub use middleware::app::RequestApp;
-    pub use middleware::current_user::RequestUser;
+    pub use crate::middleware::app::RequestApp;
+    pub use crate::middleware::current_user::RequestUser;
 
     use std::collections::HashMap;
     use std::io;
@@ -28,7 +28,7 @@ mod prelude {
 
     impl<'a> RequestUtils for dyn Request + 'a {
         fn json<T: Serialize>(&self, t: &T) -> Response {
-            ::util::json_response(t)
+            crate::util::json_response(t)
         }
 
         fn query(&self) -> HashMap<String, String> {

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -1,8 +1,8 @@
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
-use models::Team;
-use schema::teams;
-use views::EncodableTeam;
+use crate::models::Team;
+use crate::schema::teams;
+use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
 pub fn show_team(req: &mut dyn Request) -> CargoResult<Response> {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -1,13 +1,12 @@
 use super::prelude::*;
 
 use crate::middleware::current_user::AuthenticationSource;
-use crate::util::{bad_request, read_fill, ChainError};
-use diesel;
-use serde_json as json;
-
 use crate::models::ApiToken;
 use crate::schema::api_tokens;
+use crate::util::{bad_request, read_fill, ChainError};
 use crate::views::EncodableApiTokenWithToken;
+
+use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.
 pub fn list(req: &mut dyn Request) -> CargoResult<Response> {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -1,13 +1,13 @@
 use super::prelude::*;
 
+use crate::middleware::current_user::AuthenticationSource;
+use crate::util::{bad_request, read_fill, ChainError};
 use diesel;
-use middleware::current_user::AuthenticationSource;
 use serde_json as json;
-use util::{bad_request, read_fill, ChainError};
 
-use models::ApiToken;
-use schema::api_tokens;
-use views::EncodableApiTokenWithToken;
+use crate::models::ApiToken;
+use crate::schema::api_tokens;
+use crate::views::EncodableApiTokenWithToken;
 
 /// Handles the `GET /me/tokens` route.
 pub fn list(req: &mut dyn Request) -> CargoResult<Response> {

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -1,14 +1,14 @@
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
 use serde_json;
 
-use controllers::helpers::Paginate;
-use email;
-use util::bad_request;
+use crate::controllers::helpers::Paginate;
+use crate::email;
+use crate::util::bad_request;
 
-use models::{Email, Follow, NewEmail, User, Version};
-use schema::{crates, emails, follows, users, versions};
-use views::{EncodableMe, EncodableVersion};
+use crate::models::{Email, Follow, NewEmail, User, Version};
+use crate::schema::{crates, emails, follows, users, versions};
+use crate::views::{EncodableMe, EncodableVersion};
 
 /// Handles the `GET /me` route.
 pub fn me(req: &mut dyn Request) -> CargoResult<Response> {
@@ -148,7 +148,7 @@ pub fn update_user(req: &mut dyn Request) -> CargoResult<Response> {
             .get_result::<String>(&*conn)
             .map_err(|_| human("Error in creating token"))?;
 
-        ::email::send_user_confirm_email(user_email, &user.gh_login, &token)
+        crate::email::send_user_confirm_email(user_email, &user.gh_login, &token)
             .map_err(|_| bad_request("Email could not be sent"))
     })?;
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -1,7 +1,5 @@
 use crate::controllers::prelude::*;
 
-use serde_json;
-
 use crate::controllers::helpers::Paginate;
 use crate::email;
 use crate::util::bad_request;

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,8 +1,8 @@
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
-use models::{OwnerKind, User};
-use schema::{crate_owners, crates, users};
-use views::EncodablePublicUser;
+use crate::models::{OwnerKind, User};
+use crate::schema::{crate_owners, crates, users};
+use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
 pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
@@ -11,7 +11,7 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
     let name = &req.params()["user_id"].to_lowercase();
     let conn = req.db_conn()?;
     let user = users
-        .filter(::lower(gh_login).eq(name))
+        .filter(crate::lower(gh_login).eq(name))
         .order(id.desc())
         .first::<User>(&*conn)?;
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -1,10 +1,10 @@
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
+use crate::github;
 use conduit_cookie::RequestSession;
-use github;
 use rand::{thread_rng, Rng};
 
-use models::NewUser;
+use crate::models::NewUser;
 
 /// Handles the `GET /authorize_url` route.
 ///

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -7,8 +7,6 @@
 
 use crate::controllers::prelude::*;
 
-use url;
-
 use crate::models::Version;
 use crate::schema::*;
 use crate::views::EncodableVersion;

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -5,13 +5,13 @@
 //! period of time to ensure there are no external users of an endpoint before
 //! it is removed.
 
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
 use url;
 
-use models::Version;
-use schema::*;
-use views::EncodableVersion;
+use crate::models::Version;
+use crate::schema::*;
+use crate::views::EncodableVersion;
 
 use super::version_and_crate;
 
@@ -60,7 +60,7 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
             versions::table
                 .find(id)
                 .inner_join(crates::table)
-                .select((versions::all_columns, ::models::krate::ALL_COLUMNS))
+                .select((versions::all_columns, crate::models::krate::ALL_COLUMNS))
                 .first(&*conn)?
         }
     };

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -2,15 +2,15 @@
 //!
 //! Crate level functionality is located in `krate::downloads`.
 
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
 use chrono::{Duration, NaiveDate, Utc};
 
-use Replica;
+use crate::Replica;
 
-use models::{Crate, VersionDownload};
-use schema::*;
-use views::EncodableVersionDownload;
+use crate::models::{Crate, VersionDownload};
+use crate::schema::*;
+use crate::views::EncodableVersionDownload;
 
 use super::version_and_crate;
 

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -4,10 +4,10 @@
 //! index or cached metadata which was extracted (client side) from the
 //! `Cargo.toml` file.
 
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
-use schema::*;
-use views::{EncodableDependency, EncodablePublicUser};
+use crate::schema::*;
+use crate::views::{EncodableDependency, EncodablePublicUser};
 
 use super::version_and_crate;
 

--- a/src/controllers/version/mod.rs
+++ b/src/controllers/version/mod.rs
@@ -4,7 +4,6 @@ pub mod metadata;
 pub mod yank;
 
 use super::prelude::*;
-use semver;
 
 use crate::models::{Crate, CrateVersions, Version};
 use crate::schema::versions;

--- a/src/controllers/version/mod.rs
+++ b/src/controllers/version/mod.rs
@@ -6,8 +6,8 @@ pub mod yank;
 use super::prelude::*;
 use semver;
 
-use models::{Crate, CrateVersions, Version};
-use schema::versions;
+use crate::models::{Crate, CrateVersions, Version};
+use crate::schema::versions;
 
 fn version_and_crate(req: &mut dyn Request) -> CargoResult<(Version, Crate)> {
     let crate_name = &req.params()["crate_id"];

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -2,8 +2,6 @@
 
 use crate::controllers::prelude::*;
 
-use diesel;
-
 use crate::git;
 use crate::util::errors::CargoError;
 

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -1,14 +1,14 @@
 //! Endpoints for yanking and unyanking specific versions of crates
 
-use controllers::prelude::*;
+use crate::controllers::prelude::*;
 
 use diesel;
 
-use git;
-use util::errors::CargoError;
+use crate::git;
+use crate::util::errors::CargoError;
 
-use models::Rights;
-use schema::*;
+use crate::models::Rights;
+use crate::schema::*;
 
 use super::version_and_crate;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,15 +5,15 @@ use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager, CustomizeConnection};
 use url::Url;
 
-use middleware::app::RequestApp;
-use util::CargoResult;
+use crate::middleware::app::RequestApp;
+use crate::util::CargoResult;
 
 pub type DieselPool = r2d2::Pool<ConnectionManager<PgConnection>>;
 type DieselPooledConn = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
 
 pub fn connect_now() -> ConnectionResult<PgConnection> {
     use diesel::Connection;
-    let mut url = Url::parse(&::env("DATABASE_URL")).expect("Invalid database URL");
+    let mut url = Url::parse(&crate::env("DATABASE_URL")).expect("Invalid database URL");
     if env::var("HEROKU").is_ok() && !url.query_pairs().any(|(k, _)| k == "sslmode") {
         url.query_pairs_mut().append_pair("sslmode", "require");
     }

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,8 +1,8 @@
 use std::env;
 use std::path::Path;
 
+use crate::util::{bad_request, CargoResult};
 use dotenv::dotenv;
-use util::{bad_request, CargoResult};
 
 use lettre::file::FileEmailTransport;
 use lettre::smtp::authentication::{Credentials, Mechanism};

--- a/src/git.rs
+++ b/src/git.rs
@@ -4,10 +4,6 @@ use std::fs::{self, File};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 
-use git2;
-use semver;
-use serde_json;
-
 use crate::app::App;
 use crate::util::{internal, CargoResult};
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -8,10 +8,10 @@ use git2;
 use semver;
 use serde_json;
 
-use app::App;
-use util::{internal, CargoResult};
+use crate::app::App;
+use crate::util::{internal, CargoResult};
 
-use models::DependencyKind;
+use crate::models::DependencyKind;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Crate {

--- a/src/github.rs
+++ b/src/github.rs
@@ -7,8 +7,8 @@ use serde::de::DeserializeOwned;
 
 use std::str;
 
-use app::App;
-use util::{errors::NotFound, human, internal, CargoError, CargoResult};
+use crate::app::App;
+use crate::util::{errors::NotFound, human, internal, CargoError, CargoResult};
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
 /// because custom error-code handling may be desirable. Use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,8 @@ extern crate conduit_static;
 extern crate cookie;
 
 pub use self::uploaders::{Bomb, Uploader};
-pub use app::App;
-pub use config::Config;
+pub use crate::app::App;
+pub use crate::config::Config;
 
 use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,61 +9,25 @@
 #![recursion_limit = "256"]
 #![allow(unknown_lints, proc_macro_derive_resolution_fallback)] // TODO: This can be removed after diesel-1.4
 
-extern crate ammonia;
-extern crate chrono;
-extern crate comrak;
 #[macro_use]
 extern crate derive_deref;
 #[macro_use]
 extern crate diesel;
-extern crate diesel_full_text_search;
-extern crate diesel_ltree;
-extern crate dotenv;
-extern crate flate2;
-extern crate git2;
-extern crate hex;
-extern crate htmlescape;
-extern crate lettre;
-extern crate lettre_email;
-extern crate license_exprs;
 #[macro_use]
 extern crate log;
-extern crate oauth2;
-extern crate openssl;
-extern crate rand;
-extern crate reqwest;
-extern crate s3;
-extern crate scheduled_thread_pool;
-extern crate semver;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
-extern crate tar;
-extern crate toml;
-extern crate url;
 
-extern crate conduit;
-extern crate conduit_conditional_get;
-extern crate conduit_cookie;
-extern crate conduit_git_http_backend;
-extern crate conduit_middleware;
-extern crate conduit_router;
-extern crate conduit_static;
-extern crate cookie;
-
-pub use self::uploaders::{Bomb, Uploader};
-pub use crate::app::App;
-pub use crate::config::Config;
-
+pub use crate::{app::App, config::Config, uploaders::Uploader};
 use std::sync::Arc;
 
 use conduit_middleware::MiddlewareBuilder;
 
-pub mod app;
+mod app;
 pub mod boot;
-pub mod config;
+mod config;
 pub mod db;
 pub mod email;
 pub mod git;

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -1,7 +1,7 @@
 use super::prelude::*;
 
+use crate::App;
 use std::sync::Arc;
-use App;
 
 /// Middleware that injects the `App` instance into the `Request` extensions
 // Can't derive Debug because `App` can't.

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -3,11 +3,11 @@ use super::prelude::*;
 use conduit_cookie::RequestSession;
 use diesel::prelude::*;
 
-use db::RequestTransaction;
-use util::errors::{std_error, CargoResult, ChainError, Unauthorized};
+use crate::db::RequestTransaction;
+use crate::util::errors::{std_error, CargoResult, ChainError, Unauthorized};
 
-use models::User;
-use schema::users;
+use crate::models::User;
+use crate::schema::users;
 
 #[derive(Debug, Clone, Copy)]
 pub struct CurrentUser;

--- a/src/middleware/ember_index_rewrite.rs
+++ b/src/middleware/ember_index_rewrite.rs
@@ -3,7 +3,7 @@
 
 use super::prelude::*;
 
-use util::RequestProxy;
+use crate::util::RequestProxy;
 
 // Can't derive debug because of Handler and Static.
 #[allow(missing_debug_implementations)]

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -2,9 +2,9 @@
 
 use super::prelude::*;
 
+use crate::util::RequestProxy;
 use conduit::Method;
 use std::io;
-use util::RequestProxy;
 
 // Can't derive debug because of Handler.
 #[allow(missing_debug_implementations)]

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -2,10 +2,10 @@
 //! information that we care about like User-Agent and Referer
 
 use super::prelude::*;
+use crate::util::request_header;
 use conduit::Request;
 use std::fmt;
 use std::time::Instant;
-use util::request_header;
 
 #[allow(missing_debug_implementations)] // We can't
 #[derive(Default)]

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -28,7 +28,6 @@ use conduit_conditional_get::ConditionalGet;
 use conduit_cookie::{Middleware as Cookie, SessionMiddleware};
 use conduit_middleware::MiddlewareBuilder;
 
-use cookie;
 use std::env;
 use std::sync::Arc;
 

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -32,8 +32,8 @@ use cookie;
 use std::env;
 use std::sync::Arc;
 
-use router::R404;
-use {App, Env};
+use crate::router::R404;
+use crate::{App, Env};
 
 pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -2,9 +2,9 @@
 
 use super::prelude::*;
 
+use crate::util::request_header;
 use std::collections::HashMap;
 use std::io::Cursor;
-use util::request_header;
 
 // Can't derive debug because of Handler.
 #[allow(missing_debug_implementations)]

--- a/src/middleware/security_headers.rs
+++ b/src/middleware/security_headers.rs
@@ -3,7 +3,7 @@
 use super::prelude::*;
 use std::collections::HashMap;
 
-use Uploader;
+use crate::Uploader;
 
 #[derive(Clone, Debug)]
 pub struct SecurityHeaders {

--- a/src/middleware/security_headers.rs
+++ b/src/middleware/security_headers.rs
@@ -1,9 +1,8 @@
 //! Middleware that adds secuirty headers to http responses in production.
 
 use super::prelude::*;
-use std::collections::HashMap;
-
 use crate::Uploader;
+use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub struct SecurityHeaders {

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -1,7 +1,6 @@
 use diesel::associations::HasTable;
 use diesel::pg::Pg;
 use diesel::prelude::*;
-use serde_json;
 use std::collections::HashMap;
 
 use crate::models::Crate;

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -4,9 +4,9 @@ use diesel::prelude::*;
 use serde_json;
 use std::collections::HashMap;
 
-use models::Crate;
-use schema::badges;
-use views::EncodableBadge;
+use crate::models::Crate;
+use crate::schema::badges;
+use crate::views::EncodableBadge;
 
 /// A combination of a `Badge` and a crate ID.
 ///

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -1,9 +1,9 @@
 use chrono::NaiveDateTime;
 use diesel::{self, *};
 
-use models::Crate;
-use schema::*;
-use views::EncodableCategory;
+use crate::models::Crate;
+use crate::schema::*;
+use crate::views::EncodableCategory;
 
 #[derive(Clone, Identifiable, Queryable, QueryableByName, Debug)]
 #[table_name = "categories"]
@@ -37,7 +37,7 @@ pub const ALL_COLUMNS: AllColumns = (
 );
 
 type All = diesel::dsl::Select<categories::table, AllColumns>;
-type WithSlug<'a> = diesel::dsl::Eq<categories::slug, ::lower::HelperType<&'a str>>;
+type WithSlug<'a> = diesel::dsl::Eq<categories::slug, crate::lower::HelperType<&'a str>>;
 type BySlug<'a> = diesel::dsl::Filter<All, WithSlug<'a>>;
 type WithSlugsCaseSensitive<'a> = diesel::dsl::Eq<
     categories::slug,
@@ -62,7 +62,7 @@ pub struct CrateCategory {
 
 impl Category {
     pub fn with_slug(slug: &str) -> WithSlug {
-        categories::slug.eq(::lower(slug))
+        categories::slug.eq(crate::lower(slug))
     }
 
     pub fn by_slug(slug: &str) -> BySlug {
@@ -194,7 +194,7 @@ pub struct NewCategory<'a> {
 impl<'a> NewCategory<'a> {
     /// Inserts the category into the database, or updates an existing one.
     pub fn create_or_update(&self, conn: &PgConnection) -> QueryResult<Category> {
-        use schema::categories::dsl::*;
+        use crate::schema::categories::dsl::*;
 
         insert_into(categories)
             .values(self)

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -61,11 +61,11 @@ pub struct CrateCategory {
 }
 
 impl Category {
-    pub fn with_slug(slug: &str) -> WithSlug {
+    pub fn with_slug(slug: &str) -> WithSlug<'_> {
         categories::slug.eq(crate::lower(slug))
     }
 
-    pub fn by_slug(slug: &str) -> BySlug {
+    pub fn by_slug(slug: &str) -> BySlug<'_> {
         Category::all().filter(Self::with_slug(slug))
     }
 

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -1,8 +1,8 @@
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
-use schema::{crate_owner_invitations, crates, users};
-use views::EncodableCrateOwnerInvitation;
+use crate::schema::{crate_owner_invitations, crates, users};
+use crate::views::EncodableCrateOwnerInvitation;
 
 /// The model representing a row in the `crate_owner_invitations` database table.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Identifiable, Queryable)]

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -1,12 +1,12 @@
 use diesel::prelude::*;
 use semver;
 
-use git;
-use util::{human, CargoResult};
+use crate::git;
+use crate::util::{human, CargoResult};
 
-use models::{Crate, Version};
-use schema::*;
-use views::{EncodableCrateDependency, EncodableDependency};
+use crate::models::{Crate, Version};
+use crate::schema::*;
+use crate::views::{EncodableCrateDependency, EncodableDependency};
 
 #[derive(Identifiable, Associations, Debug, Queryable, QueryableByName)]
 #[belongs_to(Version)]

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -1,5 +1,4 @@
 use diesel::prelude::*;
-use semver;
 
 use crate::git;
 use crate::util::{human, CargoResult};

--- a/src/models/download.rs
+++ b/src/models/download.rs
@@ -1,5 +1,4 @@
 use chrono::NaiveDate;
-use diesel;
 use diesel::prelude::*;
 
 use crate::models::Version;

--- a/src/models/download.rs
+++ b/src/models/download.rs
@@ -2,9 +2,9 @@ use chrono::NaiveDate;
 use diesel;
 use diesel::prelude::*;
 
-use models::Version;
-use schema::version_downloads;
-use views::EncodableVersionDownload;
+use crate::models::Version;
+use crate::schema::version_downloads;
+use crate::views::EncodableVersionDownload;
 
 #[derive(Queryable, Identifiable, Associations, Debug, Clone, Copy)]
 #[belongs_to(Version)]

--- a/src/models/email.rs
+++ b/src/models/email.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 
-use models::User;
-use schema::emails;
+use crate::models::User;
+use crate::schema::emails;
 
 #[derive(Debug, Queryable, AsChangeset, Identifiable, Associations)]
 #[belongs_to(User)]

--- a/src/models/follow.rs
+++ b/src/models/follow.rs
@@ -1,5 +1,5 @@
-use models::User;
-use schema::follows;
+use crate::models::User;
+use crate::schema::follows;
 
 #[derive(Insertable, Queryable, Identifiable, Associations, Clone, Copy, Debug)]
 #[belongs_to(User)]

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -1,5 +1,4 @@
 use chrono::NaiveDateTime;
-use diesel;
 use diesel::prelude::*;
 
 use crate::models::Crate;

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -2,9 +2,9 @@ use chrono::NaiveDateTime;
 use diesel;
 use diesel::prelude::*;
 
-use models::Crate;
-use schema::*;
-use views::EncodableKeyword;
+use crate::models::Crate;
+use crate::schema::*;
+use crate::views::EncodableKeyword;
 
 #[derive(Clone, Identifiable, Queryable, Debug)]
 pub struct Keyword {
@@ -27,7 +27,7 @@ pub struct CrateKeyword {
 impl Keyword {
     pub fn find_by_keyword(conn: &PgConnection, name: &str) -> QueryResult<Keyword> {
         keywords::table
-            .filter(keywords::keyword.eq(::lower(name)))
+            .filter(keywords::keyword.eq(crate::lower(name)))
             .first(&*conn)
     }
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -1,10 +1,7 @@
 use chrono::{NaiveDate, NaiveDateTime};
-use diesel;
 use diesel::associations::Identifiable;
 use diesel::pg::Pg;
 use diesel::prelude::*;
-use license_exprs;
-use semver;
 use url::Url;
 
 use crate::app::App;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -7,17 +7,17 @@ use license_exprs;
 use semver;
 use url::Url;
 
-use app::App;
-use util::{human, CargoResult};
+use crate::app::App;
+use crate::util::{human, CargoResult};
 
-use models::{
+use crate::models::{
     Badge, Category, CrateOwner, Keyword, NewCrateOwnerInvitation, Owner, OwnerKind,
     ReverseDependency, User, Version,
 };
-use views::{EncodableCrate, EncodableCrateLinks};
+use crate::views::{EncodableCrate, EncodableCrateLinks};
 
-use models::helpers::with_count::*;
-use schema::*;
+use crate::models::helpers::with_count::*;
+use crate::schema::*;
 
 /// Hosts in this list are known to not be hosting documentation,
 /// and are possibly of malicious intent e.g. ad tracking networks, etc.
@@ -194,9 +194,9 @@ impl<'a> NewCrate<'a> {
     }
 
     fn ensure_name_not_reserved(&self, conn: &PgConnection) -> CargoResult<()> {
+        use crate::schema::reserved_crate_names::dsl::*;
         use diesel::dsl::exists;
         use diesel::select;
-        use schema::reserved_crate_names::dsl::*;
 
         let reserved_name = select(exists(
             reserved_crate_names.filter(canon_crate_name(name).eq(canon_crate_name(self.name))),
@@ -210,7 +210,7 @@ impl<'a> NewCrate<'a> {
     }
 
     fn save_new_crate(&self, conn: &PgConnection, user_id: i32) -> QueryResult<Option<Crate>> {
-        use schema::crates::dsl::*;
+        use crate::schema::crates::dsl::*;
 
         conn.transaction(|| {
             let maybe_inserted = diesel::insert_into(crates)
@@ -396,7 +396,7 @@ impl Crate {
     }
 
     pub fn max_version(&self, conn: &PgConnection) -> CargoResult<semver::Version> {
-        use schema::versions::dsl::*;
+        use crate::schema::versions::dsl::*;
 
         let vs = self
             .versions()
@@ -526,7 +526,7 @@ sql_function!(fn to_char(a: Date, b: Text) -> Text);
 
 #[cfg(test)]
 mod tests {
-    use models::Crate;
+    use crate::models::Crate;
 
     #[test]
     fn documentation_blocked_no_url_provided() {

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -1,12 +1,12 @@
 use diesel::prelude::*;
 
-use app::App;
-use github;
-use util::{human, CargoResult};
+use crate::app::App;
+use crate::github;
+use crate::util::{human, CargoResult};
 
-use models::{Crate, Team, User};
-use schema::{crate_owners, users};
-use views::EncodableOwner;
+use crate::models::{Crate, Team, User};
+use crate::schema::{crate_owners, users};
+use crate::views::EncodableOwner;
 
 #[derive(Insertable, Associations, Identifiable, Debug, Clone, Copy)]
 #[belongs_to(Crate)]

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -1,12 +1,12 @@
 use diesel::prelude::*;
 
-use app::App;
-use github;
-use util::{errors::NotFound, human, CargoResult};
+use crate::app::App;
+use crate::github;
+use crate::util::{errors::NotFound, human, CargoResult};
 
-use models::{Crate, CrateOwner, Owner, OwnerKind, User};
-use schema::{crate_owners, teams};
-use views::EncodableTeam;
+use crate::models::{Crate, CrateOwner, Owner, OwnerKind, User};
+use crate::schema::{crate_owners, teams};
+use crate::views::EncodableTeam;
 
 /// For now, just a Github Team. Can be upgraded to other teams
 /// later if desirable.
@@ -52,8 +52,8 @@ impl<'a> NewTeam<'a> {
     }
 
     pub fn create_or_update(&self, conn: &PgConnection) -> QueryResult<Team> {
+        use crate::schema::teams::dsl::*;
         use diesel::insert_into;
-        use schema::teams::dsl::*;
 
         insert_into(teams)
             .values(self)

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -118,7 +118,7 @@ impl Team {
         // "sanitization"
         fn whitelist(c: char) -> bool {
             match c {
-                'a'...'z' | 'A'...'Z' | '0'...'9' | '-' | '_' => false,
+                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => false,
                 _ => true,
             }
         }

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -2,10 +2,10 @@ use chrono::NaiveDateTime;
 use diesel;
 use diesel::prelude::*;
 
-use models::User;
-use schema::api_tokens;
-use util::rfc3339;
-use views::EncodableApiTokenWithToken;
+use crate::models::User;
+use crate::schema::api_tokens;
+use crate::util::rfc3339;
+use crate::views::EncodableApiTokenWithToken;
 
 /// The model representing a row in the `api_tokens` database table.
 #[derive(Clone, Debug, PartialEq, Eq, Identifiable, Queryable, Associations, Serialize)]

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,5 +1,4 @@
 use chrono::NaiveDateTime;
-use diesel;
 use diesel::prelude::*;
 
 use crate::models::User;

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -6,12 +6,12 @@ use diesel::prelude::*;
 use semver;
 use serde_json;
 
+use crate::util::{human, CargoResult};
 use license_exprs;
-use util::{human, CargoResult};
 
-use models::{Crate, Dependency};
-use schema::*;
-use views::{EncodableVersion, EncodableVersionLinks};
+use crate::models::{Crate, Dependency};
+use crate::schema::*;
+use crate::views::{EncodableVersion, EncodableVersionLinks};
 
 // Queryable has a custom implementation below
 #[derive(Clone, Identifiable, Associations, Debug, Queryable)]
@@ -101,8 +101,8 @@ impl Version {
     }
 
     pub fn record_readme_rendering(&self, conn: &PgConnection) -> QueryResult<usize> {
+        use crate::schema::readme_renderings::dsl::*;
         use diesel::dsl::now;
-        use schema::readme_renderings::dsl::*;
 
         diesel::insert_into(readme_renderings)
             .values(version_id.eq(self.id))
@@ -139,10 +139,10 @@ impl NewVersion {
     }
 
     pub fn save(&self, conn: &PgConnection, authors: &[String]) -> CargoResult<Version> {
+        use crate::schema::version_authors::{name, version_id};
+        use crate::schema::versions::dsl::*;
         use diesel::dsl::exists;
         use diesel::{insert_into, select};
-        use schema::version_authors::{name, version_id};
-        use schema::versions::dsl::*;
 
         conn.transaction(|| {
             let already_uploaded = versions

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -1,13 +1,9 @@
 use std::collections::HashMap;
 
 use chrono::NaiveDateTime;
-use diesel;
 use diesel::prelude::*;
-use semver;
-use serde_json;
 
 use crate::util::{human, CargoResult};
-use license_exprs;
 
 use crate::models::{Crate, Dependency};
 use crate::schema::*;

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use std::path::Path;
 use url::Url;
 
-use util::CargoResult;
+use crate::util::CargoResult;
 
 /// Context for markdown to HTML rendering.
 #[allow(missing_debug_implementations)]

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,5 +1,4 @@
 use ammonia::{Builder, UrlRelative};
-use comrak;
 use htmlescape::encode_minimal;
 use std::borrow::Cow;
 use std::path::Path;

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,10 +5,10 @@ use conduit::{Handler, Request, Response};
 use conduit_git_http_backend;
 use conduit_router::{RequestParams, RouteBuilder};
 
-use controllers::*;
-use util::errors::{std_error, CargoError, CargoResult, NotFound};
-use util::RequestProxy;
-use {App, Env};
+use crate::controllers::*;
+use crate::util::errors::{std_error, CargoError, CargoResult, NotFound};
+use crate::util::RequestProxy;
+use crate::{App, Env};
 
 pub fn build_router(app: &App) -> R404 {
     let mut api_router = RouteBuilder::new();
@@ -178,8 +178,8 @@ mod tests {
 
     use self::conduit_test::MockRequest;
     use super::*;
+    use crate::util::errors::*;
     use diesel::result::Error as DieselError;
-    use util::errors::*;
 
     fn err<E: CargoError>(err: E) -> CargoResult<Response> {
         Err(Box::new(err))

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::sync::Arc;
 
 use conduit::{Handler, Request, Response};
-use conduit_git_http_backend;
 use conduit_router::{RequestParams, RouteBuilder};
 
 use crate::controllers::*;
@@ -174,11 +173,10 @@ impl Handler for R404 {
 
 #[cfg(test)]
 mod tests {
-    extern crate conduit_test;
-
-    use self::conduit_test::MockRequest;
     use super::*;
-    use crate::util::errors::*;
+    use crate::util::errors::{bad_request, human, internal, NotFound, Unauthorized};
+
+    use conduit_test::MockRequest;
     use diesel::result::Error as DieselError;
 
     fn err<E: CargoError>(err: E) -> CargoResult<Response> {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -240,7 +240,7 @@ fn add_team_to_crate(t: &Team, krate: &Crate, u: &User, conn: &PgConnection) -> 
     Ok(())
 }
 
-fn sign_in_as(req: &mut Request, user: &User) {
+fn sign_in_as(req: &mut dyn Request, user: &User) {
     req.mut_extensions().insert(user.clone());
     req.mut_extensions()
         .insert(AuthenticationSource::SessionCookie);
@@ -271,6 +271,6 @@ fn new_category<'a>(category: &'a str, slug: &'a str, description: &'a str) -> N
     }
 }
 
-fn logout(req: &mut Request) {
+fn logout(req: &mut dyn Request) {
     req.mut_extensions().pop::<User>();
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -35,13 +35,13 @@ use conduit::Request;
 use conduit_test::MockRequest;
 use diesel::prelude::*;
 
+use crate::util::{Bad, RequestHelper, TestApp};
 use cargo_registry::{models, schema, views};
-use util::{Bad, RequestHelper, TestApp};
 
-use models::{Crate, CrateOwner, Dependency, Team, User, Version};
-use models::{NewCategory, NewTeam, NewUser};
-use schema::*;
-use views::{EncodableCrate, EncodableKeyword, EncodableOwner, EncodableVersion, GoodCrate};
+use crate::models::{Crate, CrateOwner, Dependency, Team, User, Version};
+use crate::models::{NewCategory, NewTeam, NewUser};
+use crate::schema::*;
+use crate::views::{EncodableCrate, EncodableKeyword, EncodableOwner, EncodableVersion, GoodCrate};
 
 macro_rules! t {
     ($e:expr) => {
@@ -55,7 +55,7 @@ macro_rules! t {
 macro_rules! ok_resp {
     ($e:expr) => {{
         let resp = t!($e);
-        if !::ok_resp(&resp) {
+        if !crate::ok_resp(&resp) {
             panic!("bad response: {:?}", resp.status);
         }
         resp
@@ -65,7 +65,7 @@ macro_rules! ok_resp {
 macro_rules! bad_resp {
     ($e:expr) => {{
         let mut resp = t!($e);
-        match ::bad_resp(&mut resp) {
+        match crate::bad_resp(&mut resp) {
             None => panic!("ok response: {:?}", resp.status),
             Some(b) => b,
         }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,47 +1,36 @@
 #![deny(warnings)]
 #![allow(unknown_lints, proc_macro_derive_resolution_fallback)] // TODO: This can be removed after diesel-1.4
 
-extern crate cargo_registry;
-extern crate chrono;
-extern crate conduit;
-extern crate conduit_middleware;
-extern crate conduit_test;
 #[macro_use]
 extern crate diesel;
-extern crate dotenv;
-extern crate flate2;
-extern crate git2;
 #[macro_use]
 extern crate lazy_static;
-extern crate s3;
-extern crate semver;
-extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate serde_json;
-extern crate tar;
-extern crate url;
 
-use std::borrow::Cow;
-use std::env;
-use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
-use std::sync::Arc;
+use crate::util::{Bad, RequestHelper, TestApp};
+use cargo_registry::{
+    middleware::current_user::AuthenticationSource,
+    models::{Crate, CrateOwner, Dependency, NewCategory, NewTeam, NewUser, Team, User, Version},
+    schema::crate_owners,
+    util::CargoResult,
+    views::{EncodableCrate, EncodableKeyword, EncodableOwner, EncodableVersion, GoodCrate},
+    App, Config, Env, Replica, Uploader,
+};
+use std::{
+    borrow::Cow,
+    env,
+    sync::{
+        atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
+        Arc,
+    },
+};
 
-use cargo_registry::app::App;
-use cargo_registry::middleware::current_user::AuthenticationSource;
-use cargo_registry::Replica;
 use conduit::Request;
 use conduit_test::MockRequest;
 use diesel::prelude::*;
-
-use crate::util::{Bad, RequestHelper, TestApp};
-use cargo_registry::{models, schema, views};
-
-use crate::models::{Crate, CrateOwner, Dependency, Team, User, Version};
-use crate::models::{NewCategory, NewTeam, NewUser};
-use crate::schema::*;
-use crate::views::{EncodableCrate, EncodableKeyword, EncodableOwner, EncodableVersion, GoodCrate};
 
 macro_rules! t {
     ($e:expr) => {
@@ -126,7 +115,7 @@ fn app() -> (
     dotenv::dotenv().ok();
 
     let (proxy, bomb) = record::proxy();
-    let uploader = cargo_registry::Uploader::S3 {
+    let uploader = Uploader::S3 {
         bucket: s3::Bucket::new(
             String::from("alexcrichton-test"),
             None,
@@ -144,18 +133,16 @@ fn app() -> (
     (bomb, app, handler)
 }
 
-fn simple_app(
-    uploader: cargo_registry::Uploader,
-) -> (Arc<App>, conduit_middleware::MiddlewareBuilder) {
+fn simple_app(uploader: Uploader) -> (Arc<App>, conduit_middleware::MiddlewareBuilder) {
     git::init();
-    let config = cargo_registry::Config {
+    let config = Config {
         uploader,
         session_key: "test this has to be over 32 bytes long".to_string(),
         git_repo_checkout: git::checkout(),
         gh_client_id: env::var("GH_CLIENT_ID").unwrap_or_default(),
         gh_client_secret: env::var("GH_CLIENT_SECRET").unwrap_or_default(),
         db_url: env("TEST_DATABASE_URL"),
-        env: cargo_registry::Env::Test,
+        env: Env::Test,
         max_upload_size: 3000,
         max_unpack_size: 2000,
         mirror: Replica::Primary,
@@ -252,8 +239,6 @@ fn add_team_to_crate(t: &Team, krate: &Crate, u: &User, conn: &PgConnection) -> 
 
     Ok(())
 }
-
-use cargo_registry::util::CargoResult;
 
 fn sign_in_as(req: &mut Request, user: &User) {
     req.mut_extensions().insert(user.clone());

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
-use builders::CrateBuilder;
-use models::{Badge, Crate, MaintenanceStatus};
-use TestApp;
+use crate::builders::CrateBuilder;
+use crate::models::{Badge, Crate, MaintenanceStatus};
+use crate::TestApp;
 
 struct BadgeRef {
     appveyor: Badge,

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -1,8 +1,6 @@
+use crate::{builders::CrateBuilder, TestApp};
+use cargo_registry::models::{Badge, Crate, MaintenanceStatus};
 use std::collections::HashMap;
-
-use crate::builders::CrateBuilder;
-use crate::models::{Badge, Crate, MaintenanceStatus};
-use crate::TestApp;
 
 struct BadgeRef {
     appveyor: Badge,

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -358,7 +358,7 @@ impl PublishBuilder {
             .zip(&mut slices)
             .map(|(&(name, _), data)| {
                 let len = data.len() as u64;
-                (name, data as &mut Read, len)
+                (name, data as &mut dyn Read, len)
             })
             .collect::<Vec<_>>();
 
@@ -366,7 +366,7 @@ impl PublishBuilder {
     }
 
     /// Set the tarball from a Read trait object
-    pub fn files_with_io(mut self, files: &mut [(&str, &mut Read, u64)]) -> Self {
+    pub fn files_with_io(mut self, files: &mut [(&str, &mut dyn Read, u64)]) -> Self {
         let mut tarball = Vec::new();
         {
             let mut ar = tar::Builder::new(GzEncoder::new(&mut tarball, Compression::default()));

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -13,9 +13,9 @@ use tar;
 
 use cargo_registry::util::CargoResult;
 
-use models::{Crate, CrateDownload, Keyword, NewCrate, NewVersion, Version};
-use schema::*;
-use views::krate_publish as u;
+use crate::models::{Crate, CrateDownload, Keyword, NewCrate, NewVersion, Version};
+use crate::schema::*;
+use crate::views::krate_publish as u;
 
 /// A builder to create version records for the purpose of inserting directly into the database.
 pub struct VersionBuilder<'a> {

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -1,21 +1,16 @@
 //! Structs using the builder pattern that make it easier to create records in tests.
 
-use std::collections::HashMap;
-use std::io::Read;
+use cargo_registry::{
+    models::{Crate, CrateDownload, Keyword, NewCrate, NewVersion, Version},
+    schema::{crate_downloads, dependencies, versions},
+    util::CargoResult,
+    views::krate_publish as u,
+};
+use std::{collections::HashMap, io::Read};
 
-use chrono;
 use chrono::Utc;
 use diesel::prelude::*;
-use flate2::write::GzEncoder;
-use flate2::Compression;
-use semver;
-use tar;
-
-use cargo_registry::util::CargoResult;
-
-use crate::models::{Crate, CrateDownload, Keyword, NewCrate, NewVersion, Version};
-use crate::schema::*;
-use crate::views::krate_publish as u;
+use flate2::{write::GzEncoder, Compression};
 
 /// A builder to create version records for the purpose of inserting directly into the database.
 pub struct VersionBuilder<'a> {

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -3,7 +3,7 @@ use std::env;
 use diesel::*;
 use dotenv::dotenv;
 
-use schema::categories;
+use crate::schema::categories;
 
 const ALGORITHMS: &str = r#"
 [algorithms]

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -1,9 +1,8 @@
+use cargo_registry::schema::categories;
 use std::env;
 
 use diesel::*;
 use dotenv::dotenv;
-
-use crate::schema::categories;
 
 const ALGORITHMS: &str = r#"
 [algorithms]

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,9 +1,9 @@
 use conduit::{Handler, Method};
 
-use builders::CrateBuilder;
-use models::Category;
-use views::{EncodableCategory, EncodableCategoryWithSubcategories};
-use {app, new_category, new_user, req, RequestHelper, TestApp};
+use crate::builders::CrateBuilder;
+use crate::models::Category;
+use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
+use crate::{app, new_category, new_user, req, RequestHelper, TestApp};
 
 #[derive(Deserialize)]
 struct CategoryList {
@@ -81,7 +81,9 @@ fn update_crate() {
         ($req:expr, $cat:expr) => {{
             $req.with_path(&format!("/api/v1/categories/{}", $cat));
             let mut response = ok_resp!(middle.call($req));
-            ::json::<GoodCategory>(&mut response).category.crates_cnt as usize
+            crate::json::<GoodCategory>(&mut response)
+                .category
+                .crates_cnt as usize
         }};
     }
 
@@ -143,7 +145,7 @@ fn update_crate() {
     // (unlike the behavior of keywords)
     req.with_path("/api/v1/categories");
     let mut response = ok_resp!(middle.call(&mut req));
-    let json: CategoryList = ::json(&mut response);
+    let json: CategoryList = crate::json(&mut response);
     assert_eq!(json.categories.len(), 2);
     assert_eq!(json.meta.total, 2);
 

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -1,9 +1,10 @@
-use conduit::{Handler, Method};
+use crate::{app, builders::CrateBuilder, new_category, new_user, req, RequestHelper, TestApp};
+use cargo_registry::{
+    models::Category,
+    views::{EncodableCategory, EncodableCategoryWithSubcategories},
+};
 
-use crate::builders::CrateBuilder;
-use crate::models::Category;
-use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
-use crate::{app, new_category, new_user, req, RequestHelper, TestApp};
+use conduit::{Handler, Method};
 
 #[derive(Deserialize)]
 struct CategoryList {

--- a/src/tests/git.rs
+++ b/src/tests/git.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use std::sync::{Once, ONCE_INIT};
 use std::thread;
 
-use git2;
 use url::Url;
 
 fn root() -> PathBuf {

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,7 +1,7 @@
-use builders::CrateBuilder;
-use models::Keyword;
-use views::EncodableKeyword;
-use {RequestHelper, TestApp};
+use crate::builders::CrateBuilder;
+use crate::models::Keyword;
+use crate::views::EncodableKeyword;
+use crate::{RequestHelper, TestApp};
 
 #[derive(Deserialize)]
 struct KeywordList {

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -1,7 +1,5 @@
-use crate::builders::CrateBuilder;
-use crate::models::Keyword;
-use crate::views::EncodableKeyword;
-use crate::{RequestHelper, TestApp};
+use crate::{builders::CrateBuilder, RequestHelper, TestApp};
+use cargo_registry::{models::Keyword, views::EncodableKeyword};
 
 #[derive(Deserialize)]
 struct KeywordList {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1,36 +1,27 @@
-extern crate diesel;
-extern crate tempdir;
-
-use std::collections::HashMap;
-use std::fs::{self, File};
-use std::io;
-use std::io::prelude::*;
-
-use self::diesel::prelude::*;
-use self::tempdir::TempDir;
-use chrono::Utc;
-use diesel::dsl::*;
-use diesel::update;
-use flate2::write::GzEncoder;
-use flate2::Compression;
-use git2;
-use serde_json;
-use tar;
-
-use cargo_registry::git;
-use cargo_registry::models::krate::MAX_NAME_LENGTH;
-
-use crate::builders::{CrateBuilder, DependencyBuilder, PublishBuilder, VersionBuilder};
-use crate::models::{Category, Crate};
-use crate::schema::{api_tokens, crates, emails, metadata, versions};
-use crate::views::{
-    EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
-    EncodableVersionDownload,
-};
 use crate::{
+    builders::{CrateBuilder, DependencyBuilder, PublishBuilder, VersionBuilder},
     new_category, new_dependency, new_user, CrateMeta, CrateResponse, GoodCrate, OkBool,
     RequestHelper, TestApp,
 };
+use cargo_registry::{
+    git,
+    models::{krate::MAX_NAME_LENGTH, Category, Crate},
+    schema::{api_tokens, crates, emails, metadata, versions},
+    views::{
+        EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
+        EncodableVersionDownload,
+    },
+};
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::{self, prelude::*},
+};
+
+use chrono::Utc;
+use diesel::{dsl::*, prelude::*, update};
+use flate2::{write::GzEncoder, Compression};
+use tempdir::TempDir;
 
 #[derive(Deserialize)]
 struct VersionsList {

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -20,14 +20,14 @@ use tar;
 use cargo_registry::git;
 use cargo_registry::models::krate::MAX_NAME_LENGTH;
 
-use builders::{CrateBuilder, DependencyBuilder, PublishBuilder, VersionBuilder};
-use models::{Category, Crate};
-use schema::{api_tokens, crates, emails, metadata, versions};
-use views::{
+use crate::builders::{CrateBuilder, DependencyBuilder, PublishBuilder, VersionBuilder};
+use crate::models::{Category, Crate};
+use crate::schema::{api_tokens, crates, emails, metadata, versions};
+use crate::views::{
     EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
     EncodableVersionDownload,
 };
-use {
+use crate::{
     new_category, new_dependency, new_user, CrateMeta, CrateResponse, GoodCrate, OkBool,
     RequestHelper, TestApp,
 };
@@ -63,22 +63,22 @@ struct SummaryResponse {
     popular_categories: Vec<EncodableCategory>,
 }
 
-impl ::util::MockAnonymousUser {
+impl crate::util::MockAnonymousUser {
     fn reverse_dependencies(&self, krate_name: &str) -> RevDeps {
         let url = format!("/api/v1/crates/{}/reverse_dependencies", krate_name);
         self.get(&url).good()
     }
 }
 
-impl ::util::MockTokenUser {
+impl crate::util::MockTokenUser {
     /// Yank the specified version of the specified crate.
-    fn yank(&self, krate_name: &str, version: &str) -> ::util::Response<OkBool> {
+    fn yank(&self, krate_name: &str, version: &str) -> crate::util::Response<OkBool> {
         let url = format!("/api/v1/crates/{}/{}/yank", krate_name, version);
         self.delete(&url)
     }
 
     /// Unyank the specified version of the specified crate.
-    fn unyank(&self, krate_name: &str, version: &str) -> ::util::Response<OkBool> {
+    fn unyank(&self, krate_name: &str, version: &str) -> crate::util::Response<OkBool> {
         let url = format!("/api/v1/crates/{}/{}/unyank", krate_name, version);
         self.put(&url, &[])
     }
@@ -977,8 +977,8 @@ fn new_krate_git_upload_appends() {
 #[test]
 fn new_krate_git_upload_with_conflicts() {
     {
-        ::git::init();
-        let repo = git2::Repository::open(&::git::bare()).unwrap();
+        crate::git::init();
+        let repo = git2::Repository::open(&crate::git::bare()).unwrap();
         let target = repo.head().unwrap().target().unwrap();
         let sig = repo.signature().unwrap();
         let parent = repo.find_commit(target).unwrap();
@@ -2006,7 +2006,7 @@ fn clone_remote_repo() -> TempDir {
     use url::Url;
 
     let tempdir = TempDir::new("tests").unwrap();
-    let url = Url::from_file_path(::git::bare()).unwrap();
+    let url = Url::from_file_path(crate::git::bare()).unwrap();
     git2::Repository::clone(url.as_str(), tempdir.path()).unwrap();
     tempdir
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -2,14 +2,14 @@ use conduit::{Handler, Method};
 use diesel;
 use diesel::prelude::*;
 
-use builders::{CrateBuilder, PublishBuilder};
-use models::{Crate, NewCrateOwnerInvitation};
-use schema::crate_owner_invitations;
-use util::RequestHelper;
-use views::{
+use crate::builders::{CrateBuilder, PublishBuilder};
+use crate::models::{Crate, NewCrateOwnerInvitation};
+use crate::schema::crate_owner_invitations;
+use crate::util::RequestHelper;
+use crate::views::{
     EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse,
 };
-use {add_team_to_crate, app, new_team, new_user, req, sign_in_as, TestApp};
+use crate::{add_team_to_crate, app, new_team, new_user, req, sign_in_as, TestApp};
 
 #[derive(Deserialize)]
 struct TeamResponse {
@@ -25,11 +25,11 @@ struct InvitationListResponse {
 }
 
 // Implementing locally for now, unless these are needed elsewhere
-impl ::util::MockCookieUser {
+impl crate::util::MockCookieUser {
     /// As the currently logged in user, accept an invitation to become an owner of the named
     /// crate.
     fn accept_ownership_invitation(&self, krate_name: &str, krate_id: i32) {
-        use views::InvitationResponse;
+        use crate::views::InvitationResponse;
 
         let body = json!({
             "crate_owner_invite": {
@@ -270,7 +270,7 @@ fn test_accept_invitation() {
             .with_body(body.to_string().as_bytes()),
     ));
 
-    let json: T = ::json(&mut response);
+    let json: T = crate::json(&mut response);
     assert_eq!(json.crate_owner_invitation.accepted, true);
     assert_eq!(json.crate_owner_invitation.crate_id, krate.id);
 
@@ -281,7 +281,7 @@ fn test_accept_invitation() {
         req.with_path("api/v1/me/crate_owner_invitations")
             .with_method(Method::Get)
     ));
-    let json: InvitationListResponse = ::json(&mut response);
+    let json: InvitationListResponse = crate::json(&mut response);
     assert_eq!(json.crate_owner_invitations.len(), 0);
 
     // new crate owner was inserted
@@ -289,7 +289,7 @@ fn test_accept_invitation() {
         req.with_path("/api/v1/crates/invited_crate/owners")
             .with_method(Method::Get)
     ));
-    let json: Q = ::json(&mut response);
+    let json: Q = crate::json(&mut response);
     assert_eq!(json.users.len(), 2);
 }
 
@@ -350,7 +350,7 @@ fn test_decline_invitation() {
             .with_body(body.to_string().as_bytes()),
     ));
 
-    let json: T = ::json(&mut response);
+    let json: T = crate::json(&mut response);
     assert_eq!(json.crate_owner_invitation.accepted, false);
     assert_eq!(json.crate_owner_invitation.crate_id, krate.id);
 
@@ -361,7 +361,7 @@ fn test_decline_invitation() {
         req.with_path("api/v1/me/crate_owner_invitations")
             .with_method(Method::Get)
     ));
-    let json: InvitationListResponse = ::json(&mut response);
+    let json: InvitationListResponse = crate::json(&mut response);
     assert_eq!(json.crate_owner_invitations.len(), 0);
 
     // new crate owner was not inserted
@@ -369,6 +369,6 @@ fn test_decline_invitation() {
         req.with_path("/api/v1/crates/invited_crate/owners")
             .with_method(Method::Get)
     ));
-    let json: Q = ::json(&mut response);
+    let json: Q = crate::json(&mut response);
     assert_eq!(json.users.len(), 1);
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -1,15 +1,20 @@
-use conduit::{Handler, Method};
-use diesel;
-use diesel::prelude::*;
-
-use crate::builders::{CrateBuilder, PublishBuilder};
-use crate::models::{Crate, NewCrateOwnerInvitation};
-use crate::schema::crate_owner_invitations;
-use crate::util::RequestHelper;
-use crate::views::{
-    EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse,
+use crate::{
+    add_team_to_crate, app,
+    builders::{CrateBuilder, PublishBuilder},
+    new_team, new_user, req, sign_in_as,
+    util::RequestHelper,
+    TestApp,
 };
-use crate::{add_team_to_crate, app, new_team, new_user, req, sign_in_as, TestApp};
+use cargo_registry::{
+    models::{Crate, NewCrateOwnerInvitation},
+    schema::crate_owner_invitations,
+    views::{
+        EncodableCrateOwnerInvitation, EncodableOwner, EncodablePublicUser, InvitationResponse,
+    },
+};
+
+use conduit::{Handler, Method};
+use diesel::prelude::*;
 
 #[derive(Deserialize)]
 struct TeamResponse {
@@ -29,7 +34,7 @@ impl crate::util::MockCookieUser {
     /// As the currently logged in user, accept an invitation to become an owner of the named
     /// crate.
     fn accept_ownership_invitation(&self, krate_name: &str, krate_id: i32) {
-        use crate::views::InvitationResponse;
+        use cargo_registry::views::InvitationResponse;
 
         let body = json!({
             "crate_owner_invite": {

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -1,31 +1,20 @@
-extern crate base64;
-extern crate futures;
-extern crate hyper;
-extern crate hyper_tls;
-extern crate reqwest;
-extern crate tokio_core;
-extern crate tokio_service;
-
-use std::borrow::Cow;
-use std::collections::HashSet;
-use std::env;
-use std::fs::{self, File};
-use std::io;
-use std::io::prelude::*;
-use std::net;
-use std::path::PathBuf;
-use std::str;
-use std::sync::{Arc, Mutex, Once};
-use std::thread;
-
-use self::futures::sync::oneshot;
-use self::futures::{future, Future, Stream};
-use self::tokio_core::net::TcpListener;
-use self::tokio_core::reactor::Core;
-use serde_json;
-
-use crate::models::NewUser;
 use crate::new_user;
+use cargo_registry::models::NewUser;
+use std::{
+    borrow::Cow,
+    collections::HashSet,
+    env,
+    fs::{self, File},
+    io::{self, prelude::*},
+    net,
+    path::PathBuf,
+    str,
+    sync::{Arc, Mutex, Once},
+    thread,
+};
+
+use futures::{future, sync::oneshot, Future, Stream};
+use tokio_core::{net::TcpListener, reactor::Core};
 
 // A "bomb" so when the test task exists we know when to shut down
 // the server and fail if the subtask failed.

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -24,8 +24,8 @@ use self::tokio_core::net::TcpListener;
 use self::tokio_core::reactor::Core;
 use serde_json;
 
-use models::NewUser;
-use new_user;
+use crate::models::NewUser;
+use crate::new_user;
 
 // A "bomb" so when the test task exists we know when to shut down
 // the server and fail if the subtask failed.
@@ -350,7 +350,7 @@ impl GhUser {
             return;
         }
 
-        let password = ::env(&format!("GH_PASS_{}", self.login.replace("-", "_")));
+        let password = crate::env(&format!("GH_PASS_{}", self.login.replace("-", "_")));
         #[derive(Serialize)]
         struct Authorization {
             scopes: Vec<String>,
@@ -364,8 +364,8 @@ impl GhUser {
             .json(&Authorization {
                 scopes: vec!["read:org".to_string()],
                 note: "crates.io test".to_string(),
-                client_id: ::env("GH_CLIENT_ID"),
-                client_secret: ::env("GH_CLIENT_SECRET"),
+                client_id: crate::env("GH_CLIENT_ID"),
+                client_secret: crate::env("GH_CLIENT_SECRET"),
             })
             .basic_auth(self.login, Some(password));
 

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -150,7 +150,8 @@ impl hyper::service::Service for Proxy {
     type ReqBody = hyper::Body;
     type ResBody = hyper::Body;
     type Error = hyper::Error;
-    type Future = Box<Future<Item = hyper::Response<Self::ResBody>, Error = Self::Error> + Send>;
+    type Future =
+        Box<dyn Future<Item = hyper::Response<Self::ResBody>, Error = Self::Error> + Send>;
 
     fn call(&mut self, req: hyper::Request<Self::ReqBody>) -> Self::Future {
         let record2 = self.record.clone();
@@ -175,7 +176,7 @@ impl hyper::service::NewService for Proxy {
     type ResBody = hyper::Body;
     type Error = hyper::Error;
     type Service = Proxy;
-    type Future = Box<Future<Item = Self::Service, Error = Self::InitError> + Send>;
+    type Future = Box<dyn Future<Item = Self::Service, Error = Self::InitError> + Send>;
     type InitError = hyper::Error;
 
     fn new_service(&self) -> Self::Future {
@@ -209,7 +210,7 @@ type Client = hyper::Client<hyper_tls::HttpsConnector<hyper::client::HttpConnect
 fn record_http(
     req: hyper::Request<hyper::Body>,
     client: &Client,
-) -> Box<Future<Item = (hyper::Response<hyper::Body>, Exchange), Error = hyper::Error> + Send> {
+) -> Box<dyn Future<Item = (hyper::Response<hyper::Body>, Exchange), Error = hyper::Error> + Send> {
     let (header_parts, body) = req.into_parts();
     let method = header_parts.method;
     let uri = header_parts.uri;
@@ -266,8 +267,8 @@ fn record_http(
 fn replay_http(
     req: hyper::Request<hyper::Body>,
     mut exchange: Exchange,
-    stdout: &mut Write,
-) -> Box<Future<Item = hyper::Response<hyper::Body>, Error = hyper::Error> + Send> {
+    stdout: &mut dyn Write,
+) -> Box<dyn Future<Item = hyper::Response<hyper::Body>, Error = hyper::Error> + Send> {
     static IGNORED_HEADERS: &[&str] = &["authorization", "date", "user-agent"];
 
     assert_eq!(req.uri().to_string(), exchange.request.uri);

--- a/src/tests/schema_details.rs
+++ b/src/tests/schema_details.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::*;
 use diesel::sql_types::Text;
 
-use TestApp;
+use crate::TestApp;
 
 #[test]
 fn all_columns_called_crate_id_have_a_cascading_foreign_key() {

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -1,11 +1,14 @@
-use diesel::*;
+use crate::{
+    add_team_to_crate,
+    builders::{CrateBuilder, PublishBuilder},
+    new_team,
+    record::GhUser,
+    OwnerTeamsResponse, RequestHelper, TestApp,
+};
+use cargo_registry::models::{Crate, NewUser};
 use std::sync::ONCE_INIT;
 
-use super::OwnerTeamsResponse;
-use crate::builders::{CrateBuilder, PublishBuilder};
-use crate::models::{Crate, NewUser};
-use crate::record::GhUser;
-use crate::{add_team_to_crate, new_team, RequestHelper, TestApp};
+use diesel::*;
 
 impl crate::util::MockAnonymousUser {
     /// List the team owners of the specified crate.

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -2,14 +2,14 @@ use diesel::*;
 use std::sync::ONCE_INIT;
 
 use super::OwnerTeamsResponse;
-use builders::{CrateBuilder, PublishBuilder};
-use models::{Crate, NewUser};
-use record::GhUser;
-use {add_team_to_crate, new_team, RequestHelper, TestApp};
+use crate::builders::{CrateBuilder, PublishBuilder};
+use crate::models::{Crate, NewUser};
+use crate::record::GhUser;
+use crate::{add_team_to_crate, new_team, RequestHelper, TestApp};
 
-impl ::util::MockAnonymousUser {
+impl crate::util::MockAnonymousUser {
     /// List the team owners of the specified crate.
-    fn crate_owner_teams(&self, krate_name: &str) -> ::util::Response<OwnerTeamsResponse> {
+    fn crate_owner_teams(&self, krate_name: &str) -> crate::util::Response<OwnerTeamsResponse> {
         let url = format!("/api/v1/crates/{}/owner_team", krate_name);
         self.get(&url)
     }

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,11 +1,12 @@
+use crate::{user::UserShowPrivateResponse, RequestHelper, TestApp};
+use cargo_registry::{
+    models::ApiToken,
+    schema::api_tokens,
+    views::{EncodableApiTokenWithToken, EncodableMe},
+};
 use std::collections::HashSet;
 
 use diesel::prelude::*;
-
-use crate::models::ApiToken;
-use crate::schema::api_tokens;
-use crate::views::{EncodableApiTokenWithToken, EncodableMe};
-use crate::{user::UserShowPrivateResponse, RequestHelper, TestApp};
 
 #[derive(Deserialize)]
 struct DecodableApiToken {

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 
 use diesel::prelude::*;
 
-use models::ApiToken;
-use schema::api_tokens;
-use views::{EncodableApiTokenWithToken, EncodableMe};
-use {user::UserShowPrivateResponse, RequestHelper, TestApp};
+use crate::models::ApiToken;
+use crate::schema::api_tokens;
+use crate::views::{EncodableApiTokenWithToken, EncodableMe};
+use crate::{user::UserShowPrivateResponse, RequestHelper, TestApp};
 
 #[derive(Deserialize)]
 struct DecodableApiToken {

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,11 +1,17 @@
+use crate::{
+    app,
+    builders::{CrateBuilder, VersionBuilder},
+    logout, new_user, req, sign_in_as,
+    util::RequestHelper,
+    OkBool, TestApp,
+};
+use cargo_registry::{
+    models::{Email, NewUser, User},
+    views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion},
+};
+
 use conduit::{Handler, Method};
 use diesel::prelude::*;
-
-use crate::builders::{CrateBuilder, VersionBuilder};
-use crate::models::{Email, NewUser, User};
-use crate::util::RequestHelper;
-use crate::views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
-use crate::{app, logout, new_user, req, sign_in_as, OkBool, TestApp};
 
 #[derive(Deserialize)]
 struct AuthResponse {

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,11 +1,11 @@
 use conduit::{Handler, Method};
 use diesel::prelude::*;
 
-use builders::{CrateBuilder, VersionBuilder};
-use models::{Email, NewUser, User};
-use util::RequestHelper;
-use views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
-use {app, logout, new_user, req, sign_in_as, OkBool, TestApp};
+use crate::builders::{CrateBuilder, VersionBuilder};
+use crate::models::{Email, NewUser, User};
+use crate::util::RequestHelper;
+use crate::views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion};
+use crate::{app, logout, new_user, req, sign_in_as, OkBool, TestApp};
 
 #[derive(Deserialize)]
 struct AuthResponse {
@@ -275,7 +275,7 @@ fn test_github_login_does_not_overwrite_email() {
     };
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email, None);
     assert_eq!(r.user.login, "apricot");
 
@@ -286,7 +286,7 @@ fn test_github_login_does_not_overwrite_email() {
             .with_method(Method::Put)
             .with_body(body.as_bytes()),
     ));
-    assert!(::json::<OkBool>(&mut response).ok);
+    assert!(crate::json::<OkBool>(&mut response).ok);
 
     logout(&mut req);
 
@@ -302,7 +302,7 @@ fn test_github_login_does_not_overwrite_email() {
     }
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "apricot@apricots.apricot");
     assert_eq!(r.user.login, "apricot");
 }
@@ -323,7 +323,7 @@ fn test_email_get_and_put() {
     };
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email, None);
     assert_eq!(r.user.login, "mango");
 
@@ -334,10 +334,10 @@ fn test_email_get_and_put() {
             .with_method(Method::Put)
             .with_body(body.as_bytes()),
     ));
-    assert!(::json::<OkBool>(&mut response).ok);
+    assert!(crate::json::<OkBool>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "mango@mangos.mango");
     assert_eq!(r.user.login, "mango");
     assert!(!r.user.email_verified);
@@ -456,7 +456,7 @@ fn test_insert_into_email_table() {
     }
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "apple@example.com");
     assert_eq!(r.user.login, "apple");
 
@@ -476,7 +476,7 @@ fn test_insert_into_email_table() {
     }
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "apple@example.com");
     assert_eq!(r.user.login, "apple");
 }
@@ -504,7 +504,7 @@ fn test_insert_into_email_table_with_email_change() {
     };
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "test_insert_with_change@example.com");
     assert_eq!(r.user.login, "potato");
     assert!(!r.user.email_verified);
@@ -517,7 +517,7 @@ fn test_insert_into_email_table_with_email_change() {
             .with_method(Method::Put)
             .with_body(body.as_bytes()),
     ));
-    assert!(::json::<OkBool>(&mut response).ok);
+    assert!(crate::json::<OkBool>(&mut response).ok);
 
     logout(&mut req);
 
@@ -535,7 +535,7 @@ fn test_insert_into_email_table_with_email_change() {
     }
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "apricot@apricots.apricot");
     assert!(!r.user.email_verified);
     assert!(r.user.email_verification_sent);
@@ -578,10 +578,10 @@ fn test_confirm_user_email() {
         req.with_path(&format!("/api/v1/confirm/{}", email_token))
             .with_method(Method::Put),
     ));
-    assert!(::json::<OkBool>(&mut response).ok);
+    assert!(crate::json::<OkBool>(&mut response).ok);
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "potato2@example.com");
     assert_eq!(r.user.login, "potato");
     assert!(r.user.email_verified);
@@ -617,7 +617,7 @@ fn test_existing_user_email() {
     }
 
     let mut response = ok_resp!(middle.call(req.with_path("/api/v1/me").with_method(Method::Get),));
-    let r = ::json::<UserShowPrivateResponse>(&mut response);
+    let r = crate::json::<UserShowPrivateResponse>(&mut response);
     assert_eq!(r.user.email.unwrap(), "potahto@example.com");
     assert!(!r.user.email_verified);
     assert!(!r.user.email_verification_sent);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -323,13 +323,13 @@ pub struct Bad {
 
 pub type DieselConnection =
     diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
-type ResponseResult = Result<conduit::Response, Box<std::error::Error + Send>>;
+type ResponseResult = Result<conduit::Response, Box<dyn std::error::Error + Send>>;
 
 /// A type providing helper methods for working with responses
 #[must_use]
 pub struct Response<T> {
     response: conduit::Response,
-    callback_on_good: Option<Box<Fn(&T)>>,
+    callback_on_good: Option<Box<dyn Fn(&T)>>,
 }
 
 impl<T> Response<T>
@@ -343,7 +343,7 @@ where
         }
     }
 
-    fn with_callback(self, callback_on_good: Box<Fn(&T)>) -> Self {
+    fn with_callback(self, callback_on_good: Box<dyn Fn(&T)>) -> Self {
         Self {
             response: self.response,
             callback_on_good: Some(callback_on_good),

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -19,19 +19,20 @@
 //! `MockCookieUser` and `MockTokenUser` provide an `as_model` function which returns a reference
 //! to the underlying database model value (`User` and `ApiToken` respectively).
 
-use std::{self, rc::Rc, sync::Arc};
-
-use {cargo_registry, conduit, conduit_middleware, diesel, dotenv, serde};
+use crate::{
+    app, builders::PublishBuilder, record, CrateList, CrateResponse, GoodCrate, OkBool,
+    VersionResponse,
+};
+use cargo_registry::{
+    middleware::current_user::AuthenticationSource,
+    models::{ApiToken, User},
+    uploaders::Uploader,
+    App,
+};
+use std::{rc::Rc, sync::Arc};
 
 use conduit::{Handler, Method, Request};
 use conduit_test::MockRequest;
-
-use crate::builders::PublishBuilder;
-use crate::models::{ApiToken, User};
-use cargo_registry::app::App;
-use cargo_registry::middleware::current_user::AuthenticationSource;
-
-use super::{app, record, CrateList, CrateResponse, GoodCrate, OkBool, VersionResponse};
 
 struct TestAppInner {
     app: Arc<App>,
@@ -47,7 +48,7 @@ impl TestApp {
     /// Initialize an application with an `Uploader` that panics
     pub fn init() -> TestAppBuilder {
         dotenv::dotenv().ok();
-        let (app, middle) = crate::simple_app(cargo_registry::Uploader::Panic);
+        let (app, middle) = crate::simple_app(Uploader::Panic);
         let inner = Rc::new(TestAppInner {
             app,
             _bomb: None,

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -26,10 +26,10 @@ use {cargo_registry, conduit, conduit_middleware, diesel, dotenv, serde};
 use conduit::{Handler, Method, Request};
 use conduit_test::MockRequest;
 
-use builders::PublishBuilder;
+use crate::builders::PublishBuilder;
+use crate::models::{ApiToken, User};
 use cargo_registry::app::App;
 use cargo_registry::middleware::current_user::AuthenticationSource;
-use models::{ApiToken, User};
 
 use super::{app, record, CrateList, CrateResponse, GoodCrate, OkBool, VersionResponse};
 
@@ -47,7 +47,7 @@ impl TestApp {
     /// Initialize an application with an `Uploader` that panics
     pub fn init() -> TestAppBuilder {
         dotenv::dotenv().ok();
-        let (app, middle) = ::simple_app(cargo_registry::Uploader::Panic);
+        let (app, middle) = crate::simple_app(cargo_registry::Uploader::Panic);
         let inner = Rc::new(TestAppInner {
             app,
             _bomb: None,
@@ -81,7 +81,7 @@ impl TestApp {
     ///
     /// This method updates the database directly
     pub fn db_new_user(&self, user: &str) -> MockCookieUser {
-        let user = self.db(|conn| ::new_user(user).create_or_update(conn).unwrap());
+        let user = self.db(|conn| crate::new_user(user).create_or_update(conn).unwrap());
         MockCookieUser {
             app: TestApp(Rc::clone(&self.0)),
             user,
@@ -214,7 +214,7 @@ pub struct MockAnonymousUser {
 
 impl RequestHelper for MockAnonymousUser {
     fn request_builder(&self, method: Method, path: &str) -> MockRequest {
-        ::req(method, path)
+        crate::req(method, path)
     }
 
     fn app(&self) -> &TestApp {
@@ -233,7 +233,7 @@ pub struct MockCookieUser {
 
 impl RequestHelper for MockCookieUser {
     fn request_builder(&self, method: Method, path: &str) -> MockRequest {
-        let mut request = ::req(method, path);
+        let mut request = crate::req(method, path);
         request.mut_extensions().insert(self.user.clone());
         request
             .mut_extensions()
@@ -274,7 +274,7 @@ pub struct MockTokenUser {
 
 impl RequestHelper for MockTokenUser {
     fn request_builder(&self, method: Method, path: &str) -> MockRequest {
-        let mut request = ::req(method, path);
+        let mut request = crate::req(method, path);
         request.header("Authorization", &self.token.token);
         request
     }
@@ -351,10 +351,10 @@ where
 
     /// Assert that the response is good and deserialize the message
     pub fn good(mut self) -> T {
-        if !::ok_resp(&self.response) {
+        if !crate::ok_resp(&self.response) {
             panic!("bad response: {:?}", self.response.status);
         }
-        let good = ::json(&mut self.response);
+        let good = crate::json(&mut self.response);
         if let Some(callback) = self.callback_on_good {
             callback(&good)
         }
@@ -366,7 +366,7 @@ where
     /// Cargo endpoints return a status 200 on error instead of 400.
     pub fn bad_with_status(&mut self, code: u32) -> Bad {
         assert_eq!(self.response.status.0, code);
-        match ::bad_resp(&mut self.response) {
+        match crate::bad_resp(&mut self.response) {
             None => panic!("ok response: {:?}", self.response.status),
             Some(b) => b,
         }

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -2,10 +2,10 @@ use serde_json::Value;
 
 use diesel::prelude::*;
 
-use builders::{CrateBuilder, PublishBuilder, VersionBuilder};
-use schema::versions;
-use views::EncodableVersion;
-use {RequestHelper, TestApp, VersionResponse};
+use crate::builders::{CrateBuilder, PublishBuilder, VersionBuilder};
+use crate::schema::versions;
+use crate::views::EncodableVersion;
+use crate::{RequestHelper, TestApp, VersionResponse};
 
 #[derive(Deserialize)]
 struct VersionList {

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -1,11 +1,11 @@
-use serde_json::Value;
+use crate::{
+    builders::{CrateBuilder, PublishBuilder, VersionBuilder},
+    RequestHelper, TestApp, VersionResponse,
+};
+use cargo_registry::{schema::versions, views::EncodableVersion};
 
 use diesel::prelude::*;
-
-use crate::builders::{CrateBuilder, PublishBuilder, VersionBuilder};
-use crate::schema::versions;
-use crate::views::EncodableVersion;
-use crate::{RequestHelper, TestApp, VersionResponse};
+use serde_json::Value;
 
 #[derive(Deserialize)]
 struct VersionList {

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -1,10 +1,6 @@
 use conduit::Request;
 use flate2::read::GzDecoder;
 use openssl::hash::{Hasher, MessageDigest};
-use reqwest;
-use s3;
-use semver;
-use tar;
 
 use crate::util::LimitErrorReader;
 use crate::util::{human, internal, CargoResult, ChainError, Maximums};

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -6,17 +6,17 @@ use s3;
 use semver;
 use tar;
 
-use util::LimitErrorReader;
-use util::{human, internal, CargoResult, ChainError, Maximums};
+use crate::util::LimitErrorReader;
+use crate::util::{human, internal, CargoResult, ChainError, Maximums};
 
 use std::env;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::sync::Arc;
 
-use app::App;
-use middleware::app::RequestApp;
-use models::Crate;
+use crate::app::App;
+use crate::middleware::app::RequestApp;
+use crate::models::Crate;
 
 fn require_test_app_with_proxy() -> ! {
     panic!("No uploader is configured.  In tests, use `TestApp::with_proxy()`.");

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use conduit::Response;
 use diesel::result::Error as DieselError;
 
-use util::json_response;
+use crate::util::json_response;
 
 #[derive(Serialize)]
 struct StringError {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,10 +2,8 @@ use std::cmp;
 use std::collections::HashMap;
 use std::io::Cursor;
 
-use serde::Serialize;
-use serde_json;
-
 use conduit::Response;
+use serde::Serialize;
 
 pub use self::errors::{bad_request, human, internal, internal_error, CargoError, CargoResult};
 pub use self::errors::{std_error, ChainError};

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -1,11 +1,7 @@
-extern crate old_semver;
+use std::{io::Read, net::SocketAddr};
 
-use std::io::Read;
-use std::net::SocketAddr;
-
-use self::old_semver::semver;
-use conduit;
 use conduit::Request;
+use old_semver::semver;
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -7,11 +7,11 @@ use std::collections::HashMap;
 use semver;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use models::krate::MAX_NAME_LENGTH;
+use crate::models::krate::MAX_NAME_LENGTH;
 
-use models::Crate;
-use models::DependencyKind;
-use models::Keyword as CrateKeyword;
+use crate::models::Crate;
+use crate::models::DependencyKind;
+use crate::models::Keyword as CrateKeyword;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct EncodableCrateUpload {

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -4,7 +4,6 @@
 //! integration tests.
 use std::collections::HashMap;
 
-use semver;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::models::krate::MAX_NAME_LENGTH;

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,5 +1,4 @@
 use chrono::NaiveDateTime;
-use serde_json;
 use std::collections::HashMap;
 
 use crate::models::DependencyKind;

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -2,8 +2,8 @@ use chrono::NaiveDateTime;
 use serde_json;
 use std::collections::HashMap;
 
-use models::DependencyKind;
-use util::rfc3339;
+use crate::models::DependencyKind;
+use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct EncodableBadge {


### PR DESCRIPTION
The migration is split into three commits.  The first applies edition fixes.  The second enables the edition and cleans up `extern crate` and `use` statements in many places.  The final commit applies any remaining edition idioms.