### PR TITLE
docker: use --locked-schema for diesel migrations

### DIFF
--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # If the backend is started before postgres is ready, the migrations will fail
-until diesel migration run; do
+until diesel migration run --locked-schema; do
   echo "Migrations failed, retrying in 5 seconds..."
   sleep 5
 done


### PR DESCRIPTION
When using `docker-compose up` to bring up everything for development,
we mount the source directory as read-only so that changes can only
happen on the host machine and not because of something that the code
running in docker does.

This read-only mount was causing problems because `patch`, called by
`diesel migration run`, would try to write to the filesystem and fail.

When bringing up a docker environment for the first time from a fresh
clone, we expect that the schema.rs file is already pristine, and that
we just need to run migrations. For that reason, use `diesel migration
run`'s `--locked-schema` option to just run migrations.

This change makes it so that a new contributor can clone the repo, run
`docker-compose up`, and have an almost complete environment to poke at
and start exploring.

Fixes #1631