### PR TITLE
Allow the database to be set in read only mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -69,6 +69,11 @@ impl App {
             (_, Env::Test) => 1,
             _ => 30,
         };
+        let read_only_mode = dotenv::var("READ_ONLY_MODE").is_ok();
+        let connection_config = db::ConnectionConfig {
+            statement_timeout: db_connection_timeout,
+            read_only: read_only_mode,
+        };
 
         let thread_pool = Arc::new(ScheduledThreadPool::new(db_helper_threads));
 
@@ -76,7 +81,7 @@ impl App {
             .max_size(db_pool_size)
             .min_idle(db_min_idle)
             .connection_timeout(Duration::from_secs(db_connection_timeout))
-            .connection_customizer(Box::new(db::SetStatementTimeout(db_connection_timeout)))
+            .connection_customizer(Box::new(connection_config))
             .thread_pool(thread_pool);
 
         App {

--- a/src/git.rs
+++ b/src/git.rs
@@ -12,7 +12,7 @@ use url::Url;
 use crate::background_jobs::Environment;
 use crate::models::{DependencyKind, Version};
 use crate::schema::versions;
-use crate::util::errors::{internal, std_error_no_send, CargoResult};
+use crate::util::errors::{std_error_no_send, CargoError, CargoResult};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Crate {
@@ -159,7 +159,9 @@ impl Job for AddCrate {
 }
 
 pub fn add_crate(conn: &PgConnection, krate: Crate) -> CargoResult<()> {
-    AddCrate { krate }.enqueue(conn).map_err(|e| internal(&e))
+    AddCrate { krate }
+        .enqueue(conn)
+        .map_err(|e| CargoError::from_std_error(e))
 }
 
 #[derive(Serialize, Deserialize)]
@@ -239,5 +241,5 @@ pub fn yank(conn: &PgConnection, krate: String, version: Version, yanked: bool) 
         yanked,
     }
     .enqueue(conn)
-    .map_err(|e| internal(&e))
+    .map_err(|e| CargoError::from_std_error(e))
 }

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -45,7 +45,9 @@ impl Middleware for CurrentUser {
             // Otherwise, look for an `Authorization` header on the request
             // and try to find a user in the database with a matching API token
             let user = if let Some(headers) = req.headers().find("Authorization") {
-                User::find_by_api_token(&conn, headers[0]).ok()
+                User::find_by_api_token(&conn, headers[0])
+                    .optional()
+                    .map_err(|e| Box::new(e) as Box<dyn Error + Send>)?
             } else {
                 None
             };

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -106,18 +106,26 @@ impl<'a> NewUser<'a> {
 
 impl User {
     /// Queries the database for a user with a certain `api_token` value.
-    pub fn find_by_api_token(conn: &PgConnection, token_: &str) -> CargoResult<User> {
+    pub fn find_by_api_token(conn: &PgConnection, token_: &str) -> QueryResult<User> {
         use crate::schema::api_tokens::dsl::{api_tokens, last_used_at, revoked, token, user_id};
-        use crate::schema::users::dsl::{id, users};
         use diesel::update;
+
         let tokens = api_tokens
             .filter(token.eq(token_))
             .filter(revoked.eq(false));
-        let user_id_ = update(tokens)
-            .set(last_used_at.eq(now.nullable()))
-            .returning(user_id)
-            .get_result::<i32>(conn)?;
-        Ok(users.filter(id.eq(user_id_)).get_result(conn)?)
+
+        // If the database is in read only mode, we can't update last_used_at.
+        // Try updating in a new transaction, if that fails, fall back to reading
+        let user_id_ = conn
+            .transaction(|| {
+                update(tokens)
+                    .set(last_used_at.eq(now.nullable()))
+                    .returning(user_id)
+                    .get_result::<i32>(conn)
+            })
+            .or_else(|_| tokens.select(user_id).first(conn))?;
+
+        users::table.find(user_id_).first(conn)
     }
 
     pub fn owning(krate: &Crate, conn: &PgConnection) -> CargoResult<Vec<Owner>> {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -68,6 +68,7 @@ mod git;
 mod keyword;
 mod krate;
 mod owners;
+mod read_only_mode;
 mod record;
 mod schema_details;
 mod server;

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -1,0 +1,56 @@
+use crate::builders::CrateBuilder;
+use crate::{RequestHelper, TestApp};
+use diesel::prelude::*;
+
+#[test]
+fn can_hit_read_only_endpoints_in_read_only_mode() {
+    let (app, anon) = TestApp::init().empty();
+    app.db(set_read_only).unwrap();
+    anon.get::<()>("/api/v1/crates").assert_status(200);
+}
+
+#[test]
+fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
+    let (app, _, user, token) = TestApp::init().with_token();
+    app.db(|conn| {
+        CrateBuilder::new("foo_yank_read_only", user.as_model().id)
+            .version("1.0.0")
+            .expect_build(conn);
+        set_read_only(conn).unwrap();
+    });
+    token
+        .delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
+        .assert_status(503);
+}
+
+#[test]
+#[ignore] // Will be implicitly fixed by #1387, no need to special case here
+fn can_download_crate_in_read_only_mode() {
+    let (app, anon, user) = TestApp::with_proxy().with_user();
+
+    app.db(|conn| {
+        CrateBuilder::new("foo_download_read_only", user.as_model().id)
+            .version("1.0.0")
+            .expect_build(conn);
+        set_read_only(conn).unwrap();
+    });
+
+    anon.get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download")
+        .assert_status(302);
+
+    // We're in read only mode so the download should not have been counted
+    app.db(|conn| {
+        use cargo_registry::schema::version_downloads::dsl::*;
+        use diesel::dsl::sum;
+
+        let dl_count = version_downloads
+            .select(sum(downloads))
+            .get_result::<Option<i64>>(conn);
+        assert_eq!(Ok(None), dl_count);
+    })
+}
+
+fn set_read_only(conn: &PgConnection) -> QueryResult<()> {
+    diesel::sql_query("SET TRANSACTION READ ONLY").execute(conn)?;
+    Ok(())
+}


### PR DESCRIPTION
This is in preparation for our next database upgrade. Last time we
needed to do this, we took the whole site down. This means that for 30
minutes, `cargo build` just didn't work. This is no longer something we
consider acceptable. While we could just take everything down *except*
`cargo build`, we can do better.

The upgrade process is basically:

- Set up a new replica of the primary database
- Wait until the replica is "caught up" (< 200 commits behind)
- Take down the site
- Upgrade the replica in place
- Verify the upgrade was successful
- Swap over to the replica
- Bring the site back up

There's no reason that we actually need to bring the site down though,
we just need to stop writing to the primary during the upgrade process.

This does that by setting the default transaction mode to READ ONLY, and
handling the error we will get back if we try to do a write.
Unfortunately, Diesel doesn't expose any API to give us the underlying
database error code, so we have to match on the error message instead.

This code assumes that:

- We are never manually setting a transaction to `READ WRITE`
- We are never manually setting a transaction to `READ ONLY`, and
  expecting write errors to bubble up to the user

We're not currently doing either of those things, and I can't imagine
that we'll start doing either one in the future.

During testing I found some issues with how this interacts with token
auth. The middleware was assuming that *any* error from
`User::find_by_api_token` was `diesel::NotFound`, and would proceed to
run the request (this finally explains a spurious failure I've been
getting about a poisoned transaction, it was probably a deadlock in the
API key update)

Because our tests run in a single transaction, we need to wrap that
update to ensure that the error doesn't poison the transaction. If we
didn't do anything else, we'd just assume that any user trying to do
something with token auth was not logged in, and would give a 403
instead of a 503. To fix this, I've set it up to fall back to a simple
find if the update fails.

This does *not* make the download endpoint work when we're in read only
mode, there is a separate issue for that which will come in a separate
PR. I have, however, added an explicit test to ensure it works in read
only mode.