### PR TITLE
Refactor pagination to prepare for cursor-based pagination.

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -16,7 +16,7 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
     let offset = options.offset().unwrap_or_default();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 
-    let categories = Category::toplevel(&conn, sort, options.per_page as i64, offset as i64)?;
+    let categories = Category::toplevel(&conn, sort, i64::from(options.per_page), i64::from(offset))?;
     let categories = categories.into_iter().map(Category::encodable).collect();
 
     // Query for the total count of categories

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -16,7 +16,8 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
     let offset = options.offset().unwrap_or_default();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 
-    let categories = Category::toplevel(&conn, sort, i64::from(options.per_page), i64::from(offset))?;
+    let categories =
+        Category::toplevel(&conn, sort, i64::from(options.per_page), i64::from(offset))?;
     let categories = categories.into_iter().map(Category::encodable).collect();
 
     // Query for the total count of categories

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,9 +1,9 @@
 use crate::util::{json_response, CargoResult};
 use conduit::Response;
 
-pub mod pagination;
+pub(crate) mod pagination;
 
-pub use self::pagination::Paginate;
+pub(crate) use self::pagination::Paginate;
 
 pub fn ok_true() -> CargoResult<Response> {
     #[derive(Serialize)]

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -174,10 +174,10 @@ where
         out.push_sql("SELECT *, COUNT(*) OVER () FROM (");
         self.query.walk_ast(out.reborrow())?;
         out.push_sql(") t LIMIT ");
-        out.push_bind_param::<BigInt, _>(&(self.options.per_page as i64))?;
+        out.push_bind_param::<BigInt, _>(&i64::from(self.options.per_page))?;
         if let Some(offset) = self.options.offset() {
             out.push_sql(" OFFSET ");
-            out.push_bind_param::<BigInt, _>(&(offset as i64))?;
+            out.push_bind_param::<BigInt, _>(&i64::from(offset))?;
         }
         Ok(())
     }

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -146,7 +146,7 @@ impl<T> PaginatedQuery<T> {
     where
         Self: LoadQuery<PgConnection, WithCount<U>>,
     {
-        let options = self.options.clone();
+        let options = self.options;
         let records_and_total = self.internal_load(conn)?;
         Ok(Paginated {
             records_and_total,

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -1,11 +1,11 @@
+use crate::models::helpers::with_count::*;
+use crate::util::errors::*;
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::query_builder::*;
-use diesel::sql_types::BigInt;
 use diesel::query_dsl::LoadQuery;
+use diesel::sql_types::BigInt;
 use indexmap::IndexMap;
-use crate::util::errors::*;
-use crate::models::helpers::with_count::*;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum Page {
@@ -87,10 +87,12 @@ pub struct Paginated<T> {
 
 impl<T> Paginated<T> {
     pub(crate) fn total(&self) -> Option<i64> {
-        Some(self.records_and_total
-            .get(0)
-            .map(|row| row.total)
-            .unwrap_or_default())
+        Some(
+            self.records_and_total
+                .get(0)
+                .map(|row| row.total)
+                .unwrap_or_default(),
+        )
     }
 
     pub(crate) fn next_page_params(&self) -> Option<IndexMap<String, String>> {
@@ -120,9 +122,7 @@ impl<T> Paginated<T> {
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
-        self.records_and_total
-            .iter()
-            .map(|row| &row.record)
+        self.records_and_total.iter().map(|row| &row.record)
     }
 }
 

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -20,14 +20,9 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
         query = query.order(keywords::keyword.asc());
     }
 
-    let data = query
-        .paginate(&req.query())?
-        .load::<Keyword>(&*conn)?;
+    let data = query.paginate(&req.query())?.load::<Keyword>(&*conn)?;
     let total = data.total();
-    let kws = data
-        .into_iter()
-        .map(Keyword::encodable)
-        .collect::<Vec<_>>();
+    let kws = data.into_iter().map(Keyword::encodable).collect::<Vec<_>>();
 
     #[derive(Serialize)]
     struct R {

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -212,8 +212,7 @@ pub fn reverse_dependencies(req: &mut dyn Request) -> CargoResult<Response> {
     let name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(name).first::<Crate>(&*conn)?;
-    let (offset, limit) = req.pagination(10, 100)?;
-    let (rev_deps, total) = krate.reverse_dependencies(&*conn, offset, limit)?;
+    let (rev_deps, total) = krate.reverse_dependencies(&*conn, &req.query())?;
     let rev_deps: Vec<_> = rev_deps
         .into_iter()
         .map(|dep| dep.encodable(&krate.name))

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -70,9 +70,7 @@ pub fn updates(req: &mut dyn Request) -> CargoResult<Response> {
 
     let versions = data
         .into_iter()
-        .map(|(version, crate_name, published_by)| {
-            version.encodable(&crate_name, published_by)
-        })
+        .map(|(version, crate_name, published_by)| version.encodable(&crate_name, published_by))
         .collect();
 
     #[derive(Serialize)]

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -1,6 +1,6 @@
 use crate::controllers::prelude::*;
 
-use crate::controllers::helpers::Paginate;
+use crate::controllers::helpers::*;
 use crate::email;
 use crate::util::bad_request;
 use crate::util::errors::CargoError;
@@ -50,7 +50,6 @@ pub fn updates(req: &mut dyn Request) -> CargoResult<Response> {
     use diesel::dsl::any;
 
     let user = req.user()?;
-    let (offset, limit) = req.pagination(10, 100)?;
     let conn = req.db_conn()?;
 
     let followed_crates = Follow::belonging_to(user).select(follows::crate_id);
@@ -64,17 +63,14 @@ pub fn updates(req: &mut dyn Request) -> CargoResult<Response> {
             crates::name,
             users::all_columns.nullable(),
         ))
-        .paginate(limit, offset)
-        .load::<((Version, String, Option<User>), i64)>(&*conn)?;
+        .paginate(&req.query())?
+        .load::<(Version, String, Option<User>)>(&*conn)?;
 
-    let more = data
-        .get(0)
-        .map(|&(_, count)| count > offset + limit)
-        .unwrap_or(false);
+    let more = data.next_page_params().is_some();
 
     let versions = data
         .into_iter()
-        .map(|((version, crate_name, published_by), _)| {
+        .map(|(version, crate_name, published_by)| {
             version.encodable(&crate_name, published_by)
         })
         .collect();

--- a/src/models/helpers/with_count.rs
+++ b/src/models/helpers/with_count.rs
@@ -1,9 +1,9 @@
-#[derive(QueryableByName, Debug)]
+#[derive(QueryableByName, Queryable, Debug)]
 pub struct WithCount<T> {
-    #[sql_type = "::diesel::sql_types::BigInt"]
-    total: i64,
     #[diesel(embed)]
-    record: T,
+    pub(crate) record: T,
+    #[sql_type = "::diesel::sql_types::BigInt"]
+    pub(crate) total: i64,
 }
 
 pub trait WithCountExtension<T> {

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -3,8 +3,8 @@ use diesel::associations::Identifiable;
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::sql_types::Bool;
-use url::Url;
 use indexmap::IndexMap;
+use url::Url;
 
 use crate::app::App;
 use crate::util::{human, CargoResult};
@@ -525,9 +525,9 @@ impl Crate {
         conn: &PgConnection,
         params: &IndexMap<String, String>,
     ) -> CargoResult<(Vec<ReverseDependency>, i64)> {
+        use crate::controllers::helpers::pagination::*;
         use diesel::sql_query;
         use diesel::sql_types::{BigInt, Integer};
-        use crate::controllers::helpers::pagination::*;
 
         // FIXME: It'd be great to support this with `.paginate` directly,
         // and get cursor/id pagination for free. But Diesel doesn't currently

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -537,8 +537,8 @@ impl Crate {
         let offset = options.offset().unwrap_or_default();
         let rows = sql_query(include_str!("krate_reverse_dependencies.sql"))
             .bind::<Integer, _>(self.id)
-            .bind::<BigInt, _>(offset as i64)
-            .bind::<BigInt, _>(options.per_page as i64)
+            .bind::<BigInt, _>(i64::from(offset))
+            .bind::<BigInt, _>(i64::from(options.per_page))
             .load::<WithCount<ReverseDependency>>(conn)?;
 
         Ok(rows.records_and_total())

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -4,6 +4,7 @@ use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::sql_types::Bool;
 use url::Url;
+use indexmap::IndexMap;
 
 use crate::app::App;
 use crate::util::{human, CargoResult};
@@ -522,16 +523,22 @@ impl Crate {
     pub fn reverse_dependencies(
         &self,
         conn: &PgConnection,
-        offset: i64,
-        limit: i64,
-    ) -> QueryResult<(Vec<ReverseDependency>, i64)> {
+        params: &IndexMap<String, String>,
+    ) -> CargoResult<(Vec<ReverseDependency>, i64)> {
         use diesel::sql_query;
         use diesel::sql_types::{BigInt, Integer};
+        use crate::controllers::helpers::pagination::*;
 
+        // FIXME: It'd be great to support this with `.paginate` directly,
+        // and get cursor/id pagination for free. But Diesel doesn't currently
+        // have great support for abstracting over "Is this using `Queryable`
+        // or `QueryableByName` to load things?"
+        let options = PaginationOptions::new(params)?;
+        let offset = options.offset().unwrap_or_default();
         let rows = sql_query(include_str!("krate_reverse_dependencies.sql"))
             .bind::<Integer, _>(self.id)
-            .bind::<BigInt, _>(offset)
-            .bind::<BigInt, _>(limit)
+            .bind::<BigInt, _>(offset as i64)
+            .bind::<BigInt, _>(options.per_page as i64)
             .load::<WithCount<ReverseDependency>>(conn)?;
 
         Ok(rows.records_and_total())

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -2230,11 +2230,12 @@ fn pagination_links_included_if_applicable() {
     let page1 = anon.search("per_page=1");
     let page2 = anon.search("page=2&per_page=1");
     let page3 = anon.search("page=3&per_page=1");
+    let page4 = anon.search("page=4&per_page=1");
 
     assert_eq!(Some("?per_page=1&page=2".to_string()), page1.meta.next_page);
     assert_eq!(None, page1.meta.prev_page);
     assert_eq!(Some("?page=3&per_page=1".to_string()), page2.meta.next_page);
     assert_eq!(Some("?page=1&per_page=1".to_string()), page2.meta.prev_page);
-    assert_eq!(None, page3.meta.next_page);
+    assert_eq!(None, page4.meta.next_page);
     assert_eq!(Some("?page=2&per_page=1".to_string()), page3.meta.prev_page);
 }


### PR DESCRIPTION
This continues the changes made in #1763. Since that PR was merged, one
of the non-code steps has been taken care of -- All users hitting any
endpoint with `?page=20` (which is an arbitrary search pattern that
seemed high enough to give any crawlers going through pagination) have
been contacted about the change, with a PR opened against any that
included a repo. (Intersting aside, there are *zero* records of this for
any endpoint other than search, which perhaps implies we can get rid of
a few of these endpoints, but that's a separate discussion).

This PR does not change any functionality, but moves some code around
to better encapsulate things for upcoming changes. Specifically:

- Change our frontend to show "next/prev page" links on the all crates
  page
- Stop returning the "total" meta item when the next/prev page links
  will be cursor based (which I'd actually just like to start omitting
  in general)

The main goal of this change was to stop having any code outside of
`Paginated` (which has been renamed to `PaginatedQuery`, as there's a
new type called `Paginated`) care about how pagination occurs. This
means other code can't care about *how* pagination happens (with the
exception of `reverse_dependencies`, which uses raw SQL, and sorta has
to... That was a bit of a rabbit hole, see
https://github.com/diesel-rs/diesel/issues/2150 for details. Given the
low traffic to that endpoint, I think we can safely ignore it).

The distribution of responsibilities is as follows:

- `PaginatedQuery<T>`: Given the query params, decides how to paginate
  things, generates appropriate SQL, loads a `Paginated<T>`.
- `Paginated<T>`: Handles providing an iterator to the records, getting
  the total count (to be removed in the near future), providing the
  next/prev page params
- `Request`: Takes the pagination related query params, turns that into
  an actual URL (note: Due to jankiness in our router, this will only
  ever be a query string, we have no way of getting the actual path)

The next step from here is to change our UI to stop showing page
numbers, and then remove the `total` field.

This PR will introduce a performance regression that was addressed by
 #1668. That PR was addressing "this will become a problem in a future",
not "this is about to take the site down". Given the intent to remove
the `total` field entirely, I think it is fine to cause this regression
in the short term. If we aren't confident that the changes to remove
this field will land in the near future, or want to be conservative
about this, I can add some additional complexity/git churn to retain the
previous performance characteristics