### PR TITLE
tests: Add basic "successful/failed login" test cases

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+import window from 'ember-window-mock';
 
 /**
  * This route will open a popup window directed at the `github-login` route.

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -65,9 +65,9 @@
       </RlDropdownContainer>
       <span class="sep">|</span>
       {{#if this.session.currentUser}}
-        <RlDropdownContainer class="dropdown-container">
-          <RlDropdownToggle class="dropdown">
-            <UserAvatar @user={{this.session.currentUser}} @size="small" />
+        <RlDropdownContainer class="dropdown-container" data-test-user-menu>
+          <RlDropdownToggle class="dropdown" data-test-toggle>
+            <UserAvatar @user={{this.session.currentUser}} @size="small" data-test-avatar />
             {{ this.session.currentUser.name }}
             <span class='arrow'></span>
           </RlDropdownToggle>

--- a/app/templates/components/flash-message.hbs
+++ b/app/templates/components/flash-message.hbs
@@ -1,3 +1,3 @@
-<p id="flash" class={{if this.message "shown"}} ...attributes>
+<p id="flash" class={{if this.message "shown"}} data-test-flash-message ...attributes>
   {{this.message}}
 </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37491,6 +37491,90 @@
         }
       }
     },
+    "ember-window-mock": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/ember-window-mock/-/ember-window-mock-0.5.4.tgz",
+      "integrity": "sha512-clJz0Un2vgGdNwjF2hLOtRfDASuGLePfwspfM1CHHwm8cm3jYMQvcLzP/6p7pyDNW36vgz5eKYygWATkpqUUmg==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^2.0.1",
+        "ember-cli-babel": "^6.16.0"
+      },
+      "dependencies": {
+        "broccoli-debug": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
+          "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
+          "dev": true,
+          "requires": {
+            "broccoli-plugin": "^1.2.1",
+            "fs-tree-diff": "^0.5.2",
+            "heimdalljs": "^0.2.1",
+            "heimdalljs-logger": "^0.1.7",
+            "symlink-or-copy": "^1.1.8",
+            "tree-sync": "^1.2.2"
+          }
+        },
+        "broccoli-funnel": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^1.3.0",
+            "debug": "^2.2.0",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^0.5.3",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "mkdirp": "^0.5.0",
+            "path-posix": "^1.0.0",
+            "rimraf": "^2.4.3",
+            "symlink-or-copy": "^1.0.0",
+            "walk-sync": "^0.3.1"
+          }
+        },
+        "ember-cli-babel": {
+          "version": "6.18.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz",
+          "integrity": "sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==",
+          "dev": true,
+          "requires": {
+            "amd-name-resolver": "1.2.0",
+            "babel-plugin-debug-macros": "^0.2.0-beta.6",
+            "babel-plugin-ember-modules-api-polyfill": "^2.6.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.0",
+            "babel-polyfill": "^6.26.0",
+            "babel-preset-env": "^1.7.0",
+            "broccoli-babel-transpiler": "^6.5.0",
+            "broccoli-debug": "^0.6.4",
+            "broccoli-funnel": "^2.0.0",
+            "broccoli-source": "^1.1.0",
+            "clone": "^2.0.0",
+            "ember-cli-version-checker": "^2.1.2",
+            "semver": "^5.5.0"
+          }
+        },
+        "ember-cli-version-checker": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
+          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
+          "dev": true,
+          "requires": {
+            "resolve": "^1.3.3",
+            "semver": "^5.3.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -43864,7 +43948,7 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "istanbul-lib-coverage": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ember-svg-jar": "^2.2.3",
     "ember-test-selectors": "^3.0.0",
     "ember-web-app": "^3.0.1",
+    "ember-window-mock": "^0.5.4",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-ember": "^7.7.2",

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,0 +1,56 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { visit, currentURL, click, waitFor } from '@ember/test-helpers';
+import { defer } from 'rsvp';
+import window, { setupWindowMock } from 'ember-window-mock';
+import setupMirage from '../helpers/setup-mirage';
+
+module('Acceptance | Login', function(hooks) {
+  setupApplicationTest(hooks);
+  setupWindowMock(hooks);
+  setupMirage(hooks);
+
+  test('successful login', async function(assert) {
+    let deferred = defer();
+    let fakeWindow = { closed: false };
+    window.open = (url, target, features) => {
+      assert.equal(url, '/github_login');
+      assert.equal(target, 'Authorization');
+      assert.equal(features, 'width=1000,height=450,toolbar=0,scrollbars=1,status=1,resizable=1,location=1,menuBar=0');
+      deferred.resolve();
+      return fakeWindow;
+    };
+
+    await visit('/');
+    assert.equal(currentURL(), '/');
+
+    await click('[data-test-login-link]');
+    assert.equal(currentURL(), '/');
+
+    // wait for `window.open()` to be called
+    await deferred.promise;
+
+    // simulate the response from the `github-authorize` route
+    window.github_response = JSON.stringify({
+      ok: true,
+      data: {
+        user: {
+          id: 42,
+          login: 'johnnydee',
+          name: 'John Doe',
+          email: 'john@doe.name',
+          avatar: 'https://avatars2.githubusercontent.com/u/12345?v=4',
+          url: 'https://github.com/johnnydee',
+        },
+      },
+    });
+
+    // simulate that the window has been closed by the `github-authorize` route
+    fakeWindow.closed = true;
+
+    // wait for the user menu to show up after the successful login
+    await waitFor('[data-test-user-menu]');
+
+    assert.dom('[data-test-user-menu] [data-test-toggle]').hasText('John Doe');
+  });
+});


### PR DESCRIPTION
This PR adds two basic application tests for the login button and the `login` route. Please note that this does not test the `github-login` and `github-authorize` routes yet, which we will do in a follow-up PR.

r? @locks 

/cc @carols10cents 