### PR TITLE
Log inner chained errors

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -8,6 +8,8 @@ mod frontend_prelude {
     pub use crate::util::errors::{bad_request, server_error};
 }
 
+pub(crate) use prelude::RequestUtils;
+
 mod prelude {
     pub use super::helpers::ok_true;
     pub use diesel::prelude::*;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -232,7 +232,7 @@ pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
 fn parse_new_headers(req: &mut dyn Request) -> AppResult<EncodableCrateUpload> {
     // Read the json upload request
     let metadata_length = u64::from(read_le_u32(req.body())?);
-    req.mut_extensions().insert(metadata_length);
+    req.log_metadata("metadata_length", metadata_length);
 
     let max = req.app().config.max_upload_size;
     if metadata_length > max {

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -98,10 +98,6 @@ impl Display for RequestLine<'_> {
             }
         }
 
-        if let Some(len) = self.req.extensions().find::<u64>() {
-            line.add_field("metadata_length", len)?;
-        }
-
         if let Err(err) = self.res {
             line.add_quoted_field("error", err)?;
         }

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -58,6 +58,16 @@ pub fn add_custom_metadata<V: Display>(req: &mut dyn Request, key: &'static str,
     }
 }
 
+#[cfg(test)]
+pub(crate) fn get_log_message(req: &dyn Request, key: &'static str) -> String {
+    for (k, v) in &req.extensions().find::<CustomMetadata>().unwrap().entries {
+        if key == *k {
+            return v.clone();
+        }
+    }
+    String::new()
+}
+
 struct RequestLine<'r> {
     req: &'r dyn Request,
     res: &'r Result<Response>,

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -65,7 +65,7 @@ pub(crate) fn get_log_message(req: &dyn Request, key: &'static str) -> String {
             return v.clone();
         }
     }
-    String::new()
+    panic!("expected log message for {} not found", key);
 }
 
 struct RequestLine<'r> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -230,6 +230,7 @@ mod tests {
         let response = C(|_| {
             Err("-1"
                 .parse::<u8>()
+                .chain_error(|| internal("middle error"))
                 .chain_error(|| bad_request("outer user facing error"))
                 .unwrap_err())
         })
@@ -238,7 +239,7 @@ mod tests {
         assert_eq!(response.status.0, 400);
         assert_eq!(
             crate::middleware::log_request::get_log_message(&req, "cause"),
-            "invalid digit found in string"
+            "middle error caused by invalid digit found in string"
         );
 
         // All other error types are propogated up the middleware, eventually becoming status 500


### PR DESCRIPTION
This builds on the logging infrastructure recently added by @pietroalbini.  Whenever a user facing error is chained around an internal error, the router now captures that message and adds it to the log metadata.

In particular, this should allow us to identify errors sent to cargo via `cargo_err` which are sent via a status 200 response and left no indication in the logs that an error has occurred.

r? @pietroalbini 