### PR TITLE
Don't allow crate names in use to be added to `reserved_crate_names`

### DIFF
--- a/migrations/2019-08-07-153647_ensure_existing_crates_not_reserved/down.sql
+++ b/migrations/2019-08-07-153647_ensure_existing_crates_not_reserved/down.sql
@@ -1,0 +1,2 @@
+DROP TRIGGER trigger_ensure_reserved_name_not_in_use ON reserved_crate_names;
+DROP FUNCTION ensure_reserved_name_not_in_use();

--- a/migrations/2019-08-07-153647_ensure_existing_crates_not_reserved/up.sql
+++ b/migrations/2019-08-07-153647_ensure_existing_crates_not_reserved/up.sql
@@ -1,0 +1,14 @@
+CREATE FUNCTION ensure_reserved_name_not_in_use() RETURNS trigger AS $$
+BEGIN
+    IF canon_crate_name(NEW.name) IN (
+        SELECT canon_crate_name(name) FROM crates
+    ) THEN
+        RAISE EXCEPTION 'crate exists with name %', NEW.name;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_ensure_reserved_name_not_in_use
+BEFORE INSERT OR UPDATE ON reserved_crate_names
+FOR EACH ROW EXECUTE PROCEDURE ensure_reserved_name_not_in_use();


### PR DESCRIPTION
We've made this mistake twice now. If a record gets added to this table
and a crate already exists with that name, we will fail to update
download statistics as we can no longer update that row in `crates`. The
expected invariant is that the crates table never overlaps with
`reserved_crate_names`, we should enforce that remains true.