### PR TITLE
ember-router-scroll: Fix deprecation warning

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'cargo',
     environment,
     rootURL: '/',
-    locationType: 'router-scroll',
+    locationType: 'auto',
     historySupportMiddleware: true,
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
Overriding the default `locationType` is deprecated now

r? @locks 