### PR TITLE
mirage: Add basic route handler for `builds.json` API from docs.rs

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -1,5 +1,6 @@
 import * as Categories from './route-handlers/categories';
 import * as Crates from './route-handlers/crates';
+import * as DocsRS from './route-handlers/docs-rs';
 import * as Keywords from './route-handlers/keywords';
 import * as Summary from './route-handlers/summary';
 import * as Teams from './route-handlers/teams';
@@ -8,6 +9,7 @@ import * as Users from './route-handlers/users';
 export default function() {
   Categories.register(this);
   Crates.register(this);
+  DocsRS.register(this);
   Keywords.register(this);
   Summary.register(this);
   Teams.register(this);

--- a/mirage/route-handlers/docs-rs.js
+++ b/mirage/route-handlers/docs-rs.js
@@ -1,0 +1,5 @@
+export function register(server) {
+  server.get('https://docs.rs/crate/:crate/:version/builds.json', function() {
+    return [];
+  });
+}


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/blob/5cc7fb4d17c7400ce4a8db6218d6c773326b8de5/app/routes/crate/version.js#L31 is requesting data from docs.rs that we currently don't catch in our mock server. This MR adds a basic request handler for it that returns an empty response.

r? @locks 