### PR TITLE
Pin quote version to avoid compilation failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "oauth2",
  "openssl",
  "parking_lot",
+ "quote 1.0.2",
  "rand 0.6.5",
  "reqwest",
  "scheduled-thread-pool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,9 @@ ctrlc = { version = "3.0", features = ["termination"] }
 indexmap = "1.0.2"
 handlebars = "2.0.1"
 
+# FIXME: Remove this once failure_derive replaces private item.
+quote = "=1.0.2"
+
 [dev-dependencies]
 conduit-test = "0.8"
 hyper-tls = "0.4"


### PR DESCRIPTION
quote modified private-ish API in v1.0.3 but failure_derive depends on that therefore compilation will fail when we update quote v1. This avoids that failure and accidental updates by pinning quote v1 version.
ref: https://users.rust-lang.org/t/failure-derive-compilation-error/39062

r? @jtgeibel 