### PR TITLE
crate.version: Remove obsolete `refreshAfterLogin` observer

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -1,5 +1,3 @@
-// eslint-disable-next-line ember/no-observers
-import { observer } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import prerelease from 'semver/functions/prerelease';
@@ -7,14 +5,7 @@ import prerelease from 'semver/functions/prerelease';
 import ajax from '../../utils/ajax';
 
 export default Route.extend({
-  session: service(),
-
   flashMessages: service(),
-
-  // eslint-disable-next-line ember/no-observers
-  refreshAfterLogin: observer('session.isLoggedIn', function () {
-    this.refresh();
-  }),
 
   async model(params) {
     const requestedVersion = params.version_num === 'all' ? '' : params.version_num;


### PR DESCRIPTION
This was only used when we were loading the `following` status in the model hook, but we no longer do that, so this observer is not useful anymore.

r? @locks 