### PR TITLE
add support for Bitbucket Pipelines badges (Shields.io)

### DIFF
--- a/app/components/badge-bitbucket-pipelines.js
+++ b/app/components/badge-bitbucket-pipelines.js
@@ -1,0 +1,16 @@
+import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: 'span',
+  classNames: ['badge'],
+  repository: alias('badge.attributes.repository'),
+  branch: computed('badge.attributes.branch', function() {
+    return encodeURIComponent(this.get('badge.attributes.branch'));
+  }),
+  text: computed('badge.attributes.branch', function() {
+    const branch = this.get('badge.attributes.branch');
+    return `Bitbucket Pipelines build status for the ${branch} branch`;
+  }),
+});

--- a/app/templates/components/badge-bitbucket-pipelines.hbs
+++ b/app/templates/components/badge-bitbucket-pipelines.hbs
@@ -1,0 +1,6 @@
+<a href="https://bitbucket.org/delan/nonymous/addon/pipelines/home#!/results/branch/{{ branch }}/page/1">
+  <img
+      src="https://img.shields.io/bitbucket/pipelines/{{ repository }}/{{ branch }}"
+      alt="{{ text }}"
+      title="{{ text }}">
+</a>

--- a/app/templates/components/badge-bitbucket-pipelines.hbs
+++ b/app/templates/components/badge-bitbucket-pipelines.hbs
@@ -1,4 +1,4 @@
-<a href="https://bitbucket.org/delan/nonymous/addon/pipelines/home#!/results/branch/{{ branch }}/page/1">
+<a href="https://bitbucket.org/{{ repository }}/addon/pipelines/home#!/results/branch/{{ branch }}/page/1">
   <img
       src="https://img.shields.io/bitbucket/pipelines/{{ repository }}/{{ branch }}"
       alt="{{ text }}"

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -68,6 +68,10 @@ pub enum Badge {
         branch: Option<String>,
         service: Option<String>,
     },
+    BitbucketPipelines {
+        repository: String,
+        branch: String,
+    },
     Maintenance {
         status: MaintenanceStatus,
     },

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -151,7 +151,8 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
         branch: String::from("beta"),
     };
     let mut badge_attributes_bitbucket_pipelines = HashMap::new();
-    badge_attributes_bitbucket_pipelines.insert(String::from("repository"), String::from("rust-lang/rust"));
+    badge_attributes_bitbucket_pipelines
+        .insert(String::from("repository"), String::from("rust-lang/rust"));
     badge_attributes_bitbucket_pipelines.insert(String::from("branch"), String::from("beta"));
 
     let maintenance = Badge::Maintenance {
@@ -331,7 +332,10 @@ fn update_add_bitbucket_pipelines() {
     let (krate, test_badges) = set_up();
 
     let mut badges = HashMap::new();
-    badges.insert(String::from("bitbucket-pipelines"), test_badges.bitbucket_pipelines_attributes);
+    badges.insert(
+        String::from("bitbucket-pipelines"),
+        test_badges.bitbucket_pipelines_attributes,
+    );
     krate.update(&badges);
     assert_eq!(krate.badges(), vec![test_badges.bitbucket_pipelines]);
 }

--- a/src/tests/badge.rs
+++ b/src/tests/badge.rs
@@ -23,6 +23,8 @@ struct BadgeRef {
     circle_ci_attributes: HashMap<String, String>,
     cirrus_ci: Badge,
     cirrus_ci_attributes: HashMap<String, String>,
+    bitbucket_pipelines: Badge,
+    bitbucket_pipelines_attributes: HashMap<String, String>,
     maintenance: Badge,
     maintenance_attributes: HashMap<String, String>,
 }
@@ -144,6 +146,14 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
     badge_attributes_cirrus_ci.insert(String::from("branch"), String::from("beta"));
     badge_attributes_cirrus_ci.insert(String::from("repository"), String::from("rust-lang/rust"));
 
+    let bitbucket_pipelines = Badge::BitbucketPipelines {
+        repository: String::from("rust-lang/rust"),
+        branch: String::from("beta"),
+    };
+    let mut badge_attributes_bitbucket_pipelines = HashMap::new();
+    badge_attributes_bitbucket_pipelines.insert(String::from("repository"), String::from("rust-lang/rust"));
+    badge_attributes_bitbucket_pipelines.insert(String::from("branch"), String::from("beta"));
+
     let maintenance = Badge::Maintenance {
         status: MaintenanceStatus::LookingForMaintainer,
     };
@@ -175,6 +185,8 @@ fn set_up() -> (BadgeTestCrate, BadgeRef) {
         circle_ci_attributes: badge_attributes_circle_ci,
         cirrus_ci,
         cirrus_ci_attributes: badge_attributes_cirrus_ci,
+        bitbucket_pipelines,
+        bitbucket_pipelines_attributes: badge_attributes_bitbucket_pipelines,
         maintenance,
         maintenance_attributes,
     };
@@ -311,6 +323,17 @@ fn update_add_cirrus_ci() {
     badges.insert(String::from("cirrus-ci"), test_badges.cirrus_ci_attributes);
     krate.update(&badges);
     assert_eq!(krate.badges(), vec![test_badges.cirrus_ci]);
+}
+
+#[test]
+fn update_add_bitbucket_pipelines() {
+    // Add a Bitbucket Pipelines badge
+    let (krate, test_badges) = set_up();
+
+    let mut badges = HashMap::new();
+    badges.insert(String::from("bitbucket-pipelines"), test_badges.bitbucket_pipelines_attributes);
+    krate.update(&badges);
+    assert_eq!(krate.badges(), vec![test_badges.bitbucket_pipelines]);
 }
 
 #[test]
@@ -585,6 +608,25 @@ fn cirrus_ci_required_keys() {
     assert_eq!(invalid_badges.len(), 1);
     assert_eq!(invalid_badges.first().unwrap(), "cirrus-ci");
     assert_eq!(krate.badges(), vec![]);
+}
+
+#[test]
+fn bitbucket_pipelines_required_keys() {
+    // Add a Bitbucket Pipelines badge missing a required field
+    let (krate, test_badges) = set_up();
+
+    for required in &["repository", "branch"] {
+        let mut attributes = test_badges.bitbucket_pipelines_attributes.clone();
+        attributes.remove(*required);
+
+        let mut badges = HashMap::new();
+        badges.insert(String::from("bitbucket-pipelines"), attributes);
+
+        let invalid_badges = krate.update(&badges);
+        assert_eq!(invalid_badges.len(), 1);
+        assert_eq!(invalid_badges.first().unwrap(), "bitbucket-pipelines");
+        assert_eq!(krate.badges(), vec![]);
+    }
 }
 
 #[test]


### PR DESCRIPTION
- based on #1782
- [link in screenshot](https://bitbucket.org/delan/nonymous/addon/pipelines/home#!/results/branch/branch%2Fname%2Fwith%2Fslashes/page/1)

![screenshot](https://user-images.githubusercontent.com/465303/70138734-0545be00-16e5-11ea-9de2-3c726843f9ed.png)