### PR TITLE
Update swirl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,9 +205,8 @@ dependencies = [
  "scheduled-thread-pool 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (git+https://github.com/steveklabnik/semver.git)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "swirl 0.1.0 (git+https://github.com/sgrif/swirl.git?rev=95d3a35bc39a7274335cad6d7cab64acd5eb3904)",
+ "swirl 0.1.0 (git+https://github.com/sgrif/swirl.git?rev=de5d8bb)",
  "tar 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -455,6 +454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -847,6 +855,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghost"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "git2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,6 +1003,26 @@ dependencies = [
 name = "indexmap"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "inventory"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inventory-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "inventory-impl"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "iovec"
@@ -1973,6 +2011,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -2094,12 +2135,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "swirl"
 version = "0.1.0"
-source = "git+https://github.com/sgrif/swirl.git?rev=95d3a35bc39a7274335cad6d7cab64acd5eb3904#95d3a35bc39a7274335cad6d7cab64acd5eb3904"
+source = "git+https://github.com/sgrif/swirl.git?rev=de5d8bb#de5d8bbcfbf7878aa2c248c105938567b32ed8a8"
 dependencies = [
  "diesel 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "swirl_proc_macro 0.1.0 (git+https://github.com/sgrif/swirl.git?rev=de5d8bb)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "swirl_proc_macro"
+version = "0.1.0"
+source = "git+https://github.com/sgrif/swirl.git?rev=de5d8bb#de5d8bbcfbf7878aa2c248c105938567b32ed8a8"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2728,6 +2781,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum ctor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
 "checksum curl 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "aaf20bbe084f285f215eef2165feed70d6b75ba29cad24469badb853a4a287d0"
 "checksum curl-sys 0.4.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ca79238a79fb294be6173b4057c95b22a718c94c4e38475d5faa82b8383f3502"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
@@ -2773,6 +2827,7 @@ dependencies = [
 "checksum futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)" = "49e7653e374fe0d0c12de4250f0bdb60680b8c80eed558c5c7538eec9c89e21b"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5297b71943dc9fea26a3241b178c140ee215798b7f79f7773fd61683e25bca74"
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -2786,6 +2841,8 @@ dependencies = [
 "checksum hyper-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "caaee4dea92794a9e697038bd401e264307d1f22c883dbcb6f6618ba0d3b3bd3"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum inventory 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21df85981fe094480bc2267723d3dc0fd1ae0d1f136affc659b7398be615d922"
+"checksum inventory-impl 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8a877ae8bce77402d5e9ed870730939e097aad827b2a932b361958fa9d6e75aa"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4e93b0f37e7d735c6b610176d5b1bde8e1621ff3f6f7ac23cdfa4e7f7d0111b5"
@@ -2914,7 +2971,8 @@ dependencies = [
 "checksum string_cache_codegen 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1eea1eee654ef80933142157fdad9dd8bc43cf7c74e999e369263496f04ff4da"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
-"checksum swirl 0.1.0 (git+https://github.com/sgrif/swirl.git?rev=95d3a35bc39a7274335cad6d7cab64acd5eb3904)" = "<none>"
+"checksum swirl 0.1.0 (git+https://github.com/sgrif/swirl.git?rev=de5d8bb)" = "<none>"
+"checksum swirl_proc_macro 0.1.0 (git+https://github.com/sgrif/swirl.git?rev=de5d8bb)" = "<none>"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,10 +48,9 @@ dotenv = "0.11.0"
 toml = "0.4"
 diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
 diesel_full_text_search = "1.0.0"
-swirl = { git = "https://github.com/sgrif/swirl.git", rev = "95d3a35bc39a7274335cad6d7cab64acd5eb3904" }
+swirl = { git = "https://github.com/sgrif/swirl.git", rev = "de5d8bb" }
 serde_json = "1.0.0"
-serde_derive = "1.0.0"
-serde = "1.0.0"
+serde = { version = "1.0.0", features = ["derive"] }
 chrono = { version = "0.4.0", features = ["serde"] }
 comrak = { version = "0.4.0", default-features = false }
 ammonia = "2.0.0"

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -1,22 +1,20 @@
 use std::panic::AssertUnwindSafe;
 use std::sync::{Mutex, MutexGuard};
-use swirl::{Builder, Runner};
 
 use crate::db::{DieselPool, DieselPooledConn};
-use crate::git::{AddCrate, Repository, Yank};
+use crate::git::Repository;
 use crate::util::errors::{CargoErrToStdErr, CargoResult};
 
-impl<'a> swirl::DieselPool<'a> for DieselPool {
+impl<'a> swirl::db::BorrowedConnection<'a> for DieselPool {
     type Connection = DieselPooledConn<'a>;
-    type Error = CargoErrToStdErr;
-
-    fn get(&'a self) -> Result<Self::Connection, Self::Error> {
-        self.get().map_err(CargoErrToStdErr)
-    }
 }
 
-pub fn job_runner(config: Builder<Environment, DieselPool>) -> Runner<Environment, DieselPool> {
-    config.register::<AddCrate>().register::<Yank>().build()
+impl swirl::db::DieselPool for DieselPool {
+    type Error = CargoErrToStdErr;
+
+    fn get(&self) -> Result<swirl::db::DieselPooledConn<'_, Self>, Self::Error> {
+        self.get().map_err(CargoErrToStdErr)
+    }
 }
 
 #[allow(missing_debug_implementations)]

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -37,8 +37,10 @@ fn main() {
 
     let environment = Environment::new(repository, credentials, db_pool.clone());
 
-    let builder = swirl::Runner::builder(db_pool, environment).thread_count(1);
-    let runner = job_runner(builder);
+    let runner = swirl::Runner::builder(db_pool, environment)
+        .thread_count(1)
+        .job_start_timeout(Duration::from_secs(10))
+        .build();
 
     println!("Runner booted, running jobs");
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -6,9 +6,6 @@
 
 #![deny(warnings)]
 
-#[macro_use]
-extern crate serde_derive;
-
 mod on_call;
 
 use cargo_registry::{db, util::CargoResult};

--- a/src/bin/on_call/mod.rs
+++ b/src/bin/on_call/mod.rs
@@ -2,7 +2,7 @@ use cargo_registry::util::{internal, CargoResult};
 
 use reqwest::{header, StatusCode as Status};
 
-#[derive(Serialize, Debug)]
+#[derive(serde::Serialize, Debug)]
 #[serde(rename_all = "snake_case", tag = "event_type")]
 pub enum Event {
     Trigger {
@@ -54,14 +54,14 @@ impl Event {
     }
 }
 
-#[derive(Serialize, Debug)]
+#[derive(serde::Serialize, Debug)]
 struct FullEvent {
     service_key: String,
     #[serde(flatten)]
     event: Event,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug)]
 struct InvalidEvent {
     message: String,
     errors: Vec<String>,

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -6,7 +6,7 @@
 #![deny(warnings)]
 
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 use cargo_registry::{
     db,

--- a/src/bin/test-pagerduty.rs
+++ b/src/bin/test-pagerduty.rs
@@ -7,9 +7,6 @@
 
 #![deny(warnings)]
 
-#[macro_use]
-extern crate serde_derive;
-
 mod on_call;
 
 use std::env::args;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -1,12 +1,12 @@
 //! Endpoints for yanking and unyanking specific versions of crates
 
-use crate::controllers::prelude::*;
-
-use crate::git;
-
-use crate::models::Rights;
+use swirl::Job;
 
 use super::version_and_crate;
+use crate::controllers::prelude::*;
+use crate::git;
+use crate::models::Rights;
+use crate::util::CargoError;
 
 /// Handles the `DELETE /crates/:crate_id/:version/yank` route.
 /// This does not delete a crate version, it makes the crate
@@ -36,7 +36,9 @@ fn modify_yank(req: &mut dyn Request, yanked: bool) -> CargoResult<Response> {
         return Err(human("must already be an owner to yank or unyank"));
     }
 
-    git::yank(&conn, krate.name, version, yanked)?;
+    git::yank(krate.name, version, yanked)
+        .enqueue(&conn)
+        .map_err(|e| CargoError::from_std_error(e))?;
 
     #[derive(Serialize)]
     struct R {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ extern crate diesel;
 #[macro_use]
 extern crate log;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 #[macro_use]
 extern crate serde_json;
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -5,7 +5,7 @@ extern crate diesel;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 #[macro_use]
 extern crate serde_json;
 


### PR DESCRIPTION
New features in this version:

- Codegen for jobs which reduces boilerplate when defining them
- Jobs no longer need to be registered with the runner
- Rework of how `run_all_pending_jobs` works so errors loading the job
  actually bubble up
- Configurable timeout for how long to wait for a job to begin running

We aren't fully taking advantage of the timeout yet, I'd eventually like
to try rebuilding the runner in-process a few times when an error
happens, and then crash the process if it fails a few times in a row.
This needs a bit more refactoring though (I'm not sure if we want to
keep the `Repository` in memory like we are now, and whether we want to
assume a full re-clone is needed on error). For now I've set it to
ensure our jobs don't hang forever though.

Warts in this version:

- Rust thinks imports only used in the job body are unused.
  (https://github.com/sgrif/swirl/issues/6)
  - Worked around for now by moving the imports into the job body
- `swirl::Job` has to be imported by calling code
- Codegen assumes that `serde::Deserialize` and `serde::Serialize` are
  available. (https://github.com/sgrif/swirl/issues/9)

Issues with this version:

- The new impl of `run_all_pending_jobs` will return an error if the DB
  is in read only mode. If the DB is read only, we couldn't have
  enqueued jobs anyway, so the workaround is "fine", but we need some
  more robust APIs in swirl to fix this. This only affects us in tests.
  - https://github.com/sgrif/swirl/issues/8