### PR TITLE
Propagate 'public' field on dependencies to the index

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -37,7 +37,7 @@ pub struct Dependency {
     pub kind: Option<DependencyKind>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub package: Option<String>,
-    pub public: bool
+    pub public: bool,
 }
 
 pub struct Repository {

--- a/src/git.rs
+++ b/src/git.rs
@@ -37,6 +37,7 @@ pub struct Dependency {
     pub kind: Option<DependencyKind>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub package: Option<String>,
+    pub public: bool
 }
 
 pub struct Repository {

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -119,6 +119,7 @@ pub fn add_dependencies(
                     target: dep.target.clone(),
                     kind: dep.kind.or(Some(DependencyKind::Normal)),
                     package,
+                    public: dep.public.unwrap_or(false)
                 },
                 (
                     version_id.eq(target_version_id),

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -588,7 +588,7 @@ impl DependencyBuilder {
             kind: None,
             explicit_name_in_toml: self.explicit_name_in_toml,
             registry: self.registry,
-            public: Some(false)
+            public: Some(false),
         }
     }
 }

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -588,6 +588,7 @@ impl DependencyBuilder {
             kind: None,
             explicit_name_in_toml: self.explicit_name_in_toml,
             registry: self.registry,
+            public: Some(false)
         }
     }
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -64,7 +64,7 @@ pub struct EncodableCrateDependency {
     pub kind: Option<DependencyKind>,
     pub explicit_name_in_toml: Option<EncodableCrateName>,
     pub registry: Option<String>,
-    pub public: Option<bool>
+    pub public: Option<bool>,
 }
 
 impl<'de> Deserialize<'de> for EncodableCrateName {

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -64,6 +64,7 @@ pub struct EncodableCrateDependency {
     pub kind: Option<DependencyKind>,
     pub explicit_name_in_toml: Option<EncodableCrateName>,
     pub registry: Option<String>,
+    pub public: Option<bool>
 }
 
 impl<'de> Deserialize<'de> for EncodableCrateName {


### PR DESCRIPTION
This implements the crates.io side of https://github.com/rust-lang/rust/issues/44663

This is fully backwards-compatible - 'public' will default to 'false'
for old versions of Cargo that don't include it in their manifest