### PR TITLE
Remove some unnecessary eslint overrides

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -12,6 +12,5 @@ module.exports = {
     'no-html-comments': false,
     'no-implicit-this': false,
     'no-unnecessary-concat': false,
-    quotes: false,
   },
 };

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -9,8 +9,6 @@ module.exports = {
     'require-valid-alt-text': false,
     'no-action': false,
     'no-curly-component-invocation': false,
-    'no-html-comments': false,
     'no-implicit-this': false,
-    'no-unnecessary-concat': false,
   },
 };

--- a/fastboot.js
+++ b/fastboot.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 /* eslint-env node */
 
 'use strict';

--- a/mirage/fixtures/categories.js
+++ b/mirage/fixtures/categories.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     category: 'API bindings',

--- a/mirage/fixtures/crates.js
+++ b/mirage/fixtures/crates.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     badges: [

--- a/mirage/fixtures/dependencies.js
+++ b/mirage/fixtures/dependencies.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     crate_id: 'libc',

--- a/mirage/fixtures/keywords.js
+++ b/mirage/fixtures/keywords.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     crates_cnt: 38,

--- a/mirage/fixtures/teams.js
+++ b/mirage/fixtures/teams.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     avatar: 'https://avatars.githubusercontent.com/u/565790?v=3',

--- a/mirage/fixtures/users.js
+++ b/mirage/fixtures/users.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     avatar: 'https://avatars0.githubusercontent.com/u/9447137?v=3',

--- a/mirage/fixtures/version-downloads.js
+++ b/mirage/fixtures/version-downloads.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     date: '2017-02-10T00:00:00Z',

--- a/mirage/fixtures/versions.js
+++ b/mirage/fixtures/versions.js
@@ -1,4 +1,3 @@
-/* eslint-disable quotes */
 export default [
   {
     crate: 'nanomsg',


### PR DESCRIPTION
I was experimenting with the eslint setup, and it appears that some lint overrides are no longer needed.

This PR removes all results for `git grep "eslint-disable "` and removes some overrides in `.template-lintrc.js`.  There are 10 remaining needed `eslint-disable-next-line` usages.

r? @Turbo87 