### PR TITLE
Use `AtomicUsize::new(0)` in place of deprecated `ATOMIC_USIZE_INIT`

### DIFF
--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -23,7 +23,7 @@ use std::{
     borrow::Cow,
     env,
     sync::{
-        atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT},
+        atomic::{AtomicUsize, Ordering},
         Arc,
     },
 };
@@ -200,7 +200,7 @@ where
     }
 }
 
-static NEXT_GH_ID: AtomicUsize = ATOMIC_USIZE_INIT;
+static NEXT_GH_ID: AtomicUsize = AtomicUsize::new(0);
 
 fn new_user(login: &str) -> NewUser<'_> {
     NewUser {

--- a/src/tests/git.rs
+++ b/src/tests/git.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::fs;
 use std::path::PathBuf;
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 use std::thread;
 
 use url::Url;
@@ -21,7 +21,7 @@ pub fn bare() -> PathBuf {
 }
 
 pub fn init() {
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
     let _ = fs::remove_dir_all(&checkout());
     let _ = fs::remove_dir_all(&bare());
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -6,7 +6,7 @@ use crate::{
     OwnerTeamsResponse, RequestHelper, TestApp,
 };
 use cargo_registry::models::{Crate, NewUser};
-use std::sync::ONCE_INIT;
+use std::sync::Once;
 
 use diesel::*;
 
@@ -25,11 +25,11 @@ impl crate::util::MockAnonymousUser {
 
 static GH_USER_1: GhUser = GhUser {
     login: "crates-tester-1",
-    init: ONCE_INIT,
+    init: Once::new(),
 };
 static GH_USER_2: GhUser = GhUser {
     login: "crates-tester-2",
-    init: ONCE_INIT,
+    init: Once::new(),
 };
 
 fn mock_user_on_only_one_team() -> NewUser<'static> {


### PR DESCRIPTION
`ATOMIC_USIZE_INIT` is deprecated starting in 1.34.  The new warning is
causing nightly to fail on CI.  For consistency, `Once::new()` is used
in place of `ONCE_INIT`.