### PR TITLE
Travis cache fixes

### DIFF
--- a/script/ci/cargo-clean-on-new-rustc-version.sh
+++ b/script/ci/cargo-clean-on-new-rustc-version.sh
@@ -3,7 +3,7 @@
 set -e
 
 manual_stamp_file=target/ci_manual_stamp
-manual_stamp=6 # Change this to force a clean build on CI
+manual_stamp=7 # Change this to force a clean build on CI
 
 if [ -f $manual_stamp_file ]; then
     if echo "$manual_stamp" | cmp -s $manual_stamp_file -; then

--- a/script/ci/prune-cache.sh
+++ b/script/ci/prune-cache.sh
@@ -7,7 +7,7 @@ du -hs target/debug
 
 crate_name="cargo-registry"
 test_name="all"
-bin_names="delete-crate delete-version populate render-readmes server test-pagerduty transfer-crates update-downloads background-worker monitor"
+bin_names="background-worker delete-crate delete-version enqueue-job monitor populate render-readmes server test-pagerduty transfer-crates"
 
 normalized_crate_name=${crate_name//-/_}
 rm -v target/debug/$normalized_crate_name-*


### PR DESCRIPTION
Build times have regressed and we are spending a lot of time doing caching stuff (and downloading/uploading 8GB of compressed data).  By manually wiping out the cache, stable and beta build times should align more closely with nightly (which is cleaned on every new nightly release).  This PR also fixes the list of pruned binaries:

* Remove update-downloads
* Add enqueue-job
* Sort alphabetically for easier comparison against `ls src/bin`