### PR TITLE
Permit '+' in feature name, as in "c++20"

### DIFF
--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -983,6 +983,9 @@ fn valid_feature_names() {
     assert!(!Crate::valid_feature("%/%"));
     assert!(Crate::valid_feature("a/a"));
     assert!(Crate::valid_feature("32-column-tables"));
+    assert!(Crate::valid_feature("c++20"));
+    assert!(Crate::valid_feature("krate/c++20"));
+    assert!(!Crate::valid_feature("c++20/wow"));
 }
 
 #[test]

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -113,7 +113,7 @@ impl<'de> Deserialize<'de> for EncodableFeatureName {
         if !Crate::valid_feature_name(&s) {
             let value = de::Unexpected::Str(&s);
             let expected = "a valid feature name containing only letters, \
-                            numbers, hyphens, or underscores";
+                            numbers, '-', '+', or '_'";
             Err(de::Error::invalid_value(value, &expected))
         } else {
             Ok(EncodableFeatureName(s))


### PR DESCRIPTION
Up front: I am familiar with the several discussions linked by https://github.com/rust-lang/crates-io-cargo-teams/issues/41#issuecomment-494168728, and the conversation beginning at https://github.com/rust-lang/crates.io/pull/1331#issuecomment-379608097. This PR is not motivated by attempting to match whatever behavior Cargo currently has. Instead, it's a small thing I think we can decide now whether to allow. But it's necessary to say no corresponding Cargo change is required to accommodate this crates.io change.

This PR updates feature validation during publish to accept e.g. "c++20" and "dependency/c++20". We continue to not accept "c++20/feature" as the prefix before the slash would normally refer to a crate name of a dependency and a '+' would not be allowed in those.

I am interested in using such feature names in https://github.com/dtolnay/cxx.

In a Cargo.toml plusses appear as:

```toml
[features]
default = ["c++20"]
"c++20" = ["my-dependency/c++20"]
```

To give some slight further justification for why this particular ascii character above other possible characters we might allow: `+` is pretty common in OS package names in a way that no other currently disallowed character is. Some examples pulled arbitrarily from `apt-cache pkgnames | rg '\+'`:

- https://packages.debian.org/buster/dvd+rw-tools
- https://packages.debian.org/buster/elpa-ghub+
- https://packages.debian.org/buster/libarpack++2-dev
- https://packages.debian.org/buster/libdwarf++0
- https://packages.debian.org/buster/libelf++0
- https://packages.debian.org/buster/magics++
- https://packages.debian.org/buster/memtest86+
- https://packages.debian.org/buster/minisat+
- https://packages.debian.org/buster/paw++
- https://packages.debian.org/buster/swish++
- https://packages.debian.org/buster/vera++
- https://packages.debian.org/buster/voro++

The actual names of the projects contain `+`; various ones in the descriptions in the above links are styled as ARPACK++, Memtest86+, Magics++, Paw++, MinSat+, SWISH++, Vera++, Voro++. When binding to something like this behind a feature, using `+` in the feature name is the most intuitive.