### PR TITLE
dependency-lint: Disable `generateTests` option

### DIFF
--- a/config/dependency-lint.js
+++ b/config/dependency-lint.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  generateTests: false,
+};


### PR DESCRIPTION
We already run `npm run lint:deps` as part of CI, there is no need to also generate tests for this and slow down the build doing so.