### PR TITLE
mirage: Add `team` and `user` factories

### DIFF
--- a/mirage/factories/team.js
+++ b/mirage/factories/team.js
@@ -1,0 +1,17 @@
+import { Factory } from 'ember-cli-mirage';
+
+const ORGS = ['rust-lang', 'emberjs', 'rust-random', 'georust', 'actix'];
+
+export default Factory.extend({
+  name: i => `team-${i + 1}`,
+
+  login(i) {
+    return `github:${ORGS[i % ORGS.length]}:${this.name}`;
+  },
+
+  url(i) {
+    return `https://github.com/${ORGS[i % ORGS.length]}`;
+  },
+
+  avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
+});

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,0 +1,16 @@
+import { Factory } from 'ember-cli-mirage';
+import { dasherize } from '@ember/string';
+
+export default Factory.extend({
+  name: i => `User ${i + 1}`,
+
+  login() {
+    return dasherize(this.name);
+  },
+
+  url() {
+    return `https://github.com/${this.login}`;
+  },
+
+  avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
+});


### PR DESCRIPTION
This is roughly similar to #2128, but for the `team` and `user` resources.

r? @locks 