### PR TITLE
crate.version: Replace `displayedAuthors` property with `version` model task

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,8 +1,6 @@
-import ArrayProxy from '@ember/array/proxy';
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
 import { alias, readOnly, gt } from '@ember/object/computed';
-import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
 import { inject as service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
@@ -11,8 +9,6 @@ import moment from 'moment';
 import ajax from '../../utils/ajax';
 
 const NUM_VERSIONS = 5;
-
-const PromiseArray = ArrayProxy.extend(PromiseProxyMixin);
 
 export default Controller.extend({
   session: service(),
@@ -46,19 +42,6 @@ export default Controller.extend({
   }),
 
   hasMoreVersions: gt('sortedVersions.length', NUM_VERSIONS),
-
-  displayedAuthors: computed('currentVersion.authors.[]', function () {
-    return PromiseArray.create({
-      promise: this.get('currentVersion.authors').then(authors => {
-        let ret = authors.slice();
-        let others = authors.get('meta');
-        for (let i = 0; i < others.names.length; i++) {
-          ret.push({ name: others.names[i] });
-        }
-        return ret;
-      }),
-    });
-  }),
 
   anyKeywords: gt('keywords.length', 0),
   anyCategories: gt('categories.length', 0),

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -26,6 +26,14 @@ export default class Version extends Model {
   })
   crateName;
 
+  @alias('loadAuthorsTask.last.value') authorNames;
+
+  @(task(function* () {
+    let authors = yield this.get('authors');
+    return authors.meta.names;
+  }).keepLatest())
+  loadAuthorsTask;
+
   @alias('loadDepsTask.last.value.normal') normalDependencies;
   @alias('loadDepsTask.last.value.build') buildDependencies;
   @alias('loadDepsTask.last.value.dev') devDependencies;

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -62,6 +62,10 @@ export default Route.extend({
     this._super(...arguments);
 
     model.version.loadDepsTask.perform();
+    if (!model.version.authorNames) {
+      model.version.loadAuthorsTask.perform();
+    }
+
     controller.loadReadmeTask.perform().catch(() => {
       // ignored
     });

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -93,8 +93,8 @@
         <div>
           <h3>Authors</h3>
           <ul>
-            {{#each this.displayedAuthors as |author|}}
-              <li>{{ format-email author.name }}</li>
+            {{#each this.currentVersion.authorNames as |author|}}
+              <li>{{ format-email author }}</li>
             {{/each}}
           </ul>
         </div>


### PR DESCRIPTION
This gets rid of the last remaining Array/PromiseProxy in the app and simplifies the data loading code a little more.

r? @locks 