### PR TITLE
Add mathematics category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -272,6 +272,12 @@ Crates to help adapting internationalized software to specific \
 languages and regions.\
 """
 
+[mathematics]
+name = "Mathematics"
+description = """
+Crates related to mathematics or related topics.
+"""
+
 [memory-management]
 name = "Memory management"
 description = """
@@ -398,7 +404,7 @@ Rust.\
 [science]
 name = "Science"
 description = """
-Crates related to solving problems involving math, physics, chemistry, \
+Crates related to solving problems involving physics, chemistry, \
 biology, machine learning, geoscience, and other scientific fields.\
 """
 

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -275,7 +275,7 @@ languages and regions.\
 [mathematics]
 name = "Mathematics"
 description = """
-Crates related to mathematics or related topics.
+Crates with a mathematical aspect.
 """
 
 [memory-management]


### PR DESCRIPTION
This change adds the additional mathematics category, as well as removing "math" from the list of  fields covered by the "science"
category.

I think having a separate category makes a lot of sense, as mathematics related items can be related to e.g. simulations or games, which might be worth extracting it out from "science".

I would however like some input on the description. As a non-mathematician I'm not too aware of the range of mathematics crates that are available.

#1791 