### PR TITLE
Improve build caching on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
     - TEST_DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
     - CARGO_TARGET_DIR=target
+    - CARGO_INCREMENTAL=0
     - PERCY_PARALLEL_TOTAL=2
     # Percy secrets are included here to enable Percy's GitHub integration
     # on community-submitted PRs

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - JOBS=1 # See https://git.io/vdao3 for details.
     - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
     - TEST_DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
-    - CARGO_TARGET_DIR=target
     - CARGO_INCREMENTAL=0
     - PERCY_PARALLEL_TOTAL=2
     # Percy secrets are included here to enable Percy's GitHub integration
@@ -21,12 +20,13 @@ env:
     - PERCY_TOKEN=0d8707a02b19aebbec79bb0bf302b8d2fa95edb33169cfe41b084289596670b1
     - PERCY_PROJECT=crates-io/crates.io
     - PGPORT=5433
+    - PATH=$HOME/.cargo/bin:$PATH
 
 install:
   - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf
   - sudo systemctl restart postgresql@11-main
   - script/ci/cargo-clean-on-new-rustc-version.sh
-  - cargo install --force diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres && export PATH=$HOME/.cargo/bin:$PATH
+  - which diesel || cargo install diesel_cli --vers `cat .diesel_version` --no-default-features --features postgres
 
 before_script:
   - diesel database setup --locked-schema

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - PERCY_PROJECT=crates-io/crates.io
     - PGPORT=5433
     - PATH=$HOME/.cargo/bin:$PATH
+    - RUSTFLAGS="-C debuginfo=0"
 
 install:
   - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf

--- a/script/ci/cargo-clean-on-new-rustc-version.sh
+++ b/script/ci/cargo-clean-on-new-rustc-version.sh
@@ -3,7 +3,7 @@
 set -e
 
 manual_stamp_file=target/ci_manual_stamp
-manual_stamp=7 # Change this to force a clean build on CI
+manual_stamp=8 # Change this to force a clean build on CI
 
 if [ -f $manual_stamp_file ]; then
     if echo "$manual_stamp" | cmp -s $manual_stamp_file -; then

--- a/script/ci/prune-cache.sh
+++ b/script/ci/prune-cache.sh
@@ -25,5 +25,7 @@ for name in $bin_names; do
     rm -v target/debug/deps/$normalized-*
 done
 
+rm -v target/.rustc_info.json
+
 echo "Final cache size:"
 du -hs target/debug


### PR DESCRIPTION
These changes started based on a discussion over on [internals](https://internals.rust-lang.org/t/evaluating-github-actions/11292/8?u=jtgeibel).  Basically, on every single build we end up touching some files and invaliding the caches.  This forces Travis to compress and upload a new cache on every single build.

This PR includes several changes on CI:

* Incremental compilation is disabled.  It appears that incremental files can change even if nothing in the codebase changes.
* Drop the `target/.rustc_info.json` file before caching, as it can change on each build.
* Running `cargo install` for the diesel CLI acts similar to a `cargo update` causing changes to the index and some caches maintained under `$HOME/.cargo`.  `cargo install` is now only run if the diesel binary is not on the path.  The downside to this is that if we bump the `.diesel_version` file then Travis will not be using the exact same version as Heroku until we clear the CI cache.  Since we only use this binary to run migrations and we haven't bumped versions since January, I think this change is low risk compared to the improvement.
* Add `RUSTFLAGS="-C debuginfo=0"` to disable debug info, which helps shrink the cache size.

Based on my observations while putting together this PR, it looks like disabling incremental compilation has an impact on compile times, but this is small relative to the overall win on caching behavior.  Additionally, our cache size has been reduced from 3948.04MB to 2439.19MB.