### PR TITLE
Fix auth

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -13,17 +13,6 @@ use crate::views::{EncodableMe, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
 pub fn me(req: &mut dyn Request) -> AppResult<Response> {
-    // Changed to getting User information from database because in
-    // src/tests/user.rs, when testing put and get on updating email,
-    // request seems to be somehow 'cached'. When we try to get a
-    // request from the /me route with the just updated user (call
-    // this function) the user is the same as the initial GET request
-    // and does not seem to get the updated user information from the
-    // database
-    // This change is not preferable, we'd rather fix the request,
-    // perhaps adding `req.mut_extensions().insert(user)` to the
-    // update_user route, however this somehow does not seem to work
-
     let conn = req.db_conn()?;
     let user_id = req.authenticate(&conn)?.user_id();
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -5,6 +5,7 @@ use conduit_cookie::RequestSession;
 use failure::Fail;
 use oauth2::{prelude::*, AuthorizationCode, TokenResponse};
 
+use crate::middleware::current_user::TrustedUserId;
 use crate::models::{NewUser, User};
 use crate::schema::users;
 use crate::util::errors::ReadOnlyMode;
@@ -102,7 +103,8 @@ pub fn authorize(req: &mut dyn Request) -> AppResult<Response> {
     let user = ghuser.save_to_database(&token.secret(), &*req.db_conn()?)?;
     req.session()
         .insert("user_id".to_string(), user.id.to_string());
-    req.mut_extensions().insert(user);
+    req.mut_extensions().insert(TrustedUserId(user.id));
+
     super::me::me(req)
 }
 


### PR DESCRIPTION
Set the TrustedUserId in the extensions when logging in

Fixes #2166.

In #2077 (d0b9bccc4cf80d3e311696a7a9e62ee469cce892), we changed the type of the authentication data stored in the extensions from `User` to `TrustedUserId`, but we missed this spot :( We're allowed to insert anything we want into the extensions, but if we use a different type than what we use when looking up data in the extensions, it won't find what we inserted.

I checked all the other locations of `mut_extensions` and `extensions` and I think they're good, but overall this system feels a bit loosey-goosey to me. Not sure how to improve it, though.

r? @jtgeibel 
