### PR TITLE
Remove obsolete `FetchAdapter` mixin

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,6 +1,5 @@
 import DS from 'ember-data';
-import AdapterFetch from 'ember-fetch/mixins/adapter-fetch';
 
-export default DS.RESTAdapter.extend(AdapterFetch, {
+export default DS.RESTAdapter.extend({
   namespace: 'api/v1',
 });


### PR DESCRIPTION
`ember-data` will use it `fetch()` automatically now (see https://github.com/emberjs/data/pull/6082)

Resolves https://github.com/rust-lang/crates.io/issues/1995

r? @locks 