### PR TITLE
Remove unused `.small-text` CSS class assignments

### DIFF
--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -1,13 +1,13 @@
 <div ...attributes>
   {{#if this.emailIsNull }}
     <div class='friendly-message'>
-      <p class='small-text'>
+      <p>
         Please add your email address. We will only use
         it to contact you about your account. We promise we'll never share it!
       </p>
     </div>
   {{/if}}
-  
+
   {{#if this.isEditing }}
     <div class='row'>
       <div class='label'>
@@ -17,7 +17,7 @@
         <Input @type={{this.type}} @value={{this.value}} placeholder="Email" class="form-control space-right" />
         {{#if this.notValidEmail }}
           <div class='error'>
-            <p class='small-text error'>Whoops, that email format is invalid</p>
+            <p class='error'>Whoops, that email format is invalid</p>
           </div>
         {{/if}}
         <div class='actions'>
@@ -47,9 +47,9 @@
       <div class='row'>
         <div class='label'>
           {{#if this.user.email_verification_sent}}
-            <p class='small-text'>We have sent a verification email to your address.</p>
+            <p>We have sent a verification email to your address.</p>
           {{/if}}
-          <p class='small-text'>Your email has not yet been verified.</p>
+          <p>Your email has not yet been verified.</p>
         </div>
         <div class='actions'>
           <button type="button" class='small yellow-button space-left' {{action 'resendEmail'}} disabled={{this.disableResend}}>
@@ -61,10 +61,10 @@
     {{#if this.isError}}
       <div class='row'>
         <div class='label'>
-          <p class='small-text'>{{this.emailError}}</p>
+          <p>{{this.emailError}}</p>
         </div>
       </div>
     {{/if}}
   {{/if}}
-  
+
 </div>

--- a/app/templates/crate/owners.hbs
+++ b/app/templates/crate/owners.hbs
@@ -18,7 +18,7 @@
 
       {{#if this.error}}
         <div class='error'>
-          <p class='small-text error'>{{this.error}}</p>
+          <p class='error'>{{this.error}}</p>
         </div>
       {{/if}}
 


### PR DESCRIPTION
There is no `.small-text` style definition for these cases so we might as well remove those unused assignments.

r? @locks