### PR TITLE
Import `ajax()` utility from `ember-fetch`

### DIFF
--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -2,7 +2,8 @@ import Component from '@ember/component';
 import { empty } from '@ember/object/computed';
 import { computed } from '@ember/object';
 import { inject as service } from '@ember/service';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 export default Component.extend({
   tagName: '',

--- a/app/components/follow-button.js
+++ b/app/components/follow-button.js
@@ -1,7 +1,8 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 import { task } from 'ember-concurrency';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 export default class extends Component {
   @tracked following = false;

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
 import { A } from '@ember/array';
 import { computed } from '@ember/object';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 const TO_SHOW = 5;
 

--- a/app/controllers/me/index.js
+++ b/app/controllers/me/index.js
@@ -1,7 +1,8 @@
 import Controller from '@ember/controller';
 import { alias, sort, filterBy, notEmpty } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../../utils/ajax';
 
 export default Controller.extend({
   // eslint-disable-next-line ember/avoid-leaking-state-in-ember-objects

--- a/app/routes/accept-invite.js
+++ b/app/routes/accept-invite.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 export default Route.extend({
   async model(params) {

--- a/app/routes/confirm.js
+++ b/app/routes/confirm.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 export default Route.extend({
   flashMessages: service(),

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -5,7 +5,8 @@ import { inject as service } from '@ember/service';
 import prerelease from 'semver/functions/prerelease';
 
 import fetch from 'fetch';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../../utils/ajax';
 
 export default Route.extend({
   session: service(),

--- a/app/routes/github-login.js
+++ b/app/routes/github-login.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 /**
  * Calling this route will query the `/api/private/session/begin` API endpoint

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -1,7 +1,8 @@
 import { run } from '@ember/runloop';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 export default Route.extend({
   session: service(),

--- a/app/services/fetcher.js
+++ b/app/services/fetcher.js
@@ -1,5 +1,6 @@
 import Service, { inject as service } from '@ember/service';
-import ajax from 'ember-fetch/ajax';
+
+import ajax from '../utils/ajax';
 
 export default class FetcherService extends Service {
   @service fastboot;

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,6 +1,7 @@
 import Service, { inject as service } from '@ember/service';
-import ajax from 'ember-fetch/ajax';
 import window from 'ember-window-mock';
+
+import ajax from '../utils/ajax';
 
 export default class SessionService extends Service {
   @service store;

--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -1,0 +1,9 @@
+import fetch from 'fetch';
+
+export default async function ajax(input, init) {
+  let response = await fetch(input, init);
+  if (response.ok) {
+    return await response.json();
+  }
+  throw response;
+}


### PR DESCRIPTION
This utility is being removed from `ember-fetch` in v8, so we should import it into our own code to continue to use it.

Unblocks #2364 

r? @locks 