### PR TITLE
ESLint: Use `eslint-plugin-import-helpers` to enforce consistent import order

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
       legacyDecorators: true,
     },
   },
-  plugins: ['ember', 'prettier'],
+  plugins: ['ember', 'prettier', 'import-helpers'],
   extends: ['eslint:recommended', 'plugin:ember/recommended', 'plugin:prettier/recommended'],
   env: {
     browser: true,
@@ -20,6 +20,25 @@ module.exports = {
     'ember/no-get': 'off',
     'ember/no-mixins': 'off',
     'ember/require-computed-property-dependencies': 'off',
+
+    'import-helpers/order-imports': [
+      'error',
+      {
+        newlinesBetween: 'always',
+        groups: [
+          // Node.js built-in modules
+          '/^(assert|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|http2|https|inspector|module|net|os|path|perf_hooks|process|punycode|querystring|readline|repl|stream|string_decoder|timers|tls|trace_events|tty|url|util|v8|vm|zli)/',
+          // Testing modules
+          ['/^(qunit|ember-qunit|@ember/test-helpers|ember-exam|htmlbars-inline-precompile)$/', '/^ember-exam\\//'],
+          // Ember.js modules
+          ['/^@(ember|ember-data|glimmer)\\//', '/^(ember|ember-data|rsvp)$/', '/^ember-data\\//'],
+          ['module'],
+          [`/^${require('./package.json').name}\\//`],
+          ['parent', 'sibling', 'index'],
+        ],
+        alphabetize: { order: 'asc', ignoreCase: true },
+      },
+    ],
   },
   overrides: [
     // node files

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,6 +1,6 @@
 import RESTAdapter from '@ember-data/adapter/rest';
-import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default RESTAdapter.extend({
   fastboot: service(),

--- a/app/adapters/category-slug.js
+++ b/app/adapters/category-slug.js
@@ -1,5 +1,6 @@
-import { pluralize } from 'ember-inflector';
 import { underscore, decamelize } from '@ember/string';
+
+import { pluralize } from 'ember-inflector';
 
 import ApplicationAdapter from './application';
 

--- a/app/app.js
+++ b/app/app.js
@@ -1,8 +1,9 @@
 import Application from '@ember/application';
-import Resolver from './resolver';
+
 import loadInitializers from 'ember-load-initializers';
 
 import config from './config/environment';
+import Resolver from './resolver';
 
 const App = Application.extend({
   modulePrefix: config.modulePrefix,

--- a/app/components/badge-bitbucket-pipelines.js
+++ b/app/components/badge-bitbucket-pipelines.js
@@ -1,6 +1,6 @@
+import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import Component from '@ember/component';
 
 export default Component.extend({
   tagName: '',

--- a/app/components/badge-circle-ci.js
+++ b/app/components/badge-circle-ci.js
@@ -1,6 +1,6 @@
+import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import Component from '@ember/component';
 
 export default Component.extend({
   tagName: '',

--- a/app/components/badge-cirrus-ci.js
+++ b/app/components/badge-cirrus-ci.js
@@ -1,6 +1,6 @@
+import Component from '@ember/component';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
-import Component from '@ember/component';
 
 export default Component.extend({
   tagName: '',

--- a/app/components/dropdown.js
+++ b/app/components/dropdown.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
-import { EKMixin, EKOnInsertMixin, keyDown } from 'ember-keyboard';
 import { on } from '@ember/object/evented';
+
+import { EKMixin, EKOnInsertMixin, keyDown } from 'ember-keyboard';
 
 export default Component.extend(EKMixin, EKOnInsertMixin, {
   tagName: '',

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
-import { empty } from '@ember/object/computed';
 import { computed } from '@ember/object';
+import { empty } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
 import { task } from 'ember-concurrency';

--- a/app/components/follow-button.js
+++ b/app/components/follow-button.js
@@ -1,5 +1,6 @@
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+
 import { task } from 'ember-concurrency';
 
 import ajax from '../utils/ajax';

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 export default Component.extend({
   size: 'small',

--- a/app/components/user-link.js
+++ b/app/components/user-link.js
@@ -1,5 +1,5 @@
-import { readOnly } from '@ember/object/computed';
 import Component from '@ember/component';
+import { readOnly } from '@ember/object/computed';
 
 export default Component.extend({
   user: null,

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,8 +1,9 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
 import { oneWay } from '@ember/object/computed';
-import { EKMixin, keyDown, keyPress } from 'ember-keyboard';
 import { on } from '@ember/object/evented';
+import { inject as service } from '@ember/service';
+
+import { EKMixin, keyDown, keyPress } from 'ember-keyboard';
 
 export default Controller.extend(EKMixin, {
   flashMessages: service(),

--- a/app/controllers/categories.js
+++ b/app/controllers/categories.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../mixins/pagination';
 

--- a/app/controllers/category/index.js
+++ b/app/controllers/category/index.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../../mixins/pagination';
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,11 +1,12 @@
-import { alias, readOnly, gt } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
-import Controller from '@ember/controller';
-import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import ArrayProxy from '@ember/array/proxy';
+import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import moment from 'moment';
+import { alias, readOnly, gt } from '@ember/object/computed';
+import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
+import { inject as service } from '@ember/service';
+
 import { task } from 'ember-concurrency';
+import moment from 'moment';
 
 const NUM_VERSIONS = 5;
 

--- a/app/controllers/crates.js
+++ b/app/controllers/crates.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../mixins/pagination';
 

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,5 +1,5 @@
-import Controller from '@ember/controller';
 import { A } from '@ember/array';
+import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 
 import ajax from '../utils/ajax';

--- a/app/controllers/keyword/index.js
+++ b/app/controllers/keyword/index.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../../mixins/pagination';
 

--- a/app/controllers/keywords.js
+++ b/app/controllers/keywords.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../mixins/pagination';
 

--- a/app/controllers/me/crates.js
+++ b/app/controllers/me/crates.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../../mixins/pagination';
 

--- a/app/controllers/me/following.js
+++ b/app/controllers/me/following.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../../mixins/pagination';
 

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -1,6 +1,6 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
 
 import PaginationMixin from '../mixins/pagination';
 

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -1,6 +1,7 @@
-import { readOnly } from '@ember/object/computed';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
+import { readOnly } from '@ember/object/computed';
+
 import PaginationMixin from '../mixins/pagination';
 
 // TODO: reduce duplication with controllers/crates

--- a/app/mixins/pagination.js
+++ b/app/mixins/pagination.js
@@ -1,6 +1,6 @@
+import { computed } from '@ember/object';
 import { readOnly } from '@ember/object/computed';
 import Mixin from '@ember/object/mixin';
-import { computed } from '@ember/object';
 
 const VIEWABLE_PAGES = 9;
 

--- a/app/models/dependency.js
+++ b/app/models/dependency.js
@@ -1,4 +1,5 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
+
 import Inflector from 'ember-inflector';
 
 Inflector.inflector.irregular('dependency', 'dependencies');

--- a/app/router.js
+++ b/app/router.js
@@ -1,5 +1,6 @@
-import config from './config/environment';
 import RouterScroll from 'ember-router-scroll';
+
+import config from './config/environment';
 
 export default class Router extends RouterScroll {
   location = config.locationType;

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -2,6 +2,7 @@
 import { observer } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+
 import prerelease from 'semver/functions/prerelease';
 
 import ajax from '../../utils/ajax';

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -1,5 +1,5 @@
-import Route from '@ember/routing/route';
 import { A } from '@ember/array';
+import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 
 import AuthenticatedRoute from '../mixins/authenticated-route';

--- a/app/routes/github-authorize.js
+++ b/app/routes/github-authorize.js
@@ -1,6 +1,7 @@
 import Route from '@ember/routing/route';
-import fetch from 'fetch';
+
 import window from 'ember-window-mock';
+import fetch from 'fetch';
 
 /**
  * This route will be called from the GitHub OAuth flow once the user has

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,5 +1,6 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
+
 import window from 'ember-window-mock';
 
 /**

--- a/app/routes/logout.js
+++ b/app/routes/logout.js
@@ -1,5 +1,5 @@
-import { run } from '@ember/runloop';
 import Route from '@ember/routing/route';
+import { run } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 
 import ajax from '../utils/ajax';

--- a/app/services/redirector.js
+++ b/app/services/redirector.js
@@ -1,4 +1,5 @@
 import Service, { inject as service } from '@ember/service';
+
 import window from 'ember-window-mock';
 
 export default class RedirectorService extends Service {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,4 +1,5 @@
 import Service, { inject as service } from '@ember/service';
+
 import window from 'ember-window-mock';
 
 import ajax from '../utils/ajax';

--- a/fastboot.js
+++ b/fastboot.js
@@ -2,13 +2,12 @@
 
 'use strict';
 
-const fs = require('fs');
-const os = require('os');
-const FastBootAppServer = require('fastboot-app-server');
-
 // because fastboot-app-server uses cluster, but it might change in future
 const cluster = require('cluster');
+const fs = require('fs');
+const os = require('os');
 
+const FastBootAppServer = require('fastboot-app-server');
 const morgan = require('morgan');
 
 class LoggerWithoutTimestamp {

--- a/mirage/factories/category.js
+++ b/mirage/factories/category.js
@@ -1,5 +1,6 @@
-import { Factory } from 'ember-cli-mirage';
 import { dasherize } from '@ember/string';
+
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   category: i => `Category ${i}`,

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -1,5 +1,6 @@
-import { Factory } from 'ember-cli-mirage';
 import { dasherize } from '@ember/string';
+
+import { Factory } from 'ember-cli-mirage';
 
 export default Factory.extend({
   name: i => `User ${i + 1}`,

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -1,6 +1,7 @@
 import { Response } from 'ember-cli-mirage';
-import { compareIsoDates, compareStrings, notFound, pageParams, withMeta } from './-utils';
+
 import { getSession } from '../utils/session';
+import { compareIsoDates, compareStrings, notFound, pageParams, withMeta } from './-utils';
 
 export function register(server) {
   server.get('/api/v1/crates', function (schema, request) {

--- a/mirage/serializers/crate.js
+++ b/mirage/serializers/crate.js
@@ -1,7 +1,9 @@
 import { assert } from '@ember/debug';
+
 import semverSort from 'semver/functions/rsort';
-import BaseSerializer from './application';
+
 import { compareIsoDates } from '../route-handlers/-utils';
+import BaseSerializer from './application';
 
 export default BaseSerializer.extend({
   attrs: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -39004,6 +39004,12 @@
         "snake-case": "^3.0.3"
       }
     },
+    "eslint-plugin-import-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.0.2.tgz",
+      "integrity": "sha512-aSoqeEEkJou/1NhbSO7Xr2SKSs8mI53qe8uFh9tMl4WCbrOwoel0eA3hRajlJ7MLCG44umf+mY3/dWuufneFzw==",
+      "dev": true
+    },
     "eslint-plugin-prettier": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-ember": "^8.1.1",
+    "eslint-plugin-import-helpers": "^1.0.2",
     "eslint-plugin-prettier": "^3.1.2",
     "loader.js": "^4.7.0",
     "normalize.css": "^8.0.1",

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -1,6 +1,7 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { currentURL, findAll, click, fillIn } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { Response } from 'ember-cli-mirage';
 import { percySnapshot } from 'ember-percy';
 

--- a/tests/acceptance/categories-test.js
+++ b/tests/acceptance/categories-test.js
@@ -1,10 +1,12 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | categories', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/crate-following-test.js
+++ b/tests/acceptance/crate-following-test.js
@@ -1,6 +1,7 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { visit, waitFor, settled, click } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { defer } from 'rsvp';
 
 import setupMirage from '../helpers/setup-mirage';

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,11 +1,13 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { click, fillIn, currentURL, currentRouteName, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import { title } from '../helpers/dom';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | crate page', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -1,11 +1,13 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { click, currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import { title } from '../helpers/dom';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | crates page', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -1,6 +1,7 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { percySnapshot } from 'ember-percy';
 
 import setupMirage from '../helpers/setup-mirage';

--- a/tests/acceptance/email-confirmation-test.js
+++ b/tests/acceptance/email-confirmation-test.js
@@ -1,9 +1,9 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 
-import { visit } from '../helpers/visit-ignoring-abort';
 import setupMirage from '../helpers/setup-mirage';
+import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | Email Confirmation', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -1,11 +1,13 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import { title } from '../helpers/dom';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | front page', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -1,8 +1,9 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { currentURL, click } from '@ember/test-helpers';
-import { percySnapshot } from 'ember-percy';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import Response from 'ember-cli-mirage/response';
+import { percySnapshot } from 'ember-percy';
 
 import setupMirage from '../helpers/setup-mirage';
 import { visit } from '../helpers/visit-ignoring-abort';

--- a/tests/acceptance/keyword-test.js
+++ b/tests/acceptance/keyword-test.js
@@ -1,10 +1,12 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | keywords', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,10 +1,13 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { visit, currentURL, click, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { defer } from 'rsvp';
+
 import window, { setupWindowMock } from 'ember-window-mock';
 
 import flashStyles from 'cargo/components/flash-message.module.css';
+
 import setupMirage from '../helpers/setup-mirage';
 
 module('Acceptance | Login', function (hooks) {

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -1,12 +1,14 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { fillIn, currentURL, triggerEvent, visit, blur } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
 import { keyDown, keyPress } from 'ember-keyboard/test-support/test-helpers';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import { title } from '../helpers/dom';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | search', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/team-page-test.js
+++ b/tests/acceptance/team-page-test.js
@@ -1,10 +1,12 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | team page', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/acceptance/token-invites-test.js
+++ b/tests/acceptance/token-invites-test.js
@@ -1,8 +1,9 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { currentURL } from '@ember/test-helpers';
-import { percySnapshot } from 'ember-percy';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import Response from 'ember-cli-mirage/response';
+import { percySnapshot } from 'ember-percy';
 
 import setupMirage from '../helpers/setup-mirage';
 import { visit } from '../helpers/visit-ignoring-abort';

--- a/tests/acceptance/user-page-test.js
+++ b/tests/acceptance/user-page-test.js
@@ -1,10 +1,12 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
+import { percySnapshot } from 'ember-percy';
+
 import axeConfig from '../axe-config';
 import setupMirage from '../helpers/setup-mirage';
-import { percySnapshot } from 'ember-percy';
 
 module('Acceptance | user page', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/bugs/2329-test.js
+++ b/tests/bugs/2329-test.js
@@ -1,6 +1,7 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { currentURL, click, waitFor } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import window, { setupWindowMock } from 'ember-window-mock';
 
 import setupMirage from '../helpers/setup-mirage';

--- a/tests/helpers/setup-mirage.js
+++ b/tests/helpers/setup-mirage.js
@@ -1,6 +1,6 @@
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
-import timekeeper from 'timekeeper';
 import window, { setupWindowMock } from 'ember-window-mock';
+import timekeeper from 'timekeeper';
 
 export default function (hooks) {
   setupMirage(hooks);

--- a/tests/integration/components/api-token-row-test.js
+++ b/tests/integration/components/api-token-row-test.js
@@ -1,6 +1,7 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | api-token-row', function (hooks) {

--- a/tests/mirage/categories-test.js
+++ b/tests/mirage/categories-test.js
@@ -1,8 +1,9 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Mirage | Categories', function (hooks) {
   setupTest(hooks);

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -1,8 +1,9 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Mirage | Crates', function (hooks) {
   setupTest(hooks);

--- a/tests/mirage/keywords-test.js
+++ b/tests/mirage/keywords-test.js
@@ -1,8 +1,9 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Mirage | Keywords', function (hooks) {
   setupTest(hooks);

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -1,9 +1,10 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
 import timekeeper from 'timekeeper';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Mirage | /me', function (hooks) {
   setupTest(hooks);

--- a/tests/mirage/summary-test.js
+++ b/tests/mirage/summary-test.js
@@ -1,8 +1,9 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Mirage | Summary', function (hooks) {
   setupTest(hooks);

--- a/tests/mirage/teams-test.js
+++ b/tests/mirage/teams-test.js
@@ -1,8 +1,9 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Mirage | Teams', function (hooks) {
   setupTest(hooks);

--- a/tests/mirage/users-test.js
+++ b/tests/mirage/users-test.js
@@ -1,8 +1,9 @@
 import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import setupMirage from '../helpers/setup-mirage';
 import fetch from 'fetch';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Mirage | Users', function (hooks) {
   setupTest(hooks);

--- a/tests/models/crate-test.js
+++ b/tests/models/crate-test.js
@@ -1,5 +1,5 @@
-import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 
 import AdapterError from '@ember-data/adapter/error';
 

--- a/tests/modifiers/highlight-syntax-test.js
+++ b/tests/modifiers/highlight-syntax-test.js
@@ -1,6 +1,7 @@
-import { module, test } from 'qunit';
-import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Modifier | highlight-syntax', function (hooks) {

--- a/tests/routes/github-authorize-test.js
+++ b/tests/routes/github-authorize-test.js
@@ -1,9 +1,11 @@
-import { module, test } from 'qunit';
-import { setupApplicationTest } from 'ember-qunit';
 import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { Response } from 'ember-cli-mirage';
-import setupMirage from '../helpers/setup-mirage';
 import window, { setupWindowMock } from 'ember-window-mock';
+
+import setupMirage from '../helpers/setup-mirage';
 
 module('Route | github-authorized', function (hooks) {
   setupApplicationTest(hooks);

--- a/tests/services/redirector-test.js
+++ b/tests/services/redirector-test.js
@@ -1,5 +1,6 @@
-import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import window, { setupWindowMock } from 'ember-window-mock';
 
 const URL = 'https://turbo.fish/';

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,7 +1,8 @@
-import Application from '../app';
-import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import start from 'ember-exam/test-support/start';
+
+import Application from '../app';
+import config from '../config/environment';
 
 setApplication(Application.create(config.APP));
 

--- a/tests/unit/controllers/crate/version-test.js
+++ b/tests/unit/controllers/crate/version-test.js
@@ -1,5 +1,6 @@
-import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
 import { A } from '@ember/array';
 import Service from '@ember/service';
 

--- a/tests/unit/helpers/format-crate-size-test.js
+++ b/tests/unit/helpers/format-crate-size-test.js
@@ -1,5 +1,6 @@
-import { formatCrateSize } from '../../../helpers/format-crate-size';
 import { module, test } from 'qunit';
+
+import { formatCrateSize } from '../../../helpers/format-crate-size';
 
 module('Unit | Helper | format-crate-size', function () {
   test('Small crate size formats in kB', function (assert) {

--- a/tests/unit/helpers/format-email-test.js
+++ b/tests/unit/helpers/format-email-test.js
@@ -1,5 +1,6 @@
-import { formatEmail } from '../../../helpers/format-email';
 import { module, test } from 'qunit';
+
+import { formatEmail } from '../../../helpers/format-email';
 
 module('Unit | Helper | format-email', function () {
   // Replace this with your real tests.

--- a/tests/unit/helpers/format-num-test.js
+++ b/tests/unit/helpers/format-num-test.js
@@ -1,5 +1,6 @@
-import { formatNum } from '../../../helpers/format-num';
 import { module, test } from 'qunit';
+
+import { formatNum } from '../../../helpers/format-num';
 
 module('Unit | Helper | format-num', function () {
   test('it works', function (assert) {

--- a/tests/unit/mixins/pagination-test.js
+++ b/tests/unit/mixins/pagination-test.js
@@ -1,5 +1,6 @@
-import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
+
+import EmberObject from '@ember/object';
 
 import PaginationMixin from '../../../mixins/pagination';
 


### PR DESCRIPTION
except for the ESLint config changes, all the other changes were performed via `npm run lint:js -- --fix`

see https://github.com/Tibfib/eslint-plugin-import-helpers

r? @pichfl