### PR TITLE
Bump to latest release of conduit-hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,13 +372,14 @@ dependencies = [
 
 [[package]]
 name = "conduit-hyper"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8258f712af3fc3b9ca293f12e322024f192aa9c793c07ab15f2eda544eef0e"
+checksum = "d4d0c38b49434c95e0a7cd8dc805c90e3c6975cb9454e158c994c35fa1bfe641"
 dependencies = [
  "conduit",
  "http",
  "hyper",
+ "percent-encoding 2.1.0",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ conduit-router = "0.9.0-alpha.2"
 conduit-static = "0.9.0-alpha.3"
 conduit-git-http-backend = "0.9.0-alpha.2"
 civet = "0.12.0-alpha.3"
-conduit-hyper = "0.3.0-alpha.3"
+conduit-hyper = "0.3.0-alpha.4"
 http = "0.2"
 
 futures-util = "0.3"


### PR DESCRIPTION
This upstream release now percent decodes the path component but not the
query string. This behavior aligns with the `civet` server. The known
difference is that `conduit-hyper` does a lossy utf8 conversion while
`civet` panics on invalid utf8 and closes the connection immediately.

This seems like a good compromise of matching the existing behavior as
closely as possible without copying the panic. I looked into fixing the
panic in `civet`, however the `to_str_slice` function returns an
`Option<&str>` and there is nowhere to store a newly allocated `String`
so changing the behavior there is not practical.

r? @JohnTitor 
cc #2204

https://github.com/jtgeibel/conduit-hyper/compare/v0.3.0-alpha.3...v0.3.0-alpha.4