### PR TITLE
Migrate `faker` imports

### DIFF
--- a/mirage/factories/category.js
+++ b/mirage/factories/category.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
 import { dasherize } from '@ember/string';
 
 export default Factory.extend({

--- a/mirage/factories/crate.js
+++ b/mirage/factories/crate.js
@@ -1,4 +1,5 @@
-import { Factory, trait, faker } from 'ember-cli-mirage';
+import { Factory, trait } from 'ember-cli-mirage';
+import faker from 'faker';
 
 export default Factory.extend({
   id(i) {

--- a/mirage/factories/version.js
+++ b/mirage/factories/version.js
@@ -1,4 +1,5 @@
-import { Factory, faker } from 'ember-cli-mirage';
+import { Factory } from 'ember-cli-mirage';
+import faker from 'faker';
 
 export default Factory.extend({
   id: i => i,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9206,18 +9206,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      }
-    },
     "crypto": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
@@ -13070,6 +13058,12 @@
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/exists-sync/-/exists-sync-0.0.3.tgz",
           "integrity": "sha1-uRAAC+27ETs3i4L19adjgQdiLc8=",
+          "dev": true
+        },
+        "faker": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
+          "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8=",
           "dev": true
         }
       }
@@ -25639,9 +25633,9 @@
       "dev": true
     },
     "faker": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-3.1.0.tgz",
-      "integrity": "sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
       "dev": true
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-prettier": "^3.1.0",
+    "faker": "^4.1.0",
     "loader.js": "^4.5.1",
     "normalize.css": "^7.0.0",
     "nyc": "^14.1.1",

--- a/tests/helpers/setup-mirage.js
+++ b/tests/helpers/setup-mirage.js
@@ -1,5 +1,5 @@
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import { faker } from 'ember-cli-mirage';
+import faker from 'faker';
 import timekeeper from 'timekeeper';
 
 export default function(hooks) {


### PR DESCRIPTION
`ember-cli-mirage` v1.0.0 removed its `faker` dependency in favor of importing via `ember-auto-import`. This PR adds an explicit dependency on `faker`, and migrates all the existing import to import from the `'faker'` module directly.