### PR TITLE
Fix CSP error - script-src directive

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -156,7 +156,7 @@ http {
 		add_header X-Content-Type-Options "nosniff";
 		add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-XSS-Protection "1; mode=block";
-		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://fonts.googleapis.com; font-src: https://fonts.gstatic.com; img-src *; object-src 'none'";
+		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://fonts.googleapis.com; font-src: https://fonts.gstatic.com; img-src *; object-src 'none'";
 
 		add_header Strict-Transport-Security "max-age=31536000" always;
 		add_header Vary 'Accept, Accept-Encoding, Cookie';


### PR DESCRIPTION
Attempt to fix `Content Security Policy: The page’s settings blocked the loading of a resource at inline (“script-src”).` presumably related to this commit https://github.com/rust-lang/crates.io/commit/38758b3fae1387247f7b256f4cf2712bd85acff1

cc/ @JohnTitor 