### PR TITLE
Extract `application` serializer

### DIFF
--- a/app/serializers/api-token.js
+++ b/app/serializers/api-token.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import ApplicationSerializer from './application';
 
-export default DS.RESTSerializer.extend({
+export default ApplicationSerializer.extend({
   payloadKeyFromModelName() {
     return 'api_token';
   },

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,0 +1,3 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer;

--- a/app/serializers/crate-owner-invite.js
+++ b/app/serializers/crate-owner-invite.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import ApplicationSerializer from './application';
 
-export default DS.RESTSerializer.extend({
+export default ApplicationSerializer.extend({
   primaryKey: 'crate_id',
   modelNameFromPayloadKey() {
     return 'crate-owner-invite';

--- a/app/serializers/crate.js
+++ b/app/serializers/crate.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import ApplicationSerializer from './application';
 
-export default DS.RESTSerializer.extend({
+export default ApplicationSerializer.extend({
   isNewSerializerAPI: true,
 
   extractRelationships(modelClass, resourceHash) {

--- a/app/serializers/dependency.js
+++ b/app/serializers/dependency.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import ApplicationSerializer from './application';
 
-export default DS.RESTSerializer.extend({
+export default ApplicationSerializer.extend({
   attrs: {
     version: 'version_id',
   },

--- a/app/serializers/version-download.js
+++ b/app/serializers/version-download.js
@@ -1,6 +1,6 @@
-import DS from 'ember-data';
+import ApplicationSerializer from './application';
 
-export default DS.RESTSerializer.extend({
+export default ApplicationSerializer.extend({
   extractId(modelClass, resourceHash) {
     return `${resourceHash.date}-${resourceHash.version}`;
   },


### PR DESCRIPTION
This resolves a few deprecation warnings from Ember Data about using the implicit default serializer which will be removed in the next major version release

r? @locks 