### PR TITLE
helpers/format-num: Simplify implementation using `Intl.NumberFormat`

### DIFF
--- a/app/helpers/format-num.js
+++ b/app/helpers/format-num.js
@@ -1,22 +1,9 @@
 import { helper } from '@ember/component/helper';
 
-export function formatNum(value) {
-  if (value === 0) {
-    return '0';
-  }
+const numberFormat = new Intl.NumberFormat('en');
 
-  let ret = '';
-  let cnt = 0;
-  while (value > 0) {
-    if (cnt > 0 && cnt % 3 === 0) {
-      ret = `,${ret}`;
-      cnt = 0;
-    }
-    ret = (value % 10) + ret;
-    cnt += 1;
-    value = Math.floor(value / 10);
-  }
-  return ret;
+export function formatNum(value) {
+  return numberFormat.format(value);
 }
 
 export default helper(params => formatNum(params[0]));


### PR DESCRIPTION
There is no need to implement this ourselves, and using the native browser APIs for this will make it easier in the future to localize the application.