### PR TITLE
Reject publishing of crates that depend on an alternative registry

### DIFF
--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -80,6 +80,12 @@ pub fn add_dependencies(
     let git_and_new_dependencies = deps
         .iter()
         .map(|dep| {
+            if let Some(registry) = &dep.registry {
+                if !registry.is_empty() {
+                    return Err(human(&format_args!("Dependency `{}` is hosted on another registry. Cross-registry dependencies are not permitted on crates.io.", &*dep.name)));
+                }
+            }
+
             // Match only identical names to ensure the index always references the original crate name
             let krate = Crate::by_exact_name(&dep.name)
                 .first::<Crate>(&*conn)

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -522,6 +522,7 @@ impl PublishBuilder {
 /// A builder for constructing a dependency of another crate.
 pub struct DependencyBuilder {
     name: String,
+    registry: Option<String>,
     explicit_name_in_toml: Option<u::EncodableCrateName>,
     version_req: u::EncodableCrateVersionReq,
 }
@@ -531,6 +532,7 @@ impl DependencyBuilder {
     pub fn new(name: &str) -> Self {
         DependencyBuilder {
             name: name.to_string(),
+            registry: None,
             explicit_name_in_toml: None,
             version_req: u::EncodableCrateVersionReq(semver::VersionReq::parse(">= 0").unwrap()),
         }
@@ -539,6 +541,12 @@ impl DependencyBuilder {
     /// Rename this dependency.
     pub fn rename(mut self, new_name: &str) -> Self {
         self.explicit_name_in_toml = Some(u::EncodableCrateName(new_name.to_string()));
+        self
+    }
+
+    /// Set an alternative registry for this dependency.
+    pub fn registry(mut self, registry: &str) -> Self {
+        self.registry = Some(registry.to_string());
         self
     }
 
@@ -567,6 +575,7 @@ impl DependencyBuilder {
             target: None,
             kind: None,
             explicit_name_in_toml: self.explicit_name_in_toml,
+            registry: self.registry,
         }
     }
 }

--- a/src/tests/http-data/krate_new_crate_allow_empty_alternative_registry_dependency
+++ b/src/tests/http-data/krate_new_crate_allow_empty_alternative_registry_dependency
@@ -1,0 +1,36 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "host",
+          "alexcrichton-test.s3.amazonaws.com"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-type",
+          "application/x-tar"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -63,6 +63,7 @@ pub struct EncodableCrateDependency {
     pub target: Option<String>,
     pub kind: Option<DependencyKind>,
     pub explicit_name_in_toml: Option<EncodableCrateName>,
+    pub registry: Option<String>,
 }
 
 impl<'de> Deserialize<'de> for EncodableCrateName {


### PR DESCRIPTION
See also #1579 and rust-lang/crates-io-cargo-teams#21.