### PR TITLE
Tweak links in the footer

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -130,6 +130,8 @@
   <span class="sep">|</span>
   <a href='mailto:help@crates.io'>Send us an email</a>
   <span class="sep">|</span>
+  <a href='https://www.rust-lang.org/policies/security'>Report a security issue</a>
+  <span class="sep">|</span>
   {{#link-to 'policies'}}Policies{{/link-to}}
 </footer>
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -122,7 +122,7 @@
 </main>
 
 <footer class='after-main-links'>
-  {{#link-to 'install'}}Install{{/link-to}}
+  <a href='https://doc.rust-lang.org/cargo/getting-started/installation.html'>Install</a>
   <span class="sep">|</span>
   <a href='https://doc.rust-lang.org/cargo/'>Getting Started</a>
   <span class="sep">|</span>


### PR DESCRIPTION
This PR tweaks two things in the footer:

* A link to the [security policy](https://www.rust-lang.org/policies/security) was added: we had a person asking where to report a security issue on Discord, so hopefully this extra link should point people to the right disclosure guide.
* Removed a redirect when someone presses "Install": the old page it linked to ([`/install`](https://crates.io/install)) instantly redirected the viewer to [the cargo guide](https://doc.rust-lang.org/cargo/getting-started/installation.html), so I changed the link to point directly to it.

r? @sgrif