### PR TITLE
Support Cirrus CI badges

### DIFF
--- a/app/components/badge-cirrus-ci.js
+++ b/app/components/badge-cirrus-ci.js
@@ -1,0 +1,15 @@
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import Component from '@ember/component';
+
+export default Component.extend({
+    tagName: 'span',
+    classNames: ['badge'],
+    repository: alias('badge.attributes.repository'),
+    branch: computed('badge.attributes.branch', function() {
+        return encodeURIComponent(this.get('badge.attributes.branch') || 'master');
+    }),
+    text: computed('branch', function() {
+        return `Cirrus CI build status for the ${this.branch} branch`;
+    }),
+});

--- a/app/templates/components/badge-cirrus-ci.hbs
+++ b/app/templates/components/badge-cirrus-ci.hbs
@@ -1,0 +1,6 @@
+<a href="https://cirrus-ci.com/github/{{ repository }}">
+    <img
+        src="https://api.cirrus-ci.com/github/{{ repository }}.svg?branch={{ branch }}"
+        alt="{{ text }}"
+        title="{{ text }}">
+</a>

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -48,6 +48,10 @@ pub enum Badge {
         repository: String,
         branch: Option<String>,
     },
+    CirrusCi {
+        repository: String,
+        branch: Option<String>,
+    },
     IsItMaintainedIssueResolution {
         repository: String,
     },

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -21,6 +21,8 @@ struct BadgeRef {
     coveralls_attributes: HashMap<String, String>,
     circle_ci: Badge,
     circle_ci_attributes: HashMap<String, String>,
+    cirrus_ci: Badge,
+    cirrus_ci_attributes: HashMap<String, String>,
     maintenance: Badge,
     maintenance_attributes: HashMap<String, String>,
 }
@@ -134,6 +136,14 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
     badge_attributes_circle_ci.insert(String::from("branch"), String::from("beta"));
     badge_attributes_circle_ci.insert(String::from("repository"), String::from("rust-lang/rust"));
 
+    let cirrus_ci = Badge::CirrusCi {
+        repository: String::from("rust-lang/rust"),
+        branch: Some(String::from("beta")),
+    };
+    let mut badge_attributes_cirrus_ci = HashMap::new();
+    badge_attributes_cirrus_ci.insert(String::from("branch"), String::from("beta"));
+    badge_attributes_cirrus_ci.insert(String::from("repository"), String::from("rust-lang/rust"));
+
     let maintenance = Badge::Maintenance {
         status: MaintenanceStatus::LookingForMaintainer,
     };
@@ -163,6 +173,8 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
         coveralls_attributes: badge_attributes_coveralls,
         circle_ci,
         circle_ci_attributes: badge_attributes_circle_ci,
+        cirrus_ci,
+        cirrus_ci_attributes: badge_attributes_cirrus_ci,
         maintenance,
         maintenance_attributes,
     };
@@ -288,6 +300,17 @@ fn update_add_circle_ci() {
     badges.insert(String::from("circle-ci"), test_badges.circle_ci_attributes);
     krate.update(&badges);
     assert_eq!(krate.badges(), vec![test_badges.circle_ci]);
+}
+
+#[test]
+fn update_add_cirrus_ci() {
+    // Add a Cirrus CI badge
+    let (krate, test_badges) = set_up();
+
+    let mut badges = HashMap::new();
+    badges.insert(String::from("cirrus-ci"), test_badges.cirrus_ci_attributes);
+    krate.update(&badges);
+    assert_eq!(krate.badges(), vec![test_badges.cirrus_ci]);
 }
 
 #[test]
@@ -544,6 +567,23 @@ fn circle_ci_required_keys() {
     let invalid_badges = krate.update(&badges);
     assert_eq!(invalid_badges.len(), 1);
     assert_eq!(invalid_badges.first().unwrap(), "circle-ci");
+    assert_eq!(krate.badges(), vec![]);
+}
+
+#[test]
+fn cirrus_ci_required_keys() {
+    // Add a Cirrus CI badge missing a required field
+    let (krate, mut test_badges) = set_up();
+
+    let mut badges = HashMap::new();
+
+    // Repository is a required key
+    test_badges.cirrus_ci_attributes.remove("repository");
+    badges.insert(String::from("cirrus-ci"), test_badges.cirrus_ci_attributes);
+
+    let invalid_badges = krate.update(&badges);
+    assert_eq!(invalid_badges.len(), 1);
+    assert_eq!(invalid_badges.first().unwrap(), "cirrus-ci");
     assert_eq!(krate.badges(), vec![]);
 }
 


### PR DESCRIPTION
Upstream API: https://cirrus-ci.org/guide/writing-tasks/#embedded-badges

Modeled after https://github.com/rust-lang/crates.io/pull/807.