### PR TITLE
Encapsulate the RequestProxy use cases

### DIFF
--- a/src/middleware/ember_index_rewrite.rs
+++ b/src/middleware/ember_index_rewrite.rs
@@ -37,11 +37,7 @@ impl Handler for EmberIndexRewrite {
         let is_api_path = req.path().starts_with("/api");
         let handler = self.handler.as_ref().unwrap();
         if wants_html && !is_api_path {
-            handler.call(&mut RequestProxy {
-                other: req,
-                path: Some("/index.html"),
-                method: None,
-            })
+            handler.call(&mut RequestProxy::rewrite_path(req, "/index.html"))
         } else {
             handler.call(req)
         }

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -22,11 +22,7 @@ impl AroundMiddleware for Head {
 impl Handler for Head {
     fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
         if req.method() == Method::Head {
-            let mut req = RequestProxy {
-                other: req,
-                path: None,
-                method: Some(Method::Get),
-            };
+            let mut req = RequestProxy::rewrite_method(req, Method::Get);
             self.handler
                 .as_ref()
                 .unwrap()

--- a/src/router.rs
+++ b/src/router.rs
@@ -146,11 +146,7 @@ impl<H: Handler> Handler for R<H> {
     fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
         let path = req.params()["path"].to_string();
         let R(ref sub_router) = *self;
-        sub_router.call(&mut RequestProxy {
-            other: req,
-            path: Some(&path),
-            method: None,
-        })
+        sub_router.call(&mut RequestProxy::rewrite_path(req, &path))
     }
 }
 

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -1,25 +1,52 @@
 use std::{io::Read, net::SocketAddr};
 
-use conduit::Request;
+use conduit::{Method, Request};
 use conduit_hyper::semver;
+
+type RequestMutRef<'a> = &'a mut (dyn Request + 'a);
 
 // Can't derive Debug because of Request.
 #[allow(missing_debug_implementations)]
 pub struct RequestProxy<'a> {
-    pub other: &'a mut (dyn Request + 'a),
-    pub path: Option<&'a str>,
-    pub method: Option<conduit::Method>,
+    other: RequestMutRef<'a>,
+    path: Option<&'a str>,
+    method: Option<conduit::Method>,
+}
+
+impl<'a> RequestProxy<'a> {
+    pub(crate) fn rewrite_path(req: RequestMutRef<'a>, path: &'a str) -> Self {
+        RequestProxy {
+            other: req,
+            path: Some(path),
+            method: None, // Defer to original request
+        }
+    }
+
+    pub(crate) fn rewrite_method(req: RequestMutRef<'a>, method: Method) -> Self {
+        RequestProxy {
+            other: req,
+            path: None, // Defer to original request
+            method: Some(method),
+        }
+    }
 }
 
 impl<'a> Request for RequestProxy<'a> {
+    // Use local value if available, defer to the original request
+    fn method(&self) -> conduit::Method {
+        self.method.clone().unwrap_or_else(|| self.other.method())
+    }
+
+    fn path(&self) -> &str {
+        self.path.unwrap_or_else(|| self.other.path())
+    }
+
+    // Pass-through
     fn http_version(&self) -> semver::Version {
         self.other.http_version()
     }
     fn conduit_version(&self) -> semver::Version {
         self.other.conduit_version()
-    }
-    fn method(&self) -> conduit::Method {
-        self.method.clone().unwrap_or_else(|| self.other.method())
     }
     fn scheme(&self) -> conduit::Scheme {
         self.other.scheme()
@@ -29,9 +56,6 @@ impl<'a> Request for RequestProxy<'a> {
     }
     fn virtual_root(&self) -> Option<&str> {
         self.other.virtual_root()
-    }
-    fn path(&self) -> &str {
-        self.path.unwrap_or_else(|| self.other.path())
     }
     fn query_string(&self) -> Option<&str> {
         self.other.query_string()

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -1,3 +1,5 @@
+//! A helper that wraps a request and can overwrite either the path or the method.
+
 use std::{io::Read, net::SocketAddr};
 
 use conduit::{Method, Request};
@@ -14,6 +16,7 @@ pub struct RequestProxy<'a> {
 }
 
 impl<'a> RequestProxy<'a> {
+    /// Wrap a request and overwrite the path with the provided value.
     pub(crate) fn rewrite_path(req: RequestMutRef<'a>, path: &'a str) -> Self {
         RequestProxy {
             other: req,
@@ -22,6 +25,7 @@ impl<'a> RequestProxy<'a> {
         }
     }
 
+    /// Wrap a request and overwrite the method with the provided value.
     pub(crate) fn rewrite_method(req: RequestMutRef<'a>, method: Method) -> Self {
         RequestProxy {
             other: req,


### PR DESCRIPTION
The RequestProxy value is constructed 3 places, overwriting 1 of 2
values.  The fields are made private and 2 new constructors give each
use case a name.