### PR TITLE
Improve Mirage setup

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -2,6 +2,7 @@ import * as Categories from './route-handlers/categories';
 import * as Crates from './route-handlers/crates';
 import * as DocsRS from './route-handlers/docs-rs';
 import * as Keywords from './route-handlers/keywords';
+import * as Me from './route-handlers/me';
 import * as Summary from './route-handlers/summary';
 import * as Teams from './route-handlers/teams';
 import * as Users from './route-handlers/users';
@@ -11,6 +12,7 @@ export default function () {
   Crates.register(this);
   DocsRS.register(this);
   Keywords.register(this);
+  Me.register(this);
   Summary.register(this);
   Teams.register(this);
   Users.register(this);

--- a/mirage/factories/api-token.js
+++ b/mirage/factories/api-token.js
@@ -1,0 +1,18 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  createdAt: '2017-11-19T17:59:22',
+  lastUsedAt: null,
+  name: i => `API Token ${i + 1}`,
+  token: () => generateToken(),
+
+  afterCreate(model) {
+    if (!model.user) {
+      throw new Error('Missing `user` relationship on `api-token`');
+    }
+  },
+});
+
+function generateToken() {
+  return Math.random().toString().slice(2);
+}

--- a/mirage/factories/crate-ownership.js
+++ b/mirage/factories/crate-ownership.js
@@ -1,0 +1,14 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  emailNotifications: true,
+
+  afterCreate(model) {
+    if (!model.crate) {
+      throw new Error('Missing `crate` relationship on `crate-ownership`');
+    }
+    if (model.team && model.user) {
+      throw new Error('`team` and `user` on a `crate-ownership` are mutually exclusive');
+    }
+  },
+});

--- a/mirage/factories/mirage-session.js
+++ b/mirage/factories/mirage-session.js
@@ -1,0 +1,9 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  afterCreate(session) {
+    if (!session.user) {
+      throw new Error('Missing `user` relationship');
+    }
+  },
+});

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -8,9 +8,16 @@ export default Factory.extend({
     return dasherize(this.name);
   },
 
+  email() {
+    return `${this.login}@crates.io`;
+  },
+
   url() {
     return `https://github.com/${this.login}`;
   },
 
   avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
+
+  emailVerified: true,
+  emailVerificationSent: true,
 });

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -18,6 +18,12 @@ export default Factory.extend({
 
   avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
 
-  emailVerified: true,
-  emailVerificationSent: true,
+  emailVerified: null,
+  emailVerificationToken: null,
+
+  afterCreate(model) {
+    if (model.emailVerified === null) {
+      model.update({ emailVerified: !model.emailVerificationToken });
+    }
+  },
 });

--- a/mirage/fixtures/crate-ownerships.js
+++ b/mirage/fixtures/crate-ownerships.js
@@ -1,0 +1,18 @@
+export default [
+  {
+    crateId: 'nanomsg',
+    teamId: 1,
+  },
+  {
+    crateId: 'nanomsg',
+    teamId: 303,
+  },
+  {
+    crateId: 'nanomsg',
+    userId: 2,
+  },
+  {
+    crateId: 'nanomsg',
+    userId: 303,
+  },
+];

--- a/mirage/models/api-token.js
+++ b/mirage/models/api-token.js
@@ -1,3 +1,5 @@
-import { Model } from 'ember-cli-mirage';
+import { Model, belongsTo } from 'ember-cli-mirage';
 
-export default Model.extend({});
+export default Model.extend({
+  user: belongsTo(),
+});

--- a/mirage/models/crate-ownership.js
+++ b/mirage/models/crate-ownership.js
@@ -1,0 +1,7 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  crate: belongsTo(),
+  team: belongsTo(),
+  user: belongsTo(),
+});

--- a/mirage/models/crate.js
+++ b/mirage/models/crate.js
@@ -3,7 +3,5 @@ import { Model, hasMany } from 'ember-cli-mirage';
 export default Model.extend({
   categories: hasMany(),
   keywords: hasMany(),
-  teamOwners: hasMany('team'),
   versions: hasMany(),
-  userOwners: hasMany('user'),
 });

--- a/mirage/models/mirage-session.js
+++ b/mirage/models/mirage-session.js
@@ -1,0 +1,13 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+/**
+ * This is a mirage-only model, that is used to keep track of the current
+ * session and the associated `user` model, because in route handlers we don't
+ * have access to the cookie data that the actual API is using for these things.
+ *
+ * This mock implementation means that there can only ever exist one
+ * session at a time.
+ */
+export default Model.extend({
+  user: belongsTo(),
+});

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -99,13 +99,15 @@ export function register(server) {
     let crate = schema.crates.find(crateId);
     if (!crate) return notFound();
 
-    let response = this.serialize(crate.userOwners);
+    let ownerships = schema.crateOwnerships.where({ crateId }).filter(it => it.userId).models;
 
-    response.users.forEach(user => {
-      user.kind = 'user';
-    });
-
-    return response;
+    return {
+      users: ownerships.map(it => {
+        let json = this.serialize(it.user, 'user').user;
+        json.kind = 'user';
+        return json;
+      }),
+    };
   });
 
   server.get('/api/v1/crates/:crate_id/owner_team', function (schema, request) {
@@ -113,13 +115,15 @@ export function register(server) {
     let crate = schema.crates.find(crateId);
     if (!crate) return notFound();
 
-    let response = this.serialize(crate.teamOwners);
+    let ownerships = schema.crateOwnerships.where({ crateId }).filter(it => it.teamId).models;
 
-    response.teams.forEach(team => {
-      team.kind = 'team';
-    });
-
-    return response;
+    return {
+      teams: ownerships.map(it => {
+        let json = this.serialize(it.team, 'team').team;
+        json.kind = 'team';
+        return json;
+      }),
+    };
   });
 
   server.get('/api/v1/crates/:crate_id/reverse_dependencies', function (schema, request) {

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -18,12 +18,12 @@ export function register(server) {
 
     if (request.queryParams.user_id) {
       let userId = parseInt(request.queryParams.user_id, 10);
-      crates = crates.filter(crate => (crate._owner_users || []).indexOf(userId) !== -1);
+      crates = crates.filter(crate => schema.crateOwnerships.findBy({ crateId: crate.id, userId }));
     }
 
     if (request.queryParams.team_id) {
       let teamId = parseInt(request.queryParams.team_id, 10);
-      crates = crates.filter(crate => (crate._owner_teams || []).indexOf(teamId) !== -1);
+      crates = crates.filter(crate => schema.crateOwnerships.findBy({ crateId: crate.id, teamId }));
     }
 
     if (request.queryParams.sort === 'alpha') {

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -16,4 +16,17 @@ export function register(server) {
 
     return json;
   });
+
+  server.put('/api/v1/confirm/:token', (schema, request) => {
+    let { token } = request.params;
+
+    let user = schema.users.findBy({ emailVerificationToken: token });
+    if (!user) {
+      return new Response(400, {}, { errors: [{ detail: 'Email belonging to token not found.' }] });
+    }
+
+    user.update({ emailVerified: true, emailVerificationToken: null });
+
+    return { ok: true };
+  });
 }

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -1,0 +1,19 @@
+import { Response } from 'ember-cli-mirage';
+
+import { getSession } from '../utils/session';
+
+export function register(server) {
+  server.get('/api/v1/me', function (schema) {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
+    let json = this.serialize(user);
+
+    // TODO fill this with data from the `schema`
+    json.owned_crates = [];
+
+    return json;
+  });
+}

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -9,10 +9,15 @@ export function register(server) {
       return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
     }
 
+    let ownerships = schema.crateOwnerships.where({ userId: user.id }).models;
+
     let json = this.serialize(user);
 
-    // TODO fill this with data from the `schema`
-    json.owned_crates = [];
+    json.owned_crates = ownerships.map(ownership => ({
+      id: ownership.crate.id,
+      name: ownership.crate.name,
+      email_notifications: ownership.emailNotifications,
+    }));
 
     return json;
   });

--- a/mirage/serializers/api-token.js
+++ b/mirage/serializers/api-token.js
@@ -1,0 +1,29 @@
+import BaseSerializer from './application';
+
+export default BaseSerializer.extend({
+  getHashForResource() {
+    let [hash, addToIncludes] = BaseSerializer.prototype.getHashForResource.apply(this, arguments);
+
+    if (Array.isArray(hash)) {
+      for (let resource of hash) {
+        this._adjust(resource);
+      }
+    } else {
+      this._adjust(hash);
+    }
+
+    return [hash, addToIncludes];
+  },
+
+  _adjust(hash) {
+    hash.id = Number(hash.id);
+    if (hash.created_at) {
+      hash.created_at = new Date(hash.created_at).toISOString();
+    }
+    if (hash.last_used_at) {
+      hash.last_used_at = new Date(hash.last_used_at).toISOString();
+    }
+    delete hash.token;
+    delete hash.user_id;
+  },
+});

--- a/mirage/serializers/team.js
+++ b/mirage/serializers/team.js
@@ -1,0 +1,21 @@
+import BaseSerializer from './application';
+
+export default BaseSerializer.extend({
+  getHashForResource() {
+    let [hash, addToIncludes] = BaseSerializer.prototype.getHashForResource.apply(this, arguments);
+
+    if (Array.isArray(hash)) {
+      for (let resource of hash) {
+        this._adjust(resource);
+      }
+    } else {
+      this._adjust(hash);
+    }
+
+    return [hash, addToIncludes];
+  },
+
+  _adjust(hash) {
+    hash.id = Number(hash.id);
+  },
+});

--- a/mirage/serializers/user.js
+++ b/mirage/serializers/user.js
@@ -4,22 +4,26 @@ export default BaseSerializer.extend({
   getHashForResource() {
     let [hash, addToIncludes] = BaseSerializer.prototype.getHashForResource.apply(this, arguments);
 
+    let removePrivateData = this.request.url !== '/api/v1/me';
+
     if (Array.isArray(hash)) {
       for (let resource of hash) {
-        this._adjust(resource);
+        this._adjust(resource, { removePrivateData });
       }
     } else {
-      this._adjust(hash);
+      this._adjust(hash, { removePrivateData });
     }
 
     return [hash, addToIncludes];
   },
 
-  _adjust(hash) {
+  _adjust(hash, { removePrivateData }) {
     hash.id = Number(hash.id);
 
-    delete hash.email;
-    delete hash.email_verified;
-    delete hash.email_verification_sent;
+    if (removePrivateData) {
+      delete hash.email;
+      delete hash.email_verified;
+      delete hash.email_verification_sent;
+    }
   },
 });

--- a/mirage/serializers/user.js
+++ b/mirage/serializers/user.js
@@ -23,7 +23,10 @@ export default BaseSerializer.extend({
     if (removePrivateData) {
       delete hash.email;
       delete hash.email_verified;
-      delete hash.email_verification_sent;
+    } else {
+      hash.email_verification_sent = hash.email_verified || Boolean(hash.email_verification_token);
     }
+
+    delete hash.email_verification_token;
   },
 });

--- a/mirage/serializers/user.js
+++ b/mirage/serializers/user.js
@@ -1,0 +1,21 @@
+import BaseSerializer from './application';
+
+export default BaseSerializer.extend({
+  getHashForResource() {
+    let [hash, addToIncludes] = BaseSerializer.prototype.getHashForResource.apply(this, arguments);
+
+    if (Array.isArray(hash)) {
+      for (let resource of hash) {
+        this._adjust(resource);
+      }
+    } else {
+      this._adjust(hash);
+    }
+
+    return [hash, addToIncludes];
+  },
+
+  _adjust(hash) {
+    hash.id = Number(hash.id);
+  },
+});

--- a/mirage/serializers/user.js
+++ b/mirage/serializers/user.js
@@ -17,5 +17,9 @@ export default BaseSerializer.extend({
 
   _adjust(hash) {
     hash.id = Number(hash.id);
+
+    delete hash.email;
+    delete hash.email_verified;
+    delete hash.email_verification_sent;
   },
 });

--- a/mirage/utils/session.js
+++ b/mirage/utils/session.js
@@ -1,0 +1,9 @@
+export function getSession(schema) {
+  let session = schema.mirageSessions.first();
+  if (!session || Date.parse(session.expires) < Date.now()) {
+    return {};
+  }
+
+  let user = schema.users.find(session.userId);
+  return { session, user };
+}

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -14,21 +14,15 @@ module('Acceptance | api-tokens', function (hooks) {
   setupMirage(hooks);
 
   function prepare(context) {
-    window.localStorage.setItem('isLoggedIn', '1');
-
-    context.server.get('/api/v1/me', {
-      user: {
-        id: 42,
-        login: 'johnnydee',
-        email_verified: true,
-        email_verification_sent: true,
-        name: 'John Doe',
-        email: 'john@doe.com',
-        avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
-        url: 'https://github.com/johnnydee',
-      },
-      owned_crates: [],
+    let user = context.server.create('user', {
+      login: 'johnnydee',
+      name: 'John Doe',
+      email: 'john@doe.com',
+      avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
     });
+
+    context.server.create('mirage-session', { user });
+    window.localStorage.setItem('isLoggedIn', '1');
 
     context.server.get('/api/v1/me/tokens', {
       api_tokens: [

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentURL, findAll, click, fillIn } from '@ember/test-helpers';
-import window, { setupWindowMock } from 'ember-window-mock';
 import { Response } from 'ember-cli-mirage';
 import { percySnapshot } from 'ember-percy';
 
@@ -10,7 +9,6 @@ import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | api-tokens', function (hooks) {
   setupApplicationTest(hooks);
-  setupWindowMock(hooks);
   setupMirage(hooks);
 
   function prepare(context) {
@@ -20,9 +18,6 @@ module('Acceptance | api-tokens', function (hooks) {
       email: 'john@doe.com',
       avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
     });
-
-    context.server.create('mirage-session', { user });
-    window.localStorage.setItem('isLoggedIn', '1');
 
     context.server.get('/api/v1/me/tokens', {
       api_tokens: [
@@ -35,6 +30,8 @@ module('Acceptance | api-tokens', function (hooks) {
         },
       ],
     });
+
+    context.authenticateAs(user);
   }
 
   test('/me is showing the list of active API tokens', async function (assert) {

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -19,16 +19,18 @@ module('Acceptance | api-tokens', function (hooks) {
       avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
     });
 
-    context.server.get('/api/v1/me/tokens', {
-      api_tokens: [
-        { id: 2, name: 'BAR', created_at: new Date('2017-11-19T17:59:22').toISOString(), last_used_at: null },
-        {
-          id: 1,
-          name: 'foo',
-          created_at: new Date('2017-08-01T12:34:56').toISOString(),
-          last_used_at: new Date('2017-11-02T01:45:14').toISOString(),
-        },
-      ],
+    context.server.create('api-token', {
+      user,
+      name: 'foo',
+      createdAt: '2017-08-01T12:34:56',
+      lastUsedAt: '2017-11-02T01:45:14',
+    });
+
+    context.server.create('api-token', {
+      user,
+      name: 'BAR',
+      createdAt: '2017-11-19T17:59:22',
+      lastUsedAt: null,
     });
 
     context.authenticateAs(user);
@@ -64,17 +66,12 @@ module('Acceptance | api-tokens', function (hooks) {
   test('API tokens can be revoked', async function (assert) {
     prepare(this);
 
-    this.server.delete('/api/v1/me/tokens/:id', function (schema, request) {
-      assert.step(`delete id:${request.params.id}`);
-      return {};
-    });
-
     await visit('/me');
     assert.equal(currentURL(), '/me');
     assert.dom('[data-test-api-token]').exists({ count: 2 });
 
     await click('[data-test-api-token="1"] [data-test-revoke-token-button]');
-    assert.verifySteps(['delete id:1']);
+    assert.equal(this.server.schema.apiTokens.all().length, 1, 'API token has been deleted from the backend database');
 
     assert.dom('[data-test-api-token]').exists({ count: 1 });
     assert.dom('[data-test-api-token="2"]').exists();
@@ -102,23 +99,6 @@ module('Acceptance | api-tokens', function (hooks) {
   test('new API tokens can be created', async function (assert) {
     prepare(this);
 
-    this.server.put('/api/v1/me/tokens', function (schema, request) {
-      assert.step('put');
-
-      let { api_token } = JSON.parse(request.requestBody);
-
-      return {
-        api_token: {
-          id: 5,
-          name: api_token.name,
-          token: 'zuz6nYcXJOzPDvnA9vucNwccG0lFSGbh',
-          revoked: false,
-          created_at: api_token.created_at,
-          last_used_at: api_token.last_used_at,
-        },
-      };
-    });
-
     await visit('/me');
     assert.equal(currentURL(), '/me');
     assert.dom('[data-test-api-token]').exists({ count: 2 });
@@ -134,15 +114,18 @@ module('Acceptance | api-tokens', function (hooks) {
     percySnapshot(assert);
 
     await click('[data-test-save-token-button]');
-    assert.verifySteps(['put']);
+
+    let token = this.server.schema.apiTokens.findBy({ name: 'the new token' });
+    assert.ok(Boolean(token), 'API token has been created in the backend database');
+
     assert.dom('[data-test-focused-input]').doesNotExist();
     assert.dom('[data-test-save-token-button]').doesNotExist();
 
-    assert.dom('[data-test-api-token="5"] [data-test-name]').hasText('the new token');
-    assert.dom('[data-test-api-token="5"] [data-test-save-token-button]').doesNotExist();
-    assert.dom('[data-test-api-token="5"] [data-test-revoke-token-button]').exists();
-    assert.dom('[data-test-api-token="5"] [data-test-saving-spinner]').doesNotExist();
-    assert.dom('[data-test-api-token="5"] [data-test-error]').doesNotExist();
-    assert.dom('[data-test-token]').includesText('cargo login zuz6nYcXJOzPDvnA9vucNwccG0lFSGbh');
+    assert.dom('[data-test-api-token="3"] [data-test-name]').hasText('the new token');
+    assert.dom('[data-test-api-token="3"] [data-test-save-token-button]').doesNotExist();
+    assert.dom('[data-test-api-token="3"] [data-test-revoke-token-button]').exists();
+    assert.dom('[data-test-api-token="3"] [data-test-saving-spinner]').doesNotExist();
+    assert.dom('[data-test-api-token="3"] [data-test-error]').doesNotExist();
+    assert.dom('[data-test-token]').includesText(`cargo login ${token.token}`);
   });
 });

--- a/tests/acceptance/crate-following-test.js
+++ b/tests/acceptance/crate-following-test.js
@@ -18,20 +18,8 @@ module('Acceptance | Crate following', function (hooks) {
     server.create('version', { crate, num: '0.6.0' });
 
     if (loggedIn) {
-      server.get('/api/v1/me', {
-        user: {
-          id: 42,
-          login: 'johnnydee',
-          email_verified: true,
-          email_verification_sent: true,
-          name: 'John Doe',
-          email: 'john@doe.com',
-          avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
-          url: 'https://github.com/johnnydee',
-        },
-        owned_crates: [],
-      });
-
+      let user = server.create('user');
+      server.create('mirage-session', { user });
       window.localStorage.setItem('isLoggedIn', '1');
     }
   }

--- a/tests/acceptance/crate-following-test.js
+++ b/tests/acceptance/crate-following-test.js
@@ -1,14 +1,12 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { visit, waitFor, settled, click } from '@ember/test-helpers';
-import window, { setupWindowMock } from 'ember-window-mock';
 import { defer } from 'rsvp';
 
 import setupMirage from '../helpers/setup-mirage';
 
 module('Acceptance | Crate following', function (hooks) {
   setupApplicationTest(hooks);
-  setupWindowMock(hooks);
   setupMirage(hooks);
 
   function prepare(context, { loggedIn = true } = {}) {
@@ -19,8 +17,7 @@ module('Acceptance | Crate following', function (hooks) {
 
     if (loggedIn) {
       let user = server.create('user');
-      server.create('mirage-session', { user });
-      window.localStorage.setItem('isLoggedIn', '1');
+      context.authenticateAs(user);
     }
   }
 

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
-import window, { setupWindowMock } from 'ember-window-mock';
 import { percySnapshot } from 'ember-percy';
 
 import setupMirage from '../helpers/setup-mirage';
@@ -9,7 +8,6 @@ import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | Dashboard', function (hooks) {
   setupApplicationTest(hooks);
-  setupWindowMock(hooks);
   setupMirage(hooks);
 
   test('redirects to / when not logged in', async function (assert) {
@@ -26,8 +24,7 @@ module('Acceptance | Dashboard', function (hooks) {
       avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
     });
 
-    this.server.create('mirage-session', { user });
-    window.localStorage.setItem('isLoggedIn', '1');
+    this.authenticateAs(user);
 
     {
       let crate = this.server.create('crate', { name: 'rand' });

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -33,7 +33,8 @@ module('Acceptance | Dashboard', function (hooks) {
     }
 
     {
-      let crate = this.server.create('crate', { name: 'nanomsg', _owner_users: [42] });
+      let crate = this.server.create('crate', { name: 'nanomsg' });
+      this.server.create('crate-ownership', { crate, user });
       this.server.create('version', { crate, num: '0.1.0' });
     }
 

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -19,6 +19,14 @@ module('Acceptance | Dashboard', function (hooks) {
   });
 
   test('shows the dashboard when logged in', async function (assert) {
+    let user = this.server.create('user', {
+      login: 'johnnydee',
+      name: 'John Doe',
+      email: 'john@doe.com',
+      avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
+    });
+
+    this.server.create('mirage-session', { user });
     window.localStorage.setItem('isLoggedIn', '1');
 
     {
@@ -31,23 +39,6 @@ module('Acceptance | Dashboard', function (hooks) {
       let crate = this.server.create('crate', { name: 'nanomsg', _owner_users: [42] });
       this.server.create('version', { crate, num: '0.1.0' });
     }
-
-    this.server.get('/api/v1/me', {
-      user: {
-        id: 42,
-        login: 'johnnydee',
-        email_verified: true,
-        email_verification_sent: true,
-        name: 'John Doe',
-        email: 'john@doe.com',
-        avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
-        url: 'https://github.com/johnnydee',
-      },
-      owned_crates: [
-        { id: 123, name: 'foo-bar', email_notifications: true },
-        { id: 56456, name: 'barrrrr', email_notifications: false },
-      ],
-    });
 
     this.server.get('/api/v1/me/updates', {
       versions: [
@@ -145,7 +136,7 @@ module('Acceptance | Dashboard', function (hooks) {
       meta: { more: true },
     });
 
-    this.server.get('/api/v1/users/42/stats', { total_downloads: 3892 });
+    this.server.get(`/api/v1/users/${user.id}/stats`, { total_downloads: 3892 });
 
     await visit('/dashboard');
     assert.equal(currentURL(), '/dashboard');

--- a/tests/acceptance/email-confirmation-test.js
+++ b/tests/acceptance/email-confirmation-test.js
@@ -1,14 +1,12 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
-import window, { setupWindowMock } from 'ember-window-mock';
 
 import { visit } from '../helpers/visit-ignoring-abort';
 import setupMirage from '../helpers/setup-mirage';
 
 module('Acceptance | Email Confirmation', function (hooks) {
   setupApplicationTest(hooks);
-  setupWindowMock(hooks);
   setupMirage(hooks);
 
   test('unauthenticated happy path', async function (assert) {
@@ -27,8 +25,7 @@ module('Acceptance | Email Confirmation', function (hooks) {
     let user = this.server.create('user', { emailVerificationToken: 'badc0ffee' });
     assert.strictEqual(user.emailVerified, false);
 
-    this.server.create('mirage-session', { user });
-    window.localStorage.setItem('isLoggedIn', '1');
+    this.authenticateAs(user);
 
     await visit('/confirm/badc0ffee');
     assert.equal(currentURL(), '/confirm/badc0ffee');

--- a/tests/acceptance/email-confirmation-test.js
+++ b/tests/acceptance/email-confirmation-test.js
@@ -2,7 +2,6 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
 import window, { setupWindowMock } from 'ember-window-mock';
-import { Response } from 'ember-cli-mirage';
 
 import { visit } from '../helpers/visit-ignoring-abort';
 import setupMirage from '../helpers/setup-mirage';
@@ -13,46 +12,23 @@ module('Acceptance | Email Confirmation', function (hooks) {
   setupMirage(hooks);
 
   test('unauthenticated happy path', async function (assert) {
-    assert.expect(3);
-
-    this.server.put('/api/v1/confirm/:token', (schema, request) => {
-      assert.equal(request.params.token, 'badc0ffee');
-      return { ok: true };
-    });
+    let user = this.server.create('user', { emailVerificationToken: 'badc0ffee' });
+    assert.strictEqual(user.emailVerified, false);
 
     await visit('/confirm/badc0ffee');
     assert.equal(currentURL(), '/confirm/badc0ffee');
     assert.dom('[data-test-success-message]').exists();
+
+    user.reload();
+    assert.strictEqual(user.emailVerified, true);
   });
 
   test('authenticated happy path', async function (assert) {
-    assert.expect(4);
+    let user = this.server.create('user', { emailVerificationToken: 'badc0ffee' });
+    assert.strictEqual(user.emailVerified, false);
 
-    let emailVerified = false;
-
+    this.server.create('mirage-session', { user });
     window.localStorage.setItem('isLoggedIn', '1');
-
-    this.server.get('/api/v1/me', () => ({
-      user: {
-        id: 42,
-        login: 'johnnydee',
-        email_verified: emailVerified,
-        email_verification_sent: true,
-        name: 'John Doe',
-        email: 'john@doe.com',
-        avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
-        url: 'https://github.com/johnnydee',
-      },
-      owned_crates: [],
-    }));
-
-    this.server.put('/api/v1/confirm/:token', (schema, request) => {
-      assert.equal(request.params.token, 'badc0ffee');
-
-      emailVerified = true;
-
-      return { ok: true };
-    });
 
     await visit('/confirm/badc0ffee');
     assert.equal(currentURL(), '/confirm/badc0ffee');
@@ -60,13 +36,12 @@ module('Acceptance | Email Confirmation', function (hooks) {
 
     let { currentUser } = this.owner.lookup('service:session');
     assert.strictEqual(currentUser.email_verified, true);
+
+    user.reload();
+    assert.strictEqual(user.emailVerified, true);
   });
 
   test('error case', async function (assert) {
-    this.server.put('/api/v1/confirm/:token', () => {
-      return new Response(400, {}, { errors: [{ detail: 'Email belonging to token not found.' }] });
-    });
-
     await visit('/confirm/badc0ffee');
     assert.equal(currentURL(), '/');
     assert.dom('[data-test-flash-message]').hasText('Unknown error in email confirmation');

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -1,7 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { currentURL, click } from '@ember/test-helpers';
-import window, { setupWindowMock } from 'ember-window-mock';
 import { percySnapshot } from 'ember-percy';
 import Response from 'ember-cli-mirage/response';
 
@@ -10,13 +9,11 @@ import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | /me/pending-invites', function (hooks) {
   setupApplicationTest(hooks);
-  setupWindowMock(hooks);
   setupMirage(hooks);
 
   function prepare(context) {
     let user = context.server.create('user');
-    context.server.create('mirage-session', { user });
-    window.localStorage.setItem('isLoggedIn', '1');
+    context.authenticateAs(user);
 
     context.server.get('/api/v1/me/crate_owner_invitations', {
       crate_owner_invitations: [

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -14,21 +14,9 @@ module('Acceptance | /me/pending-invites', function (hooks) {
   setupMirage(hooks);
 
   function prepare(context) {
+    let user = context.server.create('user');
+    context.server.create('mirage-session', { user });
     window.localStorage.setItem('isLoggedIn', '1');
-
-    context.server.get('/api/v1/me', {
-      user: {
-        id: 42,
-        login: 'johnnydee',
-        email_verified: true,
-        email_verification_sent: true,
-        name: 'John Doe',
-        email: 'john@doe.com',
-        avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
-        url: 'https://github.com/johnnydee',
-      },
-      owned_crates: [],
-    });
 
     context.server.get('/api/v1/me/crate_owner_invitations', {
       crate_owner_invitations: [

--- a/tests/helpers/setup-mirage.js
+++ b/tests/helpers/setup-mirage.js
@@ -1,12 +1,19 @@
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import timekeeper from 'timekeeper';
+import window, { setupWindowMock } from 'ember-window-mock';
 
 export default function (hooks) {
   setupMirage(hooks);
+  setupWindowMock(hooks);
 
   // To have deterministic visual tests, the seed has to be constant
   hooks.beforeEach(function () {
     timekeeper.freeze(new Date('11/20/2017 12:00'));
+
+    this.authenticateAs = user => {
+      this.server.create('mirage-session', { user });
+      window.localStorage.setItem('isLoggedIn', '1');
+    };
   });
 
   hooks.afterEach(function () {

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -694,7 +694,7 @@ module('Mirage | Crates', function (hooks) {
       assert.deepEqual(responsePayload, {
         users: [
           {
-            id: '1',
+            id: 1,
             avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
             kind: 'user',
             login: 'john-doe',

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -134,14 +134,19 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('supports a `user_id` parameter', async function (assert) {
+      let user1 = this.server.create('user');
+      let user2 = this.server.create('user');
+
       this.server.create('crate', { name: 'foo' });
       this.server.create('version', { crateId: 'foo' });
-      this.server.create('crate', { name: 'bar', _owner_users: [42] });
+      let bar = this.server.create('crate', { name: 'bar' });
+      this.server.create('crate-ownership', { crate: bar, user: user1 });
       this.server.create('version', { crateId: 'bar' });
-      this.server.create('crate', { name: 'baz', _owner_users: [13] });
+      let baz = this.server.create('crate', { name: 'baz' });
+      this.server.create('crate-ownership', { crate: baz, user: user2 });
       this.server.create('version', { crateId: 'baz' });
 
-      let response = await fetch('/api/v1/crates?user_id=42');
+      let response = await fetch(`/api/v1/crates?user_id=${user1.id}`);
       assert.equal(response.status, 200);
 
       let responsePayload = await response.json();
@@ -151,31 +156,19 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('supports a `team_id` parameter', async function (assert) {
+      let team1 = this.server.create('team');
+      let team2 = this.server.create('team');
+
       this.server.create('crate', { name: 'foo' });
       this.server.create('version', { crateId: 'foo' });
-      this.server.create('crate', { name: 'bar', _owner_teams: [42] });
+      let bar = this.server.create('crate', { name: 'bar' });
+      this.server.create('crate-ownership', { crate: bar, team: team1 });
       this.server.create('version', { crateId: 'bar' });
-      this.server.create('crate', { name: 'baz', _owner_teams: [13] });
+      let baz = this.server.create('crate', { name: 'baz' });
+      this.server.create('crate-ownership', { crate: baz, team: team2 });
       this.server.create('version', { crateId: 'baz' });
 
-      let response = await fetch('/api/v1/crates?team_id=42');
-      assert.equal(response.status, 200);
-
-      let responsePayload = await response.json();
-      assert.equal(responsePayload.crates.length, 1);
-      assert.equal(responsePayload.crates[0].id, 'bar');
-      assert.equal(responsePayload.meta.total, 1);
-    });
-
-    test('supports a `team_id` parameter', async function (assert) {
-      this.server.create('crate', { name: 'foo' });
-      this.server.create('version', { crateId: 'foo' });
-      this.server.create('crate', { name: 'bar', _owner_teams: [42] });
-      this.server.create('version', { crateId: 'bar' });
-      this.server.create('crate', { name: 'baz', _owner_teams: [13] });
-      this.server.create('version', { crateId: 'baz' });
-
-      let response = await fetch('/api/v1/crates?team_id=42');
+      let response = await fetch(`/api/v1/crates?team_id=${team1.id}`);
       assert.equal(response.status, 200);
 
       let responsePayload = await response.json();

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -738,7 +738,7 @@ module('Mirage | Crates', function (hooks) {
       assert.deepEqual(responsePayload, {
         teams: [
           {
-            id: '1',
+            id: 1,
             avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
             kind: 'team',
             login: 'github:rust-lang:maintainers',

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -685,7 +685,8 @@ module('Mirage | Crates', function (hooks) {
 
     test('returns the list of users that own the specified crate', async function (assert) {
       let user = this.server.create('user', { name: 'John Doe' });
-      this.server.create('crate', { name: 'rand', userOwners: [user] });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('crate-ownership', { crate, user });
 
       let response = await fetch('/api/v1/crates/rand/owner_user');
       assert.equal(response.status, 200);
@@ -729,7 +730,8 @@ module('Mirage | Crates', function (hooks) {
 
     test('returns the list of teams that own the specified crate', async function (assert) {
       let team = this.server.create('team', { name: 'maintainers' });
-      this.server.create('crate', { name: 'rand', teamOwners: [team] });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('crate-ownership', { crate, team });
 
       let response = await fetch('/api/v1/crates/rand/owner_team');
       assert.equal(response.status, 200);

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 
 import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
+import timekeeper from 'timekeeper';
 
 module('Mirage | /me', function (hooks) {
   setupTest(hooks);
@@ -55,6 +56,135 @@ module('Mirage | /me', function (hooks) {
       this.server.create('user');
 
       let response = await fetch('/api/v1/me');
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+  });
+
+  module('GET /api/v1/me/tokens', function () {
+    test('returns the list of API token for the authenticated `user`', async function (assert) {
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      this.server.create('api-token', { user, createdAt: '2017-11-19T12:59:22Z' });
+      this.server.create('api-token', { user, createdAt: '2017-11-19T13:59:22Z' });
+      this.server.create('api-token', { user, createdAt: '2017-11-19T14:59:22Z' });
+
+      let response = await fetch('/api/v1/me/tokens');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        api_tokens: [
+          {
+            id: 3,
+            created_at: '2017-11-19T14:59:22.000Z',
+            last_used_at: null,
+            name: 'API Token 3',
+          },
+          {
+            id: 2,
+            created_at: '2017-11-19T13:59:22.000Z',
+            last_used_at: null,
+            name: 'API Token 2',
+          },
+          {
+            id: 1,
+            created_at: '2017-11-19T12:59:22.000Z',
+            last_used_at: null,
+            name: 'API Token 1',
+          },
+        ],
+      });
+    });
+
+    test('empty list case', async function (assert) {
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      let response = await fetch('/api/v1/me/tokens');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { api_tokens: [] });
+    });
+
+    test('returns an error if unauthenticated', async function (assert) {
+      let response = await fetch('/api/v1/me/tokens');
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+  });
+
+  module('PUT /api/v1/me/tokens', function () {
+    test('creates a new API token', async function (assert) {
+      timekeeper.freeze(new Date('2017-11-20T11:23:45Z'));
+
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      let body = JSON.stringify({ api_token: { name: 'foooo' } });
+      let response = await fetch('/api/v1/me/tokens', { method: 'PUT', body });
+      assert.equal(response.status, 200);
+
+      let token = this.server.schema.apiTokens.all().models[0];
+      assert.ok(token);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        api_token: {
+          id: 1,
+          created_at: '2017-11-20T11:23:45.000Z',
+          last_used_at: null,
+          name: 'foooo',
+          revoked: false,
+          token: token.token,
+        },
+      });
+    });
+
+    test('returns an error if unauthenticated', async function (assert) {
+      let body = JSON.stringify({ api_token: {} });
+      let response = await fetch('/api/v1/me/tokens', { method: 'PUT', body });
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+  });
+
+  module('DELETE /api/v1/me/tokens/:tokenId', function () {
+    test('revokes an API token', async function (assert) {
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      let token = this.server.create('api-token', { user });
+
+      let response = await fetch(`/api/v1/me/tokens/${token.id}`, { method: 'DELETE' });
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {});
+
+      let tokens = this.server.schema.apiTokens.all().models;
+      assert.equal(tokens.length, 0);
+    });
+
+    test('returns an error if unauthenticated', async function (assert) {
+      let user = this.server.create('user');
+      let token = this.server.create('api-token', { user });
+
+      let response = await fetch(`/api/v1/me/tokens/${token.id}`, { method: 'DELETE' });
       assert.equal(response.status, 403);
 
       let responsePayload = await response.json();

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -32,6 +32,25 @@ module('Mirage | /me', function (hooks) {
       });
     });
 
+    test('returns a list of `owned_crates`', async function (assert) {
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      let [crate1, , crate3] = this.server.createList('crate', 3);
+
+      this.server.create('crate-ownership', { crate: crate1, user });
+      this.server.create('crate-ownership', { crate: crate3, user });
+
+      let response = await fetch('/api/v1/me');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload.owned_crates, [
+        { id: 'crate-0', name: 'crate-0', email_notifications: true },
+        { id: 'crate-2', name: 'crate-2', email_notifications: true },
+      ]);
+    });
+
     test('returns an error if unauthenticated', async function (assert) {
       this.server.create('user');
 

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -44,4 +44,46 @@ module('Mirage | /me', function (hooks) {
       });
     });
   });
+
+  module('GET /api/v1/confirm/:token', function () {
+    test('returns `ok: true` for a known token (unauthenticated)', async function (assert) {
+      let user = this.server.create('user', { emailVerificationToken: 'foo' });
+      assert.strictEqual(user.emailVerified, false);
+
+      let response = await fetch('/api/v1/confirm/foo', { method: 'PUT' });
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { ok: true });
+
+      user.reload();
+      assert.strictEqual(user.emailVerified, true);
+    });
+
+    test('returns `ok: true` for a known token (authenticated)', async function (assert) {
+      let user = this.server.create('user', { emailVerificationToken: 'foo' });
+      assert.strictEqual(user.emailVerified, false);
+
+      this.server.create('mirage-session', { user });
+
+      let response = await fetch('/api/v1/confirm/foo', { method: 'PUT' });
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { ok: true });
+
+      user.reload();
+      assert.strictEqual(user.emailVerified, true);
+    });
+
+    test('returns an error for unknown tokens', async function (assert) {
+      let response = await fetch('/api/v1/confirm/unknown', { method: 'PUT' });
+      assert.equal(response.status, 400);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'Email belonging to token not found.' }],
+      });
+    });
+  });
 });

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -1,0 +1,47 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from '../helpers/setup-mirage';
+import fetch from 'fetch';
+
+module('Mirage | /me', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  module('GET /api/v1/me', function () {
+    test('returns the `user` resource including the private fields', async function (assert) {
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      let response = await fetch('/api/v1/me');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        user: {
+          id: 1,
+          avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
+          email: 'user-1@crates.io',
+          email_verification_sent: true,
+          email_verified: true,
+          login: 'user-1',
+          name: 'User 1',
+          url: 'https://github.com/user-1',
+        },
+        owned_crates: [],
+      });
+    });
+
+    test('returns an error if unauthenticated', async function (assert) {
+      this.server.create('user');
+
+      let response = await fetch('/api/v1/me');
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+  });
+});

--- a/tests/mirage/teams-test.js
+++ b/tests/mirage/teams-test.js
@@ -26,7 +26,7 @@ module('Mirage | Teams', function (hooks) {
       let responsePayload = await response.json();
       assert.deepEqual(responsePayload, {
         team: {
-          id: '1',
+          id: 1,
           avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
           login: 'github:rust-lang:maintainers',
           name: 'maintainers',

--- a/tests/mirage/users-test.js
+++ b/tests/mirage/users-test.js
@@ -26,7 +26,7 @@ module('Mirage | Users', function (hooks) {
       let responsePayload = await response.json();
       assert.deepEqual(responsePayload, {
         user: {
-          id: '1',
+          id: 1,
           avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
           login: 'john-doe',
           name: 'John Doe',


### PR DESCRIPTION
This PR improves our "fake backend" setup which uses https://www.ember-cli-mirage.com/

Due to the number of changes this PR is likely best reviewed commit-by-commit.

The main change is that this PR will make it easier to simulate the logged-in state of the application by providing a relatively simple `this.authenticateAs(user)` helper method on the test contexts.

r? @locks 