### PR TITLE
Rename parsing category to parsing tools

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -354,7 +354,7 @@ Parsers implemented for particular formats or languages.\
 """
 
 [parsing]
-name = "Parsing"
+name = "Parsing tools"
 description = """
 Crates to help create parsers of binary and text \
 formats. Format-specific parsers belong in other, more specific \


### PR DESCRIPTION
The parsing and parser-implementations categories are commonly confused, since "parsing" correctly describes use of high-level parsers to parse specific formats, and doesn't sound related to low-level libraries for building parsers.
