### PR TITLE
Only draw chart on crates page once Google Charts has been loaded.

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -72,6 +72,9 @@ export default Component.extend({
 
         let show = data && window.google && window.googleChartsLoaded;
         this.element.style.display = show ? '' : 'none';
+        if (!show) {
+            return;
+        }
 
         let myData = window.google.visualization.arrayToDataTable(data);
 


### PR DESCRIPTION
The acceptance tests are failing for me when running them locally. Some tests error out with an error like this
```
not ok 122 Chrome 74.0 - [undefined ms] - Global error: Uncaught TypeError: window.google.visualization.arrayToDataTable is not a function at http://localhost:7357/assets/cargo.js, line 682
 While executing test: Acceptance | crate page: /crates/:crate is accessible
    ---
        browser log: |
            testContext: [object Object]
            ERROR: Uncaught TypeError: window.google.visualization.arrayToDataTable is not a function at http://localhost:7357/assets/cargo.js, line 682
            
    ...
```
while other tests time out (with a ridiculously long timeout of like three minutes per test). I get similar errors in the JavaScript console when loading the live version of crates.io in Chrome 74, though the page renders just fine.

Looking at the code, the errors are expected. The `didRender()` hook is triggered by the initial rendering of the corresponding element, regardless of whether the Google Charts library has already been completely loaded. I seem to be on a slower internet connection than most other people running these tests, so for me the Google Charts library is usually not loaded at that point. However, the current code goes ahead with calls to the library even if it isn't loaded. This trivial fix simply exits early if the lib isn't loaded yet, because in that case there is no point in doing any further work. This fixed the acceptance tests for me, and also gets rid of the logged error in the Chrome JS console when loading the page.