### PR TITLE
Bump eslint-plugin-ember from 7.7.2 to 7.8.1

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
+// eslint-disable-next-line ember/no-observers
 import { computed, observer } from '@ember/object';
 import moment from 'moment';
 

--- a/app/mixins/rl-dropdown-component.js
+++ b/app/mixins/rl-dropdown-component.js
@@ -1,4 +1,5 @@
 import Mixin from '@ember/object/mixin';
+// eslint-disable-next-line ember/no-observers
 import { observer } from '@ember/object';
 import { on } from '@ember/object/evented';
 import { bind, later } from '@ember/runloop';

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-observers
 import { observer } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';

--- a/package-lock.json
+++ b/package-lock.json
@@ -16555,12 +16555,12 @@
       }
     },
     "dot-case": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.2.tgz",
-      "integrity": "sha512-z3vMZEW2o3btKlM9I6FQF0pIWTzBuW+udrAaJr+A6JA3+p62ADZjeFthKxqxKHZlUxQmkKeEWvaKLJdwpc5u6g==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.3.tgz",
+      "integrity": "sha512-7hwEmg6RiSQfm/GwPL4AAWXKy3YNNZA3oFv2Pdiey0mwkRCPZ9x6SZbkLcn8Ma5PYeVokzoD4Twv2n7LKp5WeA==",
       "dev": true,
       "requires": {
-        "no-case": "^3.0.2",
+        "no-case": "^3.0.3",
         "tslib": "^1.10.0"
       },
       "dependencies": {
@@ -36220,6 +36220,12 @@
         }
       }
     },
+    "ember-rfc176-data": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz",
+      "integrity": "sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==",
+      "dev": true
+    },
     "ember-router-generator": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ember-router-generator/-/ember-router-generator-2.0.0.tgz",
@@ -40278,22 +40284,14 @@
       }
     },
     "eslint-plugin-ember": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-7.7.2.tgz",
-      "integrity": "sha512-Ua7+xePz8m0BrqSHfYibkRXWQMMb5RBsH9ohZy2a7ri+s6+UQre9x3BxPpawCLZMzQzIG4vQh93YiVGCSv3XYA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ember/-/eslint-plugin-ember-7.8.1.tgz",
+      "integrity": "sha512-74Whm5MHV+llWv0LA/4b4IaLQxMTj5Jc1zoK11gYEPQbPIAviTF4JsRuzPM/x7QMo5pQZyTdfGYF5zVMbgQ2RA==",
       "dev": true,
       "requires": {
         "@ember-data/rfc395-data": "^0.0.4",
         "ember-rfc176-data": "^0.3.12",
-        "snake-case": "^3.0.2"
-      },
-      "dependencies": {
-        "ember-rfc176-data": {
-          "version": "0.3.12",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz",
-          "integrity": "sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==",
-          "dev": true
-        }
+        "snake-case": "^3.0.3"
       }
     },
     "eslint-plugin-prettier": {
@@ -45706,9 +45704,9 @@
       "dev": true
     },
     "no-case": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.2.tgz",
-      "integrity": "sha512-Yber3mEOA3T9+as7Z70TJUQCUPRmmq6s8NmsZX5aSB1qk+Mt+3a5JVPpnAnONUShLTkMDF4PJY3h0GKlXdRTNA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.3.tgz",
+      "integrity": "sha512-ehY/mVQCf9BL0gKfsJBvFJen+1V//U+0HQMPrWct40ixE4jnv0bfvxDbWtAHL9EcaPEOJHVVYKoQn1TlZUB8Tw==",
       "dev": true,
       "requires": {
         "lower-case": "^2.0.1",
@@ -49038,12 +49036,12 @@
       }
     },
     "snake-case": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.2.tgz",
-      "integrity": "sha512-1fRJdasXJTcsrGnUkDsnKNjHoP9NGclbIkYyY6Vv0vBVgz32rqhPFPg/Y0yIP4hwOd41Dh8rocCRHjNIuK4EZg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.3.tgz",
+      "integrity": "sha512-WM1sIXEO+rsAHBKjGf/6R1HBBcgbncKS08d2Aqec/mrDSpU80SiOU41hO7ny6DToHSyrlwTYzQBIK1FPSx4Y3Q==",
       "dev": true,
       "requires": {
-        "dot-case": "^3.0.2",
+        "dot-case": "^3.0.3",
         "tslib": "^1.10.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "ember-window-mock": "^0.6.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
-    "eslint-plugin-ember": "^7.7.2",
+    "eslint-plugin-ember": "^7.8.1",
     "eslint-plugin-prettier": "^3.1.2",
     "loader.js": "^4.7.0",
     "normalize.css": "^8.0.1",


### PR DESCRIPTION
`no-observers` now complains imports. We can also disable at file level, it's an option.

Closes #2198
r? @locks
