### PR TITLE
Update `ember-page-title` to v4.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7362,6 +7362,15 @@
         "ember-maybe-import-regenerator": "^0.1.5"
       }
     },
+    "ember-copy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-copy/-/ember-copy-1.0.0.tgz",
+      "integrity": "sha512-aiZNAvOmdemHdvZNn0b5b/0d9g3JFpcOsrDgfhYEbfd7SzE0b69YiaVK2y3wjqfjuuiA54vOllGN4pjSzECNSw==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^6.6.0"
+      }
+    },
     "ember-data": {
       "version": "2.18.2",
       "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-2.18.2.tgz",
@@ -7791,26 +7800,15 @@
       }
     },
     "ember-page-title": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ember-page-title/-/ember-page-title-4.0.3.tgz",
-      "integrity": "sha512-Q6eTS4f00MGOVYqokA6sYwO8n5EWtUGwWNx1iqZwrpiWs5utsRz3nwYN/DfbBJJ/YCZSBpQezd3zvDvt1P32LA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/ember-page-title/-/ember-page-title-4.0.5.tgz",
+      "integrity": "sha512-coBzaaIs/WKhjosUjegyiiS7s4/mXGonTaG1hUFG2oOJfcVrPWjCml6NutkC9Gb2b3xsaUfbJv5IMNaynVzNSA==",
       "dev": true,
       "requires": {
-        "ember-cli-babel": "^6.7.1",
+        "ember-cli-babel": "^6.6.0",
         "ember-cli-head": "^0.4.0",
-        "ember-cli-htmlbars": "^2.0.1"
-      },
-      "dependencies": {
-        "ember-cli-head": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-head/-/ember-cli-head-0.4.0.tgz",
-          "integrity": "sha512-Z1Sfs7edjwsarksQdNIR7kSDKQ7jMapoeSmrTHXBGyFd43MjiMTaFd2BeZtXVxDEifHn7qOdCJmIJikvlbp71A==",
-          "dev": true,
-          "requires": {
-            "ember-cli-babel": "^6.1.0",
-            "ember-cli-htmlbars": "^2.0.1"
-          }
-        }
+        "ember-cli-htmlbars": "^2.0.1",
+        "ember-copy": "^1.0.0"
       }
     },
     "ember-percy": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-moment": "^7.5.0",
-    "ember-page-title": "^4.0.3",
+    "ember-page-title": "^4.0.5",
     "ember-percy": "^1.4.0",
     "ember-prism": "^0.2.0",
     "ember-resolver": "^4.1.0",


### PR DESCRIPTION
The main reason for this is that it deduplicates the `ember-cli-head` subdependency.