### PR TITLE
Add a `USE_FASTBOOT=staging-experimental` mode

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -107,7 +107,7 @@ http {
 
 	upstream app_server {
 		server localhost:8888 fail_timeout=0;
- 	}
+	}
 
 	server {
 		listen <%= ENV["PORT"] %>;
@@ -130,15 +130,33 @@ http {
 			rewrite ^ https://$host$request_uri? permanent;
 		}
 
-		location / {
-			proxy_pass http://app_server;
-		}
+		<% if ENV['USE_FASTBOOT'] == "staging-experimental" %>
+			# Experimentally send all non-backend requests to FastBoot
 
-		<% if ENV['USE_FASTBOOT'] %>
-		# Just in case, only forward "/policies" to Ember for a moment
-		location = /policies {
-			proxy_pass http://localhost:9000;
-		}
+			location /api/ {
+				proxy_pass http://app_server;
+			}
+
+			# FastBoot
+			location / {
+				proxy_pass http://localhost:9000;
+			}
+		<% elsif ['USE_FASTBOOT'] %>
+			# Fastboot is enabled only for allowed paths
+
+			location = /policies {
+				proxy_pass http://localhost:9000;
+			}
+
+			location / {
+				proxy_pass http://app_server;
+			}
+		<% else %>
+			# FastBoot is disabled, backend sends the static Ember index HTML for non-backend paths
+
+			location / {
+				proxy_pass http://app_server;
+			}
 		<% end %>
 
 		location ~ ^/api/v./crates/new$ {

--- a/script/ember.sh
+++ b/script/ember.sh
@@ -3,7 +3,7 @@ set -ue
 
 export FASTBOOT_DISABLED
 
-if [ "${USE_FASTBOOT:-0}" = '1' ]; then
+if [ -z "${USE_FASTBOOT}" ]; then
     unset FASTBOOT_DISABLED
 else
     FASTBOOT_DISABLED=1

--- a/script/ember.sh
+++ b/script/ember.sh
@@ -4,9 +4,9 @@ set -ue
 export FASTBOOT_DISABLED
 
 if [ -z "${USE_FASTBOOT-}" ]; then
-    unset FASTBOOT_DISABLED
-else
     FASTBOOT_DISABLED=1
+else
+    unset FASTBOOT_DISABLED
 fi
 
 ember "$@"

--- a/script/ember.sh
+++ b/script/ember.sh
@@ -3,7 +3,7 @@ set -ue
 
 export FASTBOOT_DISABLED
 
-if [ -z "${USE_FASTBOOT}" ]; then
+if [ -z "${USE_FASTBOOT-}" ]; then
     unset FASTBOOT_DISABLED
 else
     FASTBOOT_DISABLED=1

--- a/script/start-web.sh
+++ b/script/start-web.sh
@@ -1,7 +1,7 @@
 #! /bin/bash
 set -ue
 
-if [[ -z "${USE_FASTBOOT}" ]]; then
+if [[ -z "${USE_FASTBOOT-}" ]]; then
     unset USE_FASTBOOT
     bin/start-nginx ./target/release/server
 else

--- a/script/start-web.sh
+++ b/script/start-web.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 set -ue
 
-if [[ "${USE_FASTBOOT:-0}" = 1 ]]; then
-    export USE_FASTBOOT=1
+if [[ -z "${USE_FASTBOOT}" ]]; then
+    unset USE_FASTBOOT
+    bin/start-nginx ./target/release/server
+else
+    export USE_FASTBOOT
     node --optimize_for_size --max_old_space_size=200 fastboot.js &
     bin/start-nginx ./target/release/server &
     wait -n
-else
-    unset USE_FASTBOOT
-    bin/start-nginx ./target/release/server
 fi


### PR DESCRIPTION
This adds a new mode to the `USE_FASTBOOT` environment variable.  The logic is now:

* When deployed on Heroku (staging or production - via `script/start-web.sh`):
  * If `USE_FASTBOOT=staging-experimental` then non-backend requests are sent to FastBoot.
  * If `USE_FASTBOOT` is set and non-zero length, FastBoot is enabled only for allowed paths.
  * Otherwise (`USE_FASTBOOT` is not set, or is zero length), FastBoot is disabled.
* When doing local development (via `script/ember.sh`):
  * If `USE_FASTBOOT` is set, all (initial) frontend requests are served via FastBoot.  This is equivalent to `staging-experimental` above.
  * If `USE_FASTBOOT` is not set, FastBoot is disabled.

Because our development environment doesn't go through nginx, it isn't possible to support the "FastBoot is enabled only for allowed paths" mode.  However, once the frontend has booted, all further requests hit the backend (unless JS is disabled, then every client navigation results in a new request served via FastBoot).