### PR TITLE
Fix new lint on nightly

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -57,7 +57,6 @@ impl Deref for DieselPooledConn<'_> {
 }
 
 pub fn connect_now() -> ConnectionResult<PgConnection> {
-    use diesel::Connection;
     let mut url = Url::parse(&crate::env("DATABASE_URL")).expect("Invalid database URL");
     if dotenv::var("HEROKU").is_ok() && !url.query_pairs().any(|(k, _)| k == "sslmode") {
         url.query_pairs_mut().append_pair("sslmode", "require");

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -20,8 +20,6 @@ pub enum AuthenticationSource {
 
 impl Middleware for CurrentUser {
     fn before(&self, req: &mut dyn Request) -> Result<(), Box<dyn Error + Send>> {
-        use std::mem::drop;
-
         // Check if the request has a session cookie with a `user_id` property inside
         let id = {
             req.session()

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -34,8 +34,6 @@ impl crate::util::MockCookieUser {
     /// As the currently logged in user, accept an invitation to become an owner of the named
     /// crate.
     fn accept_ownership_invitation(&self, krate_name: &str, krate_id: i32) {
-        use cargo_registry::views::InvitationResponse;
-
         let body = json!({
             "crate_owner_invite": {
                 "invited_by_username": "",


### PR DESCRIPTION
`unused_imports` now triggers for redundant imports.
`diesel::Connection` is part of `diesel::prelude`, `mem::drop` is part
of `std::prelude`, and `InvitationResponse` was explicitly imported at
the top of the file