### PR TITLE
Fix environment variable's name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:9.6
     environment:
       POSTGRES_DB: cargo_registry
-      POSTRES_USER: postgres
+      POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     ports:
       - 5432:5432


### PR DESCRIPTION
There's a typo in docker-compose.yml