### PR TITLE
Use "Fira Sans" font from Mozilla CDN as default font

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/cargo.css">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Fira+Sans:ital,wght@0,400;0,600;0,800;1,400;1,600;1,800&display=swap">
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
 
     <link rel="manifest" href="{{rootURL}}manifest.webmanifest">
     <meta name="msapplication-config" content="{{rootURL}}browserconfig.xml">

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -6,8 +6,7 @@
     --header-bg-color: var(--dark-green);
     --footer-bg-color: var(--dark-green);
 
-    /* Use the modern font stack inspired by Bootstrap 4 */
-    --font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-family: "Fira Sans", sans-serif;
 
     --main-color: #383838;
     --main-color-light: #858585;
@@ -23,8 +22,6 @@
     --header-bg-color: var(--violet);
     --main-bg: white;
     --footer-bg-color: var(--dark-grey);
-
-    --font-family: "Fira Sans", sans-serif;
 }
 
 * {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -188,7 +188,7 @@ http {
 		add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-XSS-Protection "1; mode=block";
 
-		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src *; object-src 'none'";
+		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
 		add_header Access-Control-Allow-Origin "*";
 
 		add_header Strict-Transport-Security "max-age=31536000" always;


### PR DESCRIPTION
This brings us closer to a unified style with the other Rust web assets.

Currently deployed at https://staging-crates-io.herokuapp.com/

r? @locks 