### PR TITLE
Extract `localStorage` wrappers with try/catch

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -3,6 +3,8 @@ import { inject as service } from '@ember/service';
 
 import window from 'ember-window-mock';
 
+import * as localStorage from '../utils/local-storage';
+
 /**
  * This route will open a popup window directed at the `github-login` route.
  * After the window has opened it will wait for the window to close and
@@ -15,11 +17,7 @@ export default Route.extend({
   session: service(),
 
   beforeModel(transition) {
-    try {
-      window.localStorage.removeItem('github_response');
-    } catch (e) {
-      // ignore error
-    }
+    localStorage.removeItem('github_response');
 
     window.github_response = undefined;
     let windowDimensions = [

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -5,11 +5,12 @@ import { tracked } from '@glimmer/tracking';
 import window from 'ember-window-mock';
 
 import config from '../config/environment';
+import * as localStorage from '../utils/local-storage';
 
 export default class DesignService extends Service {
   @service fastboot;
 
-  @tracked useNewDesign = !this.fastboot.isFastBoot && window.localStorage.getItem('use-new-design') === 'true';
+  @tracked useNewDesign = !this.fastboot.isFastBoot && localStorage.getItem('use-new-design') === 'true';
   @tracked showToggleButton = config.environment === 'development';
 
   constructor() {
@@ -20,6 +21,6 @@ export default class DesignService extends Service {
   @action
   toggle() {
     this.useNewDesign = !this.useNewDesign;
-    window.localStorage.setItem('use-new-design', String(this.useNewDesign));
+    localStorage.setItem('use-new-design', String(this.useNewDesign));
   }
 }

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -2,9 +2,9 @@ import { alias } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
-import window from 'ember-window-mock';
 
 import ajax from '../utils/ajax';
+import * as localStorage from '../utils/local-storage';
 
 export default class SessionService extends Service {
   @service store;
@@ -16,22 +16,14 @@ export default class SessionService extends Service {
   @alias('loadUserTask.last.value.ownedCrates') ownedCrates;
 
   get isLoggedIn() {
-    try {
-      return window.localStorage.getItem('isLoggedIn') === '1';
-    } catch (e) {
-      return false;
-    }
+    return localStorage.getItem('isLoggedIn') === '1';
   }
 
   set isLoggedIn(value) {
-    try {
-      if (value) {
-        window.localStorage.setItem('isLoggedIn', '1');
-      } else {
-        window.localStorage.removeItem('isLoggedIn');
-      }
-    } catch (e) {
-      // ignore error
+    if (value) {
+      localStorage.setItem('isLoggedIn', '1');
+    } else {
+      localStorage.removeItem('isLoggedIn');
     }
   }
 

--- a/app/utils/local-storage.js
+++ b/app/utils/local-storage.js
@@ -1,0 +1,25 @@
+import window from 'ember-window-mock';
+
+export function getItem(key) {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (e) {
+    return null;
+  }
+}
+
+export function setItem(key, value) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch (e) {
+    // ignored
+  }
+}
+
+export function removeItem(key) {
+  try {
+    window.localStorage.removeItem(key);
+  } catch (e) {
+    // ignored
+  }
+}


### PR DESCRIPTION
We should fail gracefully if the browser has `localStorage` blocked. This wrapper will make sure to handle this case in a predictable way.

Resolves #2502 

r? @pichfl 

/cc @danielzgtg