### PR TITLE
Remove default null setting of the all_keywords parameter

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -29,7 +29,6 @@ export default Controller.extend(EKMixin, {
         queryParams: {
           q: this.searchQuery,
           page: 1,
-          all_keywords: null,
         },
       });
     },


### PR DESCRIPTION
Fixes #2106, I think.

I don't think we actually need this parameter set to null here?

Alternatively, the backend could be changed to treat "presence but empty" differently than "presence with value", which currently we do not :(