### PR TITLE
search: Remove unnecessary `#no-results` wrapper elements

### DIFF
--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -13,9 +13,7 @@
 </div>
 
 {{#if this.firstResultPending}}
-  <div id="no-results">
-    <h2>Loading search results...</h2>
-  </div>
+  <h2>Loading search results...</h2>
 {{else if this.hasItems}}
   <div id='results'>
     <ResultsCount
@@ -85,7 +83,5 @@
 
   <Pagination @pages={{this.pages}} @prevPage={{this.prevPage}} @nextPage={{this.nextPage}} />
 {{else}}
-  <div id="no-results">
-    <h2>0 crates found. <a href='https://doc.rust-lang.org/cargo/getting-started/'>Get started</a> and create your own.</h2>
-  </div>
+  <h2>0 crates found. <a href='https://doc.rust-lang.org/cargo/getting-started/'>Get started</a> and create your own.</h2>
 {{/if}}


### PR DESCRIPTION
There is no CSS associated with these IDs and it seems unlikely that anyone wants/needs to link directly to these anchors.

r? @locks 