### PR TITLE
Display errors during login

### DIFF
--- a/app/routes/github-authorize.js
+++ b/app/routes/github-authorize.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import ajax from 'ember-fetch/ajax';
+import fetch from 'fetch';
 import { serializeQueryParams } from 'ember-fetch/mixins/adapter-fetch';
 
 /**
@@ -19,8 +19,9 @@ export default Route.extend({
     async beforeModel(transition) {
         try {
             let queryParams = serializeQueryParams(transition.queryParams);
-            let d = await ajax(`/authorize?${queryParams}`);
-            let item = JSON.stringify({ ok: true, data: d });
+            let resp = await fetch(`/authorize?${queryParams}`);
+            let json = await resp.json();
+            let item = JSON.stringify({ ok: resp.ok, data: json });
             if (window.opener) {
                 window.opener.github_response = item;
             }

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -53,14 +53,14 @@ export default Route.extend({
             if (!response) {
                 return;
             }
-            if (!response.ok) {
-                this.flashMessages.show('Failed to log in');
-                return;
-            }
+
             let { data } = response;
-            if (data.errors) {
+            if (data && data.errors) {
                 let error = `Failed to log in: ${data.errors[0].detail}`;
                 this.flashMessages.show(error);
+                return;
+            } else if (!response.ok) {
+                this.flashMessages.show('Failed to log in');
                 return;
             }
 


### PR DESCRIPTION
The code was serializing an entire response object, which didn't
actually contain the errors that came back from the API, so we'd never
show anything other than "Failed to log in". With this change we now
show the error returned by the API if it returned any. Notably, if a
user tries to create a new account while we're in read only mode, they
will now see an error saying that.