### PR TITLE
restore crate prefixes to browser-tab titles

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,7 +5,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>crates.io: Rust Package Registry</title>
+    <noscript>
+      <title>crates.io: Rust Package Registry</title>
+    </noscript>
 
     {{content-for 'head'}}
 


### PR DESCRIPTION
I'm not sure when it got broken, but all of the crates.io brower tabs I have open currently say `crates.io: Rust Package Registry` when they previously said things like `mio - crates.io: Rust Package Registry` or `Search Results for 'mio' - crates.io: Rust Package Registry`. This patch fixes this.

There is a bunch of code that sets the page title dynamically,
but it is all being overridden by a title tag in the main
app/index.html template (the DOM is only allowed to have
a single title tag in it, so subsequent title tags are
ignored by all browsers).

There is probably a better way to do this (using fastboot
to fill in the correct title on the backend would be ideal)
but this patch should be enough to restore the dynamic
titles for browsers with javascript enabled.