### PR TITLE
Address clippy lint for unnecessary imports

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -27,7 +27,6 @@ mod prelude {
 
     use indexmap::IndexMap;
     use serde::Serialize;
-    use url;
 
     pub trait UserAuthenticationExt {
         fn authenticate(&self, conn: &PgConnection) -> AppResult<super::util::AuthenticatedUser>;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -1,7 +1,5 @@
 //! All routes related to managing owners of a crate
 
-use serde_json;
-
 use crate::controllers::prelude::*;
 use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -98,7 +98,6 @@ impl Keyword {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use diesel;
     use diesel::connection::SimpleConnection;
 
     fn pg_connection() -> PgConnection {

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -70,7 +70,6 @@ impl ApiToken {
 mod tests {
     use super::*;
     use chrono::NaiveDate;
-    use serde_json;
 
     #[test]
     fn api_token_serializes_to_rfc3339() {

--- a/src/views.rs
+++ b/src/views.rs
@@ -249,7 +249,6 @@ pub use self::krate_publish::{EncodableCrateDependency, EncodableCrateUpload};
 mod tests {
     use super::*;
     use chrono::NaiveDate;
-    use serde_json;
 
     #[test]
     fn category_dates_serializes_to_rfc3339() {


### PR DESCRIPTION
Resolves `clippy::single_component_path_imports`

r? @JohnTitor 