### PR TITLE
css-modules: Remove `intermediateOutputPath` override

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,1 +1,0 @@
-@import "modules";

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -30,7 +30,6 @@ module.exports = function (defaults) {
     },
     cssModules: {
       extension: 'module.scss',
-      intermediateOutputPath: 'app/styles/_modules.scss',
     },
     fingerprint: {
       extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'ttf', 'woff', 'woff2'],


### PR DESCRIPTION
This is no longer needed, now that the `app.scss` file is essentially empty  🎉 

This brings us another step closer to being able to use https://github.com/embroider-build/embroider/

r? @locks
