### PR TITLE
ci/prune-cache: Use `rm -f` to delete unnecessary files

### DIFF
--- a/script/ci/prune-cache.sh
+++ b/script/ci/prune-cache.sh
@@ -15,22 +15,22 @@ test_name="all"
 bin_names="background-worker delete-crate delete-version enqueue-job monitor populate render-readmes server test-pagerduty transfer-crates"
 
 normalized_crate_name=${crate_name//-/_}
-rm -v target/debug/$normalized_crate_name-*
-rm -v target/debug/deps/$normalized_crate_name-*
-rm -v target/debug/deps/lib$normalized_crate_name-*
+rm -vf target/debug/$normalized_crate_name-*
+rm -vf target/debug/deps/$normalized_crate_name-*
+rm -vf target/debug/deps/lib$normalized_crate_name-*
 
 normalized_test_name=${test_name//-/_}
-rm -v target/debug/$normalized_test_name-*
-rm -v target/debug/deps/$normalized_test_name-*
+rm -vf target/debug/$normalized_test_name-*
+rm -vf target/debug/deps/$normalized_test_name-*
 
 for name in $bin_names; do
-    rm -v target/debug/$name
+    rm -vf target/debug/$name
     normalized=${name//-/_}
-    rm -v target/debug/$normalized-*
-    rm -v target/debug/deps/$normalized-*
+    rm -vf target/debug/$normalized-*
+    rm -vf target/debug/deps/$normalized-*
 done
 
-rm -v target/.rustc_info.json
+rm -vf target/.rustc_info.json
 
 echo "Final cache size:"
 du -hs target/debug


### PR DESCRIPTION
This ensures that `rm` does not fail when files don't exist and will hopefully fix the broken GitHub Actions job.

r? @jtgeibel 