### PR TITLE
template-lint: Enable `no-curly-component-invocation` and `require-valid-alt-text` rules

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -8,6 +8,5 @@ module.exports = {
   rules: {
     'require-valid-alt-text': false,
     'no-action': false,
-    'no-curly-component-invocation': false,
   },
 };

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -6,7 +6,6 @@ module.exports = {
   extends: 'octane',
 
   rules: {
-    'require-valid-alt-text': false,
     'no-action': false,
   },
 };

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -62,7 +62,7 @@
 
       {{#if this.loadMoreTask.isRunning}}
         <span local-class='load-more'>
-          <img src="/assets/ajax-loader.gif">
+          <img src="/assets/ajax-loader.gif" alt="Loading">
         </span>
       {{else}}
         {{#if this.hasMore}}


### PR DESCRIPTION
This PR enables two more recommended ember-template-lint rules 🎉 