### PR TITLE
Simplify search field handling code

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -5,8 +5,8 @@ import { inject as service } from '@ember/service';
 import { EKMixin, keyDown, keyPress } from 'ember-keyboard';
 
 export default Controller.extend(EKMixin, {
+  header: service(),
   flashMessages: service(),
-  search: service(),
   session: service(),
 
   keyboardActivated: true,
@@ -26,7 +26,7 @@ export default Controller.extend(EKMixin, {
     search() {
       this.transitionToRoute('search', {
         queryParams: {
-          q: this.search.inputValue,
+          q: this.header.searchValue,
           page: 1,
         },
       });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { oneWay } from '@ember/object/computed';
 import { on } from '@ember/object/evented';
 import { inject as service } from '@ember/service';
 
@@ -8,7 +7,6 @@ import { EKMixin, keyDown, keyPress } from 'ember-keyboard';
 export default Controller.extend(EKMixin, {
   flashMessages: service(),
   search: service(),
-  searchQuery: oneWay('search.q'),
   session: service(),
 
   keyboardActivated: true,
@@ -28,7 +26,7 @@ export default Controller.extend(EKMixin, {
     search() {
       this.transitionToRoute('search', {
         queryParams: {
-          q: this.searchQuery,
+          q: this.search.inputValue,
           page: 1,
         },
       });

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -1,16 +1,14 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import { alias, bool, readOnly } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { bool, readOnly } from '@ember/object/computed';
 
 import { task } from 'ember-concurrency';
 
 import PaginationMixin from '../mixins/pagination';
 
 export default Controller.extend(PaginationMixin, {
-  search: service(),
   queryParams: ['all_keywords', 'page', 'per_page', 'q', 'sort'],
-  q: alias('search.q'),
+  q: null,
   page: '1',
   per_page: 10,
 

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   fastboot: service(),
+  search: service(),
 
   headTags() {
     return [
@@ -17,7 +18,7 @@ export default Route.extend({
   },
 
   setupController(controller) {
-    this.controllerFor('application').set('searchQuery', null);
+    this.search.set('inputValue', null);
 
     if (!controller.dataTask.hasData) {
       let promise = controller.dataTask.perform();

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,7 +3,6 @@ import { inject as service } from '@ember/service';
 
 export default Route.extend({
   fastboot: service(),
-  search: service(),
 
   headTags() {
     return [
@@ -18,8 +17,6 @@ export default Route.extend({
   },
 
   setupController(controller) {
-    this.search.set('inputValue', null);
-
     if (!controller.dataTask.hasData) {
       let promise = controller.dataTask.perform();
       if (this.fastboot.isFastBoot) {

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default Route.extend({
+  search: service(),
+
   queryParams: {
     all_keywords: { refreshModel: true },
     page: { refreshModel: true },
@@ -15,7 +18,7 @@ export default Route.extend({
   },
 
   setupController(controller, params) {
-    this.controllerFor('application').set('searchQuery', params.q);
+    this.search.set('inputValue', params.q);
     controller.dataTask.perform(params);
   },
 });

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -21,4 +21,9 @@ export default Route.extend({
     this.search.set('inputValue', params.q);
     controller.dataTask.perform(params);
   },
+
+  deactivate() {
+    this._super(...arguments);
+    this.search.set('inputValue', null);
+  },
 });

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default Route.extend({
-  search: service(),
+  header: service(),
 
   queryParams: {
     all_keywords: { refreshModel: true },
@@ -18,12 +18,12 @@ export default Route.extend({
   },
 
   setupController(controller, params) {
-    this.search.set('inputValue', params.q);
+    this.header.set('searchValue', params.q);
     controller.dataTask.perform(params);
   },
 
   deactivate() {
     this._super(...arguments);
-    this.search.set('inputValue', null);
+    this.header.set('searchValue', null);
   },
 });

--- a/app/services/header.js
+++ b/app/services/header.js
@@ -1,5 +1,6 @@
 import Service from '@ember/service';
 
 export default class SearchService extends Service {
-  inputValue = null;
+  // the value of the search input fields in the header
+  searchValue = null;
 }

--- a/app/services/search.js
+++ b/app/services/search.js
@@ -1,5 +1,8 @@
+import { oneWay } from '@ember/object/computed';
 import Service from '@ember/service';
 
 export default class SearchService extends Service {
   q = null;
+
+  @oneWay('q') inputValue;
 }

--- a/app/services/search.js
+++ b/app/services/search.js
@@ -1,6 +1,5 @@
 import Service from '@ember/service';
 
 export default class SearchService extends Service {
-  q = null;
   inputValue = null;
 }

--- a/app/services/search.js
+++ b/app/services/search.js
@@ -1,8 +1,6 @@
-import { oneWay } from '@ember/object/computed';
 import Service from '@ember/service';
 
 export default class SearchService extends Service {
   q = null;
-
-  @oneWay('q') inputValue;
+  inputValue = null;
 }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -15,8 +15,8 @@
       name="q"
       id="cargo-desktop-search"
       placeholder="Click or press 'S' to search..."
-      value={{this.searchQuery}}
-      oninput={{action (mut this.searchQuery) value="target.value"}}
+      value={{this.search.inputValue}}
+      oninput={{action (mut this.search.inputValue) value="target.value"}}
       autocorrect="off"
       autocapitalize="off"
       autofocus="autofocus"
@@ -103,8 +103,8 @@
       name="q"
       id="cargo-mobile-search"
       placeholder="Search"
-      value={{this.searchQuery}}
-      oninput={{action (mut this.searchQuery) value="target.value"}}
+      value={{this.search.inputValue}}
+      oninput={{action (mut this.search.inputValue) value="target.value"}}
       autocorrect="off"
       required
     >

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -15,8 +15,8 @@
       name="q"
       id="cargo-desktop-search"
       placeholder="Click or press 'S' to search..."
-      value={{this.search.inputValue}}
-      oninput={{action (mut this.search.inputValue) value="target.value"}}
+      value={{this.header.searchValue}}
+      oninput={{action (mut this.header.searchValue) value="target.value"}}
       autocorrect="off"
       autocapitalize="off"
       autofocus="autofocus"
@@ -103,8 +103,8 @@
       name="q"
       id="cargo-mobile-search"
       placeholder="Search"
-      value={{this.search.inputValue}}
-      oninput={{action (mut this.search.inputValue) value="target.value"}}
+      value={{this.header.searchValue}}
+      oninput={{action (mut this.header.searchValue) value="target.value"}}
       autocorrect="off"
       required
     >


### PR DESCRIPTION
This PR simplifies the code that handles the values of the two search boxes in the header. It mainly gets rid of a query param `alias()`, an unnecessary `oneWay()` property and two `controllerFor()` lookups. It also removes the `search` service and adds a new `header` service instead.

r? @locks