### PR TITLE
Enable debug MALLOC_CONF options on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       TEST_DATABASE_URL: postgres://postgres:@localhost/cargo_registry_test
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C debuginfo=0 -D warnings"
+      MALLOC_CONF: "background_thread:true,abort_conf:true"
 
     steps:
       - uses: actions/checkout@v2-beta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       TEST_DATABASE_URL: postgres://postgres:@localhost/cargo_registry_test
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C debuginfo=0 -D warnings"
-      MALLOC_CONF: "background_thread:true,abort_conf:true"
+      MALLOC_CONF: "background_thread:true,abort_conf:true,abort:true,junk:true"
 
     steps:
       - uses: actions/checkout@v2-beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     - PGPORT=5433
     - PATH=$HOME/.cargo/bin:$PATH
     - RUSTFLAGS="-C debuginfo=0 -D warnings"
+    - MALLOC_CONF=background_thread:true,abort_conf:true
 
 install:
   - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - PGPORT=5433
     - PATH=$HOME/.cargo/bin:$PATH
     - RUSTFLAGS="-C debuginfo=0 -D warnings"
-    - MALLOC_CONF=background_thread:true,abort_conf:true
+    - MALLOC_CONF=background_thread:true,abort_conf:true,abort:true,junk:true
 
 install:
   - sudo cp /etc/postgresql/10/main/pg_hba.conf /etc/postgresql/11/main/pg_hba.conf


### PR DESCRIPTION
On top of the production configuration, this commit adds two options:

* `abort:true` - most jemalloc warnings become fatal ([opt.abort])
* `junk:true` - both allocated and deallocated memory will be
  initialized to 0xa5. ([opt.junk])

Combined with the existing `abort_conf:true`, this should be equivalent
to enabling the `debug` feature of `jemallocator`.  We cannot enable
this feature in `Cargo.toml` because that would affect performance in
production.

[opt.abort]: http://jemalloc.net/jemalloc.3.html#opt.abort
[opt.junk]: http://jemalloc.net/jemalloc.3.html#opt.junk

r? @carols10cents 