### PR TITLE
services/session: Replace manual state management with `loadUserTask`

### DIFF
--- a/app/mixins/authenticated-route.js
+++ b/app/mixins/authenticated-route.js
@@ -4,11 +4,18 @@ import { inject as service } from '@ember/service';
 // eslint-disable-next-line ember/no-new-mixins
 export default Mixin.create({
   flashMessages: service(),
+  router: service(),
   session: service(),
 
-  beforeModel(transition) {
-    return this.session.checkCurrentUser(transition, () => {
+  async beforeModel(transition) {
+    // wait for the `loadUserTask.perform()` of either the `application` route,
+    // or the `session.login()` call
+    let result = await this.session.loadUserTask.last;
+
+    if (!result.currentUser) {
       this.flashMessages.queue('Please log in to proceed');
-    });
+      this.session.savedTransition = transition;
+      this.router.transitionTo('index');
+    }
   },
 });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -7,7 +7,8 @@ export default Route.extend({
   session: service(),
 
   beforeModel() {
-    this.session.loadUser();
+    // trigger the task, but don't wait for the result here
+    this.session.loadUserTask.perform();
 
     // start loading the Google Charts JS library already
     this.googleCharts.load();

--- a/app/routes/confirm.js
+++ b/app/routes/confirm.js
@@ -12,6 +12,10 @@ export default Route.extend({
     try {
       await ajax(`/api/v1/confirm/${params.email_token}`, { method: 'PUT', body: '{}' });
 
+      // wait for the `GET /api/v1/me` call to complete before
+      // trying to update the Ember Data store
+      await this.session.loadUserTask.last;
+
       if (this.session.currentUser) {
         this.store.pushPayload({ user: { id: this.session.currentUser.id, email_verified: true } });
       }

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -66,12 +66,7 @@ export default Route.extend({
         return;
       }
 
-      let user = this.store.push(this.store.normalize('user', data.user));
-      let transition = this.get('session.savedTransition');
-      this.session.loginUser(user);
-      if (transition) {
-        transition.retry();
-      }
+      this.session.login();
     }, 200);
 
     transition.abort();

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -11,28 +11,32 @@ export default class SessionService extends Service {
   @service router;
 
   savedTransition = null;
-  isLoggedIn = false;
 
   @alias('loadUserTask.last.value.currentUser') currentUser;
   @alias('loadUserTask.last.value.ownedCrates') ownedCrates;
 
-  constructor() {
-    super(...arguments);
-
+  get isLoggedIn() {
     try {
-      this.isLoggedIn = window.localStorage.getItem('isLoggedIn') === '1';
+      return window.localStorage.getItem('isLoggedIn') === '1';
     } catch (e) {
-      this.isLoggedIn = false;
+      return false;
+    }
+  }
+
+  set isLoggedIn(value) {
+    try {
+      if (value) {
+        window.localStorage.setItem('isLoggedIn', '1');
+      } else {
+        window.localStorage.removeItem('isLoggedIn');
+      }
+    } catch (e) {
+      // ignore error
     }
   }
 
   login() {
     this.isLoggedIn = true;
-    try {
-      window.localStorage.setItem('isLoggedIn', '1');
-    } catch (e) {
-      // ignore error
-    }
 
     // just trigger the task, but don't wait for the result here
     this.loadUserTask.perform();
@@ -49,12 +53,6 @@ export default class SessionService extends Service {
     this.isLoggedIn = false;
 
     this.loadUserTask.cancelAll({ resetState: true });
-
-    try {
-      window.localStorage.removeItem('isLoggedIn');
-    } catch (e) {
-      // ignore error
-    }
   }
 
   @(task(function* () {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,5 +1,7 @@
+import { alias } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
+import { task } from 'ember-concurrency';
 import window from 'ember-window-mock';
 
 import ajax from '../utils/ajax';
@@ -9,11 +11,10 @@ export default class SessionService extends Service {
   @service router;
 
   savedTransition = null;
-  abortedTransition = null;
   isLoggedIn = false;
-  currentUser = null;
-  currentUserDetected = false;
-  ownedCrates = null;
+
+  @alias('loadUserTask.last.value.currentUser') currentUser;
+  @alias('loadUserTask.last.value.ownedCrates') ownedCrates;
 
   constructor() {
     super(...arguments);
@@ -25,24 +26,31 @@ export default class SessionService extends Service {
       isLoggedIn = false;
     }
     this.set('isLoggedIn', isLoggedIn);
-    this.set('currentUser', null);
   }
 
-  loginUser(user) {
+  login() {
     this.set('isLoggedIn', true);
-    this.set('currentUser', user);
     try {
       window.localStorage.setItem('isLoggedIn', '1');
     } catch (e) {
       // ignore error
     }
+
+    // just trigger the task, but don't wait for the result here
+    this.loadUserTask.perform();
+
+    // perform the originally saved transition, if it exists
+    let transition = this.savedTransition;
+    if (transition) {
+      transition.retry();
+    }
   }
 
   logoutUser() {
     this.set('savedTransition', null);
-    this.set('abortedTransition', null);
     this.set('isLoggedIn', null);
-    this.set('currentUser', null);
+
+    this.loadUserTask.cancelAll({ resetState: true });
 
     try {
       window.localStorage.removeItem('isLoggedIn');
@@ -51,52 +59,20 @@ export default class SessionService extends Service {
     }
   }
 
-  async loadUser() {
-    if (this.isLoggedIn && !this.currentUser) {
-      try {
-        await this.fetchUser();
-      } catch (error) {
-        this.logoutUser();
-      } finally {
-        this.set('currentUserDetected', true);
-        let transition = this.abortedTransition;
-        if (transition) {
-          transition.retry();
-          this.set('abortedTransition', null);
-        }
-      }
-    } else {
-      this.set('currentUserDetected', true);
-    }
-  }
+  @(task(function* () {
+    if (!this.isLoggedIn) return {};
 
-  async fetchUser() {
-    let response = await ajax('/api/v1/me');
-    this.set('currentUser', this.store.push(this.store.normalize('user', response.user)));
-    this.set(
-      'ownedCrates',
-      response.owned_crates.map(c => this.store.push(this.store.normalize('owned-crate', c))),
-    );
-  }
-
-  checkCurrentUser(transition, beforeRedirect) {
-    if (this.currentUser) {
-      return;
+    let response;
+    try {
+      response = yield ajax('/api/v1/me');
+    } catch (error) {
+      return {};
     }
 
-    // The current user is loaded asynchronously, so if we haven't actually
-    // loaded the current user yet then we need to wait for it to be loaded.
-    // Once we've done that we can retry the transition and start the whole
-    // process over again!
-    if (!this.currentUserDetected) {
-      transition.abort();
-      this.set('abortedTransition', transition);
-    } else {
-      this.set('savedTransition', transition);
-      if (beforeRedirect) {
-        beforeRedirect();
-      }
-      return this.router.transitionTo('index');
-    }
-  }
+    let currentUser = this.store.push(this.store.normalize('user', response.user));
+    let ownedCrates = response.owned_crates.map(c => this.store.push(this.store.normalize('owned-crate', c)));
+
+    return { currentUser, ownedCrates };
+  }).drop())
+  loadUserTask;
 }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -19,17 +19,15 @@ export default class SessionService extends Service {
   constructor() {
     super(...arguments);
 
-    let isLoggedIn;
     try {
-      isLoggedIn = window.localStorage.getItem('isLoggedIn') === '1';
+      this.isLoggedIn = window.localStorage.getItem('isLoggedIn') === '1';
     } catch (e) {
-      isLoggedIn = false;
+      this.isLoggedIn = false;
     }
-    this.set('isLoggedIn', isLoggedIn);
   }
 
   login() {
-    this.set('isLoggedIn', true);
+    this.isLoggedIn = true;
     try {
       window.localStorage.setItem('isLoggedIn', '1');
     } catch (e) {
@@ -47,8 +45,8 @@ export default class SessionService extends Service {
   }
 
   logoutUser() {
-    this.set('savedTransition', null);
-    this.set('isLoggedIn', null);
+    this.savedTransition = null;
+    this.isLoggedIn = false;
 
     this.loadUserTask.cancelAll({ resetState: true });
 

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -26,6 +26,18 @@ module('Acceptance | Login', function (hooks) {
       return fakeWindow;
     };
 
+    this.server.get('/api/v1/me', () => ({
+      user: {
+        id: 42,
+        login: 'johnnydee',
+        name: 'John Doe',
+        email: 'john@doe.name',
+        avatar: 'https://avatars2.githubusercontent.com/u/12345?v=4',
+        url: 'https://github.com/johnnydee',
+      },
+      owned_crates: [],
+    }));
+
     await visit('/');
     assert.equal(currentURL(), '/');
 
@@ -36,19 +48,7 @@ module('Acceptance | Login', function (hooks) {
     await deferred.promise;
 
     // simulate the response from the `github-authorize` route
-    window.github_response = JSON.stringify({
-      ok: true,
-      data: {
-        user: {
-          id: 42,
-          login: 'johnnydee',
-          name: 'John Doe',
-          email: 'john@doe.name',
-          avatar: 'https://avatars2.githubusercontent.com/u/12345?v=4',
-          url: 'https://github.com/johnnydee',
-        },
-      },
-    });
+    window.github_response = JSON.stringify({ ok: true });
 
     // simulate that the window has been closed by the `github-authorize` route
     fakeWindow.closed = true;


### PR DESCRIPTION
This PR aims to simplify the state management in the `session` service. Instead of the various properties that were manually set I'm using a `loadUserTask` with a return value and a bit of derived task state.

The async nature of the authentication process is preserved by the `application` route triggering the new task, but not waiting for the result. The authenticated route mixin relies on the `application` route having triggered the task and waits for that specific task instance to resolve before continuing.

r? @locks 