### PR TITLE
Serve Ember bootstrap HTML for all non-api requests

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -108,6 +108,8 @@ pub fn build_router(app: &App) -> R404 {
     router.head("/api/v1/*path", R(Arc::clone(&api_router)));
     router.delete("/api/v1/*path", R(api_router));
 
+    // These routes are special cased in the EmberIndexRewrite middleware.
+    // Avoid adding new ones and keep in sync with the list there!
     router.get("/authorize_url", C(user::session::github_authorize));
     router.get("/authorize", C(user::session::github_access_token));
     router.delete("/logout", C(user::session::logout));


### PR DESCRIPTION
The backend no longer checks for an "html" in the `Accept` header.
With the exception of 3 session related routes, all paths not starting
with "/api" will be redirected to the static Ember bootstrap page.

As a result of this change all non-api requests that don't contain
"html" in the `Accept` header will now unconditionally return `200`,
rather than `404`.  In a sense, this expands the scope of #556 to all
requests, not just those that set the header.  It also inverts the
problem described in #788, effectively turning it into a duplicate
of #556.

Fixes: #163