### PR TITLE
Increase the default thread count to 5 in development

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"))
         .unwrap_or_else(|_| {
             if config.env == Env::Development {
-                1
+                5
             } else {
                 50
             }


### PR DESCRIPTION
When using `conduit-hyper` to serve requests, if the max thread count is
reached then new requests are rejected immediately rather than blocking.
The fallback value for `SERVER_THREADS` is increased to ease local
testing when setting `USE_HYPER=1`.

cc #2204
r? @carols10cents