### PR TITLE
Allow features prefixed with "crate:" for namespaced-features

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -280,6 +280,9 @@ impl Crate {
     pub fn valid_feature(name: &str) -> bool {
         let mut parts = name.split('/');
         match parts.next() {
+            Some(part) if part.starts_with("crate:") => {
+                return Crate::valid_feature_name(&part[6..]) && parts.next().is_none();
+            }
             Some(part) if !Crate::valid_feature_name(part) => return false,
             None => return false,
             _ => {}


### PR DESCRIPTION
See description of the unstable cargo feature here:

https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#namespaced-features

I would like some mentoring on how/where to add tests for this. Ideally in my mind we'd have some kind of end-to-end test that we can publish a crate that makes use of the new explicit dependency features. I did search for tests around the features aspect, but didn't find any.