### PR TITLE
Add `hyper` support as a boot-time option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,7 @@ dependencies = [
  "conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-cookie 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conduit-hyper 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-router 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conduit-static 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -181,7 +182,6 @@ dependencies = [
  "license-exprs 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "old_semver 0.1.0",
  "openssl 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -312,6 +312,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "conduit-hyper"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "conduit 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1338,13 +1352,6 @@ dependencies = [
  "curl 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "old_semver"
-version = "0.1.0"
-dependencies = [
- "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2569,6 +2576,7 @@ dependencies = [
 "checksum conduit-conditional-get 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "614f67083e437fd0b8fb9f13067203f358f1c6f52989eb6539292fde007fc6d6"
 "checksum conduit-cookie 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "17cef818a14458d6b074a813a1934cfa4d8dc098f859307f4a3d17cc0dc91361"
 "checksum conduit-git-http-backend 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "027a1900afd70becd52b5061afc85a24de6af0d9199f39d4e1af8b7ac55fbe6e"
+"checksum conduit-hyper 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "82e345933d4a5b4ba7e30d071bd5fa7ab0b92262a2bf9347e929ae4e55b2370a"
 "checksum conduit-middleware 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "19b4b5a3a60b976f9219490e895cf573a6d17547e009e3c0e9f01a584b5b74d0"
 "checksum conduit-mime-types 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "95ca30253581af809925ef68c2641cc140d6183f43e12e0af4992d53768bd7b8"
 "checksum conduit-router 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a70ad2d0c8c41ada8ad4ff35070652972d75da7e7bccfb6d1d23463b1714c3ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ rustdoc-args = [
 
 [dependencies]
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
-old_semver = { path = "src/old_semver", version = "0.1.0" }
 rand = "0.6"
 git2 = "0.6.4"
 flate2 = "1.0"
@@ -76,6 +75,7 @@ conduit-router = "0.8"
 conduit-static = "0.8"
 conduit-git-http-backend = "0.8"
 civet = "0.9"
+conduit-hyper = "0.1.3"
 
 [dev-dependencies]
 conduit-test = "0.8"

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -12,12 +12,12 @@ The server does the following things:
 3. Reads values from environment variables to configure a new instance of `cargo_registry::App`
 4. Adds middleware to the app by calling `cargo_registry::middleware`
 5. Syncs the categories defined in *src/categories.toml* with the categories in the database
-6. Starts a [civet][] `Server` that uses the `cargo_registry::App` instance
+6. Starts either a [conduit] or a [hyper] server that uses the `cargo_registry::App` instance
 7. Tells Nginx on Heroku that the application is ready to receive requests, if running on Heroku
-8. Blocks forever (or until the process is killed) waiting to receive messages on a channel that no
-   messages are ever sent to, in order to outive the civet `Server` threads
+8. Blocks forever (or until the process is killed)
 
 [civet]: https://crates.io/crates/civet
+[hyper]: https://crates.io/crates/hyper
 
 ## Routes
 

--- a/src/old_semver/Cargo.toml
+++ b/src/old_semver/Cargo.toml
@@ -1,7 +1,0 @@
-[package]
-name = "old_semver"
-version = "0.1.0"
-authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
-
-[dependencies]
-semver = "0.5.0"

--- a/src/old_semver/src/lib.rs
+++ b/src/old_semver/src/lib.rs
@@ -1,3 +1,0 @@
-/// We need semver 0.5.0 for conduit, but we want to use newer versions.
-/// This is a silly workaround.
-pub extern crate semver;

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -1,7 +1,7 @@
 use std::{io::Read, net::SocketAddr};
 
 use conduit::Request;
-use old_semver::semver;
+use conduit_hyper::semver;
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]


### PR DESCRIPTION
If the `USE_HYPER` environment variable is set then `hyper` is used as
the backend server.  If the variable is not set, the default remains a
`civet` based server.

This has a trivial impact on build times and binary sizes, as `hyper`
is already pulled in (as a `Client`) on production via `reqwest`.

This will also aid in profiling performance differences, as backend
instances can be run in parallel in two terminals:

```
$ PORT=8888 cargo run --release --bin server
$ PORT=8889 USE_HYPER=1 cargo run --release --bin server
```