### PR TITLE
Fix `event.clearSelection is not a function` error

### DIFF
--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -20,8 +20,7 @@ export default Component.extend({
     );
   },
   actions: {
-    copySuccess(event) {
-      event.clearSelection();
+    copySuccess() {
       this.toggleClipboardProps(true);
     },
 


### PR DESCRIPTION
I'm not sure what that call was originally supposed to do, but without it this seems to work quite fine and makes the "Copied!" notification appear again.

r? @locks