### PR TITLE
Import `normalize.css` via `app.import()`

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,5 +1,3 @@
-@import "normalize";
-
 $html-bg: #3b6837;
 $main-color: #383838;
 $main-color-light: lighten($main-color, 30%);

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -28,9 +28,6 @@ module.exports = function (defaults) {
       theme: 'twilight',
       components: highlightedLanguages,
     },
-    sassOptions: {
-      includePaths: ['node_modules/normalize.css'],
-    },
     cssModules: {
       extension: 'module.scss',
       intermediateOutputPath: 'app/styles/_modules.scss',
@@ -39,6 +36,8 @@ module.exports = function (defaults) {
       extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'ttf', 'woff', 'woff2'],
     },
   });
+
+  app.import('node_modules/normalize.css/normalize.css');
 
   return app.toTree();
 };


### PR DESCRIPTION
This moves the code into the `vendor.css` file

r? @locks 