### PR TITLE
Use absolute path for GIT_REPO_URL file:// URL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,7 +6,7 @@ export DATABASE_URL=
 # If you are running a mirror of crates.io, uncomment this line.
 # export MIRROR=1
 
-# Key to sign and encrypt cookies with. Must be at least 32 bytes. Change this 
+# Key to sign and encrypt cookies with. Must be at least 32 bytes. Change this
 # to a long, random string for production.
 export SESSION_KEY=badkeyabcdefghijklmnopqrstuvwxyzabcdef
 
@@ -28,7 +28,7 @@ export TEST_DATABASE_URL=
 # Remote and local locations of the registry index. You can leave these to
 # use a `tmp` subdirectory of the working directory, which is what the
 # script in `./script/init-local-index.sh` will set up for you.
-export GIT_REPO_URL=file://./tmp/index-bare
+export GIT_REPO_URL=file://$PWD/tmp/index-bare
 export GIT_REPO_CHECKOUT=./tmp/index-co
 
 # Credentials for talking to github. You can leave these blank if you're


### PR DESCRIPTION
file:// URLs do not support relative paths. This change uses $PWD to make an absolute path based on where the user is running Crates on their local machine.

This fixes issue #2030 