### PR TITLE
conditionally add request metadata length to log output (no test)

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -217,6 +217,8 @@ pub fn publish(req: &mut dyn Request) -> CargoResult<Response> {
 fn parse_new_headers(req: &mut dyn Request) -> CargoResult<(EncodableCrateUpload, User)> {
     // Read the json upload request
     let metadata_length = u64::from(read_le_u32(req.body())?);
+    req.mut_extensions().insert(metadata_length);
+
     let max = req.app().config.max_upload_size;
     if metadata_length > max {
         return Err(human(&format_args!("max upload size is: {}", max)));

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -31,10 +31,16 @@ impl Handler for LogRequests {
         let response_time =
             response_time.as_secs() * 1000 + u64::from(response_time.subsec_nanos()) / 1_000_000;
 
+        let metadata_length = req
+            .extensions()
+            .find::<u64>()
+            .map_or(String::new(), |l| format!(" metadata_length={}", l));
+
         print!(
             "at={level} method={method} path=\"{path}\" \
              request_id={request_id} fwd=\"{ip}\" service={time_ms}ms \
-             status={status} user_agent=\"{user_agent}\"",
+             status={status} user_agent=\"{user_agent}\"\
+             {metadata_length}",
             level = level,
             method = req.method(),
             path = FullPath(req),
@@ -43,6 +49,7 @@ impl Handler for LogRequests {
             user_agent = request_header(req, "User-Agent"),
             request_id = request_header(req, "X-Request-Id"),
             status = response_code,
+            metadata_length = metadata_length,
         );
 
         if let Err(ref e) = res {


### PR DESCRIPTION
This pull request implements the first step in determining a maximum metadata size for uploads as described in issue 1896 [https://github.com/rust-lang/crates.io/issues/1896](url). There was no test added for this change as log output is not automatically tested.