### PR TITLE
Convert async actions on components to tasks

### DIFF
--- a/app/components/api-token-row.hbs
+++ b/app/components/api-token-row.hbs
@@ -7,7 +7,7 @@
         @disabled={{this.api_token.isSaving}}
         @value={{this.api_token.name}}
         @autofocus="autofocus"
-        @enter={{action "saveToken"}}
+        @enter={{action (perform this.saveTokenTask)}}
         data-test-focused-input
       />
     {{else}}
@@ -38,7 +38,7 @@
         disabled={{this.disableCreate}}
         title={{if this.emptyName "You must specify a name" ""}}
         data-test-save-token-button
-        {{action "saveToken"}}
+        {{action (perform this.saveTokenTask)}}
       >
         Create
       </button>
@@ -48,7 +48,7 @@
         local-class="revoke-button"
         disabled={{this.api_token.isSaving}}
         data-test-revoke-token-button
-        {{action "revokeToken"}}
+        {{action (perform this.revokeTokenTask)}}
       >
         Revoke
       </button>

--- a/app/components/api-token-row.js
+++ b/app/components/api-token-row.js
@@ -1,6 +1,8 @@
 import Component from '@ember/component';
 import { empty, or } from '@ember/object/computed';
 
+import { task } from 'ember-concurrency';
+
 export default Component.extend({
   emptyName: empty('api_token.name'),
   disableCreate: or('api_token.isSaving', 'emptyName'),
@@ -13,34 +15,32 @@ export default Component.extend({
     }
   },
 
-  actions: {
-    async saveToken() {
-      try {
-        await this.api_token.save();
-        this.set('serverError', null);
-      } catch (err) {
-        let msg;
-        if (err.errors && err.errors[0] && err.errors[0].detail) {
-          msg = `An error occurred while saving this token, ${err.errors[0].detail}`;
-        } else {
-          msg = 'An unknown error occurred while saving this token';
-        }
-        this.set('serverError', msg);
+  saveTokenTask: task(function* () {
+    try {
+      yield this.api_token.save();
+      this.set('serverError', null);
+    } catch (err) {
+      let msg;
+      if (err.errors && err.errors[0] && err.errors[0].detail) {
+        msg = `An error occurred while saving this token, ${err.errors[0].detail}`;
+      } else {
+        msg = 'An unknown error occurred while saving this token';
       }
-    },
+      this.set('serverError', msg);
+    }
+  }),
 
-    async revokeToken() {
-      try {
-        await this.api_token.destroyRecord();
-      } catch (err) {
-        let msg;
-        if (err.errors && err.errors[0] && err.errors[0].detail) {
-          msg = `An error occurred while revoking this token, ${err.errors[0].detail}`;
-        } else {
-          msg = 'An unknown error occurred while revoking this token';
-        }
-        this.set('serverError', msg);
+  revokeTokenTask: task(function* () {
+    try {
+      yield this.api_token.destroyRecord();
+    } catch (err) {
+      let msg;
+      if (err.errors && err.errors[0] && err.errors[0].detail) {
+        msg = `An error occurred while revoking this token, ${err.errors[0].detail}`;
+      } else {
+        msg = 'An unknown error occurred while revoking this token';
       }
-    },
-  },
+      this.set('serverError', msg);
+    }
+  }),
 });

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -52,7 +52,7 @@
           <p>Your email has not yet been verified.</p>
         </div>
         <div local-class="actions">
-          <button type="button" local-class="resend-button" {{action 'resendEmail'}} disabled={{this.disableResend}}>
+          <button type="button" local-class="resend-button" {{action (perform this.resendEmailTask)}} disabled={{this.disableResend}}>
             {{this.resendButtonText}}
           </button>
         </div>

--- a/app/components/pending-owner-invite-row.hbs
+++ b/app/components/pending-owner-invite-row.hbs
@@ -29,8 +29,8 @@
       {{moment-from-now this.invite.created_at}}
     </div>
     <div>
-      <button type="button" local-class="accept-button" data-test-accept-button {{action 'acceptInvitation' this.invite}}>Accept</button>
-      <button type="button" local-class="decline-button" data-test-decline-button {{action 'declineInvitation' this.invite}}>Decline</button>
+      <button type="button" local-class="accept-button" data-test-accept-button {{action (perform this.acceptInvitationTask)}}>Accept</button>
+      <button type="button" local-class="decline-button" data-test-decline-button {{action (perform this.declineInvitationTask)}}>Decline</button>
     </div>
     {{#if this.isError}}
       <p local-class="error-message" data-test-error-message>{{this.inviteError}}</p>

--- a/app/components/pending-owner-invite-row.js
+++ b/app/components/pending-owner-invite-row.js
@@ -1,5 +1,7 @@
 import Component from '@ember/component';
 
+import { task } from 'ember-concurrency';
+
 export default Component.extend({
   tagName: '',
   isAccepted: false,
@@ -7,37 +9,35 @@ export default Component.extend({
   isError: false,
   inviteError: 'default error message',
 
-  actions: {
-    async acceptInvitation(invite) {
-      invite.set('accepted', true);
+  acceptInvitationTask: task(function* () {
+    this.invite.set('accepted', true);
 
-      try {
-        await invite.save();
-        this.set('isAccepted', true);
-      } catch (error) {
-        this.set('isError', true);
-        if (error.errors) {
-          this.set('inviteError', `Error in accepting invite: ${error.errors[0].detail}`);
-        } else {
-          this.set('inviteError', 'Error in accepting invite');
-        }
+    try {
+      yield this.invite.save();
+      this.set('isAccepted', true);
+    } catch (error) {
+      this.set('isError', true);
+      if (error.errors) {
+        this.set('inviteError', `Error in accepting invite: ${error.errors[0].detail}`);
+      } else {
+        this.set('inviteError', 'Error in accepting invite');
       }
-    },
+    }
+  }),
 
-    async declineInvitation(invite) {
-      invite.set('accepted', false);
+  declineInvitationTask: task(function* () {
+    this.invite.set('accepted', false);
 
-      try {
-        await invite.save();
-        this.set('isDeclined', true);
-      } catch (error) {
-        this.set('isError', true);
-        if (error.errors) {
-          this.set('inviteError', `Error in declining invite: ${error.errors[0].detail}`);
-        } else {
-          this.set('inviteError', 'Error in declining invite');
-        }
+    try {
+      yield this.invite.save();
+      this.set('isDeclined', true);
+    } catch (error) {
+      this.set('isError', true);
+      if (error.errors) {
+        this.set('inviteError', `Error in declining invite: ${error.errors[0].detail}`);
+      } else {
+        this.set('inviteError', 'Error in declining invite');
       }
-    },
-  },
+    }
+  }),
 });


### PR DESCRIPTION
async actions are dangerous because they reference component instances that might have already been destroyed when the async behavior finishes. ember-concurrency tasks resolve this issue by cancelling themselves if the parent object is destroyed.

r? @locks 