### PR TITLE
Replace `{{ title }}` with `{{page-title}}`

### DIFF
--- a/app/templates/categories.hbs
+++ b/app/templates/categories.hbs
@@ -1,4 +1,4 @@
-{{ title 'Categories' }}
+{{page-title 'Categories'}}
 
 <PageHeader @title="All Categories"/>
 

--- a/app/templates/category-slugs.hbs
+++ b/app/templates/category-slugs.hbs
@@ -1,4 +1,4 @@
-{{ title 'Category Slugs' }}
+{{page-title 'Category Slugs'}}
 
 <PageHeader @title="All Valid Category Slugs"/>
 

--- a/app/templates/category/error.hbs
+++ b/app/templates/category/error.hbs
@@ -1,1 +1,1 @@
-{{ title 'Category Not Found' }}
+{{page-title 'Category Not Found'}}

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -1,4 +1,4 @@
-{{ title this.category.category ' - Categories' }}
+{{page-title this.category.category ' - Categories'}}
 
 <PageHeader local-class="header">
   <LinkTo @route="categories" aria-label="Categories">{{svg-jar "crate"}}</LinkTo>

--- a/app/templates/crate/error.hbs
+++ b/app/templates/crate/error.hbs
@@ -1,1 +1,1 @@
-{{ title 'Crate Not Found' }}
+{{page-title 'Crate Not Found'}}

--- a/app/templates/crate/owners.hbs
+++ b/app/templates/crate/owners.hbs
@@ -1,4 +1,4 @@
-{{ title 'Manage Crate Owners' }}
+{{page-title 'Manage Crate Owners'}}
 
 <PageHeader
   @title="Manager Crate Owners"

--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -1,4 +1,4 @@
-{{ title 'Crates' }}
+{{page-title 'Crates'}}
 
 <PageHeader @title="All Crates" @suffix={{if this.letter (concat "starting with '" this.letter "'")}}/>
 

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -1,4 +1,4 @@
-{{ title 'Dashboard' }}
+{{page-title 'Dashboard'}}
 
 <PageHeader local-class="header">
   {{svg-jar "dashboard" local-class="header-icon"}}

--- a/app/templates/keyword/error.hbs
+++ b/app/templates/keyword/error.hbs
@@ -1,1 +1,1 @@
-{{ title 'Keyword Not Found' }}
+{{page-title 'Keyword Not Found'}}

--- a/app/templates/keyword/index.hbs
+++ b/app/templates/keyword/index.hbs
@@ -1,4 +1,4 @@
-{{ title this.keyword.keyword ' - Keywords' }}
+{{page-title this.keyword.keyword ' - Keywords'}}
 
 <PageHeader @title="All Crates" @suffix="for keyword '{{this.keyword.keyword}}'"/>
 

--- a/app/templates/keywords.hbs
+++ b/app/templates/keywords.hbs
@@ -1,4 +1,4 @@
-{{ title 'Keywords' }}
+{{page-title 'Keywords'}}
 
 <PageHeader @title="All Keywords"/>
 

--- a/app/templates/me/crates.hbs
+++ b/app/templates/me/crates.hbs
@@ -1,4 +1,4 @@
-{{ title 'My Crates' }}
+{{page-title 'My Crates'}}
 
 <PageHeader @title="My Crates"/>
 

--- a/app/templates/me/index.hbs
+++ b/app/templates/me/index.hbs
@@ -1,4 +1,4 @@
-{{ title 'Settings' }}
+{{page-title 'Settings'}}
 
 <PageHeader @title="Account Settings" @icon="gear"/>
 

--- a/app/templates/me/pending-invites.hbs
+++ b/app/templates/me/pending-invites.hbs
@@ -1,4 +1,4 @@
-{{ title 'Pending Invites' }}
+{{page-title 'Pending Invites'}}
 
 <PageHeader @title="Pending Owner Invites" @icon="gear"/>
 


### PR DESCRIPTION
turns out searching for `{{title` doesn't catch the usages that have a space between the curlies and the helper name 😅 

r? @locks 