### PR TITLE
Make the number of threads on the server configurable

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -42,11 +42,15 @@ fn main() {
             .and_then(|s| s.parse().ok())
             .unwrap_or(8888)
     };
-    let threads = if config.env == Env::Development {
-        1
-    } else {
-        50
-    };
+    let threads = env::var("SERVER_THREADS")
+        .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"))
+        .unwrap_or_else(|_| {
+            if config.env == Env::Development {
+                1
+            } else {
+                50
+            }
+        });
 
     let server = if env::var("USE_HYPER").is_ok() {
         println!("Booting with a hyper based server");


### PR DESCRIPTION
50 is probably way too high. @jtgeibel and I are interested in seeing
how this is affecting our memory usage, it'd be great to configure this
without a redeploy.