### PR TITLE
Remove `--locked-schema` when running migrations on Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bin/diesel migration run --locked-schema && bin/start-nginx ./target/release/server
+web: bin/diesel migration run && bin/start-nginx ./target/release/server
 worker: ./target/release/update-downloads daemon 300


### PR DESCRIPTION
This reverts a portion of #1611.  Heroku does not make a checkout of
the source code available at runtime, so at the point in time we run
migrations `src/schema.rs` will not exist, and will thus always fail
this check.

The `--locked-schema` check is still run on CI, so this still gives us
confidence that our schema and `src/schema.rs` do not diverge.