### PR TITLE
index: Reuse `GET /summary` result

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -19,9 +19,11 @@ export default Route.extend({
   setupController(controller) {
     this.controllerFor('application').set('searchQuery', null);
 
-    let promise = controller.dataTask.perform();
-    if (this.fastboot.isFastBoot) {
-      this.fastboot.deferRendering(promise);
+    if (!controller.dataTask.hasData) {
+      let promise = controller.dataTask.perform();
+      if (this.fastboot.isFastBoot) {
+        this.fastboot.deferRendering(promise);
+      }
     }
   },
 });


### PR DESCRIPTION
This will cause the app to only once perform the `GET /summary` call and then keep showing the same data until the whole app is refreshed. This should get rid of the annoying loading screen when navigating from the frontpage to a crate and then back again.

r? @locks 