### PR TITLE
Update `semver` to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
  "rand 0.7.3",
  "reqwest",
  "scheduled-thread-pool",
- "semver 0.9.0 (git+https://github.com/steveklabnik/semver.git)",
+ "semver 0.10.0",
  "serde",
  "serde_json",
  "swirl",
@@ -2134,7 +2134,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2200,20 +2200,21 @@ dependencies = [
 [[package]]
 name = "semver"
 version = "0.9.0"
-source = "git+https://github.com/steveklabnik/semver.git#27c2b066cc0d3818f8b2047388ce29be2e4c97e1"
-dependencies = [
- "diesel",
- "semver-parser",
- "serde",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+dependencies = [
+ "diesel",
+ "semver-parser",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 rand = "0.7"
 git2 = "0.13.0"
 flate2 = "1.0"
-semver = { version = "0.9", git = "https://github.com/steveklabnik/semver.git", features = ["diesel", "serde"] }
+semver = { version = "0.10", features = ["diesel", "serde"] }
 url = "1.2.1"
 tar = "0.4.16"
 base64 = "0.11"


### PR DESCRIPTION
I think we can now use `semver` dependency without specifying the repo.
PR for rustc-version that uses `semver` 0.9: https://github.com/Kimundi/rustc-version-rs/pull/29
r? @jtgeibel 