### PR TITLE
Add missing foreign key constraint for columns badges.crate_id.

### DIFF
--- a/migrations/2019-09-15-194259_add_badges_crate_id_foreign_key/down.sql
+++ b/migrations/2019-09-15-194259_add_badges_crate_id_foreign_key/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE badges DROP CONSTRAINT fk_badges_crate_id;

--- a/migrations/2019-09-15-194259_add_badges_crate_id_foreign_key/up.sql
+++ b/migrations/2019-09-15-194259_add_badges_crate_id_foreign_key/up.sql
@@ -1,0 +1,3 @@
+DELETE FROM badges WHERE crate_id NOT IN (SELECT id FROM crates);
+ALTER TABLE badges
+    ADD CONSTRAINT fk_badges_crate_id FOREIGN KEY (crate_id) REFERENCES crates(id) ON DELETE CASCADE;

--- a/src/schema.patch
+++ b/src/schema.patch
@@ -56,9 +56,9 @@ index df884e4..18e08cd 100644
      /// Representation of the `reserved_crate_names` table.
      ///
 @@ -881,23 +901,25 @@ table! {
- }
  
  joinable!(api_tokens -> users (user_id));
+ joinable!(badges -> crates (crate_id));
  joinable!(crate_owner_invitations -> crates (crate_id));
  joinable!(crate_owners -> crates (crate_id));
 -joinable!(crate_owners -> users (created_by));

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -961,6 +961,7 @@ table! {
 }
 
 joinable!(api_tokens -> users (user_id));
+joinable!(badges -> crates (crate_id));
 joinable!(crate_owner_invitations -> crates (crate_id));
 joinable!(crate_owners -> crates (crate_id));
 joinable!(crate_owners -> teams (owner_id));

--- a/src/tests/load_foreign_key_constraints.sql
+++ b/src/tests/load_foreign_key_constraints.sql
@@ -4,5 +4,8 @@ SELECT relname, conname, pg_get_constraintdef(pg_constraint.oid, true) AS defini
     FROM pg_attribute
     INNER JOIN pg_class ON pg_class.oid = attrelid
     LEFT JOIN pg_constraint ON pg_class.oid = conrelid AND ARRAY[attnum] = conkey
+    INNER JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
     WHERE attname = $1
-      AND contype = 'f'
+      AND relkind = 'r'
+      AND (contype IS NULL OR contype = 'f')
+      AND nspname = 'public';


### PR DESCRIPTION
Since we may already have entries in the `badges` table referring to crates that don't exist, we
need to delete these entries before creating the foreign key constraint. This is a destructive
operation in the sense that it cannot be reverted, but it should only delete rows that should have
been deleted together with the crates they belong to.

We have a test to verify that all columns called `crate_id` are actually foreign keys referring to
`crates.id`. However, the query for the relevant columns contains the filter `contype = 'f'`,
effectively limiting the result to columns that already have foreign key constraints. This change
fixes the query to also allow `contype IS NULL`.

In addition, I modified the query to only verify tables in the schema `public`. This is useful for
an integration test for the database dumps in #1800.