### PR TITLE
manually run dependabot for caniuse-lite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1225,12 +1225,6 @@
             "node-releases": "^1.1.14"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000962",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz",
-          "integrity": "sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.125",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
@@ -4486,12 +4480,6 @@
             "node-releases": "^1.1.42"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
-        },
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -6113,12 +6101,6 @@
             "electron-to-chromium": "^1.3.322",
             "node-releases": "^1.1.42"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
         },
         "clone": {
           "version": "2.1.2",
@@ -9031,12 +9013,6 @@
             "electron-to-chromium": "^1.3.47"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30000851",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000851.tgz",
-          "integrity": "sha512-Y1ecA1cL9wg0vni8t33nBw/poX8ypm+2c3fbwAESj8cm4ufK9CBFQ1+nUK8Dp5dtFo5Fc3JzkI5DKmQbuIo6hQ==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.3.48",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz",
@@ -11145,12 +11121,6 @@
         "node-releases": "^1.1.42"
       },
       "dependencies": {
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
-        },
         "node-releases": {
           "version": "1.1.43",
           "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.43.tgz",
@@ -11448,14 +11418,6 @@
             "caniuse-lite": "^1.0.30001015",
             "electron-to-chromium": "^1.3.322",
             "node-releases": "^1.1.42"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001016",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-              "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-              "dev": true
-            }
           }
         },
         "electron-to-chromium": {
@@ -11476,9 +11438,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000735",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000735.tgz",
-      "integrity": "sha1-qrRAFu8kPiFe9D/RND79IpMIQvg=",
+      "version": "1.0.30001017",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001017.tgz",
+      "integrity": "sha512-EDnZyOJ6eYh6lHmCvCdHAFbfV4KJ9lSdfv4h/ppEhrU/Yudkl7jujwMZ1we6RX7DXqBfT04pVMQ4J+1wcTlsKA==",
       "dev": true
     },
     "capture-exit": {
@@ -12354,12 +12316,6 @@
             "electron-to-chromium": "^1.3.124",
             "node-releases": "^1.1.14"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30000962",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz",
-          "integrity": "sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA==",
-          "dev": true
         },
         "core-js": {
           "version": "3.0.1",
@@ -17313,12 +17269,6 @@
             "node-releases": "^1.1.42"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
-        },
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -22136,12 +22086,6 @@
             "node-releases": "^1.1.42"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
-        },
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -24150,12 +24094,6 @@
             "node-releases": "^1.1.42"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
-        },
         "chalk": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
@@ -25635,12 +25573,6 @@
           "requires": {
             "json-stable-stringify": "^1.0.1"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
         },
         "chalk": {
           "version": "2.4.2",
@@ -27695,12 +27627,6 @@
             "node-releases": "^1.1.42"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
-        },
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -28943,12 +28869,6 @@
             "electron-to-chromium": "^1.3.322",
             "node-releases": "^1.1.42"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
         },
         "clone": {
           "version": "2.1.2",
@@ -30909,12 +30829,6 @@
             "node-releases": "^1.1.42"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
-        },
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -32178,12 +32092,6 @@
             "electron-to-chromium": "^1.3.322",
             "node-releases": "^1.1.42"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
         },
         "clone": {
           "version": "2.1.2",
@@ -34124,12 +34032,6 @@
             "node-releases": "^1.1.42"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001015",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
-          "dev": true
-        },
         "clone": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -35361,12 +35263,6 @@
             "electron-to-chromium": "^1.3.322",
             "node-releases": "^1.1.42"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001016",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001016.tgz",
-          "integrity": "sha512-yYQ2QfotceRiH4U+h1Us86WJXtVHDmy3nEKIdYPsZCYnOV5/tMgGbmoIlrMzmh2VXlproqYtVaKeGDBkMZifFA==",
-          "dev": true
         },
         "clone": {
           "version": "2.1.2",
@@ -37189,12 +37085,6 @@
             "electron-to-chromium": "^1.3.322",
             "node-releases": "^1.1.42"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001015",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
-          "dev": true
         },
         "clone": {
           "version": "2.1.2",


### PR DESCRIPTION
It looks like dependabot is able to make a minimal incision and update
caniuse-lite without messing around with the rest of the package lock.
I suspect that dependabot will eventually get around to updating
caniuse-lite if we wait long enough, but I was curious to see how hard
it is to run manually, so I had a go. Turns out it's really easy, but
takes quite a long time.

Steps to reproduce:

* clone https://github.com/dependabot/dependabot-core
* docker pull dependabot/dependabot-core
* bin/docker-dev-shell
  * bin/dry-run.rb --dep caniuse-lite npm_and_yarn rust-lang/crates.io
* paste the printed patch into a file (e.g. patchfile.txt)
* patch package-lock.json patchfile.txt
* npm ci && npm start

Fixes #1914