### PR TITLE
Link directly to cargo install page

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -2,10 +2,10 @@
   <h1>The Rust community&rsquo;s crate registry</h1>
 
   <div class='links'>
-    {{#link-to "install" class='yellow-button' data-test-install-cargo-link=true}}
+    <a href="https://doc.rust-lang.org/cargo/getting-started/installation.html" class='yellow-button' data-test-install-cargo-link>
       {{svg-jar "button-download"}}
       Install Cargo
-    {{/link-to}}
+    </a>
 
     <a href='https://doc.rust-lang.org/cargo/guide/' class='yellow-button'>
       {{svg-jar "flag"}}


### PR DESCRIPTION
This fixes a paper-cut where after clicking on the button, clicking the
back button causes the user to immediately redirect again.

Additionally, on Firefox 71, it was not possible to long-click on the
back button to return to crates.io (as the only entry in the list was
the redirect.  On Chromium 79 I had no such issue.