### PR TITLE
Use http types from `http` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "rand 0.6.5",
  "reqwest",
  "scheduled-thread-pool",
- "semver 0.9.0 (git+https://github.com/steveklabnik/semver.git)",
+ "semver",
  "serde",
  "serde_json",
  "swirl",
@@ -277,14 +277,13 @@ dependencies = [
 
 [[package]]
 name = "civet"
-version = "0.12.0-alpha.1"
+version = "0.12.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae04519752da172ab2e82540b28244da241064aa50e64de83645d0ae8d952"
+checksum = "b6ae786c5519f3740ffe88639d6d404c102c7af4acf206a94567c68f93d25b38"
 dependencies = [
  "civet-sys",
  "conduit",
  "libc",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -320,18 +319,18 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ae2b5937afd049324f246e5ecd1d628bd23ba221879b9f56cd45674e9194bf"
+checksum = "2ca703f41f1b6a01299404ea407c2ae5b1cffc09a3d77af0e760130621cb3795"
 dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http",
 ]
 
 [[package]]
 name = "conduit-conditional-get"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1e0b06d987366f9fc85a76260bc4057bab5dcc73f85b23fb633a49d8130136"
+checksum = "9a686f3233875b24b228b3362738de7cd16c74a8c81d8acfc0617edf427a2741"
 dependencies = [
  "conduit",
  "conduit-middleware",
@@ -340,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-cookie"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdba83653b08d6b2f082433e678ece2039f25f554fb68daf2a39f8c9ad351af"
+checksum = "7645e2fa9b3fdbae7ce77b29a7e353af2e616c936dae950e927c6bb5209c265a"
 dependencies = [
  "base64 0.11.0",
  "conduit",
@@ -352,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-git-http-backend"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf9cbbd931a7f6ecc159a70325e3e487f5f96a7310d02abbf62846e12ce9eab"
+checksum = "7a5962ccb612bd8e435978519a0acc13879cb86c087902fc8f8c3ab7bf2a7d4a"
 dependencies = [
  "conduit",
  "flate2",
@@ -362,15 +361,14 @@ dependencies = [
 
 [[package]]
 name = "conduit-hyper"
-version = "0.3.0-alpha.0"
+version = "0.3.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8802341cb1b01e4fc706804edde75789927fc3b05f9a0235ef59507dac5b0acf"
+checksum = "c305c4a09c27fe168fad4539eef738b0898063b7ca8c26a7434605c9aa954be6"
 dependencies = [
  "conduit",
  "futures",
  "http",
  "hyper",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
  "tower-service",
  "tracing",
@@ -378,12 +376,11 @@ dependencies = [
 
 [[package]]
 name = "conduit-middleware"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cc6359459dc275cd9715aa84954ed861d0f68bde9e1f53edf494113a9ea005"
+checksum = "800bd3641b7b986cf1305f18243d50fe668f8b4d8bb543856119f55d84622223"
 dependencies = [
  "conduit",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -397,20 +394,19 @@ dependencies = [
 
 [[package]]
 name = "conduit-router"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbe1cb2c36d3ec99795c6c2fe6fc54199513240166a16f7cf471d8b8a1d5287"
+checksum = "79f5fd8e955ceb288e230572935c323cd84f1042a2804ef5a8b41b1c67fd85c8"
 dependencies = [
  "conduit",
  "route-recognizer",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "conduit-static"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9937e95a4192c239ed588a1d8190126441435de5bebcc7d0db34474c21c9558c"
+checksum = "b5b0cec0864a37f86320e0a0781d173b8c8fe7d878b16421c477a345f14bece8"
 dependencies = [
  "conduit",
  "conduit-mime-types",
@@ -420,12 +416,11 @@ dependencies = [
 
 [[package]]
 name = "conduit-test"
-version = "0.9.0-alpha.0"
+version = "0.9.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81b2a279a7630087a56e8772ddef85670ae4d53dd2c9dbe361866ec0be9842f"
+checksum = "a29e3574fbffef97d38eabe60757ca26a44d1f5aec8ea549543291cda91c73d9"
 dependencies = [
  "conduit",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2205,15 +2200,6 @@ dependencies = [
  "diesel",
  "semver-parser",
  "serde",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,6 +213,7 @@ dependencies = [
  "handlebars",
  "hex",
  "htmlescape",
+ "http",
  "hyper",
  "hyper-tls",
  "indexmap",
@@ -277,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "civet"
-version = "0.12.0-alpha.2"
+version = "0.12.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ae786c5519f3740ffe88639d6d404c102c7af4acf206a94567c68f93d25b38"
+checksum = "f360e1a48dd03961dfac6120d9d90a189e2274a09b00c9f536cce844d462239d"
 dependencies = [
  "civet-sys",
  "conduit",
@@ -319,18 +320,18 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ca703f41f1b6a01299404ea407c2ae5b1cffc09a3d77af0e760130621cb3795"
+checksum = "47432edd46e337326eed753ec7c9a9163a5e297f82a299d24f106221a2dee412"
 dependencies = [
  "http",
 ]
 
 [[package]]
 name = "conduit-conditional-get"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a686f3233875b24b228b3362738de7cd16c74a8c81d8acfc0617edf427a2741"
+checksum = "769c01b79af748e1be176bea12603a2f7087608b84c1857a31ddd861d34de5a8"
 dependencies = [
  "conduit",
  "conduit-middleware",
@@ -339,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-cookie"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7645e2fa9b3fdbae7ce77b29a7e353af2e616c936dae950e927c6bb5209c265a"
+checksum = "fb6928c01306c79f16ec946b12846ae5e90bb0f4d8700a5d90373d72cb27711d"
 dependencies = [
  "base64 0.11.0",
  "conduit",
@@ -351,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-git-http-backend"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5962ccb612bd8e435978519a0acc13879cb86c087902fc8f8c3ab7bf2a7d4a"
+checksum = "2a41aef2b54111fa1703d7b033b518d279e5938b83e7fe94aa51bd9f3671c383"
 dependencies = [
  "conduit",
  "flate2",
@@ -361,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-hyper"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c305c4a09c27fe168fad4539eef738b0898063b7ca8c26a7434605c9aa954be6"
+checksum = "8c5bdc8858250eafc0d006e43002caa122b306d3571d0242e68e7770240a424e"
 dependencies = [
  "conduit",
  "futures",
@@ -376,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-middleware"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "800bd3641b7b986cf1305f18243d50fe668f8b4d8bb543856119f55d84622223"
+checksum = "bda9153060cd9c67b2f13e04c93f2f0d4f3c49c22e35763d7a700ce2a26afb04"
 dependencies = [
  "conduit",
 ]
@@ -394,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-router"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79f5fd8e955ceb288e230572935c323cd84f1042a2804ef5a8b41b1c67fd85c8"
+checksum = "6eaa68ea0121fc61e2bf515f6dce485fa7674e57d17a2201762bfbc9380f65ec"
 dependencies = [
  "conduit",
  "route-recognizer",
@@ -404,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-static"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b0cec0864a37f86320e0a0781d173b8c8fe7d878b16421c477a345f14bece8"
+checksum = "e89d5ef0f88a5cbf0ba01e35ec2114d87527090508de47c3a1de7f5740ab69a5"
 dependencies = [
  "conduit",
  "conduit-mime-types",
@@ -416,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-test"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29e3574fbffef97d38eabe60757ca26a44d1f5aec8ea549543291cda91c73d9"
+checksum = "19f72c6a9f57a45242f3df7a46907d1f1983d1ee279e8d9b8c355679732122dc"
 dependencies = [
  "conduit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,16 +66,16 @@ lettre = "0.9"
 lettre_email = "0.9"
 failure = "0.1.1"
 
-conduit = "0.9.0-alpha.0"
-conduit-conditional-get = "0.9.0-alpha.0"
-conduit-cookie = "0.9.0-alpha.0"
+conduit = "0.9.0-alpha.1"
+conduit-conditional-get = "0.9.0-alpha.1"
+conduit-cookie = "0.9.0-alpha.1"
 cookie = { version = "0.12", features = ["secure"] }
-conduit-middleware = "0.9.0-alpha.0"
-conduit-router = "0.9.0-alpha.0"
-conduit-static = "0.9.0-alpha.0"
-conduit-git-http-backend = "0.9.0-alpha.0"
-civet = "0.12.0-alpha.1"
-conduit-hyper = "0.3.0-alpha.0"
+conduit-middleware = "0.9.0-alpha.1"
+conduit-router = "0.9.0-alpha.1"
+conduit-static = "0.9.0-alpha.1"
+conduit-git-http-backend = "0.9.0-alpha.1"
+civet = "0.12.0-alpha.2"
+conduit-hyper = "0.3.0-alpha.1"
 
 futures-util = "0.3"
 futures-channel = { version = "0.3.1", default-features = false }
@@ -86,7 +86,7 @@ indexmap = "1.0.2"
 handlebars = "3.0.1"
 
 [dev-dependencies]
-conduit-test = "0.9.0-alpha.0"
+conduit-test = "0.9.0-alpha.1"
 hyper-tls = "0.4"
 lazy_static = "1.0"
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,16 +66,17 @@ lettre = "0.9"
 lettre_email = "0.9"
 failure = "0.1.1"
 
-conduit = "0.9.0-alpha.1"
-conduit-conditional-get = "0.9.0-alpha.1"
-conduit-cookie = "0.9.0-alpha.1"
+conduit = "0.9.0-alpha.2"
+conduit-conditional-get = "0.9.0-alpha.2"
+conduit-cookie = "0.9.0-alpha.2"
 cookie = { version = "0.12", features = ["secure"] }
-conduit-middleware = "0.9.0-alpha.1"
-conduit-router = "0.9.0-alpha.1"
-conduit-static = "0.9.0-alpha.1"
-conduit-git-http-backend = "0.9.0-alpha.1"
-civet = "0.12.0-alpha.2"
-conduit-hyper = "0.3.0-alpha.1"
+conduit-middleware = "0.9.0-alpha.2"
+conduit-router = "0.9.0-alpha.2"
+conduit-static = "0.9.0-alpha.2"
+conduit-git-http-backend = "0.9.0-alpha.2"
+civet = "0.12.0-alpha.3"
+conduit-hyper = "0.3.0-alpha.2"
+http = "0.2"
 
 futures-util = "0.3"
 futures-channel = { version = "0.3.1", default-features = false }
@@ -86,7 +87,7 @@ indexmap = "1.0.2"
 handlebars = "3.0.1"
 
 [dev-dependencies]
-conduit-test = "0.9.0-alpha.1"
+conduit-test = "0.9.0-alpha.2"
 hyper-tls = "0.4"
 lazy_static = "1.0"
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -14,15 +14,14 @@ mod prelude {
     pub use super::helpers::ok_true;
     pub use diesel::prelude::*;
 
-    pub use conduit::{Request, Response};
+    pub use conduit::{header, RequestExt, StatusCode};
     pub use conduit_router::RequestParams;
 
     pub use crate::db::RequestTransaction;
-    pub use crate::util::errors::{cargo_err, AppError, AppResult, ChainError}; // TODO: Remove cargo_err from here
-
     pub use crate::middleware::app::RequestApp;
+    pub use crate::util::errors::{cargo_err, AppError, AppResult, ChainError}; // TODO: Remove cargo_err from here
+    pub use crate::util::{AppResponse, EndpointResult};
 
-    use std::collections::HashMap;
     use std::io;
 
     use indexmap::IndexMap;
@@ -33,9 +32,9 @@ mod prelude {
     }
 
     pub trait RequestUtils {
-        fn redirect(&self, url: String) -> Response;
+        fn redirect(&self, url: String) -> AppResponse;
 
-        fn json<T: Serialize>(&self, t: &T) -> Response;
+        fn json<T: Serialize>(&self, t: &T) -> AppResponse;
         fn query(&self) -> IndexMap<String, String>;
         fn wants_json(&self) -> bool;
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
@@ -43,8 +42,8 @@ mod prelude {
         fn log_metadata<V: std::fmt::Display>(&mut self, key: &'static str, value: V);
     }
 
-    impl<'a> RequestUtils for dyn Request + 'a {
-        fn json<T: Serialize>(&self, t: &T) -> Response {
+    impl<'a> RequestUtils for dyn RequestExt + 'a {
+        fn json<T: Serialize>(&self, t: &T) -> AppResponse {
             crate::util::json_response(t)
         }
 
@@ -54,21 +53,19 @@ mod prelude {
                 .collect()
         }
 
-        fn redirect(&self, url: String) -> Response {
-            let mut headers = HashMap::new();
-            headers.insert("Location".to_string(), vec![url]);
-            Response {
-                status: (302, "Found"),
-                headers,
-                body: Box::new(io::empty()),
-            }
+        fn redirect(&self, url: String) -> AppResponse {
+            conduit::Response::builder()
+                .status(StatusCode::FOUND)
+                .header(header::LOCATION, url)
+                .body(Box::new(io::empty()) as conduit::Body)
+                .unwrap() // Should not panic unless url contains "\r\n"
         }
 
         fn wants_json(&self) -> bool {
             self.headers()
-                .find("Accept")
-                .map(|accept| accept.iter().any(|s| s.contains("json")))
-                .unwrap_or(false)
+                .get_all(header::ACCEPT)
+                .iter()
+                .any(|val| val.to_str().unwrap_or_default().contains("json"))
         }
 
         fn query_with_params(&self, new_params: IndexMap<String, String>) -> String {

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -22,8 +22,6 @@ mod prelude {
     pub use crate::util::errors::{cargo_err, AppError, AppResult, ChainError}; // TODO: Remove cargo_err from here
     pub use crate::util::{AppResponse, EndpointResult};
 
-    use std::io;
-
     use indexmap::IndexMap;
     use serde::Serialize;
 
@@ -57,7 +55,7 @@ mod prelude {
             conduit::Response::builder()
                 .status(StatusCode::FOUND)
                 .header(header::LOCATION, url)
-                .body(Box::new(io::empty()) as conduit::Body)
+                .body(conduit::Body::empty())
                 .unwrap() // Should not panic unless url contains "\r\n"
         }
 

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub fn index(req: &mut dyn Request) -> AppResult<Response> {
+pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let query = req.query();
     // FIXME: There are 69 categories, 47 top level. This isn't going to
@@ -40,7 +40,7 @@ pub fn index(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub fn show(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let slug = &req.params()["category_id"];
     let conn = req.db_conn()?;
     let cat = Category::by_slug(slug).first::<Category>(&*conn)?;
@@ -77,7 +77,7 @@ pub fn show(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /category_slugs` route.
-pub fn slugs(req: &mut dyn Request) -> AppResult<Response> {
+pub fn slugs(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let slugs = categories::table
         .select((categories::slug, categories::slug, categories::description))

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -5,7 +5,7 @@ use crate::schema::{crate_owner_invitations, crate_owners};
 use crate::views::{EncodableCrateOwnerInvitation, InvitationResponse};
 
 /// Handles the `GET /me/crate_owner_invitations` route.
-pub fn list(req: &mut dyn Request) -> AppResult<Response> {
+pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = &*req.db_conn()?;
     let user_id = req.authenticate(conn)?.user_id();
 
@@ -31,7 +31,7 @@ struct OwnerInvitation {
 }
 
 /// Handles the `PUT /me/crate_owner_invitations/:crate_id` route.
-pub fn handle_invite(req: &mut dyn Request) -> AppResult<Response> {
+pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
     let mut body = String::new();
     req.body().read_to_string(&mut body)?;
 
@@ -51,7 +51,7 @@ pub fn handle_invite(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `PUT /me/crate_owner_invitations/accept/:token` route.
-pub fn handle_invite_with_token(req: &mut dyn Request) -> AppResult<Response> {
+pub fn handle_invite_with_token(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let req_token = &req.params()["token"];
 
@@ -72,11 +72,11 @@ pub fn handle_invite_with_token(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 fn accept_invite(
-    req: &dyn Request,
+    req: &dyn RequestExt,
     conn: &PgConnection,
     crate_invite: InvitationResponse,
     user_id: i32,
-) -> AppResult<Response> {
+) -> EndpointResult {
     use diesel::{delete, insert_into};
 
     conn.transaction(|| {
@@ -110,10 +110,10 @@ fn accept_invite(
 }
 
 fn decline_invite(
-    req: &dyn Request,
+    req: &dyn RequestExt,
     conn: &PgConnection,
     crate_invite: InvitationResponse,
-) -> AppResult<Response> {
+) -> EndpointResult {
     use diesel::delete;
 
     let user_id = req.authenticate(conn)?.user_id();

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,11 +1,10 @@
-use crate::util::{errors::AppResult, json_response};
-use conduit::Response;
+use crate::util::{json_response, EndpointResult};
 
 pub(crate) mod pagination;
 
 pub(crate) use self::pagination::Paginate;
 
-pub fn ok_true() -> AppResult<Response> {
+pub fn ok_true() -> EndpointResult {
     #[derive(Serialize)]
     struct R {
         ok: bool,

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -186,6 +186,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{Page, PaginationOptions};
+
+    use conduit::StatusCode;
     use indexmap::IndexMap;
 
     #[test]
@@ -194,7 +196,7 @@ mod tests {
         params.insert(String::from("page"), String::from("not a number"));
         let page_error = Page::new(&params).unwrap_err().response().unwrap();
 
-        assert_eq!(page_error.status, (400, "Bad Request"));
+        assert_eq!(page_error.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]
@@ -206,6 +208,6 @@ mod tests {
             .response()
             .unwrap();
 
-        assert_eq!(per_page_error.status, (400, "Bad Request"));
+        assert_eq!(per_page_error.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -5,7 +5,7 @@ use crate::models::Keyword;
 use crate::views::EncodableKeyword;
 
 /// Handles the `GET /keywords` route.
-pub fn index(req: &mut dyn Request) -> AppResult<Response> {
+pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     use crate::schema::keywords;
 
     let conn = req.db_conn()?;
@@ -41,7 +41,7 @@ pub fn index(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /keywords/:keyword_id` route.
-pub fn show(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["keyword_id"];
     let conn = req.db_conn()?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -14,7 +14,7 @@ use crate::views::EncodableVersionDownload;
 use crate::models::krate::to_char;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub fn downloads(req: &mut dyn Request) -> AppResult<Response> {
+pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -7,7 +7,7 @@ use crate::db::DieselPooledConn;
 use crate::models::{Crate, Follow};
 use crate::schema::*;
 
-fn follow_target(req: &dyn Request, conn: &DieselPooledConn<'_>) -> AppResult<Follow> {
+fn follow_target(req: &dyn RequestExt, conn: &DieselPooledConn<'_>) -> AppResult<Follow> {
     let user_id = req.authenticate(conn)?.user_id();
     let crate_name = &req.params()["crate_id"];
     let crate_id = Crate::by_name(crate_name)
@@ -17,7 +17,7 @@ fn follow_target(req: &dyn Request, conn: &DieselPooledConn<'_>) -> AppResult<Fo
 }
 
 /// Handles the `PUT /crates/:crate_id/follow` route.
-pub fn follow(req: &mut dyn Request) -> AppResult<Response> {
+pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let follow = follow_target(req, &conn)?;
     diesel::insert_into(follows::table)
@@ -29,7 +29,7 @@ pub fn follow(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `DELETE /crates/:crate_id/follow` route.
-pub fn unfollow(req: &mut dyn Request) -> AppResult<Response> {
+pub fn unfollow(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let follow = follow_target(req, &conn)?;
     diesel::delete(&follow).execute(&*conn)?;
@@ -38,7 +38,7 @@ pub fn unfollow(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/following` route.
-pub fn following(req: &mut dyn Request) -> AppResult<Response> {
+pub fn following(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::exists;
 
     let conn = req.db_conn()?;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -18,7 +18,7 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub fn summary(req: &mut dyn Request) -> AppResult<Response> {
+pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
     use crate::schema::crates::dsl::*;
 
     let conn = req.db_read_only()?;
@@ -101,7 +101,7 @@ pub fn summary(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id` route.
-pub fn show(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["crate_id"];
     let conn = req.db_read_only()?;
     let krate = Crate::by_name(name).first::<Crate>(&*conn)?;
@@ -173,7 +173,7 @@ pub fn show(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/readme` route.
-pub fn readme(req: &mut dyn Request) -> AppResult<Response> {
+pub fn readme(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let version = &req.params()["version"];
 
@@ -197,7 +197,7 @@ pub fn readme(req: &mut dyn Request) -> AppResult<Response> {
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub fn versions(req: &mut dyn Request) -> AppResult<Response> {
+pub fn versions(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_read_only()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -226,7 +226,7 @@ pub fn versions(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/reverse_dependencies` route.
-pub fn reverse_dependencies(req: &mut dyn Request) -> AppResult<Response> {
+pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::any;
 
     let name = &req.params()["crate_id"];

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -5,7 +5,7 @@ use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub fn owners(req: &mut dyn Request) -> AppResult<Response> {
+pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -23,7 +23,7 @@ pub fn owners(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub fn owner_team(req: &mut dyn Request) -> AppResult<Response> {
+pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -40,7 +40,7 @@ pub fn owner_team(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub fn owner_user(req: &mut dyn Request) -> AppResult<Response> {
+pub fn owner_user(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
@@ -57,12 +57,12 @@ pub fn owner_user(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
-pub fn add_owners(req: &mut dyn Request) -> AppResult<Response> {
+pub fn add_owners(req: &mut dyn RequestExt) -> EndpointResult {
     modify_owners(req, true)
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
-pub fn remove_owners(req: &mut dyn Request) -> AppResult<Response> {
+pub fn remove_owners(req: &mut dyn RequestExt) -> EndpointResult {
     modify_owners(req, false)
 }
 
@@ -70,7 +70,7 @@ pub fn remove_owners(req: &mut dyn Request) -> AppResult<Response> {
 /// The format is
 ///
 ///     {"owners": ["username", "github:org:team", ...]}
-fn parse_owners_request(req: &mut dyn Request) -> AppResult<Vec<String>> {
+fn parse_owners_request(req: &mut dyn RequestExt) -> AppResult<Vec<String>> {
     let mut body = String::new();
     req.body().read_to_string(&mut body)?;
     #[derive(Deserialize)]
@@ -87,7 +87,7 @@ fn parse_owners_request(req: &mut dyn Request) -> AppResult<Vec<String>> {
         .ok_or_else(|| cargo_err("invalid json request"))
 }
 
-fn modify_owners(req: &mut dyn Request, add: bool) -> AppResult<Response> {
+fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
     let logins = parse_owners_request(req)?;
     let app = req.app();
     let crate_name = &req.params()["crate_id"];

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -23,7 +23,7 @@ use crate::views::{EncodableCrateUpload, GoodCrate, PublishWarnings};
 /// Currently blocks the HTTP thread, perhaps some function calls can spawn new
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
-pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
+pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
     let app = Arc::clone(req.app());
 
     // The format of the req.body() of a publish request is as follows:
@@ -228,7 +228,7 @@ pub fn publish(req: &mut dyn Request) -> AppResult<Response> {
 ///
 /// This function parses the JSON headers to interpret the data and validates
 /// the data during and after the parsing. Returns crate metadata.
-fn parse_new_headers(req: &mut dyn Request) -> AppResult<EncodableCrateUpload> {
+fn parse_new_headers(req: &mut dyn RequestExt) -> AppResult<EncodableCrateUpload> {
     // Read the json upload request
     let metadata_length = u64::from(read_le_u32(req.body())?);
     req.log_metadata("metadata_length", metadata_length);

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -33,7 +33,7 @@ use crate::models::krate::{canon_crate_name, ALL_COLUMNS};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub fn search(req: &mut dyn Request) -> AppResult<Response> {
+pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::sql_types::{Bool, Text};
 
     let conn = req.db_read_only()?;

--- a/src/controllers/site_metadata.rs
+++ b/src/controllers/site_metadata.rs
@@ -4,7 +4,7 @@ use super::prelude::*;
 ///
 /// The sha is contained within the `HEROKU_SLUG_COMMIT` environment variable.
 /// If `HEROKU_SLUG_COMMIT` is not set, returns `"unknown"`.
-pub fn show_deployed_sha(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show_deployed_sha(req: &mut dyn RequestExt) -> EndpointResult {
     let deployed_sha =
         dotenv::var("HEROKU_SLUG_COMMIT").unwrap_or_else(|_| String::from("unknown"));
 

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,7 +5,7 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub fn show_team(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show_team(req: &mut dyn RequestExt) -> EndpointResult {
     use self::teams::dsl::{login, teams};
 
     let name = &req.params()["team_id"];

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -8,7 +8,7 @@ use crate::views::EncodableApiTokenWithToken;
 use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.
-pub fn list(req: &mut dyn Request) -> AppResult<Response> {
+pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let user = req.authenticate(&conn)?.find_user(&conn)?;
 
@@ -24,7 +24,7 @@ pub fn list(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `PUT /me/tokens` route.
-pub fn new(req: &mut dyn Request) -> AppResult<Response> {
+pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
     /// The incoming serialization format for the `ApiToken` model.
     #[derive(Deserialize, Serialize)]
     struct NewApiToken {
@@ -93,7 +93,7 @@ pub fn new(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `DELETE /me/tokens/:id` route.
-pub fn revoke(req: &mut dyn Request) -> AppResult<Response> {
+pub fn revoke(req: &mut dyn RequestExt) -> EndpointResult {
     let id = req.params()["id"]
         .parse::<i32>()
         .map_err(|e| bad_request(&format!("invalid token id: {:?}", e)))?;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -12,7 +12,7 @@ use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::views::{EncodableMe, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
-pub fn me(req: &mut dyn Request) -> AppResult<Response> {
+pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let user_id = req.authenticate(&conn)?.user_id();
 
@@ -50,7 +50,7 @@ pub fn me(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /me/updates` route.
-pub fn updates(req: &mut dyn Request) -> AppResult<Response> {
+pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::any;
 
     let conn = req.db_conn()?;
@@ -100,7 +100,7 @@ pub fn updates(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `PUT /user/:user_id` route.
-pub fn update_user(req: &mut dyn Request) -> AppResult<Response> {
+pub fn update_user(req: &mut dyn RequestExt) -> EndpointResult {
     use self::emails::user_id;
     use diesel::insert_into;
 
@@ -162,7 +162,7 @@ pub fn update_user(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `PUT /confirm/:email_token` route
-pub fn confirm_user_email(req: &mut dyn Request) -> AppResult<Response> {
+pub fn confirm_user_email(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::update;
 
     let conn = req.db_conn()?;
@@ -180,7 +180,7 @@ pub fn confirm_user_email(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles `PUT /user/:user_id/resend` route
-pub fn regenerate_token_and_send(req: &mut dyn Request) -> AppResult<Response> {
+pub fn regenerate_token_and_send(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::sql;
     use diesel::update;
 
@@ -209,7 +209,7 @@ pub fn regenerate_token_and_send(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles `PUT /me/email_notifications` route
-pub fn update_email_notifications(req: &mut dyn Request) -> AppResult<Response> {
+pub fn update_email_notifications(req: &mut dyn RequestExt) -> EndpointResult {
     use self::crate_owners::dsl::*;
     use diesel::pg::upsert::excluded;
 

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,7 +6,7 @@ use crate::util::errors::ChainError;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub fn show(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     use self::users::dsl::{gh_login, id, users};
 
     let name = &req.params()["user_id"].to_lowercase();
@@ -26,7 +26,7 @@ pub fn show(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub fn stats(req: &mut dyn Request) -> AppResult<Response> {
+pub fn stats(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::sum;
 
     let user_id = &req.params()["user_id"]

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -25,7 +25,7 @@ use crate::util::errors::ReadOnlyMode;
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub fn begin(req: &mut dyn Request) -> AppResult<Response> {
+pub fn begin(req: &mut dyn RequestExt) -> EndpointResult {
     let (url, state) = req
         .app()
         .github
@@ -73,7 +73,7 @@ pub fn begin(req: &mut dyn Request) -> AppResult<Response> {
 ///     }
 /// }
 /// ```
-pub fn authorize(req: &mut dyn Request) -> AppResult<Response> {
+pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
     // Parse the url query
     let mut query = req.query();
     let code = query.remove("code").unwrap_or_default();
@@ -148,7 +148,7 @@ impl GithubUser {
 }
 
 /// Handles the `DELETE /api/private/session` route.
-pub fn logout(req: &mut dyn Request) -> AppResult<Response> {
+pub fn logout(req: &mut dyn RequestExt) -> EndpointResult {
     req.session().remove(&"user_id".to_string());
     Ok(req.json(&true))
 }

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -8,7 +8,7 @@ use super::prelude::*;
 use crate::db::DieselPooledConn;
 use crate::models::{Crate, Version};
 
-fn version_and_crate(req: &dyn Request) -> AppResult<(DieselPooledConn<'_>, Version, Crate)> {
+fn version_and_crate(req: &dyn RequestExt) -> AppResult<(DieselPooledConn<'_>, Version, Crate)> {
     let crate_name = extract_crate_name(req);
     let semver = extract_semver(req)?;
 
@@ -19,11 +19,11 @@ fn version_and_crate(req: &dyn Request) -> AppResult<(DieselPooledConn<'_>, Vers
     Ok((conn, version, krate))
 }
 
-fn extract_crate_name(req: &dyn Request) -> &str {
+fn extract_crate_name(req: &dyn RequestExt) -> &str {
     &req.params()["crate_id"]
 }
 
-fn extract_semver(req: &dyn Request) -> AppResult<&str> {
+fn extract_semver(req: &dyn RequestExt) -> AppResult<&str> {
     let semver = &req.params()["version"];
     if semver::Version::parse(semver).is_err() {
         return Err(cargo_err(&format_args!("invalid semver: {}", semver)));

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -12,7 +12,7 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub fn index(req: &mut dyn Request) -> AppResult<Response> {
+pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::any;
     let conn = req.db_conn()?;
 
@@ -55,7 +55,7 @@ pub fn index(req: &mut dyn Request) -> AppResult<Response> {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub fn show_by_id(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show_by_id(req: &mut dyn RequestExt) -> EndpointResult {
     let id = &req.params()["version_id"];
     let id = id.parse().unwrap_or(0);
     let conn = req.db_conn()?;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -14,7 +14,7 @@ use super::{extract_crate_name, extract_semver};
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
-pub fn download(req: &mut dyn Request) -> AppResult<Response> {
+pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let version = &req.params()["version"];
 
@@ -47,7 +47,7 @@ pub fn download(req: &mut dyn Request) -> AppResult<Response> {
 /// Even if failure occurs for unexpected reasons, we would rather have `cargo
 /// build` succeed and not count the download than break people's builds.
 fn increment_download_counts(
-    req: &dyn Request,
+    req: &dyn RequestExt,
     crate_name: &str,
     version: &str,
 ) -> AppResult<String> {
@@ -68,7 +68,7 @@ fn increment_download_counts(
 }
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
-pub fn downloads(req: &mut dyn Request) -> AppResult<Response> {
+pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = extract_crate_name(req);
     let semver = extract_semver(req)?;
 

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -19,7 +19,7 @@ use super::version_and_crate;
 /// In addition to returning cached data from the index, this returns
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
-pub fn dependencies(req: &mut dyn Request) -> AppResult<Response> {
+pub fn dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     let (conn, version, _) = version_and_crate(req)?;
     let deps = version.dependencies(&*conn)?;
     let deps = deps
@@ -35,7 +35,7 @@ pub fn dependencies(req: &mut dyn Request) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
-pub fn authors(req: &mut dyn Request) -> AppResult<Response> {
+pub fn authors(req: &mut dyn RequestExt) -> EndpointResult {
     let (conn, version, _) = version_and_crate(req)?;
     let names = version_authors::table
         .filter(version_authors::version_id.eq(version.id))
@@ -65,7 +65,7 @@ pub fn authors(req: &mut dyn Request) -> AppResult<Response> {
 ///
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
-pub fn show(req: &mut dyn Request) -> AppResult<Response> {
+pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let (conn, version, krate) = version_and_crate(req)?;
     let published_by = version.published_by(&conn);
     let actions = VersionOwnerAction::by_version(&conn, &version)?;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -17,17 +17,17 @@ use crate::models::{insert_version_owner_action, VersionAction};
 /// Crate deletion is not implemented to avoid breaking builds,
 /// and the goal of yanking a crate is to prevent crates
 /// beginning to depend on the yanked crate version.
-pub fn yank(req: &mut dyn Request) -> AppResult<Response> {
+pub fn yank(req: &mut dyn RequestExt) -> EndpointResult {
     modify_yank(req, true)
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
-pub fn unyank(req: &mut dyn Request) -> AppResult<Response> {
+pub fn unyank(req: &mut dyn RequestExt) -> EndpointResult {
     modify_yank(req, false)
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank(req: &mut dyn Request, yanked: bool) -> AppResult<Response> {
+fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
     let (conn, version, krate) = version_and_crate(req)?;
     let ids = req.authenticate(&conn)?;
     let user = ids.find_user(&conn)?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,4 @@
-use conduit::Request;
+use conduit::RequestExt;
 use diesel::prelude::*;
 use diesel::r2d2::{self, ConnectionManager, CustomizeConnection};
 use parking_lot::{ReentrantMutex, ReentrantMutexGuard};
@@ -93,7 +93,7 @@ pub trait RequestTransaction {
     fn db_read_only(&self) -> Result<DieselPooledConn<'_>, r2d2::PoolError>;
 }
 
-impl<T: Request + ?Sized> RequestTransaction for T {
+impl<T: RequestExt + ?Sized> RequestTransaction for T {
     fn db_conn(&self) -> Result<DieselPooledConn<'_>, r2d2::PoolError> {
         self.app().primary_database.get().map_err(Into::into)
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,13 +1,7 @@
 mod prelude {
-    pub use conduit::{Handler, Request, Response};
-    pub use conduit_middleware::{AroundMiddleware, Middleware};
-
-    use std::error::Error;
-    pub type BoxError = Box<dyn Error + Send>;
-    pub type Result<T> = std::result::Result<T, BoxError>;
+    pub use conduit::{box_error, header, Body, Handler, RequestExt, Response, StatusCode};
+    pub use conduit_middleware::{AfterResult, AroundMiddleware, BeforeResult, Middleware};
 }
-
-pub use prelude::Result;
 
 use self::app::AppMiddleware;
 use self::current_user::CaptureUserIdFromCookie;

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -17,12 +17,12 @@ impl AppMiddleware {
 }
 
 impl Middleware for AppMiddleware {
-    fn before(&self, req: &mut dyn Request) -> Result<()> {
+    fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
         req.mut_extensions().insert(Arc::clone(&self.app));
         Ok(())
     }
 
-    fn after(&self, req: &mut dyn Request, res: Result<Response>) -> Result<Response> {
+    fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
         req.mut_extensions().pop::<Arc<App>>().unwrap();
         res
     }
@@ -33,7 +33,7 @@ pub trait RequestApp {
     fn app(&self) -> &Arc<App>;
 }
 
-impl<T: Request + ?Sized> RequestApp for T {
+impl<T: RequestExt + ?Sized> RequestApp for T {
     fn app(&self) -> &Arc<App> {
         self.extensions().find::<Arc<App>>().expect("Missing app")
     }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -10,8 +10,6 @@
 
 use super::prelude::*;
 
-use std::io::Cursor;
-
 // Can't derive debug because of Handler.
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
@@ -65,7 +63,7 @@ impl Handler for BlockTraffic {
             Response::builder()
                 .status(StatusCode::FORBIDDEN)
                 .header(header::CONTENT_LENGTH, body.len())
-                .body(Box::new(Cursor::new(body.into_bytes())) as Body)
+                .body(Body::from_vec(body.into_bytes()) as Body)
                 .map_err(box_error)
         } else {
             self.handler.as_ref().unwrap().call(req)

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -10,7 +10,6 @@
 
 use super::prelude::*;
 
-use std::collections::HashMap;
 use std::io::Cursor;
 
 // Can't derive debug because of Handler.
@@ -39,12 +38,12 @@ impl AroundMiddleware for BlockTraffic {
 }
 
 impl Handler for BlockTraffic {
-    fn call(&self, req: &mut dyn Request) -> Result<Response> {
+    fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
         let has_blocked_value = req
             .headers()
-            .find(&self.header_name)
-            .unwrap_or_default()
+            .get_all(&self.header_name)
             .iter()
+            .map(|val| val.to_str().unwrap_or_default())
             .any(|value| self.blocked_values.iter().any(|v| v == value));
         if has_blocked_value {
             let cause = format!("blocked due to contents of header {}", self.header_name);
@@ -57,15 +56,17 @@ impl Handler for BlockTraffic {
                  or email help@crates.io \
                  and provide the request id {}",
                 // Heroku should always set this header
-                req.headers().find("X-Request-Id").unwrap()[0]
+                req.headers()
+                    .get("x-request-id")
+                    .map(|val| val.to_str().unwrap_or_default())
+                    .unwrap_or_default()
             );
-            let mut headers = HashMap::new();
-            headers.insert("Content-Length".to_string(), vec![body.len().to_string()]);
-            Ok(Response {
-                status: (403, "Forbidden"),
-                headers,
-                body: Box::new(Cursor::new(body.into_bytes())),
-            })
+
+            Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .header(header::CONTENT_LENGTH, body.len())
+                .body(Box::new(Cursor::new(body.into_bytes())) as Body)
+                .map_err(box_error)
         } else {
             self.handler.as_ref().unwrap().call(req)
         }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -63,7 +63,7 @@ impl Handler for BlockTraffic {
             Response::builder()
                 .status(StatusCode::FORBIDDEN)
                 .header(header::CONTENT_LENGTH, body.len())
-                .body(Body::from_vec(body.into_bytes()) as Body)
+                .body(Body::from_vec(body.into_bytes()))
                 .map_err(box_error)
         } else {
             self.handler.as_ref().unwrap().call(req)

--- a/src/middleware/current_user.rs
+++ b/src/middleware/current_user.rs
@@ -10,7 +10,7 @@
 //! This is particularly problematic for the user authentication code.  When an API token is used
 //! for authentication, the datbase must be queried to obtain the `user_id`, so endpoint code must
 //! obtain and pass in a database connection.  Because of that connection, it is no longer possible
-//! to use or pass around the `&mut dyn Request` that it was derived from and it is not possible
+//! to use or pass around the `&mut dyn RequestExt` that it was derived from and it is not possible
 //! to access the session cookie.  In order to support authentication via session cookies and API
 //! tokens via the same code path, the `user_id` is extracted from the session cookie and stored in
 //! a `TrustedUserId` that can be read from while a connection reference is live.
@@ -27,7 +27,7 @@ pub struct TrustedUserId(pub i32);
 pub(super) struct CaptureUserIdFromCookie;
 
 impl Middleware for CaptureUserIdFromCookie {
-    fn before(&self, req: &mut dyn Request) -> Result<()> {
+    fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
         if let Some(id) = req.session().get("user_id").and_then(|s| s.parse().ok()) {
             req.mut_extensions().insert(TrustedUserId(id));
         }

--- a/src/middleware/debug.rs
+++ b/src/middleware/debug.rs
@@ -6,14 +6,14 @@ use super::prelude::*;
 pub struct Debug;
 
 impl Middleware for Debug {
-    fn before(&self, req: &mut dyn Request) -> Result<()> {
+    fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
         DebugRequest.before(req)
     }
 
-    fn after(&self, _req: &mut dyn Request, res: Result<Response>) -> Result<Response> {
+    fn after(&self, _req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
         res.map(|res| {
-            println!("  <- {:?}", res.status);
-            for (k, v) in &res.headers {
+            println!("  <- {:?}", res.status());
+            for (k, v) in res.headers().iter() {
                 println!("  <- {} {:?}", k, v);
             }
             res
@@ -25,15 +25,15 @@ impl Middleware for Debug {
 pub struct DebugRequest;
 
 impl Middleware for DebugRequest {
-    fn before(&self, req: &mut dyn Request) -> Result<()> {
-        println!("  version: {}", req.http_version());
+    fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
+        println!("  version: {:?}", req.http_version());
         println!("  method: {:?}", req.method());
         println!("  scheme: {:?}", req.scheme());
         println!("  host: {:?}", req.host());
         println!("  path: {}", req.path());
         println!("  query_string: {:?}", req.query_string());
         println!("  remote_addr: {:?}", req.remote_addr());
-        for &(k, ref v) in &req.headers().all() {
+        for (k, ref v) in req.headers().iter() {
             println!("  hdr: {}={:?}", k, v);
         }
         Ok(())

--- a/src/middleware/ember_index_rewrite.rs
+++ b/src/middleware/ember_index_rewrite.rs
@@ -24,14 +24,14 @@ impl AroundMiddleware for EmberIndexRewrite {
 }
 
 impl Handler for EmberIndexRewrite {
-    fn call(&self, req: &mut dyn Request) -> Result<Response> {
+    fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
         // If the client is requesting html, then we've only got one page so
         // rewrite the request.
         let wants_html = req
             .headers()
-            .find("Accept")
-            .map(|accept| accept.iter().any(|s| s.contains("html")))
-            .unwrap_or(false);
+            .get_all(header::ACCEPT)
+            .iter()
+            .any(|val| val.to_str().unwrap_or_default().contains("html"));
         // If the route starts with /api, just assume they want the API
         // response and fall through.
         let is_api_path = req.path().starts_with("/api");

--- a/src/middleware/ensure_well_formed_500.rs
+++ b/src/middleware/ensure_well_formed_500.rs
@@ -2,24 +2,20 @@
 
 use super::prelude::*;
 
-use std::collections::HashMap;
-
 // Can't derive debug because of Handler.
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct EnsureWellFormed500;
 
 impl Middleware for EnsureWellFormed500 {
-    fn after(&self, _: &mut dyn Request, res: Result<Response>) -> Result<Response> {
+    fn after(&self, _: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
         res.or_else(|_| {
             let body = "Internal Server Error";
-            let mut headers = HashMap::new();
-            headers.insert("Content-Length".to_string(), vec![body.len().to_string()]);
-            Ok(Response {
-                status: (500, "Internal Server Error"),
-                headers,
-                body: Box::new(body.as_bytes()),
-            })
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header(header::CONTENT_LENGTH, body.len())
+                .body(Box::new(body.as_bytes()) as Body)
+                .map_err(box_error)
         })
     }
 }

--- a/src/middleware/ensure_well_formed_500.rs
+++ b/src/middleware/ensure_well_formed_500.rs
@@ -14,7 +14,7 @@ impl Middleware for EnsureWellFormed500 {
             Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .header(header::CONTENT_LENGTH, body.len())
-                .body(Box::new(body.as_bytes()) as Body)
+                .body(Body::from_static(body.as_bytes()))
                 .map_err(box_error)
         })
     }

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -4,7 +4,6 @@ use super::prelude::*;
 
 use crate::util::RequestProxy;
 use conduit::Method;
-use std::io;
 
 // Can't derive debug because of Handler.
 #[allow(missing_debug_implementations)]
@@ -24,7 +23,7 @@ impl Handler for Head {
         if req.method() == Method::HEAD {
             let mut req = RequestProxy::rewrite_method(req, Method::GET);
             self.handler.as_ref().unwrap().call(&mut req).map(|mut r| {
-                *r.body_mut() = Box::new(io::empty()) as Body;
+                *r.body_mut() = Body::empty();
                 r
             })
         } else {

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -20,17 +20,13 @@ impl AroundMiddleware for Head {
 }
 
 impl Handler for Head {
-    fn call(&self, req: &mut dyn Request) -> Result<Response> {
-        if req.method() == Method::Head {
-            let mut req = RequestProxy::rewrite_method(req, Method::Get);
-            self.handler
-                .as_ref()
-                .unwrap()
-                .call(&mut req)
-                .map(|r| Response {
-                    body: Box::new(io::empty()),
-                    ..r
-                })
+    fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
+        if req.method() == Method::HEAD {
+            let mut req = RequestProxy::rewrite_method(req, Method::GET);
+            self.handler.as_ref().unwrap().call(&mut req).map(|mut r| {
+                *r.body_mut() = Box::new(io::empty()) as Body;
+                r
+            })
         } else {
             self.handler.as_ref().unwrap().call(req)
         }

--- a/src/middleware/log_connection_pool_status.rs
+++ b/src/middleware/log_connection_pool_status.rs
@@ -3,7 +3,7 @@
 use super::prelude::*;
 use crate::app::App;
 
-use conduit::Request;
+use conduit::RequestExt;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Mutex, PoisonError,
@@ -28,7 +28,7 @@ impl LogConnectionPoolStatus {
 }
 
 impl Middleware for LogConnectionPoolStatus {
-    fn before(&self, _: &mut dyn Request) -> Result<()> {
+    fn before(&self, _: &mut dyn RequestExt) -> BeforeResult {
         let mut last_log_time = self
             .last_log_time
             .lock()
@@ -49,7 +49,7 @@ impl Middleware for LogConnectionPoolStatus {
         Ok(())
     }
 
-    fn after(&self, _: &mut dyn Request, res: Result<Response>) -> Result<Response> {
+    fn after(&self, _: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
         self.in_flight_requests.fetch_sub(1, Ordering::SeqCst);
         res
     }

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -88,7 +88,7 @@ impl Display for RequestLine<'_> {
         line.add_field("request_id", request_header(self.req, "x-request-id"))?;
         line.add_quoted_field("fwd", request_header(self.req, "x-real-ip"))?;
         line.add_field("service", TimeMs(self.response_time))?;
-        line.add_field("status", status)?;
+        line.add_field("status", status.as_str())?;
         line.add_quoted_field("user_agent", request_header(self.req, header::USER_AGENT))?;
 
         if let Some(metadata) = self.req.extensions().find::<CustomMetadata>() {

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -3,7 +3,6 @@
 use super::prelude::*;
 
 use crate::util::request_header;
-use std::io::Cursor;
 
 // Can't derive debug because of Handler.
 #[allow(missing_debug_implementations)]
@@ -32,7 +31,7 @@ impl Handler for RequireUserAgent {
             Response::builder()
                 .status(StatusCode::FORBIDDEN)
                 .header(header::CONTENT_LENGTH, body.len())
-                .body(Box::new(Cursor::new(body.into_bytes())) as Body)
+                .body(Body::from_vec(body.into_bytes()))
                 .map_err(box_error)
         } else {
             self.handler.as_ref().unwrap().call(req)

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -3,7 +3,6 @@
 use super::prelude::*;
 
 use crate::util::request_header;
-use std::collections::HashMap;
 use std::io::Cursor;
 
 // Can't derive debug because of Handler.
@@ -20,22 +19,21 @@ impl AroundMiddleware for RequireUserAgent {
 }
 
 impl Handler for RequireUserAgent {
-    fn call(&self, req: &mut dyn Request) -> Result<Response> {
-        let has_user_agent = request_header(req, "User-Agent") != "";
+    fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
+        let has_user_agent = request_header(req, header::USER_AGENT) != "";
         let is_download = req.path().ends_with("download");
         if !has_user_agent && !is_download {
             super::log_request::add_custom_metadata(req, "cause", "no user agent");
             let body = format!(
                 include_str!("no_user_agent_message.txt"),
-                request_header(req, "X-Request-Id"),
+                request_header(req, "x-request-id"),
             );
-            let mut headers = HashMap::new();
-            headers.insert("Content-Length".to_string(), vec![body.len().to_string()]);
-            Ok(Response {
-                status: (403, "Forbidden"),
-                headers,
-                body: Box::new(Cursor::new(body.into_bytes())),
-            })
+
+            Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .header(header::CONTENT_LENGTH, body.len())
+                .body(Box::new(Cursor::new(body.into_bytes())) as Body)
+                .map_err(box_error)
         } else {
             self.handler.as_ref().unwrap().call(req)
         }

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -27,9 +27,9 @@ impl AroundMiddleware for StaticOrContinue {
 }
 
 impl Handler for StaticOrContinue {
-    fn call(&self, req: &mut dyn Request) -> Result<Response> {
+    fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
         match self.static_handler.call(req) {
-            Ok(ref resp) if resp.status.0 == 404 => {}
+            Ok(ref resp) if resp.status() == StatusCode::NOT_FOUND => {}
             ret => return ret,
         }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -191,6 +191,7 @@ mod tests {
     };
     use crate::util::EndpointResult;
 
+    use conduit::StatusCode;
     use conduit_test::MockRequest;
     use diesel::result::Error as DieselError;
 
@@ -205,25 +206,28 @@ mod tests {
         // Types for handling common error status codes
         assert_eq!(
             C(|_| Err(bad_request(""))).call(&mut req).unwrap().status(),
-            400
+            StatusCode::BAD_REQUEST
         );
         assert_eq!(
             C(|_| err(Unauthorized)).call(&mut req).unwrap().status(),
-            403
+            StatusCode::FORBIDDEN
         );
         assert_eq!(
             C(|_| Err(DieselError::NotFound.into()))
                 .call(&mut req)
                 .unwrap()
                 .status(),
-            404
+            StatusCode::NOT_FOUND
         );
-        assert_eq!(C(|_| err(NotFound)).call(&mut req).unwrap().status(), 404);
+        assert_eq!(
+            C(|_| err(NotFound)).call(&mut req).unwrap().status(),
+            StatusCode::NOT_FOUND
+        );
 
         // cargo_err errors are returned as 200 so that cargo displays this nicely on the command line
         assert_eq!(
             C(|_| Err(cargo_err(""))).call(&mut req).unwrap().status(),
-            200
+            StatusCode::OK
         );
 
         // Inner errors are captured for logging when wrapped by a user facing error
@@ -236,7 +240,7 @@ mod tests {
         })
         .call(&mut req)
         .unwrap();
-        assert_eq!(response.status(), 400);
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
             crate::middleware::log_request::get_log_message(&req, "cause"),
             "middle error caused by invalid digit found in string"

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -15,11 +15,11 @@ fn call(app: &TestApp, mut request: MockRequest) -> HandlerResult {
     app.as_middleware().call(&mut request)
 }
 
-fn into_parts(response: HandlerResult) -> (StatusCode, Vec<u8>) {
-    let mut response = response.unwrap();
-    let mut body = Vec::new();
-    response.body_mut().write_body(&mut body).unwrap();
-    (response.status(), body)
+fn into_parts(response: HandlerResult) -> (StatusCode, std::borrow::Cow<'static, [u8]>) {
+    use conduit_test::ResponseExt;
+
+    let response = response.unwrap();
+    (response.status(), response.into_cow())
 }
 
 #[test]

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -28,7 +28,7 @@ fn anonymous_user_unauthorized() {
     let request = anon.request_builder(Method::GET, URL);
 
     let (status, body) = into_parts(call(&app, request));
-    assert_eq!(status, 403);
+    assert_eq!(status, StatusCode::FORBIDDEN);
     assert_eq!(body, MUST_LOGIN);
 }
 
@@ -39,7 +39,7 @@ fn token_auth_cannot_find_token() {
     request.header(header::AUTHORIZATION, "fake-token");
 
     let (status, body) = into_parts(call(&app, request));
-    assert_eq!(status, 403);
+    assert_eq!(status, StatusCode::FORBIDDEN);
     assert_eq!(body, MUST_LOGIN);
 }
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -10,6 +10,7 @@ use cargo_registry::{
     views::{EncodableCrateOwnerInvitation, EncodableOwner, InvitationResponse},
 };
 
+use conduit::StatusCode;
 use diesel::prelude::*;
 
 #[derive(Deserialize)]
@@ -136,7 +137,7 @@ fn owners_can_remove_self() {
     // Deleting yourself when you're the only owner isn't allowed.
     let json = token
         .remove_named_owner("owners_selfremove", username)
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
     assert!(json.errors[0]
         .detail
         .contains("cannot remove all individual owners of a crate"));
@@ -152,7 +153,7 @@ fn owners_can_remove_self() {
     // After you delete yourself, you no longer have permisions to manage the crate.
     let json = token
         .remove_named_owner("owners_selfremove", username)
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
     assert!(json.errors[0]
         .detail
         .contains("only owners have permission to modify owners",));
@@ -173,7 +174,7 @@ fn modify_multiple_owners() {
     // Deleting all owners is not allowed.
     let json = token
         .remove_named_owners("owners_multiple", &[username, "user2", "user3"])
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
     assert!(&json.errors[0]
         .detail
         .contains("cannot remove all individual owners of a crate"));
@@ -189,7 +190,7 @@ fn modify_multiple_owners() {
     // Adding multiple users fails if one of them already is an owner.
     let json = token
         .add_named_owners("owners_multiple", &["user2", username])
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
     assert!(&json.errors[0].detail.contains("is already an owner"));
     assert_eq!(app.db(|conn| krate.owners(&conn).unwrap()).len(), 1);
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -8,6 +8,7 @@ use crate::{
 use cargo_registry::models::{Crate, NewUser};
 use std::sync::Once;
 
+use conduit::StatusCode;
 use diesel::*;
 
 impl crate::util::MockAnonymousUser {
@@ -50,7 +51,7 @@ fn not_github() {
 
     let json = token
         .add_named_owner("foo_not_github", "dropbox:foo:foo")
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0].detail.contains("unknown organization"),
@@ -69,7 +70,7 @@ fn weird_name() {
 
     let json = token
         .add_named_owner("foo_weird_name", "github:foo/../bar:wut")
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0]
@@ -91,7 +92,7 @@ fn one_colon() {
 
     let json = token
         .add_named_owner("foo_one_colon", "github:foo")
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0].detail.contains("missing github team"),
@@ -113,7 +114,7 @@ fn nonexistent_team() {
             "foo_nonexistent",
             "github:crates-test-org:this-does-not-exist",
         )
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0]
@@ -170,7 +171,7 @@ fn add_team_as_non_member() {
             "foo_team_non_member",
             "github:crates-test-org:just-for-crates-2",
         )
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0]
@@ -200,7 +201,7 @@ fn remove_team_as_named_owner() {
     // have permission to manage ownership
     let json = token_on_both_teams
         .remove_named_owner("foo_remove_team", username)
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
     assert!(json.errors[0]
         .detail
         .contains("cannot remove all individual owners of a crate"));
@@ -213,7 +214,7 @@ fn remove_team_as_named_owner() {
     let crate_to_publish = PublishBuilder::new("foo_remove_team").version("2.0.0");
     let json = user_on_one_team
         .enqueue_publish(crate_to_publish)
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0]
@@ -244,7 +245,7 @@ fn remove_team_as_team_owner() {
 
     let json = token_on_one_team
         .remove_named_owner("foo_remove_team_owner", "github:crates-test-org:core")
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0]
@@ -275,7 +276,7 @@ fn publish_not_owned() {
     let crate_to_publish = PublishBuilder::new("foo_not_owned").version("2.0.0");
     let json = user_on_one_team
         .enqueue_publish(crate_to_publish)
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0]
@@ -327,7 +328,7 @@ fn add_owners_as_team_owner() {
 
     let json = token_on_one_team
         .add_named_owner("foo_add_owner", "arbitrary_username")
-        .bad_with_status(200);
+        .bad_with_status(StatusCode::OK);
 
     assert!(
         json.errors[0]

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,7 +1,7 @@
 use crate::{
     builders::{CrateBuilder, VersionBuilder},
     new_user,
-    util::{MockCookieUser, RequestHelper, Response},
+    util::{MockCookieUser, RequestHelper, Response, StatusCode},
     OkBool, TestApp,
 };
 use cargo_registry::{
@@ -115,7 +115,7 @@ fn access_token_needs_data() {
     let (_, anon) = TestApp::init().empty();
     let json = anon
         .get::<()>("/api/private/session/authorize")
-        .bad_with_status(400);
+        .bad_with_status(StatusCode::BAD_REQUEST);
     assert!(json.errors[0].detail.contains("invalid state"));
 }
 
@@ -296,7 +296,7 @@ fn following() {
     assert_eq!(r.meta.more, false);
 
     user.get_with_query::<()>("/api/v1/me/updates", "page=0")
-        .bad_with_status(400);
+        .bad_with_status(StatusCode::BAD_REQUEST);
 }
 
 #[test]
@@ -486,7 +486,7 @@ fn test_empty_email_not_added() {
 
     let json = user
         .update_email_more_control(model.id, Some(""))
-        .bad_with_status(400);
+        .bad_with_status(StatusCode::BAD_REQUEST);
     assert!(
         json.errors[0].detail.contains("empty email rejected"),
         "{:?}",
@@ -495,7 +495,7 @@ fn test_empty_email_not_added() {
 
     let json = user
         .update_email_more_control(model.id, None)
-        .bad_with_status(400);
+        .bad_with_status(StatusCode::BAD_REQUEST);
 
     assert!(
         json.errors[0].detail.contains("empty email rejected"),
@@ -521,7 +521,7 @@ fn test_other_users_cannot_change_my_email() {
             another_user_model.id,
             Some("pineapple@pineapples.pineapple"),
         )
-        .bad_with_status(400);
+        .bad_with_status(StatusCode::BAD_REQUEST);
     assert!(
         json.errors[0]
             .detail
@@ -534,7 +534,7 @@ fn test_other_users_cannot_change_my_email() {
         another_user_model.id,
         Some("pineapple@pineapples.pineapple"),
     )
-    .bad_with_status(403);
+    .bad_with_status(StatusCode::FORBIDDEN);
 }
 
 /* Given a new user, test that their email can be added

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -1,4 +1,4 @@
-use conduit::Request;
+use conduit::RequestExt;
 use flate2::read::GzDecoder;
 use openssl::error::ErrorStack;
 use openssl::hash::{Hasher, MessageDigest};
@@ -129,7 +129,7 @@ impl Uploader {
     /// Uploads a crate and returns the checksum of the uploaded crate file.
     pub fn upload_crate(
         &self,
-        req: &mut dyn Request,
+        req: &mut dyn RequestExt,
         krate: &Crate,
         maximums: Maximums,
         vers: &semver::Version,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use conduit::{header, vec_to_body, Response};
+use conduit::{header, Body, Response};
 use serde::Serialize;
 
 pub use self::errors::concrete::Error;
@@ -29,7 +29,7 @@ pub fn json_response<T: Serialize>(t: &T) -> AppResponse {
     Response::builder()
         .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
         .header(header::CONTENT_LENGTH, json.len())
-        .body(vec_to_body(json.into_bytes()))
+        .body(Body::from_vec(json.into_bytes()))
         .unwrap() // Header values are well formed, so should not panic
 }
 

--- a/src/util/errors/http.rs
+++ b/src/util/errors/http.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 
-use conduit::Response;
-
 use super::{json_error, AppError};
+use crate::util::AppResponse;
+
+use conduit::StatusCode;
 
 #[derive(Debug)]
 pub(super) struct Ok(pub(super) String);
@@ -12,8 +13,8 @@ pub(super) struct BadRequest(pub(super) String);
 pub(super) struct ServerError(pub(super) String);
 
 impl AppError for Ok {
-    fn response(&self) -> Option<Response> {
-        Some(json_error(&self.0, (200, "OK")))
+    fn response(&self) -> Option<AppResponse> {
+        Some(json_error(&self.0, StatusCode::OK))
     }
 }
 
@@ -24,8 +25,8 @@ impl fmt::Display for Ok {
 }
 
 impl AppError for BadRequest {
-    fn response(&self) -> Option<Response> {
-        Some(json_error(&self.0, (400, "Bad Request")))
+    fn response(&self) -> Option<AppResponse> {
+        Some(json_error(&self.0, StatusCode::BAD_REQUEST))
     }
 }
 
@@ -36,8 +37,8 @@ impl fmt::Display for BadRequest {
 }
 
 impl AppError for ServerError {
-    fn response(&self) -> Option<Response> {
-        Some(json_error(&self.0, (500, "Internal Server Error")))
+    fn response(&self) -> Option<AppResponse> {
+        Some(json_error(&self.0, StatusCode::INTERNAL_SERVER_ERROR))
     }
 }
 

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -1,18 +1,17 @@
-use conduit::Request;
+use conduit::{header::AsHeaderName, RequestExt};
 
-/// Returns the value of the request header, or an empty string if it is not
+/// Returns the value of the request header, or an empty slice if it is not
 /// present.
 ///
-/// The implementation should return only the first line if it's a multiline
-/// header, but rust-civet is just wrapping the whole thing in a `vec!` anyway,
-/// and I have no clue what the C code it's wrapping does.
+/// If a header appears multiple times, this will return only one of them.
 ///
-/// The C library rust-civet is wrapping does not document whether headers are
-/// case sensitive or not, so I have no clue if this follows the HTTP spec in
-/// that regard.
-pub fn request_header<'a>(req: &'a dyn Request, header_name: &str) -> &'a str {
+/// If the header value is invalid utf8, an empty slice will be returned.
+pub fn request_header<'a, K>(req: &'a dyn RequestExt, key: K) -> &'a str
+where
+    K: AsHeaderName,
+{
     req.headers()
-        .find(header_name)
-        .and_then(|x| x.first().cloned())
+        .get(key)
+        .map(|value| value.to_str().unwrap_or_default())
         .unwrap_or_default()
 }

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -6,7 +6,7 @@ use conduit::{header::AsHeaderName, RequestExt};
 /// If a header appears multiple times, this will return only one of them.
 ///
 /// If the header value is invalid utf8, an empty slice will be returned.
-pub fn request_header<'a, K>(req: &'a dyn RequestExt, key: K) -> &'a str
+pub fn request_header<K>(req: &dyn RequestExt, key: K) -> &str
 where
     K: AsHeaderName,
 {


### PR DESCRIPTION
In the upstream conduit crates, I've dropped the custom HTTP related types in favor of types from the `http` crate.  This reduces the amount of code to maintain upstream and generally provides a cleaner API, such as named `StatusCode::*` constants instead of naked integers.

This should also make it easier and more efficient to support both `civet` and `hyper` as web servers, as they (and our middleware stack) now use the same types and avoid unnecessary conversions.

r? @JohnTitor 