### PR TITLE
Require a verified email after 2019-03-01 00:00 UTC

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use chrono::offset::TimeZone;
+use chrono::{DateTime, Utc};
 use hex::ToHex;
 
 use crate::git;
@@ -67,13 +69,12 @@ pub fn publish(req: &mut dyn Request) -> CargoResult<Response> {
 
     let mut other_warnings = vec![];
     let verified_email_address = user.verified_email(&conn)?;
-    if verified_email_address.is_none() {
-        other_warnings.push(String::from(
-            "You do not currently have a verified email address associated with your crates.io \
-             account. Starting 2019-02-28, a verified email will be required to publish crates. \
-             Visit https://crates.io/me to set and verify your email address.",
-        ));
-    }
+
+    // This function can be inlined (with only the error-returning functionality) and its unit
+    // tests deleted after 2019-02-28; it was created to make injecting the date for tests easier.
+    // The integration tests in src/tests/krate.rs cover the current production behavior (and will
+    // need to be updated at that time)
+    verified_email_check(&mut other_warnings, &verified_email_address, Utc::now())?;
 
     // Create a transaction on the database, if there are no errors,
     // commit the transactions to record a new or updated crate.
@@ -266,4 +267,98 @@ fn parse_new_headers(req: &mut dyn Request) -> CargoResult<(EncodableCrateUpload
 
     let user = req.user()?;
     Ok((new, user.clone()))
+}
+
+fn verified_email_check(
+    other_warnings: &mut Vec<String>,
+    verified_email_address: &Option<String>,
+    now: DateTime<Utc>,
+) -> CargoResult<()> {
+    match verified_email_address {
+        Some(_) => Ok(()),
+        None => {
+            if now < Utc.ymd(2019, 3, 1).and_hms(0, 0, 0) {
+                other_warnings.push(String::from(
+                    "You do not currently have a verified email address associated with your \
+                     crates.io account. Starting 2019-02-28, a verified email will be required to \
+                     publish crates. Visit https://crates.io/me to set and verify your email \
+                     address.",
+                ));
+                Ok(())
+            } else {
+                Err(human(
+                    "A verified email address is required to publish crates to crates.io. \
+                     Visit https://crates.io/me to set and verify your email address.",
+                ))
+            }
+        }
+    }
+}
+
+// These tests should be deleted after 2018-02-28; this functionality will then be covered by
+// integration tests in src/tests/krate.rs.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::offset::TimeZone;
+
+    #[test]
+    fn allow_publish_with_verified_email_without_warning_before_2018_02_28() {
+        let mut warnings = vec![];
+
+        let fake_current_date = Utc.ymd(2019, 2, 27).and_hms(0, 0, 0);
+        let result = verified_email_check(
+            &mut warnings,
+            &Some("someone@example.com".into()),
+            fake_current_date,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(warnings.len(), 0);
+    }
+
+    #[test]
+    fn allow_publish_with_verified_email_without_error_after_2018_02_28() {
+        let mut warnings = vec![];
+
+        let fake_current_date = Utc.ymd(2019, 3, 1).and_hms(0, 0, 0);
+        let result = verified_email_check(
+            &mut warnings,
+            &Some("someone@example.com".into()),
+            fake_current_date,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(warnings.len(), 0);
+    }
+
+    #[test]
+    fn warn_without_verified_email_before_2018_02_28() {
+        let mut warnings = vec![];
+
+        let fake_current_date = Utc.ymd(2019, 2, 27).and_hms(0, 0, 0);
+        let result = verified_email_check(&mut warnings, &None, fake_current_date);
+
+        assert!(result.is_ok());
+        assert_eq!(warnings.len(), 1);
+        assert_eq!(warnings[0], "You do not currently have a verified email address associated \
+            with your crates.io account. Starting 2019-02-28, a verified email will be required to \
+            publish crates. Visit https://crates.io/me to set and verify your email address.");
+    }
+
+    #[test]
+    fn error_without_verified_email_after_2018_02_28() {
+        let mut warnings = vec![];
+
+        let fake_current_date = Utc.ymd(2019, 3, 1).and_hms(0, 0, 0);
+        let result = verified_email_check(&mut warnings, &None, fake_current_date);
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.err().unwrap().description(),
+            "A verified email address is required to \
+             publish crates to crates.io. Visit https://crates.io/me to set and verify your email \
+             address."
+        );
+    }
 }

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1073,7 +1073,7 @@ fn new_krate_with_readme() {
     assert_eq!(json.krate.max_version, "1.0.0");
 }
 
-// This warning will soon become a hard error.
+// This test will start failing on 2019-02-28 and should be updated at that time.
 // See https://github.com/rust-lang/crates-io-cargo-teams/issues/8
 #[test]
 fn new_krate_without_any_email_warns() {
@@ -1096,7 +1096,7 @@ fn new_krate_without_any_email_warns() {
     });
 }
 
-// This warning will soon become a hard error.
+// This test will start failing on 2019-02-28 and should be updated at that time.
 // See https://github.com/rust-lang/crates-io-cargo-teams/issues/8
 #[test]
 fn new_krate_with_unverified_email_warns() {


### PR DESCRIPTION
Because that's at least on 2019-02-28 (the date we announced) in all timezones,
and should definitely be after the release scheduled for that day.

As per the plan at https://github.com/rust-lang/crates-io-cargo-teams/issues/8

Needs to be merged and deployed anytime before 2019-03-01 00:00 UTC to be on time with our announced date.