### PR TITLE
Improve README loading code

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -127,20 +127,24 @@ export default Controller.extend({
     return data;
   }),
 
-  loadReadmeTask: task(function* () {
-    try {
-      this.crate.set('readme', yield this.currentVersion.loadReadmeTask.perform());
+  readme: alias('loadReadmeTask.last.value'),
 
-      if (typeof document !== 'undefined') {
-        setTimeout(() => {
-          let e = document.createEvent('CustomEvent');
-          e.initCustomEvent('hashchange', true, true);
-          window.dispatchEvent(e);
-        });
-      }
-    } catch (error) {
-      this.crate.set('readme', null);
+  loadReadmeTask: task(function* () {
+    let version = this.currentVersion;
+
+    let readme = version.loadReadmeTask.lastSuccessful
+      ? version.loadReadmeTask.lastSuccessful.value
+      : yield version.loadReadmeTask.perform();
+
+    if (typeof document !== 'undefined') {
+      setTimeout(() => {
+        let e = document.createEvent('CustomEvent');
+        e.initCustomEvent('hashchange', true, true);
+        window.dispatchEvent(e);
+      });
     }
+
+    return readme;
   }),
 
   documentationLink: computed(

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -128,25 +128,18 @@ export default Controller.extend({
   }),
 
   loadReadmeTask: task(function* () {
-    if (this.currentVersion.get('readme_path')) {
-      try {
-        let r = yield fetch(this.currentVersion.get('readme_path'));
-        if (r.ok) {
-          this.crate.set('readme', yield r.text());
+    try {
+      this.crate.set('readme', yield this.currentVersion.loadReadmeTask.perform());
 
-          if (typeof document !== 'undefined') {
-            setTimeout(() => {
-              let e = document.createEvent('CustomEvent');
-              e.initCustomEvent('hashchange', true, true);
-              window.dispatchEvent(e);
-            });
-          }
-        } else {
-          this.crate.set('readme', null);
-        }
-      } catch (error) {
-        this.crate.set('readme', null);
+      if (typeof document !== 'undefined') {
+        setTimeout(() => {
+          let e = document.createEvent('CustomEvent');
+          e.initCustomEvent('hashchange', true, true);
+          window.dispatchEvent(e);
+        });
       }
+    } catch (error) {
+      this.crate.set('readme', null);
     }
   }),
 

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -39,4 +39,15 @@ export default Model.extend({
 
     return { normal, build, dev };
   }).keepLatest(),
+
+  loadReadmeTask: task(function* () {
+    if (this.readme_path) {
+      let response = yield fetch(this.readme_path);
+      if (!response.ok) {
+        throw new Error(`README request for ${this.crateName} v${this.num} failed`);
+      }
+
+      return yield response.text();
+    }
+  }).keepLatest(),
 });

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -62,7 +62,9 @@ export default Route.extend({
     this._super(...arguments);
 
     model.version.loadDepsTask.perform();
-    controller.loadReadmeTask.perform();
+    controller.loadReadmeTask.perform().catch(() => {
+      // ignored
+    });
 
     let { crate } = model;
     if (!crate.documentation || crate.documentation.startsWith('https://docs.rs/')) {

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -56,9 +56,9 @@
           <CrateTomlCopy @copyText={{this.crateTomlText}} />
         {{/if}}
       </div>
-      {{#if this.crate.readme}}
+      {{#if this.readme}}
         <section local-class="crate-readme" aria-label="Readme" {{highlight-syntax selector="pre > code"}}>
-          {{html-safe this.crate.readme}}
+          {{html-safe this.readme}}
         </section>
       {{else}}
         {{#if this.crate.description}}


### PR DESCRIPTION
The `readme_path` property is on the `version` resource, but we currently cache the README file content per crate. This PR cleans up the README loading code to cache the README per version instead, which means that we now show the correct README file corresponding to the selected version.

r? @locks 