### PR TITLE
Add Cryptocurrencies category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -98,6 +98,12 @@ description = """
 Algorithms intended for securing data.\
 """
 
+[cryptography.categories.cryptocurrencies]
+name = "Cryptocurrencies"
+description = """
+Crates for digital currencies, wallets, and distributed ledgers.\
+"""
+
 [database]
 name = "Database interfaces"
 description = """


### PR DESCRIPTION
As described in #1475, there are many crates related to cryptocurrencies, which don't have a better category than cryptography.

