### PR TITLE
Fix a new lint - clippy::iter-nth-zero

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -252,7 +252,7 @@ impl Crate {
         Self::valid_feature_name(name)
             && name
                 .chars()
-                .nth(0)
+                .next()
                 .map(char::is_alphabetic)
                 .unwrap_or(false)
     }


### PR DESCRIPTION
This lint was recently added to nightly and is a reasonable change.

I plan to r+ soon, so:
r? @ghost