### PR TITLE
mirage: Add factories for `dependency` and `version-download` resources

### DIFF
--- a/mirage/factories/dependency.js
+++ b/mirage/factories/dependency.js
@@ -1,0 +1,15 @@
+import { Factory } from 'ember-cli-mirage';
+
+const REQS = ['^0.1.0', '^2.1.3', '0.3.7', '~5.2.12'];
+
+export default Factory.extend({
+  // crate_id,
+  // version_id,
+
+  default_features: i => i % 4 === 3,
+  features: () => [],
+  kind: i => (i % 3 === 0 ? 'dev' : 'normal'),
+  optional: i => i % 4 !== 3,
+  req: i => REQS[i % REQS.length],
+  target: null,
+});

--- a/mirage/factories/version-download.js
+++ b/mirage/factories/version-download.js
@@ -1,0 +1,8 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  // version
+
+  date: '2019-05-21',
+  downloads: i => (((i * 42) % 13) + 4) * 2345,
+});


### PR DESCRIPTION
similar to #2129 

r? @locks 