### PR TITLE
Simplify README loading code

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -3,8 +3,7 @@ import { inject as service } from '@ember/service';
 import Controller from '@ember/controller';
 import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
-// eslint-disable-next-line ember/no-observers
-import { computed, observer } from '@ember/object';
+import { computed } from '@ember/object';
 import moment from 'moment';
 
 const NUM_VERSIONS = 5;
@@ -163,6 +162,14 @@ export default Controller.extend({
         let r = await fetch(this.currentVersion.get('readme_path'));
         if (r.ok) {
           this.crate.set('readme', await r.text());
+
+          if (typeof document !== 'undefined') {
+            setTimeout(() => {
+              let e = document.createEvent('CustomEvent');
+              e.initCustomEvent('hashchange', true, true);
+              window.dispatchEvent(e);
+            });
+          }
         } else {
           this.crate.set('readme', null);
         }
@@ -171,16 +178,4 @@ export default Controller.extend({
       }
     }
   },
-
-  // eslint-disable-next-line ember/no-observers
-  report: observer('crate.readme', function () {
-    if (typeof document === 'undefined') {
-      return;
-    }
-    setTimeout(() => {
-      let e = document.createEvent('CustomEvent');
-      e.initCustomEvent('hashchange', true, true);
-      window.dispatchEvent(e);
-    });
-  }),
 });

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -157,19 +157,18 @@ export default Controller.extend({
     return data;
   }),
 
-  loadReadme() {
+  async loadReadme() {
     if (this.currentVersion.get('readme_path')) {
-      fetch(this.currentVersion.get('readme_path'))
-        .then(async r => {
-          if (r.ok) {
-            this.crate.set('readme', await r.text());
-          } else {
-            this.crate.set('readme', null);
-          }
-        })
-        .catch(() => {
+      try {
+        let r = await fetch(this.currentVersion.get('readme_path'));
+        if (r.ok) {
+          this.crate.set('readme', await r.text());
+        } else {
           this.crate.set('readme', null);
-        });
+        }
+      } catch (error) {
+        this.crate.set('readme', null);
+      }
     }
   },
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -5,6 +5,7 @@ import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
 import { computed } from '@ember/object';
 import moment from 'moment';
+import { task } from 'ember-concurrency';
 
 const NUM_VERSIONS = 5;
 
@@ -156,12 +157,12 @@ export default Controller.extend({
     return data;
   }),
 
-  async loadReadme() {
+  loadReadmeTask: task(function* () {
     if (this.currentVersion.get('readme_path')) {
       try {
-        let r = await fetch(this.currentVersion.get('readme_path'));
+        let r = yield fetch(this.currentVersion.get('readme_path'));
         if (r.ok) {
-          this.crate.set('readme', await r.text());
+          this.crate.set('readme', yield r.text());
 
           if (typeof document !== 'undefined') {
             setTimeout(() => {
@@ -177,5 +178,5 @@ export default Controller.extend({
         this.crate.set('readme', null);
       }
     }
-  },
+  }),
 });

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -157,6 +157,22 @@ export default Controller.extend({
     return data;
   }),
 
+  loadReadme() {
+    if (this.currentVersion.get('readme_path')) {
+      fetch(this.currentVersion.get('readme_path'))
+        .then(async r => {
+          if (r.ok) {
+            this.crate.set('readme', await r.text());
+          } else {
+            this.crate.set('readme', null);
+          }
+        })
+        .catch(() => {
+          this.crate.set('readme', null);
+        });
+    }
+  },
+
   // eslint-disable-next-line ember/no-observers
   report: observer('crate.readme', function () {
     if (typeof document === 'undefined') {

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -4,8 +4,6 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import prerelease from 'semver/functions/prerelease';
 
-import fetch from 'fetch';
-
 import ajax from '../../utils/ajax';
 
 export default Route.extend({
@@ -93,23 +91,12 @@ export default Route.extend({
       this.flashMessages.queue(`Version '${params.version_num}' of crate '${crate.get('name')}' does not exist`);
     }
 
-    const result = version || versions.find(version => version.get('num') === maxVersion) || versions.objectAt(0);
+    return version || versions.find(version => version.get('num') === maxVersion) || versions.objectAt(0);
+  },
 
-    if (result.get('readme_path')) {
-      fetch(result.get('readme_path'))
-        .then(async r => {
-          if (r.ok) {
-            crate.set('readme', await r.text());
-          } else {
-            crate.set('readme', null);
-          }
-        })
-        .catch(() => {
-          crate.set('readme', null);
-        });
-    }
-
-    return result;
+  setupController(controller) {
+    this._super(...arguments);
+    controller.loadReadme();
   },
 
   serialize(model) {

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -96,7 +96,7 @@ export default Route.extend({
 
   setupController(controller) {
     this._super(...arguments);
-    controller.loadReadme();
+    controller.loadReadmeTask.perform();
   },
 
   serialize(model) {


### PR DESCRIPTION
This converts the README loading code into an ember-concurrency task in the controller, and removes the observer on the `readme` property by calling the code in the task directly.

r? @locks 