### PR TITLE
Convert `AuthenticatedRoute` mixin to regular base class

### DIFF
--- a/app/routes/-authenticated-route.js
+++ b/app/routes/-authenticated-route.js
@@ -1,8 +1,7 @@
-import Mixin from '@ember/object/mixin';
+import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-// eslint-disable-next-line ember/no-new-mixins
-export default Mixin.create({
+export default Route.extend({
   flashMessages: service(),
   router: service(),
   session: service(),

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -1,10 +1,9 @@
 import { A } from '@ember/array';
-import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 
-import AuthenticatedRoute from '../mixins/authenticated-route';
+import AuthenticatedRoute from './-authenticated-route';
 
-export default Route.extend(AuthenticatedRoute, {
+export default AuthenticatedRoute.extend({
   async model() {
     let user = this.session.currentUser;
 

--- a/app/routes/me/crates.js
+++ b/app/routes/me/crates.js
@@ -1,8 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../-authenticated-route';
 
-import AuthenticatedRoute from '../../mixins/authenticated-route';
-
-export default Route.extend(AuthenticatedRoute, {
+export default AuthenticatedRoute.extend({
   queryParams: {
     page: { refreshModel: true },
     sort: { refreshModel: true },

--- a/app/routes/me/following.js
+++ b/app/routes/me/following.js
@@ -1,8 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../-authenticated-route';
 
-import AuthenticatedRoute from '../../mixins/authenticated-route';
-
-export default Route.extend(AuthenticatedRoute, {
+export default AuthenticatedRoute.extend({
   queryParams: {
     page: { refreshModel: true },
     sort: { refreshModel: true },

--- a/app/routes/me/index.js
+++ b/app/routes/me/index.js
@@ -1,8 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../-authenticated-route';
 
-import AuthenticatedRoute from '../../mixins/authenticated-route';
-
-export default Route.extend(AuthenticatedRoute, {
+export default AuthenticatedRoute.extend({
   actions: {
     willTransition: function () {
       this.controller

--- a/app/routes/me/pending-invites.js
+++ b/app/routes/me/pending-invites.js
@@ -1,8 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../-authenticated-route';
 
-import AuthenticatedRoute from '../../mixins/authenticated-route';
-
-export default Route.extend(AuthenticatedRoute, {
+export default AuthenticatedRoute.extend({
   model() {
     return this.store.findAll('crate-owner-invite');
   },


### PR DESCRIPTION
This will make it easier to eventually use ES6 classes instead, and gets rid of one more mixin.

r? @locks 