### PR TITLE
Migration to remove an index already removed from prod by hand

### DIFF
--- a/migrations/2019-09-19-191534_remove-index-already-removed-in-prod/down.sql
+++ b/migrations/2019-09-19-191534_remove-index-already-removed-in-prod/down.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS index_version_crate_id ON versions USING btree (crate_id);

--- a/migrations/2019-09-19-191534_remove-index-already-removed-in-prod/up.sql
+++ b/migrations/2019-09-19-191534_remove-index-already-removed-in-prod/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS index_version_crate_id;


### PR DESCRIPTION
This index doesn't exist in production currently, but it still exists in a db created from this codebase because we never made a migration to remove it.

Should be a no-op on prod so can be merged and deployed at any time.
