### PR TITLE
Send email on crate owner invitation

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -92,7 +92,7 @@ https://crates.io/confirm/{}",
 /// the database and the user will see the invitation when they visit
 /// https://crates.io/me/pending-invites/.
 pub fn send_owner_invite_email(email: &str, user_name: &str, crate_name: &str) {
-    let subject = "Please confirm crate ownership";
+    let subject = "Crate ownership invitation";
     let body = format!(
         "{} has invited you to become an owner of the crate {}!\n
 Please visit https://crates.io/me/pending-invites to accept or reject

--- a/src/email.rs
+++ b/src/email.rs
@@ -86,6 +86,23 @@ https://crates.io/confirm/{}",
     send_email(email, subject, &body)
 }
 
+/// Attempts to send a crate owner invitation email. Swallows all errors.
+///
+/// Whether or not the email is sent, the invitation entry will be created in
+/// the database and the user will see the invitation when they visit
+/// https://crates.io/me/pending-invites/.
+pub fn send_owner_invite_email(email: &str, user_name: &str, crate_name: &str) {
+    let subject = "Please confirm crate ownership";
+    let body = format!(
+        "{} has invited you to become an owner of the crate {}!\n
+Please visit https://crates.io/me/pending-invites to accept or reject
+this invitation.",
+        user_name, crate_name
+    );
+
+    let _ = send_email(email, subject, &body);
+}
+
 fn send_email(recipient: &str, subject: &str, body: &str) -> CargoResult<()> {
     let mailgun_config = init_config_vars();
     let email = build_email(recipient, subject, body, &mailgun_config)?;


### PR DESCRIPTION
If the recipient of a crate ownership invitation has a verified email address, they will be sent an email indicating that a specified user has invited them to become an owner of a named crate. Only sends the email on the first instance of an invitation.

Completes the first part of #1360. 