### PR TITLE
Serve more static files from nginx

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -132,11 +132,25 @@ http {
 		server_name _;
 		keepalive_timeout 5;
 
-		location ~ ^/assets/ {
+		location ~ ^/(assets|ember-fetch|moment)/ {
 			add_header X-Content-Type-Options nosniff;
 			add_header Cache-Control public;
 			root dist;
 			expires max;
+		}
+
+		location ~ ^/cargo-[0-9a-f]*\.png$ {
+			add_header X-Content-Type-Options nosniff;
+			add_header Cache-Control public;
+			root dist;
+			expires max;
+		}
+
+		location ~ /(favicon\.ico|robots\.txt|opensearch\.xml) {
+			add_header X-Content-Type-Options nosniff;
+			add_header Cache-Control public;
+			root dist;
+			expires 1d;
 		}
 
 		add_header X-Content-Type-Options "nosniff";


### PR DESCRIPTION
Serve more folders containing files with hashed filenames directly from
nginx with a max expiration date.  Additionally, some unhashed static
files are allowed to be cached for up to 1 day.

These changes serve as a workaround for an authentication issue.
Currently `conduit-cookie` includes a `Set-Cookie` header in every
backend response.  During the authentication steps, the popup window
requests static assets such as `favicon.ico` and `cargo-{hash}.png`.
If these assets are served by the backend, they will echo whatever
cookie was sent in the request.  Therefore, there is a race between the
request to `/api/private/session/authorize?...` and requests for these
static assets.  If a request for one of these assets is sent before
authorization is complete and the response arrives after successful
authorization, then the stale cookie will be stored again by the
browser, overwriting the contents.

I've opened conduit-rust/conduit-cookie#12 to track the progress of the
proposed long-term solution.  This commit should be sufficient to fix
the behavior for now and should reduce the number of requests for these
static assets (due to improved caching).

Closes #2252
r? @carols10cents