### PR TITLE
Show right-hand column for yanked versions to crate owners.

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -33,6 +33,11 @@ export default Controller.extend({
     isOwner: computed('crate.owner_user', 'session.currentUser.id', function() {
         return this.get('crate.owner_user').findBy('id', this.get('session.currentUser.id'));
     }),
+    notYankedOrIsOwner: computed('model', 'crate.owner_user', 'session.currentUser.id', function() {
+        return (
+            !this.get('model').yanked || this.get('crate.owner_user').findBy('id', this.get('session.currentUser.id'))
+        );
+    }),
 
     sortedVersions: readOnly('crate.versions'),
 

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -51,20 +51,18 @@
     </div>
 </div>
 
-{{#if currentVersion.yanked}}
-    <div class='crate-info'>
-        <div>
-        <p>This crate has been yanked, but it is still available for download for
-        other crates that may be depending on it.</p>
-        <p>You may wish to
-          {{#link-to 'crate.versions' crate}}view all versions{{/link-to}} to find one that
-          has not been yanked.
-        </p>
-        </div>
-    </div>
-{{else}}
 <div class='crate-info'>
     <div class='docs'>
+        {{#if currentVersion.yanked}}
+        <p>
+            This crate has been yanked, but it is still available for download for other crates that
+            may be depending on it.
+        </p>
+        <p>
+            You may wish to {{#link-to 'crate.versions' crate}}view all versions{{/link-to}} to find
+            one that has not been yanked.
+        </p>
+        {{else}}
         <div class='install'>
             <div class='action'>Cargo.toml</div>
             <code id="crate-toml">{{ crate.name }} = "{{ currentVersion.num }}"</code>
@@ -99,7 +97,9 @@
                 </div>
             {{/if}}
         {{/if}}
+        {{/if}}
     </div>
+    {{#if notYankedOrIsOwner}}
     <section class='authorship' aria-label="Crate metadata">
         <div class='top'>
             <div>
@@ -240,8 +240,10 @@
             {{/if}}
         </div>
     </section>
+    {{/if}}
 </div>
 
+{{#unless currentVersion.yanked}}
 <div id='crate-downloads'>
     <div class='stats'>
         <h3>Stats Overview</h3>
@@ -293,4 +295,4 @@
         {{download-graph data=downloadData}}
     </div>
 </div>
-{{/if}}
+{{/unless}}

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -43,9 +43,9 @@
             <li><a href="{{crate.repository}}">Repository</a></li>
         {{/if}}
         <li>
-          {{#link-to 'crate.reverse-dependencies' (query-params dependency=crate.crate_id) data-test-reverse-deps-link=true}}
-            Dependent crates
-          {{/link-to}}
+            {{#link-to 'crate.reverse-dependencies' (query-params dependency=crate.crate_id) data-test-reverse-deps-link=true}}
+                Dependent crates
+            {{/link-to}}
         </li>
     </ul>
     </div>
@@ -54,245 +54,243 @@
 <div class='crate-info'>
     <div class='docs'>
         {{#if currentVersion.yanked}}
-        <p>
-            This crate has been yanked, but it is still available for download for other crates that
-            may be depending on it.
-        </p>
-        <p>
-            You may wish to {{#link-to 'crate.versions' crate}}view all versions{{/link-to}} to find
-            one that has not been yanked.
-        </p>
+            <p>
+                This crate has been yanked, but it is still available for download for other crates that
+                may be depending on it.
+            </p>
+            <p>
+                You may wish to {{#link-to 'crate.versions' crate}}view all versions{{/link-to}} to find
+                one that has not been yanked.
+            </p>
         {{else}}
-        <div class='install'>
-            <div class='action'>Cargo.toml</div>
-            <code id="crate-toml">{{ crate.name }} = "{{ currentVersion.num }}"</code>
-
-            {{#if (is-clipboard-supported)}}
-              {{#copy-button clipboardTarget="#crate-toml" success=(action 'copySuccess') error=(action 'copyError') title="Copy to clipboard"}}
-                    {{svg-jar "copy" alt="Copy to clipboard"}}
-                {{/copy-button}}
-            {{/if}}
-
-        </div>
-        <div class="copy-result">
-            <span id="copy-notification" class="{{if showSuccess "copy-success" "copy-failure"}}">
-                {{#if showNotification}}
-                    {{#if showSuccess}}
-                        Copied!
-                    {{else}}
-                        An error occured. Please use CTRL+C.
-                    {{/if}}
+            <div class='install'>
+                <div class='action'>Cargo.toml</div>
+                <code id="crate-toml">{{ crate.name }} = "{{ currentVersion.num }}"</code>
+                {{#if (is-clipboard-supported)}}
+                    {{#copy-button clipboardTarget="#crate-toml" success=(action 'copySuccess') error=(action 'copyError') title="Copy to clipboard"}}
+                        {{svg-jar "copy" alt="Copy to clipboard"}}
+                    {{/copy-button}}
                 {{/if}}
-            </span>
-        </div>
-        {{#if crate.readme}}
-            <section class="crate-readme" aria-label="Readme">
-                {{crate-readme rendered=crate.readme}}
-            </section>
-        {{else}}
-            {{#if crate.description}}
-                <div class='about'>
-                    <h3>About This Package</h3>
-                    <p>{{ crate.description }}</p>
-                </div>
-            {{/if}}
-        {{/if}}
-        {{/if}}
-    </div>
-    {{#if notYankedOrIsOwner}}
-    <section class='authorship' aria-label="Crate metadata">
-        <div class='top'>
-            <div>
-                <div class='last-update'><span class='small'>Last Updated</span></div>
-                <div class='{{if currentVersion.crate_size 'date-with-small-margin-bot' 'date'}}'>{{moment-from-now crate.updated_at}}</div>
-                {{#each crate.annotated_badges as |badge|}}
-                    <p>
-                        {{component badge.component_name badge=badge}}
-                    </p>
-                {{/each}}
             </div>
-
-            {{#if currentVersion.crate_size}}
-                <div>
-                    <div class='crate-size'><span class='small'>Crate Size</span></div>
-                    <div class='size'>{{format-crate-size currentVersion.crate_size}}</div>
-                </div>
-            {{/if}}
-
-            <div class="authors">
-                <h3>Authors</h3>
-                <ul>
-                    {{#each displayedAuthors as |author|}}
-                        <li>{{ format-email author.name }}</li>
-                    {{/each}}
-                </ul>
-            </div>
-        </div>
-
-        <div class='bottom'>
-            {{#if currentVersion.license}}
-                <div>
-                    <h3>License</h3>
-                    <p class="license" data-test-license>{{ currentVersion.license }}</p>
-                </div>
-            {{/if}}
-
-            {{#unless crate.keywords.isPending}}
-                {{#if anyKeywords}}
-                    <div>
-                        <h3>Keywords</h3>
-                        <ul class='keywords'>
-                            {{#each keywords as |keyword|}}
-                                <li>{{link-to keyword.id 'keyword' keyword}}</li>
-                            {{/each}}
-                        </ul>
-                    </div>
-                {{/if}}
-            {{/unless}}
-
-            {{#unless crate.categories.isPending}}
-                {{#if anyCategories}}
-                    <div>
-                        <h3>Categories</h3>
-                        <ul class='categories'>
-                            {{#each categories as |category|}}
-                                <li>{{link-to category.category 'category' category.slug}}</li>
-                            {{/each}}
-                        </ul>
-                    </div>
-                {{/if}}
-            {{/unless}}
-
-            <div id='crate-owners'>
-                <h3>Owners</h3>
-
-                {{#if isOwner}}
-                <p>
-                    {{#link-to 'crate.owners' crate}}
-                        Manage owners
-                    {{/link-to}}
-                </p>
-                {{/if}}
-
-                <ul class='owners' data-test-owners>
-                   {{#each crate.owner_team as |team|}}
-                        <li>
-                            {{#link-to team.kind team.login data-test-team-link=team.login}}
-                                {{user-avatar user=team size='medium-small'}}
-                            {{/link-to}}
-                        </li>
-                    {{/each}}
-
-                    {{#each crate.owner_user as |user|}}
-                        <li>
-                            {{#link-to user.kind user.login data-test-user-link=user.login}}
-                                {{user-avatar user=user size='medium-small'}}
-                            {{/link-to}}
-                        </li>
-                    {{/each}}
-                </ul>
-            </div>
-
-            <div class='section' id='crate-versions' data-test-versions>
-                <h3>Versions</h3>
-                <ul>
-                    {{#each smallSortedVersions as |version|}}
-                        <li>
-                            {{#link-to 'crate.version' version.num data-test-version-link=version.num}}
-                                {{ version.num }}
-                            {{/link-to}}
-                            <span class='date'>{{moment-format version.created_at 'll'}}</span>
-                            {{#if version.yanked}}
-                                <span class='yanked'>yanked</span>
-                            {{/if}}
-                        </li>
-                    {{/each}}
-                </ul>
-                <span class='small'>
-                    {{#if hasMoreVersions}}
-                        {{#link-to 'crate.versions' crate data-test-all-versions-link=true}}
-                            show all {{ crate.versions.length }} versions
-                        {{/link-to}}
+            <div class="copy-result">
+                <span id="copy-notification" class="{{if showSuccess "copy-success" "copy-failure"}}">
+                    {{#if showNotification}}
+                        {{#if showSuccess}}
+                            Copied!
+                        {{else}}
+                            An error occured. Please use CTRL+C.
+                        {{/if}}
                     {{/if}}
                 </span>
             </div>
+            {{#if crate.readme}}
+                <section class="crate-readme" aria-label="Readme">
+                    {{crate-readme rendered=crate.readme}}
+                </section>
+            {{else}}
+                {{#if crate.description}}
+                    <div class='about'>
+                        <h3>About This Package</h3>
+                        <p>{{ crate.description }}</p>
+                    </div>
+                {{/if}}
+            {{/if}}
+        {{/if}}
+    </div>
+    {{#if notYankedOrIsOwner}}
+        <section class='authorship' aria-label="Crate metadata">
+            <div class='top'>
+                <div>
+                    <div class='last-update'><span class='small'>Last Updated</span></div>
+                    <div class='{{if currentVersion.crate_size 'date-with-small-margin-bot' 'date'}}'>{{moment-from-now crate.updated_at}}</div>
+                    {{#each crate.annotated_badges as |badge|}}
+                        <p>
+                            {{component badge.component_name badge=badge}}
+                        </p>
+                    {{/each}}
+                </div>
 
-            <div class='section' id='crate-dependencies'>
-                <h3>Dependencies</h3>
-                    <ul>
-                        {{#each currentDependencies as |dep|}}
-                            {{link-to-dep tagName="li" dep=dep}}
-                        {{else}}
-                            <li>None</li>
-                        {{/each}}
-                    </ul>
-            </div>
+                {{#if currentVersion.crate_size}}
+                    <div>
+                        <div class='crate-size'><span class='small'>Crate Size</span></div>
+                        <div class='size'>{{format-crate-size currentVersion.crate_size}}</div>
+                    </div>
+                {{/if}}
 
-            {{#if currentDevDependencies}}
-                <div class='section' id='crate-dev-dependencies'>
-                    <h3>Dev-Dependencies</h3>
+                <div class="authors">
+                    <h3>Authors</h3>
                     <ul>
-                        {{#each currentDevDependencies as |dep|}}
-                            {{link-to-dep tagName="li" dep=dep}}
+                        {{#each displayedAuthors as |author|}}
+                            <li>{{ format-email author.name }}</li>
                         {{/each}}
                     </ul>
                 </div>
-            {{/if}}
-        </div>
-    </section>
+            </div>
+
+            <div class='bottom'>
+                {{#if currentVersion.license}}
+                    <div>
+                        <h3>License</h3>
+                        <p class="license" data-test-license>{{ currentVersion.license }}</p>
+                    </div>
+                {{/if}}
+
+                {{#unless crate.keywords.isPending}}
+                    {{#if anyKeywords}}
+                        <div>
+                            <h3>Keywords</h3>
+                            <ul class='keywords'>
+                                {{#each keywords as |keyword|}}
+                                    <li>{{link-to keyword.id 'keyword' keyword}}</li>
+                                {{/each}}
+                            </ul>
+                        </div>
+                    {{/if}}
+                {{/unless}}
+
+                {{#unless crate.categories.isPending}}
+                    {{#if anyCategories}}
+                        <div>
+                            <h3>Categories</h3>
+                            <ul class='categories'>
+                                {{#each categories as |category|}}
+                                    <li>{{link-to category.category 'category' category.slug}}</li>
+                                {{/each}}
+                            </ul>
+                        </div>
+                    {{/if}}
+                {{/unless}}
+
+                <div id='crate-owners'>
+                    <h3>Owners</h3>
+
+                    {{#if isOwner}}
+                    <p>
+                        {{#link-to 'crate.owners' crate}}
+                            Manage owners
+                        {{/link-to}}
+                    </p>
+                    {{/if}}
+
+                    <ul class='owners' data-test-owners>
+                    {{#each crate.owner_team as |team|}}
+                            <li>
+                                {{#link-to team.kind team.login data-test-team-link=team.login}}
+                                    {{user-avatar user=team size='medium-small'}}
+                                {{/link-to}}
+                            </li>
+                        {{/each}}
+
+                        {{#each crate.owner_user as |user|}}
+                            <li>
+                                {{#link-to user.kind user.login data-test-user-link=user.login}}
+                                    {{user-avatar user=user size='medium-small'}}
+                                {{/link-to}}
+                            </li>
+                        {{/each}}
+                    </ul>
+                </div>
+
+                <div class='section' id='crate-versions' data-test-versions>
+                    <h3>Versions</h3>
+                    <ul>
+                        {{#each smallSortedVersions as |version|}}
+                            <li>
+                                {{#link-to 'crate.version' version.num data-test-version-link=version.num}}
+                                    {{ version.num }}
+                                {{/link-to}}
+                                <span class='date'>{{moment-format version.created_at 'll'}}</span>
+                                {{#if version.yanked}}
+                                    <span class='yanked'>yanked</span>
+                                {{/if}}
+                            </li>
+                        {{/each}}
+                    </ul>
+                    <span class='small'>
+                        {{#if hasMoreVersions}}
+                            {{#link-to 'crate.versions' crate data-test-all-versions-link=true}}
+                                show all {{ crate.versions.length }} versions
+                            {{/link-to}}
+                        {{/if}}
+                    </span>
+                </div>
+
+                <div class='section' id='crate-dependencies'>
+                    <h3>Dependencies</h3>
+                        <ul>
+                            {{#each currentDependencies as |dep|}}
+                                {{link-to-dep tagName="li" dep=dep}}
+                            {{else}}
+                                <li>None</li>
+                            {{/each}}
+                        </ul>
+                </div>
+
+                {{#if currentDevDependencies}}
+                    <div class='section' id='crate-dev-dependencies'>
+                        <h3>Dev-Dependencies</h3>
+                        <ul>
+                            {{#each currentDevDependencies as |dep|}}
+                                {{link-to-dep tagName="li" dep=dep}}
+                            {{/each}}
+                        </ul>
+                    </div>
+                {{/if}}
+            </div>
+        </section>
     {{/if}}
 </div>
 
 {{#unless currentVersion.yanked}}
-<div id='crate-downloads'>
-    <div class='stats'>
-        <h3>Stats Overview</h3>
-        <div class='stat'>
-            <span class='num'>
-                {{svg-jar "download"}}
-                <span class="num__align">{{ format-num downloadsContext.downloads }}</span>
-            </span>
-            <span class='desc small'>Downloads all time</span>
+    <div id='crate-downloads'>
+        <div class='stats'>
+            <h3>Stats Overview</h3>
+            <div class='stat'>
+                <span class='num'>
+                    {{svg-jar "download"}}
+                    <span class="num__align">{{ format-num downloadsContext.downloads }}</span>
+                </span>
+                <span class='desc small'>Downloads all time</span>
+            </div>
+            <div class='stat'>
+                <span class="{{if crate.versions.isPending 'loading'}} num">
+                    {{svg-jar "crate"}}
+                <span class="num__align">{{ crate.versions.length }}</span>
+                </span>
+                <span class='desc small'>Versions published</span>
+            </div>
         </div>
-        <div class='stat'>
-            <span class="{{if crate.versions.isPending 'loading'}} num">
-                {{svg-jar "crate"}}
-            <span class="num__align">{{ crate.versions.length }}</span>
-            </span>
-            <span class='desc small'>Versions published</span>
-        </div>
-    </div>
 
-    <div class='versions'>
-        <span class='small'>Showing stats for</span>
+        <div class='versions'>
+            <span class='small'>Showing stats for</span>
 
-        {{#rl-dropdown-container class="button-holder"}}
-            {{#rl-dropdown-toggle class="tan-button dropdown"}}
-                {{#if requestedVersion}}
-                    {{ requestedVersion }}
-                {{else}}
-                    All Versions
-                {{/if}}
-                <span class='arrow'></span>
-            {{/rl-dropdown-toggle}}
+            {{#rl-dropdown-container class="button-holder"}}
+                {{#rl-dropdown-toggle class="tan-button dropdown"}}
+                    {{#if requestedVersion}}
+                        {{ requestedVersion }}
+                    {{else}}
+                        All Versions
+                    {{/if}}
+                    <span class='arrow'></span>
+                {{/rl-dropdown-toggle}}
 
-            {{#rl-dropdown id="all-versions" tagName="ul" class="dropdown" closeOnChildClick="a:link"}}
-                <li class='all'>
-                    {{#link-to 'crate.version' 'all'}}All Versions{{/link-to}}
-                </li>
-                {{#each smallSortedVersions as |version|}}
-                    <li>
-                        {{#link-to 'crate.version' version.num}}
-                            {{ version.num }}
-                        {{/link-to}}
+                {{#rl-dropdown id="all-versions" tagName="ul" class="dropdown" closeOnChildClick="a:link"}}
+                    <li class='all'>
+                        {{#link-to 'crate.version' 'all'}}All Versions{{/link-to}}
                     </li>
-                {{/each}}
-            {{/rl-dropdown}}
-        {{/rl-dropdown-container}}
+                    {{#each smallSortedVersions as |version|}}
+                        <li>
+                            {{#link-to 'crate.version' version.num}}
+                                {{ version.num }}
+                            {{/link-to}}
+                        </li>
+                    {{/each}}
+                {{/rl-dropdown}}
+            {{/rl-dropdown-container}}
+        </div>
+        <div class='graph'>
+            <h4>Downloads over the last 90 days</h4>
+            {{download-graph data=downloadData}}
+        </div>
     </div>
-    <div class='graph'>
-        <h4>Downloads over the last 90 days</h4>
-        {{download-graph data=downloadData}}
-    </div>
-</div>
 {{/unless}}

--- a/tests/unit/controllers/crate/version-test.js
+++ b/tests/unit/controllers/crate/version-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { A } from '@ember/array';
+import Service from '@ember/service';
+
+module('Unit | Controller | crate/version', function(hooks) {
+    setupTest(hooks);
+    const userId = 1;
+    // stub the session service
+    // https://guides.emberjs.com/release/testing/testing-components/#toc_stubbing-services
+    const sessionStub = Service.extend();
+
+    hooks.beforeEach(function() {
+        sessionStub.currentUser = { id: userId };
+        this.owner.register('service:session', sessionStub);
+    });
+
+    test('notYankedOrIsOwner is true when conditions fulfilled', function(assert) {
+        assert.expect(2);
+        let controller = this.owner.lookup('controller:crate/version');
+        controller.model = { yanked: false };
+        controller.crate = { owner_user: A([{ id: userId }]) };
+        assert.ok(controller);
+        assert.ok(controller.notYankedOrIsOwner);
+    });
+
+    test('notYankedOrIsOwner is false when conditions fulfilled', function(assert) {
+        assert.expect(2);
+        let controller = this.owner.lookup('controller:crate/version');
+        controller.model = { yanked: true };
+        controller.crate = { owner_user: A([{ id: userId }]) };
+        assert.ok(controller);
+        assert.notOk(controller.notYankedOrIsOwner);
+    });
+});


### PR DESCRIPTION
Fixes #1660.

Without this change, the page for a yanked version looks like this:

![image](https://user-images.githubusercontent.com/249196/58944345-ec823d00-8781-11e9-9322-019250a6fb1d.png)

With this change applied, crate owners see this page instead:

![image](https://user-images.githubusercontent.com/249196/58944390-0de32900-8782-11e9-9c58-ac649c9c23c0.png)