### PR TITLE
Disable database triggers during import

### DIFF
--- a/src/tasks/dump_db/dump-import.sql.hbs
+++ b/src/tasks/dump_db/dump-import.sql.hbs
@@ -3,9 +3,7 @@ BEGIN;
 {{~#each tables}}
     ALTER TABLE "{{this.name}}" DISABLE TRIGGER ALL;
 {{~/each}}
-COMMIT;
 
-BEGIN;
     -- Set defaults for non-nullable columns not included in the dump.
 {{~#each tables as |table|}}
 {{~#each column_defaults}}
@@ -29,9 +27,7 @@ BEGIN;
     ALTER TABLE "{{table.name}}" ALTER COLUMN "{{@key}}" DROP DEFAULT;
 {{~/each}}
 {{~/each}}
-COMMIT;
 
-BEGIN;
     -- Reenable triggers on each table.
 {{~#each tables}}
     ALTER TABLE "{{this.name}}" ENABLE TRIGGER ALL;

--- a/src/tasks/dump_db/dump-import.sql.hbs
+++ b/src/tasks/dump_db/dump-import.sql.hbs
@@ -1,4 +1,11 @@
 BEGIN;
+    -- Disable triggers on each table.
+{{~#each tables}}
+    ALTER TABLE "{{this.name}}" DISABLE TRIGGER ALL;
+{{~/each}}
+COMMIT;
+
+BEGIN;
     -- Set defaults for non-nullable columns not included in the dump.
 {{~#each tables as |table|}}
 {{~#each column_defaults}}
@@ -21,5 +28,12 @@ BEGIN;
 {{~#each column_defaults}}
     ALTER TABLE "{{table.name}}" ALTER COLUMN "{{@key}}" DROP DEFAULT;
 {{~/each}}
+{{~/each}}
+COMMIT;
+
+BEGIN;
+    -- Reenable triggers on each table.
+{{~#each tables}}
+    ALTER TABLE "{{this.name}}" ENABLE TRIGGER ALL;
 {{~/each}}
 COMMIT;


### PR DESCRIPTION
- This allows `updated_at` field values to be loaded during import.
  Before this change, `updated_at` was set to when the import ran,
  overwriting the values being loaded.
- Also, the import completes in about one fifth the time
  (on my slow MacBook Air).