### PR TITLE
Use Option::as_deref to convert Option<String> to Option<&str>

### DIFF
--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -223,7 +223,7 @@ fn get_readme(
                 .readme_file
                 .as_ref()
                 .map_or("README.md", |e| &**e),
-            manifest.package.repository.as_ref().map(|e| &**e),
+            manifest.package.repository.as_deref(),
         )
     };
     return Some(rendered);

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -83,7 +83,7 @@ pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
             homepage: new_crate.homepage.as_ref().map(|s| &**s),
             documentation: new_crate.documentation.as_ref().map(|s| &**s),
             readme: new_crate.readme.as_ref().map(|s| &**s),
-            repository: repo.as_ref().map(String::as_str),
+            repository: repo.as_deref(),
             max_upload_size: None,
         };
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -79,15 +79,15 @@ pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
         // Persist the new crate, if it doesn't already exist
         let persist = NewCrate {
             name: &name,
-            description: new_crate.description.as_ref().map(|s| &**s),
-            homepage: new_crate.homepage.as_ref().map(|s| &**s),
-            documentation: new_crate.documentation.as_ref().map(|s| &**s),
-            readme: new_crate.readme.as_ref().map(|s| &**s),
+            description: new_crate.description.as_deref(),
+            homepage: new_crate.homepage.as_deref(),
+            documentation: new_crate.documentation.as_deref(),
+            readme: new_crate.readme.as_deref(),
             repository: repo.as_deref(),
             max_upload_size: None,
         };
 
-        let license_file = new_crate.license_file.as_ref().map(|s| &**s);
+        let license_file = new_crate.license_file.as_deref();
         let krate =
             persist.create_or_update(&conn, user.id, Some(&app.config.publish_rate_limit))?;
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -83,7 +83,7 @@ pub fn authorize(req: &mut dyn Request) -> AppResult<Response> {
     // should have issued earlier.
     {
         let session_state = req.session().remove(&"github_oauth_state".to_string());
-        let session_state = session_state.as_ref().map(|a| &a[..]);
+        let session_state = session_state.as_deref();
         if Some(&state[..]) != session_state {
             return Err(bad_request("invalid state parameter"));
         }
@@ -125,11 +125,11 @@ impl GithubUser {
         NewUser::new(
             self.id,
             &self.login,
-            self.name.as_ref().map(|s| &s[..]),
-            self.avatar_url.as_ref().map(|s| &s[..]),
+            self.name.as_deref(),
+            self.avatar_url.as_deref(),
             access_token,
         )
-        .create_or_update(self.email.as_ref().map(|s| &s[..]), conn)
+        .create_or_update(self.email.as_deref(), conn)
         .map_err(Into::into)
         .or_else(|e: Box<dyn AppError>| {
             // If we're in read only mode, we can't update their details

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -128,7 +128,7 @@ pub fn add_dependencies(
                     optional.eq(dep.optional),
                     default_features.eq(dep.default_features),
                     features.eq(&dep.features),
-                    target.eq(dep.target.as_ref().map(|s| &**s)),
+                    target.eq(dep.target.as_deref()),
                 ),
             ))
         })

--- a/src/render.rs
+++ b/src/render.rs
@@ -231,7 +231,7 @@ pub fn render_and_upload_readme(
     use crate::schema::*;
     use diesel::prelude::*;
 
-    let rendered = readme_to_html(&text, &file_name, base_url.as_ref().map(String::as_str));
+    let rendered = readme_to_html(&text, &file_name, base_url.as_deref());
     let conn = env.connection()?;
 
     conn.transaction(|| {


### PR DESCRIPTION
Option::as_deref was introduced in rustc 1.40.0.  There is a new clippy lint on nightly that recommended the changes in the first commit.  The second commit converts 2 other equivalent syntax forms.  The old forms were:

* `as_ref().map(String::as_str)`
* `as_ref().map(|s| &**s)`
* `as_ref().map(|s| &s[..])`