### PR TITLE
Replace SASS variables with CSS variables

### DIFF
--- a/app/components/api-token-row.module.scss
+++ b/app/components/api-token-row.module.scss
@@ -10,7 +10,7 @@
 }
 
 .create-token {
-    background-color: $main-bg-dark;
+    background-color: var(--main-bg-dark);
 
     .name {
         padding-right: 20px;

--- a/app/components/crate-row.module.scss
+++ b/app/components/crate-row.module.scss
@@ -11,7 +11,7 @@
 }
 
 .name {
-    color: $main-color;
+    color: var(--main-color);
     font-weight: bold;
     text-decoration: none;
     font-size: 120%;
@@ -28,7 +28,7 @@
 
 .stats {
     width: 25%;
-    color: $main-color-light;
+    color: var(--main-color-light);
 }
 
 .downloads {

--- a/app/components/crate-toml-copy.module.scss
+++ b/app/components/crate-toml-copy.module.scss
@@ -12,7 +12,7 @@
         position: absolute;
 
         &.copy-success {
-            color: $link-color;
+            color: var(--link-color);
         }
 
         &.copy-failure {

--- a/app/components/dropdown/menu-item.module.scss
+++ b/app/components/dropdown/menu-item.module.scss
@@ -5,10 +5,10 @@
         display: inline-block;
         padding: 8px 10px;
         text-decoration: none;
-        color: $main-color !important;
+        color: var(--main-color) !important;
 
         &:hover {
-            background: lighten($main-color, 15%);
+            background: #5e5e5e;
             color: white !important;
         }
     }

--- a/app/components/dropdown/menu.module.scss
+++ b/app/components/dropdown/menu.module.scss
@@ -3,7 +3,7 @@
     text-align: left;
     padding: 0;
     background: white;
-    border: 1px solid $gray-border;
+    border: 1px solid var(--gray-border);
     list-style: none;
     overflow: hidden;
     border-radius: 5px;

--- a/app/components/front-page-list/item.module.scss
+++ b/app/components/front-page-list/item.module.scss
@@ -1,9 +1,9 @@
 .link {
     margin: 8px 0;
     width: 100%;
-    color: lighten($main-color, 10%);
+    color: #525252;
     text-decoration: none;
-    background-color: $main-bg-dark;
+    background-color: var(--main-bg-dark);
     font-size: 90%;
     padding: 20px 10px;
     display: flex;
@@ -11,7 +11,7 @@
     align-items: center;
 
     &:hover {
-        background-color: darken($main-bg-dark, 5%);
+        background-color: #e4e1cc;
     }
 
     span {

--- a/app/components/owned-crate-row.module.scss
+++ b/app/components/owned-crate-row.module.scss
@@ -21,7 +21,7 @@
             height: 10px;
             border-radius: 50%;
             content: '';
-            background-color: $main-bg-dark;
+            background-color: var(--main-bg-dark);
             position: absolute;
             left: 50%;
             top: 50%;

--- a/app/components/page-header.module.scss
+++ b/app/components/page-header.module.scss
@@ -1,6 +1,6 @@
 .header {
     padding: 20px;
-    background-color: $main-bg-dark;
+    background-color: var(--main-bg-dark);
     margin-bottom: 20px;
     border-radius: 5px;
 }
@@ -18,7 +18,7 @@
 }
 
 .suffix {
-    color: $main-color-light;
+    color: var(--main-color-light);
     padding-left: 10px;
 }
 

--- a/app/components/pagination.module.scss
+++ b/app/components/pagination.module.scss
@@ -10,12 +10,12 @@
     ol, li { display: inline; }
 
     a {
-        color: $main-color-light;
+        color: var(--main-color-light);
         text-decoration: none;
         padding: 5px 6px;
     }
-    a:hover { background-color: $main-bg-dark; }
-    a:global(.active) { background-color: $main-bg-dark; }
+    a:hover { background-color: var(--main-bg-dark); }
+    a:global(.active) { background-color: var(--main-bg-dark); }
 
     img, svg { vertical-align: middle; }
 

--- a/app/components/results-count.module.scss
+++ b/app/components/results-count.module.scss
@@ -3,6 +3,6 @@
 }
 
 .highlight {
-    color: $main-color;
+    color: var(--main-color);
     font-weight: bold;
 }

--- a/app/components/sort-dropdown.module.scss
+++ b/app/components/sort-dropdown.module.scss
@@ -1,5 +1,5 @@
 .trigger {
-    background-color: $main-bg-dark;
+    background-color: var(--main-bg-dark);
     font-size: 85%;
     padding: 10px;
     display: inline-block;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,9 +1,1 @@
-$html-bg: #3b6837;
-$main-color: #383838;
-$main-color-light: lighten($main-color, 30%);
-$main-bg: #f9f7ec;
-$main-bg-dark: #edebdd;
-$gray-border: #d5d3cb;
-$link-color: rgb(0, 172, 91);
-
 @import "modules";

--- a/app/styles/application.module.scss
+++ b/app/styles/application.module.scss
@@ -3,8 +3,17 @@
 }
 
 html {
+    --main-color: #383838;
+    --main-color-light: #858585;
+    --main-bg: #f9f7ec;
+    --main-bg-dark: #edebdd;
+    --gray-border: #d5d3cb;
+    --link-color: rgb(0, 172, 91);
+    --link-hover-color: #007940;
+    --separator-color: #284725;
+
     background: url('/assets/noise.png');
-    background-color: $html-bg;
+    background-color: #3b6837;
 }
 
 html, body {
@@ -27,16 +36,16 @@ h1 {
 }
 
 a {
-    color: $link-color;
+    color: var(--link-color);
     text-decoration: none;
 
     &:hover {
-        color: darken($link-color, 10%);
+        color: var(--link-hover-color);
     }
 }
 
 pre {
-    background: $main-color;
+    background: var(--main-color);
     color: white;
     padding: 20px;
     /* Use the modern font stack inspired by Bootstrap 4 */
@@ -131,7 +140,7 @@ input.search {
 
 .sep {
     margin: 0 10px;
-    color: darken($html-bg, 10%);
+    color: var(--separator-color);
 }
 
 .doc-links {
@@ -160,7 +169,7 @@ input.search {
 }
 
 .menu-item-with-separator {
-    border-top: 1px solid $gray-border;
+    border-top: 1px solid var(--gray-border);
 }
 
 .current-user-links {
@@ -184,12 +193,12 @@ input.search {
     flex-direction: column;
 
     margin-bottom: 10px;
-    background-color: $main-bg;
+    background-color: var(--main-bg);
     padding: 15px;
     border-radius: 10px;
     box-shadow: 0px 0px 5px 2px #3b6837;
     border: 5px solid #62865f;
-    color: $main-color;
+    color: var(--main-color);
 }
 
 .after-main-links {
@@ -208,7 +217,10 @@ input.search {
             width: 50%;
             font-size: 110%;
             padding: 5px;
-            &:not(:first-child) { border-top: 1px solid darken($html-bg, 10%); }
+
+            &:not(:first-child) {
+                border-top: 1px solid var(--separator-color);
+            }
         }
     }
 }

--- a/app/styles/categories.module.scss
+++ b/app/styles/categories.module.scss
@@ -19,7 +19,7 @@
 
 .row {
     width: 100%;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
     padding: 20px 0;
 
     &:last-of-type { border: none; }

--- a/app/styles/category/index.module.scss
+++ b/app/styles/category/index.module.scss
@@ -14,7 +14,7 @@
 }
 
 .subcategory {
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
     padding: 20px 0;
 
     &:last-of-type {
@@ -50,7 +50,7 @@
 
 .row {
     padding: 20px 0;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
 
     &:last-of-type {
         border: none;

--- a/app/styles/crate/owners.module.scss
+++ b/app/styles/crate/owners.module.scss
@@ -1,5 +1,5 @@
 .me-email {
-    border-bottom: 5px solid $gray-border;
+    border-bottom: 5px solid var(--gray-border);
     padding-bottom: 20px;
     margin-bottom: 20px;
 }
@@ -9,7 +9,7 @@
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
-    border: 2px solid $gray-border;
+    border: 2px solid var(--gray-border);
     padding: 10px 20px;
 }
 
@@ -33,7 +33,7 @@
 }
 
 .row {
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
     padding: 20px 0;
     display: flex;
     justify-content: space-between;
@@ -45,7 +45,7 @@
 
 .email-column {
     width: 25%;
-    color: $main-color-light;
+    color: var(--main-color-light);
 }
 
 .remove-button {

--- a/app/styles/crate/reverse-dependencies.module.scss
+++ b/app/styles/crate/reverse-dependencies.module.scss
@@ -13,7 +13,7 @@
 }
 
 .row {
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
     padding: 20px 0;
     display: flex;
     justify-content: space-between;
@@ -26,7 +26,7 @@
 
 .stats {
     width: 25%;
-    color: $main-color-light;
+    color: var(--main-color-light);
 }
 
 .downloads {

--- a/app/styles/crate/version.module.scss
+++ b/app/styles/crate/version.module.scss
@@ -19,7 +19,7 @@ div.header {
     }
 
     h2 {
-        color: $main-color-light;
+        color: var(--main-color-light);
         margin-left: 10px;
     }
 }
@@ -55,7 +55,7 @@ div.header {
     display: flex;
     flex-direction: column;
     padding-bottom: 20px;
-    border-bottom: 5px solid $gray-border;
+    border-bottom: 5px solid var(--gray-border);
     margin-bottom: 20px;
 
     @media only screen and (min-width: 890px) {
@@ -74,12 +74,12 @@ div.header {
 .install {
     font-size: 120%;
     padding: 10px;
-    background-color: darken($main-bg-dark, 8%);
+    background-color: #dfdbc2;
     display: flex;
 
     code {
         flex: 1;
-        background: $main-color;
+        background: var(--main-color);
         color: white;
         padding: 20px;
 
@@ -154,7 +154,7 @@ div.header {
 
     @media only screen and (min-width: 890px) {
         flex: 3;
-        border-left: 2px solid $gray-border;
+        border-left: 2px solid var(--gray-border);
         padding-left: 20px;
 
         .top, .bottom {
@@ -224,7 +224,7 @@ div.header {
 }
 
 .stat {
-    border-left: 1px solid $gray-border;
+    border-left: 1px solid var(--gray-border);
     padding: 10px 20px;
     display: flex;
     flex-wrap: wrap;
@@ -253,7 +253,9 @@ div.header {
     margin: 30px 0;
     padding-bottom: 20px;
 
-    h4 { color: $main-color-light; }
+    h4 {
+        color: var(--main-color-light);
+    }
 
     @media only percy {
         display: none;

--- a/app/styles/crates.module.scss
+++ b/app/styles/crates.module.scss
@@ -13,8 +13,8 @@
         color: inherit;
         padding: 5px;
     }
-    a:hover { background-color: $main-bg-dark; }
-    a:global(.active) { background-color: $main-bg-dark; }
+    a:hover { background-color: var(--main-bg-dark); }
+    a:global(.active) { background-color: var(--main-bg-dark); }
 
     select {
         display: none;
@@ -48,7 +48,7 @@
 }
 
 .row {
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
     padding: 20px 0;
 
     &:last-of-type {

--- a/app/styles/dashboard.module.scss
+++ b/app/styles/dashboard.module.scss
@@ -61,13 +61,13 @@
 
 .my-crates-link,
 .followed-crates-link {
-    color: $main-color-light;
+    color: var(--main-color-light);
     text-decoration: underline;
     font-size: 90%;
     font-weight: normal;
 
     &:hover {
-        color: darken($main-color-light, 10%);
+        color: #6b6b6b;
     }
 }
 
@@ -94,7 +94,7 @@
     display: flex;
     align-items: baseline;
     padding: 20px 0;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
 
     &:last-of-type {
         border: none;
@@ -122,14 +122,16 @@
 }
 
 .load-more {
-    $bg: rgb(219, 217, 207);
     text-align: center;
     width: 100%;
     padding: 10px;
     outline: 0;
     border: 0;
     margin-bottom: 20px;
-    background-color: $bg;
+    background-color: #dbd9cf;
     color: white;
-    &:hover, &:focus { background-color: darken($bg, 10%); }
+
+    &:hover, &:focus {
+        background-color: #c5c2b2;
+    }
 }

--- a/app/styles/index.module.scss
+++ b/app/styles/index.module.scss
@@ -1,6 +1,6 @@
 .title-header {
     text-align: center;
-    border-bottom: 5px solid $gray-border;
+    border-bottom: 5px solid var(--gray-border);
     padding-bottom: 40px;
 
     h1 {
@@ -34,7 +34,7 @@
         display: flex;
         flex-direction: column;
 
-        border-left: 1px solid $gray-border;
+        border-left: 1px solid var(--gray-border);
         padding: 10px;
 
         span { margin-left: 10px; }

--- a/app/styles/keyword/index.module.scss
+++ b/app/styles/keyword/index.module.scss
@@ -17,7 +17,7 @@
 
 .row {
     padding: 20px 0;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
 
     &:last-of-type {
         border: none;

--- a/app/styles/keywords.module.scss
+++ b/app/styles/keywords.module.scss
@@ -16,7 +16,7 @@
 }
 
 .row {
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
     padding: 20px 0;
 
     &:last-of-type {

--- a/app/styles/me/crates.module.scss
+++ b/app/styles/me/crates.module.scss
@@ -17,7 +17,7 @@
 
 .row {
     padding: 20px 0;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
 
     &:last-of-type {
         border: none;

--- a/app/styles/me/following.module.scss
+++ b/app/styles/me/following.module.scss
@@ -17,7 +17,7 @@
 
 .row {
     padding: 20px 0;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
 
     &:last-of-type {
         border: none;

--- a/app/styles/me/index.module.scss
+++ b/app/styles/me/index.module.scss
@@ -1,5 +1,5 @@
 .me-profile {
-    border-bottom: 5px solid $gray-border;
+    border-bottom: 5px solid var(--gray-border);
     padding-bottom: 20px;
     margin-bottom: 20px;
 
@@ -24,7 +24,7 @@
 }
 
 .me-email {
-    border-bottom: 5px solid $gray-border;
+    border-bottom: 5px solid var(--gray-border);
     padding-bottom: 20px;
     margin-bottom: 20px;
     display: flex;
@@ -32,7 +32,7 @@
 }
 
 .me-email-notifications {
-    border-bottom: 5px solid $gray-border;
+    border-bottom: 5px solid var(--gray-border);
     padding-bottom: 20px;
     margin-bottom: 20px;
     display: flex;
@@ -98,7 +98,7 @@
 }
 
 .token-list {
-    background-color: $main-bg-dark;
+    background-color: var(--main-bg-dark);
     display: flex;
     flex-direction: column;
 }

--- a/app/styles/shared/typography.module.scss
+++ b/app/styles/shared/typography.module.scss
@@ -1,19 +1,19 @@
 .small {
-    color: $main-color-light;
+    color: var(--main-color-light);
     font-size: 80%;
 
     strong {
-        color: $main-color;
+        color: var(--main-color);
     }
 }
 
 .small a, a.small {
-    color: $main-color-light;
+    color: var(--main-color-light);
     text-decoration: underline;
     font-weight: normal;
 
     &:hover {
-        color: darken($main-color-light, 10%);
+        color: #6b6b6b;
     }
 }
 

--- a/app/styles/team.module.scss
+++ b/app/styles/team.module.scss
@@ -9,7 +9,7 @@
 
     h2 {
         margin-top: 10px;
-        color: $main-color-light;
+        color: var(--main-color-light);
     }
 }
 
@@ -45,7 +45,7 @@
 
 .row {
     padding: 20px 0;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
 
     &:last-of-type {
         border: none;

--- a/app/styles/user.module.scss
+++ b/app/styles/user.module.scss
@@ -26,7 +26,7 @@
 
 .row {
     padding: 20px 0;
-    border-bottom: 2px solid $gray-border;
+    border-bottom: 2px solid var(--gray-border);
 
     &:last-of-type {
         border: none;


### PR DESCRIPTION
This will allow us to get rid of the `app.scss` file and finally disable the `intermediateOutputPath` option of ember-css-modules.