### PR TITLE
Make crate stats look more consistent

### DIFF
--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -19,7 +19,7 @@
   <div class='stats'>
     <div class='downloads' data-test-downloads>
       {{svg-jar "download"}}
-      <span class='num'>All-Time: {{ format-num this.crate.downloads }}</span>
+      <span class='num'><abbr title="Total number of downloads">All-Time:</abbr> {{ format-num this.crate.downloads }}</span>
     </div>
     <div class="recent-downloads" data-test-recent-downloads>
       {{svg-jar "download"}}
@@ -27,9 +27,12 @@
     </div>
     <div class="updated-at" >
       {{svg-jar "latest-updates" height="32" width="32"}}
-      <time title="Last updated: {{ this.crate.updated_at }}" datetime="{{ moment-format this.crate.updated_at 'YYYY-MM-DDTHH:mm:ssZ' }}" data-test-updated-at>
-        {{ moment-from-now this.crate.updated_at }}
-      </time>
+      <span>
+        <abbr title="The last time crate was updated">Updated:</abbr>
+        <time title="Last updated: {{ this.crate.updated_at }}" datetime="{{ moment-format this.crate.updated_at 'YYYY-MM-DDTHH:mm:ssZ' }}" data-test-updated-at>
+          {{ moment-from-now this.crate.updated_at }}
+        </time>
+      </span>
     </div>
   </div>
   <div class="quick-links">


### PR DESCRIPTION
<img width="1026" alt="Screenshot 2020-02-16 at 19 20 05" src="https://user-images.githubusercontent.com/110424/74610296-3d5c7a80-50f2-11ea-93cd-aa96b990f5c9.png">
