### PR TITLE
Begin refactoring error handling/fallback logic

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -5,17 +5,17 @@ use swirl::PerformError;
 use crate::db::{DieselPool, DieselPooledConn};
 use crate::git::Repository;
 use crate::uploaders::Uploader;
-use crate::util::errors::{CargoErrToStdErr, CargoResult};
+use crate::util::errors::{AppErrToStdErr, AppResult};
 
 impl<'a> swirl::db::BorrowedConnection<'a> for DieselPool {
     type Connection = DieselPooledConn<'a>;
 }
 
 impl swirl::db::DieselPool for DieselPool {
-    type Error = CargoErrToStdErr;
+    type Error = AppErrToStdErr;
 
     fn get(&self) -> Result<swirl::db::DieselPooledConn<'_, Self>, Self::Error> {
-        self.get().map_err(CargoErrToStdErr)
+        self.get().map_err(AppErrToStdErr)
     }
 }
 
@@ -59,10 +59,10 @@ impl Environment {
     pub fn connection(&self) -> Result<DieselPooledConn<'_>, PerformError> {
         self.connection_pool
             .get()
-            .map_err(|e| CargoErrToStdErr(e).into())
+            .map_err(|e| AppErrToStdErr(e).into())
     }
 
-    pub fn lock_index(&self) -> CargoResult<MutexGuard<'_, Repository>> {
+    pub fn lock_index(&self) -> AppResult<MutexGuard<'_, Repository>> {
         let repo = self.index.lock().unwrap_or_else(PoisonError::into_inner);
         repo.reset_head()?;
         Ok(repo)

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,8 +1,8 @@
-use cargo_registry::util::{human, CargoError, CargoResult};
+use cargo_registry::util::{human, AppError, AppResult};
 use cargo_registry::{db, env, tasks};
 use diesel::PgConnection;
 
-fn main() -> CargoResult<()> {
+fn main() -> AppResult<()> {
     let conn = db::connect_now()?;
     let mut args = std::env::args().skip(1);
     match &*args.next().unwrap_or_default() {
@@ -19,10 +19,10 @@ fn main() -> CargoResult<()> {
 }
 
 /// Helper to map the `PerformError` returned by `swirl::Job::enqueue()` to a
-/// `CargoError`. Can be removed once `map_err()` isn't needed any more.
+/// `AppError`. Can be removed once `map_err()` isn't needed any more.
 trait Enqueue: swirl::Job {
-    fn enqueue(self, conn: &PgConnection) -> CargoResult<()> {
-        <Self as swirl::Job>::enqueue(self, conn).map_err(|e| CargoError::from_std_error(e))
+    fn enqueue(self, conn: &PgConnection) -> AppResult<()> {
+        <Self as swirl::Job>::enqueue(self, conn).map_err(|e| AppError::from_std_error(e))
     }
 }
 

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,4 +1,4 @@
-use cargo_registry::util::{human, AppError, AppResult};
+use cargo_registry::util::{cargo_err, AppError, AppResult};
 use cargo_registry::{db, env, tasks};
 use diesel::PgConnection;
 
@@ -14,7 +14,7 @@ fn main() -> AppResult<()> {
                 .unwrap_or_else(|| String::from("db-dump.tar.gz"));
             tasks::dump_db(database_url, target_name).enqueue(&conn)
         }
-        other => Err(human(&format!("Unrecognized job type `{}`", other))),
+        other => Err(cargo_err(&format!("Unrecognized job type `{}`", other))),
     }
 }
 

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -8,10 +8,10 @@
 
 mod on_call;
 
-use cargo_registry::{db, schema::*, util::CargoResult};
+use cargo_registry::{db, schema::*, util::AppResult};
 use diesel::prelude::*;
 
-fn main() -> CargoResult<()> {
+fn main() -> AppResult<()> {
     let conn = db::connect_now()?;
 
     check_stalled_background_jobs(&conn)?;
@@ -19,7 +19,7 @@ fn main() -> CargoResult<()> {
     Ok(())
 }
 
-fn check_stalled_background_jobs(conn: &PgConnection) -> CargoResult<()> {
+fn check_stalled_background_jobs(conn: &PgConnection) -> AppResult<()> {
     use cargo_registry::schema::background_jobs::dsl::*;
     use diesel::dsl::*;
 
@@ -55,7 +55,7 @@ fn check_stalled_background_jobs(conn: &PgConnection) -> CargoResult<()> {
     Ok(())
 }
 
-fn check_spam_attack(conn: &PgConnection) -> CargoResult<()> {
+fn check_spam_attack(conn: &PgConnection) -> AppResult<()> {
     use cargo_registry::models::krate::canon_crate_name;
     use diesel::dsl::*;
     use diesel::sql_types::Bool;
@@ -116,7 +116,7 @@ fn check_spam_attack(conn: &PgConnection) -> CargoResult<()> {
     Ok(())
 }
 
-fn log_and_trigger_event(event: on_call::Event) -> CargoResult<()> {
+fn log_and_trigger_event(event: on_call::Event) -> AppResult<()> {
     match event {
         on_call::Event::Trigger {
             ref description, ..

--- a/src/bin/on_call/mod.rs
+++ b/src/bin/on_call/mod.rs
@@ -1,4 +1,4 @@
-use cargo_registry::util::{internal, CargoResult};
+use cargo_registry::util::{internal, AppResult};
 
 use reqwest::{header, StatusCode as Status};
 
@@ -25,7 +25,7 @@ impl Event {
     ///
     /// If the variant is `Trigger`, this will page whoever is on call
     /// (potentially waking them up at 3 AM).
-    pub fn send(self) -> CargoResult<()> {
+    pub fn send(self) -> AppResult<()> {
         let api_token = dotenv::var("PAGERDUTY_API_TOKEN")?;
         let service_key = dotenv::var("PAGERDUTY_INTEGRATION_KEY")?;
 

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     db,
-    util::errors::{internal, CargoResult, ChainError},
+    util::errors::{internal, AppResult, ChainError},
 };
 
 use diesel::prelude::*;
@@ -37,7 +37,7 @@ impl Category {
     }
 }
 
-fn required_string_from_toml<'a>(toml: &'a toml::value::Table, key: &str) -> CargoResult<&'a str> {
+fn required_string_from_toml<'a>(toml: &'a toml::value::Table, key: &str) -> AppResult<&'a str> {
     toml.get(key).and_then(toml::Value::as_str).chain_error(|| {
         internal(&format_args!(
             "Expected category TOML attribute '{}' to be a String",
@@ -53,7 +53,7 @@ fn optional_string_from_toml<'a>(toml: &'a toml::value::Table, key: &str) -> &'a
 fn categories_from_toml(
     categories: &toml::value::Table,
     parent: Option<&Category>,
-) -> CargoResult<Vec<Category>> {
+) -> AppResult<Vec<Category>> {
     let mut result = vec![];
 
     for (slug, details) in categories {
@@ -85,12 +85,12 @@ fn categories_from_toml(
     Ok(result)
 }
 
-pub fn sync(toml_str: &str) -> CargoResult<()> {
+pub fn sync(toml_str: &str) -> AppResult<()> {
     let conn = db::connect_now().unwrap();
     sync_with_connection(toml_str, &conn)
 }
 
-pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> CargoResult<()> {
+pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> AppResult<()> {
     use crate::schema::categories::dsl::*;
     use diesel::dsl::all;
     use diesel::pg::upsert::excluded;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -6,7 +6,7 @@ mod prelude {
     pub use conduit_router::RequestParams;
 
     pub use crate::db::RequestTransaction;
-    pub use crate::util::{human, CargoResult};
+    pub use crate::util::{human, AppResult};
 
     pub use crate::middleware::app::RequestApp;
     pub use crate::middleware::current_user::RequestUser;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -6,7 +6,7 @@ mod prelude {
     pub use conduit_router::RequestParams;
 
     pub use crate::db::RequestTransaction;
-    pub use crate::util::{human, AppResult};
+    pub use crate::util::{cargo_err, AppResult};
 
     pub use crate::middleware::app::RequestApp;
     pub use crate::middleware::current_user::RequestUser;

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn index(req: &mut dyn Request) -> AppResult<Response> {
     let conn = req.db_conn()?;
     let query = req.query();
     // FIXME: There are 69 categories, 47 top level. This isn't going to
@@ -40,7 +40,7 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show(req: &mut dyn Request) -> AppResult<Response> {
     let slug = &req.params()["category_id"];
     let conn = req.db_conn()?;
     let cat = Category::by_slug(slug).first::<Category>(&*conn)?;
@@ -77,7 +77,7 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /category_slugs` route.
-pub fn slugs(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn slugs(req: &mut dyn Request) -> AppResult<Response> {
     let conn = req.db_conn()?;
     let slugs = categories::table
         .select((categories::slug, categories::slug, categories::description))

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -38,7 +38,7 @@ pub fn handle_invite(req: &mut dyn Request) -> AppResult<Response> {
     let conn = &*req.db_conn()?;
 
     let crate_invite: OwnerInvitation =
-        serde_json::from_str(&body).map_err(|_| human("invalid json request"))?;
+        serde_json::from_str(&body).map_err(|_| cargo_err("invalid json request"))?;
 
     let crate_invite = crate_invite.crate_owner_invite;
 

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -5,7 +5,7 @@ use crate::schema::{crate_owner_invitations, crate_owners};
 use crate::views::{EncodableCrateOwnerInvitation, InvitationResponse};
 
 /// Handles the `GET /me/crate_owner_invitations` route.
-pub fn list(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn list(req: &mut dyn Request) -> AppResult<Response> {
     let conn = &*req.db_conn()?;
     let user_id = req.user()?.id;
 
@@ -31,7 +31,7 @@ struct OwnerInvitation {
 }
 
 /// Handles the `PUT /me/crate_owner_invitations/:crate_id` route.
-pub fn handle_invite(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn handle_invite(req: &mut dyn Request) -> AppResult<Response> {
     let mut body = String::new();
     req.body().read_to_string(&mut body)?;
 
@@ -53,7 +53,7 @@ fn accept_invite(
     req: &dyn Request,
     conn: &PgConnection,
     crate_invite: InvitationResponse,
-) -> CargoResult<Response> {
+) -> AppResult<Response> {
     use diesel::{delete, insert_into};
 
     let user_id = req.user()?.id;
@@ -92,7 +92,7 @@ fn decline_invite(
     req: &dyn Request,
     conn: &PgConnection,
     crate_invite: InvitationResponse,
-) -> CargoResult<Response> {
+) -> AppResult<Response> {
     use diesel::delete;
 
     let user_id = req.user()?.id;

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,11 +1,11 @@
-use crate::util::{json_response, CargoResult};
+use crate::util::{json_response, AppResult};
 use conduit::Response;
 
 pub(crate) mod pagination;
 
 pub(crate) use self::pagination::Paginate;
 
-pub fn ok_true() -> CargoResult<Response> {
+pub fn ok_true() -> AppResult<Response> {
     #[derive(Serialize)]
     struct R {
         ok: bool,

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -14,7 +14,7 @@ pub(crate) enum Page {
 }
 
 impl Page {
-    fn new(params: &IndexMap<String, String>) -> CargoResult<Self> {
+    fn new(params: &IndexMap<String, String>) -> AppResult<Self> {
         if let Some(s) = params.get("page") {
             let numeric_page = s.parse()?;
             if numeric_page < 1 {
@@ -38,7 +38,7 @@ pub(crate) struct PaginationOptions {
 }
 
 impl PaginationOptions {
-    pub(crate) fn new(params: &IndexMap<String, String>) -> CargoResult<Self> {
+    pub(crate) fn new(params: &IndexMap<String, String>) -> AppResult<Self> {
         const DEFAULT_PER_PAGE: u32 = 10;
         const MAX_PER_PAGE: u32 = 100;
 
@@ -70,7 +70,7 @@ impl PaginationOptions {
 }
 
 pub(crate) trait Paginate: Sized {
-    fn paginate(self, params: &IndexMap<String, String>) -> CargoResult<PaginatedQuery<Self>> {
+    fn paginate(self, params: &IndexMap<String, String>) -> AppResult<PaginatedQuery<Self>> {
         Ok(PaginatedQuery {
             query: self,
             options: PaginationOptions::new(params)?,

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -18,7 +18,7 @@ impl Page {
         if let Some(s) = params.get("page") {
             let numeric_page = s.parse()?;
             if numeric_page < 1 {
-                return Err(human(&format_args!(
+                return Err(cargo_err(&format_args!(
                     "page indexing starts from 1, page {} is invalid",
                     numeric_page,
                 )));
@@ -48,7 +48,7 @@ impl PaginationOptions {
             .unwrap_or(Ok(DEFAULT_PER_PAGE))?;
 
         if per_page > MAX_PER_PAGE {
-            return Err(human(&format_args!(
+            return Err(cargo_err(&format_args!(
                 "cannot request more than {} items",
                 MAX_PER_PAGE,
             )));

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -5,7 +5,7 @@ use crate::models::Keyword;
 use crate::views::EncodableKeyword;
 
 /// Handles the `GET /keywords` route.
-pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn index(req: &mut dyn Request) -> AppResult<Response> {
     use crate::schema::keywords;
 
     let conn = req.db_conn()?;
@@ -41,7 +41,7 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /keywords/:keyword_id` route.
-pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show(req: &mut dyn Request) -> AppResult<Response> {
     let name = &req.params()["keyword_id"];
     let conn = req.db_conn()?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -14,7 +14,7 @@ use crate::views::EncodableVersionDownload;
 use crate::models::krate::to_char;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub fn downloads(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn downloads(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -7,7 +7,7 @@ use crate::db::DieselPooledConn;
 use crate::models::{Crate, Follow};
 use crate::schema::*;
 
-fn follow_target(req: &dyn Request, conn: &DieselPooledConn<'_>) -> CargoResult<Follow> {
+fn follow_target(req: &dyn Request, conn: &DieselPooledConn<'_>) -> AppResult<Follow> {
     let user = req.user()?;
     let crate_name = &req.params()["crate_id"];
     let crate_id = Crate::by_name(crate_name)
@@ -20,7 +20,7 @@ fn follow_target(req: &dyn Request, conn: &DieselPooledConn<'_>) -> CargoResult<
 }
 
 /// Handles the `PUT /crates/:crate_id/follow` route.
-pub fn follow(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn follow(req: &mut dyn Request) -> AppResult<Response> {
     let conn = req.db_conn()?;
     let follow = follow_target(req, &conn)?;
     diesel::insert_into(follows::table)
@@ -32,7 +32,7 @@ pub fn follow(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `DELETE /crates/:crate_id/follow` route.
-pub fn unfollow(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn unfollow(req: &mut dyn Request) -> AppResult<Response> {
     let conn = req.db_conn()?;
     let follow = follow_target(req, &conn)?;
     diesel::delete(&follow).execute(&*conn)?;
@@ -41,7 +41,7 @@ pub fn unfollow(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/following` route.
-pub fn following(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn following(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::dsl::exists;
 
     let conn = req.db_conn()?;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -19,7 +19,7 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub fn summary(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn summary(req: &mut dyn Request) -> AppResult<Response> {
     use crate::schema::crates::dsl::*;
 
     let conn = req.db_conn()?;
@@ -28,7 +28,7 @@ pub fn summary(req: &mut dyn Request) -> CargoResult<Response> {
         .select(metadata::total_downloads)
         .get_result(&*conn)?;
 
-    let encode_crates = |krates: Vec<Crate>| -> CargoResult<Vec<_>> {
+    let encode_crates = |krates: Vec<Crate>| -> AppResult<Vec<_>> {
         let versions = krates.versions().load::<Version>(&*conn)?;
         versions
             .grouped_by(&krates)
@@ -102,7 +102,7 @@ pub fn summary(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id` route.
-pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show(req: &mut dyn Request) -> AppResult<Response> {
     let name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(name).first::<Crate>(&*conn)?;
@@ -161,7 +161,7 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/readme` route.
-pub fn readme(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn readme(req: &mut dyn Request) -> AppResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let version = &req.params()["version"];
 
@@ -185,7 +185,7 @@ pub fn readme(req: &mut dyn Request) -> CargoResult<Response> {
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub fn versions(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn versions(req: &mut dyn Request) -> AppResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -208,7 +208,7 @@ pub fn versions(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/reverse_dependencies` route.
-pub fn reverse_dependencies(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn reverse_dependencies(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::dsl::any;
 
     let name = &req.params()["crate_id"];

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -82,11 +82,11 @@ fn parse_owners_request(req: &mut dyn Request) -> AppResult<Vec<String>> {
         owners: Option<Vec<String>>,
     }
     let request: Request =
-        serde_json::from_str(&body).map_err(|_| human("invalid json request"))?;
+        serde_json::from_str(&body).map_err(|_| cargo_err("invalid json request"))?;
     request
         .owners
         .or(request.users)
-        .ok_or_else(|| human("invalid json request"))
+        .ok_or_else(|| cargo_err("invalid json request"))
 }
 
 fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
@@ -104,10 +104,10 @@ fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
             Rights::Full => {}
             // Yes!
             Rights::Publish => {
-                return Err(human("team members don't have permission to modify owners"));
+                return Err(cargo_err("team members don't have permission to modify owners"));
             }
             Rights::None => {
-                return Err(human("only owners have permission to modify owners"));
+                return Err(cargo_err("only owners have permission to modify owners"));
             }
         }
 
@@ -117,7 +117,7 @@ fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
                 let login_test =
                     |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
                 if owners.iter().any(login_test) {
-                    return Err(human(&format_args!("`{}` is already an owner", login)));
+                    return Err(cargo_err(&format_args!("`{}` is already an owner", login)));
                 }
                 let msg = krate.owner_add(app, &conn, user, login)?;
                 msgs.push(msg);
@@ -128,7 +128,7 @@ fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
                 krate.owner_remove(app, &conn, user, login)?;
             }
             if User::owning(&krate, &conn)?.is_empty() {
-                return Err(human(
+                return Err(cargo_err(
                     "cannot remove all individual owners of a crate. \
                      Team member don't have permission to modify owners, so \
                      at least one individual owner is required.",

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -7,7 +7,7 @@ use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub fn owners(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn owners(req: &mut dyn Request) -> AppResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -25,7 +25,7 @@ pub fn owners(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub fn owner_team(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn owner_team(req: &mut dyn Request) -> AppResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -42,7 +42,7 @@ pub fn owner_team(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub fn owner_user(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn owner_user(req: &mut dyn Request) -> AppResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -59,12 +59,12 @@ pub fn owner_user(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
-pub fn add_owners(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn add_owners(req: &mut dyn Request) -> AppResult<Response> {
     modify_owners(req, true)
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
-pub fn remove_owners(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn remove_owners(req: &mut dyn Request) -> AppResult<Response> {
     modify_owners(req, false)
 }
 
@@ -72,7 +72,7 @@ pub fn remove_owners(req: &mut dyn Request) -> CargoResult<Response> {
 /// The format is
 ///
 ///     {"owners": ["username", "github:org:team", ...]}
-fn parse_owners_request(req: &mut dyn Request) -> CargoResult<Vec<String>> {
+fn parse_owners_request(req: &mut dyn Request) -> AppResult<Vec<String>> {
     let mut body = String::new();
     req.body().read_to_string(&mut body)?;
     #[derive(Deserialize)]
@@ -89,7 +89,7 @@ fn parse_owners_request(req: &mut dyn Request) -> CargoResult<Vec<String>> {
         .ok_or_else(|| human("invalid json request"))
 }
 
-fn modify_owners(req: &mut dyn Request, add: bool) -> CargoResult<Response> {
+fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
     let logins = parse_owners_request(req)?;
     let app = req.app();
     let user = req.user()?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -104,7 +104,9 @@ fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
             Rights::Full => {}
             // Yes!
             Rights::Publish => {
-                return Err(cargo_err("team members don't have permission to modify owners"));
+                return Err(cargo_err(
+                    "team members don't have permission to modify owners",
+                ));
             }
             Rights::None => {
                 return Err(cargo_err("only owners have permission to modify owners"));

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -32,7 +32,7 @@ use crate::models::krate::{canon_crate_name, ALL_COLUMNS};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub fn search(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn search(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::sql_types::{Bool, Text};
 
     let conn = req.db_conn()?;

--- a/src/controllers/site_metadata.rs
+++ b/src/controllers/site_metadata.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 ///
 /// The sha is contained within the `HEROKU_SLUG_COMMIT` environment variable.
 /// If `HEROKU_SLUG_COMMIT` is not set, returns `"unknown"`.
-pub fn show_deployed_sha(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show_deployed_sha(req: &mut dyn Request) -> AppResult<Response> {
     let deployed_sha =
         dotenv::var("HEROKU_SLUG_COMMIT").unwrap_or_else(|_| String::from("unknown"));
 

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,7 +5,7 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub fn show_team(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show_team(req: &mut dyn Request) -> AppResult<Response> {
     use self::teams::dsl::{login, teams};
 
     let name = &req.params()["team_id"];

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -9,7 +9,7 @@ use crate::views::EncodableApiTokenWithToken;
 use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.
-pub fn list(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn list(req: &mut dyn Request) -> AppResult<Response> {
     let tokens = ApiToken::belonging_to(req.user()?)
         .filter(api_tokens::revoked.eq(false))
         .order(api_tokens::created_at.desc())
@@ -22,7 +22,7 @@ pub fn list(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `PUT /me/tokens` route.
-pub fn new(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn new(req: &mut dyn Request) -> AppResult<Response> {
     /// The incoming serialization format for the `ApiToken` model.
     #[derive(Deserialize, Serialize)]
     struct NewApiToken {
@@ -90,7 +90,7 @@ pub fn new(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `DELETE /me/tokens/:id` route.
-pub fn revoke(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn revoke(req: &mut dyn Request) -> AppResult<Response> {
     let id = req.params()["id"]
         .parse::<i32>()
         .map_err(|e| bad_request(&format!("invalid token id: {:?}", e)))?;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -122,7 +122,7 @@ pub fn update_user(req: &mut dyn Request) -> AppResult<Response> {
 
     // need to check if current user matches user to be updated
     if &user.id.to_string() != name {
-        return Err(human("current user does not match requested user"));
+        return Err(cargo_err("current user does not match requested user"));
     }
 
     #[derive(Deserialize)]
@@ -136,17 +136,17 @@ pub fn update_user(req: &mut dyn Request) -> AppResult<Response> {
     }
 
     let user_update: UserUpdate =
-        serde_json::from_str(&body).map_err(|_| human("invalid json request"))?;
+        serde_json::from_str(&body).map_err(|_| cargo_err("invalid json request"))?;
 
     if user_update.user.email.is_none() {
-        return Err(human("empty email rejected"));
+        return Err(cargo_err("empty email rejected"));
     }
 
     let user_email = user_update.user.email.unwrap();
     let user_email = user_email.trim();
 
     if user_email == "" {
-        return Err(human("empty email rejected"));
+        return Err(cargo_err("empty email rejected"));
     }
 
     conn.transaction::<_, Box<dyn AppError>, _>(|| {
@@ -166,7 +166,7 @@ pub fn update_user(req: &mut dyn Request) -> AppResult<Response> {
             .set(&new_email)
             .returning(emails::token)
             .get_result::<String>(&*conn)
-            .map_err(|_| human("Error in creating token"))?;
+            .map_err(|_| cargo_err("Error in creating token"))?;
 
         crate::email::send_user_confirm_email(user_email, &user.gh_login, &token);
 
@@ -213,7 +213,7 @@ pub fn regenerate_token_and_send(req: &mut dyn Request) -> AppResult<Response> {
 
     // need to check if current user matches user to be updated
     if &user.id != name {
-        return Err(human("current user does not match requested user"));
+        return Err(cargo_err("current user does not match requested user"));
     }
 
     conn.transaction(|| {

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -5,7 +5,7 @@ use crate::controllers::prelude::*;
 use crate::controllers::helpers::*;
 use crate::email;
 use crate::util::bad_request;
-use crate::util::errors::CargoError;
+use crate::util::errors::AppError;
 
 use crate::models::user::{UserNoEmailType, ALL_COLUMNS};
 use crate::models::{CrateOwner, Email, Follow, NewEmail, OwnerKind, User, Version};
@@ -13,7 +13,7 @@ use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::views::{EncodableMe, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
-pub fn me(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn me(req: &mut dyn Request) -> AppResult<Response> {
     // Changed to getting User information from database because in
     // src/tests/user.rs, when testing put and get on updating email,
     // request seems to be somehow 'cached'. When we try to get a
@@ -68,7 +68,7 @@ pub fn me(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /me/updates` route.
-pub fn updates(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn updates(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::dsl::any;
 
     let user = req.user()?;
@@ -109,7 +109,7 @@ pub fn updates(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `PUT /user/:user_id` route.
-pub fn update_user(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn update_user(req: &mut dyn Request) -> AppResult<Response> {
     use self::emails::user_id;
     use self::users::dsl::{email, gh_login, users};
     use diesel::{insert_into, update};
@@ -149,7 +149,7 @@ pub fn update_user(req: &mut dyn Request) -> CargoResult<Response> {
         return Err(human("empty email rejected"));
     }
 
-    conn.transaction::<_, Box<dyn CargoError>, _>(|| {
+    conn.transaction::<_, Box<dyn AppError>, _>(|| {
         update(users.filter(gh_login.eq(&user.gh_login)))
             .set(email.eq(user_email))
             .execute(&*conn)?;
@@ -181,7 +181,7 @@ pub fn update_user(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `PUT /confirm/:email_token` route
-pub fn confirm_user_email(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn confirm_user_email(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::update;
 
     let conn = req.db_conn()?;
@@ -203,7 +203,7 @@ pub fn confirm_user_email(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles `PUT /user/:user_id/resend` route
-pub fn regenerate_token_and_send(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn regenerate_token_and_send(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::dsl::sql;
     use diesel::update;
 
@@ -234,7 +234,7 @@ pub fn regenerate_token_and_send(req: &mut dyn Request) -> CargoResult<Response>
 }
 
 /// Handles `PUT /me/email_notifications` route
-pub fn update_email_notifications(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn update_email_notifications(req: &mut dyn Request) -> AppResult<Response> {
     use self::crate_owners::dsl::*;
     use diesel::pg::upsert::excluded;
 

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -7,7 +7,7 @@ use crate::schema::{crate_owners, crates, users};
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show(req: &mut dyn Request) -> AppResult<Response> {
     use self::users::dsl::{gh_login, id, users};
 
     let name = &req.params()["user_id"].to_lowercase();
@@ -28,7 +28,7 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub fn stats(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn stats(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::dsl::sum;
 
     let user_id = &req.params()["user_id"].parse::<i32>().ok().unwrap();

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -85,7 +85,7 @@ pub fn github_access_token(req: &mut dyn Request) -> AppResult<Response> {
         let session_state = req.session().remove(&"github_oauth_state".to_string());
         let session_state = session_state.as_ref().map(|a| &a[..]);
         if Some(&state[..]) != session_state {
-            return Err(human("invalid state parameter"));
+            return Err(cargo_err("invalid state parameter"));
         }
     }
 
@@ -96,7 +96,7 @@ pub fn github_access_token(req: &mut dyn Request) -> AppResult<Response> {
         .app()
         .github
         .exchange_code(code)
-        .map_err(|s| human(&s))?;
+        .map_err(|s| cargo_err(&s))?;
     let token = token.access_token();
     let ghuser = github::github_api::<GithubUser>(req.app(), "/user", token)?;
     let user = ghuser.save_to_database(&token.secret(), &*req.db_conn()?)?;

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -8,7 +8,7 @@ use crate::models::user;
 use crate::models::user::UserNoEmailType;
 use crate::models::{NewUser, User};
 use crate::schema::users;
-use crate::util::errors::{CargoError, ReadOnlyMode};
+use crate::util::errors::{AppError, ReadOnlyMode};
 
 /// Handles the `GET /authorize_url` route.
 ///
@@ -25,7 +25,7 @@ use crate::util::errors::{CargoError, ReadOnlyMode};
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub fn github_authorize(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn github_authorize(req: &mut dyn Request) -> AppResult<Response> {
     let (url, state) = req
         .app()
         .github
@@ -73,7 +73,7 @@ pub fn github_authorize(req: &mut dyn Request) -> CargoResult<Response> {
 ///     }
 /// }
 /// ```
-pub fn github_access_token(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn github_access_token(req: &mut dyn Request) -> AppResult<Response> {
     // Parse the url query
     let mut query = req.query();
     let code = query.remove("code").unwrap_or_default();
@@ -116,7 +116,7 @@ struct GithubUser {
 }
 
 impl GithubUser {
-    fn save_to_database(&self, access_token: &str, conn: &PgConnection) -> CargoResult<User> {
+    fn save_to_database(&self, access_token: &str, conn: &PgConnection) -> AppResult<User> {
         NewUser::new(
             self.id,
             &self.login,
@@ -127,7 +127,7 @@ impl GithubUser {
         )
         .create_or_update(conn)
         .map_err(Into::into)
-        .or_else(|e: Box<dyn CargoError>| {
+        .or_else(|e: Box<dyn AppError>| {
             // If we're in read only mode, we can't update their details
             // just look for an existing user
             if e.is::<ReadOnlyMode>() {
@@ -145,7 +145,7 @@ impl GithubUser {
 }
 
 /// Handles the `GET /logout` route.
-pub fn logout(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn logout(req: &mut dyn Request) -> AppResult<Response> {
     req.session().remove(&"user_id".to_string());
     Ok(req.json(&true))
 }

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -12,7 +12,7 @@ fn version_and_crate(req: &mut dyn Request) -> AppResult<(Version, Crate)> {
     let crate_name = &req.params()["crate_id"];
     let semver = &req.params()["version"];
     if semver::Version::parse(semver).is_err() {
-        return Err(human(&format_args!("invalid semver: {}", semver)));
+        return Err(cargo_err(&format_args!("invalid semver: {}", semver)));
     };
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -21,7 +21,7 @@ fn version_and_crate(req: &mut dyn Request) -> AppResult<(Version, Crate)> {
         .filter(versions::num.eq(semver))
         .first(&*conn)
         .map_err(|_| {
-            human(&format_args!(
+            cargo_err(&format_args!(
                 "crate `{}` does not have a version `{}`",
                 crate_name, semver
             ))

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -8,7 +8,7 @@ use super::prelude::*;
 use crate::models::{Crate, CrateVersions, Version};
 use crate::schema::versions;
 
-fn version_and_crate(req: &mut dyn Request) -> CargoResult<(Version, Crate)> {
+fn version_and_crate(req: &mut dyn Request) -> AppResult<(Version, Crate)> {
     let crate_name = &req.params()["crate_id"];
     let semver = &req.params()["version"];
     if semver::Version::parse(semver).is_err() {

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -14,7 +14,7 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn index(req: &mut dyn Request) -> AppResult<Response> {
     use diesel::dsl::any;
     let conn = req.db_conn()?;
 
@@ -50,7 +50,7 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub fn show_by_id(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show_by_id(req: &mut dyn Request) -> AppResult<Response> {
     let id = &req.params()["version_id"];
     let id = id.parse().unwrap_or(0);
     let conn = req.db_conn()?;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -14,7 +14,7 @@ use super::version_and_crate;
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
-pub fn download(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn download(req: &mut dyn Request) -> AppResult<Response> {
     let crate_name = &req.params()["crate_id"];
     let version = &req.params()["version"];
 
@@ -50,7 +50,7 @@ fn increment_download_counts(
     req: &dyn Request,
     crate_name: &str,
     version: &str,
-) -> CargoResult<String> {
+) -> AppResult<String> {
     use self::versions::dsl::*;
 
     let conn = req.db_conn()?;
@@ -68,7 +68,7 @@ fn increment_download_counts(
 }
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
-pub fn downloads(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn downloads(req: &mut dyn Request) -> AppResult<Response> {
     let (version, _) = version_and_crate(req)?;
     let conn = req.db_conn()?;
     let cutoff_end_date = req

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -18,7 +18,7 @@ use super::version_and_crate;
 /// In addition to returning cached data from the index, this returns
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
-pub fn dependencies(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn dependencies(req: &mut dyn Request) -> AppResult<Response> {
     let (version, _) = version_and_crate(req)?;
     let conn = req.db_conn()?;
     let deps = version.dependencies(&*conn)?;
@@ -35,7 +35,7 @@ pub fn dependencies(req: &mut dyn Request) -> CargoResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
-pub fn authors(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn authors(req: &mut dyn Request) -> AppResult<Response> {
     let (version, _) = version_and_crate(req)?;
     let conn = req.db_conn()?;
     let names = version_authors::table
@@ -66,7 +66,7 @@ pub fn authors(req: &mut dyn Request) -> CargoResult<Response> {
 ///
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
-pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn show(req: &mut dyn Request) -> AppResult<Response> {
     let (version, krate) = version_and_crate(req)?;
     let conn = req.db_conn()?;
     let published_by = version.published_by(&conn);

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -6,7 +6,7 @@ use super::version_and_crate;
 use crate::controllers::prelude::*;
 use crate::git;
 use crate::models::Rights;
-use crate::util::CargoError;
+use crate::util::AppError;
 
 /// Handles the `DELETE /crates/:crate_id/:version/yank` route.
 /// This does not delete a crate version, it makes the crate
@@ -17,17 +17,17 @@ use crate::util::CargoError;
 /// Crate deletion is not implemented to avoid breaking builds,
 /// and the goal of yanking a crate is to prevent crates
 /// beginning to depend on the yanked crate version.
-pub fn yank(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn yank(req: &mut dyn Request) -> AppResult<Response> {
     modify_yank(req, true)
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
-pub fn unyank(req: &mut dyn Request) -> CargoResult<Response> {
+pub fn unyank(req: &mut dyn Request) -> AppResult<Response> {
     modify_yank(req, false)
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank(req: &mut dyn Request, yanked: bool) -> CargoResult<Response> {
+fn modify_yank(req: &mut dyn Request, yanked: bool) -> AppResult<Response> {
     let (version, krate) = version_and_crate(req)?;
     let user = req.user()?;
     let conn = req.db_conn()?;
@@ -38,7 +38,7 @@ fn modify_yank(req: &mut dyn Request, yanked: bool) -> CargoResult<Response> {
 
     git::yank(krate.name, version, yanked)
         .enqueue(&conn)
-        .map_err(|e| CargoError::from_std_error(e))?;
+        .map_err(|e| AppError::from_std_error(e))?;
 
     #[derive(Serialize)]
     struct R {

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -33,7 +33,7 @@ fn modify_yank(req: &mut dyn Request, yanked: bool) -> AppResult<Response> {
     let conn = req.db_conn()?;
     let owners = krate.owners(&conn)?;
     if user.rights(req.app(), &owners)? < Rights::Publish {
-        return Err(human("must already be an owner to yank or unyank"));
+        return Err(cargo_err("must already be an owner to yank or unyank"));
     }
 
     git::yank(krate.name, version, yanked)

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use url::Url;
 
 use crate::middleware::app::RequestApp;
-use crate::util::CargoResult;
+use crate::util::AppResult;
 use crate::Env;
 
 #[allow(missing_debug_implementations)]
@@ -18,7 +18,7 @@ pub enum DieselPool {
 }
 
 impl DieselPool {
-    pub fn get(&self) -> CargoResult<DieselPooledConn<'_>> {
+    pub fn get(&self) -> AppResult<DieselPooledConn<'_>> {
         match self {
             DieselPool::Pool(pool) => Ok(DieselPooledConn::Pool(pool.get()?)),
             DieselPool::Test(conn) => Ok(DieselPooledConn::Test(conn.lock())),
@@ -89,11 +89,11 @@ pub trait RequestTransaction {
     ///
     /// The connection will live for the lifetime of the request.
     // FIXME: This description does not match the implementation below.
-    fn db_conn(&self) -> CargoResult<DieselPooledConn<'_>>;
+    fn db_conn(&self) -> AppResult<DieselPooledConn<'_>>;
 }
 
 impl<T: Request + ?Sized> RequestTransaction for T {
-    fn db_conn(&self) -> CargoResult<DieselPooledConn<'_>> {
+    fn db_conn(&self) -> AppResult<DieselPooledConn<'_>> {
         self.app().diesel_database.get().map_err(Into::into)
     }
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::util::{bad_request, CargoResult};
+use crate::util::{bad_request, AppResult};
 
 use failure::Fail;
 use lettre::file::FileTransport;
@@ -37,7 +37,7 @@ fn build_email(
     subject: &str,
     body: &str,
     mailgun_config: &Option<MailgunConfigVars>,
-) -> CargoResult<SendableEmail> {
+) -> AppResult<SendableEmail> {
     let sender = mailgun_config
         .as_ref()
         .map(|s| s.smtp_login.as_str())
@@ -70,7 +70,7 @@ pub fn send_user_confirm_email(email: &str, user_name: &str, token: &str) {
 /// For use in cases where we want to fail if an email is bad because the user is directly trying
 /// to set their email correctly, as opposed to us silently trying to use the email from their
 /// GitHub profile during signup.
-pub fn try_send_user_confirm_email(email: &str, user_name: &str, token: &str) -> CargoResult<()> {
+pub fn try_send_user_confirm_email(email: &str, user_name: &str, token: &str) -> AppResult<()> {
     // Create a URL with token string as path to send to user
     // If user clicks on path, look email/user up in database,
     // make sure tokens match
@@ -103,7 +103,7 @@ this invitation.",
     let _ = send_email(email, subject, &body);
 }
 
-fn send_email(recipient: &str, subject: &str, body: &str) -> CargoResult<()> {
+fn send_email(recipient: &str, subject: &str, body: &str) -> AppResult<()> {
     let mailgun_config = init_config_vars();
     let email = build_email(recipient, subject, body, &mailgun_config)?;
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -10,7 +10,7 @@ use url::Url;
 use crate::background_jobs::Environment;
 use crate::models::{DependencyKind, Version};
 use crate::schema::versions;
-use crate::util::errors::{std_error_no_send, CargoResult};
+use crate::util::errors::{std_error_no_send, AppResult};
 
 static DEFAULT_GIT_SSH_USERNAME: &str = "git";
 
@@ -148,7 +148,7 @@ pub struct Repository {
 }
 
 impl Repository {
-    pub fn open(repository_config: &RepositoryConfig) -> CargoResult<Self> {
+    pub fn open(repository_config: &RepositoryConfig) -> AppResult<Self> {
         let checkout_path = TempDir::new("git")?;
 
         let repository = git2::build::RepoBuilder::new()
@@ -224,7 +224,7 @@ impl Repository {
         ref_status
     }
 
-    pub fn reset_head(&self) -> CargoResult<()> {
+    pub fn reset_head(&self) -> AppResult<()> {
         let mut origin = self.repository.find_remote("origin")?;
         origin.fetch(
             &["refs/heads/*:refs/heads/*"],

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,12 +8,12 @@ use serde::de::DeserializeOwned;
 use std::str;
 
 use crate::app::App;
-use crate::util::{errors::NotFound, human, internal, CargoError, CargoResult};
+use crate::util::{errors::NotFound, human, internal, AppError, AppResult};
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
 /// because custom error-code handling may be desirable. Use
 /// `parse_github_response` to handle the "common" processing of responses.
-pub fn github_api<T>(app: &App, url: &str, auth: &AccessToken) -> CargoResult<T>
+pub fn github_api<T>(app: &App, url: &str, auth: &AccessToken) -> AppResult<T>
 where
     T: DeserializeOwned,
 {
@@ -31,7 +31,7 @@ where
         .map_err(Into::into)
 }
 
-fn handle_error_response(error: &reqwest::Error) -> Box<dyn CargoError> {
+fn handle_error_response(error: &reqwest::Error) -> Box<dyn AppError> {
     use reqwest::StatusCode as Status;
 
     match error.status() {

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 use std::str;
 
 use crate::app::App;
-use crate::util::{errors::NotFound, cargo_err, internal, AppError, AppResult};
+use crate::util::{cargo_err, errors::NotFound, internal, AppError, AppResult};
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
 /// because custom error-code handling may be desirable. Use

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 use std::str;
 
 use crate::app::App;
-use crate::util::{errors::NotFound, human, internal, AppError, AppResult};
+use crate::util::{errors::NotFound, cargo_err, internal, AppError, AppResult};
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
 /// because custom error-code handling may be desirable. Use
@@ -35,7 +35,7 @@ fn handle_error_response(error: &reqwest::Error) -> Box<dyn AppError> {
     use reqwest::StatusCode as Status;
 
     match error.status() {
-        Some(Status::UNAUTHORIZED) | Some(Status::FORBIDDEN) => human(
+        Some(Status::UNAUTHORIZED) | Some(Status::FORBIDDEN) => cargo_err(
             "It looks like you don't have permission \
              to query a necessary property from Github \
              to complete this request. \

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -4,7 +4,7 @@ use conduit_cookie::RequestSession;
 use diesel::prelude::*;
 
 use crate::db::RequestTransaction;
-use crate::util::errors::{std_error, CargoResult, ChainError, Unauthorized};
+use crate::util::errors::{std_error, AppResult, ChainError, Unauthorized};
 
 use crate::models::user::{UserNoEmailType, ALL_COLUMNS};
 use crate::models::User;
@@ -72,18 +72,18 @@ impl Middleware for CurrentUser {
 }
 
 pub trait RequestUser {
-    fn user(&self) -> CargoResult<&User>;
-    fn authentication_source(&self) -> CargoResult<AuthenticationSource>;
+    fn user(&self) -> AppResult<&User>;
+    fn authentication_source(&self) -> AppResult<AuthenticationSource>;
 }
 
 impl<'a> RequestUser for dyn Request + 'a {
-    fn user(&self) -> CargoResult<&User> {
+    fn user(&self) -> AppResult<&User> {
         self.extensions()
             .find::<User>()
             .chain_error(|| Unauthorized)
     }
 
-    fn authentication_source(&self) -> CargoResult<AuthenticationSource> {
+    fn authentication_source(&self) -> AppResult<AuthenticationSource> {
         self.extensions()
             .find::<AuthenticationSource>()
             .cloned()

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::*;
 
 use crate::git;
-use crate::util::{human, CargoResult};
+use crate::util::{human, AppResult};
 
 use crate::models::{Crate, Version};
 use crate::schema::*;
@@ -73,7 +73,7 @@ pub fn add_dependencies(
     conn: &PgConnection,
     deps: &[EncodableCrateDependency],
     target_version_id: i32,
-) -> CargoResult<Vec<git::Dependency>> {
+) -> AppResult<Vec<git::Dependency>> {
     use self::dependencies::dsl::*;
     use diesel::insert_into;
 

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::*;
 
 use crate::git;
-use crate::util::{human, AppResult};
+use crate::util::{cargo_err, AppResult};
 
 use crate::models::{Crate, Version};
 use crate::schema::*;
@@ -82,16 +82,16 @@ pub fn add_dependencies(
         .map(|dep| {
             if let Some(registry) = &dep.registry {
                 if !registry.is_empty() {
-                    return Err(human(&format_args!("Dependency `{}` is hosted on another registry. Cross-registry dependencies are not permitted on crates.io.", &*dep.name)));
+                    return Err(cargo_err(&format_args!("Dependency `{}` is hosted on another registry. Cross-registry dependencies are not permitted on crates.io.", &*dep.name)));
                 }
             }
 
             // Match only identical names to ensure the index always references the original crate name
             let krate = Crate::by_exact_name(&dep.name)
                 .first::<Crate>(&*conn)
-                .map_err(|_| human(&format_args!("no known crate named `{}`", &*dep.name)))?;
+                .map_err(|_| cargo_err(&format_args!("no known crate named `{}`", &*dep.name)))?;
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {
-                return Err(human(
+                return Err(cargo_err(
                     "wildcard (`*`) dependency constraints are not allowed \
                      on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-\
                      libraries-use--as-a-version-for-their-dependencies for more \

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -148,8 +148,9 @@ impl<'a> NewCrate<'a> {
             }
 
             // Ensure the entire URL parses as well
-            Url::parse(url)
-                .map_err(|_| cargo_err(&format_args!("`{}` is not a valid url: `{}`", field, url)))?;
+            Url::parse(url).map_err(|_| {
+                cargo_err(&format_args!("`{}` is not a valid url: `{}`", field, url))
+            })?;
             Ok(())
         }
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -10,7 +10,7 @@ use crate::app::App;
 use crate::email;
 use crate::models::user;
 use crate::models::user::UserNoEmailType;
-use crate::util::{human, AppResult};
+use crate::util::{cargo_err, AppResult};
 
 use crate::models::{
     Badge, Category, CrateOwner, CrateOwnerInvitation, Keyword, NewCrateOwnerInvitation, Owner,
@@ -141,7 +141,7 @@ impl<'a> NewCrate<'a> {
             // Manually check the string, as `Url::parse` may normalize relative URLs
             // making it difficult to ensure that both slashes are present.
             if !url.starts_with("http://") && !url.starts_with("https://") {
-                return Err(human(&format_args!(
+                return Err(cargo_err(&format_args!(
                     "URL for field `{}` must begin with http:// or https:// (url: {})",
                     field, url
                 )));
@@ -149,7 +149,7 @@ impl<'a> NewCrate<'a> {
 
             // Ensure the entire URL parses as well
             Url::parse(url)
-                .map_err(|_| human(&format_args!("`{}` is not a valid url: `{}`", field, url)))?;
+                .map_err(|_| cargo_err(&format_args!("`{}` is not a valid url: `{}`", field, url)))?;
             Ok(())
         }
 
@@ -169,7 +169,7 @@ impl<'a> NewCrate<'a> {
         ))
         .get_result::<bool>(conn)?;
         if reserved_name {
-            Err(human("cannot upload a crate with a reserved name"))
+            Err(cargo_err("cannot upload a crate with a reserved name"))
         } else {
             Ok(())
         }

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 
 use crate::app::App;
 use crate::github;
-use crate::util::{human, AppResult};
+use crate::util::{cargo_err, AppResult};
 
 use crate::models::user::{UserNoEmailType, ALL_COLUMNS};
 use crate::models::{Crate, Team, User};
@@ -77,7 +77,7 @@ impl Owner {
                 .first::<UserNoEmailType>(conn)
                 .map(User::from)
                 .map(Owner::User)
-                .map_err(|_| human(&format_args!("could not find user with login `{}`", name)))
+                .map_err(|_| cargo_err(&format_args!("could not find user with login `{}`", name)))
         }
     }
 

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 
 use crate::app::App;
 use crate::github;
-use crate::util::{human, CargoResult};
+use crate::util::{human, AppResult};
 
 use crate::models::user::{UserNoEmailType, ALL_COLUMNS};
 use crate::models::{Crate, Team, User};
@@ -65,7 +65,7 @@ impl Owner {
         conn: &PgConnection,
         req_user: &User,
         name: &str,
-    ) -> CargoResult<Owner> {
+    ) -> AppResult<Owner> {
         if name.contains(':') {
             Ok(Owner::Team(Team::create_or_update(
                 app, conn, name, req_user,

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 
 use crate::app::App;
 use crate::github::{github_api, team_url};
-use crate::util::{errors::NotFound, human, CargoResult};
+use crate::util::{errors::NotFound, human, AppResult};
 
 use oauth2::{prelude::*, AccessToken};
 
@@ -73,7 +73,7 @@ impl Team {
         conn: &PgConnection,
         login: &str,
         req_user: &User,
-    ) -> CargoResult<Self> {
+    ) -> AppResult<Self> {
         // must look like system:xxxxxxx
         let mut chunks = login.split(':');
         match chunks.next().unwrap() {
@@ -113,7 +113,7 @@ impl Team {
         org_name: &str,
         team_name: &str,
         req_user: &User,
-    ) -> CargoResult<Self> {
+    ) -> AppResult<Self> {
         // GET orgs/:org/teams
         // check that `team` is the `slug` in results, and grab its data
 
@@ -177,11 +177,11 @@ impl Team {
     /// Note that we're assuming that the given user is the one interested in
     /// the answer. If this is not the case, then we could accidentally leak
     /// private membership information here.
-    pub fn contains_user(&self, app: &App, user: &User) -> CargoResult<bool> {
+    pub fn contains_user(&self, app: &App, user: &User) -> AppResult<bool> {
         team_with_gh_id_contains_user(app, self.github_id, user)
     }
 
-    pub fn owning(krate: &Crate, conn: &PgConnection) -> CargoResult<Vec<Owner>> {
+    pub fn owning(krate: &Crate, conn: &PgConnection) -> AppResult<Vec<Owner>> {
         let base_query = CrateOwner::belonging_to(krate).filter(crate_owners::deleted.eq(false));
         let teams = base_query
             .inner_join(teams::table)
@@ -214,7 +214,7 @@ impl Team {
     }
 }
 
-fn team_with_gh_id_contains_user(app: &App, github_id: i32, user: &User) -> CargoResult<bool> {
+fn team_with_gh_id_contains_user(app: &App, github_id: i32, user: &User) -> AppResult<bool> {
     // GET teams/:team_id/memberships/:user_name
     // check that "state": "active"
 

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 
 use crate::app::App;
 use crate::github::{github_api, team_url};
-use crate::util::{errors::NotFound, human, AppResult};
+use crate::util::{errors::NotFound, cargo_err, AppResult};
 
 use oauth2::{prelude::*, AccessToken};
 
@@ -82,7 +82,7 @@ impl Team {
                 // Ok to unwrap since we know one ":" is contained
                 let org = chunks.next().unwrap();
                 let team = chunks.next().ok_or_else(|| {
-                    human(
+                    cargo_err(
                         "missing github team argument; \
                          format is github:org:team",
                     )
@@ -96,7 +96,7 @@ impl Team {
                     req_user,
                 )
             }
-            _ => Err(human(
+            _ => Err(cargo_err(
                 "unknown organization handler, \
                  only 'github:org:team' is supported",
             )),
@@ -126,7 +126,7 @@ impl Team {
         }
 
         if let Some(c) = org_name.chars().find(|c| whitelist(*c)) {
-            return Err(human(&format_args!(
+            return Err(cargo_err(&format_args!(
                 "organization cannot contain special \
                  characters like {}",
                 c
@@ -150,14 +150,14 @@ impl Team {
             .into_iter()
             .find(|team| team.slug.to_lowercase() == team_name.to_lowercase())
             .ok_or_else(|| {
-                human(&format_args!(
+                cargo_err(&format_args!(
                     "could not find the github team {}/{}",
                     org_name, team_name
                 ))
             })?;
 
         if !team_with_gh_id_contains_user(app, team.id, req_user)? {
-            return Err(human("only members of a team can add it as an owner"));
+            return Err(cargo_err("only members of a team can add it as an owner"));
         }
 
         #[derive(Deserialize)]

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 
 use crate::app::App;
 use crate::github::{github_api, team_url};
-use crate::util::{errors::NotFound, cargo_err, AppResult};
+use crate::util::{cargo_err, errors::NotFound, AppResult};
 
 use oauth2::{prelude::*, AccessToken};
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use std::borrow::Cow;
 
 use crate::app::App;
-use crate::util::CargoResult;
+use crate::util::AppResult;
 
 use crate::models::{Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};
 use crate::schema::{crate_owners, emails, users};
@@ -168,7 +168,7 @@ impl User {
             .map(User::from)
     }
 
-    pub fn owning(krate: &Crate, conn: &PgConnection) -> CargoResult<Vec<Owner>> {
+    pub fn owning(krate: &Crate, conn: &PgConnection) -> AppResult<Vec<Owner>> {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(users::table)
             .select(ALL_COLUMNS)
@@ -189,7 +189,7 @@ impl User {
     /// `Publish` as well, but this is a non-obvious invariant so we don't bother.
     /// Sweet free optimization if teams are proving burdensome to check.
     /// More than one team isn't really expected, though.
-    pub fn rights(&self, app: &App, owners: &[Owner]) -> CargoResult<Rights> {
+    pub fn rights(&self, app: &App, owners: &[Owner]) -> AppResult<Rights> {
         let mut best = Rights::None;
         for owner in owners {
             match *owner {
@@ -208,7 +208,7 @@ impl User {
         Ok(best)
     }
 
-    pub fn verified_email(&self, conn: &PgConnection) -> CargoResult<Option<String>> {
+    pub fn verified_email(&self, conn: &PgConnection) -> AppResult<Option<String>> {
         Ok(Email::belonging_to(self)
             .select(emails::email)
             .filter(emails::verified.eq(true))

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
-use crate::util::{human, CargoResult};
+use crate::util::{human, AppResult};
 
 use crate::models::user;
 use crate::models::user::UserNoEmailType;
@@ -138,7 +138,7 @@ impl NewVersion {
         license_file: Option<&str>,
         crate_size: i32,
         published_by: i32,
-    ) -> CargoResult<Self> {
+    ) -> AppResult<Self> {
         let features = serde_json::to_value(features)?;
 
         let mut new_version = NewVersion {
@@ -160,7 +160,7 @@ impl NewVersion {
         conn: &PgConnection,
         authors: &[String],
         published_by_email: &str,
-    ) -> CargoResult<Version> {
+    ) -> AppResult<Version> {
         use crate::schema::version_authors::{name, version_id};
         use crate::schema::versions::dsl::*;
         use diesel::dsl::exists;
@@ -201,7 +201,7 @@ impl NewVersion {
         })
     }
 
-    fn validate_license(&mut self, license_file: Option<&str>) -> CargoResult<()> {
+    fn validate_license(&mut self, license_file: Option<&str>) -> AppResult<()> {
         if let Some(ref license) = self.license {
             for part in license.split('/') {
                 license_exprs::validate_license_expr(part).map_err(|e| {

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
-use crate::util::{human, AppResult};
+use crate::util::{cargo_err, AppResult};
 
 use crate::models::user;
 use crate::models::user::UserNoEmailType;
@@ -171,7 +171,7 @@ impl NewVersion {
                 .filter(crate_id.eq(self.crate_id))
                 .filter(num.eq(&self.num));
             if select(exists(already_uploaded)).get_result(conn)? {
-                return Err(human(&format_args!(
+                return Err(cargo_err(&format_args!(
                     "crate version `{}` is already \
                      uploaded",
                     self.num
@@ -205,7 +205,7 @@ impl NewVersion {
         if let Some(ref license) = self.license {
             for part in license.split('/') {
                 license_exprs::validate_license_expr(part).map_err(|e| {
-                    human(&format_args!(
+                    cargo_err(&format_args!(
                         "{}; see http://opensource.org/licenses \
                          for options, and http://spdx.org/licenses/ \
                          for their identifiers",

--- a/src/router.rs
+++ b/src/router.rs
@@ -174,7 +174,7 @@ impl Handler for R404 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::errors::{bad_request, human, internal, NotFound, Unauthorized};
+    use crate::util::errors::{bad_request, cargo_err, internal, NotFound, Unauthorized};
 
     use conduit_test::MockRequest;
     use diesel::result::Error as DieselError;
@@ -206,8 +206,8 @@ mod tests {
         );
         assert_eq!(C(|_| err(NotFound)).call(&mut req).unwrap().status.0, 404);
 
-        // Human errors are returned as 200 so that cargo displays this nicely on the command line
-        assert_eq!(C(|_| Err(human(""))).call(&mut req).unwrap().status.0, 200);
+        // cargo_err errors are returned as 200 so that cargo displays this nicely on the command line
+        assert_eq!(C(|_| Err(cargo_err(""))).call(&mut req).unwrap().status.0, 200);
 
         // All other error types are propogated up the middleware, eventually becoming status 500
         assert!(C(|_| Err(internal(""))).call(&mut req).is_err());

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,7 +5,7 @@ use conduit::{Handler, Request, Response};
 use conduit_router::{RequestParams, RouteBuilder};
 
 use crate::controllers::*;
-use crate::util::errors::{std_error, CargoError, CargoResult, NotFound};
+use crate::util::errors::{std_error, AppError, AppResult, NotFound};
 use crate::util::RequestProxy;
 use crate::{App, Env};
 
@@ -129,7 +129,7 @@ pub fn build_router(app: &App) -> R404 {
     R404(router)
 }
 
-struct C(pub fn(&mut dyn Request) -> CargoResult<Response>);
+struct C(pub fn(&mut dyn Request) -> AppResult<Response>);
 
 impl Handler for C {
     fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
@@ -179,7 +179,7 @@ mod tests {
     use conduit_test::MockRequest;
     use diesel::result::Error as DieselError;
 
-    fn err<E: CargoError>(err: E) -> CargoResult<Response> {
+    fn err<E: AppError>(err: E) -> AppResult<Response> {
         Err(Box::new(err))
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -207,7 +207,10 @@ mod tests {
         assert_eq!(C(|_| err(NotFound)).call(&mut req).unwrap().status.0, 404);
 
         // cargo_err errors are returned as 200 so that cargo displays this nicely on the command line
-        assert_eq!(C(|_| Err(cargo_err(""))).call(&mut req).unwrap().status.0, 200);
+        assert_eq!(
+            C(|_| Err(cargo_err(""))).call(&mut req).unwrap().status.0,
+            200
+        );
 
         // All other error types are propogated up the middleware, eventually becoming status 500
         assert!(C(|_| Err(internal(""))).call(&mut req).is_err());

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -19,7 +19,7 @@ use crate::util::{Bad, RequestHelper, TestApp};
 use cargo_registry::{
     models::{Crate, CrateOwner, Dependency, NewCategory, NewTeam, NewUser, Team, User, Version},
     schema::crate_owners,
-    util::CargoResult,
+    util::AppResult,
     views::{
         EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
         EncodableOwner, EncodableVersion, GoodCrate,
@@ -236,7 +236,7 @@ fn new_team(login: &str) -> NewTeam<'_> {
     }
 }
 
-fn add_team_to_crate(t: &Team, krate: &Crate, u: &User, conn: &PgConnection) -> CargoResult<()> {
+fn add_team_to_crate(t: &Team, krate: &Crate, u: &User, conn: &PgConnection) -> AppResult<()> {
     let crate_owner = CrateOwner {
         crate_id: krate.id,
         owner_id: t.id,

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -3,7 +3,7 @@
 use cargo_registry::{
     models::{Crate, Keyword, NewCrate, NewVersion, Version},
     schema::{crates, dependencies, version_downloads, versions},
-    util::CargoResult,
+    util::AppResult,
     views::krate_publish as u,
 };
 use std::{collections::HashMap, io::Read};
@@ -72,7 +72,7 @@ impl<'a> VersionBuilder<'a> {
         crate_id: i32,
         published_by: i32,
         connection: &PgConnection,
-    ) -> CargoResult<Version> {
+    ) -> AppResult<Version> {
         use diesel::{insert_into, update};
 
         let license = match self.license {
@@ -229,7 +229,7 @@ impl<'a> CrateBuilder<'a> {
         self
     }
 
-    fn build(mut self, connection: &PgConnection) -> CargoResult<Crate> {
+    fn build(mut self, connection: &PgConnection) -> AppResult<Crate> {
         use diesel::{insert_into, select, update};
 
         let mut krate = self

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -4,7 +4,7 @@ use openssl::hash::{Hasher, MessageDigest};
 use reqwest::header;
 
 use crate::util::LimitErrorReader;
-use crate::util::{human, internal, CargoResult, ChainError, Maximums};
+use crate::util::{human, internal, AppResult, ChainError, Maximums};
 
 use std::env;
 use std::fs::{self, File};
@@ -96,7 +96,7 @@ impl Uploader {
         content_length: u64,
         content_type: &str,
         extra_headers: header::HeaderMap,
-    ) -> CargoResult<Option<String>> {
+    ) -> AppResult<Option<String>> {
         match *self {
             Uploader::S3 { ref bucket, .. } => {
                 bucket
@@ -129,7 +129,7 @@ impl Uploader {
         krate: &Crate,
         maximums: Maximums,
         vers: &semver::Version,
-    ) -> CargoResult<Vec<u8>> {
+    ) -> AppResult<Vec<u8>> {
         let app = Arc::clone(req.app());
         let path = Uploader::crate_path(&krate.name, &vers.to_string());
         let mut body = Vec::new();
@@ -157,7 +157,7 @@ impl Uploader {
         crate_name: &str,
         vers: &str,
         readme: String,
-    ) -> CargoResult<()> {
+    ) -> AppResult<()> {
         let path = Uploader::readme_path(crate_name, vers);
         let content_length = readme.len() as u64;
         let content = Cursor::new(readme);
@@ -183,7 +183,7 @@ fn verify_tarball(
     vers: &semver::Version,
     tarball: &[u8],
     max_unpack: u64,
-) -> CargoResult<()> {
+) -> AppResult<()> {
     // All our data is currently encoded with gzip
     let decoder = GzDecoder::new(tarball);
 

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -4,7 +4,7 @@ use openssl::hash::{Hasher, MessageDigest};
 use reqwest::header;
 
 use crate::util::LimitErrorReader;
-use crate::util::{human, internal, AppResult, ChainError, Maximums};
+use crate::util::{cargo_err, internal, AppResult, ChainError, Maximums};
 
 use std::env;
 use std::fs::{self, File};
@@ -196,7 +196,7 @@ fn verify_tarball(
     let prefix = format!("{}-{}", krate.name, vers);
     for entry in archive.entries()? {
         let entry = entry.chain_error(|| {
-            human("uploaded tarball is malformed or too large when decompressed")
+            cargo_err("uploaded tarball is malformed or too large when decompressed")
         })?;
 
         // Verify that all entries actually start with `$name-$vers/`.
@@ -205,7 +205,7 @@ fn verify_tarball(
         // as `bar-0.1.0/` source code, and this could overwrite other crates in
         // the registry!
         if !entry.path()?.starts_with(&prefix) {
-            return Err(human("invalid tarball uploaded"));
+            return Err(cargo_err("invalid tarball uploaded"));
         }
 
         // Historical versions of the `tar` crate which Cargo uses internally
@@ -215,7 +215,7 @@ fn verify_tarball(
         // generate a tarball with these file types so this should work for now.
         let entry_type = entry.header().entry_type();
         if entry_type.is_hard_link() || entry_type.is_symlink() {
-            return Err(human("invalid tarball uploaded"));
+            return Err(cargo_err("invalid tarball uploaded"));
         }
     }
     Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@ use conduit::Response;
 use serde::Serialize;
 
 pub use self::errors::ChainError;
-pub use self::errors::{bad_request, cargo_err, internal, internal_error, AppError, AppResult};
+pub use self::errors::{bad_request, cargo_err, internal, AppError, AppResult};
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
 pub use self::request_proxy::RequestProxy;

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@ use conduit::Response;
 use serde::Serialize;
 
 pub use self::errors::ChainError;
-pub use self::errors::{bad_request, human, internal, internal_error, AppError, AppResult};
+pub use self::errors::{bad_request, cargo_err, internal, internal_error, AppError, AppResult};
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
 pub use self::request_proxy::RequestProxy;

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@ use conduit::Response;
 use serde::Serialize;
 
 pub use self::errors::ChainError;
-pub use self::errors::{bad_request, human, internal, internal_error, CargoError, CargoResult};
+pub use self::errors::{bad_request, human, internal, internal_error, AppError, AppResult};
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
 pub use self::request_proxy::RequestProxy;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -285,15 +285,6 @@ impl fmt::Display for BadRequest {
     }
 }
 
-pub fn internal_error(error: &str, detail: &str) -> Box<dyn AppError> {
-    Box::new(ConcreteAppError {
-        description: error.to_string(),
-        detail: Some(detail.to_string()),
-        cause: None,
-        cargo_err: false,
-    })
-}
-
 pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
     Box::new(ConcreteAppError {
         description: error.to_string(),

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -18,11 +18,11 @@ struct Bad {
 }
 
 // =============================================================================
-// CargoError trait
+// AppError trait
 
-pub trait CargoError: Send + fmt::Display + fmt::Debug + 'static {
+pub trait AppError: Send + fmt::Display + fmt::Debug + 'static {
     fn description(&self) -> &str;
-    fn cause(&self) -> Option<&(dyn CargoError)> {
+    fn cause(&self) -> Option<&(dyn AppError)> {
         None
     }
 
@@ -34,7 +34,7 @@ pub trait CargoError: Send + fmt::Display + fmt::Debug + 'static {
                 }],
             }))
         } else {
-            self.cause().and_then(CargoError::response)
+            self.cause().and_then(AppError::response)
         }
     }
     fn human(&self) -> bool {
@@ -46,12 +46,12 @@ pub trait CargoError: Send + fmt::Display + fmt::Debug + 'static {
     }
 }
 
-impl dyn CargoError {
+impl dyn AppError {
     pub fn is<T: Any>(&self) -> bool {
         self.get_type_id() == TypeId::of::<T>()
     }
 
-    pub fn from_std_error(err: Box<dyn Error + Send>) -> Box<dyn CargoError> {
+    pub fn from_std_error(err: Box<dyn Error + Send>) -> Box<dyn AppError> {
         Self::try_convert(&*err).unwrap_or_else(|| internal(&err))
     }
 
@@ -68,11 +68,11 @@ impl dyn CargoError {
     }
 }
 
-impl CargoError for Box<dyn CargoError> {
+impl AppError for Box<dyn AppError> {
     fn description(&self) -> &str {
         (**self).description()
     }
-    fn cause(&self) -> Option<&dyn CargoError> {
+    fn cause(&self) -> Option<&dyn AppError> {
         (**self).cause()
     }
     fn human(&self) -> bool {
@@ -83,56 +83,56 @@ impl CargoError for Box<dyn CargoError> {
     }
 }
 
-pub type CargoResult<T> = Result<T, Box<dyn CargoError>>;
+pub type AppResult<T> = Result<T, Box<dyn AppError>>;
 
 // =============================================================================
 // Chaining errors
 
 pub trait ChainError<T> {
-    fn chain_error<E, F>(self, callback: F) -> CargoResult<T>
+    fn chain_error<E, F>(self, callback: F) -> AppResult<T>
     where
-        E: CargoError,
+        E: AppError,
         F: FnOnce() -> E;
 }
 
 #[derive(Debug)]
 struct ChainedError<E> {
     error: E,
-    cause: Box<dyn CargoError>,
+    cause: Box<dyn AppError>,
 }
 
 impl<T, F> ChainError<T> for F
 where
-    F: FnOnce() -> CargoResult<T>,
+    F: FnOnce() -> AppResult<T>,
 {
-    fn chain_error<E, C>(self, callback: C) -> CargoResult<T>
+    fn chain_error<E, C>(self, callback: C) -> AppResult<T>
     where
-        E: CargoError,
+        E: AppError,
         C: FnOnce() -> E,
     {
         self().chain_error(callback)
     }
 }
 
-impl<T, E: CargoError> ChainError<T> for Result<T, E> {
-    fn chain_error<E2, C>(self, callback: C) -> CargoResult<T>
+impl<T, E: AppError> ChainError<T> for Result<T, E> {
+    fn chain_error<E2, C>(self, callback: C) -> AppResult<T>
     where
-        E2: CargoError,
+        E2: AppError,
         C: FnOnce() -> E2,
     {
         self.map_err(move |err| {
             Box::new(ChainedError {
                 error: callback(),
                 cause: Box::new(err),
-            }) as Box<dyn CargoError>
+            }) as Box<dyn AppError>
         })
     }
 }
 
 impl<T> ChainError<T> for Option<T> {
-    fn chain_error<E, C>(self, callback: C) -> CargoResult<T>
+    fn chain_error<E, C>(self, callback: C) -> AppResult<T>
     where
-        E: CargoError,
+        E: AppError,
         C: FnOnce() -> E,
     {
         match self {
@@ -142,11 +142,11 @@ impl<T> ChainError<T> for Option<T> {
     }
 }
 
-impl<E: CargoError> CargoError for ChainedError<E> {
+impl<E: AppError> AppError for ChainedError<E> {
     fn description(&self) -> &str {
         self.error.description()
     }
-    fn cause(&self) -> Option<&dyn CargoError> {
+    fn cause(&self) -> Option<&dyn AppError> {
         Some(&*self.cause)
     }
     fn response(&self) -> Option<Response> {
@@ -157,7 +157,7 @@ impl<E: CargoError> CargoError for ChainedError<E> {
     }
 }
 
-impl<E: CargoError> fmt::Display for ChainedError<E> {
+impl<E: AppError> fmt::Display for ChainedError<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} caused by {}", self.error, self.cause)
     }
@@ -166,29 +166,29 @@ impl<E: CargoError> fmt::Display for ChainedError<E> {
 // =============================================================================
 // Error impls
 
-impl<E: Error + Send + 'static> CargoError for E {
+impl<E: Error + Send + 'static> AppError for E {
     fn description(&self) -> &str {
         Error::description(self)
     }
 }
 
-impl<E: Error + Send + 'static> From<E> for Box<dyn CargoError> {
-    fn from(err: E) -> Box<dyn CargoError> {
-        CargoError::try_convert(&err).unwrap_or_else(|| Box::new(err))
+impl<E: Error + Send + 'static> From<E> for Box<dyn AppError> {
+    fn from(err: E) -> Box<dyn AppError> {
+        AppError::try_convert(&err).unwrap_or_else(|| Box::new(err))
     }
 }
 // =============================================================================
 // Concrete errors
 
 #[derive(Debug)]
-struct ConcreteCargoError {
+struct ConcreteAppError {
     description: String,
     detail: Option<String>,
-    cause: Option<Box<dyn CargoError>>,
+    cause: Option<Box<dyn AppError>>,
     human: bool,
 }
 
-impl fmt::Display for ConcreteCargoError {
+impl fmt::Display for ConcreteAppError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.description)?;
         if let Some(ref s) = self.detail {
@@ -198,11 +198,11 @@ impl fmt::Display for ConcreteCargoError {
     }
 }
 
-impl CargoError for ConcreteCargoError {
+impl AppError for ConcreteAppError {
     fn description(&self) -> &str {
         &self.description
     }
-    fn cause(&self) -> Option<&dyn CargoError> {
+    fn cause(&self) -> Option<&dyn AppError> {
         self.cause.as_ref().map(|c| &**c)
     }
     fn human(&self) -> bool {
@@ -213,7 +213,7 @@ impl CargoError for ConcreteCargoError {
 #[derive(Debug, Clone, Copy)]
 pub struct NotFound;
 
-impl CargoError for NotFound {
+impl AppError for NotFound {
     fn description(&self) -> &str {
         "not found"
     }
@@ -238,7 +238,7 @@ impl fmt::Display for NotFound {
 #[derive(Debug, Clone, Copy)]
 pub struct Unauthorized;
 
-impl CargoError for Unauthorized {
+impl AppError for Unauthorized {
     fn description(&self) -> &str {
         "unauthorized"
     }
@@ -263,7 +263,7 @@ impl fmt::Display for Unauthorized {
 #[derive(Debug)]
 struct BadRequest(String);
 
-impl CargoError for BadRequest {
+impl AppError for BadRequest {
     fn description(&self) -> &str {
         self.0.as_ref()
     }
@@ -285,8 +285,8 @@ impl fmt::Display for BadRequest {
     }
 }
 
-pub fn internal_error(error: &str, detail: &str) -> Box<dyn CargoError> {
-    Box::new(ConcreteCargoError {
+pub fn internal_error(error: &str, detail: &str) -> Box<dyn AppError> {
+    Box::new(ConcreteAppError {
         description: error.to_string(),
         detail: Some(detail.to_string()),
         cause: None,
@@ -294,8 +294,8 @@ pub fn internal_error(error: &str, detail: &str) -> Box<dyn CargoError> {
     })
 }
 
-pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<dyn CargoError> {
-    Box::new(ConcreteCargoError {
+pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
+    Box::new(ConcreteAppError {
         description: error.to_string(),
         detail: None,
         cause: None,
@@ -303,8 +303,8 @@ pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<dyn CargoError> {
     })
 }
 
-pub fn human<S: ToString + ?Sized>(error: &S) -> Box<dyn CargoError> {
-    Box::new(ConcreteCargoError {
+pub fn human<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
+    Box::new(ConcreteAppError {
         description: error.to_string(),
         detail: None,
         cause: None,
@@ -319,20 +319,20 @@ pub fn human<S: ToString + ?Sized>(error: &S) -> Box<dyn CargoError> {
 ///
 /// Since this is going back to the UI these errors are treated the same as
 /// `human` errors, other than the HTTP status code.
-pub fn bad_request<S: ToString + ?Sized>(error: &S) -> Box<dyn CargoError> {
+pub fn bad_request<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
     Box::new(BadRequest(error.to_string()))
 }
 
 #[derive(Debug)]
-pub struct CargoErrToStdErr(pub Box<dyn CargoError>);
+pub struct AppErrToStdErr(pub Box<dyn AppError>);
 
-impl Error for CargoErrToStdErr {
+impl Error for AppErrToStdErr {
     fn description(&self) -> &str {
         self.0.description()
     }
 }
 
-impl fmt::Display for CargoErrToStdErr {
+impl fmt::Display for AppErrToStdErr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)?;
 
@@ -346,18 +346,18 @@ impl fmt::Display for CargoErrToStdErr {
     }
 }
 
-pub(crate) fn std_error(e: Box<dyn CargoError>) -> Box<dyn Error + Send> {
-    Box::new(CargoErrToStdErr(e))
+pub(crate) fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
+    Box::new(AppErrToStdErr(e))
 }
 
-pub(crate) fn std_error_no_send(e: Box<dyn CargoError>) -> Box<dyn Error> {
-    Box::new(CargoErrToStdErr(e))
+pub(crate) fn std_error_no_send(e: Box<dyn AppError>) -> Box<dyn Error> {
+    Box::new(AppErrToStdErr(e))
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct ReadOnlyMode;
 
-impl CargoError for ReadOnlyMode {
+impl AppError for ReadOnlyMode {
     fn description(&self) -> &str {
         "tried to write in read only mode"
     }
@@ -390,7 +390,7 @@ pub struct TooManyRequests {
     pub retry_after: NaiveDateTime,
 }
 
-impl CargoError for TooManyRequests {
+impl AppError for TooManyRequests {
     fn description(&self) -> &str {
         "too many requests"
     }


### PR DESCRIPTION
This PR is best reviewed as individual commits.  The first commits rename some types and functions without changing anything.  The final commits remove some unused logic and lay some groundwork for future refactoring.

The overall intent of this PR is to more clearly document the existing behavior.  In particular, the top level error types no longer include `Cargo` in the name as not all error types are intended for cargo endpoints.

r? @smarnach 