### PR TITLE
Fix a deprecation warning during `ember build`

### DIFF
--- a/app/templates/components/api-token-row.hbs
+++ b/app/templates/components/api-token-row.hbs
@@ -7,7 +7,7 @@
         @disabled={{this.api_token.isSaving}}
         @value={{this.api_token.name}}
         @autofocus="autofocus"
-        @enter="saveToken"
+        @enter={{action "saveToken"}}
         data-test-focused-input
       />
     {{else}}


### PR DESCRIPTION
The lint references https://emberjs.com/deprecations/v3.x#toc_ember-component-send-action.  There is no usage of `sendAction` in the component, so I believe no further changes are needed there.

r? Turbo87