### PR TITLE
Fix font-src in CSP

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -188,8 +188,8 @@ http {
 		add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-XSS-Protection "1; mode=block";
 
-		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://fonts.googleapis.com; font-src: https://fonts.gstatic.com; img-src *; object-src 'none'";
-    add_header Access-Control-Allow-Origin "*";
+		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src *; object-src 'none'";
+		add_header Access-Control-Allow-Origin "*";
 
 		add_header Strict-Transport-Security "max-age=31536000" always;
 		add_header Vary 'Accept, Accept-Encoding, Cookie';


### PR DESCRIPTION
This removes an unnecessary `:` from `font-src` that was causing the directive to fail.

r? @ghost
cc #2519