### PR TITLE
Migrate to tagless components

### DIFF
--- a/app/components/badge-appveyor.js
+++ b/app/components/badge-appveyor.js
@@ -3,9 +3,7 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
-
+  tagName: '',
   id: alias('badge.attributes.id'),
   repository: alias('badge.attributes.repository'),
 

--- a/app/components/badge-azure-devops.js
+++ b/app/components/badge-azure-devops.js
@@ -3,13 +3,14 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   project: alias('badge.attributes.project'),
   pipeline: alias('badge.attributes.pipeline'),
+
   build: computed('badge.attributes.build', function() {
     return this.get('badge.attributes.build') || '1';
   }),
+
   text: computed('pipeline', function() {
     return `Azure Devops build status for the ${this.pipeline} pipeline`;
   }),

--- a/app/components/badge-bitbucket-pipelines.js
+++ b/app/components/badge-bitbucket-pipelines.js
@@ -3,12 +3,13 @@ import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   branch: computed('badge.attributes.branch', function() {
     return encodeURIComponent(this.get('badge.attributes.branch'));
   }),
+
   text: computed('badge.attributes.branch', function() {
     const branch = this.get('badge.attributes.branch');
     return `Bitbucket Pipelines build status for the ${branch} branch`;

--- a/app/components/badge-circle-ci.js
+++ b/app/components/badge-circle-ci.js
@@ -3,12 +3,13 @@ import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   branch: computed('badge.attributes.branch', function() {
     return encodeURIComponent(this.get('badge.attributes.branch') || 'master');
   }),
+
   text: computed('branch', function() {
     return `Circle CI build status for the ${this.branch} branch`;
   }),

--- a/app/components/badge-cirrus-ci.js
+++ b/app/components/badge-cirrus-ci.js
@@ -3,12 +3,13 @@ import { alias } from '@ember/object/computed';
 import Component from '@ember/component';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   branch: computed('badge.attributes.branch', function() {
     return encodeURIComponent(this.get('badge.attributes.branch') || 'master');
   }),
+
   text: computed('branch', function() {
     return `Cirrus CI build status for the ${this.branch} branch`;
   }),

--- a/app/components/badge-codecov.js
+++ b/app/components/badge-codecov.js
@@ -3,15 +3,17 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   branch: computed('badge.attributes.branch', function() {
     return this.get('badge.attributes.branch') || 'master';
   }),
+
   service: computed('badge.attributes.service', function() {
     return this.get('badge.attributes.service') || 'github';
   }),
+
   text: computed('branch', function() {
     return `CodeCov coverage status for the ${this.branch} branch`;
   }),

--- a/app/components/badge-coveralls.js
+++ b/app/components/badge-coveralls.js
@@ -3,15 +3,17 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   branch: computed('badge.attributes.branch', function() {
     return this.get('badge.attributes.branch') || 'master';
   }),
+
   service: computed('badge.attributes.service', function() {
     return this.get('badge.attributes.service') || 'github';
   }),
+
   text: computed('branch', function() {
     return `Coveralls coverage status for the ${this.branch} branch`;
   }),

--- a/app/components/badge-gitlab.js
+++ b/app/components/badge-gitlab.js
@@ -3,12 +3,13 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   branch: computed('badge.attributes.branch', function() {
     return this.get('badge.attributes.branch') || 'master';
   }),
+
   text: computed('badge', function() {
     return `GitLab build status for the ${this.branch} branch`;
   }),

--- a/app/components/badge-is-it-maintained-issue-resolution.js
+++ b/app/components/badge-is-it-maintained-issue-resolution.js
@@ -3,9 +3,9 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   text: computed('badge', function() {
     return `Is It Maintained average time to resolve an issue`;
   }),

--- a/app/components/badge-is-it-maintained-open-issues.js
+++ b/app/components/badge-is-it-maintained-open-issues.js
@@ -3,9 +3,9 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   text: computed('badge', function() {
     return `Is It Maintained percentage of issues still open`;
   }),

--- a/app/components/badge-maintenance.js
+++ b/app/components/badge-maintenance.js
@@ -3,15 +3,18 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
+
   escapedStatus: computed('badge', function() {
     return this.get('badge.attributes.status').replace(/-/g, '--');
   }),
+
   none: computed('badge', function() {
     return this.get('badge.attributes.status') === 'none' || !this.get('badge.attributes.status');
   }),
+
   status: alias('badge.attributes.status'),
+
   // eslint-disable-next-line ember/require-return-from-computed
   color: computed('badge', function() {
     switch (this.get('badge.attributes.status')) {
@@ -29,5 +32,6 @@ export default Component.extend({
         return 'red';
     }
   }),
+
   text: 'Maintenance intention for this crate',
 });

--- a/app/components/badge-travis-ci.js
+++ b/app/components/badge-travis-ci.js
@@ -3,12 +3,13 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'span',
-  classNames: ['badge'],
+  tagName: '',
   repository: alias('badge.attributes.repository'),
+
   branch: computed('badge.attributes.branch', function() {
     return this.get('badge.attributes.branch') || 'master';
   }),
+
   text: computed('branch', function() {
     return `Travis CI build status for the ${this.branch} branch`;
   }),

--- a/app/components/crate-badge.js
+++ b/app/components/crate-badge.js
@@ -2,9 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  classNames: ['vers'],
-
-  tagName: 'span',
+  tagName: '',
 
   version: computed('crate.max_version', function() {
     return this.get('crate.max_version').replace('-', '--');

--- a/app/components/crate-row.js
+++ b/app/components/crate-row.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { computed } from '@ember/object';
 
 export default Component.extend({
-  classNames: ['crate', 'row'],
+  tagName: '',
   crateTomlText: computed('crate.name', 'max_version', function() {
     return `${this.get('crate.name')} = "${this.get('crate.max_version')}"`;
   }),

--- a/app/components/crate-row.js
+++ b/app/components/crate-row.js
@@ -6,6 +6,4 @@ export default Component.extend({
   crateTomlText: computed('crate.name', 'max_version', function() {
     return `${this.get('crate.name')} = "${this.get('crate.max_version')}"`;
   }),
-
-  'data-test-crate-row': true,
 });

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { later } from '@ember/runloop';
 
 export default Component.extend({
-  classNames: ['crate-toml-copy'],
+  tagName: '',
   copyText: '',
   showSuccess: false,
   showNotification: false,

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -5,8 +5,8 @@ import { inject as service } from '@ember/service';
 import ajax from 'ember-fetch/ajax';
 
 export default Component.extend({
+  tagName: '',
   flashMessages: service(),
-
   type: '',
   value: '',
   isEditing: false,
@@ -14,19 +14,23 @@ export default Component.extend({
   disableSave: empty('user.email'),
   notValidEmail: false,
   prevEmail: '',
+
   emailIsNull: computed('user.email', function() {
     let email = this.get('user.email');
     return email == null;
   }),
+
   emailNotVerified: computed('user.{email,email_verified}', function() {
     let email = this.get('user.email');
     let verified = this.get('user.email_verified');
 
     return email != null && !verified;
   }),
+
   isError: false,
   emailError: '',
   disableResend: false,
+
   resendButtonText: computed('disableResend', 'user.email_verification_sent', function() {
     if (this.disableResend) {
       return 'Sent!';

--- a/app/components/flash-message.js
+++ b/app/components/flash-message.js
@@ -5,8 +5,5 @@ import { inject as service } from '@ember/service';
 export default Component.extend({
   flashMessages: service(),
   message: readOnly('flashMessages.message'),
-
-  elementId: 'flash',
-  tagName: 'p',
-  classNameBindings: ['message:shown'],
+  tagName: '',
 });

--- a/app/components/owned-crate-row.js
+++ b/app/components/owned-crate-row.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
 export default Component.extend({
-  tagName: 'li',
+  tagName: '',
 
   name: alias('ownedCrate.name'),
   controlId: computed('ownedCrate.id', function() {

--- a/app/components/pending-owner-invite-row.js
+++ b/app/components/pending-owner-invite-row.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 
 export default Component.extend({
+  tagName: '',
   isAccepted: false,
   isDeclined: false,
   isError: false,

--- a/app/templates/components/badge-appveyor.hbs
+++ b/app/templates/components/badge-appveyor.hbs
@@ -1,8 +1,11 @@
-<a href="https://ci.appveyor.com/project/{{ this.projectName }}">
-  <img
-      src="{{ this.imageUrl }}"
-      alt="{{ this.text }}"
-      width="106"
-      height="20"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://ci.appveyor.com/project/{{ this.projectName }}">
+    <img
+        src="{{ this.imageUrl }}"
+        alt="{{ this.text }}"
+        width="106"
+        height="20"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-azure-devops.hbs
+++ b/app/templates/components/badge-azure-devops.hbs
@@ -1,3 +1,6 @@
-<a href="https://dev.azure.com/{{ this.project }}/_build/latest?definitionId={{ this.build }}">
-  <img src="https://dev.azure.com/{{ this.project }}/_apis/build/status/{{ this.pipeline }}" alt="{{ this.text }}" title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://dev.azure.com/{{ this.project }}/_build/latest?definitionId={{ this.build }}">
+    <img src="https://dev.azure.com/{{ this.project }}/_apis/build/status/{{ this.pipeline }}" alt="{{ this.text }}" title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-bitbucket-pipelines.hbs
+++ b/app/templates/components/badge-bitbucket-pipelines.hbs
@@ -1,6 +1,9 @@
-<a href="https://bitbucket.org/{{ this.repository }}/addon/pipelines/home#!/results/branch/{{ this.branch }}/page/1">
-  <img
-      src="https://img.shields.io/bitbucket/pipelines/{{ this.repository }}/{{ this.branch }}"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://bitbucket.org/{{ this.repository }}/addon/pipelines/home#!/results/branch/{{ this.branch }}/page/1">
+    <img
+        src="https://img.shields.io/bitbucket/pipelines/{{ this.repository }}/{{ this.branch }}"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-circle-ci.hbs
+++ b/app/templates/components/badge-circle-ci.hbs
@@ -1,6 +1,9 @@
-<a href="https://circleci.com/gh/{{ this.repository }}">
-  <img
-      src="https://circleci.com/gh/{{ this.repository }}/tree/{{ this.branch }}.svg?style=shield"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://circleci.com/gh/{{ this.repository }}">
+    <img
+        src="https://circleci.com/gh/{{ this.repository }}/tree/{{ this.branch }}.svg?style=shield"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-cirrus-ci.hbs
+++ b/app/templates/components/badge-cirrus-ci.hbs
@@ -1,6 +1,9 @@
-<a href="https://cirrus-ci.com/github/{{ this.repository }}">
-  <img
-      src="https://api.cirrus-ci.com/github/{{ this.repository }}.svg?branch={{ this.branch }}"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://cirrus-ci.com/github/{{ this.repository }}">
+    <img
+        src="https://api.cirrus-ci.com/github/{{ this.repository }}.svg?branch={{ this.branch }}"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-codecov.hbs
+++ b/app/templates/components/badge-codecov.hbs
@@ -1,6 +1,9 @@
-<a href="https://codecov.io/{{ this.service }}/{{ this.repository }}?branch={{ this.branch }}">
-  <img
-      src="https://codecov.io/{{ this.service }}/{{ this.repository }}/coverage.svg?branch={{ this.branch }}"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://codecov.io/{{ this.service }}/{{ this.repository }}?branch={{ this.branch }}">
+    <img
+        src="https://codecov.io/{{ this.service }}/{{ this.repository }}/coverage.svg?branch={{ this.branch }}"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-coveralls.hbs
+++ b/app/templates/components/badge-coveralls.hbs
@@ -1,6 +1,9 @@
-<a href="https://coveralls.io/{{ this.service }}/{{ this.repository }}?branch={{ this.branch }}">
-  <img
-      src="https://coveralls.io/repos/{{ this.service }}/{{ this.repository }}/badge.svg?branch={{ this.branch }}"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://coveralls.io/{{ this.service }}/{{ this.repository }}?branch={{ this.branch }}">
+    <img
+        src="https://coveralls.io/repos/{{ this.service }}/{{ this.repository }}/badge.svg?branch={{ this.branch }}"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-gitlab.hbs
+++ b/app/templates/components/badge-gitlab.hbs
@@ -1,6 +1,9 @@
-<a href="https://gitlab.com/{{ this.repository }}/pipelines">
-  <img
-      src="https://gitlab.com/{{ this.repository }}/badges/{{ this.branch }}/pipeline.svg"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://gitlab.com/{{ this.repository }}/pipelines">
+    <img
+        src="https://gitlab.com/{{ this.repository }}/badges/{{ this.branch }}/pipeline.svg"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-is-it-maintained-issue-resolution.hbs
+++ b/app/templates/components/badge-is-it-maintained-issue-resolution.hbs
@@ -1,6 +1,9 @@
-<a href="https://isitmaintained.com/project/{{ this.repository }}">
-  <img
-      src="https://isitmaintained.com/badge/resolution/{{ this.repository }}.svg"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://isitmaintained.com/project/{{ this.repository }}">
+    <img
+        src="https://isitmaintained.com/badge/resolution/{{ this.repository }}.svg"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-is-it-maintained-open-issues.hbs
+++ b/app/templates/components/badge-is-it-maintained-open-issues.hbs
@@ -1,6 +1,9 @@
-<a href="https://isitmaintained.com/project/{{ this.repository }}">
-  <img
-      src="https://isitmaintained.com/badge/open/{{ this.repository }}.svg"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://isitmaintained.com/project/{{ this.repository }}">
+    <img
+        src="https://isitmaintained.com/badge/open/{{ this.repository }}.svg"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/badge-maintenance.hbs
+++ b/app/templates/components/badge-maintenance.hbs
@@ -1,6 +1,9 @@
-{{#unless this.none}}
-  <img
-      src="https://img.shields.io/badge/maintenance-{{this.escapedStatus}}-{{this.color}}.svg"
-      alt="{{this.text}}"
-      title="{{this.text}}">
-{{/unless}}
+<span class="badge" ...attributes>
+  {{#unless this.none}}
+    <img
+        src="https://img.shields.io/badge/maintenance-{{this.escapedStatus}}-{{this.color}}.svg"
+        alt="{{this.text}}"
+        title="{{this.text}}">
+  {{/unless}}
+  
+</span>

--- a/app/templates/components/badge-travis-ci.hbs
+++ b/app/templates/components/badge-travis-ci.hbs
@@ -1,6 +1,9 @@
-<a href="https://travis-ci.org/{{ this.repository }}">
-  <img
-      src="https://travis-ci.org/{{ this.repository }}.svg?branch={{ this.branch }}"
-      alt="{{ this.text }}"
-      title="{{ this.text }}">
-</a>
+<span class="badge" ...attributes>
+  <a href="https://travis-ci.org/{{ this.repository }}">
+    <img
+        src="https://travis-ci.org/{{ this.repository }}.svg?branch={{ this.branch }}"
+        alt="{{ this.text }}"
+        title="{{ this.text }}">
+  </a>
+  
+</span>

--- a/app/templates/components/crate-badge.hbs
+++ b/app/templates/components/crate-badge.hbs
@@ -1,5 +1,8 @@
-<img
-    src="https://img.shields.io/badge/crates.io-v{{ this.version }}-{{ this.color }}.svg?longCache=true"
-    alt="{{ this.crate.max_version }}"
-    title="{{ this.crate.name }}’s current version badge"
-    data-test-version-badge>
+<span class="vers" ...attributes>
+  <img
+      src="https://img.shields.io/badge/crates.io-v{{ this.version }}-{{ this.color }}.svg?longCache=true"
+      alt="{{ this.crate.max_version }}"
+      title="{{ this.crate.name }}’s current version badge"
+      data-test-version-badge>
+  
+</span>

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -5,7 +5,9 @@
       <CrateTomlCopy @copyText={{this.crateTomlText}} />
       <CrateBadge @crate={{this.crate}} />
       {{#each this.crate.annotated_badges as |badge|}}
-        {{component badge.component_name badge=badge data-test-badge=badge.badge_type}}
+        {{#let (component badge.component_name) as |Badge|}}
+          <Badge @badge={{badge}} data-test-badge={{badge.badge_type}} />
+        {{/let}}
       {{/each}}
     </div>
     <div class='summary' data-test-description>
@@ -43,5 +45,5 @@
       {{/if}}
     </ul>
   </div>
-  
+
 </div>

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -1,44 +1,47 @@
-<div class='desc'>
-  <div class='info'>
-    <LinkTo @route="crate" @model={{this.crate.id}} data-test-crate-link>{{ this.crate.name }}</LinkTo>
-    <CrateTomlCopy @copyText={{this.crateTomlText}} />
-    <CrateBadge @crate={{this.crate}} />
-    {{#each this.crate.annotated_badges as |badge|}}
-      {{component badge.component_name badge=badge data-test-badge=badge.badge_type}}
-    {{/each}}
+<div class="crate row" ...attributes>
+  <div class='desc'>
+    <div class='info'>
+      <LinkTo @route="crate" @model={{this.crate.id}} data-test-crate-link>{{ this.crate.name }}</LinkTo>
+      <CrateTomlCopy @copyText={{this.crateTomlText}} />
+      <CrateBadge @crate={{this.crate}} />
+      {{#each this.crate.annotated_badges as |badge|}}
+        {{component badge.component_name badge=badge data-test-badge=badge.badge_type}}
+      {{/each}}
+    </div>
+    <div class='summary' data-test-description>
+      <span class='small'>
+        {{ truncate-text this.crate.description }}
+      </span>
+    </div>
   </div>
-  <div class='summary' data-test-description>
-    <span class='small'>
-      {{ truncate-text this.crate.description }}
-    </span>
+  <div class='stats'>
+    <div class='downloads' data-test-downloads>
+      {{svg-jar "download"}}
+      <span class='num'>All-Time: {{ format-num this.crate.downloads }}</span>
+    </div>
+    <div class="recent-downloads" data-test-recent-downloads>
+      {{svg-jar "download"}}
+      <span class='num'><abbr title="Downloads in the last 90 days">Recent:</abbr> {{ format-num this.crate.recent_downloads }}</span>
+    </div>
+    <div class="updated-at" >
+      {{svg-jar "latest-updates" height="32" width="32"}}
+      <time title="Last updated: {{ this.crate.updated_at }}" datetime="{{ moment-format this.crate.updated_at 'YYYY-MM-DDTHH:mm:ssZ' }}" data-test-updated-at>
+        {{ moment-from-now this.crate.updated_at }}
+      </time>
+    </div>
   </div>
-</div>
-<div class='stats'>
-  <div class='downloads' data-test-downloads>
-    {{svg-jar "download"}}
-    <span class='num'>All-Time: {{ format-num this.crate.downloads }}</span>
+  <div class="quick-links">
+    <ul>
+      {{#if this.crate.homepage}}
+        <li><a href="{{this.crate.homepage}}">Homepage</a></li>
+      {{/if}}
+      {{#if this.crate.documentation}}
+        <li><a href="{{this.crate.documentation}}">Documentation</a></li>
+      {{/if}}
+      {{#if this.crate.repository}}
+        <li><a href="{{this.crate.repository}}">Repository</a></li>
+      {{/if}}
+    </ul>
   </div>
-  <div class="recent-downloads" data-test-recent-downloads>
-    {{svg-jar "download"}}
-    <span class='num'><abbr title="Downloads in the last 90 days">Recent:</abbr> {{ format-num this.crate.recent_downloads }}</span>
-  </div>
-  <div class="updated-at" >
-    {{svg-jar "latest-updates" height="32" width="32"}}
-    <time title="Last updated: {{ this.crate.updated_at }}" datetime="{{ moment-format this.crate.updated_at 'YYYY-MM-DDTHH:mm:ssZ' }}" data-test-updated-at>
-      {{ moment-from-now this.crate.updated_at }}
-    </time>
-  </div>
-</div>
-<div class="quick-links">
-  <ul>
-    {{#if this.crate.homepage}}
-      <li><a href="{{this.crate.homepage}}">Homepage</a></li>
-    {{/if}}
-    {{#if this.crate.documentation}}
-      <li><a href="{{this.crate.documentation}}">Documentation</a></li>
-    {{/if}}
-    {{#if this.crate.repository}}
-      <li><a href="{{this.crate.repository}}">Repository</a></li>
-    {{/if}}
-  </ul>
+  
 </div>

--- a/app/templates/components/crate-row.hbs
+++ b/app/templates/components/crate-row.hbs
@@ -1,4 +1,4 @@
-<div class="crate row" ...attributes>
+<div class="crate row" data-test-crate-row ...attributes>
   <div class='desc'>
     <div class='info'>
       <LinkTo @route="crate" @model={{this.crate.id}} data-test-crate-link>{{ this.crate.name }}</LinkTo>

--- a/app/templates/components/crate-toml-copy.hbs
+++ b/app/templates/components/crate-toml-copy.hbs
@@ -1,12 +1,15 @@
-<CopyButton @clipboardText={{this.copyText}} @success={{action "copySuccess"}} @error={{action "copyError"}} @title="Copy Cargo.toml snippet to clipboard">
-  {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
-  <div class="copy-notification {{if this.showSuccess "copy-success" "copy-failure"}}">
-    {{#if this.showNotification}}
-      {{#if this.showSuccess}}
-        Copied!
-      {{else}}
-        An error occured. Please use CTRL+C.
+<div class="crate-toml-copy" ...attributes>
+  <CopyButton @clipboardText={{this.copyText}} @success={{action "copySuccess"}} @error={{action "copyError"}} @title="Copy Cargo.toml snippet to clipboard">
+    {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
+    <div class="copy-notification {{if this.showSuccess "copy-success" "copy-failure"}}">
+      {{#if this.showNotification}}
+        {{#if this.showSuccess}}
+          Copied!
+        {{else}}
+          An error occured. Please use CTRL+C.
+        {{/if}}
       {{/if}}
-    {{/if}}
-  </div>
-</CopyButton>
+    </div>
+  </CopyButton>
+  
+</div>

--- a/app/templates/components/email-input.hbs
+++ b/app/templates/components/email-input.hbs
@@ -1,67 +1,70 @@
-{{#if this.emailIsNull }}
-  <div class='friendly-message'>
-    <p class='small-text'>
-      Please add your email address. We will only use
-      it to contact you about your account. We promise we'll never share it!
-    </p>
-  </div>
-{{/if}}
-
-{{#if this.isEditing }}
-  <div class='row'>
-    <div class='label'>
-      <dt>Email</dt>
+<div ...attributes>
+  {{#if this.emailIsNull }}
+    <div class='friendly-message'>
+      <p class='small-text'>
+        Please add your email address. We will only use
+        it to contact you about your account. We promise we'll never share it!
+      </p>
     </div>
-    <form class='email-form' {{action 'saveEmail' on='submit'}}>
-      <Input @type={{this.type}} @value={{this.value}} placeholder="Email" class="form-control space-right" />
-      {{#if this.notValidEmail }}
-        <div class='error'>
-          <p class='small-text error'>Whoops, that email format is invalid</p>
+  {{/if}}
+  
+  {{#if this.isEditing }}
+    <div class='row'>
+      <div class='label'>
+        <dt>Email</dt>
+      </div>
+      <form class='email-form' {{action 'saveEmail' on='submit'}}>
+        <Input @type={{this.type}} @value={{this.value}} placeholder="Email" class="form-control space-right" />
+        {{#if this.notValidEmail }}
+          <div class='error'>
+            <p class='small-text error'>Whoops, that email format is invalid</p>
+          </div>
+        {{/if}}
+        <div class='actions'>
+          <button type='submit' class='small yellow-button space-right' disabled={{this.disableSave}}>Save</button>
+          <button type="button" class='small yellow-button' {{action 'cancelEdit'}}>Cancel</button>
         </div>
-      {{/if}}
-      <div class='actions'>
-        <button type='submit' class='small yellow-button space-right' disabled={{this.disableSave}}>Save</button>
-        <button type="button" class='small yellow-button' {{action 'cancelEdit'}}>Cancel</button>
-      </div>
-    </form>
-  </div>
-{{else}}
-  <div class='row'>
-    <div class='label'>
-      <dt>Email</dt>
+      </form>
     </div>
-    <div class='email'>
-      <dd class='no-space-left'>
-        {{ this.user.email }}
-        {{#if this.user.email_verified}}
-          <span class='verified'>Verified!</span>
-        {{/if}}
-      </dd>
-    </div>
-    <div class='actions'>
-      <button type="button" class='small yellow-button space-left' {{action 'editEmail'}}>Edit</button>
-    </div>
-  </div>
-  {{#if this.emailNotVerified }}
+  {{else}}
     <div class='row'>
       <div class='label'>
-        {{#if this.user.email_verification_sent}}
-          <p class='small-text'>We have sent a verification email to your address.</p>
-        {{/if}}
-        <p class='small-text'>Your email has not yet been verified.</p>
+        <dt>Email</dt>
+      </div>
+      <div class='email'>
+        <dd class='no-space-left'>
+          {{ this.user.email }}
+          {{#if this.user.email_verified}}
+            <span class='verified'>Verified!</span>
+          {{/if}}
+        </dd>
       </div>
       <div class='actions'>
-        <button type="button" class='small yellow-button space-left' {{action 'resendEmail'}} disabled={{this.disableResend}}>
-          {{this.resendButtonText}}
-        </button>
+        <button type="button" class='small yellow-button space-left' {{action 'editEmail'}}>Edit</button>
       </div>
     </div>
-  {{/if}}
-  {{#if this.isError}}
-    <div class='row'>
-      <div class='label'>
-        <p class='small-text'>{{this.emailError}}</p>
+    {{#if this.emailNotVerified }}
+      <div class='row'>
+        <div class='label'>
+          {{#if this.user.email_verification_sent}}
+            <p class='small-text'>We have sent a verification email to your address.</p>
+          {{/if}}
+          <p class='small-text'>Your email has not yet been verified.</p>
+        </div>
+        <div class='actions'>
+          <button type="button" class='small yellow-button space-left' {{action 'resendEmail'}} disabled={{this.disableResend}}>
+            {{this.resendButtonText}}
+          </button>
+        </div>
       </div>
-    </div>
+    {{/if}}
+    {{#if this.isError}}
+      <div class='row'>
+        <div class='label'>
+          <p class='small-text'>{{this.emailError}}</p>
+        </div>
+      </div>
+    {{/if}}
   {{/if}}
-{{/if}}
+  
+</div>

--- a/app/templates/components/flash-message.hbs
+++ b/app/templates/components/flash-message.hbs
@@ -1,1 +1,3 @@
-{{this.message}}
+<p id="flash" class={{if this.message "shown"}} ...attributes>
+  {{this.message}}
+</p>

--- a/app/templates/components/owned-crate-row.hbs
+++ b/app/templates/components/owned-crate-row.hbs
@@ -1,11 +1,14 @@
-<Input
-  @type="checkbox"
-  @name={{this.controlId}}
-  @id={{this.controlId}}
-  @checked={{this.emailNotifications}}
-  @change={{action "toggleEmailNotifications"}}
-  class="form-control"
-/>
-<label for="{{ this.controlId }}">
-  {{ this.name }}
-</label>
+<li ...attributes>
+  <Input
+    @type="checkbox"
+    @name={{this.controlId}}
+    @id={{this.controlId}}
+    @checked={{this.emailNotifications}}
+    @change={{action "toggleEmailNotifications"}}
+    class="form-control"
+  />
+  <label for="{{ this.controlId }}">
+    {{ this.name }}
+  </label>
+  
+</li>

--- a/app/templates/components/pending-owner-invite-row.hbs
+++ b/app/templates/components/pending-owner-invite-row.hbs
@@ -1,43 +1,46 @@
-<div class='row'>
-  {{#if this.isAccepted }}
-    <p>
-      Success! You've been added as an owner of crate
-      <LinkTo @route="crate" @model={{this.invite.crate_name}}>{{this.invite.crate_name}}</LinkTo>.
-    </p>
-  {{else if this.isDeclined}}
-    <p>
-      Declined. You have not been added as an owner of crate
-      <LinkTo @route="crate" @model={{this.invite.crate_name}}>{{this.invite.crate_name}}</LinkTo>.
-    </p>
-  {{else}}
-    <div class='info'>
-      <div class='name'>
-        <h3>
-          <LinkTo @route="crate" @model={{this.invite.crate_name}}>
-            {{this.invite.crate_name}}
-          </LinkTo>
-        </h3>
-      </div>
-      <div class='invite'>
-        <p>
-          Invited by:
-          <LinkTo @route="user" @model={{this.invite.invited_by_username}}>
-            {{this.invite.invited_by_username}}
-          </LinkTo>
-        </p>
-      </div>
-      <div class='sent'>
-        <span class='small'>{{moment-from-now this.invite.created_at}}</span>
-      </div>
-      <div class='actions'>
-        <button type="button" class='small yellow-button' {{action 'acceptInvitation' this.invite}}>Accept</button>
-        <button type="button" class='small yellow-button' {{action 'declineInvitation' this.invite}}>Decline</button>
-      </div>
-      {{#if this.isError}}
-        <div class='label'>
-          <p class='small-text'>{{this.inviteError}}</p>
+<div ...attributes>
+  <div class='row'>
+    {{#if this.isAccepted }}
+      <p>
+        Success! You've been added as an owner of crate
+        <LinkTo @route="crate" @model={{this.invite.crate_name}}>{{this.invite.crate_name}}</LinkTo>.
+      </p>
+    {{else if this.isDeclined}}
+      <p>
+        Declined. You have not been added as an owner of crate
+        <LinkTo @route="crate" @model={{this.invite.crate_name}}>{{this.invite.crate_name}}</LinkTo>.
+      </p>
+    {{else}}
+      <div class='info'>
+        <div class='name'>
+          <h3>
+            <LinkTo @route="crate" @model={{this.invite.crate_name}}>
+              {{this.invite.crate_name}}
+            </LinkTo>
+          </h3>
         </div>
-      {{/if}}
-    </div>
-  {{/if}}
+        <div class='invite'>
+          <p>
+            Invited by:
+            <LinkTo @route="user" @model={{this.invite.invited_by_username}}>
+              {{this.invite.invited_by_username}}
+            </LinkTo>
+          </p>
+        </div>
+        <div class='sent'>
+          <span class='small'>{{moment-from-now this.invite.created_at}}</span>
+        </div>
+        <div class='actions'>
+          <button type="button" class='small yellow-button' {{action 'acceptInvitation' this.invite}}>Accept</button>
+          <button type="button" class='small yellow-button' {{action 'declineInvitation' this.invite}}>Decline</button>
+        </div>
+        {{#if this.isError}}
+          <div class='label'>
+            <p class='small-text'>{{this.inviteError}}</p>
+          </div>
+        {{/if}}
+      </div>
+    {{/if}}
+  </div>
+  
 </div>


### PR DESCRIPTION
"Tagless" components are components with `tagName: ''`, which causes them to not have an implicit wrapping element. This is the new default in Ember.js apps with components based on `@glimmer/component`. To make it easier to eventually migrate to these new Glimmer components we'll set `tagName: ''` on some of the existing components that can automatically be migrated.

This PR was created using https://github.com/ember-codemods/tagless-ember-components-codemod

r? @locks

