### PR TITLE
Add a manual trigger to clean the cache on CI

### DIFF
--- a/script/ci/cargo-clean-on-new-rustc-version.sh
+++ b/script/ci/cargo-clean-on-new-rustc-version.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+manual_stamp_file=target/ci_manual_stamp
+manual_stamp=0 # Change this to force a clean build on CI
+
+if [ -f $manual_stamp_file ]; then
+    if echo "$manual_stamp" | cmp -s $manual_stamp_file -; then
+        : # Do nothing, fall through to version check below
+    else
+        echo "A clean build has been requested, running cargo clean"
+        cargo clean
+        # The target/ directory is now gone, and the messages below will not be printed
+    fi
+fi
+
 stamp_file=target/rustc_version_stamp
 current_version=$(rustc --version)
 
@@ -13,10 +26,9 @@ if [ -f $stamp_file ]; then
         echo "The version of rustc has changed, running cargo clean"
         cargo clean
     fi
-else
-    echo "There is no existing version stamp, keeping the cache intact"
 fi
 
-# Save the version stamp for next time
+# Save the version stamps for next time
 mkdir -p target/
 echo $current_version > $stamp_file
+echo $manual_stamp > $manual_stamp_file


### PR DESCRIPTION
When we bump a low-level dependency, such as `libc`, a large number of
crates are rebuilt and this can grow our cache to the point where
caching hits a timeout (and is not persisted).

By changing the value of `manual_stamp` in the script, the cache can be
cleared without waiting for the next compiler release.