### PR TITLE
Disable the background_threads jemallocator feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ derive_deref = "1.0.0"
 reqwest = "0.9.1"
 tempdir = "0.3.7"
 parking_lot = "0.7.1"
-jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling', "background_threads"] }
+jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 
 lettre = "0.9"
 lettre_email = "0.9"


### PR DESCRIPTION
It's not supported on macOS :(

![Sad mac icon](https://user-images.githubusercontent.com/193874/70942958-c20d1880-201d-11ea-88bb-4f4188ce0d36.png)


When I try to `cargo run --bin server` on macOS Catalina 10.15.1, I get:

```
$ cargo run --bin server
    Finished dev [unoptimized + debuginfo] target(s) in 0.51s
     Running `target/debug/server`
<jemalloc>: option background_thread currently supports pthread only
memory allocation of 40 bytes failedAbort trap: 6
```

Leave [the upgrade](https://github.com/rust-lang/crates.io/pull/1953) but turn off the `background_threads` feature for now. [Someday we might be able to enable features per-target](https://github.com/rust-lang/cargo/issues/1197), but that day is not today.

r? @jtgeibel 