### PR TITLE
Revert "Auto merge of #1618 - jtgeibel:conduit-hyper-round2, r=sgrif"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,12 +153,12 @@ dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cargo-registry-s3 0.2.0",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "comrak 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-cookie 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conduit-hyper 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-router 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-static 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,6 +188,7 @@ dependencies = [
  "license-exprs 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "old_semver 0.1.0",
  "openssl 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -234,6 +235,22 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "civet"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "civet-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "civet-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cloudabi"
@@ -302,20 +319,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "conduit-hyper"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1417,6 +1420,13 @@ dependencies = [
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "old_semver"
+version = "0.1.0"
+dependencies = [
+ "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2642,6 +2652,8 @@ dependencies = [
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
+"checksum civet 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6263e7af767a5bf9e4d3d0a6c3ceb5f3940ec85cf2fbfee59024b8a264be180f"
+"checksum civet-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "958d15372bf28b7983cb35e1d4bf36dd843b0d42e507c1c73aad7150372c5936"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
 "checksum comrak 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f2c1e2cc9384b402a97e0f2b3f8bc1ef45425fe810e030a189f05ed701f4b5b1"
@@ -2649,7 +2661,6 @@ dependencies = [
 "checksum conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "614f67083e437fd0b8fb9f13067203f358f1c6f52989eb6539292fde007fc6d6"
 "checksum conduit-cookie 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "17cef818a14458d6b074a813a1934cfa4d8dc098f859307f4a3d17cc0dc91361"
 "checksum conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "027a1900afd70becd52b5061afc85a24de6af0d9199f39d4e1af8b7ac55fbe6e"
-"checksum conduit-hyper 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "82e345933d4a5b4ba7e30d071bd5fa7ab0b92262a2bf9347e929ae4e55b2370a"
 "checksum conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19b4b5a3a60b976f9219490e895cf573a6d17547e009e3c0e9f01a584b5b74d0"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum conduit-router 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a70ad2d0c8c41ada8ad4ff35070652972d75da7e7bccfb6d1d23463b1714c3ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rustdoc-args = [
 
 [dependencies]
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
+old_semver = { path = "src/old_semver", version = "0.1.0" }
 rand = "0.3"
 git2 = "0.6.4"
 flate2 = "1.0"
@@ -76,7 +77,7 @@ conduit-middleware = "0.8"
 conduit-router = "0.8"
 conduit-static = "0.8"
 conduit-git-http-backend = "0.8"
-conduit-hyper = "0.1.3"
+civet = "0.9"
 
 [dev-dependencies]
 conduit-test = "0.8"

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -12,11 +12,12 @@ The server does the following things:
 3. Reads values from environment variables to configure a new instance of `cargo_registry::App`
 4. Adds middleware to the app by calling `cargo_registry::middleware`
 5. Syncs the categories defined in *src/categories.toml* with the categories in the database
-6. Starts a [hyper] server that uses the `cargo_registry::App` instance
+6. Starts a [civet][] `Server` that uses the `cargo_registry::App` instance
 7. Tells Nginx on Heroku that the application is ready to receive requests, if running on Heroku
-8. Blocks forever (or until the process is killed)
+8. Blocks forever (or until the process is killed) waiting to receive messages on a channel that no
+   messages are ever sent to, in order to outive the civet `Server` threads
 
-[hyper]: https://crates.io/crates/hyper
+[civet]: https://crates.io/crates/civet
 
 ## Routes
 

--- a/src/old_semver/Cargo.toml
+++ b/src/old_semver/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "old_semver"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+
+[dependencies]
+semver = "0.5.0"

--- a/src/old_semver/src/lib.rs
+++ b/src/old_semver/src/lib.rs
@@ -1,0 +1,3 @@
+/// We need semver 0.5.0 for conduit, but we want to use newer versions.
+/// This is a silly workaround.
+pub extern crate semver;

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -1,7 +1,7 @@
 use std::{io::Read, net::SocketAddr};
 
 use conduit::Request;
-use conduit_hyper::semver;
+use old_semver::semver;
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
This reverts commit 69368a6efe228f3a7cc91a3b8783ff03ec9e9d92, reversing
changes made to 6fa8ad32cc3470b3d320d4620ba305c8d220ff2d.

When deploying this change, we saw response times nearly triple, and our
CPU usage went through the roof. Additionally, this did not appear to
fix the memory issues we were hoping to address by removing civet.

/cc @jtgeibel 