### PR TITLE
Remove bors-ng config; we now use rust-lang's main bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,1 +1,0 @@
-status = ["continuous-integration/travis-ci/push"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,7 +87,6 @@ for another platform.
 
 These files are mostly only relevant when running crates.io's code in development mode.
 
-* `bors.toml` - Configure our instance of [bors-ng][] for continous integration
 * `.editorconfig` - Coding style definitions supported by some IDEs // TODO: Reference extensions
   for common editors
 * `.env` - Environment variables loaded by the backend - (ignored in `.gitignore`)
@@ -104,5 +103,4 @@ local development environment
 * `.travis.yml` - Configuration for continous integration at [Travis CI][]
 * `.watchmanconfig` - Use by Ember CLI to efficiently watch for file changes if you install watchman
 
-[bors-ng]: https://github.com/bors-ng/bors-ng
 [Travis CI]: https://travis-ci.com/rust-lang/crates.io


### PR DESCRIPTION
We've been using rust-lang's bors since
[2019-01](https://github.com/rust-lang/rust-central-station/pull/124)
and just never removed the references to bors-ng, oops