### PR TITLE
Fix new instances caught by `clippy::redundant_closure`

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -1,5 +1,5 @@
 use std::panic::AssertUnwindSafe;
-use std::sync::{Mutex, MutexGuard};
+use std::sync::{Mutex, MutexGuard, PoisonError};
 
 use crate::db::{DieselPool, DieselPooledConn};
 use crate::git::Repository;
@@ -49,7 +49,7 @@ impl Environment {
     }
 
     pub fn lock_index(&self) -> CargoResult<MutexGuard<'_, Repository>> {
-        let repo = self.index.lock().unwrap_or_else(|e| e.into_inner());
+        let repo = self.index.lock().unwrap_or_else(PoisonError::into_inner);
         repo.reset_head()?;
         Ok(repo)
     }

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -153,8 +153,8 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
             .into_iter()
             .map(|(v, pb)| v.encodable(&krate.name, pb))
             .collect(),
-        keywords: kws.into_iter().map(|k| k.encodable()).collect(),
-        categories: cats.into_iter().map(|k| k.encodable()).collect(),
+        keywords: kws.into_iter().map(Keyword::encodable).collect(),
+        categories: cats.into_iter().map(Category::encodable).collect(),
     }))
 }
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -245,7 +245,7 @@ fn parse_new_headers(req: &mut dyn Request) -> CargoResult<(EncodableCrateUpload
 
     // Make sure required fields are provided
     fn empty(s: Option<&String>) -> bool {
-        s.map_or(true, |s| s.is_empty())
+        s.map_or(true, String::is_empty)
     }
     let mut missing = Vec::new();
 
@@ -255,7 +255,7 @@ fn parse_new_headers(req: &mut dyn Request) -> CargoResult<(EncodableCrateUpload
     if empty(new.license.as_ref()) && empty(new.license_file.as_ref()) {
         missing.push("license");
     }
-    if new.authors.iter().all(|s| s.is_empty()) {
+    if new.authors.iter().all(String::is_empty) {
         missing.push("authors");
     }
     if !missing.is_empty() {

--- a/src/email.rs
+++ b/src/email.rs
@@ -42,6 +42,7 @@ fn build_email(
         .map(|s| s.smtp_login.as_str())
         .unwrap_or("test@localhost");
 
+    #[allow(clippy::redundant_closure)]
     let email = Email::builder()
         .to(recipient)
         .from(sender)

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -87,7 +87,7 @@ impl Category {
                 .iter()
                 .cloned()
                 .filter(|s| !categories.iter().any(|c| c.slug == *s))
-                .map(|s| s.to_string())
+                .map(ToString::to_string)
                 .collect();
             let crate_categories = categories
                 .iter()

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -113,7 +113,7 @@ pub fn add_dependencies(
                 git::Dependency {
                     name,
                     req: dep.version_req.to_string(),
-                    features: dep.features.iter().map(|s| s.to_string()).collect(),
+                    features: dep.features.iter().map(|s| s.0.to_string()).collect(),
                     optional: dep.optional,
                     default_features: dep.default_features,
                     target: dep.target.clone(),

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -332,7 +332,7 @@ impl Crate {
         };
         let keyword_ids = keywords.map(|kws| kws.iter().map(|kw| kw.keyword.clone()).collect());
         let category_ids = categories.map(|cats| cats.iter().map(|cat| cat.slug.clone()).collect());
-        let badges = badges.map(|bs| bs.into_iter().map(|b| b.encodable()).collect());
+        let badges = badges.map(|bs| bs.into_iter().map(Badge::encodable).collect());
         let documentation = Crate::remove_blocked_documentation_urls(documentation);
 
         EncodableCrate {

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -70,7 +70,7 @@ impl Version {
                 authors: format!("/api/v1/crates/{}/{}/authors", crate_name, num),
             },
             crate_size,
-            published_by: published_by.map(|pb| pb.encodable_public()),
+            published_by: published_by.map(User::encodable_public),
         }
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -102,7 +102,7 @@ impl<'a> MarkdownRenderer<'a> {
         .cloned()
         .collect();
 
-        let sanitizer_base_url = base_url.map(|s| s.to_string());
+        let sanitizer_base_url = base_url.map(ToString::to_string);
 
         // Constrain the type of the closures given to the HTML sanitizer.
         fn constrain_closure<F>(f: F) -> F
@@ -124,7 +124,7 @@ impl<'a> MarkdownRenderer<'a> {
         fn is_media_url(url: &str) -> bool {
             Path::new(url)
                 .extension()
-                .and_then(|e| e.to_str())
+                .and_then(std::ffi::OsStr::to_str)
                 .map_or(false, |e| match e {
                     "png" | "svg" | "jpg" | "jpeg" | "gif" | "mp4" | "webm" | "ogg" => true,
                     _ => false,

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -358,7 +358,7 @@ impl GhUser {
             })
             .basic_auth(self.login, Some(password));
 
-        let mut response = t!(req.send().and_then(|r| r.error_for_status()));
+        let mut response = t!(req.send().and_then(reqwest::Response::error_for_status));
 
         #[derive(Deserialize)]
         struct Response {

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -33,7 +33,7 @@ pub trait CargoError: Send + fmt::Display + fmt::Debug + 'static {
                 }],
             }))
         } else {
-            self.cause().and_then(|cause| cause.response())
+            self.cause().and_then(CargoError::response)
         }
     }
     fn human(&self) -> bool {


### PR DESCRIPTION
The lint is more sensitive starting in 1.34 (currently in beta).  This
addresses the new warnings so that CI isn't affected after the release
next week.

There is one case that recommends using `failure::error::Error::compat`
however we do not currently include `failure` in our TOML file.  Rather
than add it just for this case, I've allowed the lint for this
expression.