### PR TITLE
build.svg -> pipeline.svg to correctly display GitLab pipeline badge

### DIFF
--- a/app/templates/components/badge-gitlab.hbs
+++ b/app/templates/components/badge-gitlab.hbs
@@ -1,6 +1,6 @@
 <a href="https://gitlab.com/{{ repository }}/pipelines">
   <img
-      src="https://gitlab.com/{{ repository }}/badges/{{ branch }}/build.svg"
+      src="https://gitlab.com/{{ repository }}/badges/{{ branch }}/pipeline.svg"
       alt="{{ text }}"
       title="{{ text }}">
 </a>


### PR DESCRIPTION
Fixes: https://github.com/rust-lang/crates.io/issues/1997