### PR TITLE
Show crate last updated at on search results

### DIFF
--- a/app/styles/crate.scss
+++ b/app/styles/crate.scss
@@ -155,6 +155,15 @@
         @include display-flex;
         @include align-items(center);
     }
+    .updated-at {
+        padding-top: 5px;
+        @include display-flex;
+        @include align-items(center);
+
+        svg {
+            padding: 10px;
+        }
+    }
 
     .rev-dep-downloads {padding-left: 7px}
 }

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -21,6 +21,12 @@
     {{svg-jar "download"}}
     <span class='num'><abbr title="Downloads in the last 90 days">Recent:</abbr> {{ format-num crate.recent_downloads }}</span>
   </div>
+  <div class="updated-at" >
+    {{svg-jar "latest-updates" height="32" width="32"}}
+    <time title="Last updated: {{ crate.updated_at }}" datetime="{{ moment-format crate.updated_at 'YYYY-MM-DDTHH:mm:ssZ' }}" data-test-updated-at>
+      {{ moment-from-now crate.updated_at }}
+    </time>
+  </div>
 </div>
 <div class="quick-links">
   <ul>

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -45,6 +45,7 @@ module('Acceptance | search', function(hooks) {
       .hasText('A Kinetic protocol library written in Rust');
     assert.dom('[data-test-crate-row="0"] [data-test-downloads]').hasText('All-Time: 225');
     assert.dom('[data-test-crate-row="0"] [data-test-badge="maintenance"]').exists();
+    assert.dom('[data-test-crate-row="0"] [data-test-updated-at]').exists();
   });
 
   test('searching for "rust" from query', async function(assert) {


### PR DESCRIPTION
Adds the crate's last updated at time to search results on the right:

<img width="901" alt="image" src="https://user-images.githubusercontent.com/175237/67069778-0ae64500-f133-11e9-95fa-f9df665aa131.png">

And with hover state to display exact date and time:

<img width="937" alt="image" src="https://user-images.githubusercontent.com/175237/67069861-54cf2b00-f133-11e9-8a10-218a22aec92e.png">



Happy to move it to a different location if preferrable, reasonable alternatives could be at the end of the quick links? or under the crate title?

Fixes #1597 