### PR TITLE
ember: Enable optional `default-async-observers` feature

### DIFF
--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -1,5 +1,6 @@
 {
   "application-template-wrapper": false,
+  "default-async-observers": true,
   "jquery-integration": false,
   "template-only-glimmer-components": true
 }


### PR DESCRIPTION
We don't have any observers in the app anymore, so this should be safe to do. This is the final missing piece before we can toggle the Ember Octane flag.

r? @locks 