### PR TITLE
adapters/application: Pass `User-Agent` header to backend in fastboot mode

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,5 +1,17 @@
 import RESTAdapter from '@ember-data/adapter/rest';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 
 export default RESTAdapter.extend({
+  fastboot: service(),
+
   namespace: 'api/v1',
+
+  headers: computed('fastboot.{isFastBoot,request.headers}', function() {
+    if (this.fastboot.isFastBoot) {
+      return { 'User-Agent': this.fastboot.request.headers.get('User-Agent') };
+    }
+
+    return {};
+  }),
 });


### PR DESCRIPTION
The backend was complaining about only accepting requests with a `User-Agent` header, so let's give it such a header 😉 

r? @locks 