### PR TITLE
Clear search input on index route

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -14,6 +14,7 @@ export default Route.extend({
   },
 
   setupController(controller) {
+    this.controllerFor('application').set('searchQuery', null);
     controller.dataTask.perform();
   },
 });

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -14,6 +14,7 @@ export default Route.extend({
   },
 
   setupController(controller, params) {
+    this.controllerFor('application').set('searchQuery', params.q);
     controller.dataTask.perform(params);
   },
 });

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -62,6 +62,20 @@ module('Acceptance | search', function(hooks) {
     assert.dom('[data-test-search-nav]').hasText('Displaying 1-8 of 8 total results');
   });
 
+  test('clearing search results', async function(assert) {
+    this.server.loadFixtures();
+
+    await visit('/search?q=rust');
+
+    assert.equal(currentURL(), '/search?q=rust');
+    assert.dom('[data-test-search-input]').hasValue('rust');
+
+    await visit('/');
+
+    assert.equal(currentURL(), '/');
+    assert.dom('[data-test-search-input]').hasValue('');
+  });
+
   test('pressing S key to focus the search bar', async function(assert) {
     this.server.loadFixtures();
 


### PR DESCRIPTION
Not sure what the correct product choice is here, but this clears the search input when navigating back to index route if that is in fact the behavior that is preferred.

Fixes #1230 

(for some context both npm and rubygems.org do NOT clear the index if you search and then navigate back via browser, but both clear if you navigate forward to the index route via top left icon clicks)