### PR TITLE
Fix fallback to unstable version when looking for unyanked versions

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -61,7 +61,7 @@ export default Route.extend({
                 }
               });
 
-              if (latestStableVersion == null) {
+              if (latestUnyankedVersion == null) {
                 // There's not even any unyanked version...
                 params.version_num = maxVersion;
               } else {

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -45,9 +45,7 @@ export default Route.extend({
           .then(versions => {
             const latestStableVersion = versions.find(version => {
               // Find the latest version that is stable AND not-yanked.
-              if (!isUnstableVersion(version.get('num')) && !version.get('yanked')) {
-                return version;
-              }
+              return !isUnstableVersion(version.get('num')) && !version.get('yanked');
             });
 
             if (latestStableVersion == null) {
@@ -56,9 +54,7 @@ export default Route.extend({
               // we have to fall back to the latest one that is unstable....
               const latestUnyankedVersion = versions.find(version => {
                 // Find the latest version that is not-yanked.
-                if (!version.get('yanked')) {
-                  return version;
-                }
+                return !version.get('yanked');
               });
 
               if (latestUnyankedVersion == null) {

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -55,7 +55,7 @@ export default Route.extend({
               // The fact that "maxVersion" itself cannot be found means that
               // we have to fall back to the latest one that is unstable....
               const latestUnyankedVersion = versions.find(version => {
-                // Find the latest version that is stable AND not-yanked.
+                // Find the latest version that is not-yanked.
                 if (!version.get('yanked')) {
                   return version;
                 }


### PR DESCRIPTION
See the commit “Fix fallback to unstable version” for the behaviour change.

- [ ] find out how to write a test for this