### PR TITLE
Consolidate logging into a single `println!()`

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -43,7 +43,7 @@ impl Handler for LogRequests {
         };
 
         let error = if let Err(ref e) = res {
-            format!(" error=\"{}\"", e.to_string())
+            format!(" error=\"{}\"", e)
         } else {
             String::new()
         };


### PR DESCRIPTION
In production I observed serveral log lines with only " SLOW REQUEST".
Occasionally another thread will obtain the lock on stdout between our
calls to `print!()`.

This implementation consolidates the entire log line into a single
`println!()` and avoids an allocation unless an error is being logged.

r? @smarnach 