### PR TITLE
Revert #2201 to fix broken new token button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36425,9 +36425,9 @@
       }
     },
     "ember-source": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.16.2.tgz",
-      "integrity": "sha512-aRF90V88rJ6h47ootUw8oGcV7O4ulwLYNVqnokTr9RTeWjEimwMtzLLazUfDR1LZMkdMTLVLGcQkJCJVvUAg5A==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/ember-source/-/ember-source-3.16.1.tgz",
+      "integrity": "sha512-4cYfQ+DsqeSTqG0RztuTsh8d8p0XdeIaPWe9Ol229GhQjM1JgpjQNTXGJDTIB8FfbAxycPlCwIk2qXygA+pFsA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "ember-resolver": "^7.0.0",
     "ember-router-scroll": "^2.0.0",
     "ember-template-lint": "^1.13.2",
-    "ember-source": "~3.16.2",
+    "ember-source": "~3.16.1",
     "ember-svg-jar": "^2.2.3",
     "ember-test-selectors": "^3.0.0",
     "ember-web-app": "^4.0.0",


### PR DESCRIPTION
I've bisected the issue with the broken "New Token" button to this merge.  What is very strange is that the original commit 28a03bfd that implemented the change does not appear to have this issue.  Therefore it seems the issue is some sort of conflict between multiple pull requests somewhere in https://github.com/rust-lang/crates.io/compare/c970817d...663259cb.

I'm deploying to staging now and will deploy to production as soon as I test the change there.

cc @locks
r? @ghost