### PR TITLE
Missed a conversion from UserNoEmailType to User

### DIFF
--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -7,7 +7,7 @@
 
 use cargo_registry::{
     db,
-    models::{Crate, OwnerKind, User},
+    models::{user, Crate, OwnerKind, User},
     schema::{crate_owners, crates, users},
 };
 use std::{
@@ -16,6 +16,7 @@ use std::{
     process::exit,
 };
 
+use cargo_registry::models::user::UserNoEmailType;
 use diesel::prelude::*;
 
 fn main() {
@@ -44,12 +45,16 @@ fn transfer(conn: &PgConnection) {
     };
 
     let from = users::table
+        .select(user::ALL_COLUMNS)
         .filter(users::gh_login.eq(from))
-        .first::<User>(conn)
+        .first::<UserNoEmailType>(conn)
+        .map(User::from)
         .unwrap();
     let to = users::table
+        .select(user::ALL_COLUMNS)
         .filter(users::gh_login.eq(to))
-        .first::<User>(conn)
+        .first::<UserNoEmailType>(conn)
+        .map(User::from)
         .unwrap();
 
     if from.gh_id != to.gh_id {

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,5 +1,7 @@
 use crate::controllers::prelude::*;
 
+use crate::models::user;
+use crate::models::user::UserNoEmailType;
 use crate::models::{OwnerKind, User};
 use crate::schema::{crate_owners, crates, users};
 use crate::views::EncodablePublicUser;
@@ -11,16 +13,17 @@ pub fn show(req: &mut dyn Request) -> CargoResult<Response> {
     let name = &req.params()["user_id"].to_lowercase();
     let conn = req.db_conn()?;
     let user = users
+        .select(user::ALL_COLUMNS)
         .filter(crate::lower(gh_login).eq(name))
         .order(id.desc())
-        .first::<User>(&*conn)?;
+        .first::<UserNoEmailType>(&*conn)?;
 
     #[derive(Serialize)]
     struct R {
         user: EncodablePublicUser,
     }
     Ok(req.json(&R {
-        user: user.encodable_public(),
+        user: User::from(user).encodable_public(),
     }))
 }
 

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -7,7 +7,9 @@
 
 use crate::controllers::prelude::*;
 
-use crate::models::{Crate, User, Version};
+use crate::models::user;
+use crate::models::user::UserNoEmailType;
+use crate::models::{Crate, Version};
 use crate::schema::*;
 use crate::views::EncodableVersion;
 
@@ -28,12 +30,14 @@ pub fn index(req: &mut dyn Request) -> CargoResult<Response> {
         .select((
             versions::all_columns,
             crates::name,
-            users::all_columns.nullable(),
+            user::ALL_COLUMNS.nullable(),
         ))
         .filter(versions::id.eq(any(ids)))
-        .load::<(Version, String, Option<User>)>(&*conn)?
+        .load::<(Version, String, Option<UserNoEmailType>)>(&*conn)?
         .into_iter()
-        .map(|(version, crate_name, published_by)| version.encodable(&crate_name, published_by))
+        .map(|(version, crate_name, published_by)| {
+            version.encodable(&crate_name, published_by.map(From::from))
+        })
         .collect();
 
     #[derive(Serialize)]
@@ -50,14 +54,14 @@ pub fn show_by_id(req: &mut dyn Request) -> CargoResult<Response> {
     let id = &req.params()["version_id"];
     let id = id.parse().unwrap_or(0);
     let conn = req.db_conn()?;
-    let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table
+    let (version, krate, published_by): (Version, Crate, Option<UserNoEmailType>) = versions::table
         .find(id)
         .inner_join(crates::table)
         .left_outer_join(users::table)
         .select((
             versions::all_columns,
             crate::models::krate::ALL_COLUMNS,
-            users::all_columns.nullable(),
+            user::ALL_COLUMNS.nullable(),
         ))
         .first(&*conn)?;
 
@@ -66,6 +70,6 @@ pub fn show_by_id(req: &mut dyn Request) -> CargoResult<Response> {
         version: EncodableVersion,
     }
     Ok(req.json(&R {
-        version: version.encodable(&krate.name, published_by),
+        version: version.encodable(&krate.name, published_by.map(From::from)),
     }))
 }

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -6,6 +6,7 @@ use diesel::prelude::*;
 use crate::db::RequestTransaction;
 use crate::util::errors::{std_error, CargoResult, ChainError, Unauthorized};
 
+use crate::models::user::{UserNoEmailType, ALL_COLUMNS};
 use crate::models::User;
 use crate::schema::users;
 
@@ -31,7 +32,10 @@ impl Middleware for CurrentUser {
 
         if let Some(id) = id {
             // If it did, look for a user in the database with the given `user_id`
-            let maybe_user = users::table.find(id).first::<User>(&*conn);
+            let maybe_user = users::table
+                .select(ALL_COLUMNS)
+                .find(id)
+                .first::<UserNoEmailType>(&*conn);
             drop(conn);
             if let Ok(user) = maybe_user {
                 // Attach the `User` model from the database to the request

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -38,6 +38,7 @@ impl Middleware for CurrentUser {
                 .first::<UserNoEmailType>(&*conn);
             drop(conn);
             if let Ok(user) = maybe_user {
+                let user = User::from(user);
                 // Attach the `User` model from the database to the request
                 req.mut_extensions().insert(user);
                 req.mut_extensions()

--- a/src/models.rs
+++ b/src/models.rs
@@ -31,5 +31,5 @@ mod owner;
 mod rights;
 mod team;
 mod token;
-mod user;
+pub mod user;
 mod version;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -8,6 +8,8 @@ use url::Url;
 
 use crate::app::App;
 use crate::email;
+use crate::models::user;
+use crate::models::user::UserNoEmailType;
 use crate::util::{human, CargoResult};
 
 use crate::models::{
@@ -399,9 +401,10 @@ impl Crate {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .filter(crate_owners::crate_id.eq(self.id))
             .inner_join(users::table)
-            .select(users::all_columns)
-            .load(conn)?
+            .select(user::ALL_COLUMNS)
+            .load::<UserNoEmailType>(conn)?
             .into_iter()
+            .map(User::from)
             .map(Owner::User);
         let teams = CrateOwner::by_owner_kind(OwnerKind::Team)
             .filter(crate_owners::crate_id.eq(self.id))

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -5,6 +5,7 @@ use crate::app::App;
 use crate::github;
 use crate::util::{human, CargoResult};
 
+use crate::models::user::{UserNoEmailType, ALL_COLUMNS};
 use crate::models::{Crate, Team, User};
 use crate::schema::{crate_owners, users};
 use crate::views::EncodableOwner;
@@ -71,8 +72,10 @@ impl Owner {
             )?))
         } else {
             users::table
+                .select(ALL_COLUMNS)
                 .filter(users::gh_login.eq(name))
-                .first(conn)
+                .first::<UserNoEmailType>(conn)
+                .map(User::from)
                 .map(Owner::User)
                 .map_err(|_| human(&format_args!("could not find user with login `{}`", name)))
         }

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -5,6 +5,8 @@ use diesel::prelude::*;
 
 use crate::util::{human, CargoResult};
 
+use crate::models::user;
+use crate::models::user::UserNoEmailType;
 use crate::models::{Crate, Dependency, User};
 use crate::schema::*;
 use crate::views::{EncodableVersion, EncodableVersionLinks};
@@ -115,7 +117,12 @@ impl Version {
     /// Not for use when you have a group of versions you need the publishers for.
     pub fn published_by(&self, conn: &PgConnection) -> Option<User> {
         match self.published_by {
-            Some(pb) => users::table.find(pb).first(conn).ok(),
+            Some(pb) => users::table
+                .find(pb)
+                .select(user::ALL_COLUMNS)
+                .first::<UserNoEmailType>(conn)
+                .map(User::from)
+                .ok(),
             None => None,
         }
     }


### PR DESCRIPTION
When reviewing #1911, I missed a spot. I reverted the PR merge on master, so this PR reverts the revert and adds the fix.

I tried to write a test that would have caught this, but I utterly failed at making a real-enough app/request that would have `.user()` but would let me set the `session()` :(

Also a lot of this code is temporary and will be undone once I've rebased #1891, but this needs to be deployed separately from #1891 to ensure there aren't any uses of the email column.

r? @jtgeibel 