### PR TITLE
Add triagebot to the repository

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,4 @@
+[relabel]
+allow-unauthenticated = ["*"]
+
+[assign]


### PR DESCRIPTION
This adds [triagebot](https://github.com/rust-lang/triagebot) (@rustbot) to the repo, allowing people outside the team to relabel issues (with `@rustbot modify labels: foo bar`) and to claim issues for themselves (with `@rustbot claim`).

Currently non team members can add or remove any labels, but we can whitelist only a few of them if y'all want.

r? @sgrif