### PR TITLE
Use `Vec::with_capacity()` as possible

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -115,7 +115,7 @@ fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
         }
 
         let comma_sep_msg = if add {
-            let mut msgs = Vec::new();
+            let mut msgs = Vec::with_capacity(logins.len());
             for login in &logins {
                 let login_test =
                     |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -245,7 +245,9 @@ fn parse_new_headers(req: &mut dyn Request) -> AppResult<EncodableCrateUpload> {
     fn empty(s: Option<&String>) -> bool {
         s.map_or(true, String::is_empty)
     }
-    let mut missing = Vec::new();
+
+    // It can have up to three elements per below conditions.
+    let mut missing = Vec::with_capacity(3);
 
     if empty(new.description.as_ref()) {
         missing.push("description");

--- a/src/tasks/dump_db/gen_scripts.rs
+++ b/src/tasks/dump_db/gen_scripts.rs
@@ -91,7 +91,6 @@ impl VisibilityConfig {
     ///
     /// Returns a vector of table names.
     fn topological_sort(&self) -> Vec<&str> {
-        let mut result = Vec::new();
         let mut num_deps = BTreeMap::new();
         let mut rev_deps: BTreeMap<_, Vec<_>> = BTreeMap::new();
         for (table, config) in self.0.iter() {
@@ -108,6 +107,7 @@ impl VisibilityConfig {
             .filter(|(_, &count)| count == 0)
             .map(|(&table, _)| table)
             .collect();
+        let mut result = Vec::with_capacity(ready.len());
         while let Some(table) = ready.pop_front() {
             result.push(table);
             for dep in rev_deps.get(table).iter().cloned().flatten() {


### PR DESCRIPTION
It's a minor cleanup, uses `Vec::with_capacity()` as possible to prevent reallocation.