### PR TITLE
Bump to alpha releases of conduit-* crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,22 +108,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
-dependencies = [
- "byteorder",
- "safemem 0.2.0",
-]
-
-[[package]]
-name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 dependencies = [
  "byteorder",
- "safemem 0.3.3",
+ "safemem",
 ]
 
 [[package]]
@@ -192,7 +182,7 @@ name = "cargo-registry"
 version = "0.2.2"
 dependencies = [
  "ammonia",
- "base64 0.9.3",
+ "base64 0.11.0",
  "cargo-registry-s3",
  "chrono",
  "civet",
@@ -254,7 +244,7 @@ dependencies = [
 name = "cargo-registry-s3"
 version = "0.2.0"
 dependencies = [
- "base64 0.6.0",
+ "base64 0.11.0",
  "chrono",
  "openssl",
  "reqwest",
@@ -2154,12 +2144,6 @@ name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-
-[[package]]
-name = "safemem"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 
 [[package]]
 name = "safemem"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,20 +8,11 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
-dependencies = [
- "memchr 0.1.11",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
 ]
 
 [[package]]
@@ -31,7 +22,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89eac85170f4b3fb3dc5e442c1cfb036cb8eecf9dbbd431a161ffad15d90ea3b"
 dependencies = [
  "html5ever",
- "lazy_static 1.4.0",
+ "lazy_static",
  "maplit",
  "markup5ever_rcdom",
  "matches",
@@ -64,9 +55,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670843da104a1339d46c967382f78d9debb1713aee20e09ba1b25445076f40f4"
 dependencies = [
  "bytes",
- "flate2 1.0.13",
+ "flate2",
  "futures-core",
- "memchr 2.3.3",
+ "memchr",
  "pin-project-lite",
 ]
 
@@ -225,7 +216,7 @@ dependencies = [
  "dotenv",
  "env_logger",
  "failure",
- "flate2 1.0.13",
+ "flate2",
  "futures-channel",
  "futures-util",
  "git2",
@@ -236,7 +227,7 @@ dependencies = [
  "hyper-tls",
  "indexmap",
  "jemallocator",
- "lazy_static 1.4.0",
+ "lazy_static",
  "lettre",
  "lettre_email",
  "license-exprs",
@@ -247,7 +238,7 @@ dependencies = [
  "rand 0.6.5",
  "reqwest",
  "scheduled-thread-pool",
- "semver 0.9.0",
+ "semver 0.9.0 (git+https://github.com/steveklabnik/semver.git)",
  "serde",
  "serde_json",
  "swirl",
@@ -296,14 +287,14 @@ dependencies = [
 
 [[package]]
 name = "civet"
-version = "0.9.1"
+version = "0.12.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6263e7af767a5bf9e4d3d0a6c3ceb5f3940ec85cf2fbfee59024b8a264be180f"
+checksum = "5f5ae04519752da172ab2e82540b28244da241064aa50e64de83645d0ae8d952"
 dependencies = [
  "civet-sys",
  "conduit",
  "libc",
- "semver 0.5.1",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -328,10 +319,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c6a70fb894be1bf51ca939f9e9008d93679908541793a6bf752bd313640a1d8"
 dependencies = [
  "entities",
- "lazy_static 1.4.0",
+ "lazy_static",
  "pest",
  "pest_derive",
- "regex 1.2.1",
+ "regex",
  "twoway",
  "typed-arena",
  "unicode_categories",
@@ -339,18 +330,18 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.8.1"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0caa30f78c207dc14c071b62512253ece5c4459897815682786aff1028bc82"
+checksum = "37ae2b5937afd049324f246e5ecd1d628bd23ba221879b9f56cd45674e9194bf"
 dependencies = [
- "semver 0.5.1",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conduit-conditional-get"
-version = "0.8.0"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614f67083e437fd0b8fb9f13067203f358f1c6f52989eb6539292fde007fc6d6"
+checksum = "2b1e0b06d987366f9fc85a76260bc4057bab5dcc73f85b23fb633a49d8130136"
 dependencies = [
  "conduit",
  "conduit-middleware",
@@ -359,11 +350,11 @@ dependencies = [
 
 [[package]]
 name = "conduit-cookie"
-version = "0.8.5"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cef818a14458d6b074a813a1934cfa4d8dc098f859307f4a3d17cc0dc91361"
+checksum = "8cdba83653b08d6b2f082433e678ece2039f25f554fb68daf2a39f8c9ad351af"
 dependencies = [
- "base64 0.6.0",
+ "base64 0.11.0",
  "conduit",
  "conduit-middleware",
  "cookie",
@@ -371,25 +362,25 @@ dependencies = [
 
 [[package]]
 name = "conduit-git-http-backend"
-version = "0.8.0"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027a1900afd70becd52b5061afc85a24de6af0d9199f39d4e1af8b7ac55fbe6e"
+checksum = "4cf9cbbd931a7f6ecc159a70325e3e487f5f96a7310d02abbf62846e12ce9eab"
 dependencies = [
  "conduit",
- "flate2 0.2.20",
+ "flate2",
 ]
 
 [[package]]
 name = "conduit-hyper"
-version = "0.2.0"
+version = "0.3.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ad0f3d682827dec2b41ead1c954ba7829d8d20e168e51c239bb33dab67c1aae"
+checksum = "8802341cb1b01e4fc706804edde75789927fc3b05f9a0235ef59507dac5b0acf"
 dependencies = [
  "conduit",
  "futures",
  "http",
  "hyper",
- "semver 0.5.1",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tower-service",
  "tracing",
@@ -397,12 +388,12 @@ dependencies = [
 
 [[package]]
 name = "conduit-middleware"
-version = "0.8.1"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b4b5a3a60b976f9219490e895cf573a6d17547e009e3c0e9f01a584b5b74d0"
+checksum = "83cc6359459dc275cd9715aa84954ed861d0f68bde9e1f53edf494113a9ea005"
 dependencies = [
  "conduit",
- "semver 0.5.1",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -416,44 +407,44 @@ dependencies = [
 
 [[package]]
 name = "conduit-router"
-version = "0.8.0"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70ad2d0c8c41ada8ad4ff35070652972d75da7e7bccfb6d1d23463b1714c3ec"
+checksum = "7cbe1cb2c36d3ec99795c6c2fe6fc54199513240166a16f7cf471d8b8a1d5287"
 dependencies = [
  "conduit",
  "route-recognizer",
- "semver 0.5.1",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conduit-static"
-version = "0.8.1"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5dadad9ced84acc9f67c778c25cec1c1065d6503d283cc6a1b2a4e545752d51"
+checksum = "9937e95a4192c239ed588a1d8190126441435de5bebcc7d0db34474c21c9558c"
 dependencies = [
  "conduit",
  "conduit-mime-types",
- "filetime 0.1.15",
+ "filetime",
  "time",
 ]
 
 [[package]]
 name = "conduit-test"
-version = "0.8.1"
+version = "0.9.0-alpha.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75684ce3713e1507fbf85796c9e74e7c4c8148bc82bcf823fec83b551189d429"
+checksum = "d81b2a279a7630087a56e8772ddef85670ae4d53dd2c9dbe361866ec0be9842f"
 dependencies = [
  "conduit",
- "semver 0.5.1",
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cookie"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465f8134efa296b4c19db34d909637cb2bf0f7aaf21299e23e18fa29ac557cf"
+checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 dependencies = [
- "base64 0.9.3",
+ "base64 0.10.1",
  "ring",
  "time",
 ]
@@ -604,8 +595,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
 dependencies = [
- "lazy_static 1.4.0",
- "regex 1.2.1",
+ "lazy_static",
+ "regex",
  "serde",
  "strsim",
 ]
@@ -631,7 +622,7 @@ dependencies = [
  "base64 0.9.3",
  "chrono",
  "encoding",
- "lazy_static 1.4.0",
+ "lazy_static",
  "rand 0.4.2",
  "time",
  "version_check 0.1.5",
@@ -725,7 +716,7 @@ dependencies = [
  "atty",
  "humantime",
  "log",
- "regex 1.2.1",
+ "regex",
  "termcolor",
 ]
 
@@ -768,17 +759,6 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
-name = "filetime"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "450537dc346f0c4d738dda31e790da1da5d4bd12145aad4da0d03d713cb3794f"
@@ -787,16 +767,6 @@ dependencies = [
  "libc",
  "redox_syscall",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "flate2"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
-dependencies = [
- "libc",
- "miniz-sys",
 ]
 
 [[package]]
@@ -954,7 +924,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr 2.3.3",
+ "memchr",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1268,12 +1238,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -1430,15 +1394,6 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
@@ -1478,16 +1433,6 @@ checksum = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "miniz-sys"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -1547,7 +1492,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1595,7 +1540,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
  "version_check 0.1.5",
 ]
 
@@ -1655,7 +1600,7 @@ dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "openssl-sys",
 ]
@@ -2110,34 +2055,15 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-dependencies = [
- "aho-corasick 0.5.3",
- "memchr 0.1.11",
- "regex-syntax 0.3.9",
- "thread_local 0.2.7",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
 dependencies = [
- "aho-corasick 0.7.6",
- "memchr 2.3.3",
- "regex-syntax 0.6.11",
- "thread_local 0.3.6",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+ "thread_local",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 
 [[package]]
 name = "regex-syntax"
@@ -2171,7 +2097,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "js-sys",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "mime",
  "mime_guess",
@@ -2193,14 +2119,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.13.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4db68a2e35f3497146b7e4563df7d4773a2433230c5e4b448328e31740458a"
+checksum = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 dependencies = [
  "cc",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
+ "spin",
  "untrusted",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -2245,7 +2173,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507a9e6e8ffe0a4e0ebb9a10293e62fdf7657c06f1b8bb07a8fcf697d2abf295"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi 0.3.8",
 ]
 
@@ -2287,31 +2215,21 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2ff60ecdb19c255841c066cbfa5f8c2a4ada1eb3ae47c77ab6667128da71f5"
+version = "0.9.0"
+source = "git+https://github.com/steveklabnik/semver.git#27c2b066cc0d3818f8b2047388ce29be2e4c97e1"
 dependencies = [
- "semver-parser 0.6.2",
+ "diesel",
+ "semver-parser",
+ "serde",
 ]
 
 [[package]]
 name = "semver"
 version = "0.9.0"
-source = "git+https://github.com/steveklabnik/semver.git#27c2b066cc0d3818f8b2047388ce29be2e4c97e1"
-dependencies = [
- "diesel",
- "semver-parser 0.7.0",
- "serde",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fff3c9c5a54636ab95acd8c1349926e04cb1eb8cd70b5adced8a1d1f703a67"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "lazy_static 0.2.11",
- "regex 0.1.80",
+ "semver-parser",
 ]
 
 [[package]]
@@ -2428,12 +2346,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
 name = "string_cache"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2940c75beb4e3bf3a494cef919a747a2cb81e52571e212bfbd185074add7208a"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "new_debug_unreachable",
  "phf_shared",
  "precomputed-hash",
@@ -2521,7 +2445,7 @@ version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 dependencies = [
- "filetime 0.2.6",
+ "filetime",
  "libc",
  "redox_syscall",
  "xattr",
@@ -2562,31 +2486,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-dependencies = [
- "kernel32-sys",
- "libc",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
-dependencies = [
- "thread-id",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -2619,9 +2524,9 @@ dependencies = [
  "fnv",
  "futures-core",
  "iovec",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
- "memchr 2.3.3",
+ "memchr",
  "mio",
  "mio-uds",
  "num_cpus",
@@ -2698,7 +2603,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a46f11e372b8bd4b4398ea54353412fdd7fd42a8370c7e543e218cf7661978"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -2713,7 +2618,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59b11b2b5241ba34be09c3cc85a36e56e48f9888862e19cedf23336d35316ed1"
 dependencies = [
- "memchr 2.3.3",
+ "memchr",
 ]
 
 [[package]]
@@ -2814,12 +2719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
 
 [[package]]
-name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
-
-[[package]]
 name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,7 +2786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0da9c9a19850d3af6df1cb9574970b566d617ecfaf36eb0b706b6f3ef9bd2f8"
 dependencies = [
  "bumpalo",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "proc-macro2 1.0.9",
  "quote 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ flate2 = "1.0"
 semver = { version = "0.9", git = "https://github.com/steveklabnik/semver.git", features = ["diesel", "serde"] }
 url = "1.2.1"
 tar = "0.4.16"
-base64 = "0.9"
+base64 = "0.11"
 
 openssl = "0.10.13"
 oauth2 = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,16 +66,16 @@ lettre = "0.9"
 lettre_email = "0.9"
 failure = "0.1.1"
 
-conduit = "0.8"
-conduit-conditional-get = "0.8"
-conduit-cookie = "0.8.5"
-cookie = "0.11"
-conduit-middleware = "0.8"
-conduit-router = "0.8"
-conduit-static = "0.8"
-conduit-git-http-backend = "0.8"
-civet = "0.9"
-conduit-hyper = "0.2.0"
+conduit = "0.9.0-alpha.0"
+conduit-conditional-get = "0.9.0-alpha.0"
+conduit-cookie = "0.9.0-alpha.0"
+cookie = { version = "0.12", features = ["secure"] }
+conduit-middleware = "0.9.0-alpha.0"
+conduit-router = "0.9.0-alpha.0"
+conduit-static = "0.9.0-alpha.0"
+conduit-git-http-backend = "0.9.0-alpha.0"
+civet = "0.12.0-alpha.1"
+conduit-hyper = "0.3.0-alpha.0"
 
 futures-util = "0.3"
 futures-channel = { version = "0.3.1", default-features = false }
@@ -86,7 +86,7 @@ indexmap = "1.0.2"
 handlebars = "3.0.1"
 
 [dev-dependencies]
-conduit-test = "0.8"
+conduit-test = "0.9.0-alpha.0"
 hyper-tls = "0.4"
 lazy_static = "1.0"
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }

--- a/src/s3/Cargo.toml
+++ b/src/s3/Cargo.toml
@@ -14,7 +14,7 @@ name = "s3"
 path = "lib.rs"
 
 [dependencies]
-base64 = "0.6"
+base64 = "0.11"
 chrono = "0.4"
 openssl = "0.10.13"
 reqwest = { version = "0.10", features = ["blocking"] }


### PR DESCRIPTION
These upstream packages have been updated to prune old dependencies and
include no functional changes at this time.  This PR removes 14
dependencies.

The updated version of `civet` is based on the 0.9 release we have been
pinned to.  The 0.12 release abandons the attempts to update to the
underlying library which resulted in build failures on macOS for the
0.10 and 0.11 releases.