### PR TITLE
Increase background job timeout for tests

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -233,7 +233,7 @@ impl TestAppBuilder {
                     // We only have 1 connection in tests, so trying to run more than
                     // 1 job concurrently will just block
                     .thread_count(1)
-                    .job_start_timeout(Duration::from_secs(1))
+                    .job_start_timeout(Duration::from_secs(5))
                     .build(),
             )
         } else {


### PR DESCRIPTION
The intermittent errors on GH Actions appear to be coming from two
places ([1], [2]) related to running background jobs.  It's possible
we're hitting the 1 second [timeout] and that the background job is not
completing in time.

Refs: #2059

r? @carols10cents

[1]: https://github.com/rust-lang/crates.io/blob/e74de84f3d69dd623a83dfc0d8b43191e064104d/src/tests/util.rs#L76
[2]: https://github.com/rust-lang/crates.io/blob/e74de84f3d69dd623a83dfc0d8b43191e064104d/src/tests/util.rs#L190
[timeout]: https://github.com/rust-lang/crates.io/blob/e74de84f3d69dd623a83dfc0d8b43191e064104d/src/tests/util.rs#L236