### PR TITLE
Add computer-vision slug

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -81,7 +81,7 @@ Algorithms for making data smaller.\
 """
 
 [computer-vision]
-name = "Computer Vision"
+name = "Computer vision"
 description = """
 Crates for comprehending the world from video or images.\
 """

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -80,6 +80,12 @@ description = """
 Algorithms for making data smaller.\
 """
 
+[computer-vision]
+name = "Computer Vision"
+description = """
+Crates for comprehending the world from video or images.\
+"""
+
 [config]
 name = "Configuration"
 description = """


### PR DESCRIPTION
Right now the closest thing in the list to computer vision is `science::robotics`. Computer vision algorithms are not always used for robotics. This slug also allows computer vision crates to be found easier instead of being lost among the other robotics crates.