### PR TITLE
mirage: Add `followedCrates` relationship to the `user` model

### DIFF
--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -1,3 +1,5 @@
-import { Model } from 'ember-cli-mirage';
+import { Model, hasMany } from 'ember-cli-mirage';
 
-export default Model.extend({});
+export default Model.extend({
+  followedCrates: hasMany('crate'),
+});

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -83,6 +83,24 @@ export function register(server) {
     return { ok: true };
   });
 
+  server.delete('/api/v1/crates/:crateId/follow', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
+    let { crateId } = request.params;
+    let crate = schema.crates.find(crateId);
+    if (!crate) {
+      return new Response(404, {}, { errors: [{ detail: 'Not Found' }] });
+    }
+
+    user.followedCrates.remove(crate);
+    user.save();
+
+    return { ok: true };
+  });
+
   server.get('/api/v1/crates/:crate_id/versions', (schema, request) => {
     let crateId = request.params.crate_id;
     let crate = schema.crates.find(crateId);

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -8,6 +8,15 @@ export function register(server) {
 
     let crates = schema.crates.all();
 
+    if (request.queryParams.following === '1') {
+      let { user } = getSession(schema);
+      if (!user) {
+        return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+      }
+
+      crates = user.followedCrates;
+    }
+
     if (request.queryParams.letter) {
       let letter = request.queryParams.letter.toLowerCase();
       crates = crates.filter(crate => crate.id[0].toLowerCase() === letter);

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -65,6 +65,24 @@ export function register(server) {
     return { following };
   });
 
+  server.put('/api/v1/crates/:crateId/follow', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
+    let { crateId } = request.params;
+    let crate = schema.crates.find(crateId);
+    if (!crate) {
+      return new Response(404, {}, { errors: [{ detail: 'Not Found' }] });
+    }
+
+    user.followedCrates.add(crate);
+    user.save();
+
+    return { ok: true };
+  });
+
   server.get('/api/v1/crates/:crate_id/versions', (schema, request) => {
     let crateId = request.params.crate_id;
     let crate = schema.crates.find(crateId);

--- a/mirage/serializers/user.js
+++ b/mirage/serializers/user.js
@@ -28,5 +28,6 @@ export default BaseSerializer.extend({
     }
 
     delete hash.email_verification_token;
+    delete hash.followed_crate_ids;
   },
 });

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,4 +1,3 @@
-import Service from '@ember/service';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { click, fillIn, currentURL, currentRouteName, visit } from '@ember/test-helpers';
@@ -216,15 +215,8 @@ module('Acceptance | crate page', function (hooks) {
   test('navigating to the owners page when not an owner', async function (assert) {
     this.server.loadFixtures();
 
-    this.owner.register(
-      'service:session',
-      Service.extend({
-        get currentUser() {
-          return { login: 'iain8' };
-        },
-        loadUser() {},
-      }),
-    );
+    let user = this.server.schema.users.findBy({ login: 'iain8' });
+    this.authenticateAs(user);
 
     await visit('/crates/nanomsg');
 
@@ -234,15 +226,8 @@ module('Acceptance | crate page', function (hooks) {
   test('navigating to the owners page', async function (assert) {
     this.server.loadFixtures();
 
-    this.owner.register(
-      'service:session',
-      Service.extend({
-        get currentUser() {
-          return { login: 'thehydroimpulse', id: '2' };
-        },
-        loadUser() {},
-      }),
-    );
+    let user = this.server.schema.users.findBy({ login: 'thehydroimpulse' });
+    this.authenticateAs(user);
 
     await visit('/crates/nanomsg');
     await click('[data-test-manage-owners-link]');

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -30,13 +30,17 @@ module('Acceptance | Dashboard', function (hooks) {
       let crate = this.server.create('crate', { name: 'rand' });
       this.server.create('version', { crate, num: '1.0.0' });
       this.server.create('version', { crate, num: '1.1.0' });
+      user.followedCrates.add(crate);
     }
 
     {
       let crate = this.server.create('crate', { name: 'nanomsg' });
       this.server.create('crate-ownership', { crate, user });
       this.server.create('version', { crate, num: '0.1.0' });
+      user.followedCrates.add(crate);
     }
+
+    user.save();
 
     this.server.get('/api/v1/me/updates', {
       versions: [

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -28,6 +28,15 @@ module('Acceptance | Dashboard', function (hooks) {
 
     {
       let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '0.5.0' });
+      this.server.create('version', { crate, num: '0.6.0' });
+      this.server.create('version', { crate, num: '0.7.0' });
+      this.server.create('version', { crate, num: '0.7.1' });
+      this.server.create('version', { crate, num: '0.7.2' });
+      this.server.create('version', { crate, num: '0.7.3' });
+      this.server.create('version', { crate, num: '0.8.0' });
+      this.server.create('version', { crate, num: '0.8.1' });
+      this.server.create('version', { crate, num: '0.9.0' });
       this.server.create('version', { crate, num: '1.0.0' });
       this.server.create('version', { crate, num: '1.1.0' });
       user.followedCrates.add(crate);
@@ -41,102 +50,6 @@ module('Acceptance | Dashboard', function (hooks) {
     }
 
     user.save();
-
-    this.server.get('/api/v1/me/updates', {
-      versions: [
-        {
-          id: 152946,
-          crate: 'geo',
-          num: '0.12.2',
-          dl_path: '/api/v1/crates/geo/0.12.2/download',
-          readme_path: '/api/v1/crates/geo/0.12.2/readme',
-          updated_at: '2019-05-26T14:47:10.220868+00:00',
-          created_at: '2019-05-26T14:47:10.220868+00:00',
-          downloads: 19372,
-          features: {
-            default: [],
-            'postgis-integration': ['postgis'],
-            'use-proj': ['proj'],
-            'use-serde': ['serde', 'geo-types/serde'],
-          },
-          yanked: false,
-          license: 'MIT/Apache-2.0',
-          links: {
-            dependencies: '/api/v1/crates/geo/0.12.2/dependencies',
-            version_downloads: '/api/v1/crates/geo/0.12.2/downloads',
-            authors: '/api/v1/crates/geo/0.12.2/authors',
-          },
-          crate_size: 179841,
-          published_by: {
-            id: 227,
-            login: 'frewsxcv',
-            name: 'Corey Farwell',
-            avatar: 'https://avatars2.githubusercontent.com/u/416575?v=4',
-            url: 'https://github.com/frewsxcv',
-          },
-          audit_actions: [],
-        },
-        {
-          id: 143262,
-          crate: 'geo',
-          num: '0.12.1',
-          dl_path: '/api/v1/crates/geo/0.12.1/download',
-          readme_path: '/api/v1/crates/geo/0.12.1/readme',
-          updated_at: '2019-04-05T09:00:59.629392+00:00',
-          created_at: '2019-04-05T09:00:59.629392+00:00',
-          downloads: 2940,
-          features: {
-            default: [],
-            'postgis-integration': ['postgis'],
-            'use-proj': ['proj'],
-            'use-serde': ['serde', 'geo-types/serde'],
-          },
-          yanked: false,
-          license: 'MIT/Apache-2.0',
-          links: {
-            dependencies: '/api/v1/crates/geo/0.12.1/dependencies',
-            version_downloads: '/api/v1/crates/geo/0.12.1/downloads',
-            authors: '/api/v1/crates/geo/0.12.1/authors',
-          },
-          crate_size: 179259,
-          published_by: {
-            id: 227,
-            login: 'frewsxcv',
-            name: 'Corey Farwell',
-            avatar: 'https://avatars2.githubusercontent.com/u/416575?v=4',
-            url: 'https://github.com/frewsxcv',
-          },
-          audit_actions: [],
-        },
-        {
-          id: 134231,
-          crate: 'geo',
-          num: '0.12.0',
-          dl_path: '/api/v1/crates/geo/0.12.0/download',
-          readme_path: '/api/v1/crates/geo/0.12.0/readme',
-          updated_at: '2019-02-17T03:19:08.118477+00:00',
-          created_at: '2019-02-17T03:19:08.118477+00:00',
-          downloads: 4420,
-          features: {
-            default: [],
-            'postgis-integration': ['postgis'],
-            'use-proj': ['proj'],
-            'use-serde': ['serde', 'geo-types/serde'],
-          },
-          yanked: false,
-          license: 'MIT/Apache-2.0',
-          links: {
-            dependencies: '/api/v1/crates/geo/0.12.0/dependencies',
-            version_downloads: '/api/v1/crates/geo/0.12.0/downloads',
-            authors: '/api/v1/crates/geo/0.12.0/authors',
-          },
-          crate_size: 178368,
-          published_by: null,
-          audit_actions: [],
-        },
-      ],
-      meta: { more: true },
-    });
 
     this.server.get(`/api/v1/users/${user.id}/stats`, { total_downloads: 3892 });
 

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -444,6 +444,47 @@ module('Mirage | Crates', function (hooks) {
     });
   });
 
+  module('DELETE /api/v1/crates/:crateId/follow', function () {
+    test('returns 403 if unauthenticated', async function (assert) {
+      let response = await fetch('/api/v1/crates/foo/follow', { method: 'DELETE' });
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+
+    test('returns 404 for unknown crates', async function (assert) {
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/crates/foo/follow', { method: 'DELETE' });
+      assert.equal(response.status, 404);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'Not Found' }] });
+    });
+
+    test('makes the authenticated user unfollow the crate', async function (assert) {
+      let crate = this.server.create('crate', { name: 'rand' });
+
+      let user = this.server.create('user', { followedCrates: [crate] });
+      this.authenticateAs(user);
+
+      assert.deepEqual(user.followedCrateIds, [crate.id]);
+
+      let response = await fetch('/api/v1/crates/rand/follow', { method: 'DELETE' });
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { ok: true });
+
+      user.reload();
+      assert.deepEqual(user.followedCrateIds, []);
+    });
+  });
+
   module('GET /api/v1/crates/:id/versions', function () {
     test('returns 404 for unknown crates', async function (assert) {
       let response = await fetch('/api/v1/crates/foo/versions');

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -354,6 +354,55 @@ module('Mirage | Crates', function (hooks) {
     });
   });
 
+  module('GET /api/v1/crates/:crateId/following', function () {
+    test('returns 403 if unauthenticated', async function (assert) {
+      let response = await fetch('/api/v1/crates/foo/following');
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+
+    test('returns 404 for unknown crates', async function (assert) {
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/crates/foo/following');
+      assert.equal(response.status, 404);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'Not Found' }] });
+    });
+
+    test('returns true if the authenticated user follows the crate', async function (assert) {
+      let crate = this.server.create('crate', { name: 'rand' });
+
+      let user = this.server.create('user', { followedCrates: [crate] });
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/crates/rand/following');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { following: true });
+    });
+
+    test('returns false if the authenticated user is not following the crate', async function (assert) {
+      this.server.create('crate', { name: 'rand' });
+
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/crates/rand/following');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { following: false });
+    });
+  });
+
   module('GET /api/v1/crates/:id/versions', function () {
     test('returns 404 for unknown crates', async function (assert) {
       let response = await fetch('/api/v1/crates/foo/versions');

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -176,6 +176,24 @@ module('Mirage | Crates', function (hooks) {
       assert.equal(responsePayload.crates[0].id, 'bar');
       assert.equal(responsePayload.meta.total, 1);
     });
+
+    test('supports a `following` parameter', async function (assert) {
+      this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crateId: 'foo' });
+      this.server.create('crate', { name: 'bar' });
+      this.server.create('version', { crateId: 'bar' });
+
+      let user = this.server.create('user', { followedCrateIds: ['bar'] });
+      this.authenticateAs(user);
+
+      let response = await fetch(`/api/v1/crates?following=1`);
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.equal(responsePayload.crates.length, 1);
+      assert.equal(responsePayload.crates[0].id, 'bar');
+      assert.equal(responsePayload.meta.total, 1);
+    });
   });
 
   module('GET /api/v1/crates/:id', function () {

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -403,6 +403,47 @@ module('Mirage | Crates', function (hooks) {
     });
   });
 
+  module('PUT /api/v1/crates/:crateId/follow', function () {
+    test('returns 403 if unauthenticated', async function (assert) {
+      let response = await fetch('/api/v1/crates/foo/follow', { method: 'PUT' });
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+
+    test('returns 404 for unknown crates', async function (assert) {
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/crates/foo/follow', { method: 'PUT' });
+      assert.equal(response.status, 404);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'Not Found' }] });
+    });
+
+    test('makes the authenticated user follow the crate', async function (assert) {
+      let crate = this.server.create('crate', { name: 'rand' });
+
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
+      assert.deepEqual(user.followedCrateIds, []);
+
+      let response = await fetch('/api/v1/crates/rand/follow', { method: 'PUT' });
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { ok: true });
+
+      user.reload();
+      assert.deepEqual(user.followedCrateIds, [crate.id]);
+    });
+  });
+
   module('GET /api/v1/crates/:id/versions', function () {
     test('returns 404 for unknown crates', async function (assert) {
       let response = await fetch('/api/v1/crates/foo/versions');

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -194,6 +194,95 @@ module('Mirage | /me', function (hooks) {
     });
   });
 
+  module('GET /api/v1/me/updates', function () {
+    test('returns 403 for unauthenticated user', async function (assert) {
+      let response = await fetch('/api/v1/me/updates');
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        errors: [{ detail: 'must be logged in to perform that action' }],
+      });
+    });
+
+    test('returns latest versions of followed crates', async function (assert) {
+      {
+        let crate = this.server.create('crate', { name: 'foo' });
+        this.server.create('version', { crate, num: '1.2.3' });
+      }
+
+      {
+        let crate = this.server.create('crate', { name: 'bar' });
+        this.server.create('version', { crate, num: '0.8.6' });
+      }
+
+      let user = this.server.create('user', { followedCrateIds: ['foo'] });
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/me/updates');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        versions: [
+          {
+            id: '1',
+            crate: 'foo',
+            crate_size: 0,
+            created_at: '2010-06-16T21:30:45Z',
+            dl_path: '/api/v1/crates/foo/1.2.3/download',
+            downloads: 0,
+            license: 'MIT/Apache-2.0',
+            links: {
+              authors: '/api/v1/crates/foo/1.2.3/authors',
+              dependencies: '/api/v1/crates/foo/1.2.3/dependencies',
+              version_downloads: '/api/v1/crates/foo/1.2.3/downloads',
+            },
+            num: '1.2.3',
+            updated_at: '2017-02-24T12:34:56Z',
+            yanked: false,
+          },
+        ],
+        meta: {
+          more: false,
+        },
+      });
+    });
+
+    test('empty case', async function (assert) {
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/me/updates');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, {
+        versions: [],
+        meta: { more: false },
+      });
+    });
+
+    test('supports pagination', async function (assert) {
+      let crate = this.server.create('crate', { name: 'foo' });
+      this.server.createList('version', 25, { crate });
+
+      let user = this.server.create('user', { followedCrates: [crate] });
+      this.authenticateAs(user);
+
+      let response = await fetch('/api/v1/me/updates?page=2');
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.equal(responsePayload.versions.length, 10);
+      assert.deepEqual(
+        responsePayload.versions.map(it => it.id),
+        ['15', '14', '13', '12', '11', '10', '9', '8', '7', '6'],
+      );
+      assert.deepEqual(responsePayload.meta, { more: true });
+    });
+  });
+
   module('GET /api/v1/confirm/:token', function () {
     test('returns `ok: true` for a known token (unauthenticated)', async function (assert) {
       let user = this.server.create('user', { emailVerificationToken: 'foo' });


### PR DESCRIPTION
Using this relationship we can finally implement several of the e-c-mirage route handlers related to users following crates.

Note that Percy.io will most likely complain about this PR due to the change of the dashboard test fixture data.

r? @locks 