### PR TITLE
Add a concrete `util::Error` type (step 3 of refactoring)

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -2,7 +2,7 @@ use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use diesel::r2d2::PoolError;
-use swirl::errors::PerformError;
+use swirl::PerformError;
 
 use crate::db::{DieselPool, DieselPooledConn};
 use crate::git::Repository;

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -2,11 +2,11 @@ use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 use diesel::r2d2::PoolError;
+use swirl::errors::PerformError;
 
 use crate::db::{DieselPool, DieselPooledConn};
 use crate::git::Repository;
 use crate::uploaders::Uploader;
-use crate::util::errors::AppResult;
 
 impl<'a> swirl::db::BorrowedConnection<'a> for DieselPool {
     type Connection = DieselPooledConn<'a>;
@@ -61,7 +61,7 @@ impl Environment {
         self.connection_pool.get()
     }
 
-    pub fn lock_index(&self) -> AppResult<MutexGuard<'_, Repository>> {
+    pub fn lock_index(&self) -> Result<MutexGuard<'_, Repository>, PerformError> {
         let repo = self.index.lock().unwrap_or_else(PoisonError::into_inner);
         repo.reset_head()?;
         Ok(repo)

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,8 +1,9 @@
-use cargo_registry::util::{cargo_err, AppError, AppResult};
-use cargo_registry::{db, env, tasks};
-use diesel::PgConnection;
+#![deny(clippy::all)]
 
-fn main() -> AppResult<()> {
+use cargo_registry::{db, env, tasks, util::Error};
+use swirl::Job;
+
+fn main() -> Result<(), Error> {
     let conn = db::connect_now()?;
     let mut args = std::env::args().skip(1);
 
@@ -10,24 +11,14 @@ fn main() -> AppResult<()> {
     println!("Enqueueing background job: {}", job);
 
     match &*job {
-        "update_downloads" => tasks::update_downloads().enqueue(&conn),
+        "update_downloads" => Ok(tasks::update_downloads().enqueue(&conn)?),
         "dump_db" => {
             let database_url = args.next().unwrap_or_else(|| env("DATABASE_URL"));
             let target_name = args
                 .next()
                 .unwrap_or_else(|| String::from("db-dump.tar.gz"));
-            tasks::dump_db(database_url, target_name).enqueue(&conn)
+            Ok(tasks::dump_db(database_url, target_name).enqueue(&conn)?)
         }
-        other => Err(cargo_err(&format!("Unrecognized job type `{}`", other))),
+        other => Err(Error::from(format!("Unrecognized job type `{}`", other))),
     }
 }
-
-/// Helper to map the `PerformError` returned by `swirl::Job::enqueue()` to a
-/// `AppError`. Can be removed once `map_err()` isn't needed any more.
-trait Enqueue: swirl::Job {
-    fn enqueue(self, conn: &PgConnection) -> AppResult<()> {
-        <Self as swirl::Job>::enqueue(self, conn).map_err(|e| AppError::from_std_error(e))
-    }
-}
-
-impl<J: swirl::Job> Enqueue for J {}

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -8,10 +8,10 @@
 
 mod on_call;
 
-use cargo_registry::{db, schema::*, util::AppResult};
+use cargo_registry::{db, schema::*, util::Error};
 use diesel::prelude::*;
 
-fn main() -> AppResult<()> {
+fn main() -> Result<(), Error> {
     let conn = db::connect_now()?;
 
     check_stalled_background_jobs(&conn)?;
@@ -19,7 +19,7 @@ fn main() -> AppResult<()> {
     Ok(())
 }
 
-fn check_stalled_background_jobs(conn: &PgConnection) -> AppResult<()> {
+fn check_stalled_background_jobs(conn: &PgConnection) -> Result<(), Error> {
     use cargo_registry::schema::background_jobs::dsl::*;
     use diesel::dsl::*;
 
@@ -55,7 +55,7 @@ fn check_stalled_background_jobs(conn: &PgConnection) -> AppResult<()> {
     Ok(())
 }
 
-fn check_spam_attack(conn: &PgConnection) -> AppResult<()> {
+fn check_spam_attack(conn: &PgConnection) -> Result<(), Error> {
     use cargo_registry::models::krate::canon_crate_name;
     use diesel::dsl::*;
     use diesel::sql_types::Bool;
@@ -116,7 +116,7 @@ fn check_spam_attack(conn: &PgConnection) -> AppResult<()> {
     Ok(())
 }
 
-fn log_and_trigger_event(event: on_call::Event) -> AppResult<()> {
+fn log_and_trigger_event(event: on_call::Event) -> Result<(), Error> {
     match event {
         on_call::Event::Trigger {
             ref description, ..

--- a/src/bin/test-pagerduty.rs
+++ b/src/bin/test-pagerduty.rs
@@ -11,7 +11,9 @@ mod on_call;
 
 use std::env::args;
 
-fn main() {
+use cargo_registry::util::Error;
+
+fn main() -> Result<(), Error> {
     let args = args().collect::<Vec<_>>();
 
     let event_type = &*args[1];
@@ -32,5 +34,5 @@ fn main() {
         },
         _ => panic!("Event type must be trigger, acknowledge, or resolve"),
     };
-    event.send().unwrap()
+    event.send()
 }

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -1,6 +1,6 @@
 mod cargo_prelude {
     pub use super::prelude::*;
-    pub use crate::util::cargo_err;
+    pub use crate::util::errors::cargo_err;
 }
 
 mod frontend_prelude {
@@ -16,7 +16,7 @@ mod prelude {
     pub use conduit_router::RequestParams;
 
     pub use crate::db::RequestTransaction;
-    pub use crate::util::{cargo_err, AppResult}; // TODO: Remove cargo_err from here
+    pub use crate::util::errors::{cargo_err, AppError, AppResult, ChainError}; // TODO: Remove cargo_err from here
 
     pub use crate::middleware::app::RequestApp;
     pub use crate::middleware::current_user::RequestUser;

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,4 +1,4 @@
-use crate::util::{json_response, AppResult};
+use crate::util::{errors::AppResult, json_response};
 use conduit::Response;
 
 pub(crate) mod pagination;

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -1,5 +1,5 @@
 use crate::models::helpers::with_count::*;
-use crate::util::errors::*;
+use crate::util::errors::{cargo_err, AppResult};
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::query_builder::*;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -13,8 +13,7 @@ use crate::models::{
 };
 
 use crate::render;
-use crate::util::{read_fill, read_le_u32};
-use crate::util::{AppError, ChainError, Maximums};
+use crate::util::{read_fill, read_le_u32, Maximums};
 use crate::views::{EncodableCrateUpload, GoodCrate, PublishWarnings};
 
 /// Handles the `PUT /crates/new` route.

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -1,9 +1,9 @@
-use super::prelude::*;
+use super::frontend_prelude::*;
 
 use crate::middleware::current_user::AuthenticationSource;
 use crate::models::ApiToken;
 use crate::schema::api_tokens;
-use crate::util::{bad_request, read_fill, ChainError};
+use crate::util::read_fill;
 use crate::views::EncodableApiTokenWithToken;
 
 use serde_json as json;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -4,7 +4,6 @@ use crate::controllers::frontend_prelude::*;
 
 use crate::controllers::helpers::*;
 use crate::email;
-use crate::util::errors::{AppError, ChainError};
 
 use crate::models::{
     CrateOwner, Email, Follow, NewEmail, OwnerKind, User, Version, VersionOwnerAction,

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -7,7 +7,7 @@ use oauth2::{prelude::*, AuthorizationCode, TokenResponse};
 
 use crate::models::{NewUser, User};
 use crate::schema::users;
-use crate::util::errors::{AppError, ChainError, ReadOnlyMode};
+use crate::util::errors::ReadOnlyMode;
 
 /// Handles the `GET /api/private/session/begin` route.
 ///

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -5,8 +5,8 @@ use swirl::Job;
 use super::version_and_crate;
 use crate::controllers::cargo_prelude::*;
 use crate::git;
-use crate::models::{insert_version_owner_action, Rights, VersionAction};
-use crate::util::AppError;
+use crate::models::Rights;
+use crate::models::{insert_version_owner_action, VersionAction};
 
 /// Handles the `DELETE /crates/:crate_id/:version/yank` route.
 /// This does not delete a crate version, it makes the crate

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use url::Url;
 
 use crate::middleware::app::RequestApp;
-use crate::util::AppResult;
 use crate::Env;
 
 #[allow(missing_debug_implementations)]
@@ -89,12 +88,12 @@ pub trait RequestTransaction {
     ///
     /// The connection will live for the lifetime of the request.
     // FIXME: This description does not match the implementation below.
-    fn db_conn(&self) -> AppResult<DieselPooledConn<'_>>;
+    fn db_conn(&self) -> Result<DieselPooledConn<'_>, r2d2::PoolError>;
 }
 
 impl<T: Request + ?Sized> RequestTransaction for T {
-    fn db_conn(&self) -> AppResult<DieselPooledConn<'_>> {
-        self.app().diesel_database.get().map_err(Into::into)
+    fn db_conn(&self) -> Result<DieselPooledConn<'_>, r2d2::PoolError> {
+        self.app().diesel_database.get()
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,7 +18,7 @@ pub enum DieselPool {
 }
 
 impl DieselPool {
-    pub fn get(&self) -> AppResult<DieselPooledConn<'_>> {
+    pub fn get(&self) -> Result<DieselPooledConn<'_>, r2d2::PoolError> {
         match self {
             DieselPool::Pool(pool) => Ok(DieselPooledConn::Pool(pool.get()?)),
             DieselPool::Test(conn) => Ok(DieselPooledConn::Test(conn.lock())),

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::util::{bad_request, AppResult};
+use crate::util::{errors::server_error, AppResult};
 
 use failure::Fail;
 use lettre::file::FileTransport;
@@ -118,12 +118,12 @@ fn send_email(recipient: &str, subject: &str, body: &str) -> AppResult<()> {
                 .transport();
 
             let result = transport.send(email);
-            result.map_err(|_| bad_request("Error in sending email"))?;
+            result.map_err(|_| server_error("Error in sending email"))?;
         }
         None => {
             let mut sender = FileTransport::new(Path::new("/tmp"));
             let result = sender.send(email);
-            result.map_err(|_| bad_request("Email file could not be generated"))?;
+            result.map_err(|_| server_error("Email file could not be generated"))?;
         }
     }
 

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::util::{errors::server_error, AppResult};
+use crate::util::errors::{server_error, AppResult};
 
 use failure::Fail;
 use lettre::file::FileTransport;

--- a/src/git.rs
+++ b/src/git.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
-use swirl::errors::PerformError;
+use swirl::PerformError;
 use tempdir::TempDir;
 use url::Url;
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 use std::str;
 
 use crate::app::App;
-use crate::util::{cargo_err, errors::NotFound, internal, AppError, AppResult};
+use crate::util::errors::{cargo_err, internal, AppError, AppResult, NotFound};
 
 /// Does all the nonsense for sending a GET to Github. Doesn't handle parsing
 /// because custom error-code handling may be desirable. Use

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,17 +1,22 @@
 mod prelude {
     pub use conduit::{Handler, Request, Response};
     pub use conduit_middleware::{AroundMiddleware, Middleware};
-    pub use std::error::Error;
+
+    use std::error::Error;
+    pub type BoxError = Box<dyn Error + Send>;
+    pub type Result<T> = std::result::Result<T, BoxError>;
 }
 
-pub use self::app::AppMiddleware;
-pub use self::current_user::CurrentUser;
-pub use self::debug::*;
-pub use self::ember_index_rewrite::EmberIndexRewrite;
-pub use self::head::Head;
+pub use prelude::Result;
+
+use self::app::AppMiddleware;
+use self::current_user::CurrentUser;
+use self::debug::*;
+use self::ember_index_rewrite::EmberIndexRewrite;
+use self::head::Head;
 use self::log_connection_pool_status::LogConnectionPoolStatus;
-pub use self::security_headers::SecurityHeaders;
-pub use self::static_or_continue::StaticOrContinue;
+use self::security_headers::SecurityHeaders;
+use self::static_or_continue::StaticOrContinue;
 
 pub mod app;
 mod block_traffic;

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -17,16 +17,12 @@ impl AppMiddleware {
 }
 
 impl Middleware for AppMiddleware {
-    fn before(&self, req: &mut dyn Request) -> Result<(), Box<dyn Error + Send>> {
+    fn before(&self, req: &mut dyn Request) -> Result<()> {
         req.mut_extensions().insert(Arc::clone(&self.app));
         Ok(())
     }
 
-    fn after(
-        &self,
-        req: &mut dyn Request,
-        res: Result<Response, Box<dyn Error + Send>>,
-    ) -> Result<Response, Box<dyn Error + Send>> {
+    fn after(&self, req: &mut dyn Request, res: Result<Response>) -> Result<Response> {
         req.mut_extensions().pop::<Arc<App>>().unwrap();
         res
     }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -39,7 +39,7 @@ impl AroundMiddleware for BlockTraffic {
 }
 
 impl Handler for BlockTraffic {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> Result<Response> {
         let has_blocked_value = req
             .headers()
             .find(&self.header_name)

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -4,7 +4,7 @@ use conduit_cookie::RequestSession;
 use diesel::prelude::*;
 
 use crate::db::RequestTransaction;
-use crate::util::errors::{std_error, AppResult, ChainError, Unauthorized};
+use crate::util::errors::{AppResult, ChainError, Unauthorized};
 
 use crate::models::ApiToken;
 use crate::models::User;
@@ -28,7 +28,9 @@ impl Middleware for CurrentUser {
                 .and_then(|s| s.parse::<i32>().ok())
         };
 
-        let conn = req.db_conn().map_err(std_error)?;
+        let conn = req
+            .db_conn()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send>)?;
 
         if let Some(id) = id {
             // If it did, look for a user in the database with the given `user_id`

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -20,7 +20,7 @@ pub enum AuthenticationSource {
 }
 
 impl Middleware for CurrentUser {
-    fn before(&self, req: &mut dyn Request) -> Result<(), Box<dyn Error + Send>> {
+    fn before(&self, req: &mut dyn Request) -> Result<()> {
         // Check if the request has a session cookie with a `user_id` property inside
         let id = {
             req.session()
@@ -28,9 +28,7 @@ impl Middleware for CurrentUser {
                 .and_then(|s| s.parse::<i32>().ok())
         };
 
-        let conn = req
-            .db_conn()
-            .map_err(|e| Box::new(e) as Box<dyn Error + Send>)?;
+        let conn = req.db_conn().map_err(|e| Box::new(e) as BoxError)?;
 
         if let Some(id) = id {
             // If it did, look for a user in the database with the given `user_id`
@@ -58,7 +56,7 @@ impl Middleware for CurrentUser {
                         })
                     })
                     .optional()
-                    .map_err(|e| Box::new(e) as Box<dyn Error + Send>)?
+                    .map_err(|e| Box::new(e) as BoxError)?
             } else {
                 None
             };

--- a/src/middleware/debug.rs
+++ b/src/middleware/debug.rs
@@ -6,15 +6,11 @@ use super::prelude::*;
 pub struct Debug;
 
 impl Middleware for Debug {
-    fn before(&self, req: &mut dyn Request) -> Result<(), Box<dyn Error + Send>> {
+    fn before(&self, req: &mut dyn Request) -> Result<()> {
         DebugRequest.before(req)
     }
 
-    fn after(
-        &self,
-        _req: &mut dyn Request,
-        res: Result<Response, Box<dyn Error + Send>>,
-    ) -> Result<Response, Box<dyn Error + Send>> {
+    fn after(&self, _req: &mut dyn Request, res: Result<Response>) -> Result<Response> {
         res.map(|res| {
             println!("  <- {:?}", res.status);
             for (k, v) in &res.headers {
@@ -29,7 +25,7 @@ impl Middleware for Debug {
 pub struct DebugRequest;
 
 impl Middleware for DebugRequest {
-    fn before(&self, req: &mut dyn Request) -> Result<(), Box<dyn Error + Send>> {
+    fn before(&self, req: &mut dyn Request) -> Result<()> {
         println!("  version: {}", req.http_version());
         println!("  method: {:?}", req.method());
         println!("  scheme: {:?}", req.scheme());

--- a/src/middleware/ember_index_rewrite.rs
+++ b/src/middleware/ember_index_rewrite.rs
@@ -24,7 +24,7 @@ impl AroundMiddleware for EmberIndexRewrite {
 }
 
 impl Handler for EmberIndexRewrite {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> Result<Response> {
         // If the client is requesting html, then we've only got one page so
         // rewrite the request.
         let wants_html = req

--- a/src/middleware/ensure_well_formed_500.rs
+++ b/src/middleware/ensure_well_formed_500.rs
@@ -10,11 +10,7 @@ use std::collections::HashMap;
 pub struct EnsureWellFormed500;
 
 impl Middleware for EnsureWellFormed500 {
-    fn after(
-        &self,
-        _: &mut dyn Request,
-        res: Result<Response, Box<dyn Error + Send>>,
-    ) -> Result<Response, Box<dyn Error + Send>> {
+    fn after(&self, _: &mut dyn Request, res: Result<Response>) -> Result<Response> {
         res.or_else(|_| {
             let body = "Internal Server Error";
             let mut headers = HashMap::new();

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -20,7 +20,7 @@ impl AroundMiddleware for Head {
 }
 
 impl Handler for Head {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> Result<Response> {
         if req.method() == Method::Head {
             let mut req = RequestProxy::rewrite_method(req, Method::Get);
             self.handler

--- a/src/middleware/log_connection_pool_status.rs
+++ b/src/middleware/log_connection_pool_status.rs
@@ -28,7 +28,7 @@ impl LogConnectionPoolStatus {
 }
 
 impl Middleware for LogConnectionPoolStatus {
-    fn before(&self, _: &mut dyn Request) -> Result<(), Box<dyn Error + Send>> {
+    fn before(&self, _: &mut dyn Request) -> Result<()> {
         let mut last_log_time = self
             .last_log_time
             .lock()
@@ -45,11 +45,7 @@ impl Middleware for LogConnectionPoolStatus {
         Ok(())
     }
 
-    fn after(
-        &self,
-        _: &mut dyn Request,
-        res: Result<Response, Box<dyn Error + Send>>,
-    ) -> Result<Response, Box<dyn Error + Send>> {
+    fn after(&self, _: &mut dyn Request, res: Result<Response>) -> Result<Response> {
         self.in_flight_requests.fetch_sub(1, Ordering::SeqCst);
         res
     }

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -20,7 +20,7 @@ impl AroundMiddleware for LogRequests {
 }
 
 impl Handler for LogRequests {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> Result<Response> {
         let request_start = Instant::now();
         let res = self.handler.as_ref().unwrap().call(req);
         let (level, response_code) = match res {

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -20,7 +20,7 @@ impl AroundMiddleware for RequireUserAgent {
 }
 
 impl Handler for RequireUserAgent {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> Result<Response> {
         let has_user_agent = request_header(req, "User-Agent") != "";
         let is_download = req.path().ends_with("download");
         if !has_user_agent && !is_download {

--- a/src/middleware/security_headers.rs
+++ b/src/middleware/security_headers.rs
@@ -57,11 +57,7 @@ impl SecurityHeaders {
 }
 
 impl Middleware for SecurityHeaders {
-    fn after(
-        &self,
-        _: &mut dyn Request,
-        mut res: Result<Response, Box<dyn Error + Send>>,
-    ) -> Result<Response, Box<dyn Error + Send>> {
+    fn after(&self, _: &mut dyn Request, mut res: Result<Response>) -> Result<Response> {
         if let Ok(ref mut response) = res {
             response.headers.extend(self.headers.clone());
         }

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -27,7 +27,7 @@ impl AroundMiddleware for StaticOrContinue {
 }
 
 impl Handler for StaticOrContinue {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> Result<Response> {
         match self.static_handler.call(req) {
             Ok(ref resp) if resp.status.0 == 404 => {}
             ret => return ret,

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::*;
 
 use crate::git;
-use crate::util::{cargo_err, AppResult};
+use crate::util::errors::{cargo_err, AppResult};
 
 use crate::models::{Crate, Version};
 use crate::schema::*;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -13,7 +13,7 @@ use crate::models::{
     Badge, Category, CrateOwner, CrateOwnerInvitation, Keyword, NewCrateOwnerInvitation, Owner,
     OwnerKind, ReverseDependency, User, Version,
 };
-use crate::util::{cargo_err, AppResult};
+use crate::util::errors::{cargo_err, AppResult};
 use crate::views::{EncodableCrate, EncodableCrateLinks};
 
 use crate::models::helpers::with_count::*;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -387,7 +387,7 @@ impl Crate {
 
     /// Return both the newest (most recently updated) and
     /// highest version (in semver order) for the current crate.
-    pub fn top_versions(&self, conn: &PgConnection) -> AppResult<TopVersions> {
+    pub fn top_versions(&self, conn: &PgConnection) -> QueryResult<TopVersions> {
         use crate::schema::versions::dsl::*;
 
         Ok(Version::top(
@@ -397,7 +397,7 @@ impl Crate {
         ))
     }
 
-    pub fn owners(&self, conn: &PgConnection) -> AppResult<Vec<Owner>> {
+    pub fn owners(&self, conn: &PgConnection) -> QueryResult<Vec<Owner>> {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .filter(crate_owners::crate_id.eq(self.id))
             .inner_join(users::table)

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 
 use crate::app::App;
 use crate::github;
-use crate::util::{cargo_err, AppResult};
+use crate::util::errors::{cargo_err, AppResult};
 
 use crate::models::{Crate, Team, User};
 use crate::schema::{crate_owners, users};

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 
 use crate::app::App;
 use crate::github::{github_api, team_url};
-use crate::util::{cargo_err, errors::NotFound, AppResult};
+use crate::util::errors::{cargo_err, AppResult, NotFound};
 
 use oauth2::{prelude::*, AccessToken};
 

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -178,7 +178,7 @@ impl Team {
         team_with_gh_id_contains_user(app, self.github_id, user)
     }
 
-    pub fn owning(krate: &Crate, conn: &PgConnection) -> AppResult<Vec<Owner>> {
+    pub fn owning(krate: &Crate, conn: &PgConnection) -> QueryResult<Vec<Owner>> {
         let base_query = CrateOwner::belonging_to(krate).filter(crate_owners::deleted.eq(false));
         let teams = base_query
             .inner_join(teams::table)

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -116,7 +116,7 @@ impl User {
         Self::find(conn, api_token.user_id)
     }
 
-    pub fn owning(krate: &Crate, conn: &PgConnection) -> AppResult<Vec<Owner>> {
+    pub fn owning(krate: &Crate, conn: &PgConnection) -> QueryResult<Vec<Owner>> {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(users::table)
             .select(users::all_columns)
@@ -157,7 +157,7 @@ impl User {
 
     /// Queries the database for the verified emails
     /// belonging to a given user
-    pub fn verified_email(&self, conn: &PgConnection) -> AppResult<Option<String>> {
+    pub fn verified_email(&self, conn: &PgConnection) -> QueryResult<Option<String>> {
         Ok(Email::belonging_to(self)
             .select(emails::email)
             .filter(emails::verified.eq(true))

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -2,7 +2,7 @@ use diesel::prelude::*;
 use std::borrow::Cow;
 
 use crate::app::App;
-use crate::util::AppResult;
+use crate::util::errors::AppResult;
 
 use crate::models::{ApiToken, Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};
 use crate::schema::{crate_owners, emails, users};

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
-use crate::util::{cargo_err, AppResult};
+use crate::util::errors::{cargo_err, AppResult};
 
 use crate::models::{Crate, Dependency, User, VersionOwnerAction};
 use crate::schema::*;

--- a/src/render.rs
+++ b/src/render.rs
@@ -229,7 +229,6 @@ pub fn render_and_upload_readme(
     base_url: Option<String>,
 ) -> Result<(), PerformError> {
     use crate::schema::*;
-    use crate::util::errors::std_error_no_send;
     use diesel::prelude::*;
 
     let rendered = readme_to_html(&text, &file_name, base_url.as_ref().map(String::as_str));
@@ -243,8 +242,7 @@ pub fn render_and_upload_readme(
             .select((crates::name, versions::num))
             .first::<(String, String)>(&*conn)?;
         env.uploader
-            .upload_readme(env.http_client(), &crate_name, &vers, rendered)
-            .map_err(std_error_no_send)?;
+            .upload_readme(env.http_client(), &crate_name, &vers, rendered)?;
         Ok(())
     })
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -4,7 +4,7 @@ use ammonia::{Builder, UrlRelative, UrlRelativeEvaluate};
 use htmlescape::encode_minimal;
 use std::borrow::Cow;
 use std::path::Path;
-use swirl::errors::PerformError;
+use swirl::PerformError;
 use url::Url;
 
 use crate::background_jobs::Environment;

--- a/src/router.rs
+++ b/src/router.rs
@@ -178,7 +178,7 @@ impl Handler for R404 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::errors::{bad_request, cargo_err, internal, NotFound, Unauthorized};
+    use crate::util::errors::{bad_request, cargo_err, internal, AppError, NotFound, Unauthorized};
 
     use conduit_test::MockRequest;
     use diesel::result::Error as DieselError;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::sync::Arc;
 
 use conduit::{Handler, Request, Response};
@@ -7,7 +6,7 @@ use conduit_router::{RequestParams, RouteBuilder};
 use crate::controllers::*;
 use crate::util::errors::{std_error, AppError, AppResult, NotFound};
 use crate::util::RequestProxy;
-use crate::{App, Env};
+use crate::{middleware, App, Env};
 
 pub fn build_router(app: &App) -> R404 {
     let mut api_router = RouteBuilder::new();
@@ -136,7 +135,7 @@ pub fn build_router(app: &App) -> R404 {
 struct C(pub fn(&mut dyn Request) -> AppResult<Response>);
 
 impl Handler for C {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> middleware::Result<Response> {
         let C(f) = *self;
         match f(req) {
             Ok(resp) => Ok(resp),
@@ -151,7 +150,7 @@ impl Handler for C {
 struct R<H>(pub Arc<H>);
 
 impl<H: Handler> Handler for R<H> {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> middleware::Result<Response> {
         let path = req.params()["path"].to_string();
         let R(ref sub_router) = *self;
         sub_router.call(&mut RequestProxy::rewrite_path(req, &path))
@@ -163,7 +162,7 @@ impl<H: Handler> Handler for R<H> {
 pub struct R404(pub RouteBuilder);
 
 impl Handler for R404 {
-    fn call(&self, req: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+    fn call(&self, req: &mut dyn Request) -> middleware::Result<Response> {
         let R404(ref router) = *self;
         match router.recognize(&req.method(), req.path()) {
             Ok(m) => {

--- a/src/tasks/dump_db.rs
+++ b/src/tasks/dump_db.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{background_jobs::Environment, uploaders::Uploader, util::errors::std_error_no_send};
+use crate::{background_jobs::Environment, uploaders::Uploader};
 use reqwest::header;
 use swirl::PerformError;
 
@@ -156,16 +156,14 @@ impl DumpTarball {
         let tarfile = File::open(&self.tarball_path)?;
         let content_length = tarfile.metadata()?.len();
         // TODO Figure out the correct content type.
-        uploader
-            .upload(
-                &client,
-                target_name,
-                tarfile,
-                content_length,
-                "application/gzip",
-                header::HeaderMap::new(),
-            )
-            .map_err(std_error_no_send)?;
+        uploader.upload(
+            &client,
+            target_name,
+            tarfile,
+            content_length,
+            "application/gzip",
+            header::HeaderMap::new(),
+        )?;
         Ok(content_length)
     }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -13,7 +13,6 @@ use crate::util::{Bad, RequestHelper, TestApp};
 use cargo_registry::{
     models::{Crate, CrateOwner, Dependency, NewCategory, NewTeam, NewUser, Team, User, Version},
     schema::crate_owners,
-    util::AppResult,
     views::{
         EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
         EncodableOwner, EncodableVersion, GoodCrate,
@@ -229,7 +228,7 @@ fn new_team(login: &str) -> NewTeam<'_> {
     }
 }
 
-fn add_team_to_crate(t: &Team, krate: &Crate, u: &User, conn: &PgConnection) -> AppResult<()> {
+fn add_team_to_crate(t: &Team, krate: &Crate, u: &User, conn: &PgConnection) -> QueryResult<()> {
     let crate_owner = CrateOwner {
         crate_id: krate.id,
         owner_id: t.id,

--- a/src/tests/builders.rs
+++ b/src/tests/builders.rs
@@ -3,7 +3,7 @@
 use cargo_registry::{
     models::{Crate, Keyword, NewCrate, NewVersion, Version},
     schema::{crates, dependencies, version_downloads, versions},
-    util::AppResult,
+    util::errors::AppResult,
     views::krate_publish as u,
 };
 use std::{collections::HashMap, io::Read};

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -4,8 +4,8 @@ use openssl::error::ErrorStack;
 use openssl::hash::{Hasher, MessageDigest};
 use reqwest::header;
 
-use crate::util::LimitErrorReader;
-use crate::util::{cargo_err, internal, AppResult, ChainError, Maximums};
+use crate::util::errors::{cargo_err, internal, AppResult, ChainError};
+use crate::util::{LimitErrorReader, Maximums};
 
 use std::env;
 use std::error::Error;

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,8 +5,8 @@ use std::io::Cursor;
 use conduit::Response;
 use serde::Serialize;
 
-pub use self::errors::ChainError;
-pub use self::errors::{bad_request, cargo_err, internal, AppError, AppResult};
+pub use self::errors::concrete::Error;
+pub use self::errors::{bad_request, cargo_err, internal, AppError, AppResult, ChainError};
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
 pub use self::request_proxy::RequestProxy;

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,6 @@ use conduit::Response;
 use serde::Serialize;
 
 pub use self::errors::concrete::Error;
-pub use self::errors::{bad_request, cargo_err, internal, AppError, AppResult, ChainError};
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
 pub use self::request_proxy::RequestProxy;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -239,7 +239,7 @@ pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
 }
 
 #[derive(Debug)]
-pub struct AppErrToStdErr(pub Box<dyn AppError>);
+struct AppErrToStdErr(pub Box<dyn AppError>);
 
 impl Error for AppErrToStdErr {}
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -1,3 +1,17 @@
+//! This module implements several error types and traits.  The suggested usage in returned results
+//! is as follows:
+//!
+//! * The concrete `util::concrete::Error` type (re-exported as `util::Error`) is great for code
+//!   that is not part of the request/response lifecycle.  It avoids pulling in the unnecessary
+//!   infrastructure to convert errors into a user facing JSON responses (relative to `AppError`).
+//! * `diesel::QueryResult` - There is a lot of code that only deals with query errors.  If only
+//!   one type of error is possible in a function, using that specific error is preferable to the
+//!   more general `util::Error`.  This is especially common in model code.
+//! * `util::errors::AppResult` - Some failures should be converted into user facing JSON
+//!   responses.  This error type is more dynamic and is box allocated.  Low-level errors are
+//!   typically not converted to user facing errors and most usage is within the models,
+//!   controllers, and middleware layers.
+
 use std::any::{Any, TypeId};
 use std::error::Error;
 use std::fmt;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -8,6 +8,7 @@ use diesel::result::Error as DieselError;
 
 use crate::util::json_response;
 
+pub(super) mod concrete;
 mod http;
 
 /// Returns an error with status 200 and the provided description as JSON
@@ -181,7 +182,7 @@ impl<E: Error + Send + 'static> From<E> for Box<dyn AppError> {
     }
 }
 // =============================================================================
-// Concrete errors
+// Internal error for use with `chain_error`
 
 #[derive(Debug)]
 struct InternalAppError {
@@ -200,6 +201,8 @@ impl AppError for InternalAppError {
         None
     }
 }
+
+// TODO: The remaining can probably move under `http`
 
 #[derive(Debug, Clone, Copy)]
 pub struct NotFound;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -35,16 +35,16 @@ pub fn server_error<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
 }
 
 #[derive(Serialize)]
-struct StringError {
-    detail: String,
+struct StringError<'a> {
+    detail: &'a str,
 }
 #[derive(Serialize)]
-struct Bad {
-    errors: Vec<StringError>,
+struct Bad<'a> {
+    errors: Vec<StringError<'a>>,
 }
 
 /// Generates a response with the provided status and description as JSON
-fn json_error(detail: String, status: (u32, &'static str)) -> Response {
+fn json_error(detail: &str, status: (u32, &'static str)) -> Response {
     let mut response = json_response(&Bad {
         errors: vec![StringError { detail }],
     });
@@ -206,7 +206,7 @@ pub struct NotFound;
 
 impl AppError for NotFound {
     fn response(&self) -> Option<Response> {
-        Some(json_error("Not Found".to_string(), (404, "Not Found")))
+        Some(json_error("Not Found", (404, "Not Found")))
     }
 }
 
@@ -221,7 +221,7 @@ pub struct Unauthorized;
 
 impl AppError for Unauthorized {
     fn response(&self) -> Option<Response> {
-        let detail = "must be logged in to perform that action".to_string();
+        let detail = "must be logged in to perform that action";
         Some(json_error(detail, (403, "Forbidden")))
     }
 }
@@ -263,8 +263,7 @@ pub struct ReadOnlyMode;
 impl AppError for ReadOnlyMode {
     fn response(&self) -> Option<Response> {
         let detail = "Crates.io is currently in read-only mode for maintenance. \
-                      Please try again later."
-            .to_string();
+                      Please try again later.";
         Some(json_error(detail, (503, "Service Unavailable")))
     }
 }
@@ -291,7 +290,7 @@ impl AppError for TooManyRequests {
              help@crates.io to have your limit increased.",
             retry_after
         );
-        let mut response = json_error(detail, (429, "TOO MANY REQUESTS"));
+        let mut response = json_error(&detail, (429, "TOO MANY REQUESTS"));
         response
             .headers
             .insert("Retry-After".into(), vec![retry_after.to_string()]);

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -253,10 +253,6 @@ pub(crate) fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
     Box::new(AppErrToStdErr(e))
 }
 
-pub(crate) fn std_error_no_send(e: Box<dyn AppError>) -> Box<dyn Error> {
-    Box::new(AppErrToStdErr(e))
-}
-
 #[derive(Debug, Clone, Copy)]
 pub struct ReadOnlyMode;
 

--- a/src/util/errors/concrete.rs
+++ b/src/util/errors/concrete.rs
@@ -3,8 +3,11 @@ use std::{error, fmt};
 #[derive(Debug)]
 pub enum Error {
     DbConnect(diesel::result::ConnectionError),
+    DbQuery(diesel::result::Error),
+    DotEnv(dotenv::Error),
     Internal(String),
     JobEnqueue(swirl::EnqueueError),
+    Reqwest(reqwest::Error),
 }
 
 impl error::Error for Error {}
@@ -13,8 +16,11 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::DbConnect(inner) => inner.fmt(f),
+            Error::DbQuery(inner) => inner.fmt(f),
+            Error::DotEnv(inner) => inner.fmt(f),
             Error::Internal(inner) => inner.fmt(f),
             Error::JobEnqueue(inner) => inner.fmt(f),
+            Error::Reqwest(inner) => inner.fmt(f),
         }
     }
 }
@@ -22,6 +28,18 @@ impl fmt::Display for Error {
 impl From<diesel::result::ConnectionError> for Error {
     fn from(err: diesel::result::ConnectionError) -> Self {
         Error::DbConnect(err)
+    }
+}
+
+impl From<diesel::result::Error> for Error {
+    fn from(err: diesel::result::Error) -> Self {
+        Error::DbQuery(err)
+    }
+}
+
+impl From<dotenv::Error> for Error {
+    fn from(err: dotenv::Error) -> Self {
+        Error::DotEnv(err)
     }
 }
 
@@ -34,5 +52,11 @@ impl From<String> for Error {
 impl From<swirl::EnqueueError> for Error {
     fn from(err: swirl::EnqueueError) -> Self {
         Error::JobEnqueue(err)
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Error::Reqwest(err)
     }
 }

--- a/src/util/errors/concrete.rs
+++ b/src/util/errors/concrete.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use std::{error, fmt, io};
 
 #[derive(Debug)]
 pub enum Error {
@@ -6,6 +6,7 @@ pub enum Error {
     DbQuery(diesel::result::Error),
     DotEnv(dotenv::Error),
     Internal(String),
+    Io(io::Error),
     JobEnqueue(swirl::EnqueueError),
     Reqwest(reqwest::Error),
 }
@@ -19,6 +20,7 @@ impl fmt::Display for Error {
             Error::DbQuery(inner) => inner.fmt(f),
             Error::DotEnv(inner) => inner.fmt(f),
             Error::Internal(inner) => inner.fmt(f),
+            Error::Io(inner) => inner.fmt(f),
             Error::JobEnqueue(inner) => inner.fmt(f),
             Error::Reqwest(inner) => inner.fmt(f),
         }
@@ -46,6 +48,12 @@ impl From<dotenv::Error> for Error {
 impl From<String> for Error {
     fn from(err: String) -> Self {
         Error::Internal(err)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Error::Io(err)
     }
 }
 

--- a/src/util/errors/concrete.rs
+++ b/src/util/errors/concrete.rs
@@ -1,0 +1,38 @@
+use std::{error, fmt};
+
+#[derive(Debug)]
+pub enum Error {
+    DbConnect(diesel::result::ConnectionError),
+    Internal(String),
+    JobEnqueue(swirl::EnqueueError),
+}
+
+impl error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::DbConnect(inner) => inner.fmt(f),
+            Error::Internal(inner) => inner.fmt(f),
+            Error::JobEnqueue(inner) => inner.fmt(f),
+        }
+    }
+}
+
+impl From<diesel::result::ConnectionError> for Error {
+    fn from(err: diesel::result::ConnectionError) -> Self {
+        Error::DbConnect(err)
+    }
+}
+
+impl From<String> for Error {
+    fn from(err: String) -> Self {
+        Error::Internal(err)
+    }
+}
+
+impl From<swirl::EnqueueError> for Error {
+    fn from(err: swirl::EnqueueError) -> Self {
+        Error::JobEnqueue(err)
+    }
+}

--- a/src/util/errors/concrete.rs
+++ b/src/util/errors/concrete.rs
@@ -8,6 +8,7 @@ pub enum Error {
     Internal(String),
     Io(io::Error),
     JobEnqueue(swirl::EnqueueError),
+    Openssl(openssl::error::ErrorStack),
     Reqwest(reqwest::Error),
 }
 
@@ -22,6 +23,7 @@ impl fmt::Display for Error {
             Error::Internal(inner) => inner.fmt(f),
             Error::Io(inner) => inner.fmt(f),
             Error::JobEnqueue(inner) => inner.fmt(f),
+            Error::Openssl(inner) => inner.fmt(f),
             Error::Reqwest(inner) => inner.fmt(f),
         }
     }
@@ -60,6 +62,15 @@ impl From<io::Error> for Error {
 impl From<swirl::EnqueueError> for Error {
     fn from(err: swirl::EnqueueError) -> Self {
         Error::JobEnqueue(err)
+    }
+}
+
+impl From<s3::Error> for Error {
+    fn from(err: s3::Error) -> Self {
+        match err {
+            s3::Error::Openssl(e) => Error::Openssl(e),
+            s3::Error::Reqwest(e) => Error::Reqwest(e),
+        }
     }
 }
 

--- a/src/util/errors/http.rs
+++ b/src/util/errors/http.rs
@@ -2,8 +2,7 @@ use std::fmt;
 
 use conduit::Response;
 
-use super::{AppError, Bad, StringError};
-use crate::util::json_response;
+use super::{json_error, AppError};
 
 #[derive(Debug)]
 pub(super) struct Ok(pub(super) String);
@@ -14,11 +13,7 @@ pub(super) struct ServerError(pub(super) String);
 
 impl AppError for Ok {
     fn response(&self) -> Option<Response> {
-        Some(json_response(&Bad {
-            errors: vec![StringError {
-                detail: self.0.clone(),
-            }],
-        }))
+        Some(json_error(self.0.clone(), (200, "OK")))
     }
 }
 
@@ -30,13 +25,7 @@ impl fmt::Display for Ok {
 
 impl AppError for BadRequest {
     fn response(&self) -> Option<Response> {
-        let mut response = json_response(&Bad {
-            errors: vec![StringError {
-                detail: self.0.clone(),
-            }],
-        });
-        response.status = (400, "Bad Request");
-        Some(response)
+        Some(json_error(self.0.clone(), (400, "Bad Request")))
     }
 }
 
@@ -48,13 +37,7 @@ impl fmt::Display for BadRequest {
 
 impl AppError for ServerError {
     fn response(&self) -> Option<Response> {
-        let mut response = json_response(&Bad {
-            errors: vec![StringError {
-                detail: self.0.clone(),
-            }],
-        });
-        response.status = (500, "Internal Server Error");
-        Some(response)
+        Some(json_error(self.0.clone(), (500, "Internal Server Error")))
     }
 }
 

--- a/src/util/errors/http.rs
+++ b/src/util/errors/http.rs
@@ -13,7 +13,7 @@ pub(super) struct ServerError(pub(super) String);
 
 impl AppError for Ok {
     fn response(&self) -> Option<Response> {
-        Some(json_error(self.0.clone(), (200, "OK")))
+        Some(json_error(&self.0, (200, "OK")))
     }
 }
 
@@ -25,7 +25,7 @@ impl fmt::Display for Ok {
 
 impl AppError for BadRequest {
     fn response(&self) -> Option<Response> {
-        Some(json_error(self.0.clone(), (400, "Bad Request")))
+        Some(json_error(&self.0, (400, "Bad Request")))
     }
 }
 
@@ -37,7 +37,7 @@ impl fmt::Display for BadRequest {
 
 impl AppError for ServerError {
     fn response(&self) -> Option<Response> {
-        Some(json_error(self.0.clone(), (500, "Internal Server Error")))
+        Some(json_error(&self.0, (500, "Internal Server Error")))
     }
 }
 

--- a/src/util/errors/http.rs
+++ b/src/util/errors/http.rs
@@ -8,6 +8,8 @@ use crate::util::json_response;
 #[derive(Debug)]
 pub(super) struct Ok(pub(super) String);
 #[derive(Debug)]
+pub(super) struct BadRequest(pub(super) String);
+#[derive(Debug)]
 pub(super) struct ServerError(pub(super) String);
 
 impl AppError for Ok {
@@ -21,6 +23,24 @@ impl AppError for Ok {
 }
 
 impl fmt::Display for Ok {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl AppError for BadRequest {
+    fn response(&self) -> Option<Response> {
+        let mut response = json_response(&Bad {
+            errors: vec![StringError {
+                detail: self.0.clone(),
+            }],
+        });
+        response.status = (400, "Bad Request");
+        Some(response)
+    }
+}
+
+impl fmt::Display for BadRequest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }


### PR DESCRIPTION
This PR may be easier to review commit by commit.  Overall this series continues the previous refactoring work in #1920 and #1929.  In particular, a concrete `util::Error` error type is introduced.  The code is updated to follow a style where:

* The new concrete type `util::Error` is great for code that is not part of the request/response lifecycle.  Binaries have been converted to `fn main() -> Result<(), Error>` where applicable.  This avoids pulling in the unnecessary infrastructure to convert errors into a user facing JSON responses (relative to `AppError`).
  * There are now 13 results across 6 files for `, Error>`.  Usage occurs in `src/bin/`, `src/boot/`, and `src/uploaders.rs`.
* `diesel::QueryResult` - There is a lot of code that only deals with query errors.  If only one type of error is possible in a function, using that specific error is preferable to the more general `util::Error`.  This is especially common in model code.
  * There are now 49 results across 16 files for `QueryResult<`.  Most usage is in `src/models/`, with some usage in `src/publish_rate_limit.rs`, `src/tasks/`, and `src/tests/`.
* `util::errors::AppResult` - Some failures should be converted into user facing JSON responses.  This error type is more dynamic and is box allocated.  Low-level errors are typically not converted to user facing errors and most usage is within the models, controllers, and middleware layers (85 of 102 results below).
  * There are now 102 results across 36 files for `AppResult<`.  Most usage is in `src/controllers/` and `src/models/`, with additional usage in `src/middleware/`, `src/{email,github,publish_rate_limit,router,uploaders}.rs`, and `src/{tests,util}/`.

Finally, a `middleware::Result` type is introduced for use in middleware and router code.

The behavior of `dyn AppError` and `chain_error` is a remaining area for improvement.  There may be cases where we want to wrap an `internal` error in a user facing error (like `cargo_err` or `server_err`) and still have the internal error make it up to the logging middleware.  However, I don't see an easy way to propagate this up the middleware stack (without encoding it in an internal response header that we later remove, :sweat:).

r? @smarnach 