### PR TITLE
Defer user authentication until requested by endpoint

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -19,7 +19,6 @@ mod prelude {
     pub use crate::util::errors::{cargo_err, AppError, AppResult, ChainError}; // TODO: Remove cargo_err from here
 
     pub use crate::middleware::app::RequestApp;
-    pub use crate::middleware::current_user::RequestUser;
 
     use std::collections::HashMap;
     use std::io;
@@ -27,6 +26,10 @@ mod prelude {
     use indexmap::IndexMap;
     use serde::Serialize;
     use url;
+
+    pub trait UserAuthenticationExt {
+        fn authenticate(&self, conn: &PgConnection) -> AppResult<super::util::AuthenticatedUser>;
+    }
 
     pub trait RequestUtils {
         fn redirect(&self, url: String) -> Response;
@@ -77,6 +80,7 @@ mod prelude {
 }
 
 pub mod helpers;
+mod util;
 
 pub mod category;
 pub mod crate_owner_invitation;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -8,15 +8,12 @@ use crate::models::{Crate, Follow};
 use crate::schema::*;
 
 fn follow_target(req: &dyn Request, conn: &DieselPooledConn<'_>) -> AppResult<Follow> {
-    let user = req.user()?;
+    let user_id = req.authenticate(conn)?.user_id();
     let crate_name = &req.params()["crate_id"];
     let crate_id = Crate::by_name(crate_name)
         .select(crates::id)
         .first(&**conn)?;
-    Ok(Follow {
-        user_id: user.id,
-        crate_id,
-    })
+    Ok(Follow { user_id, crate_id })
 }
 
 /// Handles the `PUT /crates/:crate_id/follow` route.

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -8,7 +8,7 @@ use crate::controllers::cargo_prelude::*;
 use crate::git;
 use crate::models::dependency;
 use crate::models::{
-    insert_version_owner_action, Badge, Category, Keyword, NewCrate, NewVersion, Rights, User,
+    insert_version_owner_action, Badge, Category, Keyword, NewCrate, NewVersion, Rights,
     VersionAction,
 };
 
@@ -39,9 +39,11 @@ pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
     // - Then the .crate tarball length is passed to the upload_crate function where the actual
     //   file is read and uploaded.
 
-    let (new_crate, user) = parse_new_headers(req)?;
+    let new_crate = parse_new_headers(req)?;
 
     let conn = app.diesel_database.get()?;
+    let ids = req.authenticate(&conn)?;
+    let user = ids.find_user(&conn)?;
 
     let verified_email_address = user.verified_email(&conn)?;
     let verified_email_address = verified_email_address.ok_or_else(|| {
@@ -150,7 +152,7 @@ pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
             &conn,
             version.id,
             user.id,
-            req.authentication_source()?.api_token_id(),
+            ids.api_token_id(),
             VersionAction::Publish,
         )?;
 
@@ -223,9 +225,8 @@ pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
 /// Used by the `krate::new` function.
 ///
 /// This function parses the JSON headers to interpret the data and validates
-/// the data during and after the parsing. Returns crate metadata and user
-/// information.
-fn parse_new_headers(req: &mut dyn Request) -> AppResult<(EncodableCrateUpload, User)> {
+/// the data during and after the parsing. Returns crate metadata.
+fn parse_new_headers(req: &mut dyn Request) -> AppResult<EncodableCrateUpload> {
     // Read the json upload request
     let metadata_length = u64::from(read_le_u32(req.body())?);
     req.mut_extensions().insert(metadata_length);
@@ -264,6 +265,5 @@ fn parse_new_headers(req: &mut dyn Request) -> AppResult<(EncodableCrateUpload, 
         )));
     }
 
-    let user = req.user()?;
-    Ok((new, user.clone()))
+    Ok(new)
 }

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -154,11 +154,12 @@ pub fn search(req: &mut dyn Request) -> AppResult<Response> {
             ),
         );
     } else if params.get("following").is_some() {
+        let user_id = req.authenticate(&conn)?.user_id();
         query = query.filter(
             crates::id.eq_any(
                 follows::table
                     .select(follows::crate_id)
-                    .filter(follows::user_id.eq(req.user()?.id)),
+                    .filter(follows::user_id.eq(user_id)),
             ),
         );
     }

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,0 +1,44 @@
+use super::prelude::*;
+
+use crate::middleware::current_user::TrustedUserId;
+use crate::models::{ApiToken, User};
+use crate::util::errors::{internal, AppError, AppResult, ChainError, Unauthorized};
+
+#[derive(Debug)]
+pub struct AuthenticatedUser(i32, Option<i32>);
+
+impl AuthenticatedUser {
+    pub fn user_id(&self) -> i32 {
+        self.0
+    }
+
+    pub fn api_token_id(&self) -> Option<i32> {
+        self.1
+    }
+
+    pub fn find_user(&self, conn: &PgConnection) -> AppResult<User> {
+        User::find(conn, self.user_id())
+            .chain_error(|| internal("user_id from cookie or token not found in database"))
+    }
+}
+
+impl<'a> UserAuthenticationExt for dyn Request + 'a {
+    /// Obtain `CurrentUserIds` for the request or return an `Unauthorized` error
+    fn authenticate(&self, conn: &PgConnection) -> AppResult<AuthenticatedUser> {
+        if let Some(id) = self.extensions().find::<TrustedUserId>() {
+            // A trusted user_id was provided by a signed cookie (or a test `MockCookieUser`)
+            Ok(AuthenticatedUser(id.0, None))
+        } else {
+            // Otherwise, look for an `Authorization` header on the request
+            if let Some(headers) = self.headers().find("Authorization") {
+                ApiToken::find_by_api_token(conn, headers[0])
+                    .map(|token| AuthenticatedUser(token.user_id, Some(token.id)))
+                    // Convert a NotFound (or other database error) into Unauthorized
+                    .map_err(|_| Box::new(Unauthorized) as Box<dyn AppError>)
+            } else {
+                // Unable to authenticate the user
+                Err(Box::new(Unauthorized))
+            }
+        }
+    }
+}

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -69,8 +69,7 @@ fn increment_download_counts(
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
 pub fn downloads(req: &mut dyn Request) -> AppResult<Response> {
-    let (version, _) = version_and_crate(req)?;
-    let conn = req.db_conn()?;
+    let (conn, version, _) = version_and_crate(req)?;
     let cutoff_end_date = req
         .query()
         .get("before_date")

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -20,8 +20,7 @@ use super::version_and_crate;
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
 pub fn dependencies(req: &mut dyn Request) -> AppResult<Response> {
-    let (version, _) = version_and_crate(req)?;
-    let conn = req.db_conn()?;
+    let (conn, version, _) = version_and_crate(req)?;
     let deps = version.dependencies(&*conn)?;
     let deps = deps
         .into_iter()
@@ -37,8 +36,7 @@ pub fn dependencies(req: &mut dyn Request) -> AppResult<Response> {
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
 pub fn authors(req: &mut dyn Request) -> AppResult<Response> {
-    let (version, _) = version_and_crate(req)?;
-    let conn = req.db_conn()?;
+    let (conn, version, _) = version_and_crate(req)?;
     let names = version_authors::table
         .filter(version_authors::version_id.eq(version.id))
         .select(version_authors::name)
@@ -68,8 +66,7 @@ pub fn authors(req: &mut dyn Request) -> AppResult<Response> {
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
 pub fn show(req: &mut dyn Request) -> AppResult<Response> {
-    let (version, krate) = version_and_crate(req)?;
-    let conn = req.db_conn()?;
+    let (conn, version, krate) = version_and_crate(req)?;
     let published_by = version.published_by(&conn);
     let actions = VersionOwnerAction::by_version(&conn, &version)?;
 

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -28,10 +28,11 @@ pub fn unyank(req: &mut dyn Request) -> AppResult<Response> {
 
 /// Changes `yanked` flag on a crate version record
 fn modify_yank(req: &mut dyn Request, yanked: bool) -> AppResult<Response> {
-    let (version, krate) = version_and_crate(req)?;
-    let user = req.user()?;
-    let conn = req.db_conn()?;
+    let (conn, version, krate) = version_and_crate(req)?;
+    let ids = req.authenticate(&conn)?;
+    let user = ids.find_user(&conn)?;
     let owners = krate.owners(&conn)?;
+
     if user.rights(req.app(), &owners)? < Rights::Publish {
         return Err(cargo_err("must already be an owner to yank or unyank"));
     }
@@ -40,9 +41,8 @@ fn modify_yank(req: &mut dyn Request, yanked: bool) -> AppResult<Response> {
     } else {
         VersionAction::Unyank
     };
-    let api_token_id = req.authentication_source()?.api_token_id();
 
-    insert_version_owner_action(&conn, version.id, user.id, api_token_id, action)?;
+    insert_version_owner_action(&conn, version.id, user.id, ids.api_token_id(), action)?;
 
     git::yank(krate.name, version, yanked)
         .enqueue(&conn)

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -10,7 +10,7 @@ mod prelude {
 pub use prelude::Result;
 
 use self::app::AppMiddleware;
-use self::current_user::CurrentUser;
+use self::current_user::CaptureUserIdFromCookie;
 use self::debug::*;
 use self::ember_index_rewrite::EmberIndexRewrite;
 use self::head::Head;
@@ -79,8 +79,8 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
     }
     m.add(AppMiddleware::new(app));
 
-    // Sets the current user on each request.
-    m.add(CurrentUser);
+    // Parse and save the user_id from the session cookie as part of the authentication logic
+    m.add(CaptureUserIdFromCookie);
 
     // Serve the static files in the *dist* directory, which are the frontend assets.
     // Not needed for the backend tests.

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -1,104 +1,37 @@
+//! Middleware that captures the `user_id` from the signed session cookie
+//!
+//! Due to lifetimes it is not possible to call `mut_extensions()` while a reference obtained from
+//! `extensions()` is still live.  The call to `conduit_cookie::RequestSession::session` needs
+//! mutable access to the request and its extensions, and there is no read-only alternative in
+//! `conduit_cookie` to access the session cookie.  This means that it is not possible to access
+//! the session cookie while holding onto a database connection (which is obtained from the
+//! `AppMiddleware` via `extensions()`).
+//!
+//! This is particularly problematic for the user authentication code.  When an API token is used
+//! for authentication, the datbase must be queried to obtain the `user_id`, so endpoint code must
+//! obtain and pass in a database connection.  Because of that connection, it is no longer possible
+//! to use or pass around the `&mut dyn Request` that it was derived from and it is not possible
+//! to access the session cookie.  In order to support authentication via session cookies and API
+//! tokens via the same code path, the `user_id` is extracted from the session cookie and stored in
+//! a `TrustedUserId` that can be read from while a connection reference is live.
+
 use super::prelude::*;
 
 use conduit_cookie::RequestSession;
-use diesel::prelude::*;
 
-use crate::db::RequestTransaction;
-use crate::util::errors::{AppResult, ChainError, Unauthorized};
+/// A trusted user_id extracted from a signed cookie or added to the request by the test harness
+#[derive(Clone, Copy, Debug)]
+pub struct TrustedUserId(pub i32);
 
-use crate::models::ApiToken;
-use crate::models::User;
-use crate::schema::users;
+/// Middleware that captures the `user_id` from the signed session cookie
+pub(super) struct CaptureUserIdFromCookie;
 
-#[derive(Debug, Clone, Copy)]
-pub struct CurrentUser;
-
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AuthenticationSource {
-    SessionCookie,
-    ApiToken { api_token_id: i32 },
-}
-
-impl Middleware for CurrentUser {
+impl Middleware for CaptureUserIdFromCookie {
     fn before(&self, req: &mut dyn Request) -> Result<()> {
-        // Check if the request has a session cookie with a `user_id` property inside
-        let id = {
-            req.session()
-                .get("user_id")
-                .and_then(|s| s.parse::<i32>().ok())
-        };
-
-        let conn = req.db_conn().map_err(|e| Box::new(e) as BoxError)?;
-
-        if let Some(id) = id {
-            // If it did, look for a user in the database with the given `user_id`
-            let maybe_user = users::table.find(id).first::<User>(&*conn);
-            drop(conn);
-            if let Ok(user) = maybe_user {
-                // Attach the `User` model from the database to the request
-                req.mut_extensions().insert(user);
-                req.mut_extensions()
-                    .insert(AuthenticationSource::SessionCookie);
-            }
-        } else {
-            // Otherwise, look for an `Authorization` header on the request
-            // and try to find a user in the database with a matching API token
-            let user_auth = if let Some(headers) = req.headers().find("Authorization") {
-                ApiToken::find_by_api_token(&conn, headers[0])
-                    .and_then(|api_token| {
-                        User::find(&conn, api_token.user_id).map(|user| {
-                            (
-                                AuthenticationSource::ApiToken {
-                                    api_token_id: api_token.id,
-                                },
-                                user,
-                            )
-                        })
-                    })
-                    .optional()
-                    .map_err(|e| Box::new(e) as BoxError)?
-            } else {
-                None
-            };
-
-            drop(conn);
-
-            if let Some((api_token, user)) = user_auth {
-                // Attach the `User` model from the database and the API token to the request
-                req.mut_extensions().insert(user);
-                req.mut_extensions().insert(api_token);
-            }
+        if let Some(id) = req.session().get("user_id").and_then(|s| s.parse().ok()) {
+            req.mut_extensions().insert(TrustedUserId(id));
         }
 
         Ok(())
-    }
-}
-
-pub trait RequestUser {
-    fn user(&self) -> AppResult<&User>;
-    fn authentication_source(&self) -> AppResult<AuthenticationSource>;
-}
-
-impl<'a> RequestUser for dyn Request + 'a {
-    fn user(&self) -> AppResult<&User> {
-        self.extensions()
-            .find::<User>()
-            .chain_error(|| Unauthorized)
-    }
-
-    fn authentication_source(&self) -> AppResult<AuthenticationSource> {
-        self.extensions()
-            .find::<AuthenticationSource>()
-            .cloned()
-            .chain_error(|| Unauthorized)
-    }
-}
-
-impl AuthenticationSource {
-    pub fn api_token_id(self) -> Option<i32> {
-        match self {
-            AuthenticationSource::SessionCookie => None,
-            AuthenticationSource::ApiToken { api_token_id } => Some(api_token_id),
-        }
     }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -40,6 +40,7 @@ macro_rules! t {
     };
 }
 
+mod authentication;
 mod badge;
 mod builders;
 mod categories;

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -1,0 +1,60 @@
+use crate::{util::RequestHelper, TestApp};
+
+use cargo_registry::middleware::current_user::TrustedUserId;
+
+use conduit::{Handler, Method, Request, Response};
+use conduit_test::MockRequest;
+
+type ResponseResult = Result<Response, Box<dyn std::error::Error + Send>>;
+
+static URL: &str = "/api/v1/me/updates";
+static MUST_LOGIN: &[u8] =
+    b"{\"errors\":[{\"detail\":\"must be logged in to perform that action\"}]}";
+static INTERNAL_ERROR_NO_USER: &str =
+    "user_id from cookie or token not found in database caused by NotFound";
+
+fn call(app: &TestApp, mut request: MockRequest) -> ResponseResult {
+    app.as_middleware().call(&mut request)
+}
+
+fn into_parts(response: ResponseResult) -> (u32, Vec<u8>) {
+    let mut response = response.unwrap();
+    let mut body = Vec::new();
+    response.body.write_body(&mut body).unwrap();
+    (response.status.0, body)
+}
+
+#[test]
+fn anonymous_user_unauthorized() {
+    let (app, anon) = TestApp::init().empty();
+    let request = anon.request_builder(Method::Get, URL);
+
+    let (status, body) = into_parts(call(&app, request));
+    assert_eq!(status, 403);
+    assert_eq!(body, MUST_LOGIN);
+}
+
+#[test]
+fn token_auth_cannot_find_token() {
+    let (app, anon) = TestApp::init().empty();
+    let mut request = anon.request_builder(Method::Get, URL);
+    request.header("Authorization", "fake-token");
+
+    let (status, body) = into_parts(call(&app, request));
+    assert_eq!(status, 403);
+    assert_eq!(body, MUST_LOGIN);
+}
+
+// Ensure that an unexpected authentication error is available for logging.  The user would see
+// status 500 instead of 403 as in other authentication tests.  Due to foreign-key constraints in
+// the database, it is not possible to implement this same test for a token.
+#[test]
+fn cookie_auth_cannot_find_user() {
+    let (app, anon) = TestApp::init().empty();
+    let mut request = anon.request_builder(Method::Get, URL);
+    request.mut_extensions().insert(TrustedUserId(-1));
+
+    let response = call(&app, request);
+    let log_message = response.map(|_| ()).unwrap_err().to_string();
+    assert_eq!(log_message, INTERNAL_ERROR_NO_USER);
+}


### PR DESCRIPTION
Many endpoints do not require user authentication, and by moving the
logic out of the middleware layer these endpoints now avoid obtaining a
database connection from the pool and 1 or 2 queries.

Due to lifetime issues a small middlware component remains.  Further
details are described in the middleware's documentation.

r? @carols10cents 