### PR TITLE
Add 'unsafe-inline' for style-src CSP

### DIFF
--- a/src/middleware/security_headers.rs
+++ b/src/middleware/security_headers.rs
@@ -39,13 +39,15 @@ impl SecurityHeaders {
         // to load scripts. Remove 'unsafe-eval' if google fixes the issue:
         // https://github.com/google/google-visualization-issues/issues/1356
         // or if we switch to a different graph generation library.
+        //
+        // 'unsafe-inline' for style-src is necessary for Google Charts
         headers.insert(
             "Content-Security-Policy".into(),
             vec![format!(
                 "default-src 'self'; \
                  connect-src 'self' https://docs.rs https://{}; \
                  script-src 'self' 'unsafe-eval' https://www.google.com; \
-                 style-src 'self' https://www.google.com https://ajax.googleapis.com; \
+                 style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com; \
                  img-src *; \
                  object-src 'none'",
                 s3_host


### PR DESCRIPTION
This fixes the following error seen in the console:

> Content Security Policy: The page’s settings blocked the loading of a resource at inline (“style-src”). format+en,default+en,ui+en,corechart+en.I.js:596:193

r? @carols10cents 