### PR TITLE
Ensure the update_downloads job doesn't run concurrently

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -3,3 +3,8 @@ mod update_downloads;
 
 pub use dump_db::dump_db;
 pub use update_downloads::update_downloads;
+
+use diesel::sql_types::BigInt;
+sql_function!(fn pg_try_advisory_xact_lock(key: BigInt) -> Bool);
+
+const UPDATE_DOWNLOADS_ADVISORY_LOCK_KEY: i64 = 1;


### PR DESCRIPTION
If multiple instances of this job are run concurrently then it is
possible to overcount downloads, at least temporarily.  The job first
selects all matching `version_downloads` and later uses those values to
calculate how many downloads to add to `versions` and `crates`.  If a
second job is run, it would select some rows from `version_downloads`
that were already queued for processing by the first task.

If an overcount were to occur, the next time the job is run it should
calculate a negative adjustment and correct the situation.  There's no
point in doing extra work and if we eventually need concurrency we
should built that out intentionally.  Therefore, this commit wraps the
entire job in a transaction and obtains an transaction level advisory
lock from the database.

If the lock has already been taken the job will fail and will be retried
by swirl.  If the duration of this job begins to approach the scheduling
interval, then we will want to increase that interval to avoid
triggering alerts.