### PR TITLE
Don't return `Ok` if update handler isn't run

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -203,6 +203,7 @@ impl Repository {
 
         // git push
         let mut ref_status = Ok(());
+        let mut callback_called = false;
         {
             let mut origin = self.repository.find_remote("origin")?;
             let mut callbacks = git2::RemoteCallbacks::new();
@@ -214,12 +215,18 @@ impl Repository {
                 if let Some(s) = status {
                     ref_status = Err(format!("failed to push a ref: {}", s).into())
                 }
+                callback_called = true;
                 Ok(())
             });
             let mut opts = git2::PushOptions::new();
             opts.remote_callbacks(callbacks);
             origin.push(&["refs/heads/master"], Some(&mut opts))?;
         }
+
+        if !callback_called {
+            ref_status = Err("update_reference callback was not called".into());
+        }
+
         ref_status
     }
 


### PR DESCRIPTION
We're losing jobs to publish crates. It's not clear why. The requests
are returning 200, which implies they are being queued correctly. There
is no log to indicate that these jobs failed, so right now I believe
that this job is erroneously returning `Ok` when it failed. Given GitHub
is having a partial outage, that seems to reinforce this theory.

From looking at the code, this looks like the only way we could have
returned `Ok` when the publish failed. I believe we got some sort of
error response (or lack of one) from GitHub that caused this callback
not to be run.