### PR TITLE
Disable `application-template-wrapper` feature

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -3,150 +3,152 @@
 {{title "crates.io: Rust Package Registry" separator=' - ' prepend=true}}
 <GoogleJsapi />
 
-<nav id="header">
-  <LinkTo @route="index" @tabindex="-1">
-    <img src="/assets/Cargo-Logo-Small.png" id="logo"
-         height="100" width="100" alt="Cargo Logo">
-  </LinkTo>
-  <LinkTo @route="index">
-    <h1>
-      crates.io
-      <span class="subtitle">Rust Package Registry</span>
-    </h1>
-  </LinkTo>
+<div>
+  <nav id="header">
+    <LinkTo @route="index" @tabindex="-1">
+      <img src="/assets/Cargo-Logo-Small.png" id="logo"
+           height="100" width="100" alt="Cargo Logo">
+    </LinkTo>
+    <LinkTo @route="index">
+      <h1>
+        crates.io
+        <span class="subtitle">Rust Package Registry</span>
+      </h1>
+    </LinkTo>
 
-  <form class='search' action='/search' {{ action "search" on="submit" }} data-test-search-form>
+    <form class='search' action='/search' {{ action "search" on="submit" }} data-test-search-form>
+      <input
+        type="text"
+        class="search"
+        name="q"
+        id="cargo-desktop-search"
+        placeholder="Click or press 'S' to search..."
+        value={{this.searchQuery}}
+        oninput={{action (mut this.searchQuery) value="target.value"}}
+        autocorrect="off"
+        autocapitalize="off"
+        autofocus="autofocus"
+        spellcheck="false"
+        required
+        data-test-search-input
+      >
+      <label for="cargo-desktop-search">Search</label>
+    </form>
+
+    <div class='nav'>
+      <LinkTo @route="crates" @query={{hash letter=null page=1}} data-test-all-crates-link>
+        Browse All Crates
+      </LinkTo>
+      <span class="sep">|</span>
+      <RlDropdownContainer class="dropdown-container">
+        <RlDropdownToggle class="dropdown">
+          Docs
+          <span class='arrow'></span>
+        </RlDropdownToggle>
+
+        <RlDropdown @tagName="ul" @id="doc-links" class="dropdown">
+          <li><a href='https://doc.rust-lang.org/cargo/getting-started/'>Getting Started</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html'>Specifying Dependencies</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/publishing.html'>Publishing on crates.io</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/faq.html'>FAQ</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/manifest.html'>Cargo.toml Format</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/build-scripts.html'>Build Scripts</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/config.html'>Configuration</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/pkgid-spec.html'>Package ID specs</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/environment-variables.html'>Environment Variables</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/source-replacement.html'>Source Replacement</a></li>
+          <li><a href='https://doc.rust-lang.org/cargo/reference/external-tools.html'>External Tools</a></li>
+          <li><LinkTo @route="policies">Policies</LinkTo></li>
+          <li><LinkTo @route="category-slugs">List of category slugs</LinkTo></li>
+        </RlDropdown>
+      </RlDropdownContainer>
+      <span class="sep">|</span>
+      {{#if this.session.currentUser}}
+        <RlDropdownContainer class="dropdown-container">
+          <RlDropdownToggle class="dropdown">
+            <UserAvatar @user={{this.session.currentUser}} @size="small" />
+            {{ this.session.currentUser.name }}
+            <span class='arrow'></span>
+          </RlDropdownToggle>
+
+          <RlDropdown @tagName="ul" class="dropdown current-user-links">
+            <li><LinkTo @route="dashboard">Dashboard</LinkTo></li>
+            <li><LinkTo @route="me">Account Settings</LinkTo></li>
+            <li><LinkTo @route="me.pending-invites">Owner Invites</LinkTo></li>
+            <li class='last'><LinkTo @route="logout">Sign Out</LinkTo></li>
+          </RlDropdown>
+        </RlDropdownContainer>
+      {{else}}
+        <LinkTo @route="login" data-test-login-link>
+          {{svg-jar "lock"}}
+          Log in with GitHub
+        </LinkTo>
+      {{/if}}
+    </div>
+
+    <div class='menu'>
+      <RlDropdownContainer class="dropdown-container">
+        <RlDropdownToggle class="dropdown">
+          Menu
+          <span class='arrow'></span>
+        </RlDropdownToggle>
+        <RlDropdown @tagName="ul" class="dropdown current-user-links">
+          <li><LinkTo @route="crates">Browse All Crates</LinkTo></li>
+          {{#if this.session.currentUser}}
+            <li><LinkTo @route="dashboard">Dashboard</LinkTo></li>
+            <li><LinkTo @route="me">Account Settings</LinkTo></li>
+            <li><LinkTo @route="me.pending-invites">Owner Invites</LinkTo></li>
+            <li class='last'><LinkTo @route="logout">Sign Out</LinkTo></li>
+          {{else}}
+            <li><LinkTo @route="login">Log in with GitHub</LinkTo></li>
+          {{/if}}
+        </RlDropdown>
+      </RlDropdownContainer>
+    </div>
+
+    <div class='links'>
+    </div>
+  </nav>
+
+  <form id='mobile-search' class='search' action='/search' {{ action "search" on="submit" }} >
     <input
       type="text"
       class="search"
       name="q"
-      id="cargo-desktop-search"
-      placeholder="Click or press 'S' to search..."
+      id="cargo-mobile-search"
+      placeholder="Search"
       value={{this.searchQuery}}
       oninput={{action (mut this.searchQuery) value="target.value"}}
       autocorrect="off"
-      autocapitalize="off"
-      autofocus="autofocus"
-      spellcheck="false"
       required
-      data-test-search-input
     >
-    <label for="cargo-desktop-search">Search</label>
+    <label for="cargo-mobile-search">Search</label>
   </form>
 
-  <div class='nav'>
-    <LinkTo @route="crates" @query={{hash letter=null page=1}} data-test-all-crates-link>
-      Browse All Crates
-    </LinkTo>
+  <main id="main" class='inner-content'>
+    <FlashMessage />
+
+    {{outlet}}
+  </main>
+
+  <footer class='after-main-links'>
+    <a href='https://doc.rust-lang.org/cargo/getting-started/installation.html'>Install</a>
     <span class="sep">|</span>
-    <RlDropdownContainer class="dropdown-container">
-      <RlDropdownToggle class="dropdown">
-        Docs
-        <span class='arrow'></span>
-      </RlDropdownToggle>
-
-      <RlDropdown @tagName="ul" @id="doc-links" class="dropdown">
-        <li><a href='https://doc.rust-lang.org/cargo/getting-started/'>Getting Started</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html'>Specifying Dependencies</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/publishing.html'>Publishing on crates.io</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/faq.html'>FAQ</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/manifest.html'>Cargo.toml Format</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/build-scripts.html'>Build Scripts</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/config.html'>Configuration</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/pkgid-spec.html'>Package ID specs</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/environment-variables.html'>Environment Variables</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/source-replacement.html'>Source Replacement</a></li>
-        <li><a href='https://doc.rust-lang.org/cargo/reference/external-tools.html'>External Tools</a></li>
-        <li><LinkTo @route="policies">Policies</LinkTo></li>
-        <li><LinkTo @route="category-slugs">List of category slugs</LinkTo></li>
-      </RlDropdown>
-    </RlDropdownContainer>
+    <a href='https://doc.rust-lang.org/cargo/'>Getting Started</a>
     <span class="sep">|</span>
-    {{#if this.session.currentUser}}
-      <RlDropdownContainer class="dropdown-container">
-        <RlDropdownToggle class="dropdown">
-          <UserAvatar @user={{this.session.currentUser}} @size="small" />
-          {{ this.session.currentUser.name }}
-          <span class='arrow'></span>
-        </RlDropdownToggle>
+    <a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a>
+    <span class="sep">|</span>
+    <a href='mailto:help@crates.io'>Send us an email</a>
+    <span class="sep">|</span>
+    <a href='https://www.rust-lang.org/policies/security'>Report a security issue</a>
+    <span class="sep">|</span>
+    <a href='https://www.rust-lang.org/policies/privacy'>Privacy notice</a>
+    <span class="sep">|</span>
+    <LinkTo @route="policies">Policies</LinkTo>
+  </footer>
 
-        <RlDropdown @tagName="ul" class="dropdown current-user-links">
-          <li><LinkTo @route="dashboard">Dashboard</LinkTo></li>
-          <li><LinkTo @route="me">Account Settings</LinkTo></li>
-          <li><LinkTo @route="me.pending-invites">Owner Invites</LinkTo></li>
-          <li class='last'><LinkTo @route="logout">Sign Out</LinkTo></li>
-        </RlDropdown>
-      </RlDropdownContainer>
-    {{else}}
-      <LinkTo @route="login" data-test-login-link>
-        {{svg-jar "lock"}}
-        Log in with GitHub
-      </LinkTo>
-    {{/if}}
-  </div>
-
-  <div class='menu'>
-    <RlDropdownContainer class="dropdown-container">
-      <RlDropdownToggle class="dropdown">
-        Menu
-        <span class='arrow'></span>
-      </RlDropdownToggle>
-      <RlDropdown @tagName="ul" class="dropdown current-user-links">
-        <li><LinkTo @route="crates">Browse All Crates</LinkTo></li>
-        {{#if this.session.currentUser}}
-          <li><LinkTo @route="dashboard">Dashboard</LinkTo></li>
-          <li><LinkTo @route="me">Account Settings</LinkTo></li>
-          <li><LinkTo @route="me.pending-invites">Owner Invites</LinkTo></li>
-          <li class='last'><LinkTo @route="logout">Sign Out</LinkTo></li>
-        {{else}}
-          <li><LinkTo @route="login">Log in with GitHub</LinkTo></li>
-        {{/if}}
-      </RlDropdown>
-    </RlDropdownContainer>
-  </div>
-
-  <div class='links'>
-  </div>
-</nav>
-
-<form id='mobile-search' class='search' action='/search' {{ action "search" on="submit" }} >
-  <input
-    type="text"
-    class="search"
-    name="q"
-    id="cargo-mobile-search"
-    placeholder="Search"
-    value={{this.searchQuery}}
-    oninput={{action (mut this.searchQuery) value="target.value"}}
-    autocorrect="off"
-    required
-  >
-  <label for="cargo-mobile-search">Search</label>
-</form>
-
-<main id="main" class='inner-content'>
-  <FlashMessage />
-
-  {{outlet}}
-</main>
-
-<footer class='after-main-links'>
-  <a href='https://doc.rust-lang.org/cargo/getting-started/installation.html'>Install</a>
-  <span class="sep">|</span>
-  <a href='https://doc.rust-lang.org/cargo/'>Getting Started</a>
-  <span class="sep">|</span>
-  <a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a>
-  <span class="sep">|</span>
-  <a href='mailto:help@crates.io'>Send us an email</a>
-  <span class="sep">|</span>
-  <a href='https://www.rust-lang.org/policies/security'>Report a security issue</a>
-  <span class="sep">|</span>
-  <a href='https://www.rust-lang.org/policies/privacy'>Privacy notice</a>
-  <span class="sep">|</span>
-  <LinkTo @route="policies">Policies</LinkTo>
-</footer>
-
-<a href='https://github.com/rust-lang/crates.io' class='fork-me'>
-  <img src='/assets/forkme.png' alt="Fork me on GitHub">
-</a>
+  <a href='https://github.com/rust-lang/crates.io' class='fork-me'>
+    <img src='/assets/forkme.png' alt="Fork me on GitHub">
+  </a>
+</div>

--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "application-template-wrapper": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4738,6 +4738,285 @@
         }
       }
     },
+    "@ember/optional-features": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ember/optional-features/-/optional-features-1.3.0.tgz",
+      "integrity": "sha512-Lrfojy4xKwTX+J4EAylmxZY2TO6bQtP4Lg5C8/z2priVqiT0X5fVB1+4WQCJbRBetctO1lMDnqjmhWCVKB8bmQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^3.0.0",
+        "ember-cli-version-checker": "^3.1.3",
+        "glob": "^7.1.6",
+        "inquirer": "^7.0.1",
+        "mkdirp": "^0.5.1",
+        "silent-error": "^1.1.1",
+        "util.promisify": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.0.tgz",
+          "integrity": "sha512-EiYhwo0v255HUL6eDyuLrXEkTi7WwVCLAw+SeOQ7M7qdun1z1pum4DEm/nuqIVbPvi9RPPc9k9LbyBv6H0DwVg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+          "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^3.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "ember-cli-version-checker": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-3.1.3.tgz",
+          "integrity": "sha512-PZNSvpzwWgv68hcXxyjREpj3WWb81A7rtYNQq1lLEgrWIchF8ApKJjWP3NBpHjaatwILkZAV8klair5WFlXAKg==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^1.2.6",
+            "semver": "^5.6.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "figures": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.1.0.tgz",
+          "integrity": "sha512-ravh8VRXqHuMvZt/d8GblBeqDMkdJMBdv/2KntFH+ra5MXkO7nxNKpzQ3n6QD/2da1kH0aWmNISdvhM7gl2gVg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.0.1.tgz",
+          "integrity": "sha512-V1FFQ3TIO15det8PijPLFR9M9baSlnRs9nL7zWu1MNVA2T9YVl9ZbrHJhYs7e9X8jeMZ3lr2JH/rdHFgNCBdYw==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^2.4.2",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.15",
+            "mute-stream": "0.0.8",
+            "run-async": "^2.2.0",
+            "rxjs": "^6.5.3",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^5.1.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "mute-stream": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+          "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+          "dev": true
+        },
+        "restore-cursor": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+          "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "silent-error": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/silent-error/-/silent-error-1.1.1.tgz",
+          "integrity": "sha512-n4iEKyNcg4v6/jpb3c0/iyH2G1nzUNl7Gpqtn/mHIJK9S/q/7MCfoO4rwVOoO59qPFIc0hVHvMbiOJ0NdtxKKw==",
+          "dev": true,
+          "requires": {
+            "debug": "^2.2.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          },
+          "dependencies": {
+            "strip-ansi": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+              "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^5.0.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@ember/ordered-set": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@ember/ordered-set/-/ordered-set-2.0.3.tgz",
@@ -43582,6 +43861,11 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": false,
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "istanbul-lib-coverage": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@ember/jquery": "^1.1.0",
+    "@ember/optional-features": "^1.3.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-a11y-testing": "^2.0.0",


### PR DESCRIPTION
This is one of the requirements to enable the "Octane" mode of Ember.js. It moves the implicit application template wrapper element into the `application` template and thus makes it optional for those applications that don't need it. Since we set a max width on this element we do currently still need it though.

r? @locks