### PR TITLE
Extract shared `Pagination` component

### DIFF
--- a/app/components/pagination.hbs
+++ b/app/components/pagination.hbs
@@ -1,0 +1,17 @@
+<nav class='pagination' aria-label="Pagination navigation">
+  <LinkTo @query={{hash page=@prevPage}} class="prev" @rel="prev" @title="previous page" data-test-pagination-prev>
+    {{svg-jar "left-pag"}}
+  </LinkTo>
+  <ol>
+    {{#each @pages as |page|}}
+      <li>
+        <LinkTo @query={{hash page=page}} @title={{concat "Go to page " page}}>
+          {{ page }}
+        </LinkTo>
+      </li>
+    {{/each}}
+  </ol>
+  <LinkTo @query={{hash page=@nextPage}} class="next" @rel="next" @title="next page" data-test-pagination-next>
+    {{svg-jar "right-pag"}}
+  </LinkTo>
+</nav>

--- a/app/templates/categories.hbs
+++ b/app/templates/categories.hbs
@@ -59,14 +59,4 @@
   {{/each}}
 </div>
 
-<div class='pagination'>
-  <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  {{#each this.pages as |page|}}
-    <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-  {{/each}}
-  <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</div>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -88,14 +88,4 @@
   {{/each}}
 </div>
 
-<div class='pagination'>
-  <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  {{#each this.pages as |page|}}
-    <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-  {{/each}}
-  <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</div>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -27,16 +27,4 @@
   {{/each}}
 </div>
 
-<div class='pagination'>
-  <LinkTo @query={{hash page=this.prevPage}} class="prev">
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  {{#each this.pages as |page|}}
-    <LinkTo @query={{hash page=page}}>
-      {{ page }}
-    </LinkTo>
-  {{/each}}
-  <LinkTo @query={{hash page=this.nextPage}} class="next">
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</div>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -76,20 +76,4 @@
   {{/each}}
 </div>
 
-<nav class='pagination' aria-label="Pagination navigation">
-  <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page" data-test-pagination-prev>
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  <ol>
-    {{#each this.pages as |page|}}
-      <li>
-        <LinkTo @query={{hash page=page}} @title={{concat "Go to page " page}}>
-          {{ page }}
-        </LinkTo>
-      </li>
-    {{/each}}
-  </ol>
-  <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page" data-test-pagination-next>
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</nav>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/keyword/index.hbs
+++ b/app/templates/keyword/index.hbs
@@ -56,14 +56,4 @@
   {{/each}}
 </div>
 
-<div class='pagination'>
-  <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  {{#each this.pages as |page|}}
-    <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-  {{/each}}
-  <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</div>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/keywords.hbs
+++ b/app/templates/keywords.hbs
@@ -52,14 +52,4 @@
   {{/each}}
 </div>
 
-<div class='pagination'>
-  <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  {{#each this.pages as |page|}}
-    <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-  {{/each}}
-  <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</div>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -57,14 +57,4 @@
   {{/each}}
 </div>
 
-<div class='pagination'>
-  <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  {{#each this.pages as |page|}}
-    <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-  {{/each}}
-  <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</div>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/me/following.hbs
+++ b/app/templates/me/following.hbs
@@ -45,14 +45,4 @@
   {{/each}}
 </div>
 
-<div class='pagination'>
-  <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-    {{svg-jar "left-pag"}}
-  </LinkTo>
-  {{#each this.pages as |page|}}
-    <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-  {{/each}}
-  <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-    {{svg-jar "right-pag"}}
-  </LinkTo>
-</div>
+<Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -79,17 +79,7 @@
     {{/each}}
   </div>
 
-  <nav class='pagination' aria-label="Pagination navigation">
-    <LinkTo @query={{hash page=this.prevPage}} class="prev" rel="prev" title="previous page" data-test-pagination-prev>
-      {{svg-jar "left-pag"}}
-    </LinkTo>
-    {{#each this.pages as |page|}}
-      <LinkTo @query={{hash page=page}} @title={{concat "Go to page " page}}>{{ page }}</LinkTo>
-    {{/each}}
-    <LinkTo @query={{hash page=this.nextPage}} class="next" rel="next" title="next page" data-test-pagination-next>
-      {{svg-jar "right-pag"}}
-    </LinkTo>
-  </nav>
+  <Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />
 {{else}}
   <div id="no-results">
     <h2>0 crates found. <a href='https://doc.rust-lang.org/cargo/getting-started/'>Get started</a> and create your own.</h2>

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -71,16 +71,6 @@
       {{/each}}
     </div>
 
-    <div class='pagination'>
-      <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-        {{svg-jar "left-pag"}}
-      </LinkTo>
-      {{#each this.pages as |page|}}
-        <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-      {{/each}}
-      <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-        {{svg-jar "right-pag"}}
-      </LinkTo>
-    </div>
+    <Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />
   </div>
 </div>

--- a/app/templates/user.hbs
+++ b/app/templates/user.hbs
@@ -62,16 +62,6 @@
       {{/each}}
     </div>
 
-    <div class='pagination'>
-      <LinkTo @query={{hash page=this.prevPage}} class="prev" @rel="prev" @title="previous page">
-        {{svg-jar "left-pag"}}
-      </LinkTo>
-      {{#each this.pages as |page|}}
-        <LinkTo @query={{hash page=page}}>{{ page }}</LinkTo>
-      {{/each}}
-      <LinkTo @query={{hash page=this.nextPage}} class="next" @rel="next" @title="next page">
-        {{svg-jar "right-pag"}}
-      </LinkTo>
-    </div>
+    <Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />
   </div>
 </div>


### PR DESCRIPTION
Our pagination code was pretty much the same everywhere, so we might as well extract it into a shared component to simplify the styling and have a consistent implementation everywhere that is a11y-compliant.

r? @locks 