### PR TITLE
DEPRECATION: Passing actions to components as strings is deprecated.

### DIFF
--- a/app/templates/catch-all.hbs
+++ b/app/templates/catch-all.hbs
@@ -6,6 +6,6 @@
   {{input type="text" class="search"
           placeholder="Search"
           value=search
-          enter="search"
+          enter=(action "search")
           required=true}}
 </p>


### PR DESCRIPTION
DEPRECATION: Passing actions to components as strings (like `{{input
enter="search"}}`) is deprecated. Please use closure actions instead (`{{input
enter=(action "search")}}`). ('cargo/templates/catch-all.hbs' @ L6:C2)
[deprecation id: ember-component.send-action] See
https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action for more
details.