### PR TITLE
Switch back to released versions of `lettre` and `lettre_email`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,8 +203,8 @@ dependencies = [
  "jemalloc-ctl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jemallocator 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lettre 0.9.1 (git+https://github.com/lettre/lettre)",
- "lettre_email 0.9.1 (git+https://github.com/lettre/lettre)",
+ "lettre 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lettre_email 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "license-exprs 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "oauth2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1123,8 +1123,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lettre"
-version = "0.9.1"
-source = "git+https://github.com/lettre/lettre#0ead3cde09a02918e3976aa442329fe247f05c55"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1140,12 +1140,12 @@ dependencies = [
 
 [[package]]
 name = "lettre_email"
-version = "0.9.1"
-source = "git+https://github.com/lettre/lettre#0ead3cde09a02918e3976aa442329fe247f05c55"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "email 0.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "lettre 0.9.1 (git+https://github.com/lettre/lettre)",
+ "lettre 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2915,8 +2915,8 @@ dependencies = [
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-"checksum lettre 0.9.1 (git+https://github.com/lettre/lettre)" = "<none>"
-"checksum lettre_email 0.9.1 (git+https://github.com/lettre/lettre)" = "<none>"
+"checksum lettre 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c66afaa5dfadbb81d4e00fd1d1ab057c7cd4c799c5a44e0009386d553587e728"
+"checksum lettre_email 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bbb68ca999042d965476e47bbdbacd52db0927348b6f8062c44dd04a3b1fd43b"
 "checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
 "checksum libflate 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "a686270ba9f9505d870ace79aa05838101e03572a2359dd75d8a1e734daad6a3"
 "checksum libgit2-sys 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "48441cb35dc255da8ae72825689a95368bf510659ae1ad55dc4aa88cb1789bf1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ parking_lot = "0.7.1"
 jemallocator = { version = "0.1.8", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 jemalloc-ctl = "0.2.0"
 
-lettre = { version = "0.9", git = "https://github.com/lettre/lettre" }
-lettre_email = { version = "0.9", git = "https://github.com/lettre/lettre" }
+lettre = "0.9"
+lettre_email = "0.9"
 failure = "0.1.1"
 
 conduit = "0.8"


### PR DESCRIPTION
Also see #1754 where this workaround was originally added.  The changes
were released upstream in version `0.9.2`.