### PR TITLE
Add a whatsdeployed.io badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # crates.io
 
 [![Build Status](https://travis-ci.org/rust-lang/crates.io.svg?branch=master)](https://travis-ci.org/rust-lang/crates.io)
+[![What's Deployed](https://img.shields.io/badge/whatsdeployed-prod-green.svg)](https://whatsdeployed.io/s-9IG)
 
 Source code for the default [Cargo](http://doc.crates.io) registry. Viewable
 online at [crates.io](https://crates.io).


### PR DESCRIPTION
[![What's Deployed](https://img.shields.io/badge/whatsdeployed-prod-green.svg)](https://whatsdeployed.io/s-9IG)

Right now, this only includes prod, and it basically only provides the difference between production and master. Staging, oddly enough, is *behind* prod right now, so it doesn't actually work. If @ag_dubs updated staging to master, it would be possible to do a compare between all three (which is where whatsdeployed really shines). Compare https://staging-crates-io.herokuapp.com/api/v1/site_metadata with https://crates.io/api/v1/site_metadata