### PR TITLE
Fix GitHub relative SVGs not rendering properly

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -148,15 +148,39 @@ impl SanitizeUrl {
     }
 }
 
+/// Groups media-related URL info
+struct MediaUrl {
+    is_media: bool,
+    add_sanitize_query: bool,
+}
+
 /// Determine whether the given URL has a media file externsion.
-fn is_media_url(url: &str) -> bool {
+/// Also check if `sanitize=true` must be added to the query string,
+/// which is required to load SVGs properly from GitHub.
+fn is_media_url(url: &str) -> MediaUrl {
     Path::new(url)
         .extension()
         .and_then(std::ffi::OsStr::to_str)
-        .map_or(false, |e| match e {
-            "png" | "svg" | "jpg" | "jpeg" | "gif" | "mp4" | "webm" | "ogg" => true,
-            _ => false,
-        })
+        .map_or(
+            MediaUrl {
+                is_media: false,
+                add_sanitize_query: false,
+            },
+            |e| match e {
+                "svg" => MediaUrl {
+                    is_media: true,
+                    add_sanitize_query: true,
+                },
+                "png" | "jpg" | "jpeg" | "gif" | "mp4" | "webm" | "ogg" => MediaUrl {
+                    is_media: true,
+                    add_sanitize_query: false,
+                },
+                _ => MediaUrl {
+                    is_media: false,
+                    add_sanitize_query: false,
+                },
+            },
+        )
 }
 
 impl UrlRelativeEvaluate for SanitizeUrl {
@@ -169,7 +193,11 @@ impl UrlRelativeEvaluate for SanitizeUrl {
             let mut new_url = base_url.clone();
             // Assumes GitHub’s URL scheme. GitHub renders text and markdown
             // better in the "blob" view, but images need to be served raw.
-            new_url += if is_media_url(url) {
+            let MediaUrl {
+                is_media,
+                add_sanitize_query,
+            } = is_media_url(url);
+            new_url += if is_media {
                 "raw/master"
             } else {
                 "blob/master"
@@ -178,6 +206,12 @@ impl UrlRelativeEvaluate for SanitizeUrl {
                 new_url.push('/');
             }
             new_url += url;
+            if add_sanitize_query {
+                if let Ok(mut parsed_url) = Url::parse(&new_url) {
+                    parsed_url.query_pairs_mut().append_pair("sanitize", "true");
+                    new_url = parsed_url.into_string();
+                }
+            }
             Cow::Owned(new_url)
         })
     }
@@ -356,6 +390,7 @@ mod tests {
         let absolute = "[hi](/hi)";
         let relative = "[there](there)";
         let image = "![alt](img.png)";
+        let svg = "![alt](sanitize.svg)";
 
         for host in &["github.com", "gitlab.com", "bitbucket.org"] {
             for (&extra_slash, &dot_git) in [true, false].iter().zip(&[true, false]) {
@@ -389,6 +424,15 @@ mod tests {
                     result,
                     format!(
                  "<p><img src=\"https://{}/rust-lang/test/raw/master/img.png\" alt=\"alt\"></p>\n",
+                        host
+                    )
+                );
+
+                let result = markdown_to_html(svg, Some(&url));
+                assert_eq!(
+                    result,
+                    format!(
+                        "<p><img src=\"https://{}/rust-lang/test/raw/master/sanitize.svg?sanitize=true\" alt=\"alt\"></p>\n",
                         host
                     )
                 );


### PR DESCRIPTION
Fixes #1851 where SVGs from GitHub aren't rendered in READMEs if they use relative links.

First PR, so if I did something wrong point it out!