### PR TITLE
Use deploy keys for git operations

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use swirl::PerformError;
 
 use crate::db::{DieselPool, DieselPooledConn};
-use crate::git::Repository;
+use crate::git::{Credentials, Repository};
 use crate::uploaders::Uploader;
 use crate::util::errors::{CargoErrToStdErr, CargoResult};
 
@@ -22,7 +22,7 @@ impl swirl::db::DieselPool for DieselPool {
 #[allow(missing_debug_implementations)]
 pub struct Environment {
     index: Arc<Mutex<Repository>>,
-    pub credentials: Option<(String, String)>,
+    pub credentials: Credentials,
     // FIXME: https://github.com/sfackler/r2d2/pull/70
     pub connection_pool: AssertUnwindSafe<DieselPool>,
     pub uploader: Uploader,
@@ -46,7 +46,7 @@ impl Clone for Environment {
 impl Environment {
     pub fn new(
         index: Repository,
-        credentials: Option<(String, String)>,
+        credentials: Credentials,
         connection_pool: DieselPool,
         uploader: Uploader,
         http_client: reqwest::Client,
@@ -60,10 +60,8 @@ impl Environment {
         }
     }
 
-    pub fn credentials(&self) -> Option<(&str, &str)> {
-        self.credentials
-            .as_ref()
-            .map(|(u, p)| (u.as_str(), p.as_str()))
+    pub fn credentials(&self) -> &Credentials {
+        &self.credentials
     }
 
     pub fn connection(&self) -> Result<DieselPooledConn<'_>, PerformError> {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -72,7 +72,7 @@ impl Environment {
 
     pub fn lock_index(&self) -> CargoResult<MutexGuard<'_, Repository>> {
         let repo = self.index.lock().unwrap_or_else(PoisonError::into_inner);
-        repo.reset_head()?;
+        repo.reset_head(&self.credentials)?;
         Ok(repo)
     }
 

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -59,7 +59,8 @@ fn main() {
 
     println!("Cloning index");
 
-    let repository = Repository::open(&config.index_location).expect("Failed to clone index");
+    let repository =
+        Repository::open(&config.index_location, &credentials).expect("Failed to clone index");
 
     let environment = Environment::new(
         repository,

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -36,14 +36,19 @@ fn main() {
     let password = dotenv::var("GIT_HTTP_PWD");
     let ssh_key = dotenv::var("GIT_SSH_KEY");
     let credentials = match (username, password, ssh_key) {
+        (extra_user, extra_pass, Ok(encoded_key)) => {
+            if let (Ok(_), Ok(_)) = (extra_user, extra_pass) {
+                println!("warning: both http and ssh credentials to authenticate with git are set");
+                println!("note: ssh credentials will take precedence over the http ones");
+            }
+            Credentials::Ssh {
+                key: String::from_utf8(
+                    base64::decode(&encoded_key).expect("failed to base64 decode the ssh key"),
+                )
+                .expect("failed to convert the ssh key to a string"),
+            }
+        }
         (Ok(username), Ok(password), Err(_)) => Credentials::Http { username, password },
-        (Err(_), Err(_), Ok(encoded_key)) => Credentials::Ssh {
-            key: String::from_utf8(
-                base64::decode(&encoded_key).expect("failed to base64 decode the ssh key"),
-            )
-            .expect("failed to convert the ssh key to a string"),
-        },
-        (Ok(_), Ok(_), Ok(_)) => panic!("can't configure both http and ssh authentication"),
         _ => Credentials::Missing,
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,14 +1,12 @@
 use crate::publish_rate_limit::PublishRateLimit;
 use crate::{env, uploaders::Uploader, Env, Replica};
 use std::path::PathBuf;
-use url::Url;
 
 #[derive(Clone, Debug)]
 pub struct Config {
     pub uploader: Uploader,
     pub session_key: String,
     pub git_repo_checkout: PathBuf,
-    pub index_location: Url,
     pub gh_client_id: String,
     pub gh_client_secret: String,
     pub db_url: String,
@@ -128,7 +126,6 @@ impl Default for Config {
             uploader,
             session_key: env("SESSION_KEY"),
             git_repo_checkout: checkout,
-            index_location: Url::parse(&env("GIT_REPO_URL")).unwrap(),
             gh_client_id: env("GH_CLIENT_ID"),
             gh_client_secret: env("GH_CLIENT_SECRET"),
             db_url: env("DATABASE_URL"),

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -37,7 +37,6 @@ use std::{
 use conduit_test::MockRequest;
 use diesel::prelude::*;
 use reqwest::{Client, Proxy};
-use url::Url;
 
 macro_rules! t {
     ($e:expr) => {
@@ -137,7 +136,6 @@ fn simple_config() -> Config {
         uploader,
         session_key: "test this has to be over 32 bytes long".to_string(),
         git_repo_checkout: git::checkout(),
-        index_location: Url::from_file_path(&git::bare()).unwrap(),
         gh_client_id: dotenv::var("GH_CLIENT_ID").unwrap_or_default(),
         gh_client_secret: dotenv::var("GH_CLIENT_SECRET").unwrap_or_default(),
         db_url: env("TEST_DATABASE_URL"),

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -26,7 +26,7 @@ use crate::{
 use cargo_registry::{
     background_jobs::Environment,
     db::DieselPool,
-    git::Credentials,
+    git::{Credentials, RepositoryConfig},
     middleware::current_user::AuthenticationSource,
     models::{ApiToken, User},
     App, Config,
@@ -40,6 +40,8 @@ use conduit_test::MockRequest;
 
 use cargo_registry::git::Repository as WorkerRepository;
 use git2::Repository as UpstreamRepository;
+
+use url::Url;
 
 struct TestAppInner {
     app: Arc<App>,
@@ -206,15 +208,19 @@ pub struct TestAppBuilder {
 impl TestAppBuilder {
     /// Create a `TestApp` with an empty database
     pub fn empty(self) -> (TestApp, MockAnonymousUser) {
+        use crate::git;
+
         let (app, middle) = crate::build_app(self.config, self.proxy);
 
         let runner = if self.build_job_runner {
             let connection_pool = app.diesel_database.clone();
-            let index = WorkerRepository::open(&app.config.index_location, &Credentials::Missing)
-                .expect("Could not clone index");
+            let repository_config = RepositoryConfig {
+                index_location: Url::from_file_path(&git::bare()).unwrap(),
+                credentials: Credentials::Missing,
+            };
+            let index = WorkerRepository::open(&repository_config).expect("Could not clone index");
             let environment = Environment::new(
                 index,
-                Credentials::Missing,
                 connection_pool.clone(),
                 app.config.uploader.clone(),
                 app.http_client().clone(),

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -210,8 +210,8 @@ impl TestAppBuilder {
 
         let runner = if self.build_job_runner {
             let connection_pool = app.diesel_database.clone();
-            let index =
-                WorkerRepository::open(&app.config.index_location).expect("Could not clone index");
+            let index = WorkerRepository::open(&app.config.index_location, &Credentials::Missing)
+                .expect("Could not clone index");
             let environment = Environment::new(
                 index,
                 Credentials::Missing,

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -26,6 +26,7 @@ use crate::{
 use cargo_registry::{
     background_jobs::Environment,
     db::DieselPool,
+    git::Credentials,
     middleware::current_user::AuthenticationSource,
     models::{ApiToken, User},
     App, Config,
@@ -213,7 +214,7 @@ impl TestAppBuilder {
                 WorkerRepository::open(&app.config.index_location).expect("Could not clone index");
             let environment = Environment::new(
                 index,
-                None,
+                Credentials::Missing,
                 connection_pool.clone(),
                 app.config.uploader.clone(),
                 app.http_client().clone(),


### PR DESCRIPTION
At the moment crates.io relies on Personal Access Tokens to be able to push changes to the index, but this is not great from a security point of view as it's not possible to scope a token to a single repository.

That means if an attacker managed to compromise the server hosting crates.io they'd be able to compromise other, unrelated parts of the Rust project infrastructure.

This PR changes crates.io to optionally support using deploy keys instead of tokens to push new commits to GitHub. Deploy keys are scoped to a single repository and can be either read-only or read-write (in our case we need write access).

The key must be stored in the `GIT_SSH_KEY` environment variable, base64-encoded. It has to be encoded as that way it's easier to copy-paste it, and the [setup-deploy-keys tool in rust-lang/simpleinfra](https://github.com/rust-lang/simpleinfra#setup-deploy-keys) generates them that way.

r? @carols10cents 