### PR TITLE
Fix error response payload parsing

### DIFF
--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -100,9 +100,9 @@ export default Component.extend({
         await ajax(`/api/v1/users/${user.id}/resend`, { method: 'PUT' });
         this.set('disableResend', true);
       } catch (error) {
-        if (error.payload) {
+        if (error.errors) {
           this.set('isError', true);
-          this.set('emailError', `Error in resending message: ${error.payload.errors[0].detail}`);
+          this.set('emailError', `Error in resending message: ${error.errors[0].detail}`);
         } else {
           this.set('isError', true);
           this.set('emailError', 'Unknown error in resending message');

--- a/app/components/pending-owner-invite-row.js
+++ b/app/components/pending-owner-invite-row.js
@@ -15,8 +15,8 @@ export default Component.extend({
         this.set('isAccepted', true);
       } catch (error) {
         this.set('isError', true);
-        if (error.payload) {
-          this.set('inviteError', `Error in accepting invite: ${error.payload.errors[0].detail}`);
+        if (error.errors) {
+          this.set('inviteError', `Error in accepting invite: ${error.errors[0].detail}`);
         } else {
           this.set('inviteError', 'Error in accepting invite');
         }
@@ -31,8 +31,8 @@ export default Component.extend({
         this.set('isDeclined', true);
       } catch (error) {
         this.set('isError', true);
-        if (error.payload) {
-          this.set('inviteError', `Error in declining invite: ${error.payload.errors[0].detail}`);
+        if (error.errors) {
+          this.set('inviteError', `Error in declining invite: ${error.errors[0].detail}`);
         } else {
           this.set('inviteError', 'Error in declining invite');
         }

--- a/app/controllers/crate/owners.js
+++ b/app/controllers/crate/owners.js
@@ -23,8 +23,8 @@ export default Controller.extend({
         await this.crate.inviteOwner(username);
         this.set('invited', `An invite has been sent to ${username}`);
       } catch (error) {
-        if (error.payload) {
-          this.set('error', `Error sending invite: ${error.payload.errors[0].detail}`);
+        if (error.errors) {
+          this.set('error', `Error sending invite: ${error.errors[0].detail}`);
         } else {
           this.set('error', 'Error sending invite');
         }
@@ -40,8 +40,8 @@ export default Controller.extend({
 
         this.get('crate.owner_user').removeObject(user);
       } catch (error) {
-        if (error.payload) {
-          this.set('removed', `Error removing owner: ${error.payload.errors[0].detail}`);
+        if (error.errors) {
+          this.set('removed', `Error removing owner: ${error.errors[0].detail}`);
         } else {
           this.set('removed', 'Error removing owner');
         }

--- a/app/routes/confirm.js
+++ b/app/routes/confirm.js
@@ -26,8 +26,8 @@ export default Route.extend({
         });
       }
     } catch (error) {
-      if (error.payload) {
-        this.flashMessages.queue(`Error in email confirmation: ${error.payload.errors[0].detail}`);
+      if (error.errors) {
+        this.flashMessages.queue(`Error in email confirmation: ${error.errors[0].detail}`);
         return this.replaceWith('index');
       } else {
         this.flashMessages.queue(`Unknown error in email confirmation`);

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -258,7 +258,7 @@ module('Acceptance | crate page', function(hooks) {
     await click('#add-owner');
 
     assert.dom('.error').exists();
-    assert.dom('.error').hasText('Error sending invite');
+    assert.dom('.error').hasText('Error sending invite: Not Found');
     assert.dom('.owners .row').exists({ count: 2 });
   });
 


### PR DESCRIPTION
Caught request error objects do not have a payload property, this should start properly showing error details instead of the generic fallback message.

Fixes #1547 