### PR TITLE
Turn off debug symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [profile.release]
 opt-level = 2
-debug = true
 
 [lib]
 name = "cargo_registry"


### PR DESCRIPTION
It looks like hyper may have fixed our memory issue after all. I'd still
like to spend some time looking at heap dumps because I still think our
memory usage is higher than reasonable, but it's low priority and not
something I'm going to do this week, and leaving debug info on makes our
binaries *huge*