### PR TITLE
Fix tests when linking with lld

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,13 +939,13 @@ dependencies = [
 
 [[package]]
 name = "ghost"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5297b71943dc9fea26a3241b178c140ee215798b7f79f7773fd61683e25bca74"
+checksum = "2a36606a68532b5640dc86bb1f33c64b45c4682aad4c50f3937b317ea387f3d6"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]
@@ -1147,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "inventory"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21df85981fe094480bc2267723d3dc0fd1ae0d1f136affc659b7398be615d922"
+checksum = "82d3f4b90287725c97b17478c60dda0c6324e7c84ee1ed72fb9179d0fdf13956"
 dependencies = [
  "ctor",
  "ghost",
@@ -1158,13 +1158,13 @@ dependencies = [
 
 [[package]]
 name = "inventory-impl"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a877ae8bce77402d5e9ed870730939e097aad827b2a932b361958fa9d6e75aa"
+checksum = "9092a4fefc9d503e9287ef137f03180a6e7d1b04c419563171ee14947c5e80ec"
 dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
+ "proc-macro2 1.0.9",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,12 +462,12 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.1.7"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a43db2bba5cafdc6aa068c892a518e477ee0df3705e53ec70247a9ff93546d5"
+checksum = "cf6b25ee9ac1995c54d7adb2eff8cfffb7260bc774fb63c601ec65467f43cd9d"
 dependencies = [
- "quote 0.6.13",
- "syn 0.15.44",
+ "quote 1.0.3",
+ "syn 1.0.16",
 ]
 
 [[package]]


### PR DESCRIPTION
This bumps a few dependencies (in particular `ctor`) to fix linking with `lld`.  Before this fix, tests would fail because the background jobs were not being registered correctly.

I'm seeing very promising results with `lld` locally.  Here are my times for a clean incremental build (after `touch src/lib.rs`) when running `time cargo test --no-run`:

### Ubuntu 20.04 default linker

```
real    0m54.108s
user    4m57.944s
sys     0m50.454s
```

### With `RUSTFLAGS="-C link-arg=-fuse-ld=lld"`

```
real    0m20.015s
user    0m59.601s
sys     0m14.471s
```

Our production and CI are on an Ubuntu 16.04 stack, so I'm not sure what it would take to make this configuration the default.

r? @JohnTitor 