### PR TITLE
Rerun the build script if `.env` has been changed.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,15 +1,13 @@
 use diesel::prelude::*;
 use diesel_migrations::run_pending_migrations;
-use dotenv::dotenv;
 use std::env;
 
 fn main() {
     println!("cargo:rerun-if-env-changed=TEST_DATABASE_URL");
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=.env");
     println!("cargo:rerun-if-changed=migrations/");
     if env::var("PROFILE") == Ok("debug".into()) {
-        let _ = dotenv();
-        if let Ok(database_url) = env::var("TEST_DATABASE_URL") {
+        if let Ok(database_url) = dotenv::var("TEST_DATABASE_URL") {
             let connection = PgConnection::establish(&database_url)
                 .expect("Could not connect to TEST_DATABASE_URL");
             run_pending_migrations(&connection).expect("Error running migrations");


### PR DESCRIPTION
Edits to `.env` may alter the value of the `TEST_DATABASE_URL` environment variable, so we should
rerun the build script if `.env` was changed. The build script is already configured to be rerun
when the value of `TEST_DATABASE_URL` changes, but the current setup does not capture changes
performed via `.env`, since the environment file is only loaded at runtime of the build script.

This change also removes the redundant `cargo:rerun-if-changed=build.rs`; the build script is always
rerun if it is changed.