### PR TITLE
Remove unused `id=crates` assignments

### DIFF
--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -87,7 +87,7 @@
   </div>
 </div>
 
-<div id='crates' class='white-rows'>
+<div class='white-rows'>
   {{#each this.model as |crate|}}
     <CrateRow @crate={{crate}} />
   {{/each}}

--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -75,7 +75,7 @@
   </div>
 </div>
 
-<div id='crates' class='white-rows'>
+<div class='white-rows'>
   {{#each this.model as |crate index|}}
     <CrateRow @crate={{crate}} data-test-crate-row={{index}} />
   {{/each}}

--- a/app/templates/keyword/index.hbs
+++ b/app/templates/keyword/index.hbs
@@ -55,7 +55,7 @@
   </div>
 </div>
 
-<div id='crates' class='white-rows'>
+<div class='white-rows'>
   {{#each this.model as |crate|}}
     <CrateRow @crate={{crate}} />
   {{/each}}

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -56,7 +56,7 @@
   </div>
 </div>
 
-<div id='crates' class='white-rows'>
+<div class='white-rows'>
   {{#each this.model as |crate|}}
     <CrateRow @crate={{crate}} />
   {{/each}}

--- a/app/templates/me/following.hbs
+++ b/app/templates/me/following.hbs
@@ -39,7 +39,7 @@
   </div>
 </div>
 
-<div id='crates' class='white-rows'>
+<div class='white-rows'>
   {{#each this.model as |crate|}}
     <CrateRow @crate={{crate}} />
   {{/each}}

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -67,7 +67,7 @@
     </div>
   </div>
 
-  <div id='crates' class='white-rows'>
+  <div class='white-rows'>
     {{#each this.model as |crate index|}}
       {{#if crate.exact_match}}
         <div class='exact-match'>

--- a/app/templates/team.hbs
+++ b/app/templates/team.hbs
@@ -70,7 +70,7 @@
       </div>
     </div>
 
-    <div id='crates' class='white-rows'>
+    <div class='white-rows'>
       {{#each this.model.crates as |crate|}}
         <CrateRow @crate={{crate}} />
       {{/each}}

--- a/app/templates/user.hbs
+++ b/app/templates/user.hbs
@@ -61,7 +61,7 @@
       </div>
     </div>
 
-    <div id='crates' class='white-rows'>
+    <div class='white-rows'>
       {{#each this.model.crates as |crate|}}
         <CrateRow @crate={{crate}} />
       {{/each}}


### PR DESCRIPTION
There does not seems to be any code that relies on these IDs being set, so I think it should be save to remove them.

r? @locks 