### PR TITLE
Fix new clippy lint about unnecessary parens

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -79,9 +79,7 @@ fn main() {
         query = query.filter(crates::name.eq(crate_name));
     }
 
-    let version_ids = query
-        .load::<(i32)>(&conn)
-        .expect("error loading version ids");
+    let version_ids = query.load::<i32>(&conn).expect("error loading version ids");
 
     let total_versions = version_ids.len();
     println!("Rendering {} versions", total_versions);

--- a/src/render.rs
+++ b/src/render.rs
@@ -272,8 +272,7 @@ mod tests {
 
     #[test]
     fn text_with_inline_javascript() {
-        let text =
-            r#"foo_readme\n\n<a href="https://crates.io/crates/cargo-registry" onclick="window.alert('Got you')">Crate page</a>"#;
+        let text = r#"foo_readme\n\n<a href="https://crates.io/crates/cargo-registry" onclick="window.alert('Got you')">Crate page</a>"#;
         let result = markdown_to_html(text, None);
         assert_eq!(
             result,


### PR DESCRIPTION
This just started failing builds since the new beta was cut. I'm going to merge this once CI passes.