### PR TITLE
editorconfig: Adjust indent size for Ember-related files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,20 +15,20 @@ indent_size = 4
 
 [*.js]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.hbs]
 insert_final_newline = false
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.css]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.html]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.{diff,md}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
We've switched to "2 spaces" (the default in Ember.js apps) quite a while ago, but apparently missed to adjust the editorconfig file. This PR adjusts the file to teach my editor to indent properly... 😅 

r? @locks 