### PR TITLE
Resolves issue 2143

### DIFF
--- a/app/components/crate-list-newest.hbs
+++ b/app/components/crate-list-newest.hbs
@@ -1,7 +1,7 @@
 <ol>
   {{#each @crates as |crate index|}}
     <li>
-      <LinkTo @route="crate.version" @models={{array crate.id crate.newest_version}} class="name" data-test-crate-link={{index}}>
+      <LinkTo @route="crate" @model={{crate.id}} class="name">
         <span>{{ crate.name }} ({{ crate.newest_version }})</span>
         <div class='arrow-in-list'>
           {{svg-jar "right-arrow"}}

--- a/app/components/crate-list-newest.hbs
+++ b/app/components/crate-list-newest.hbs
@@ -1,7 +1,7 @@
 <ol>
   {{#each @crates as |crate index|}}
     <li>
-      <LinkTo @route="crate" @model={{crate.id}} class="name">
+      <LinkTo @route="crate" @model={{crate.id}} class="name" data-test-crate-link={{index}}>
         <span>{{ crate.name }} ({{ crate.newest_version }})</span>
         <div class='arrow-in-list'>
           {{svg-jar "right-arrow"}}

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -247,13 +247,13 @@
   <div id='crate-downloads'>
     <div class='stats'>
       {{#if this.downloadsContext.num}}
-        <h3>
+        <h3 data-test-crate-stats-label>
           Stats Overview for {{this.downloadsContext.num}}
           <LinkTo @route="crate" @model={{this.crate}}>(see all)</LinkTo>
         </h3>
         
       {{else}}
-        <h3>Stats Overview {{this.downloadsContext.num}}</h3>
+        <h3 data-test-crate-stats-label>Stats Overview</h3>
       {{/if}}
       <div class='stat'>
         <span class='num'>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -246,7 +246,15 @@
 {{#unless this.currentVersion.yanked}}
   <div id='crate-downloads'>
     <div class='stats'>
-      <h3>Stats Overview</h3>
+      {{#if this.downloadsContext.num}}
+        <h3>
+          Stats Overview for {{this.downloadsContext.num}}
+          <LinkTo @route="crate" @model={{this.crate}}>(see all)</LinkTo>
+        </h3>
+        
+      {{else}}
+        <h3>Stats Overview {{this.downloadsContext.num}}</h3>
+      {{/if}}
       <div class='stat'>
         <span class='num'>
           {{svg-jar "download"}}

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -56,7 +56,7 @@ module('Acceptance | crate page', function(hooks) {
     await visit('/');
     await click('[data-test-just-updated] [data-test-crate-link="0"]');
 
-    assert.equal(currentURL(), '/crates/nanomsg/0.6.1');
+    assert.equal(currentURL(), '/crates/nanomsg');
     assert.equal(title(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
@@ -76,6 +76,7 @@ module('Acceptance | crate page', function(hooks) {
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
     assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
+    assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview');
   });
 
   test('visiting /crates/nanomsg/', async function(assert) {
@@ -91,6 +92,7 @@ module('Acceptance | crate page', function(hooks) {
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
     assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
+    assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview');
   });
 
   test('visiting /crates/nanomsg/0.6.0', async function(assert) {
@@ -106,6 +108,7 @@ module('Acceptance | crate page', function(hooks) {
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
     assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.0');
+    assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview for 0.6.0 (see all)');
   });
 
   test('navigating to the all versions page', async function(assert) {

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -36,13 +36,13 @@ module('Acceptance | front page', function(hooks) {
     assert.dom('[data-test-total-crates]').hasText('23');
 
     assert.dom('[data-test-new-crates] [data-test-crate-link="0"]').hasText('Inflector (0.1.6)');
-    assert.dom('[data-test-new-crates] [data-test-crate-link="0"]').hasAttribute('href', '/crates/Inflector/0.1.6');
+    assert.dom('[data-test-new-crates] [data-test-crate-link="0"]').hasAttribute('href', '/crates/Inflector');
 
     assert.dom('[data-test-most-downloaded] [data-test-crate-link="0"]').hasText('serde');
     assert.dom('[data-test-most-downloaded] [data-test-crate-link="0"]').hasAttribute('href', '/crates/serde');
 
     assert.dom('[data-test-just-updated] [data-test-crate-link="0"]').hasText('nanomsg (0.6.1)');
-    assert.dom('[data-test-just-updated] [data-test-crate-link="0"]').hasAttribute('href', '/crates/nanomsg/0.6.1');
+    assert.dom('[data-test-just-updated] [data-test-crate-link="0"]').hasAttribute('href', '/crates/nanomsg');
 
     percySnapshot(assert);
   });


### PR DESCRIPTION
I made three changes to improve the experience.

    The homepage links go to the overview instead of a specific version
    I added the version next to the stats, so you can tell what they are for.
    I added a link back to the overview page next to the stats.

On the overview page it looks like this "Stats Overview"
On a specific version it looks like this "Stats Overview for 0.2.4 (see all)"

Resolves issue #2143

Remaking to run job again