### PR TITLE
mirage/fixtures: Remove broken GitLab badge

### DIFF
--- a/mirage/fixtures/crates.js
+++ b/mirage/fixtures/crates.js
@@ -94,13 +94,6 @@ export default [
       },
       {
         attributes: {
-          branch: 'master',
-          repository: 'huonw/external_mixin',
-        },
-        badge_type: 'gitlab',
-      },
-      {
-        attributes: {
           repository: 'huonw/external_mixin',
         },
         badge_type: 'is-it-maintained-issue-resolution',


### PR DESCRIPTION
`huonw/external_mixin` no longer exists on GitLab and leads to a broken badge image