### PR TITLE
Updated crate.scss

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -343,7 +343,6 @@
             border-collapse: collapse;
             display: block;
             overflow-x: auto;
-            white-space: wrap;
 
             th, td {
                 border: 1px solid #dfe2e5;
@@ -469,6 +468,7 @@
     .small { margin-left: 20px; display: inline-block; }
     a.arrow {
         display: inline-block;
+        float: right;
     }
 }
 

--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -341,6 +341,9 @@
 
         table {
             border-collapse: collapse;
+            display: block;
+            overflow-x: auto;
+            white-space: wrap;
 
             th, td {
                 border: 1px solid #dfe2e5;
@@ -466,7 +469,6 @@
     .small { margin-left: 20px; display: inline-block; }
     a.arrow {
         display: inline-block;
-        float: right;
     }
 }
 


### PR DESCRIPTION
1. Fixed table from overflowing when the width is too large.
2. Removed a pointless CSS property. See https://developer.mozilla.org/en-US/docs/Web/CSS/float

`inline-block` is ignored due to the `float`.
If `float` has a value other than `none`, the box is floated and `display` is treated as `block`.

Fixes: #1638