### PR TITLE
Remove use of private items

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -221,13 +221,11 @@ mod tests {
 
         // All other error types are propogated up the middleware, eventually becoming status 500
         assert!(C(|_| Err(internal(""))).call(&mut req).is_err());
-        assert!(C(|_| err(::serde_json::Error::syntax(
-            ::serde_json::error::ErrorCode::ExpectedColon,
-            0,
-            0
-        )))
-        .call(&mut req)
-        .is_err());
+        assert!(
+            C(|_| err::<::serde_json::Error>(::serde::de::Error::custom("ExpectedColon")))
+                .call(&mut req)
+                .is_err()
+        );
         assert!(
             C(|_| err(::std::io::Error::new(::std::io::ErrorKind::Other, "")))
                 .call(&mut req)


### PR DESCRIPTION
`serde_json` tweaks the visibility of `ErrorCode` and `syntax()` so they are not available with further version(1.0.45). I don't update deps at this point but this tweak should be useful for further work.