### PR TITLE
Add attributes.tld for TravisCI badge

### DIFF
--- a/app/components/badge-travis-ci.js
+++ b/app/components/badge-travis-ci.js
@@ -6,6 +6,17 @@ export default Component.extend({
     tagName: 'span',
     classNames: ['badge'],
     repository: alias('badge.attributes.repository'),
+    tld: computed('badge.attributes.tld', function() {
+        let tld = this.get('badge.attributes.tld');
+        switch (tld) {
+            case 'org':
+                return 'org';
+            case 'com':
+                return 'com';
+            default:
+                return 'org';
+        }
+    }),
     branch: computed('badge.attributes.branch', function() {
         return this.get('badge.attributes.branch') || 'master';
     }),

--- a/app/templates/components/badge-travis-ci.hbs
+++ b/app/templates/components/badge-travis-ci.hbs
@@ -1,6 +1,6 @@
-<a href="https://travis-ci.org/{{ repository }}">
+<a href="https://travis-ci.{{ tld }}/{{ repository }}">
     <img
-        src="https://travis-ci.org/{{ repository }}.svg?branch={{ branch }}"
+        src="https://travis-ci.{{ tld }}/{{ repository }}.svg?branch={{ branch }}"
         alt="{{ text }}"
         title="{{ text }}">
 </a>

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -26,6 +26,7 @@ pub enum Badge {
     TravisCi {
         repository: String,
         branch: Option<String>,
+        tld: Option<String>,
     },
     Appveyor {
         repository: String,

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -69,10 +69,12 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
     let travis_ci = Badge::TravisCi {
         branch: Some(String::from("beta")),
         repository: String::from("rust-lang/rust"),
+        tld: Some(String::from("org")),
     };
     let mut badge_attributes_travis_ci = HashMap::new();
     badge_attributes_travis_ci.insert(String::from("branch"), String::from("beta"));
     badge_attributes_travis_ci.insert(String::from("repository"), String::from("rust-lang/rust"));
+    badge_attributes_travis_ci.insert(String::from("tld"), String::from("org"));
 
     let gitlab = Badge::GitLab {
         branch: Some(String::from("beta")),
@@ -342,6 +344,7 @@ fn update_attributes() {
     let travis_ci2 = Badge::TravisCi {
         branch: None,
         repository: String::from("rust-lang/rust"),
+        tld: None,
     };
     let mut badge_attributes_travis_ci2 = HashMap::new();
     badge_attributes_travis_ci2.insert(String::from("repository"), String::from("rust-lang/rust"));


### PR DESCRIPTION
Issue: https://github.com/rust-lang/crates.io/issues/1392

Idea from https://github.com/livioribeiro/cargo-readme/pull/29/files:

```
[badges]
travis-ci = { repository = "tox-rs/tox", tld = "com" }
```

Is there a parser for attributes where I can check whether tld equals to "org" or "com"?

How do I write tests for js renderer to make sure there are only travis-ci.org/com domains?