### PR TITLE
Clippy cleanups

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -44,7 +44,7 @@ impl Environment {
             .map(|(u, p)| (u.as_str(), p.as_str()))
     }
 
-    pub fn connection(&self) -> CargoResult<DieselPooledConn> {
+    pub fn connection(&self) -> CargoResult<DieselPooledConn<'_>> {
         self.connection_pool.0.get().map_err(Into::into)
     }
 

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -7,7 +7,7 @@
 // Usage:
 //      cargo run --bin background-worker
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 use cargo_registry::git::Repository;
 use cargo_registry::{background_jobs::*, db};

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -7,7 +7,7 @@
 // Usage:
 //      cargo run --bin background-worker
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 use cargo_registry::git::Repository;
 use cargo_registry::{background_jobs::*, db};

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -5,7 +5,7 @@
 // Usage:
 //      cargo run --bin delete-crate crate-name
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{db, models::Crate, schema::crates};
 use std::{

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -5,7 +5,7 @@
 // Usage:
 //      cargo run --bin delete-crate crate-name
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 use cargo_registry::{db, models::Crate, schema::crates};
 use std::{

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -5,7 +5,7 @@
 // Usage:
 //      cargo run --bin delete-version crate-name version-number
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{
     db,

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -5,7 +5,7 @@
 // Usage:
 //      cargo run --bin delete-version crate-name version-number
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 use cargo_registry::{
     db,

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -4,7 +4,7 @@
 //! Usage:
 //!     cargo run --bin monitor
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 mod on_call;
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -4,7 +4,7 @@
 //! Usage:
 //!     cargo run --bin monitor
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 mod on_call;
 

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -4,7 +4,7 @@
 // Usage:
 //      cargo run --bin populate version_id1 version_id2 ...
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{db, schema::version_downloads};
 use std::env;

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -4,7 +4,7 @@
 // Usage:
 //      cargo run --bin populate version_id1 version_id2 ...
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 use cargo_registry::{db, schema::version_downloads};
 use std::env;

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -3,7 +3,7 @@
 //
 // Warning: this can take a lot of time.
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 #[macro_use]
 extern crate serde;

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -3,7 +3,7 @@
 //
 // Warning: this can take a lot of time.
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 #[macro_use]
 extern crate serde;

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 use cargo_registry::{boot, App, Env};
 use jemalloc_ctl;

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{boot, App, Env};
 use jemalloc_ctl;

--- a/src/bin/test-pagerduty.rs
+++ b/src/bin/test-pagerduty.rs
@@ -5,7 +5,7 @@
 //!
 //! Event type can be trigger, acknowledge, or resolve
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 mod on_call;
 

--- a/src/bin/test-pagerduty.rs
+++ b/src/bin/test-pagerduty.rs
@@ -5,7 +5,7 @@
 //!
 //! Event type can be trigger, acknowledge, or resolve
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 mod on_call;
 

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -3,7 +3,7 @@
 // Usage:
 //      cargo run --bin transfer-crates from-user to-user
 
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{
     db,

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -3,7 +3,7 @@
 // Usage:
 //      cargo run --bin transfer-crates from-user to-user
 
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 use cargo_registry::{
     db,

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 #[macro_use]
 extern crate diesel;

--- a/src/bin/update-downloads.rs
+++ b/src/bin/update-downloads.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 #[macro_use]
 extern crate diesel;

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,7 +18,7 @@ pub enum DieselPool {
 }
 
 impl DieselPool {
-    pub fn get(&self) -> CargoResult<DieselPooledConn> {
+    pub fn get(&self) -> CargoResult<DieselPooledConn<'_>> {
         match self {
             DieselPool::Pool(pool) => Ok(DieselPooledConn::Pool(pool.get()?)),
             DieselPool::Test(conn) => Ok(DieselPooledConn::Test(conn.lock())),
@@ -89,11 +89,11 @@ pub trait RequestTransaction {
     ///
     /// The connection will live for the lifetime of the request.
     // FIXME: This description does not match the implementation below.
-    fn db_conn(&self) -> CargoResult<DieselPooledConn>;
+    fn db_conn(&self) -> CargoResult<DieselPooledConn<'_>>;
 }
 
 impl<T: Request + ?Sized> RequestTransaction for T {
-    fn db_conn(&self) -> CargoResult<DieselPooledConn> {
+    fn db_conn(&self) -> CargoResult<DieselPooledConn<'_>> {
         self.app().diesel_database.get().map_err(Into::into)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! All implemented routes are defined in the [middleware](fn.middleware.html) function and
 //! implemented in the [category](category/index.html), [keyword](keyword/index.html),
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 #![deny(missing_debug_implementations, missing_copy_implementations)]
 #![deny(bare_trait_objects)]
 #![recursion_limit = "256"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! All implemented routes are defined in the [middleware](fn.middleware.html) function and
 //! implemented in the [category](category/index.html), [keyword](keyword/index.html),
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 #![deny(missing_debug_implementations, missing_copy_implementations)]
 #![deny(bare_trait_objects)]
 #![recursion_limit = "256"]

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 extern crate base64;
 extern crate chrono;

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 extern crate base64;
 extern crate chrono;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, clippy::all)]
+#![deny(warnings, clippy::all, rust_2018_idioms)]
 
 #[macro_use]
 extern crate diesel;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,4 +1,10 @@
 #![deny(warnings, clippy::all, rust_2018_idioms)]
+// TODO: Remove after we can bump to Rust 1.35 stable in `RustConfig`
+#![allow(
+    renamed_and_removed_lints,
+    clippy::cyclomatic_complexity,
+    clippy::unknown_clippy_lints
+)]
 
 #[macro_use]
 extern crate diesel;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, clippy::all)]
 
 #[macro_use]
 extern crate diesel;

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -74,7 +74,7 @@ fn show() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn update_crate() {
     let (_b, app, middle) = app();
     let mut req = req(Method::Get, "/api/v1/categories/foo");

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -95,7 +95,7 @@ fn index() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn index_queries() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
@@ -316,7 +316,7 @@ fn index_sorting() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn exact_match_on_queries_with_sort() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
@@ -1459,7 +1459,7 @@ fn yank_not_owner() {
 }
 
 #[test]
-#[allow(clippy::cyclomatic_complexity)]
+#[allow(clippy::cognitive_complexity)]
 fn yank_max_version() {
     let (_, anon, _, token) = TestApp::with_proxy().with_token();
 


### PR DESCRIPTION
This series first addresses a warning now produced on nightly.  Then `clippy::all` and `rust_2018_idioms` are explicitly denied for all lib, bin, and test artifacts.

By denying `clippy::all`, the RLS will automatically show clippy warnings in an IDE.  This only affects the RLS and `cargo clippy --all-targets` should still used in a command line workflow.