### PR TITLE
mirage/factories: Use predictable values instead of random fake values

### DIFF
--- a/mirage/factories/category.js
+++ b/mirage/factories/category.js
@@ -1,21 +1,21 @@
 import { Factory } from 'ember-cli-mirage';
-import faker from 'faker';
 import { dasherize } from '@ember/string';
 
 export default Factory.extend({
-  category(i) {
-    return `Category ${i}`;
-  },
-
-  id() {
-    return dasherize(this.category);
-  },
+  category: i => `Category ${i}`,
 
   slug() {
     return dasherize(this.category);
   },
 
-  description: () => faker.lorem.sentence(),
-  created_at: () => faker.date.past(),
-  crates_cnt: () => faker.random.number({ max: 5000 }),
+  id() {
+    return this.slug;
+  },
+
+  description() {
+    return `This is the description for the category called "${this.category}"`;
+  },
+
+  created_at: '2010-06-16T21:30:45Z',
+  crates_cnt: 0,
 });

--- a/mirage/factories/crate.js
+++ b/mirage/factories/crate.js
@@ -1,27 +1,26 @@
 import { Factory } from 'ember-cli-mirage';
-import faker from 'faker';
 
 export default Factory.extend({
-  id(i) {
-    return `crate-${i}`;
+  name: i => `crate-${i}`,
+
+  id() {
+    return this.name;
   },
 
-  name() {
-    return this.id;
+  description() {
+    return `This is the description for the crate called "${this.name}"`;
   },
 
-  description: () => faker.lorem.sentence(),
-  downloads: () => faker.random.number({ max: 10000 }),
-  documentation: () => faker.internet.url(),
-  homepage: () => faker.internet.url(),
-  repository: () => faker.internet.url(),
-  max_version: () => faker.system.semver(),
-  newest_version: () => faker.system.semver(),
+  downloads: i => (((i + 13) * 42) % 13) * 12345,
 
-  created_at: () => faker.date.past(),
-  updated_at() {
-    return faker.date.between(this.created_at, new Date());
-  },
+  documentation: null,
+  homepage: null,
+  repository: null,
+  max_version: '1.0.0',
+  newest_version: '1.0.0',
+
+  created_at: '2010-06-16T21:30:45Z',
+  updated_at: '2017-02-24T12:34:56Z',
 
   badges: () => [],
   categories: () => [],

--- a/mirage/factories/version.js
+++ b/mirage/factories/version.js
@@ -1,32 +1,29 @@
 import { Factory } from 'ember-cli-mirage';
-import faker from 'faker';
+
+const LICENSES = ['MIT/Apache-2.0', 'MIT', 'Apache-2.0'];
 
 export default Factory.extend({
-  id: i => i,
+  num: i => `1.0.${i}`,
 
-  // crate: '...',
-
-  num: () => faker.system.semver(),
-
-  created_at: () => faker.date.past(),
-  updated_at() {
-    return faker.date.between(this.created_at, new Date());
-  },
+  created_at: '2010-06-16T21:30:45Z',
+  updated_at: '2017-02-24T12:34:56Z',
 
   yanked: false,
-  license: () => faker.hacker.abbreviation(),
+  license: i => LICENSES[i % LICENSES.length],
 
   dl_path() {
     return `/api/v1/crates/${this.crate}/${this.num}/download`;
   },
 
-  downloads: () => faker.random.number({ max: 10000 }),
+  downloads: i => (((i + 13) * 42) % 13) * 1234,
+
   features: () => {},
   _authors: () => [],
+
+  crate_size: i => (((i + 13) * 42) % 13) * 54321,
 
   afterCreate(version, server) {
     let crate = server.schema.crates.find(version.crate);
     crate.update({ versions: crate.versions.concat(parseInt(version.id, 10)) });
   },
-  crate_size: () => faker.random.number({ max: 10000000 }),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -37526,12 +37526,6 @@
       "integrity": "sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==",
       "dev": true
     },
-    "faker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
-      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8=",
-      "dev": true
-    },
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "eslint-config-prettier": "^6.9.0",
     "eslint-plugin-ember": "^7.7.2",
     "eslint-plugin-prettier": "^3.1.2",
-    "faker": "^4.1.0",
     "loader.js": "^4.7.0",
     "normalize.css": "^8.0.1",
     "nyc": "^15.0.0",

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -15,7 +15,7 @@ module('Acceptance | crate page', function(hooks) {
   test('/crates/:crate is accessible', async function(assert) {
     assert.expect(0);
 
-    this.server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    this.server.create('crate', { name: 'nanomsg', max_version: '0.6.1' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.0' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
@@ -28,7 +28,7 @@ module('Acceptance | crate page', function(hooks) {
   test('/crates/:crate/:version is accessible', async function(assert) {
     assert.expect(0);
 
-    this.server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    this.server.create('crate', { name: 'nanomsg', max_version: '0.6.1' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.0' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
@@ -50,7 +50,7 @@ module('Acceptance | crate page', function(hooks) {
   });
 
   test('visiting a crate page from the front page', async function(assert) {
-    this.server.create('crate', { id: 'nanomsg', newest_version: '0.6.1' });
+    this.server.create('crate', { name: 'nanomsg', newest_version: '0.6.1' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
     await visit('/');
@@ -64,7 +64,7 @@ module('Acceptance | crate page', function(hooks) {
   });
 
   test('visiting /crates/nanomsg', async function(assert) {
-    this.server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    this.server.create('crate', { name: 'nanomsg', max_version: '0.6.1' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.0' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
@@ -79,7 +79,7 @@ module('Acceptance | crate page', function(hooks) {
   });
 
   test('visiting /crates/nanomsg/', async function(assert) {
-    this.server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    this.server.create('crate', { name: 'nanomsg', max_version: '0.6.1' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.0' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 
@@ -94,7 +94,7 @@ module('Acceptance | crate page', function(hooks) {
   });
 
   test('visiting /crates/nanomsg/0.6.0', async function(assert) {
-    this.server.create('crate', { id: 'nanomsg', max_version: '0.6.1' });
+    this.server.create('crate', { name: 'nanomsg', max_version: '0.6.1' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.0' });
     this.server.create('version', { crate: 'nanomsg', num: '0.6.1' });
 

--- a/tests/helpers/setup-mirage.js
+++ b/tests/helpers/setup-mirage.js
@@ -1,5 +1,4 @@
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import faker from 'faker';
 import timekeeper from 'timekeeper';
 
 export default function(hooks) {
@@ -7,7 +6,6 @@ export default function(hooks) {
 
   // To have deterministic visual tests, the seed has to be constant
   hooks.beforeEach(function() {
-    faker.seed(12345);
     timekeeper.freeze(new Date('11/20/2017 12:00'));
   });
 


### PR DESCRIPTION
This generally is easier to work with in my experience. If we want random values we can still generate them on a case-by-case basis, but by default we will have somewhat stable test fixtures now.

This should unblock #2120 :)

r? @locks 