### PR TITLE
LinkToDep: Convert to template-only component and CSS modules

### DIFF
--- a/app/components/link-to-dep.hbs
+++ b/app/components/link-to-dep.hbs
@@ -2,5 +2,5 @@
   {{ @dep.crate_id }} {{ format-req @dep.req }}
 </LinkTo>
 {{#if @dep.optional}}
-  <span class='optional'>optional</span>
+  <span local-class="optional">optional</span>
 {{/if}}

--- a/app/components/link-to-dep.js
+++ b/app/components/link-to-dep.js
@@ -1,3 +1,0 @@
-import Component from '@ember/component';
-
-export default Component.extend({});

--- a/app/components/link-to-dep.module.scss
+++ b/app/components/link-to-dep.module.scss
@@ -1,0 +1,3 @@
+.optional {
+    font-size: 80%;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -78,10 +78,6 @@ span.small {
     }
 }
 
-.optional {
-    font-size: 80%;
-}
-
 .yanked {
     font-size: 80%;
     color: rgb(166, 0, 0)

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -206,7 +206,7 @@
           <h3>Dependencies</h3>
           <ul>
             {{#each this.currentDependencies as |dep|}}
-              <LinkToDep @tagName="li" @dep={{dep}} />
+              <li><LinkToDep @dep={{dep}} /></li>
             {{else}}
               {{#if (is-pending this.currentDependencies)}}
                 <li>Loading…</li>
@@ -222,7 +222,7 @@
             <h3>Build-Dependencies</h3>
             <ul>
               {{#each this.currentBuildDependencies as |dep|}}
-                <LinkToDep @tagName="li" @dep={{dep}} />
+                <li><LinkToDep @dep={{dep}} /></li>
               {{/each}}
             </ul>
           </div>
@@ -233,7 +233,7 @@
             <h3>Dev-Dependencies</h3>
             <ul>
               {{#each this.currentDevDependencies as |dep|}}
-                <LinkToDep @tagName="li" @dep={{dep}} />
+                <li><LinkToDep @dep={{dep}} /></li>
               {{/each}}
             </ul>
           </div>
@@ -251,7 +251,7 @@
           Stats Overview for {{this.downloadsContext.num}}
           <LinkTo @route="crate" @model={{this.crate}}>(see all)</LinkTo>
         </h3>
-        
+
       {{else}}
         <h3 data-test-crate-stats-label>Stats Overview</h3>
       {{/if}}


### PR DESCRIPTION
as the title says, this PR converts the `<LinkToDep>` component to be template-only and use CSS modules