### PR TITLE
Run crates.io inside Travis (without Docker)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,13 @@ env:
     - PERCY_TOKEN=0d8707a02b19aebbec79bb0bf302b8d2fa95edb33169cfe41b084289596670b1
     - PERCY_PROJECT=crates-io/crates.io
     - PGPORT=5433
+    - PATH=$HOME/.cargo/bin:$PATH
 
 install:
   - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf
   - sudo systemctl restart postgresql@11-main
   - script/ci/cargo-clean-on-new-rustc-version.sh
-  - cargo install --force diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
+  - cargo install --force diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres
 
 before_script:
   - diesel database setup --locked-schema
@@ -63,6 +64,16 @@ matrix:
         - npm run lint:js
         - npm run lint:deps
         - npm test
+    - name: Integration Tests
+      language: node_js
+      node_js: 12
+      before_install:
+        # Install Rust, since Travis prepares Node.js box for this job
+        - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      script:
+        - npm ci
+        - cargo build
+        - ./script/ci/start-frontend-and-backend.sh
     - rust: beta
       script:
         - cargo test

--- a/script/ci/start-frontend-and-backend.sh
+++ b/script/ci/start-frontend-and-backend.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+set -euo pipefail
+
+./script/init-local-index.sh
+
+# The below are required environment variables
+export SESSION_KEY=badkeyabcdefghijklmnopqrstuvwxyzabcdef
+export GIT_REPO_CHECKOUT=./tmp/index-co
+export GIT_REPO_URL=file://./tmp/index-bare
+export GH_CLIENT_ID=
+export GH_CLIENT_SECRET=
+
+./target/debug/server > backend.log &
+npm run start -- --proxy http://localhost:8888 > frontend.log &
+
+for i in $(seq 1 10)
+do
+    set +e
+    curl -H 'Accept: text/html' http://localhost:4200
+	case $? in
+	    0)
+	        break
+	        ;;
+	    7)
+	        # Connection refused
+	        sleep 10
+	        ;;
+	    56)
+	        # Connection reset by peer
+	        sleep 10
+	        ;;
+	    *)
+	        exit $?
+	esac
+    set -e
+done
+
+echo FRONTEND
+cat frontend.log
+
+echo BACKEND
+cat backend.log


### PR DESCRIPTION
This is the first step towards #868.

Personally I still prefer #1814 (Docker version) over this one. We have docker-compose.yml for development, Procfile and buildpacks for production, and this shell script for CI, which might cause "works on my machine" problem.