### PR TITLE
Allow streaming uploads to S3.

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -128,10 +128,12 @@ fn main() {
                     return;
                 }
                 let readme = readme.unwrap();
+                let content_length = readme.len() as u64;
+                let content = std::io::Cursor::new(readme);
                 let readme_path = format!("readmes/{0}/{0}-{1}.html", krate_name, version.num);
                 config
                     .uploader
-                    .upload(&client, &readme_path, readme.into_bytes(), "text/html")
+                    .upload(&client, &readme_path, content, content_length, "text/html")
                     .unwrap_or_else(|_| {
                         panic!(
                             "[{}-{}] Couldn't upload file to S3",

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -38,11 +38,12 @@ impl Bucket {
         }
     }
 
-    pub fn put(
+    pub fn put<R: std::io::Read + Send + 'static>(
         &self,
         client: &reqwest::Client,
         path: &str,
-        content: Vec<u8>,
+        content: R,
+        content_length: u64,
         content_type: &str,
     ) -> reqwest::Result<reqwest::Response> {
         let path = if path.starts_with('/') {
@@ -59,7 +60,7 @@ impl Bucket {
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, content_type)
             .header(header::DATE, date)
-            .body(content)
+            .body(reqwest::Body::sized(content, content_length))
             .send()?
             .error_for_status()
     }


### PR DESCRIPTION
Currently the interface in the `s3` crate accepts the contents of an upload as a byte slice, which
so far isn't much of a problem, since crate uploads are generally below 10MB. When uploading public
database dumps to S3 (#1800), however, we don't want to keep the whole dump in memory at once.

This change basically changes the type of the uploaded content from `&[u8]` to a generic type
implementing `std::io::Read + Send + 'static`, which are the trait bounds `reqwest` requires for the
request body.

The PUT request to S3 needs to include a Content-Length header. Since a `std::io::Read` does not
have a length, we need to add another parameter for the content length, and pass it on to `reqwest`.