### PR TITLE
WIP: Remove `diesel_cli` on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,6 @@ language: rust
 sudo: required
 dist: xenial
 
-# Ignore this branch per bors-ng documentation
-branches:
-  except:
-    - staging.tmp
-
 cache:
   cargo: true
   directories:
@@ -16,9 +11,7 @@ before_cache: script/ci/prune-cache.sh
 env:
   global:
     - JOBS=1 # See https://git.io/vdao3 for details.
-    - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
     - TEST_DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
-    - CARGO_TARGET_DIR=target
     - PERCY_PARALLEL_TOTAL=2
     # Percy secrets are included here to enable Percy's GitHub integration
     # on community-submitted PRs
@@ -30,10 +23,6 @@ install:
   - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf
   - sudo systemctl restart postgresql@11-main
   - script/ci/cargo-clean-on-new-rustc-version.sh
-  - cargo install --force diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
-
-before_script:
-  - diesel database setup --locked-schema
 
 addons:
   chrome: stable

--- a/script/ci/cargo-clean-on-new-rustc-version.sh
+++ b/script/ci/cargo-clean-on-new-rustc-version.sh
@@ -3,7 +3,7 @@
 set -e
 
 manual_stamp_file=target/ci_manual_stamp
-manual_stamp=2 # Change this to force a clean build on CI
+manual_stamp=3 # Change this to force a clean build on CI
 
 if [ -f $manual_stamp_file ]; then
     if echo "$manual_stamp" | cmp -s $manual_stamp_file -; then


### PR DESCRIPTION
WIP: testing to see if this actually works

Our build script should run all migrations before building tests and
installing `diesel_cli` takes build time and cache size.

This PR also closes #1603.