### PR TITLE
Support u64 version parts in SQL function semver_no_prerelease

### DIFF
--- a/migrations/2019-09-18-233204_fix_int_type_in_to_semver_no_prerelease/down.sql
+++ b/migrations/2019-09-18-233204_fix_int_type_in_to_semver_no_prerelease/down.sql
@@ -1,0 +1,21 @@
+DROP FUNCTION to_semver_no_prerelease(text);
+DROP TYPE semver_triple;
+
+-- Restores the type and function to what they were created as in
+-- migrations/20170308140537_create_to_semver_no_prerelease/up.sql
+
+CREATE TYPE semver_triple AS (
+  major int4,
+  minor int4,
+  teeny int4
+);
+
+CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE AS $$
+  SELECT (
+    split_part($1, '.', 1)::int4,
+    split_part($1, '.', 2)::int4,
+    split_part(split_part($1, '+', 1), '.', 3)::int4
+  )::semver_triple
+  WHERE strpos($1, '-') = 0
+  $$ LANGUAGE SQL
+;

--- a/migrations/2019-09-18-233204_fix_int_type_in_to_semver_no_prerelease/up.sql
+++ b/migrations/2019-09-18-233204_fix_int_type_in_to_semver_no_prerelease/up.sql
@@ -1,0 +1,18 @@
+DROP FUNCTION to_semver_no_prerelease(text);
+DROP TYPE semver_triple;
+
+CREATE TYPE semver_triple AS (
+  major numeric,
+  minor numeric,
+  teeny numeric
+);
+
+CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE AS $$
+  SELECT (
+    split_part($1, '.', 1)::numeric,
+    split_part($1, '.', 2)::numeric,
+    split_part(split_part($1, '+', 1), '.', 3)::numeric
+  )::semver_triple
+  WHERE strpos($1, '-') = 0
+  $$ LANGUAGE SQL
+;


### PR DESCRIPTION
Fixes #1839.

So the reverse dependencies API request for crc32fast started failing because the susu crate depends on crc32fast and has [published versions](https://crates.io/crates/susu/versions) like 0.1.20190509190436.

In the logs for the request that were responding with 500, I saw a message that said `value "20190409163015" is out of range for type integer` 😰 

So I went digging, and after isolating which query was the problem and then which part of the query was the problem, I figured out it was [this call to `to_semver_no_prerelease`](https://github.com/rust-lang/crates.io/blob/12c64bc716a4a7d1fd25f2a658f80cbdcbdcbf08/src/models/krate_reverse_dependencies.sql#L15).

That function was defined in [this migration](https://github.com/rust-lang/crates.io/blob/a27c704faa2982ddd75a3dc564da85c0217b950e/migrations/20170308140537_create_to_semver_no_prerelease/up.sql), which defines a type `semver_triple` as PostgreSQL type `int4`, which corresponds to Rust type `i32`. And 20,190,409,163,015 > 2,147,483,647 😰 

The SemVer spec [doesn't actually specify](https://semver.org/#does-semver-have-a-size-limit-on-the-version-string) the size of integers that should be used for the version parts.

The `semver` crate, that we use in the Rust structures, [uses `u64`](https://github.com/steveklabnik/semver/blob/15189a1d97911abc7e22fb2e7959df12d5d6f462/src/version.rs#L115-L121). Cargo uses the `semver` crate as well, and `cargo build` doesn't work if you give the current crate a version number with one part set to the value of `std::u64::MAX` + 1.

[PostgreSQL's integer types](https://www.postgresql.org/docs/9.1/datatype-numeric.html) include an `int8` type, but it's a signed integer, so that wouldn't support values between `i64::MAX` and `u64::MAX` that we need to support. So we have to use the `numeric` type.

[Here's a travis build showing the test failing](https://travis-ci.com/rust-lang/crates.io/jobs/237375256#L833)