### PR TITLE
routes/github-authorize: Fix `queryParams` code

### DIFF
--- a/app/routes/github-authorize.js
+++ b/app/routes/github-authorize.js
@@ -18,7 +18,7 @@ import { serializeQueryParams } from 'ember-fetch/utils/serialize-query-params';
 export default Route.extend({
   async beforeModel(transition) {
     try {
-      let queryParams = serializeQueryParams(transition.queryParams);
+      let queryParams = serializeQueryParams(transition.to.queryParams);
       let resp = await fetch(`/api/private/session/authorize?${queryParams}`);
       let json = await resp.json();
       let item = JSON.stringify({ ok: resp.ok, data: json });


### PR DESCRIPTION
Accessing `queryParams` on the `transition` object was never officially public API in Ember.js, and has been deprecated in Ember.js v3.6 (see https://deprecations.emberjs.com/v3.x#toc_transition-state). Since it was only considered "intimate" API its removal was done in v3.9 instead of v4.0. Since we skipped both of these versions we unfortunately never saw the corresponding deprecation warning... 😞 

But even if we did upgrade to v3.8 LTS in between, we probably still would have missed it, because the `github-authorize` route is only called in a popup window where the usual DevTools console is not attached, and we unfortunately don't have any test for the login flow (yet!).

Closes https://github.com/rust-lang/crates.io/pull/2027, Resolves https://github.com/rust-lang/crates.io/issues/2028

@carols10cents r?