### PR TITLE
Fix fastboot check in nginx erb template

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -141,7 +141,7 @@ http {
 			location / {
 				proxy_pass http://localhost:9000;
 			}
-		<% elsif ['USE_FASTBOOT'] %>
+		<% elsif ENV['USE_FASTBOOT'] && !ENV['USE_FASTBOOT'].empty? %>
 			# Fastboot is enabled only for allowed paths
 
 			location = /policies {


### PR DESCRIPTION
In production we're currently returning a 502 Bad Gateway for
`/policies`.  I intend to merge this and deploy to production shortly.

This bug was introduced in #1907.  The bad check always evaluated to
true.  An explicit check for an empty string is added as well.  I've
tested this locally with `erb` and different values and the generated
configuration is now working correctly.

r? @jtgeibel 