### PR TITLE
Adjust branding to reflect what crates.io actually does

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>Cargo: packages for Rust</title>
+    <title>crates.io: Rust Package Registry</title>
 
     {{content-for 'head'}}
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{head-layout}}
 
-{{title "Cargo: packages for Rust" separator=' - ' prepend=true}}
+{{title "crates.io: Rust Package Registry" separator=' - ' prepend=true}}
 {{google-jsapi}}
 
 <nav id="header">

--- a/config/manifest.js
+++ b/config/manifest.js
@@ -2,9 +2,9 @@
 
 module.exports = function(/* environment, appConfig */) {
     return {
-        name: 'Cargo: packages for Rust',
-        short_name: 'Cargo',
-        description: 'Cargo is the package manager and crate host for Rust.',
+        name: 'crates.io: Rust Package Registry',
+        short_name: 'crates.io',
+        description: 'crates.io is the default crate host for Rust.',
         start_url: '/',
         display: 'standalone',
         background_color: '#3b6837',

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -66,7 +66,7 @@ module('Acceptance | crate page', function(hooks) {
         await click('[data-test-just-updated] [data-test-crate-link="0"]');
 
         assert.equal(currentURL(), '/crates/nanomsg');
-        assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
+        assert.equal(document.title, 'nanomsg - crates.io: Rust Package Registry');
     });
 
     test('visiting /crates/nanomsg', async function(assert) {
@@ -78,7 +78,7 @@ module('Acceptance | crate page', function(hooks) {
 
         assert.equal(currentURL(), '/crates/nanomsg');
         assert.equal(currentRouteName(), 'crate.index');
-        assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
+        assert.equal(document.title, 'nanomsg - crates.io: Rust Package Registry');
 
         assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
         assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
@@ -93,7 +93,7 @@ module('Acceptance | crate page', function(hooks) {
 
         assert.equal(currentURL(), '/crates/nanomsg/');
         assert.equal(currentRouteName(), 'crate.index');
-        assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
+        assert.equal(document.title, 'nanomsg - crates.io: Rust Package Registry');
 
         assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
         assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
@@ -108,7 +108,7 @@ module('Acceptance | crate page', function(hooks) {
 
         assert.equal(currentURL(), '/crates/nanomsg/0.6.0');
         assert.equal(currentRouteName(), 'crate.version');
-        assert.equal(document.title, 'nanomsg - Cargo: packages for Rust');
+        assert.equal(document.title, 'nanomsg - crates.io: Rust Package Registry');
 
         assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
         assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.0');

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -1,4 +1,4 @@
-import { module, test } from 'qunit';
+yimport { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, currentURL, visit } from '@ember/test-helpers';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -39,7 +39,7 @@ module('Acceptance | crates page', function(hooks) {
         await click('[data-test-all-crates-link]');
 
         assert.equal(currentURL(), '/crates');
-        assert.equal(document.title, 'Crates - Cargo: packages for Rust');
+        assert.equal(document.title, 'Crates - crates.io: Rust Package Registry');
     });
 
     test('visiting the crates page directly', async function(assert) {
@@ -49,7 +49,7 @@ module('Acceptance | crates page', function(hooks) {
         await click('[data-test-all-crates-link]');
 
         assert.equal(currentURL(), '/crates');
-        assert.equal(document.title, 'Crates - Cargo: packages for Rust');
+        assert.equal(document.title, 'Crates - crates.io: Rust Package Registry');
     });
 
     test('listing crates', async function(assert) {

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -1,4 +1,4 @@
-yimport { module, test } from 'qunit';
+import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, currentURL, visit } from '@ember/test-helpers';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -25,7 +25,7 @@ module('Acceptance | front page', function(hooks) {
         await visit('/');
 
         assert.equal(currentURL(), '/');
-        assert.equal(document.title, 'Cargo: packages for Rust');
+        assert.equal(document.title, 'crates.io: Rust Package Registry');
 
         assert.dom('[data-test-install-cargo-link]').exists();
         assert.dom('[data-test-all-crates-link]').exists();

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -30,7 +30,7 @@ module('Acceptance | search', function(hooks) {
         await triggerEvent('[data-test-search-form]', 'submit');
 
         assert.equal(currentURL(), '/search?q=rust');
-        assert.equal(document.title, "Search Results for 'rust' - Cargo: packages for Rust");
+        assert.equal(document.title, "Search Results for 'rust' - crates.io: Rust Package Registry");
 
         assert.dom('[data-test-heading]').hasText("Search Results for 'rust'");
         assert.dom('[data-test-search-nav]').hasText('Displaying 1-8 of 8 total results');
@@ -53,7 +53,7 @@ module('Acceptance | search', function(hooks) {
         await visit('/search?q=rust');
 
         assert.equal(currentURL(), '/search?q=rust');
-        assert.equal(document.title, "Search Results for 'rust' - Cargo: packages for Rust");
+        assert.equal(document.title, "Search Results for 'rust' - crates.io: Rust Package Registry");
 
         assert.dom('[data-test-search-input]').hasValue('rust');
         assert.dom('[data-test-heading]').hasText("Search Results for 'rust'");


### PR DESCRIPTION
To be clear that crates.io is a Rust package registry&mdash;in fact the _default_ crate host for Rust---this commit changes the `name`, `short_name`, and `description` fields in the manifest to reflect the nature of the project.  crates.io isn't really "Cargo", so it seems logical to me to not mention much about it, at least in the metadata for the site.

I also more explicitly mention that `crates.io` is the "default" package registry to be a bit more neutral; it's the baked-in default in Cargo, but there are others out there. I got the branding "Rust Package Registry" from the tagline in the visible top bar on the landing page.

Also, update the various acceptance tests that I found floating around.

Should resolve #1777, I think.