### PR TITLE
Add dependabot configuration file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "weekly"
+    version_requirement_updates: "increase_versions"
+    commit_message:
+      prefix: ""


### PR DESCRIPTION
see https://dependabot.com/docs/config-file/

as discussed via Discord, I generally prefer the configuration files as it is more explicit and transparent than configuration via the dashboard. the other advantage is that not only organization admins can configure it now via PRs. :)

/cc @carols10cents 