### PR TITLE
Upload all content to s3 as public and immutable

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -133,7 +133,14 @@ fn main() {
                 let readme_path = format!("readmes/{0}/{0}-{1}.html", krate_name, version.num);
                 config
                     .uploader
-                    .upload(&client, &readme_path, content, content_length, "text/html")
+                    .upload(
+                        &client,
+                        &readme_path,
+                        content,
+                        content_length,
+                        "text/html",
+                        None,
+                    )
                     .unwrap_or_else(|_| {
                         panic!(
                             "[{}-{}] Couldn't upload file to S3",

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -45,6 +45,7 @@ impl Bucket {
         content: R,
         content_length: u64,
         content_type: &str,
+        extra_headers: Option<header::HeaderMap>,
     ) -> reqwest::Result<reqwest::Response> {
         let path = if path.starts_with('/') {
             &path[1..]
@@ -60,6 +61,7 @@ impl Bucket {
             .header(header::AUTHORIZATION, auth)
             .header(header::CONTENT_TYPE, content_type)
             .header(header::DATE, date)
+            .headers(extra_headers.unwrap_or_else(header::HeaderMap::new))
             .body(reqwest::Body::sized(content, content_length))
             .send()?
             .error_for_status()

--- a/src/tasks/dump_db.rs
+++ b/src/tasks/dump_db.rs
@@ -157,6 +157,7 @@ impl DumpTarball {
                 tarfile,
                 content_length,
                 "application/gzip",
+                None,
             )
             .map_err(std_error_no_send)?;
         Ok(())

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -272,7 +272,7 @@ fn replay_http(
     mut exchange: Exchange,
     stdout: &mut dyn Write,
 ) -> Box<dyn Future<Item = hyper::Response<hyper::Body>, Error = hyper::Error> + Send> {
-    static IGNORED_HEADERS: &[&str] = &["authorization", "date", "user-agent"];
+    static IGNORED_HEADERS: &[&str] = &["authorization", "date", "user-agent", "cache-control"];
 
     assert_eq!(req.uri().to_string(), exchange.request.uri);
     assert_eq!(req.method().to_string(), exchange.request.method);


### PR DESCRIPTION
Adds cache control header with value `public,max-age=31536000,immutable` to all future crate and README uploads.

Fixes #1826