### PR TITLE
Move `update-downloads` to a background job

### DIFF
--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,0 +1,17 @@
+use cargo_registry::util::{CargoError, CargoResult};
+use cargo_registry::{db, tasks};
+use std::env::args;
+use swirl::Job;
+
+fn main() -> CargoResult<()> {
+    let conn = db::connect_now()?;
+
+    match &*args().nth(1).unwrap_or_default() {
+        "update_downloads" => tasks::update_downloads()
+            .enqueue(&conn)
+            .map_err(|e| CargoError::from_std_error(e))?,
+        other => panic!("Unrecognized job type `{}`", other),
+    };
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ pub mod middleware;
 mod publish_rate_limit;
 pub mod render;
 pub mod schema;
+pub mod tasks;
 mod test_util;
 pub mod uploaders;
 pub mod util;

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,3 @@
+mod update_downloads;
+
+pub use update_downloads::update_downloads;


### PR DESCRIPTION
This replaces the `update-downloads` binary with a background job, and a
binary that is used to queue up a given job, which we will run from
Heroku scheduler. This accomplishes 2 things:

- It makes it easier to write tasks that need to run periodically (e.g.
  cleaning up stale rate limit buckets), since we don't need to create a
  new standalone binary.
- `update_downloads` and any future recurring tasks will automatically
  get monitoring if they fail, since we are already monitoring for
  background jobs not being successfully run.

Right now the intent is to have `enqueue-job update_downloads` get run
periodically by Heroku scheudler (and a similar scheduled task for any
future tasks that are added). Once swirl gains the ability to schedule
jobs to be run at arbitrary points in the future, we could instead have
these jobs re-queue themselves once they complete, and have the cron
task just look to see if any job is queued for each given type, queuing
it if not. That would have a bit less boilerplate, but a lot more
complexity.

Fixes #1797.