### PR TITLE
Don't make duplicated requests through Ember Data

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -4,8 +4,23 @@ import { inject as service } from '@ember/service';
 
 export default RESTAdapter.extend({
   fastboot: service(),
+  fetcher: service(),
 
   namespace: 'api/v1',
+
+  ajax(url, type, options) {
+    if (type === 'GET') {
+      let cache = this.fetcher.get(url);
+      if (cache) {
+        return cache;
+      }
+    }
+
+    return this._super(url, type, options).then(resp => {
+      this.fetcher.put(url, resp);
+      return resp;
+    });
+  },
 
   headers: computed('fastboot.{isFastBoot,request.headers}', function () {
     if (this.fastboot.isFastBoot) {

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -10,14 +10,14 @@ export default RESTAdapter.extend({
 
   ajax(url, type, options) {
     if (type === 'GET') {
-      let cache = this.fetcher.get(url);
+      let cache = this.fetcher.get(url, options);
       if (cache) {
         return cache;
       }
     }
 
     return this._super(url, type, options).then(resp => {
-      this.fetcher.put(url, resp);
+      this.fetcher.put(url, options, resp);
       return resp;
     });
   },

--- a/app/services/fetcher.js
+++ b/app/services/fetcher.js
@@ -7,16 +7,17 @@ const KEY = 'ajax-cache';
 export default class FetcherService extends Service {
   @service fastboot;
 
-  get(url) {
+  get(url, options) {
     let shoebox = this.fastboot.shoebox;
     if (!shoebox) {
       return;
     }
     let cache = shoebox.retrieve(KEY) || {};
-    return cache[url];
+    let key = cacheKey(url, options);
+    return cache[key];
   }
 
-  put(url, obj) {
+  put(url, options, obj) {
     let fastboot = this.fastboot;
     let shoebox = this.fastboot.shoebox;
     if (!(shoebox && fastboot.isFastBoot)) {
@@ -24,7 +25,8 @@ export default class FetcherService extends Service {
     }
 
     let cache = shoebox.retrieve(KEY) || {};
-    cache[url] = deepCopy(obj);
+    let key = cacheKey(url, options);
+    cache[key] = deepCopy(obj);
     shoebox.put(KEY, cache);
   }
 
@@ -39,6 +41,10 @@ export default class FetcherService extends Service {
       return resp;
     });
   }
+}
+
+function cacheKey(url, options) {
+  return url + JSON.stringify(options);
 }
 
 function deepCopy(obj) {


### PR DESCRIPTION
ember-data-storefront provides FastbootAdapter which caches XHRs in
Fastboot's Shoebox.

This will prevent duplicated requests on /crates and other
Ember Data-powered pages.