### PR TITLE
Use a consistent format for numbers in dl graph

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -78,10 +78,20 @@ export default Component.extend({
 
         let myData = window.google.visualization.arrayToDataTable(data);
 
-        let fmt = new window.google.visualization.DateFormat({
+        let dateFmt = new window.google.visualization.DateFormat({
             pattern: 'LLL d, yyyy',
         });
-        fmt.format(myData, 0);
+        dateFmt.format(myData, 0);
+
+        // Create a formatter to use for daily download numbers
+        let numberFormatWhole = new window.google.visualization.NumberFormat({
+            pattern: '#,##0',
+        });
+
+        // Create a formatter to use for 7-day average numbers
+        let numberFormatDecimal = new window.google.visualization.NumberFormat({
+            pattern: '#,##0.0',
+        });
 
         // use a DataView to calculate an x-day moving average
         let days = 7;
@@ -101,7 +111,7 @@ export default Component.extend({
                 let avg = total / days;
                 return {
                     v: avg,
-                    f: avg.toFixed(2),
+                    f: numberFormatDecimal.formatValue(avg),
                 };
             };
         };
@@ -113,6 +123,8 @@ export default Component.extend({
         // is at the end, but in the UI we want it at the top of the chart legend.
 
         range(headers.length - 1, 0, -1).forEach((dataCol, i) => {
+            // Set the number format for the colum in the data table.
+            numberFormatWhole.format(myData, dataCol);
             columns.push(dataCol); // add the column itself
             columns.push({
                 // add a 'calculated' column, the moving average


### PR DESCRIPTION
When formatting download numbers in the download graph, use a consistent numbering format for both raw numbers and the rolling 7-day average.

There are cases where the user's local can make inconsistent formatting. Specifically, we use `Number.prototype.toFixed` to format the rolling 7-day average, which always results in a number format that uses a decimal point (e.g. "1234.56"). However, the raw download numbers end up using the locale, which in some places can end up formatting the number with a decimal as the thousands separator ("1.234").

To fix this, use google.visualization.NumberFormat for *both* values, so that they are always consistent.

Fixes #1628 

Note that I couldn't fully test this, because even after changing my browser's language to `de`, I would still see English number formatting. I did test it by [forcing the Google Visualization chart locale](https://developers.google.com/chart/interactive/docs/basic_load_libs#loadwithlocale), but I'm still not 100% sure if the numbers will show in a German format for a German viewer.

I am, however, sure that they will always show in a *consistent* format.