### PR TITLE
Bump actions/cache from v1 to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -91,14 +91,14 @@ jobs:
       #
       # Current size as of 2019-12-23: ~6 MB
       - name: Cache cargo binaries
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cargo/bin
           key: ${{ runner.os }}-cargo-bin-${{ matrix.rust }}-${{ hashFiles('.diesel_version') }}
 
       # Current size as of 2019-12-23: ~77 MB
       - name: Cache cargo registry cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cargo/registry/cache
           key: ${{ runner.os }}-cargo-registry-cache-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
@@ -108,7 +108,7 @@ jobs:
 
       # Current size as of 2019-12-23: ~38 MB
       - name: Cache cargo registry index
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cargo/registry/index
           key: ${{ runner.os }}-cargo-registry-index-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
@@ -118,7 +118,7 @@ jobs:
 
       # Current size as of 2019-12-23: ~4 MB
       - name: Cache cargo git db
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cargo/git/db
           key: ${{ runner.os }}-cargo-git-db-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
@@ -148,7 +148,7 @@ jobs:
 
       # Current size as of 2019-12-23: ~336 MB
       - name: Cache cargo build
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
We just released v2. That includes a lot of improvements.
https://github.com/actions/cache/releases/tag/v2.0.0