### PR TITLE
Add minimal_metadata route for crate

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -110,6 +110,15 @@ pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
     }))
 }
 
+/// Handles the `GET /crates/:crate_id/metadata` route.
+pub fn minimal_metadata(req: &mut dyn RequestExt) -> EndpointResult {
+    let name = &req.params()["crate_id"];
+    let conn = req.db_read_only()?;
+    let krate = Crate::by_name(name).first::<Crate>(&*conn)?;
+    let top_versions = krate.top_versions(&conn)?;
+    Ok(req.json(&krate.minimal_encodable(&top_versions, None, false, None)))
+}
+
 /// Handles the `GET /crates/:crate_id` route.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["crate_id"];

--- a/src/router.rs
+++ b/src/router.rs
@@ -35,6 +35,10 @@ pub fn build_router(app: &App) -> R404 {
 
     // Routes used by the frontend
     api_router.get("/crates/:crate_id", C(krate::metadata::show));
+    api_router.get(
+        "/crates/:crate_id/metadata",
+        C(krate::metadata::minimal_metadata),
+    );
     api_router.get("/crates/:crate_id/:version", C(version::metadata::show));
     api_router.get(
         "/crates/:crate_id/:version/readme",


### PR DESCRIPTION
This PR added a new route called `minimal_metadata`, which aimed to provide a simple API to return minimal metadata of a crate.

## Why and Who needs this API?

[Rust Search Extension](https://github.com/huhu/rust-search-extension) will ship a new feature: **Prefix tripe exclamation mark (!!!) before the keyword to quickly open the repository of that crate**.  This feature relies on crates.io API (`/api/v1/crates/:crate_id`) to obtain that crate's repository URL. However, this API returns a huge set of data that is redundant in this case and also take more time to respond. We hope the user can get the repository URL as quickly as possible then redirect to it without wasting time. A minimal metadata API should be an ideal way to fix this? Maybe other people would have the same need as me? 

I don't know whether my implementation follows the best practice. Appreciation for any comment or feedback. :)

PS, the Rust Search Extension's redirection code can be found [here](https://github.com/huhu/rust-search-extension/blob/c7d80d4bf53e20ff14809ca638d0389f1c371a9b/extension/redirect/redirect.js).