### PR TITLE
Add indexes in migrations that have already been running in production

### DIFF
--- a/migrations/2019-09-19-185655_add_experimental_indexes/down.sql
+++ b/migrations/2019-09-19-185655_add_experimental_indexes/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS index_version_downloads_by_date;
+DROP INDEX IF EXISTS index_recent_crate_downloads_by_downloads;

--- a/migrations/2019-09-19-185655_add_experimental_indexes/up.sql
+++ b/migrations/2019-09-19-185655_add_experimental_indexes/up.sql
@@ -1,0 +1,9 @@
+-- These indexes were created on production by hand and never existed in migrations; give them
+-- better names now that we know we want to keep them
+ALTER INDEX IF EXISTS sgrif_testing RENAME TO index_recent_crate_downloads_by_downloads;
+ALTER INDEX IF EXISTS sgrif_testing2 RENAME TO index_version_downloads_by_date;
+
+-- Create the above indexes for databases other than production
+CREATE INDEX IF NOT EXISTS index_recent_crate_downloads_by_downloads
+  ON recent_crate_downloads USING btree (downloads);
+CREATE INDEX IF NOT EXISTS index_version_downloads_by_date ON version_downloads USING brin (date);


### PR DESCRIPTION
@sgrif added these to the production database by hand for testing
purposes a while back; they seem to be performing well so they should
get added to the codebase to keep the schema in sync.

r? @sgrif, feel free to wait to merge this until you've checked the bloat you mentioned wanting to check; I'm happy to update this PR if needed. Just wanted to have something around as a reminder.