### PR TITLE
Revert "Auto merge of #2001 - rust-lang:dependabot/npm_and_yarn/ember…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -926,15 +926,6 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
-    "@babel/plugin-transform-object-assign": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-assign/-/plugin-transform-object-assign-7.7.4.tgz",
-      "integrity": "sha512-0TpeUlnhQDwKxPLTIckdaWt46L2s61c/5w5snw1OUod5ehOJywZD98Ha3dFHVjeqkfOFtOTH7cqxddjxUuvcmg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
     "@babel/plugin-transform-object-super": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.2.0.tgz",
@@ -7620,9 +7611,9 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.2.tgz",
-      "integrity": "sha512-uWMHxJxtfj/1oZClOxDEV1sQ1HCDkA4MG8Gr69KKeBjEVH0R84WlejZ0y2DcwyBlpAEMltmVYkVgqfLFb2oyiA==",
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
       "dev": true
     },
     "astral-regex": {
@@ -20932,6 +20923,15 @@
       "requires": {
         "broccoli-uglify-sourcemap": "^3.1.0",
         "lodash.defaultsdeep": "^4.6.0"
+      }
+    },
+    "ember-cli-valid-component-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-valid-component-name/-/ember-cli-valid-component-name-1.0.0.tgz",
+      "integrity": "sha1-cVUM44fgIzBl8wswsVEKot++h+8=",
+      "dev": true,
+      "requires": {
+        "silent-error": "^1.0.0"
       }
     },
     "ember-cli-version-checker": {
@@ -35742,144 +35742,12 @@
       }
     },
     "ember-router-generator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-2.0.0.tgz",
-      "integrity": "sha512-89oVHVJwmLDvGvAUWgS87KpBoRhy3aZ6U0Ql6HOmU4TrPkyaa8pM0W81wj9cIwjYprcQtN9EwzZMHnq46+oUyw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-1.2.3.tgz",
+      "integrity": "sha1-jtLKhv8yM2MSD8FCeBkeno8TFe4=",
       "dev": true,
       "requires": {
-        "@babel/parser": "^7.4.5",
-        "@babel/traverse": "^7.4.5",
-        "recast": "^0.18.1"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-          "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "^7.0.0"
-          }
-        },
-        "@babel/generator": {
-          "version": "7.7.7",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
-          "integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.7.4",
-            "jsesc": "^2.5.1",
-            "lodash": "^4.17.13",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/helper-function-name": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
-          "integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-get-function-arity": "^7.7.4",
-            "@babel/template": "^7.7.4",
-            "@babel/types": "^7.7.4"
-          }
-        },
-        "@babel/helper-get-function-arity": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
-          "integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.7.4"
-          }
-        },
-        "@babel/helper-split-export-declaration": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
-          "integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.7.4"
-          }
-        },
-        "@babel/parser": {
-          "version": "7.7.7",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
-          "integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
-          "dev": true
-        },
-        "@babel/template": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
-          "integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "@babel/parser": "^7.7.4",
-            "@babel/types": "^7.7.4"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
-          "integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.5.5",
-            "@babel/generator": "^7.7.4",
-            "@babel/helper-function-name": "^7.7.4",
-            "@babel/helper-split-export-declaration": "^7.7.4",
-            "@babel/parser": "^7.7.4",
-            "@babel/types": "^7.7.4",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "@babel/types": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
-          "integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "to-fast-properties": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-          "dev": true
-        }
+        "recast": "^0.11.3"
       }
     },
     "ember-router-scroll": {
@@ -35894,76 +35762,30 @@
       }
     },
     "ember-source": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.15.0.tgz",
-      "integrity": "sha512-daTELJBDMGqAmQb/Puxdk1YR204/zs1DEiEMQWlqbtmhphAoDUbGi9ifJu20ajP/IcOCWw9Vp7aPzguTohWF7w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.1.2.tgz",
+      "integrity": "sha512-qnVaI3GEZxTQtJVft7xKWJky4e2FJ4dBrAPlDKWVFXkqHfgWdvV1CWpPai0etNI/ANy1MDEnaNXbfY4X00LZQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/plugin-transform-block-scoping": "^7.6.2",
-        "@babel/plugin-transform-object-assign": "^7.2.0",
-        "@ember/edition-utils": "^1.1.1",
-        "babel-plugin-debug-macros": "^0.3.3",
-        "babel-plugin-filter-imports": "^3.0.0",
-        "broccoli-concat": "^3.7.4",
-        "broccoli-funnel": "^2.0.2",
-        "broccoli-merge-trees": "^3.0.2",
-        "chalk": "^2.4.2",
-        "ember-cli-babel": "^7.11.0",
+        "broccoli-funnel": "^2.0.1",
+        "broccoli-merge-trees": "^2.0.0",
         "ember-cli-get-component-path-option": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
         "ember-cli-normalize-entity-name": "^1.0.0",
         "ember-cli-path-utils": "^1.0.0",
         "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-version-checker": "^3.1.3",
-        "ember-router-generator": "^2.0.0",
+        "ember-cli-valid-component-name": "^1.0.0",
+        "ember-cli-version-checker": "^2.1.0",
+        "ember-router-generator": "^1.2.3",
         "inflection": "^1.12.0",
-        "jquery": "^3.4.1",
-        "resolve": "^1.11.1",
-        "semver": "^6.1.1",
-        "silent-error": "^1.1.1"
+        "jquery": "^3.3.1",
+        "resolve": "^1.5.0"
       },
       "dependencies": {
-        "@babel/plugin-transform-block-scoping": {
-          "version": "7.7.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.7.4.tgz",
-          "integrity": "sha512-2VBe9u0G+fDt9B5OV5DQH4KBf5DoiNkwFKOz0TCvBWvdAN2rOykCTkrL+jTLxfCAm76l9Qo5OqL7HBOx2dWggg==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.0.0",
-            "lodash": "^4.17.13"
-          }
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "babel-plugin-debug-macros": {
-          "version": "0.3.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.3.tgz",
-          "integrity": "sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==",
-          "dev": true,
-          "requires": {
-            "semver": "^5.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "5.7.1",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-              "dev": true
-            }
-          }
-        },
         "broccoli-funnel": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
+          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
           "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
@@ -35982,34 +35804,23 @@
           }
         },
         "broccoli-merge-trees": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
-          "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-2.0.0.tgz",
+          "integrity": "sha1-EK6kbdXOvMi499WlTwqEpPC7kLk=",
           "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
-            "merge-trees": "^2.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "merge-trees": "^1.0.1"
           }
         },
         "ember-cli-version-checker": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
-          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz",
+          "integrity": "sha512-sjkHGr4IGXnO3EUcY21380Xo9Qf6bC8HWH4D62bVnrQop/8uha5XgMQRoAflMCeH6suMrezQL287JUoYc2smEw==",
           "dev": true,
           "requires": {
-            "resolve-package-path": "^1.2.6",
-            "semver": "^5.6.0"
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
           },
           "dependencies": {
             "semver": {
@@ -36020,47 +35831,13 @@
             }
           }
         },
-        "merge-trees": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/merge-trees/-/merge-trees-2.0.0.tgz",
-          "integrity": "sha512-5xBbmqYBalWqmhYm51XlohhkmVOua3VAUrrWh8t9iOkaLpS6ifqm/UVuUjQCeDVJ9Vx3g2l6ihfkbLSTeKsHbw==",
-          "dev": true,
-          "requires": {
-            "fs-updater": "^1.0.4",
-            "heimdalljs": "^0.2.5"
-          }
-        },
-        "path-parse": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-          "dev": true
-        },
         "resolve": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.1.tgz",
-          "integrity": "sha512-fn5Wobh4cxbLzuHaE+nphztHy43/b++4M6SsGFC2gB8uYwf0C8LcarfCz1un7UTW8OFQg9iNjZ4xpcFVGebDPg==",
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "silent-error": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.1.tgz",
-          "integrity": "sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==",
-          "dev": true,
-          "requires": {
-            "debug": "^2.2.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
+            "path-parse": "^1.0.5"
           }
         }
       }
@@ -45641,35 +45418,15 @@
       }
     },
     "recast": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.5.tgz",
-      "integrity": "sha512-sD1WJrpLQAkXGyQZyGzTM75WJvyAd98II5CHdK3IYbt/cZlU0UzCRVU11nUFNXX9fBVEt4E9ajkMjBlUlG+Oog==",
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
       "dev": true,
       "requires": {
-        "ast-types": "0.13.2",
-        "esprima": "~4.0.0",
-        "private": "^0.1.8",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        },
-        "private": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-          "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-          "dev": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
+        "ast-types": "0.9.6",
+        "esprima": "~3.1.0",
+        "private": "~0.1.5",
+        "source-map": "~0.5.0"
       }
     },
     "redeyed": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ember-resolver": "^7.0.0",
     "ember-router-scroll": "^1.3.3",
     "ember-template-lint": "^1.12.1",
-    "ember-source": "~3.15.0",
+    "ember-source": "~3.1.0",
     "ember-svg-jar": "^2.2.3",
     "ember-test-selectors": "^3.0.0",
     "ember-web-app": "^3.0.1",


### PR DESCRIPTION
…-source-3.15.0, r=Turbo87"

This reverts commit 97ecbf3f1e4c957f25abe0fd7f8decee3c50ddfb, reversing
changes made to 6cfc3bfd61a1e1d1bc4d99bbf724b5196b5257f8.

@Turbo87 I did manual testing of logging in because you mentioned you weren't able to test it; when I was on face1f37 logging in didn't work for me.

I did a git bisect and it pointed to the ember-source upgrade https://github.com/rust-lang/crates.io/pull/2001 which is... all of ember? I'm not really sure how to go about debugging this further, but I'm going to try and I'll open a new issue with more details as I figure them out.

Reverting the ember-source upgrade lets me log in again, so this should make master deployable.

I really really wish we could have a full-stack automated test for logging in with GitHub, but I don't see that happening anytime soon!!