### PR TITLE
Move check mark SVG to static file

### DIFF
--- a/app/styles/me.scss
+++ b/app/styles/me.scss
@@ -208,7 +208,7 @@
             &:after {
                 background-color: #cfc487;
                 border-color: #cfc487;
-                background-image: url('assets/check-mark.svg');
+                background-image: url('/assets/check-mark.svg');
                 background-repeat: no-repeat;
                 background-position: 3px 4px;
             }

--- a/app/styles/me.scss
+++ b/app/styles/me.scss
@@ -208,7 +208,7 @@
             &:after {
                 background-color: #cfc487;
                 border-color: #cfc487;
-                background-image: url("data:image/svg+xml,%3Csvg width='32' height='32' viewBox='0 0 32 32' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M5.414 11L4 12.414l5.414 5.414L20.828 6.414 19.414 5l-10 10z' fill='%23383838' fill-rule='nonzero'/%3E%3C/svg%3E ");
+                background-image: url('assets/check-mark.svg');
                 background-repeat: no-repeat;
                 background-position: 3px 4px;
             }

--- a/public/assets/check-mark.svg
+++ b/public/assets/check-mark.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5.414 11L4 12.414l5.414 5.414L20.828 6.414 19.414 5l-10 10z" fill="#383838" fill-rule="nonzero"/>
+</svg>


### PR DESCRIPTION
The content security policy of the production website was set up to not allow data URL's. Moving the logo to a static SVG policy fixes this.

Fixes #1938 