### PR TITLE
Remove obsolete `Promise` global override

### DIFF
--- a/app/initializers/set-global-promise.js
+++ b/app/initializers/set-global-promise.js
@@ -1,9 +1,0 @@
-import RSVP from 'rsvp';
-
-export function initialize() {
-  // async/await is using window.Promise by default and we want async/await to
-  // use RSVP instead which is properly integrated with Ember's runloop
-  window.Promise = RSVP.Promise;
-}
-
-export default { initialize };


### PR DESCRIPTION
This is no longer needed in modern Ember.js projects

r? @locks 