### PR TITLE
Allow configuring the application's domain name

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,10 @@ export DATABASE_URL=
 # If you are running a mirror of crates.io, uncomment this line.
 # export MIRROR=1
 
+# If you're running an instance of the application on a domain different than
+# crates.io, uncomment this line and set the variable to your domain name.
+#export DOMAIN_NAME=staging.crates.io
+
 # Key to sign and encrypt cookies with. Must be at least 32 bytes. Change this
 # to a long, random string for production.
 export SESSION_KEY=badkeyabcdefghijklmnopqrstuvwxyzabcdef

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct Config {
     pub api_protocol: String,
     pub publish_rate_limit: PublishRateLimit,
     pub blocked_traffic: Vec<(String, Vec<String>)>,
+    pub domain_name: String,
 }
 
 impl Default for Config {
@@ -134,8 +135,13 @@ impl Default for Config {
             api_protocol,
             publish_rate_limit: Default::default(),
             blocked_traffic: blocked_traffic(),
+            domain_name: domain_name(),
         }
     }
+}
+
+pub(crate) fn domain_name() -> String {
+    dotenv::var("DOMAIN_NAME").unwrap_or_else(|_| "crates.io".into())
 }
 
 fn blocked_traffic() -> Vec<(String, Vec<String>)> {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -50,10 +50,11 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
 
     let verified_email_address = user.verified_email(&conn)?;
     let verified_email_address = verified_email_address.ok_or_else(|| {
-        cargo_err(
+        cargo_err(&format!(
             "A verified email address is required to publish crates to crates.io. \
-             Visit https://crates.io/me to set and verify your email address.",
-        )
+             Visit https://{}/me to set and verify your email address.",
+            app.config.domain_name,
+        ))
     })?;
 
     // Create a transaction on the database, if there are no errors,

--- a/src/email.rs
+++ b/src/email.rs
@@ -78,8 +78,10 @@ pub fn try_send_user_confirm_email(email: &str, user_name: &str, token: &str) ->
     let body = format!(
         "Hello {}! Welcome to Crates.io. Please click the
 link below to verify your email address. Thank you!\n
-https://crates.io/confirm/{}",
-        user_name, token
+https://{}/confirm/{}",
+        user_name,
+        crate::config::domain_name(),
+        token
     );
 
     send_email(email, subject, &body)
@@ -94,9 +96,12 @@ pub fn send_owner_invite_email(email: &str, user_name: &str, crate_name: &str, t
     let subject = "Crate ownership invitation";
     let body = format!(
         "{} has invited you to become an owner of the crate {}!\n
-Visit https://crates.io/accept-invite/{} to accept this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.",
-        user_name, crate_name, token
+Visit https://{domain}/accept-invite/{} to accept this invitation,
+or go to https://{domain}/me/pending-invites to manage all of your crate ownership invitations.",
+        user_name,
+        crate_name,
+        token,
+        domain = crate::config::domain_name()
     );
 
     let _ = send_email(email, subject, &body);

--- a/src/github.rs
+++ b/src/github.rs
@@ -27,24 +27,25 @@ where
         .header(header::USER_AGENT, "crates.io (https://crates.io)")
         .send()?
         .error_for_status()
-        .map_err(|e| handle_error_response(&e))?
+        .map_err(|e| handle_error_response(app, &e))?
         .json()
         .map_err(Into::into)
 }
 
-fn handle_error_response(error: &reqwest::Error) -> Box<dyn AppError> {
+fn handle_error_response(app: &App, error: &reqwest::Error) -> Box<dyn AppError> {
     use reqwest::StatusCode as Status;
 
     match error.status() {
-        Some(Status::UNAUTHORIZED) | Some(Status::FORBIDDEN) => cargo_err(
+        Some(Status::UNAUTHORIZED) | Some(Status::FORBIDDEN) => cargo_err(&format!(
             "It looks like you don't have permission \
              to query a necessary property from Github \
              to complete this request. \
              You may need to re-authenticate on \
              crates.io to grant permission to read \
              github org memberships. Just go to \
-             https://crates.io/login",
-        ),
+             https://{}/login",
+            app.config.domain_name,
+        )),
         Some(Status::NOT_FOUND) => Box::new(NotFound),
         _ => internal(&format_args!(
             "didn't get a 200 result from github: {}",

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -144,6 +144,7 @@ fn simple_config() -> Config {
         api_protocol: String::from("http"),
         publish_rate_limit: Default::default(),
         blocked_traffic: Default::default(),
+        domain_name: "crates.io".into(),
     }
 }
 


### PR DESCRIPTION
This PR allows setting the `DOMAIN_NAME` environment variable, which configures the domain name used in absolute URLs returned by the application, for example in emails or Cargo responses.

The scenario that prompted this change is when an user creates an account on the staging instance: before this PR the link they'd get in the verification email was invalid, as the production application doesn't know staging's email verification codes.

If the variable is omitted the domain will default to "crates.io".

r? @jtgeibel 