### PR TITLE
CI: Add docs to GH Actions workflow and add `RUST_BACKTRACE=1`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       PERCY_PROJECT: crates-io/crates.io
 
     steps:
-      - uses: actions/checkout@v2-beta
+      - uses: actions/checkout@v2
 
       - uses: actions/cache@v1
         with:
@@ -68,7 +68,7 @@ jobs:
       RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
     steps:
-      - uses: actions/checkout@v2-beta
+      - uses: actions/checkout@v2
 
       - name: Cleanup pre-installed Rust toolchains
         # The pre-installed toolchain is under root permission, and this would

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           - nightly
 
     env:
+      RUST_BACKTRACE: 1
       DATABASE_URL: postgres://postgres:@localhost/cargo_registry_test
       TEST_DATABASE_URL: postgres://postgres:@localhost/cargo_registry_test
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,18 @@ jobs:
           fi
           echo "::add-path::$HOME/.cargo/bin"
 
+      # FIXME: Nightly and beta channels have high churn.  The cache quickly expires, but there is
+      # no way (that I can find) to overwrite an existing cache.  There is also no way to
+      # dynamically include the latest version number for a release channel into the cache `key`
+      # value.  Once a cached release becomes stale, every job will begin downloading the latest
+      # release from upstream and the cache becomes useless for that channel.
+      #
+      # Including `hashFiles('**/Cargo.lock')` below is a hack.  Ideally, we would change the `key`
+      # for each channel at the same rate as the release cadence for that channel.  For the stable
+      # channel this is too frequent and for the nightly channel (and probably beta as well) it is
+      # not often enough.
+      #
+      # Current size as of 2019-12-23: ~123 MB
       - name: Cache rustup
         uses: actions/cache@v1
         with:
@@ -92,6 +104,10 @@ jobs:
               ${{ runner.os }}-rustup-${{ matrix.rust }}-
               ${{ runner.os }}-rustup-
 
+      # This step has the same tradeoffs as `Cache rustup`, however the cache size is significantly
+      # smaller.  The installed `diesel` binary is also stored here.
+      #
+      # Current size as of 2019-12-23: ~6 MB
       - name: Cache cargo binaries
         uses: actions/cache@v1
         with:
@@ -101,6 +117,7 @@ jobs:
             ${{ runner.os }}-cargo-bin-${{ matrix.rust }}-
             ${{ runner.os }}-cargo-bin-
 
+      # Current size as of 2019-12-23: ~77 MB
       - name: Cache cargo registry cache
         uses: actions/cache@v1
         with:
@@ -110,6 +127,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-cache-${{ matrix.rust }}-
             ${{ runner.os }}-cargo-registry-cache-
 
+      # Current size as of 2019-12-23: ~38 MB
       - name: Cache cargo registry index
         uses: actions/cache@v1
         with:
@@ -119,6 +137,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-index-${{ matrix.rust }}-
             ${{ runner.os }}-cargo-registry-index-
 
+      # Current size as of 2019-12-23: ~4 MB
       - name: Cache cargo git db
         uses: actions/cache@v1
         with:
@@ -128,6 +147,7 @@ jobs:
             ${{ runner.os }}-cargo-git-db-${{ matrix.rust }}-
             ${{ runner.os }}-cargo-git-db-
 
+      # Current size as of 2019-12-23: ~336 MB
       - name: Cache cargo build
         uses: actions/cache@v1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_cache: script/ci/prune-cache.sh
 
 env:
   global:
+    - RUST_BACKTRACE=1
     - JOBS=1 # See https://git.io/vdao3 for details.
     - DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test
     - TEST_DATABASE_URL=postgres://postgres:@localhost/cargo_registry_test


### PR DESCRIPTION
Our caching situation on GH Actions could use some work.  For now, I've added documentation with some initial thoughts.

This also adds `RUST_BACKTRACE=1` to help us debug random test failures on GH Actions: `panicked at 'Could not run jobs: NoMessageReceived'`.

r? @carols10cents 