### PR TITLE
Move request logging near the top of the middleware stack

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -46,6 +46,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
 
     if env != Env::Test {
         m.add(ensure_well_formed_500::EnsureWellFormed500);
+        m.add(log_request::LogRequests::default());
     }
 
     if env == Env::Development {
@@ -93,10 +94,6 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
     }
 
     m.around(require_user_agent::RequireUserAgent::default());
-
-    if env != Env::Test {
-        m.around(log_request::LogRequests::default());
-    }
 
     m
 }


### PR DESCRIPTION
By converting to a regular `Middleware` (instead of `AroundMiddleware`),
the logging can now sit near the top of the middleware stack.
Previously logging occurred at the top of the around stack, which sits
under the layers added via `add()`.

This change ensures that middleware sitting below the request logger
in the stack are able to add logging metadata in a call to `after()`.

r? @JohnTitor 