### PR TITLE
Fix frontend docker configuration in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     build:
       context: .
       dockerfile: frontend.Dockerfile
-    entrypoint: npm run start --proxy http://backend:8888
+    entrypoint: npm run start -- --proxy http://backend:8888
     links:
       - backend
     ports:

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,7 +1,9 @@
 FROM node:8.6-alpine
 
 WORKDIR /app
-COPY package.json /app
+COPY package.json package-lock.json /app/
+
+RUN npm install
 
 COPY . /app
 


### PR DESCRIPTION
Fixes to frontend to make `docker-compose up` work again on a fresh clone.

Two fixes need to happen:

1. `npm install` needs to run when building the docker container, so that all of the dependencies exist.
2. A slight change to the `docker-compose.yml` file to properly link up the frontend to the backend.

---

*[Edit]: this previously consisted of only a single commit that looked at the frontend.Dockerfile file. As I continued trying to get an environment up, I noticed another fix that needed to be made and decided it was similar-enough in scope that it should be added to his pull request. The original description follows.*

**Add `npm install` to frontend Docker**

The frontend Docker image appears to be following a pretty standard Node
convention of adding the package.json, running `npm install`, and then
copying the rest of the application, which makes rebuilding new docker
images much faster if there are no dependency changes.

However, in the great `yarn` cleanup of 2017, `yarn install` was removed
but the corresponding `npm install` was not added back. This means that
when the frontend docker image tries to run ember, ember is not
available because it was never installed.