### PR TITLE
Add `-D warnings` to `RUSTFLAGS` on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - PERCY_PROJECT=crates-io/crates.io
     - PGPORT=5433
     - PATH=$HOME/.cargo/bin:$PATH
-    - RUSTFLAGS="-C debuginfo=0"
+    - RUSTFLAGS="-C debuginfo=0 -D warnings"
 
 install:
   - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -10,7 +10,7 @@
 //! Usage:
 //!      cargo run --bin background-worker
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::git::{Repository, RepositoryConfig};
 use cargo_registry::{background_jobs::*, db};

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -5,7 +5,7 @@
 // Usage:
 //      cargo run --bin delete-crate crate-name
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{db, models::Crate, schema::crates};
 use std::{

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -5,7 +5,7 @@
 // Usage:
 //      cargo run --bin delete-version crate-name version-number
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{
     db,

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -4,7 +4,7 @@
 //! Usage:
 //!     cargo run --bin monitor
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 mod on_call;
 

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -4,7 +4,7 @@
 // Usage:
 //      cargo run --bin populate version_id1 version_id2 ...
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{db, schema::version_downloads};
 use std::env;

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -3,7 +3,7 @@
 //
 // Warning: this can take a lot of time.
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 #[macro_use]
 extern crate serde;

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{boot, App, Env};
 use std::{

--- a/src/bin/test-pagerduty.rs
+++ b/src/bin/test-pagerduty.rs
@@ -5,7 +5,7 @@
 //!
 //! Event type can be trigger, acknowledge, or resolve
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 mod on_call;
 

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -3,7 +3,7 @@
 // Usage:
 //      cargo run --bin transfer-crates from-user to-user
 
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{
     db,

--- a/src/email.rs
+++ b/src/email.rs
@@ -43,7 +43,6 @@ fn build_email(
         .map(|s| s.smtp_login.as_str())
         .unwrap_or("test@localhost");
 
-    #[allow(clippy::redundant_closure)]
     let email = Email::builder()
         .to(recipient)
         .from(sender)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,9 @@
 //! All implemented routes are defined in the [middleware](fn.middleware.html) function and
 //! implemented in the [category](category/index.html), [keyword](keyword/index.html),
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
-#![deny(warnings, clippy::all, rust_2018_idioms)]
-#![deny(missing_debug_implementations, missing_copy_implementations)]
-#![deny(bare_trait_objects)]
-#![recursion_limit = "256"]
+
+#![warn(clippy::all, rust_2018_idioms)]
+#![warn(missing_debug_implementations, missing_copy_implementations)]
 
 #[macro_use]
 extern crate derive_deref;

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -129,7 +129,6 @@ impl Version {
 }
 
 impl NewVersion {
-    #[allow(clippy::new_ret_no_self)]
     pub fn new(
         crate_id: i32,
         num: &semver::Version,

--- a/src/s3/lib.rs
+++ b/src/s3/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, clippy::all, rust_2018_idioms)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 extern crate base64;
 extern crate chrono;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,10 +1,4 @@
-#![deny(warnings, clippy::all, rust_2018_idioms)]
-// TODO: Remove after we can bump to Rust 1.35 stable in `RustConfig`
-#![allow(
-    renamed_and_removed_lints,
-    clippy::cyclomatic_complexity,
-    clippy::unknown_clippy_lints
-)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 #[macro_use]
 extern crate diesel;

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1505,7 +1505,6 @@ fn yank_by_a_non_owner_fails() {
 }
 
 #[test]
-#[allow(clippy::cognitive_complexity)]
 fn yank_max_version() {
     let (_, anon, _, token) = TestApp::full().with_token();
 


### PR DESCRIPTION
By denying warnings explicitly on CI, we don't need to deny warnings in each library or binary.  `#![warn(clippy::all)]` is used to automatically enable clippy in RLS enabled IDEs and `rust_2018_idioms` is now applied consistently.  Finally, clippy allow attributes that are no longer needed have been removed.