### PR TITLE
mirage: Add `keyword` factory

### DIFF
--- a/mirage/factories/keyword.js
+++ b/mirage/factories/keyword.js
@@ -1,0 +1,11 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  keyword: i => `keyword-${i + 1}`,
+
+  id() {
+    return this.keyword;
+  },
+
+  crates_cnt: 0,
+});

--- a/tests/acceptance/keyword-test.js
+++ b/tests/acceptance/keyword-test.js
@@ -13,7 +13,7 @@ module('Acceptance | keywords', function(hooks) {
   test('keyword/:keyword_id is accessible', async function(assert) {
     assert.expect(0);
 
-    this.server.create('keyword', { id: 'network', keyword: 'network', crates_cnt: 38 });
+    this.server.create('keyword', { keyword: 'network' });
 
     await visit('keywords/network');
     percySnapshot(assert);
@@ -22,7 +22,7 @@ module('Acceptance | keywords', function(hooks) {
   });
 
   test('keyword/:keyword_id index default sort is recent-downloads', async function(assert) {
-    this.server.create('keyword', { id: 'network', keyword: 'network', crates_cnt: 38 });
+    this.server.create('keyword', { keyword: 'network' });
 
     await visit('/keywords/network');
 


### PR DESCRIPTION
This will make it easier to create mock `keyword` resources in the future :)

r? @locks 