### PR TITLE
Move 3 backend routes to `/api/private/session`

### DIFF
--- a/app/routes/github-authorize.js
+++ b/app/routes/github-authorize.js
@@ -19,7 +19,7 @@ export default Route.extend({
   async beforeModel(transition) {
     try {
       let queryParams = serializeQueryParams(transition.queryParams);
-      let resp = await fetch(`/authorize?${queryParams}`);
+      let resp = await fetch(`/api/private/session/authorize?${queryParams}`);
       let json = await resp.json();
       let item = JSON.stringify({ ok: resp.ok, data: json });
       if (window.opener) {

--- a/app/routes/github-login.js
+++ b/app/routes/github-login.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import ajax from 'ember-fetch/ajax';
 
 /**
- * Calling this route will query the `/authorize_url` API endpoint
+ * Calling this route will query the `/api/private/session/begin` API endpoint
  * and redirect to the received URL to initiate the OAuth flow.
  *
  * Example URL:
@@ -16,7 +16,7 @@ import ajax from 'ember-fetch/ajax';
  */
 export default Route.extend({
   async beforeModel() {
-    let url = await ajax(`/authorize_url`);
+    let url = await ajax(`/api/private/session/begin`);
     window.location = url.url;
   },
 });

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -7,7 +7,7 @@ export default Route.extend({
   session: service(),
 
   async activate() {
-    await ajax(`/logout`, { method: 'DELETE' });
+    await ajax(`/api/private/session`, { method: 'DELETE' });
     run(() => {
       this.session.logoutUser();
       this.transitionTo('index');

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -10,7 +10,7 @@ use crate::models::{NewUser, User};
 use crate::schema::users;
 use crate::util::errors::{AppError, ReadOnlyMode};
 
-/// Handles the `GET /authorize_url` route.
+/// Handles the `GET /api/private/session/begin` route.
 ///
 /// This route will return an authorization URL for the GitHub OAuth flow including the crates.io
 /// `client_id` and a randomly generated `state` secret.
@@ -25,7 +25,7 @@ use crate::util::errors::{AppError, ReadOnlyMode};
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub fn github_authorize(req: &mut dyn Request) -> AppResult<Response> {
+pub fn begin(req: &mut dyn Request) -> AppResult<Response> {
     let (url, state) = req
         .app()
         .github
@@ -45,7 +45,7 @@ pub fn github_authorize(req: &mut dyn Request) -> AppResult<Response> {
     }))
 }
 
-/// Handles the `GET /authorize` route.
+/// Handles the `GET /api/private/session/authorize` route.
 ///
 /// This route is called from the GitHub API OAuth flow after the user accepted or rejected
 /// the data access permissions. It will check the `state` parameter and then call the GitHub API
@@ -73,7 +73,7 @@ pub fn github_authorize(req: &mut dyn Request) -> AppResult<Response> {
 ///     }
 /// }
 /// ```
-pub fn github_access_token(req: &mut dyn Request) -> AppResult<Response> {
+pub fn authorize(req: &mut dyn Request) -> AppResult<Response> {
     // Parse the url query
     let mut query = req.query();
     let code = query.remove("code").unwrap_or_default();
@@ -144,7 +144,7 @@ impl GithubUser {
     }
 }
 
-/// Handles the `GET /logout` route.
+/// Handles the `DELETE /api/private/session` route.
 pub fn logout(req: &mut dyn Request) -> AppResult<Response> {
     req.session().remove(&"user_id".to_string());
     Ok(req.json(&true))

--- a/src/router.rs
+++ b/src/router.rs
@@ -112,9 +112,13 @@ pub fn build_router(app: &App) -> R404 {
     router.head("/api/v1/*path", R(Arc::clone(&api_router)));
     router.delete("/api/v1/*path", R(api_router));
 
-    router.get("/authorize_url", C(user::session::github_authorize));
-    router.get("/authorize", C(user::session::github_access_token));
-    router.delete("/logout", C(user::session::logout));
+    // Session management
+    router.get("/api/private/session/begin", C(user::session::begin));
+    router.get(
+        "/api/private/session/authorize",
+        C(user::session::authorize),
+    );
+    router.delete("/api/private/session", C(user::session::logout));
 
     // Only serve the local checkout of the git index in development mode.
     // In production, for crates.io, cargo gets the index from

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -106,14 +106,16 @@ impl crate::util::MockAnonymousUser {
 #[test]
 fn auth_gives_a_token() {
     let (_, anon) = TestApp::init().empty();
-    let json: AuthResponse = anon.get("/authorize_url").good();
+    let json: AuthResponse = anon.get("/api/private/session/begin").good();
     assert!(json.url.contains(&json.state));
 }
 
 #[test]
 fn access_token_needs_data() {
     let (_, anon) = TestApp::init().empty();
-    let json = anon.get::<()>("/authorize").bad_with_status(200); // Change endpoint to 400?
+    let json = anon
+        .get::<()>("/api/private/session/authorize")
+        .bad_with_status(200); // Change endpoint to 400?
     assert!(json.errors[0].detail.contains("invalid state"));
 }
 


### PR DESCRIPTION
This PR moves 3 remaining backend routes so that all backend routes are now scoped under `/api/`.  Upon further examination, I've determined that the initial OAuth callback is handled by the `/authorize/github` frontend route, which has not moved.  Therefore, this PR does not need to be synchronized with any changes to the GitHub OAuth settings!