### PR TITLE
mirage/crates: Return 404 if specified crate can't be found

### DIFF
--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -36,6 +36,8 @@ export function register(server) {
   server.get('/api/v1/crates/:crate_id', function(schema, request) {
     let crateId = request.params.crate_id;
     let crate = schema.crates.find(crateId);
+    if (!crate) return notFound();
+
     let categories = schema.categories.all().filter(category => (crate.categories || []).indexOf(category.id) !== -1);
     let keywords = schema.keywords.all().filter(keyword => (crate.keywords || []).indexOf(keyword.id) !== -1);
     let versions = schema.versions


### PR DESCRIPTION
Our `GET /api/v1/crates/:id` mirage request handler was not handling unknown crates the same way as the production API server. This PR fixes the inconsistency by returning a 404 error if the client requests a crate that does not exist on the mock server.

r? @locks