### PR TITLE
Bump CI stack from xenial to bionic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   frontend:
     name: Frontend
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     env:
       JOBS: 1 # See https://git.io/vdao3 for details.
 
@@ -175,7 +175,7 @@ jobs:
 
       - name: Setup database
         run: |
-          which diesel || cargo install diesel_cli --vers $(cat .diesel_version) --no-default-features --features postgres
+          which diesel || cargo install diesel_cli --vers $(cat .diesel_version) --no-default-features --features postgres --debug
           diesel database setup --locked-schema
 
       - name: Lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 dist: bionic
+os: linux
 
 branches:
   only:
@@ -36,14 +37,13 @@ before_script:
   - diesel database setup --locked-schema
 
 addons:
-  chrome: stable
   postgresql: "11"
   apt:
     packages:
       - postgresql-11
       - postgresql-client-11
 
-matrix:
+jobs:
   fast_finish: true
   allow_failures:
     - rust: nightly
@@ -60,6 +60,8 @@ matrix:
     - name: Frontend
       language: node_js
       node_js: 12
+      addons:
+        chrome: stable
       install:
         - npm ci
       before_script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: rust
-sudo: required
-dist: xenial
+dist: bionic
 
 branches:
   only:
@@ -18,23 +17,20 @@ env:
   global:
     - RUST_BACKTRACE=1
     - JOBS=1 # See https://git.io/vdao3 for details.
-    - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
-    - TEST_DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
+    - DATABASE_URL=postgres:///cargo_registry_test
+    - TEST_DATABASE_URL=postgres:///cargo_registry_test
     - CARGO_INCREMENTAL=0
     # Percy secrets are included here to enable Percy's GitHub integration
     # on community-submitted PRs
     - PERCY_TOKEN=0d8707a02b19aebbec79bb0bf302b8d2fa95edb33169cfe41b084289596670b1
     - PERCY_PROJECT=crates-io/crates.io
-    - PGPORT=5433
     - PATH=$HOME/.cargo/bin:$PATH
     - RUSTFLAGS="-C debuginfo=0 -D warnings"
     - MALLOC_CONF=background_thread:true,abort_conf:true,abort:true,junk:true
 
 install:
-  - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf
-  - sudo systemctl restart postgresql@11-main
   - script/ci/cargo-clean-on-new-rustc-version.sh
-  - which diesel || cargo install diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres
+  - which diesel || cargo install diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres --debug
 
 before_script:
   - diesel database setup --locked-schema


### PR DESCRIPTION
We'll want to synchronize this bump with a bump to the `heroku-18` stack in production. See the tracking issue for details.

closes: #1868