### PR TITLE
Fix an icon link that was generating bad URLs

### DIFF
--- a/config/manifest.js
+++ b/config/manifest.js
@@ -11,7 +11,7 @@ module.exports = function(/* environment, appConfig */) {
     theme_color: '#f9f7ec',
     icons: [
       {
-        src: 'cargo.png',
+        src: '/cargo.png',
         sizes: '227x227',
         type: 'image/png',
       },


### PR DESCRIPTION
On current staging, but not production, navigating directly to a path
such as `/crates/crate-name` results in a request sent to
`/crates/cargo-835dd6a18132048a52ac569f2615b59d.png` (a 404 response
status).

It appears that the `src` field is now treated as a relative path.
Using an absolute URL works for me locally.

r? @Turbo87 