### PR TITLE
Begin working on a revamped test harness

### DIFF
--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -61,6 +61,9 @@ macro_rules! bad_resp {
     }};
 }
 
+mod helpers;
+mod prelude;
+
 mod badge;
 mod builders;
 mod categories;

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -229,7 +229,7 @@ impl<'a> CrateBuilder<'a> {
         self
     }
 
-    fn build(mut self, connection: &PgConnection) -> CargoResult<Crate> {
+    pub fn build(mut self, connection: &PgConnection) -> CargoResult<Crate> {
         use diesel::{insert_into, select, update};
 
         let mut krate = self

--- a/src/tests/helpers.rs
+++ b/src/tests/helpers.rs
@@ -1,0 +1,3 @@
+pub mod app;
+pub mod request;
+pub mod response;

--- a/src/tests/helpers/app.rs
+++ b/src/tests/helpers/app.rs
@@ -1,0 +1,78 @@
+use super::request::RequestBuilder;
+use cargo_registry::models::{ApiToken, NewUser, User};
+use cargo_registry::util::CargoResult;
+use conduit::Method;
+use conduit_middleware::MiddlewareBuilder;
+use diesel::prelude::*;
+use std::sync::Arc;
+
+pub struct App {
+    app: Arc<cargo_registry::App>,
+    middleware: MiddlewareBuilder,
+}
+
+impl App {
+    pub fn new() -> Self {
+        let (app, middleware) = crate::simple_app(None);
+        Self { app, middleware }
+    }
+
+    /// Obtain the database connection and pass it to the closure
+    ///
+    /// Our tests share a database connection with the app server, so it's
+    /// important that the conenction is dropped before requests are made to
+    /// ensure it's available for the server to use. The connection will be
+    /// returned to the server after the given function returns.
+    pub fn db<T, F>(&self, f: F) -> CargoResult<T>
+    where
+        F: FnOnce(&PgConnection) -> CargoResult<T>,
+    {
+        let conn = self.app.diesel_database.get()?;
+        f(&conn)
+    }
+
+    /// Create a new user in the database with the given id
+    pub fn create_user(&self, username: &str) -> CargoResult<User> {
+        self.db(|conn| {
+            let new_user = NewUser {
+                email: Some("something@example.com"),
+                ..crate::new_user(username)
+            };
+            Ok(new_user.create_or_update(conn)?)
+        })
+    }
+
+    /// Sets the database in read only mode.
+    ///
+    /// Any attempts to modify the database after calling this function will
+    /// result in an error.
+    pub fn set_read_only(&self) -> CargoResult<()> {
+        self.db(|conn| {
+            diesel::sql_query("SET TRANSACTION READ ONLY").execute(conn)?;
+            Ok(())
+        })
+    }
+
+    /// Create an HTTP `GET` request
+    pub fn get(&self, path: &str) -> RequestBuilder<'_> {
+        RequestBuilder::new(&self.middleware, Method::Get, path)
+    }
+
+    /// Create an HTTP `DELETE` request
+    pub fn delete(&self, path: &str) -> RequestBuilder<'_> {
+        RequestBuilder::new(&self.middleware, Method::Delete, path)
+    }
+
+    /// Returns the first API token for the given user, or creates a new one
+    pub fn token_for(&self, user: &User) -> CargoResult<ApiToken> {
+        self.db(|conn| {
+            ApiToken::belonging_to(user)
+                .first(conn)
+                .optional()?
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    ApiToken::insert(conn, user.id, "test_token").map_err(Into::into)
+                })
+        })
+    }
+}

--- a/src/tests/helpers/request.rs
+++ b/src/tests/helpers/request.rs
@@ -1,6 +1,6 @@
 use super::response::{Response, ResponseError};
-use cargo_registry::models::ApiToken;
-use conduit::{Handler, Method};
+use cargo_registry::models::{ApiToken, User};
+use conduit::{Handler, Method, Request};
 use conduit_middleware::MiddlewareBuilder;
 use conduit_test::MockRequest;
 
@@ -18,6 +18,16 @@ impl<'a> RequestBuilder<'a> {
         .with_header("User-Agent", "conduit-test")
     }
 
+    /// Sends the request signed in as the given user
+    pub fn as_user(mut self, user: &User) -> Self {
+        use cargo_registry::middleware::current_user::AuthenticationSource;
+        self.request.mut_extensions().insert(user.clone());
+        self.request
+            .mut_extensions()
+            .insert(AuthenticationSource::SessionCookie);
+        self
+    }
+
     /// Uses the given token for authentication
     pub fn with_token(self, token: &ApiToken) -> Self {
         self.with_header("Authorization", &token.token)
@@ -25,6 +35,11 @@ impl<'a> RequestBuilder<'a> {
 
     pub fn with_header(mut self, name: &str, value: &str) -> Self {
         self.request.header(name, value);
+        self
+    }
+
+    pub fn with_body<T: Into<Vec<u8>>>(mut self, body: T) -> Self {
+        self.request.with_body(&body.into());
         self
     }
 

--- a/src/tests/helpers/request.rs
+++ b/src/tests/helpers/request.rs
@@ -1,0 +1,38 @@
+use super::response::{Response, ResponseError};
+use cargo_registry::models::ApiToken;
+use conduit::{Handler, Method};
+use conduit_middleware::MiddlewareBuilder;
+use conduit_test::MockRequest;
+
+pub struct RequestBuilder<'a> {
+    middleware: &'a MiddlewareBuilder,
+    request: MockRequest,
+}
+
+impl<'a> RequestBuilder<'a> {
+    pub(super) fn new(middleware: &'a MiddlewareBuilder, method: Method, path: &str) -> Self {
+        Self {
+            middleware,
+            request: MockRequest::new(method, path),
+        }
+        .with_header("User-Agent", "conduit-test")
+    }
+
+    /// Uses the given token for authentication
+    pub fn with_token(self, token: &ApiToken) -> Self {
+        self.with_header("Authorization", &token.token)
+    }
+
+    pub fn with_header(mut self, name: &str, value: &str) -> Self {
+        self.request.header(name, value);
+        self
+    }
+
+    /// Send the request
+    ///
+    /// Returns an error if any of the middlewares returned an error, or if
+    /// the response status was >= 400.
+    pub fn send(mut self) -> Result<Response, ResponseError> {
+        Response::new(self.middleware.call(&mut self.request)?)
+    }
+}

--- a/src/tests/helpers/request.rs
+++ b/src/tests/helpers/request.rs
@@ -1,9 +1,9 @@
+use super::response::{Response, ResponseError};
 use cargo_registry::middleware::current_user::AuthenticationSource;
 use cargo_registry::models::{ApiToken, User};
 use conduit::{Handler, Method, Request};
 use conduit_middleware::MiddlewareBuilder;
 use conduit_test::MockRequest;
-use super::response::{Response, ResponseError};
 
 pub struct RequestBuilder<'a> {
     middleware: &'a MiddlewareBuilder,
@@ -55,7 +55,9 @@ impl<'a> RequestBuilder<'a> {
 
     fn clear_auth(&mut self) {
         self.request.mut_extensions().remove::<User>();
-        self.request.mut_extensions().remove::<AuthenticationSource>();
+        self.request
+            .mut_extensions()
+            .remove::<AuthenticationSource>();
         self.request.header("Authorization", "");
     }
 }

--- a/src/tests/helpers/request.rs
+++ b/src/tests/helpers/request.rs
@@ -19,7 +19,7 @@ impl<'a> RequestBuilder<'a> {
     }
 
     /// Sends the request signed in as the given user
-    pub fn as_user(mut self, user: &User) -> Self {
+    pub fn signed_in_as(mut self, user: &User) -> Self {
         use cargo_registry::middleware::current_user::AuthenticationSource;
         self.request.mut_extensions().insert(user.clone());
         self.request

--- a/src/tests/helpers/response.rs
+++ b/src/tests/helpers/response.rs
@@ -1,0 +1,86 @@
+use cargo_registry::util::{CargoError, CargoResult};
+use std::error::Error;
+use std::fmt;
+
+pub struct Response {
+    inner: conduit::Response,
+    body: String,
+}
+
+impl Response {
+    pub(super) fn new(mut inner: conduit::Response) -> Result<Self, ResponseError> {
+        use ResponseError::*;
+
+        let mut body = Vec::new();
+        inner.body.write_body(&mut body).unwrap();
+
+        let resp = Response {
+            inner,
+            body: String::from_utf8(body).unwrap(),
+        };
+
+        match resp.status() {
+            400...499 => Err(BadRequest(resp)),
+            500...599 => Err(ServerError(resp)),
+            _ => Ok(resp),
+        }
+    }
+
+    pub fn status(&self) -> u32 {
+        self.inner.status.0
+    }
+
+    pub fn text(&self) -> &str {
+        &self.body
+    }
+}
+
+pub enum ResponseError {
+    MiddlewareError(Box<dyn CargoError>),
+    BadRequest(Response),
+    ServerError(Response),
+}
+
+impl From<Box<dyn Error + Send>> for ResponseError {
+    fn from(e: Box<dyn Error + Send>) -> Self {
+        ResponseError::MiddlewareError(CargoError::from_std_error(e))
+    }
+}
+
+impl fmt::Debug for ResponseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ResponseError::*;
+        match self {
+            MiddlewareError(e) => write!(f, "MiddlewareError({:?})", e),
+            BadRequest(_) => write!(f, "BadRequest(_)"),
+            ServerError(_) => write!(f, "ServerError(_)"),
+        }
+    }
+}
+
+impl fmt::Display for ResponseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use ResponseError::*;
+        match self {
+            MiddlewareError(e) => write!(f, "middleware error: {}", e),
+            BadRequest(e) => write!(f, "bad request: {}", e.text()),
+            ServerError(e) => write!(f, "server error: {}", e.text()),
+        }
+    }
+}
+
+impl Error for ResponseError {}
+
+pub trait ResultExt {
+    fn allow_errors(self) -> CargoResult<Response>;
+}
+
+impl ResultExt for Result<Response, ResponseError> {
+    fn allow_errors(self) -> CargoResult<Response> {
+        use ResponseError::*;
+        self.or_else(|e| match e {
+            MiddlewareError(e) => Err(e),
+            BadRequest(r) | ServerError(r) => Ok(r),
+        })
+    }
+}

--- a/src/tests/helpers/response.rs
+++ b/src/tests/helpers/response.rs
@@ -33,6 +33,13 @@ impl Response {
     pub fn text(&self) -> &str {
         &self.body
     }
+
+    pub fn json<'a, T>(&'a self) -> CargoResult<T>
+    where
+        T: serde::Deserialize<'a>,
+    {
+        serde_json::from_str(self.text()).map_err(Into::into)
+    }
 }
 
 pub enum ResponseError {
@@ -52,8 +59,8 @@ impl fmt::Debug for ResponseError {
         use ResponseError::*;
         match self {
             MiddlewareError(e) => write!(f, "MiddlewareError({:?})", e),
-            BadRequest(_) => write!(f, "BadRequest(_)"),
-            ServerError(_) => write!(f, "ServerError(_)"),
+            BadRequest(e) => write!(f, "BadRequest({:?})", e.text()),
+            ServerError(e) => write!(f, "ServerError({:?})", e.text()),
         }
     }
 }

--- a/src/tests/http-data/krate_only_owners_can_yank
+++ b/src/tests/http-data/krate_only_owners_can_yank
@@ -1,0 +1,73 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_not/foo_not-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "host",
+          "alexcrichton-test.s3.amazonaws.com"
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 07:53:06 -0700"
+        ],
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "user-agent",
+          "reqwest/0.9.1"
+        ],
+        [
+          "authorization",
+          "AWS AKIAICL5IWUZYWWKA7JA:xCp3sUdUdmScjI6ct58zFv6BoGQ="
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-type",
+          "application/x-tar"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "ETag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "x-amz-id-2",
+          "FCKNKZUo5EeUNwVyhZ9P7ehfXoctqePzXx2RSE1VxoSX9rdfskkyAJUNHAF2AQojRon00LfTLPY="
+        ],
+        [
+          "x-amz-request-id",
+          "3233F8227A852593"
+        ],
+        [
+          "Server",
+          "AmazonS3"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 14:53:07 GMT"
+        ]
+      ],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -81,7 +81,7 @@ fn yank_request<'a>(app: &'a App, krate_name: &str, version: &str) -> RequestBui
     app.delete(&url)
 }
 
-fn publish_request<'a>(app: &'a App, publish_builder: PublishBuilder) -> RequestBuilder<'a> {
+fn publish_request(app: &App, publish_builder: PublishBuilder) -> RequestBuilder<'_> {
     app.put("/api/v1/crates/new")
         .with_body(publish_builder.body())
 }
@@ -1420,11 +1420,11 @@ fn only_owners_can_yank() -> CargoResult<()> {
 
     let crate_to_publish = PublishBuilder::new("foo_not");
     publish_request(&app, crate_to_publish)
-        .as_user(&owner)
+        .signed_in_as(&owner)
         .send()?;
 
     let user_yank_result = yank_request(&app, "foo_not", "1.0.0")
-        .as_user(&app.create_user("new_user")?)
+        .signed_in_as(&app.create_user("new_user")?)
         .send()? // FIXME: We should return 403 here not 200
         .json::<ErrorDetails>()?;
     assert_eq!(
@@ -1433,7 +1433,7 @@ fn only_owners_can_yank() -> CargoResult<()> {
     );
 
     let owner_yank_result = yank_request(&app, "foo_not", "1.0.0")
-        .as_user(&owner)
+        .signed_in_as(&owner)
         .send()?
         .json::<OkBool>()?;
     assert!(owner_yank_result.ok);

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -1,0 +1,3 @@
+pub use crate::helpers::app::*;
+pub use crate::helpers::response::ResultExt as _;
+pub use cargo_registry::util::CargoResult;

--- a/src/tests/prelude.rs
+++ b/src/tests/prelude.rs
@@ -1,3 +1,5 @@
 pub use crate::helpers::app::*;
+pub use crate::helpers::request::RequestBuilder;
 pub use crate::helpers::response::ResultExt as _;
+pub use crate::util::Bad as ErrorDetails;
 pub use cargo_registry::util::CargoResult;

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -1,41 +1,52 @@
 use crate::builders::CrateBuilder;
-use crate::{RequestHelper, TestApp};
+use crate::prelude::*;
 use diesel::prelude::*;
 
 #[test]
-fn can_hit_read_only_endpoints_in_read_only_mode() {
-    let (app, anon) = TestApp::init().empty();
-    app.db(set_read_only).unwrap();
-    anon.get::<()>("/api/v1/crates").assert_status(200);
+fn can_hit_read_only_endpoints_in_read_only_mode() -> CargoResult<()> {
+    let app = App::new();
+    app.set_read_only()?;
+    app.get("/api/v1/crates").send()?;
+    Ok(())
 }
 
 #[test]
-fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
-    let (app, _, user, token) = TestApp::init().with_token();
+fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() -> CargoResult<()> {
+    let app = App::new();
+    let user = app.create_user("new_user")?;
+    let token = app.token_for(&user)?;
+
     app.db(|conn| {
-        CrateBuilder::new("foo_yank_read_only", user.as_model().id)
+        CrateBuilder::new("foo_yank_read_only", user.id)
             .version("1.0.0")
-            .expect_build(conn);
-        set_read_only(conn).unwrap();
-    });
-    token
-        .delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
-        .assert_status(503);
+            .build(conn)
+    })?;
+    app.set_read_only()?;
+    let resp = app
+        .delete("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
+        .with_token(&token)
+        .send()
+        .allow_errors()?;
+    assert_eq!(503, resp.status());
+    Ok(())
 }
 
 #[test]
-fn can_download_crate_in_read_only_mode() {
-    let (app, anon, user) = TestApp::with_proxy().with_user();
+fn can_download_crate_in_read_only_mode() -> CargoResult<()> {
+    let app = App::new();
 
     app.db(|conn| {
-        CrateBuilder::new("foo_download_read_only", user.as_model().id)
+        let user = app.create_user("new_user")?;
+        CrateBuilder::new("foo_download_read_only", user.id)
             .version("1.0.0")
-            .expect_build(conn);
-        set_read_only(conn).unwrap();
-    });
+            .build(conn)
+    })?;
+    app.set_read_only()?;
 
-    anon.get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download")
-        .assert_status(302);
+    let resp = app
+        .get("/api/v1/crates/foo_download_read_only/1.0.0/download")
+        .send()?;
+    assert_eq!(302, resp.status());
 
     // We're in read only mode so the download should not have been counted
     app.db(|conn| {
@@ -44,12 +55,8 @@ fn can_download_crate_in_read_only_mode() {
 
         let dl_count = version_downloads
             .select(sum(downloads))
-            .get_result::<Option<i64>>(conn);
-        assert_eq!(Ok(None), dl_count);
+            .get_result::<Option<i64>>(conn)?;
+        assert_eq!(None, dl_count);
+        Ok(())
     })
-}
-
-fn set_read_only(conn: &PgConnection) -> QueryResult<()> {
-    diesel::sql_query("SET TRANSACTION READ ONLY").execute(conn)?;
-    Ok(())
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -332,7 +332,7 @@ pub struct Error {
     pub detail: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct Bad {
     pub errors: Vec<Error>,
 }


### PR DESCRIPTION
This is yet another attempt to improve our test harness. This is
intended to be a replacement for `TestApp` which currently lives in
`tests/util.rs`

This new structure tries to address several pain points I've had using
the existing harness:

- Abstracting into smaller pieces

  Most of the functions in the current harness give no opportunity to
  modify the request, require a type to parse the response into, and
  assume the request is a 2xx or 3xx response. This has made testing our
  edge cases difficult, and they're less well tested as a result. I've
  attempted to make it easier to do: "just like this other thing but
  with an additional header set", or "I don't care about the response
  body"

  What was previously `anon.get::<T>("...")` will now be 3 separate
  pieces:
  - `app.get("...")` returns a request object that can be modified if
    needed
  - `request.send()` returns a `Result`, where a 4xx or 5xx response is
    considered an error
  - `response.json<T>()` will parse the body into the given type

  The API is roughly modeled after `reqwest`, which I've enjoyed using
  in our app.

- More explicit handling of auth

  The current API for auth has felt really funky to me. Having an object
  called `User` constructing HTTP requests felt backwards, and it also
  meant we had to decide up front whether we were going to send some
  requests signed in or not, and also how we were authenticating. It
  also didn't have a good way to send requests as more than one user.

  The new API moves auth to be a part of request construction. So
  `user.get("...")` becomes `app.get("...").as_user(&user)`

Finally, I've structured this new API around returning `Result`
everywhere, so that we can keep assertions closer to the tests where
they matter (giving line numbers in the test, not the util file). This
is a bit tricky, and I'll probably be tweaking as I move tests over,
since results bubbled all the way up with `?` will completely lose the
backtrace. Right now, I'm figuring that things we really just don't
expect to fail ever get bubbled up with `?`, while the things we're
actually testing will remain as assertions.

The tests I've moved over don't have a ton to abstract, but I'd also
like to keep helpers like `publish` off of the `App` struct, and instead
keep them in the test file where they're relevant.

I've started by just moving `tests/read_only_mode` over, since it's a
relatively small file, and also one where the old API was more painful
for me to use. I'll be porting other files over in the next few days.