### PR TITLE
template-lint: Use `octane` preset

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -3,12 +3,16 @@
 /* eslint-env node */
 
 module.exports = {
-  extends: 'recommended',
+  extends: 'octane',
 
   rules: {
-    'img-alt-attributes': false,
+    'require-valid-alt-text': false,
+    'no-action': false,
+    'no-curly-component-invocation': false,
     'no-html-comments': false,
+    'no-implicit-this': false,
     'no-unnecessary-concat': false,
     quotes: false,
+    'require-button-type': false,
   },
 };


### PR DESCRIPTION
with a few rules disabled for now until we can comply with them...

The `no-curly-component-invocation` rule should in theory be able to run without issues but it currently seems to have a small bug that is causing false positives for us (see https://github.com/ember-template-lint/ember-template-lint/issues/1026)

r? @locks 