### PR TITLE
Bump to the latest conduit-hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,12 +372,11 @@ dependencies = [
 
 [[package]]
 name = "conduit-hyper"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c5bdc8858250eafc0d006e43002caa122b306d3571d0242e68e7770240a424e"
+checksum = "fd8258f712af3fc3b9ca293f12e322024f192aa9c793c07ab15f2eda544eef0e"
 dependencies = [
  "conduit",
- "futures",
  "http",
  "hyper",
  "tokio",
@@ -842,28 +841,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -871,17 +854,6 @@ name = "futures-core"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -922,11 +894,9 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
- "futures-sink",
  "futures-task",
  "memchr",
  "pin-project",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ conduit-router = "0.9.0-alpha.2"
 conduit-static = "0.9.0-alpha.3"
 conduit-git-http-backend = "0.9.0-alpha.2"
 civet = "0.12.0-alpha.3"
-conduit-hyper = "0.3.0-alpha.2"
+conduit-hyper = "0.3.0-alpha.3"
 http = "0.2"
 
 futures-util = "0.3"

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -66,10 +66,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let mut rt = tokio::runtime::Builder::new()
             .threaded_scheduler()
             .enable_all()
+            .core_threads(4)
+            .max_threads(threads as usize)
             .build()
             .unwrap();
 
-        let handler = Arc::new(conduit_hyper::BlockingHandler::new(app, threads as usize));
+        let handler = Arc::new(conduit_hyper::BlockingHandler::new(app));
         let make_service =
             hyper::service::make_service_fn(move |socket: &hyper::server::conn::AddrStream| {
                 let addr = socket.remote_addr();


### PR DESCRIPTION
The latest upstream changes should allow us to try enabling hyper in
production. All tasks tracked in #2204 should now be completed.

r? @JohnTitor 