### PR TITLE
Fix assertion error in Ember for version downloads

### DIFF
--- a/app/serializers/version-download.js
+++ b/app/serializers/version-download.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+    extractId(modelClass, resourceHash) {
+        return `${resourceHash.date}-${resourceHash.version}`;
+    },
+});


### PR DESCRIPTION
Fix the following assertion error that occurs when running the frontend in debug mode, which cause graphs to not display at all.

> Assertion Failed: You must include an 'id' for version-download in an object passed to 'push'

This has been happening since 3c92ca2b46a6fd166b4ae556b3d925907c85250c landed.

The fix involves telling Ember how to create a unique ID for a version-download object, using the composite key.

I haven't been able to confirm, but I believe this is the reason that graphs in production are only ever counting/displaying a single version. When using this change locally in debug mode against the live website, the downloads graphs are rendering correctly.

Fixes #1704.