### PR TITLE
Fingerprinting SVGs

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -31,6 +31,9 @@ module.exports = function(defaults) {
         sassOptions: {
             includePaths: ['node_modules/normalize.css'],
         },
+        fingerprint: {
+            extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'ttf', 'woff', 'woff2'],
+        },
     });
 
     // Use `app.import` to add additional libraries to the generated


### PR DESCRIPTION
In the production build all the SVGs are copied into dist/assets without fingerprints. All other assets have fingerprints. Since all files in dist/assets are served with far-future cache headers there would be cache issues if the files were ever updated. This is not major issue as these files are not used in normal operations.

Closes #1575