### PR TITLE
Rename clippy lint to `cognitive_complexity`

### DIFF
--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -74,7 +74,7 @@ fn show() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn update_crate() {
     let (_b, app, middle) = app();
     let mut req = req(Method::Get, "/api/v1/categories/foo");

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -95,7 +95,7 @@ fn index() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn index_queries() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
@@ -316,7 +316,7 @@ fn index_sorting() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn exact_match_on_queries_with_sort() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
@@ -1419,7 +1419,6 @@ fn yank_not_owner() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
 fn yank_max_version() {
     let (_, anon, _, token) = TestApp::with_proxy().with_token();
 


### PR DESCRIPTION
This renamed lint started warning on nightly.  I've confirmed that the
new name works at least as far back as 1.32.0, our currently pinned
version in production.