### PR TITLE
Initialize a single `reqwest::Client` for the server process

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -21,6 +21,7 @@ use chrono::{TimeZone, Utc};
 use diesel::{dsl::any, prelude::*};
 use docopt::Docopt;
 use flate2::read::GzDecoder;
+use reqwest::Client;
 use tar::{self, Archive};
 
 const DEFAULT_PAGE_SIZE: usize = 25;
@@ -94,6 +95,8 @@ fn main() {
         total_pages + 1
     };
 
+    let client = Client::new();
+
     for (page_num, version_ids_chunk) in version_ids.chunks(page_size).enumerate() {
         println!(
             "= Page {} of {} ==================================",
@@ -117,9 +120,10 @@ fn main() {
                     krate_name, version.num
                 )
             });
+            let client = client.clone();
             let handle = thread::spawn(move || {
                 println!("[{}-{}] Rendering README...", krate_name, version.num);
-                let readme = get_readme(&config, &version, &krate_name);
+                let readme = get_readme(&config, &client, &version, &krate_name);
                 if readme.is_none() {
                     return;
                 }
@@ -127,12 +131,7 @@ fn main() {
                 let readme_path = format!("readmes/{0}/{0}-{1}.html", krate_name, version.num);
                 config
                     .uploader
-                    .upload(
-                        &reqwest::Client::new(),
-                        &readme_path,
-                        readme.into_bytes(),
-                        "text/html",
-                    )
+                    .upload(&client, &readme_path, readme.into_bytes(), "text/html")
                     .unwrap_or_else(|_| {
                         panic!(
                             "[{}-{}] Couldn't upload file to S3",
@@ -151,12 +150,17 @@ fn main() {
 }
 
 /// Renders the readme of an uploaded crate version.
-fn get_readme(config: &Config, version: &Version, krate_name: &str) -> Option<String> {
+fn get_readme(
+    config: &Config,
+    client: &Client,
+    version: &Version,
+    krate_name: &str,
+) -> Option<String> {
     let location = config
         .uploader
-        .crate_location(krate_name, &version.num.to_string())?;
+        .crate_location(krate_name, &version.num.to_string());
 
-    let mut response = match reqwest::get(&location) {
+    let mut response = match client.get(&location).send() {
         Ok(r) => r,
         Err(err) => {
             println!(

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -9,6 +9,7 @@ use std::{
 
 use civet::Server as CivetServer;
 use conduit_hyper::Service as HyperService;
+use reqwest::Client;
 
 enum Server {
     Civet(CivetServer),
@@ -24,7 +25,9 @@ fn main() {
     env_logger::init();
 
     let config = cargo_registry::Config::default();
-    let app = App::new(&config);
+    let client = Client::new();
+
+    let app = App::new(&config, Some(client));
     let app = cargo_registry::build_handler(Arc::new(app));
 
     // On every server restart, ensure the categories available in the database match

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,7 +68,6 @@ impl Default for Config {
                         &api_protocol,
                     ),
                     cdn: dotenv::var("S3_CDN").ok(),
-                    proxy: None,
                 }
             }
             (Env::Production, Replica::ReadOnlyMirror) => {
@@ -89,7 +88,6 @@ impl Default for Config {
                         &api_protocol,
                     ),
                     cdn: dotenv::var("S3_CDN").ok(),
-                    proxy: None,
                 }
             }
             // In Development mode, either running as a primary instance or a read-only mirror
@@ -109,7 +107,6 @@ impl Default for Config {
                             &api_protocol,
                         ),
                         cdn: dotenv::var("S3_CDN").ok(),
-                        proxy: None,
                     }
                 } else {
                     // If we don't set the `S3_BUCKET` variable, we'll use a development-only

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -169,8 +169,7 @@ pub fn readme(req: &mut dyn Request) -> CargoResult<Response> {
         .app()
         .config
         .uploader
-        .readme_location(crate_name, version)
-        .ok_or_else(|| human("crate readme not found"))?;
+        .readme_location(crate_name, version);
 
     if req.wants_json() {
         #[derive(Serialize)]

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -24,8 +24,7 @@ pub fn download(req: &mut dyn Request) -> CargoResult<Response> {
         .app()
         .config
         .uploader
-        .crate_location(crate_name, version)
-        .ok_or_else(|| human("crate files not found"))?;
+        .crate_location(crate_name, version);
 
     if req.wants_json() {
         #[derive(Serialize)]

--- a/src/github.rs
+++ b/src/github.rs
@@ -20,8 +20,7 @@ where
     let url = format!("{}://api.github.com{}", app.config.api_protocol, url);
     info!("GITHUB HTTP: {}", url);
 
-    let client = app.http_client()?;
-    client
+    app.http_client()
         .get(&url)
         .header(header::ACCEPT, "application/vnd.github.v3+json")
         .header(

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -26,7 +26,6 @@ use crate::{
 use cargo_registry::{
     middleware::current_user::AuthenticationSource,
     models::{ApiToken, User},
-    uploaders::Uploader,
     App,
 };
 use diesel::PgConnection;
@@ -48,7 +47,7 @@ pub struct TestApp(Rc<TestAppInner>);
 impl TestApp {
     /// Initialize an application with an `Uploader` that panics
     pub fn init() -> TestAppBuilder {
-        let (app, middle) = crate::simple_app(Uploader::Panic);
+        let (app, middle) = crate::simple_app(None);
         let inner = Rc::new(TestAppInner {
             app,
             _bomb: None,


### PR DESCRIPTION
A `reqwest::Client` represents a pool of connections and should be
reused.  For the `server` and `render-readme` binaries, a single pool
is now used for all requests.

This should reduce allocation activity in production for routes that
make an outgoing HTTP connection.  Each initialization costs 30,255
allocations and 2.0 MB of allocated data.  This work is also done on a
new thread which will map it to a random jemalloc arena.  The
initialization is now done once when the server is booted and any
remaining per-request allocations will occur on a smaller thread pool.

This also cleans up how proxying is implemented when running tests.
Previously, the configuration was stored in the S3 `Uploader` but this
resulted in test failures when calling functions (i.e. `crate_location`
and `readme_location`) that do not make an HTTP request.