### PR TITLE
Use the percy media query method to hide the downloads graph from percy

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -359,3 +359,9 @@ abbr[title] {
     text-decoration: none;
     border-bottom: 1px dotted;
 }
+
+@media only percy {
+    #crate-downloads .graph {
+       display: none;
+    }
+}


### PR DESCRIPTION
This is a different attempt to fix the percy problems; the percy yaml config doesn't work with the ember-percy version we're currently on.