### PR TITLE
Remove obsolete `ember-cli-htmlbars-inline-precompile` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5637,12 +5637,6 @@
       "integrity": "sha1-54WbVohrF13SYWQl0neyGeIJ6os=",
       "dev": true
     },
-    "babel-plugin-htmlbars-inline-precompile": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-0.2.3.tgz",
-      "integrity": "sha1-zTZeJ4r0Cb+mvncExDVL7udCRGs=",
-      "dev": true
-    },
     "babel-plugin-istanbul": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
@@ -17102,19 +17096,6 @@
             }
           }
         }
-      }
-    },
-    "ember-cli-htmlbars-inline-precompile": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-1.0.2.tgz",
-      "integrity": "sha1-W1RPZk1dmRHwjNl5xfcNjLDKKt0=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-htmlbars-inline-precompile": "^0.2.3",
-        "ember-cli-version-checker": "^2.0.0",
-        "hash-for-dep": "^1.0.2",
-        "heimdalljs-logger": "^0.1.7",
-        "silent-error": "^1.1.0"
       }
     },
     "ember-cli-import-polyfill": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-cli-dependency-lint": "^1.1.3",
     "ember-cli-fastboot": "^2.2.1",
     "ember-cli-htmlbars": "^4.2.0",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "1.6.1",
     "ember-cli-meta-tags": "^5.3.0",
     "ember-cli-mirage": "^0.4.7",

--- a/tests/integration/components/api-token-row-test.js
+++ b/tests/integration/components/api-token-row-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | api-token-row', function(hooks) {
   setupRenderingTest(hooks);


### PR DESCRIPTION
Since https://github.com/ember-cli/ember-cli-htmlbars/pull/286, the `ember-cli-htmlbars-inline-precompile` dependency is obsolete and replaced by `ember-cli-htmlbars` itself :)