### PR TITLE
Fixed versions suggestion

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -11,7 +11,7 @@ export default Route.extend({
 
   flashMessages: service(),
 
-  refreshAfterLogin: observer('session.isLoggedIn', function () {
+  refreshAfterLogin: observer('session.isLoggedIn', function() {
     this.refresh();
   }),
 

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -11,7 +11,7 @@ export default Route.extend({
 
   flashMessages: service(),
 
-  refreshAfterLogin: observer('session.isLoggedIn', function() {
+  refreshAfterLogin: observer('session.isLoggedIn', function () {
     this.refresh();
   }),
 
@@ -43,14 +43,28 @@ export default Route.extend({
           .get('versions')
           .then(versions => {
             const latestStableVersion = versions.find(version => {
+              // Find the latest version that is stable AND not-yanked.
               if (!isUnstableVersion(version.get('num')) && !version.get('yanked')) {
                 return version;
               }
             });
 
             if (latestStableVersion == null) {
-              // If no stable version exists, fallback to `maxVersion`
-              params.version_num = maxVersion;
+              // Cannot find any version that is stable AND not-yanked.
+              // The fact that "maxVersion" itself cannot be found means that
+              // we have to fall back to the latest one that is unstable....
+              const latestUnyankedVersion = versions.find(version => {
+                // Find the latest version that is stable AND not-yanked.
+                if (!version.get('yanked')) {
+                  return version;
+                }
+              });
+              if (latestStableVersion == null) {
+                // There's not even any unyanked version...
+                params.version_num = maxVersion;
+              } else {
+                params.version_num = latestUnyankedVersion;
+              }
             } else {
               params.version_num = latestStableVersion.get('num');
             }

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -59,6 +59,7 @@ export default Route.extend({
                   return version;
                 }
               });
+
               if (latestStableVersion == null) {
                 // There's not even any unyanked version...
                 params.version_num = maxVersion;


### PR DESCRIPTION
Previously, if it had searched everything and found nothing. However, this also means it cannot find `maxVersion`, which was what it was set to before.
Thus, this commit's solution is to provide another fallback when there are no stable and non-yanked versions available. It will simply find anything that is not yet yanked even if it is unstable.
If even this fails, then we truly have nothing to offer thereby offering an empty page.

The code could be improved imo, but I am not especially well-versed in JavaScript.