### PR TITLE
travis-ci.org -> travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # crates.io
 
-[![Build Status](https://travis-ci.org/rust-lang/crates.io.svg?branch=master)](https://travis-ci.org/rust-lang/crates.io)
+[![Build Status](https://travis-ci.com/rust-lang/crates.io.svg?branch=master)](https://travis-ci.com/rust-lang/crates.io)
 [![What's Deployed](https://img.shields.io/badge/whatsdeployed-prod-green.svg)](https://whatsdeployed.io/s-9IG)
 
 Source code for the default [Cargo](http://doc.crates.io) registry. Viewable


### PR DESCRIPTION
https://docs.travis-ci.com/user/migrate/open-source-on-travis-ci-com/