### PR TITLE
Add rustless.org to documentation blocklist

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -22,7 +22,7 @@ use crate::schema::*;
 
 /// Hosts in this list are known to not be hosting documentation,
 /// and are possibly of malicious intent e.g. ad tracking networks, etc.
-const DOCUMENTATION_BLOCKLIST: [&str; 1] = ["rust-ci.org"];
+const DOCUMENTATION_BLOCKLIST: [&str; 2] = ["rust-ci.org", "rustless.org"];
 
 #[derive(Debug, Queryable, Identifiable, Associations, Clone, Copy)]
 #[belongs_to(Crate)]


### PR DESCRIPTION
Found on: https://crates.io/crates/valico

No longer hosts any kind of rust documentation.

r? @carols10cents 