### PR TITLE
Align crate icon with crate name in heading

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -26,6 +26,12 @@
             @include flex-direction(column);
         }
     }
+    .crate-icon {
+        // Icon doesn't align nicely with text (which is being
+        // aligned by their baselines) so manual adjustment needed.
+        position: relative;
+        top: 4px;
+    }
     h1 {
         padding-left: 10px;
         padding-right: 10px;

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -3,7 +3,7 @@
 <div id='crates-heading' data-test-heading>
     <div class="wide">
         <div class='info'>
-            {{svg-jar "crate"}}
+            {{svg-jar "crate" class='crate-icon'}}
             <h1 data-test-crate-name>{{ crate.name }}</h1>
             <h2 data-test-crate-version>{{ currentVersion.num }}</h2>
         </div>


### PR DESCRIPTION
The crate heading text (with name and version) are being aligned by baseline using flex, however the icon doesn't line up because it doesn't have baseline information.

Manually pushing the icon down so aligns "correctly" with the crate name.

Before 🤢 🤮
![image](https://user-images.githubusercontent.com/1500769/51534894-efa01f00-1eab-11e9-99a2-278b50209eab.png)

After 🌹 🦄 
![image](https://user-images.githubusercontent.com/1500769/51534928-00e92b80-1eac-11e9-954d-18548d666c6c.png)
