### PR TITLE
Add status page link to footer

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -13,5 +13,7 @@
     <a href='https://www.rust-lang.org/policies/privacy'>Privacy notice</a>
     <span local-class="sep">|</span>
     <LinkTo @route="policies">Policies</LinkTo>
+    <span local-class="sep">|</span>
+    <a href='https://status.crates.io'>Status</a>
   </div>
 </footer>

--- a/app/components/footer.module.css
+++ b/app/components/footer.module.css
@@ -11,13 +11,17 @@
 }
 
 .after-main-links {
-    composes: width-limit from '../styles/application.module.css';
+    width: 1025px;
 
-    margin: 40px 20px 40px 20px;
+    margin: 40px;
     text-align: center;
 
     a { color: white; }
     a:hover { color: darken(white, 10%); }
+    
+    @media only screen and (max-width: 1025px) {
+        width: 100%;
+    }
 
     @media only screen and (max-width: 450px) {
         margin: 20px;

--- a/app/components/footer.module.css
+++ b/app/components/footer.module.css
@@ -13,7 +13,7 @@
 .after-main-links {
     composes: width-limit from '../styles/application.module.css';
 
-    margin: 40px;
+    margin: 40px 20px 40px 20px;
     text-align: center;
 
     a { color: white; }


### PR DESCRIPTION
Making this after my suggestion on Discord `#crates-io-team`.
Adding a link is helpful if the website is intermittent or not fully functional even if the site is "technically up", so users can see it's not fully operational - and docs.rs status will also show if it goes down.