### PR TITLE
CI: Don't run nightly for GH Actions    

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
         rust:
           - stable
           - beta
-          - nightly
 
     env:
       RUST_BACKTRACE: 1


### PR DESCRIPTION
Travis allows us to ignore errors building on nightly.  Because failed
Actions are shown so prominently in the UI (and sends an email to the
author), lets drop this build until we can run such non-essential
builds in Actions.

r? @JohnTitor 