### PR TITLE
Improve the maintenance badge user experience

### DIFF
--- a/app/components/badge-maintenance.hbs
+++ b/app/components/badge-maintenance.hbs
@@ -1,9 +1,11 @@
 <span ...attributes>
   {{#unless this.none}}
-    <img
-        src="https://img.shields.io/badge/maintenance-{{this.escapedStatus}}-{{this.color}}.svg"
-        alt="{{this.text}}"
-        title="{{this.text}}">
+    <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata">
+      <img
+          src="https://img.shields.io/badge/maintenance-{{this.escapedStatus}}-{{this.color}}.svg"
+          alt="{{this.text}}"
+          title="{{this.text}}">
+    </a>
   {{/unless}}
 
 </span>

--- a/app/components/badge-maintenance.hbs
+++ b/app/components/badge-maintenance.hbs
@@ -1,6 +1,6 @@
 <span ...attributes>
   {{#unless this.none}}
-    <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata">
+    <a href="https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section">
       <img
           src="https://img.shields.io/badge/maintenance-{{this.escapedStatus}}-{{this.color}}.svg"
           alt="{{this.text}}"

--- a/app/components/badge-maintenance.js
+++ b/app/components/badge-maintenance.js
@@ -33,5 +33,21 @@ export default Component.extend({
     }
   }),
 
-  text: 'Maintenance intention for this crate',
+  // eslint-disable-next-line ember/require-return-from-computed
+  text: computed('badge', function () {
+    switch (this.get('badge.attributes.status')) {
+      case 'actively-developed':
+        return 'Maintenance intention: Actively developed';
+      case 'passively-maintained':
+        return 'Maintenance intention: Passively maintained';
+      case 'as-is':
+        return 'Maintenance intention: As-is';
+      case 'experimental':
+        return 'Maintenance intention: Experimental';
+      case 'looking-for-maintainer':
+        return 'Maintenance intention: Looking for maintainer';
+      case 'deprecated':
+        return 'Maintenance intention: Deprecated';
+    }
+  }),
 });


### PR DESCRIPTION
* Change the alt-text to be a little more descriptive
  and screen-reader friendly
* Link to the Cargo documentation from the badge which describes what the maintenance intentions are

This addresses #2134. Have a read through of my summary for the motivations on the ticket to get a little context of what this is trying to achieve.
