### PR TITLE
Add a log message to add_crate background job

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -267,12 +267,11 @@ pub fn add_crate(env: &Environment, krate: Crate) -> Result<(), PerformError> {
     serde_json::to_writer(&mut file, &krate)?;
     file.write_all(b"\n")?;
 
-    println!("Updating crate `{}#{}`", krate.name, krate.vers);
+    let message: String = format!("Updating crate `{}#{}`", krate.name, krate.vers);
 
-    repo.commit_and_push(
-        &format!("Updating crate `{}#{}`", krate.name, krate.vers),
-        &repo.relative_index_file(&krate.name),
-    )
+    println!("{}", message);
+
+    repo.commit_and_push(&message, &repo.relative_index_file(&krate.name))
 }
 
 /// Yanks or unyanks a crate version. This requires finding the index
@@ -322,15 +321,14 @@ pub fn yank(
         let new = new?.join("\n") + "\n";
         fs::write(&dst, new.as_bytes())?;
 
-        repo.commit_and_push(
-            &format!(
-                "{} crate `{}#{}`",
-                if yanked { "Yanking" } else { "Unyanking" },
-                krate,
-                version.num
-            ),
-            &repo.relative_index_file(&krate),
-        )?;
+        let message: String = format!(
+            "{} crate `{}#{}`",
+            if yanked { "Yanking" } else { "Unyanking" },
+            krate,
+            version.num
+        );
+
+        repo.commit_and_push(&message, &repo.relative_index_file(&krate))?;
 
         diesel::update(&version)
             .set(versions::yanked.eq(yanked))

--- a/src/git.rs
+++ b/src/git.rs
@@ -186,9 +186,7 @@ impl Repository {
         }
     }
 
-    fn commit_and_push(&self, msg: &str, modified_file: &Path) -> Result<(), PerformError> {
-        println!("commit_and_push: Preparing \"{}\"", msg);
-
+    fn perform_commit_and_push(&self, msg: &str, modified_file: &Path) -> Result<(), PerformError> {
         // git add $file
         let mut index = self.repository.index()?;
         index.add_path(modified_file)?;
@@ -229,9 +227,18 @@ impl Repository {
             ref_status = Err("update_reference callback was not called".into());
         }
 
-        println!("commit_and_push: Finished with \"{}\"", msg);
-
         ref_status
+    }
+
+    pub fn commit_and_push(&self, message: &str, modified_file: &Path) -> Result<(), PerformError> {
+        println!("Committing and pushing \"{}\"", message);
+
+        self.perform_commit_and_push(message, modified_file)
+            .map(|_| println!("Commit and push finished for \"{}\"", message))
+            .map_err(|err| {
+                eprintln!("Commit and push errored: {}", err);
+                err
+            })
     }
 
     pub fn reset_head(&self) -> Result<(), PerformError> {

--- a/src/git.rs
+++ b/src/git.rs
@@ -187,6 +187,8 @@ impl Repository {
     }
 
     fn commit_and_push(&self, msg: &str, modified_file: &Path) -> Result<(), PerformError> {
+        println!("commit_and_push: Preparing \"{}\"", msg);
+
         // git add $file
         let mut index = self.repository.index()?;
         index.add_path(modified_file)?;
@@ -200,6 +202,8 @@ impl Repository {
         let sig = self.repository.signature()?;
         self.repository
             .commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[&parent])?;
+
+        println!("commit_and_push: Pushing \"{}\"", msg);
 
         // git push
         let mut ref_status = Ok(());
@@ -226,6 +230,8 @@ impl Repository {
         if !callback_called {
             ref_status = Err("update_reference callback was not called".into());
         }
+
+        println!("commit_and_push: Finished with \"{}\"", msg);
 
         ref_status
     }
@@ -268,8 +274,6 @@ pub fn add_crate(env: &Environment, krate: Crate) -> Result<(), PerformError> {
     file.write_all(b"\n")?;
 
     let message: String = format!("Updating crate `{}#{}`", krate.name, krate.vers);
-
-    println!("{}", message);
 
     repo.commit_and_push(&message, &repo.relative_index_file(&krate.name))
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -236,7 +236,7 @@ impl Repository {
         self.perform_commit_and_push(message, modified_file)
             .map(|_| println!("Commit and push finished for \"{}\"", message))
             .map_err(|err| {
-                eprintln!("Commit and push errored: {}", err);
+                eprintln!("Commit and push for \"{}\" errored: {}", message, err);
                 err
             })
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -203,8 +203,6 @@ impl Repository {
         self.repository
             .commit(Some("HEAD"), &sig, &sig, &msg, &tree, &[&parent])?;
 
-        println!("commit_and_push: Pushing \"{}\"", msg);
-
         // git push
         let mut ref_status = Ok(());
         let mut callback_called = false;

--- a/src/git.rs
+++ b/src/git.rs
@@ -267,6 +267,8 @@ pub fn add_crate(env: &Environment, krate: Crate) -> Result<(), PerformError> {
     serde_json::to_writer(&mut file, &krate)?;
     file.write_all(b"\n")?;
 
+    println!("Updating crate `{}#{}`", krate.name, krate.vers);
+
     repo.commit_and_push(
         &format!("Updating crate `{}#{}`", krate.name, krate.vers),
         &repo.relative_index_file(&krate.name),


### PR DESCRIPTION
Per #2226; is this sufficient to resolve that issue?

This PR simply adds a log message (`println!`) right before carrying out the final `commit_and_push` operation, which could otherwise fail silently if the Git host is experiencing an outage.