### PR TITLE
Return correct download link for requests for non-standard crate names.

### DIFF
--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1311,6 +1311,23 @@ fn download_nonexistent_version_of_existing_crate_404s() {
 }
 
 #[test]
+fn download_noncanonical_crate_name() {
+    let (app, anon, user) = TestApp::init().with_user();
+    let user = user.as_model();
+
+    app.db(|conn| {
+        CrateBuilder::new("foo_download", user.id)
+            .version(VersionBuilder::new("1.0.0"))
+            .expect_build(conn);
+    });
+
+    // Request download for "foo-download" with a dash instead of an underscore,
+    // and assert that the correct download link is returned.
+    anon.get::<()>("/api/v1/crates/foo-download/1.0.0/download")
+        .assert_redirect_ends_with("/crates/foo_download/foo_download-1.0.0.crate");
+}
+
+#[test]
 fn dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -556,6 +556,11 @@ where
         assert_eq!(status, self.response.status.0);
         self
     }
+
+    pub fn assert_redirect_ends_with(&self, target: &str) -> &Self {
+        assert!(self.response.headers["Location"][0].ends_with(target));
+        self
+    }
 }
 
 impl Response<()> {


### PR DESCRIPTION
Fixes #1687.

Crates are uploaded to S3 under the name they were first published as, but the download endpoint always uses the name as written in the request. If these names differ in their use of dashes vs. underscores, the download endpoint returns an invalid link.

To avoid adding another database request for every single crate download, this fix changes the database request that updates the download count to also return the original crate name. We will need to confirm that the performance impact of this change is negligible.
