### PR TITLE
Temporarily deny clippy::nursery and fix warnings

### DIFF
--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -138,7 +138,7 @@ mod test {
             name: "foo",
             ..Default::default()
         }
-        .create_or_update(&conn, None, user_id)
+        .create_or_update(conn, None, user_id)
         .unwrap();
         let version = NewVersion::new(
             krate.id,
@@ -149,7 +149,7 @@ mod test {
             0,
         )
         .unwrap();
-        let version = version.save(&conn, &[]).unwrap();
+        let version = version.save(conn, &[]).unwrap();
         (krate, version)
     }
 

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -39,7 +39,7 @@ mod prelude {
 
         fn redirect(&self, url: String) -> Response {
             let mut headers = HashMap::new();
-            headers.insert("Location".to_string(), vec![url.to_string()]);
+            headers.insert("Location".to_string(), vec![url]);
             Response {
                 status: (302, "Found"),
                 headers,

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -94,11 +94,7 @@ pub fn github_access_token(req: &mut dyn Request) -> CargoResult<Response> {
     }
 
     // Fetch the access token from github using the code we just got
-    let token = req
-        .app()
-        .github
-        .exchange(code)
-        .map_err(|s| human(&s))?;
+    let token = req.app().github.exchange(code).map_err(|s| human(&s))?;
 
     let ghuser = github::github::<GithubUser>(req.app(), "/user", &token)?;
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -97,7 +97,7 @@ pub fn github_access_token(req: &mut dyn Request) -> CargoResult<Response> {
     let token = req
         .app()
         .github
-        .exchange(code.clone())
+        .exchange(code)
         .map_err(|s| human(&s))?;
 
     let ghuser = github::github::<GithubUser>(req.app(), "/user", &token)?;

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -93,8 +93,8 @@ impl Category {
         } = self;
         EncodableCategory {
             id: slug.clone(),
-            slug: slug.clone(),
-            description: description.clone(),
+            slug,
+            description,
             created_at,
             crates_cnt,
             category: category.rsplit("::").collect::<Vec<_>>()[0].to_string(),

--- a/src/render.rs
+++ b/src/render.rs
@@ -381,7 +381,7 @@ mod tests {
         let readme_text =
             "[![Crates.io](https://img.shields.io/crates/v/clap.svg)](https://crates.io/crates/clap)";
         let repository = "https://github.com/kbknapp/clap-rs/";
-        let result = markdown_to_html(readme_text, Some(&repository)).unwrap();
+        let result = markdown_to_html(readme_text, Some(repository)).unwrap();
 
         assert_eq!(
             result,

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -50,7 +50,7 @@ impl Bucket {
         } else {
             path
         };
-        let date = Utc::now().to_rfc2822().to_string();
+        let date = Utc::now().to_rfc2822();
         let auth = self.auth("PUT", &date, path, "", content_type);
         let url = self.url(path);
 
@@ -74,7 +74,7 @@ impl Bucket {
         } else {
             path
         };
-        let date = Utc::now().to_rfc2822().to_string();
+        let date = Utc::now().to_rfc2822();
         let auth = self.auth("DELETE", &date, path, "", "");
         let url = self.url(path);
 

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -319,7 +319,7 @@ fn update_attributes() {
     badge_attributes_travis_ci2.insert(String::from("repository"), String::from("rust-lang/rust"));
     badges.insert(
         String::from("travis-ci"),
-        badge_attributes_travis_ci2.clone(),
+        badge_attributes_travis_ci2,
     );
     krate.update(&badges);
     let current_badges = krate.badges();

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -317,10 +317,7 @@ fn update_attributes() {
     };
     let mut badge_attributes_travis_ci2 = HashMap::new();
     badge_attributes_travis_ci2.insert(String::from("repository"), String::from("rust-lang/rust"));
-    badges.insert(
-        String::from("travis-ci"),
-        badge_attributes_travis_ci2,
-    );
+    badges.insert(String::from("travis-ci"), badge_attributes_travis_ci2);
     krate.update(&badges);
     let current_badges = krate.badges();
     assert_eq!(current_badges.len(), 1);

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -57,7 +57,7 @@ fn show() {
     let url = "/api/v1/categories/foo-bar";
 
     // Return not found if a category doesn't exist
-    anon.get(&url).assert_not_found();
+    anon.get(url).assert_not_found();
 
     // Create a category and a subcategory
     app.db(|conn| {
@@ -66,7 +66,7 @@ fn show() {
     });
 
     // The category and its subcategories should be in the json
-    let json: CategoryWithSubcategories = anon.get(&url).good();
+    let json: CategoryWithSubcategories = anon.get(url).good();
     assert_eq!(json.category.category, "Foo Bar");
     assert_eq!(json.category.slug, "foo-bar");
     assert_eq!(json.category.subcategories.len(), 1);
@@ -171,10 +171,10 @@ fn category_slugs_returns_all_slugs_in_alphabetical_order() {
     let (app, anon) = TestApp::init().empty();
     app.db(|conn| {
         new_category("Foo", "foo", "For crates that foo")
-            .create_or_update(&conn)
+            .create_or_update(conn)
             .unwrap();
         new_category("Bar", "bar", "For crates that bar")
-            .create_or_update(&conn)
+            .create_or_update(conn)
             .unwrap();
     });
 

--- a/src/tests/keyword.rs
+++ b/src/tests/keyword.rs
@@ -71,41 +71,41 @@ fn update_crate() {
 
     let krate = app.db(|conn| {
         Keyword::find_or_create_all(conn, &["kw1", "kw2"]).unwrap();
-        CrateBuilder::new("fookey", user.id).expect_build(&conn)
+        CrateBuilder::new("fookey", user.id).expect_build(conn)
     });
 
     app.db(|conn| {
-        Keyword::update_crate(&conn, &krate, &[]).unwrap();
+        Keyword::update_crate(conn, &krate, &[]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);
     assert_eq!(cnt("kw2"), 0);
 
     app.db(|conn| {
-        Keyword::update_crate(&conn, &krate, &["kw1"]).unwrap();
+        Keyword::update_crate(conn, &krate, &["kw1"]).unwrap();
     });
     assert_eq!(cnt("kw1"), 1);
     assert_eq!(cnt("kw2"), 0);
 
     app.db(|conn| {
-        Keyword::update_crate(&conn, &krate, &["kw2"]).unwrap();
+        Keyword::update_crate(conn, &krate, &["kw2"]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);
     assert_eq!(cnt("kw2"), 1);
 
     app.db(|conn| {
-        Keyword::update_crate(&conn, &krate, &[]).unwrap();
+        Keyword::update_crate(conn, &krate, &[]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);
     assert_eq!(cnt("kw2"), 0);
 
     app.db(|conn| {
-        Keyword::update_crate(&conn, &krate, &["kw1", "kw2"]).unwrap();
+        Keyword::update_crate(conn, &krate, &["kw1", "kw2"]).unwrap();
     });
     assert_eq!(cnt("kw1"), 1);
     assert_eq!(cnt("kw2"), 1);
 
     app.db(|conn| {
-        Keyword::update_crate(&conn, &krate, &[]).unwrap();
+        Keyword::update_crate(conn, &krate, &[]).unwrap();
     });
     assert_eq!(cnt("kw1"), 0);
     assert_eq!(cnt("kw2"), 0);

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -430,7 +430,7 @@ fn show() {
             .keyword("kw1")
             .downloads(20)
             .recent_downloads(10)
-            .expect_build(&conn)
+            .expect_build(conn)
     });
 
     let json = anon.show_crate("foo_show");
@@ -627,7 +627,7 @@ fn new_with_renamed_dependency() {
 
     app.db(|conn| {
         // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(&conn);
+        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
     });
 
     let dependency = DependencyBuilder::new("package-name").rename("my-name");
@@ -662,7 +662,7 @@ fn new_krate_with_dependency() {
         // The name choice of `foo-dep` is important! It has the property of
         // name != canon_crate_name(name) and is a regression test for
         // https://github.com/rust-lang/crates.io/issues/651
-        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&conn);
+        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(conn);
     });
 
     let dependency = DependencyBuilder::new("foo-dep");
@@ -678,7 +678,7 @@ fn reject_new_krate_with_non_exact_dependency() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     app.db(|conn| {
-        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&conn);
+        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(conn);
     });
 
     // Use non-exact name for the dependency
@@ -727,7 +727,7 @@ fn new_krate_with_wildcard_dependency() {
 
     app.db(|conn| {
         // Insert a crate directly into the database so that new_wild can depend on it
-        CrateBuilder::new("foo_wild", user.as_model().id).expect_build(&conn);
+        CrateBuilder::new("foo_wild", user.as_model().id).expect_build(conn);
     });
 
     let dependency = DependencyBuilder::new("foo_wild").version_req("*");
@@ -750,7 +750,7 @@ fn new_krate_twice() {
 
     app.db(|conn| {
         // Insert a crate directly into the database and then we'll try to publish another version
-        CrateBuilder::new("foo_twice", user.as_model().id).expect_build(&conn);
+        CrateBuilder::new("foo_twice", user.as_model().id).expect_build(conn);
     });
 
     let crate_to_publish = PublishBuilder::new("foo_twice")
@@ -768,7 +768,7 @@ fn new_krate_wrong_user() {
 
     app.db(|conn| {
         // Create the foo_wrong crate with one user
-        CrateBuilder::new("foo_wrong", user.as_model().id).expect_build(&conn);
+        CrateBuilder::new("foo_wrong", user.as_model().id).expect_build(conn);
     });
 
     // Then try to publish with a different user
@@ -819,7 +819,7 @@ fn new_krate_too_big_but_whitelisted() {
     app.db(|conn| {
         CrateBuilder::new("foo_whitelist", user.as_model().id)
             .max_upload_size(2_000_000)
-            .expect_build(&conn);
+            .expect_build(conn);
     });
 
     let files = [("foo_whitelist-1.1.0/big", &[b'a'; 2000] as &[_])];
@@ -875,7 +875,7 @@ fn new_krate_duplicate_version() {
         // Insert a crate directly into the database and then we'll try to publish the same version
         CrateBuilder::new("foo_dupe", user.as_model().id)
             .version("1.0.0")
-            .expect_build(&conn);
+            .expect_build(conn);
     });
 
     let crate_to_publish = PublishBuilder::new("foo_dupe").version("1.0.0");
@@ -895,7 +895,7 @@ fn new_crate_similar_name() {
     app.db(|conn| {
         CrateBuilder::new("Foo_similar", user.as_model().id)
             .version("1.0.0")
-            .expect_build(&conn);
+            .expect_build(conn);
     });
 
     let crate_to_publish = PublishBuilder::new("foo_similar").version("1.1.0");
@@ -915,7 +915,7 @@ fn new_crate_similar_name_hyphen() {
     app.db(|conn| {
         CrateBuilder::new("foo_bar_hyphen", user.as_model().id)
             .version("1.0.0")
-            .expect_build(&conn);
+            .expect_build(conn);
     });
 
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen").version("1.1.0");
@@ -935,7 +935,7 @@ fn new_crate_similar_name_underscore() {
     app.db(|conn| {
         CrateBuilder::new("foo-bar-underscore", user.as_model().id)
             .version("1.0.0")
-            .expect_build(&conn);
+            .expect_build(conn);
     });
 
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore").version("1.1.0");
@@ -1191,7 +1191,7 @@ fn download() {
     app.db(|conn| {
         CrateBuilder::new("foo_download", user.id)
             .version(VersionBuilder::new("1.0.0"))
-            .expect_build(&conn);
+            .expect_build(conn);
     });
 
     let assert_dl_count = |name_and_version: &str, query: Option<&str>, count: i32| {
@@ -1241,7 +1241,7 @@ fn download_nonexistent_version_of_existing_crate_404s() {
     let user = user.as_model();
 
     app.db(|conn| {
-        CrateBuilder::new("foo_bad", user.id).expect_build(&conn);
+        CrateBuilder::new("foo_bad", user.id).expect_build(conn);
     });
 
     anon.get("/api/v1/crates/foo_bad/0.1.0/download")
@@ -1254,10 +1254,10 @@ fn dependencies() {
     let user = user.as_model();
 
     app.db(|conn| {
-        let c1 = CrateBuilder::new("foo_deps", user.id).expect_build(&conn);
-        let v = VersionBuilder::new("1.0.0").expect_build(c1.id, &conn);
-        let c2 = CrateBuilder::new("bar_deps", user.id).expect_build(&conn);
-        new_dependency(&conn, &v, &c2);
+        let c1 = CrateBuilder::new("foo_deps", user.id).expect_build(conn);
+        let v = VersionBuilder::new("1.0.0").expect_build(c1.id, conn);
+        let c2 = CrateBuilder::new("bar_deps", user.id).expect_build(conn);
+        new_dependency(conn, &v, &c2);
     });
 
     let deps: Deps = anon
@@ -1283,7 +1283,7 @@ fn following() {
     let (app, _, user) = TestApp::init().with_user();
 
     app.db(|conn| {
-        CrateBuilder::new("foo_following", user.as_model().id).expect_build(&conn);
+        CrateBuilder::new("foo_following", user.as_model().id).expect_build(conn);
     });
 
     let is_following = || -> bool {
@@ -1487,7 +1487,7 @@ fn publish_after_removing_documentation() {
     app.db(|conn| {
         CrateBuilder::new("docscrate", user.id)
             .version("0.2.0")
-            .expect_build(&conn);
+            .expect_build(conn);
     });
 
     // Verify that crates start without any documentation so the next assertion can *prove*

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -146,7 +146,7 @@ fn check_ownership_two_crates() {
     let user2 = app.db_new_user("user_bar");
     let user2 = user2.as_model();
     let krate_not_owned_by_team =
-        app.db(|conn| CrateBuilder::new("bar", user2.id).expect_build(&conn));
+        app.db(|conn| CrateBuilder::new("bar", user2.id).expect_build(conn));
 
     let json = anon.search_by_user_id(user2.id);
     assert_eq!(json.crates[0].name, krate_not_owned_by_team.name);
@@ -176,7 +176,7 @@ fn check_ownership_one_crate() {
             .create_or_update(conn)
             .unwrap();
         let krate = CrateBuilder::new("best_crate", user.id).expect_build(conn);
-        add_team_to_crate(&t, &krate, &user, conn).unwrap();
+        add_team_to_crate(&t, &krate, user, conn).unwrap();
         t
     });
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -128,7 +128,7 @@ fn nonexistent_team() {
 #[test]
 fn add_team_mixed_case() {
     let (app, anon) = TestApp::with_proxy().empty();
-    let user = app.db_new_user(&mock_user_on_both_teams().gh_login);
+    let user = app.db_new_user(mock_user_on_both_teams().gh_login);
     let token = user.db_new_token("arbitrary token name");
 
     app.db(|conn| {
@@ -158,7 +158,7 @@ fn add_team_mixed_case() {
 #[test]
 fn add_team_as_non_member() {
     let (app, _) = TestApp::with_proxy().empty();
-    let user = app.db_new_user(&mock_user_on_only_one_team().gh_login);
+    let user = app.db_new_user(mock_user_on_only_one_team().gh_login);
     let token = user.db_new_token("arbitrary token name");
 
     app.db(|conn| {
@@ -184,7 +184,7 @@ fn add_team_as_non_member() {
 #[test]
 fn remove_team_as_named_owner() {
     let (app, _) = TestApp::with_proxy().empty();
-    let user_on_both_teams = app.db_new_user(&mock_user_on_both_teams().gh_login);
+    let user_on_both_teams = app.db_new_user(mock_user_on_both_teams().gh_login);
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     app.db(|conn| {
@@ -199,7 +199,7 @@ fn remove_team_as_named_owner() {
         .remove_named_owner("foo_remove_team", "github:crates-test-org:core")
         .good();
 
-    let user_on_one_team = app.db_new_user(&mock_user_on_only_one_team().gh_login);
+    let user_on_one_team = app.db_new_user(mock_user_on_only_one_team().gh_login);
     let crate_to_publish = PublishBuilder::new("foo_remove_team").version("2.0.0");
     let json = user_on_one_team
         .publish(crate_to_publish)
@@ -217,7 +217,7 @@ fn remove_team_as_named_owner() {
 #[test]
 fn remove_team_as_team_owner() {
     let (app, _) = TestApp::with_proxy().empty();
-    let user_on_both_teams = app.db_new_user(&mock_user_on_both_teams().gh_login);
+    let user_on_both_teams = app.db_new_user(mock_user_on_both_teams().gh_login);
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     app.db(|conn| {
@@ -229,7 +229,7 @@ fn remove_team_as_team_owner() {
         .add_named_owner("foo_remove_team_owner", "github:crates-test-org:core")
         .good();
 
-    let user_on_one_team = app.db_new_user(&mock_user_on_only_one_team().gh_login);
+    let user_on_one_team = app.db_new_user(mock_user_on_only_one_team().gh_login);
     let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
 
     let json = token_on_one_team
@@ -249,7 +249,7 @@ fn remove_team_as_team_owner() {
 #[test]
 fn publish_not_owned() {
     let (app, _) = TestApp::with_proxy().empty();
-    let user_on_both_teams = app.db_new_user(&mock_user_on_both_teams().gh_login);
+    let user_on_both_teams = app.db_new_user(mock_user_on_both_teams().gh_login);
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     app.db(|conn| {
@@ -260,7 +260,7 @@ fn publish_not_owned() {
         .add_named_owner("foo_not_owned", "github:crates-test-org:just-for-crates-2")
         .good();
 
-    let user_on_one_team = app.db_new_user(&mock_user_on_only_one_team().gh_login);
+    let user_on_one_team = app.db_new_user(mock_user_on_only_one_team().gh_login);
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned").version("2.0.0");
     let json = user_on_one_team
@@ -280,7 +280,7 @@ fn publish_not_owned() {
 #[test]
 fn publish_owned() {
     let (app, _) = TestApp::with_proxy().empty();
-    let user_on_both_teams = app.db_new_user(&mock_user_on_both_teams().gh_login);
+    let user_on_both_teams = app.db_new_user(mock_user_on_both_teams().gh_login);
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     app.db(|conn| {
@@ -291,7 +291,7 @@ fn publish_owned() {
         .add_named_owner("foo_team_owned", "github:crates-test-org:core")
         .good();
 
-    let user_on_one_team = app.db_new_user(&mock_user_on_only_one_team().gh_login);
+    let user_on_one_team = app.db_new_user(mock_user_on_only_one_team().gh_login);
 
     let crate_to_publish = PublishBuilder::new("foo_team_owned").version("2.0.0");
     user_on_one_team.publish(crate_to_publish).good();
@@ -301,7 +301,7 @@ fn publish_owned() {
 #[test]
 fn add_owners_as_team_owner() {
     let (app, _) = TestApp::with_proxy().empty();
-    let user_on_both_teams = app.db_new_user(&mock_user_on_both_teams().gh_login);
+    let user_on_both_teams = app.db_new_user(mock_user_on_both_teams().gh_login);
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     app.db(|conn| {
@@ -312,7 +312,7 @@ fn add_owners_as_team_owner() {
         .add_named_owner("foo_add_owner", "github:crates-test-org:core")
         .good();
 
-    let user_on_one_team = app.db_new_user(&mock_user_on_only_one_team().gh_login);
+    let user_on_one_team = app.db_new_user(mock_user_on_only_one_team().gh_login);
     let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
 
     let json = token_on_one_team
@@ -338,7 +338,7 @@ fn crates_by_team_id() {
             .create_or_update(conn)
             .unwrap();
         let krate = CrateBuilder::new("foo", user.id).expect_build(conn);
-        add_team_to_crate(&t, &krate, &user, conn).unwrap();
+        add_team_to_crate(&t, &krate, user, conn).unwrap();
         t
     });
 
@@ -351,7 +351,7 @@ fn crates_by_team_id_not_including_deleted_owners() {
     // This needs to use the proxy beacuse removing a team checks with github that you're on the
     // team before you're allowed to remove it from the crate
     let (app, anon) = TestApp::with_proxy().empty();
-    let user = app.db_new_user(&mock_user_on_both_teams().gh_login);
+    let user = app.db_new_user(mock_user_on_both_teams().gh_login);
     let user = user.as_model();
 
     let team = app.db(|conn| {
@@ -359,9 +359,9 @@ fn crates_by_team_id_not_including_deleted_owners() {
             .create_or_update(conn)
             .unwrap();
         let krate = CrateBuilder::new("foo", user.id).expect_build(conn);
-        add_team_to_crate(&t, &krate, &user, conn).unwrap();
+        add_team_to_crate(&t, &krate, user, conn).unwrap();
         krate
-            .owner_remove(&app.as_inner(), conn, &user, &t.login)
+            .owner_remove(app.as_inner(), conn, user, &t.login)
             .unwrap();
         t
     });

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -93,7 +93,7 @@ fn show_latest_user_case_insensitively() {
             None,
             "bar"
         )
-        .create_or_update(&conn));
+        .create_or_update(conn));
         t!(NewUser::new(
             2,
             "FOOBAR",
@@ -102,7 +102,7 @@ fn show_latest_user_case_insensitively() {
             None,
             "bar"
         )
-        .create_or_update(&conn));
+        .create_or_update(conn));
     });
 
     let json: UserShowPublicResponse = anon.get("api/v1/users/fOObAr").good();

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -118,7 +118,7 @@ impl Uploader {
         match *self {
             Uploader::S3 { ref bucket, .. } => {
                 bucket
-                    .put(&client, path, body, content_type)
+                    .put(client, path, body, content_type)
                     .map_err(|e| internal(&format_args!("failed to upload to S3: {}", e)))?;
                 Ok((Some(String::from(path)), hash))
             }

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -19,9 +19,7 @@ impl<'a> Request for RequestProxy<'a> {
         self.other.conduit_version()
     }
     fn method(&self) -> conduit::Method {
-        self.method
-            .clone()
-            .unwrap_or_else(|| self.other.method())
+        self.method.clone().unwrap_or_else(|| self.other.method())
     }
     fn scheme(&self) -> conduit::Scheme {
         self.other.scheme()

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -21,7 +21,7 @@ impl<'a> Request for RequestProxy<'a> {
     fn method(&self) -> conduit::Method {
         self.method
             .clone()
-            .unwrap_or_else(|| self.other.method().clone())
+            .unwrap_or_else(|| self.other.method())
     }
     fn scheme(&self) -> conduit::Scheme {
         self.other.scheme()


### PR DESCRIPTION
The warnings were ultimately from `clippy::needless_borrow` and
`clippy::redundant_clone`.