### PR TITLE
Exclude yanked crates on user/team pages

### DIFF
--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -16,6 +16,7 @@ export default Route.extend({
         return this.store.queryRecord('team', { team_id }).then(
             team => {
                 params.team_id = team.get('id');
+                params.include_yanked = 'n';
                 return RSVP.hash({
                     crates: this.store.query('crate', params),
                     team,

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -15,6 +15,7 @@ export default Route.extend({
         return this.store.queryRecord('user', { user_id }).then(
             user => {
                 params.user_id = user.get('id');
+                params.include_yanked = 'n';
                 return RSVP.hash({
                     crates: this.store.query('crate', params),
                     user,


### PR DESCRIPTION
Add a URL parameter to the `/api/v1/crates` endpoint that specifies whether or not the endpoint should return crates that have been fully yanked - i.e., where every version has been yanked.

If not specified, this defaults to `true` because we have typically always returned all matching crates, whether or not their versions have been yanked.

This makes it possible to display only non-yanked crates at various places in the UI without changing Rust code.

Use this from the user and team pages to exclude yanked crates from them.

Closes #958 