### PR TITLE
crate: Fix error handling in `model()` hook

### DIFF
--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -10,6 +10,8 @@ export default Route.extend({
     } catch (e) {
       if (e.errors?.some(e => e.detail === 'Not Found')) {
         this.flashMessages.show(`Crate '${params.crate_id}' does not exist`);
+      } else {
+        throw e;
       }
     }
   },

--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -8,7 +8,7 @@ export default Route.extend({
     try {
       return await this.store.find('crate', params.crate_id);
     } catch (e) {
-      if (e.errors.some(e => e.detail === 'Not Found')) {
+      if (e.errors?.some(e => e.detail === 'Not Found')) {
         this.flashMessages.show(`Crate '${params.crate_id}' does not exist`);
       }
     }

--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -4,12 +4,14 @@ import { inject as service } from '@ember/service';
 export default Route.extend({
   flashMessages: service(),
 
-  model(params) {
-    return this.store.find('crate', params.crate_id).catch(e => {
+  async model(params) {
+    try {
+      return await this.store.find('crate', params.crate_id);
+    } catch (e) {
       if (e.errors.some(e => e.detail === 'Not Found')) {
         this.flashMessages.show(`Crate '${params.crate_id}' does not exist`);
       }
-    });
+    }
   },
 
   afterModel(model) {

--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -8,7 +8,6 @@ export default Route.extend({
     return this.store.find('crate', params.crate_id).catch(e => {
       if (e.errors.some(e => e.detail === 'Not Found')) {
         this.flashMessages.show(`Crate '${params.crate_id}' does not exist`);
-        return;
       }
     });
   },


### PR DESCRIPTION
If an error was thrown without an `errors` property the error handler would crash, and if the error had such a property but without the "Not Found" detail the error would still not be shown because it wasn't rethrown.

r? @locks 