### PR TITLE
Use a modern font stack inspired by Bootstrap 4

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -33,7 +33,8 @@ html {
 html, body { margin: 0; }
 
 body {
-  font-family: "Helvetica Neue","Helvetica",Helvetica,Arial,sans-serif;
+  // Use the modern font stack inspired by Bootstrap 4
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
   font-size: 16px;
   display: flex;
   flex-direction: column;
@@ -101,7 +102,8 @@ pre {
     background: $main-color;
     color: white;
     padding: 20px;
-    font-family: Consolas, Monaco, 'Andale Mono', monospace;
+    // Use the modern font stack inspired by Bootstrap 4
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
 button.dropdown, a.dropdown {


### PR DESCRIPTION
This makes the frontend use a better-looking, more consistent font stack.

## Preview

*Note: The font used depends on the OS (as before). Screenshots below were taken on Fedora 31 with Microsoft fonts installed.*

### Before

![Before](https://user-images.githubusercontent.com/180032/72636756-0a429200-3960-11ea-904d-66f7609eac57.png)

### After

![After](https://user-images.githubusercontent.com/180032/72636762-0d3d8280-3960-11ea-87f9-5243c0968153.png)
