### PR TITLE
CI: Enable GH Actions on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - auto
+      - master
       - try
 
   pull_request:


### PR DESCRIPTION
Based on the documented cache [restrictions], pull reqeusts are failing
to access the cache.  One solution is to alway build on master, because
all builds should be able to access caches created by the default
branch.

r? @jtgeibel

[restrictions]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache