### PR TITLE
Remove more unused CSS declarations

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -116,8 +116,6 @@ ul.dropdown {
     position: relative;
 }
 
-.hidden { display: none; }
-
 @media only screen and (max-width: 400px) {
     h1 { font-size: 1.5em; }
 }

--- a/app/styles/home.scss
+++ b/app/styles/home.scss
@@ -1,8 +1,3 @@
-.dl {
-    text-decoration: underline;
-    font-weight: bold;
-}
-
 .crate-lists {
     display: flex;
 


### PR DESCRIPTION
I couldn't find these styles being used anywhere in our templates or elsewhere in the app.

r? @locks 