### PR TITLE
Fix issue where crates.io allowed the plus sign in crate names

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -261,7 +261,7 @@ impl Crate {
     }
 
     fn valid_ident(name: &str) -> bool {
-        Self::valid_feature_name(name)
+        Self::valid_feature_prefix(name)
             && name
                 .chars()
                 .next()
@@ -598,6 +598,17 @@ mod tests {
             ),),),
             None
         );
+    }
+
+    #[test]
+    fn valid_name() {
+        assert!(Crate::valid_name("foo"));
+        assert!(!Crate::valid_name("京"));
+        assert!(!Crate::valid_name(""));
+        assert!(!Crate::valid_name("💝"));
+        assert!(Crate::valid_name("foo_underscore"));
+        assert!(Crate::valid_name("foo-dash"));
+        assert!(!Crate::valid_name("foo+plus"));
     }
 }
 


### PR DESCRIPTION
A recent change allowed crates.io crate names to include `+` in their name (requires a patched version of cargo which skips the cargo validation check). See the original issue reported by @ThePuzzlemaker below (#2550):

> I was looking at code and found out that by patching Cargo's code to allow `+` in package names, you can upload a package to the crates.io registry with `+` in the name.
> 
> This issue stems from commit [5f842f7](https://github.com/rust-lang/crates.io/commit/5f842f73c6a9f32719508db4b1c534959b02f6e8), where `+` is allowed in feature names.
> 
> The function `Crate::valid_name` in [`src/models/krate.rs`](https://github.com/rust-lang/crates.io/blob/master/src/models/krate.rs) uses `Crate::valid_ident`, which uses `Crate::valid_feature_name`. Due to `Crate::valid_feature_name` now allowing `+`, and no further checks in `Crate::valid_name` to deny `+`, it allows a user to submit a package with `+` in its name.
> 
> By changing some checks in Cargo's code, and running `cargo publish --allow-dirty --no-verify` (using the patched Cargo) I was able to publish the package `test+package`.
> 
> [Here](https://github.com/rust-lang/crates.io-index/commit/3a56c06e3f827102cd9ed5a766dd6fc18cb6d5fe) [is](https://github.com/rust-lang/crates.io-index/blob/master/te/st/test%2Bpackage) [evidence](https://crates.io/crates/test%2Bpackage).

This PR resolves the first part of #2550 which states that crates.io allows the plus sign in crate names. This is resolved by having `Crate::valid_ident` call `Crate::valid_feature_prefix` instead of `Crate::valid_feature_name`.

This PR does _not_ attempt resolve the second part of #2550, which is the fact that there is an invalidly named crate present on the live environment of crates.io (the crate [test+package](https://crates.io/crates/test%2Bpackage)).