### PR TITLE
Allow some google-related domains to fix CSP errors

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -156,7 +156,7 @@ http {
 		add_header X-Content-Type-Options "nosniff";
 		add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-XSS-Protection "1; mode=block";
-		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com; img-src *; object-src 'none'";
+		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://fonts.googleapis.com; font-src: https://fonts.gstatic.com; img-src *; object-src 'none'";
 
 		add_header Strict-Transport-Security "max-age=31536000" always;
 		add_header Vary 'Accept, Accept-Encoding, Cookie';


### PR DESCRIPTION
Seems 2ae350daad12fa046bd2bc0269efb9fb58abaaf4 added the use of google fonts but our CSP config doesn't allow that.
Fixes #2518
r? @jtgeibel or @Turbo87 