### PR TITLE
category|keyword: Rethrow unhandled errors

### DIFF
--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -8,7 +9,7 @@ export default Route.extend({
     try {
       return await this.store.find('category', params.category_id);
     } catch (e) {
-      if (e.errors.some(e => e.detail === 'Not Found')) {
+      if (e instanceof NotFoundError) {
         this.flashMessages.queue(`Category '${params.category_id}' does not exist`);
         return this.replaceWith('index');
       }

--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -12,6 +12,8 @@ export default Route.extend({
         this.flashMessages.queue(`Category '${params.category_id}' does not exist`);
         return this.replaceWith('index');
       }
+
+      throw e;
     }
   },
 });

--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -12,6 +12,8 @@ export default Route.extend({
         this.flashMessages.queue(`Keyword '${keyword_id}' does not exist`);
         return this.replaceWith('index');
       }
+
+      throw e;
     }
   },
 });

--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -8,7 +9,7 @@ export default Route.extend({
     try {
       return await this.store.find('keyword', keyword_id);
     } catch (e) {
-      if (e.errors.some(e => e.detail === 'Not Found')) {
+      if (e instanceof NotFoundError) {
         this.flashMessages.queue(`Keyword '${keyword_id}' does not exist`);
         return this.replaceWith('index');
       }

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,5 +1,5 @@
 <h1>Something Went Wrong!</h1>
-<h5>{{this.model.message}}</h5>
+<h5 data-test-error-message>{{this.model.message}}</h5>
 <pre>
   {{this.model.stack}}
 </pre>

--- a/tests/routes/category-test.js
+++ b/tests/routes/category-test.js
@@ -1,0 +1,25 @@
+import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from '../helpers/setup-mirage';
+import { visit } from '../helpers/visit-ignoring-abort';
+
+module('Route | category', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test("shows an error message if the category can't be found", async function (assert) {
+    await visit('/categories/unknown');
+    assert.equal(currentURL(), '/');
+    assert.dom('[data-test-flash-message]').hasText("Category 'unknown' does not exist");
+  });
+
+  test('server error causes the error page to be shown', async function (assert) {
+    this.server.get('/api/v1/categories/:categoryId', {}, 500);
+
+    await visit('/categories/error');
+    assert.equal(currentURL(), '/categories/error');
+    assert.dom('[data-test-error-message]').includesText('GET /api/v1/categories/error returned a 500');
+  });
+});

--- a/tests/routes/keyword-test.js
+++ b/tests/routes/keyword-test.js
@@ -1,0 +1,25 @@
+import { currentURL } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from '../helpers/setup-mirage';
+import { visit } from '../helpers/visit-ignoring-abort';
+
+module('Route | keyword', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test("shows an error message if the keyword can't be found", async function (assert) {
+    await visit('/keywords/unknown');
+    assert.equal(currentURL(), '/');
+    assert.dom('[data-test-flash-message]').hasText("Keyword 'unknown' does not exist");
+  });
+
+  test('server error causes the error page to be shown', async function (assert) {
+    this.server.get('/api/v1/keywords/:keywordId', {}, 500);
+
+    await visit('/keywords/error');
+    assert.equal(currentURL(), '/keywords/error');
+    assert.dom('[data-test-error-message]').includesText('GET /api/v1/keywords/error returned a 500');
+  });
+});


### PR DESCRIPTION
When a non-404 error was returned from the backend the routes would continue with business-as-usual instead of showing the generic error page. Rethrowing the error fixes that behavior.

r? @locks 