### PR TITLE
Fix import for serializeQueryParams from ember-fetch.

### DIFF
--- a/app/routes/github-authorize.js
+++ b/app/routes/github-authorize.js
@@ -1,6 +1,6 @@
 import Route from '@ember/routing/route';
 import fetch from 'fetch';
-import { serializeQueryParams } from 'ember-fetch/mixins/adapter-fetch';
+import { serializeQueryParams } from 'ember-fetch/utils/serialize-query-params';
 
 /**
  * This route will be called from the GitHub OAuth flow once the user has


### PR DESCRIPTION
The Github login is currently broken. The bug was introduced by upgrading ember-fetch in #1733.

This fix imports `serializeQueryParams` from its new location, which fixes the Github login for me. To verify, I followed the instructions in `docs/CONTRIBUTING.md`.

Clearly test coverage is insufficient. I'm happy to add tests as desired, but would like to get feedback what kind of test you suggest first.