### PR TITLE
Simplify `CrateTomlCopy` component

### DIFF
--- a/app/components/crate-toml-copy.hbs
+++ b/app/components/crate-toml-copy.hbs
@@ -5,7 +5,7 @@
     {{on "click" this.copy}}
   >
     {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
-    {{#if this.showNotification}}
+    {{#if this.showNotificationTask.isRunning}}
       <div local-class="copy-notification {{if this.showSuccess "copy-success" "copy-failure"}}">
         {{#if this.showSuccess}}
           Copied!

--- a/app/components/crate-toml-copy.hbs
+++ b/app/components/crate-toml-copy.hbs
@@ -1,8 +1,8 @@
 <div local-class="crate-toml-copy {{if @inline "inline" "block"}}" ...attributes>
   <CopyButton
     @clipboardText={{@copyText}}
-    @success={{action "copySuccess"}}
-    @error={{action "copyError"}}
+    @success={{perform this.showNotificationTask true}}
+    @error={{perform this.showNotificationTask false}}
     @title="Copy Cargo.toml snippet to clipboard"
   >
     {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}

--- a/app/components/crate-toml-copy.hbs
+++ b/app/components/crate-toml-copy.hbs
@@ -6,14 +6,14 @@
     @title="Copy Cargo.toml snippet to clipboard"
   >
     {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
-    <div local-class="copy-notification {{if this.showSuccess "copy-success" "copy-failure"}}">
-      {{#if this.showNotification}}
+    {{#if this.showNotification}}
+      <div local-class="copy-notification {{if this.showSuccess "copy-success" "copy-failure"}}">
         {{#if this.showSuccess}}
           Copied!
         {{else}}
           An error occured. Please use CTRL+C.
         {{/if}}
-      {{/if}}
-    </div>
+      </div>
+    {{/if}}
   </CopyButton>
 </div>

--- a/app/components/crate-toml-copy.hbs
+++ b/app/components/crate-toml-copy.hbs
@@ -1,9 +1,8 @@
 <div local-class="crate-toml-copy {{if @inline "inline" "block"}}" ...attributes>
-  <CopyButton
-    @clipboardText={{@copyText}}
-    @success={{perform this.showNotificationTask true}}
-    @error={{perform this.showNotificationTask false}}
-    @title="Copy Cargo.toml snippet to clipboard"
+  <button
+    type="button"
+    title="Copy Cargo.toml snippet to clipboard"
+    {{on "click" this.copy}}
   >
     {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
     {{#if this.showNotification}}
@@ -15,5 +14,5 @@
         {{/if}}
       </div>
     {{/if}}
-  </CopyButton>
+  </button>
 </div>

--- a/app/components/crate-toml-copy.hbs
+++ b/app/components/crate-toml-copy.hbs
@@ -1,5 +1,5 @@
 <div local-class="crate-toml-copy {{if @inline "inline" "block"}}" ...attributes>
-  <CopyButton @clipboardText={{this.copyText}} @success={{action "copySuccess"}} @error={{action "copyError"}} @title="Copy Cargo.toml snippet to clipboard">
+  <CopyButton @clipboardText={{@copyText}} @success={{action "copySuccess"}} @error={{action "copyError"}} @title="Copy Cargo.toml snippet to clipboard">
     {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
     <div local-class="copy-notification {{if this.showSuccess "copy-success" "copy-failure"}}">
       {{#if this.showNotification}}

--- a/app/components/crate-toml-copy.hbs
+++ b/app/components/crate-toml-copy.hbs
@@ -1,5 +1,10 @@
 <div local-class="crate-toml-copy {{if @inline "inline" "block"}}" ...attributes>
-  <CopyButton @clipboardText={{@copyText}} @success={{action "copySuccess"}} @error={{action "copyError"}} @title="Copy Cargo.toml snippet to clipboard">
+  <CopyButton
+    @clipboardText={{@copyText}}
+    @success={{action "copySuccess"}}
+    @error={{action "copyError"}}
+    @title="Copy Cargo.toml snippet to clipboard"
+  >
     {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
     <div local-class="copy-notification {{if this.showSuccess "copy-success" "copy-failure"}}">
       {{#if this.showNotification}}

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -7,13 +7,10 @@ import { rawTimeout, task } from 'ember-concurrency';
 
 export default class CrateTomlCopy extends Component {
   @tracked showSuccess = false;
-  @tracked showNotification = false;
 
   @(task(function* (isSuccess) {
     this.showSuccess = isSuccess;
-    this.showNotification = true;
     yield rawTimeout(2000);
-    this.showNotification = false;
   }).restartable())
   showNotificationTask;
 

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -1,10 +1,13 @@
 import Component from '@ember/component';
+import { action } from '@ember/object';
 import { later } from '@ember/runloop';
 
-export default Component.extend({
-  tagName: '',
-  showSuccess: false,
-  showNotification: false,
+export default class CrateTomlCopy extends Component {
+  tagName = '';
+
+  showSuccess = false;
+  showNotification = false;
+
   toggleClipboardProps(isSuccess) {
     this.setProperties({
       showSuccess: isSuccess,
@@ -17,14 +20,15 @@ export default Component.extend({
       },
       2000,
     );
-  },
-  actions: {
-    copySuccess() {
-      this.toggleClipboardProps(true);
-    },
+  }
 
-    copyError() {
-      this.toggleClipboardProps(false);
-    },
-  },
-});
+  @action
+  copySuccess() {
+    this.toggleClipboardProps(true);
+  }
+
+  @action
+  copyError() {
+    this.toggleClipboardProps(false);
+  }
+}

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -8,15 +8,14 @@ import { rawTimeout, task } from 'ember-concurrency';
 export default class CrateTomlCopy extends Component {
   @tracked showSuccess = false;
 
-  @(task(function* (isSuccess) {
-    this.showSuccess = isSuccess;
+  @(task(function* () {
     yield rawTimeout(2000);
   }).restartable())
   showNotificationTask;
 
   @action
   copy() {
-    let isSuccess = copy(this.args.copyText);
-    this.showNotificationTask.perform(isSuccess);
+    this.showSuccess = copy(this.args.copyText);
+    this.showNotificationTask.perform();
   }
 }

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -3,7 +3,6 @@ import { later } from '@ember/runloop';
 
 export default Component.extend({
   tagName: '',
-  copyText: '',
   showSuccess: false,
   showNotification: false,
   toggleClipboardProps(isSuccess) {

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -1,4 +1,3 @@
-import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
@@ -15,14 +14,4 @@ export default class CrateTomlCopy extends Component {
     this.showNotification = false;
   }).restartable())
   showNotificationTask;
-
-  @action
-  copySuccess() {
-    this.showNotificationTask.perform(true);
-  }
-
-  @action
-  copyError() {
-    this.showNotificationTask.perform(false);
-  }
 }

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -1,22 +1,22 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
+import { tracked } from '@glimmer/tracking';
 
 export default class CrateTomlCopy extends Component {
   tagName = '';
 
-  showSuccess = false;
-  showNotification = false;
+  @tracked showSuccess = false;
+  @tracked showNotification = false;
 
   toggleClipboardProps(isSuccess) {
-    this.setProperties({
-      showSuccess: isSuccess,
-      showNotification: true,
-    });
+    this.showSuccess = isSuccess;
+    this.showNotification = true;
+
     later(
       this,
       () => {
-        this.set('showNotification', false);
+        this.showNotification = false;
       },
       2000,
     );

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -1,6 +1,8 @@
+import { action } from '@ember/object';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import copy from 'copy-text-to-clipboard';
 import { rawTimeout, task } from 'ember-concurrency';
 
 export default class CrateTomlCopy extends Component {
@@ -14,4 +16,10 @@ export default class CrateTomlCopy extends Component {
     this.showNotification = false;
   }).restartable())
   showNotificationTask;
+
+  @action
+  copy() {
+    let isSuccess = copy(this.args.copyText);
+    this.showNotificationTask.perform(isSuccess);
+  }
 }

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -1,11 +1,9 @@
-import Component from '@ember/component';
 import { action } from '@ember/object';
 import { later } from '@ember/runloop';
+import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 export default class CrateTomlCopy extends Component {
-  tagName = '';
-
   @tracked showSuccess = false;
   @tracked showNotification = false;
 

--- a/app/components/crate-toml-copy.js
+++ b/app/components/crate-toml-copy.js
@@ -1,32 +1,28 @@
 import { action } from '@ember/object';
-import { later } from '@ember/runloop';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+
+import { rawTimeout, task } from 'ember-concurrency';
 
 export default class CrateTomlCopy extends Component {
   @tracked showSuccess = false;
   @tracked showNotification = false;
 
-  toggleClipboardProps(isSuccess) {
+  @(task(function* (isSuccess) {
     this.showSuccess = isSuccess;
     this.showNotification = true;
-
-    later(
-      this,
-      () => {
-        this.showNotification = false;
-      },
-      2000,
-    );
-  }
+    yield rawTimeout(2000);
+    this.showNotification = false;
+  }).restartable())
+  showNotificationTask;
 
   @action
   copySuccess() {
-    this.toggleClipboardProps(true);
+    this.showNotificationTask.perform(true);
   }
 
   @action
   copyError() {
-    this.toggleClipboardProps(false);
+    this.showNotificationTask.perform(false);
   }
 }

--- a/app/helpers/is-clipboard-supported.js
+++ b/app/helpers/is-clipboard-supported.js
@@ -1,0 +1,5 @@
+import { helper } from '@ember/component/helper';
+
+const IS_SUPPORTED = document.queryCommandSupported && document.queryCommandSupported('copy');
+
+export default helper(() => IS_SUPPORTED);

--- a/package-lock.json
+++ b/package-lock.json
@@ -15377,6 +15377,7 @@
       "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
       "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "good-listener": "^1.2.2",
         "select": "^1.1.2",
@@ -15823,6 +15824,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
+    },
+    "copy-text-to-clipboard": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz",
+      "integrity": "sha512-WRvoIdnTs1rgPMkgA2pUOa/M4Enh2uzCwdKsOMYNAJiz/4ZvEJgmbF4OmninPmlFdAWisfeh0tH+Cpf7ni3RqQ=="
     },
     "core-js": {
       "version": "2.4.1",
@@ -16283,7 +16289,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.1.3.tgz",
       "integrity": "sha1-moJRp3fXAl+qVXN7w7BxdCEnqf0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -22643,277 +22650,6 @@
       "resolved": "https://registry.npmjs.org/ember-cli-babel-plugin-helpers/-/ember-cli-babel-plugin-helpers-1.1.0.tgz",
       "integrity": "sha512-Zr4my8Xn+CzO0gIuFNXji0eTRml5AxZUTDQz/wsNJ5AJAtyFWCY4QtKdoELNNbiCVGt1lq5yLiwTm4scGKu6xA==",
       "dev": true
-    },
-    "ember-cli-clipboard": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-clipboard/-/ember-cli-clipboard-0.14.0.tgz",
-      "integrity": "sha512-cMde6B5xFbnhSDH+OdSKPaA0gRscyBMCUCXIORf/zCN6gz7rfLvS+MJ2izILqxyqgiRGpfi15BqjTa7Kyz8cCQ==",
-      "dev": true,
-      "requires": {
-        "@ember/render-modifiers": "^1.0.1",
-        "broccoli-funnel": "^1.1.0",
-        "clipboard": "^2.0.0",
-        "ember-cli-babel": "^7.13.0",
-        "ember-cli-htmlbars": "^4.2.0",
-        "fastboot-transform": "^0.1.3"
-      },
-      "dependencies": {
-        "babel-plugin-htmlbars-inline-precompile": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-3.1.0.tgz",
-          "integrity": "sha512-ar6c4YVX6OV7Dzpq7xRyllQrHwVEzJf41qysYULnD6tu6TS+y1FxT2VcEvMC6b9Rq9xoHMzvB79HO3av89JCGg==",
-          "dev": true
-        },
-        "broccoli-debug": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/broccoli-debug/-/broccoli-debug-0.6.5.tgz",
-          "integrity": "sha512-RIVjHvNar9EMCLDW/FggxFRXqpjhncM/3qq87bn/y+/zR9tqEkHvTqbyOc4QnB97NO2m6342w4wGkemkaeOuWg==",
-          "dev": true,
-          "requires": {
-            "broccoli-plugin": "^1.2.1",
-            "fs-tree-diff": "^0.5.2",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "symlink-or-copy": "^1.1.8",
-            "tree-sync": "^1.2.2"
-          },
-          "dependencies": {
-            "broccoli-plugin": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-              "dev": true,
-              "requires": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-              }
-            },
-            "fs-tree-diff": {
-              "version": "0.5.9",
-              "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-0.5.9.tgz",
-              "integrity": "sha512-872G8ax0kHh01m9n/2KDzgYwouKza0Ad9iFltBpNykvROvf2AGtoOzPJgGx125aolGPER3JuC7uZFrQ7bG1AZw==",
-              "dev": true,
-              "requires": {
-                "heimdalljs-logger": "^0.1.7",
-                "object-assign": "^4.1.0",
-                "path-posix": "^1.0.0",
-                "symlink-or-copy": "^1.1.8"
-              }
-            }
-          }
-        },
-        "broccoli-persistent-filter": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-2.3.1.tgz",
-          "integrity": "sha512-hVsmIgCDrl2NFM+3Gs4Cr2TA6UPaIZip99hN8mtkaUPgM8UeVnCbxelCvBjUBHo0oaaqP5jzqqnRVvb568Yu5g==",
-          "dev": true,
-          "requires": {
-            "async-disk-cache": "^1.2.1",
-            "async-promise-queue": "^1.0.3",
-            "broccoli-plugin": "^1.0.0",
-            "fs-tree-diff": "^2.0.0",
-            "hash-for-dep": "^1.5.0",
-            "heimdalljs": "^0.2.1",
-            "heimdalljs-logger": "^0.1.7",
-            "mkdirp": "^0.5.1",
-            "promise-map-series": "^0.2.1",
-            "rimraf": "^2.6.1",
-            "rsvp": "^4.7.0",
-            "symlink-or-copy": "^1.0.1",
-            "sync-disk-cache": "^1.3.3",
-            "walk-sync": "^1.0.0"
-          },
-          "dependencies": {
-            "broccoli-plugin": {
-              "version": "1.3.1",
-              "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
-              "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-              "dev": true,
-              "requires": {
-                "promise-map-series": "^0.2.1",
-                "quick-temp": "^0.1.3",
-                "rimraf": "^2.3.4",
-                "symlink-or-copy": "^1.1.8"
-              }
-            },
-            "rsvp": {
-              "version": "4.8.5",
-              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-              "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-              "dev": true
-            },
-            "walk-sync": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
-              "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-              "dev": true,
-              "requires": {
-                "@types/minimatch": "^3.0.3",
-                "ensure-posix-path": "^1.1.0",
-                "matcher-collection": "^1.1.1"
-              }
-            }
-          }
-        },
-        "broccoli-plugin": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz",
-          "integrity": "sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.6.0",
-            "broccoli-output-wrapper": "^2.0.0",
-            "fs-merger": "^3.0.1",
-            "promise-map-series": "^0.2.1",
-            "quick-temp": "^0.1.3",
-            "rimraf": "^2.3.4",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-4.3.1.tgz",
-          "integrity": "sha512-CW6AY/yzjeVqoRtItOKj3hcYzc5dWPRETmeCzr2Iqjt5vxiVtpl0z5VTqHqIlT5fsFx6sGWBQXNHIe+ivYsxXQ==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^3.0.1",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^2.3.1",
-            "broccoli-plugin": "^3.1.0",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.0",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^6.3.0",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.0.2"
-          },
-          "dependencies": {
-            "heimdalljs": {
-              "version": "0.2.6",
-              "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.6.tgz",
-              "integrity": "sha512-o9bd30+5vLBvBtzCPwwGqpry2+n0Hi6H1+qwt6y+0kwRHGGF8TFIhJPmnuM0xO97zaKrDZMwO/V56fAnn8m/tA==",
-              "dev": true,
-              "requires": {
-                "rsvp": "~3.2.1"
-              }
-            },
-            "heimdalljs-logger": {
-              "version": "0.1.10",
-              "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.10.tgz",
-              "integrity": "sha512-pO++cJbhIufVI/fmB/u2Yty3KJD0TqNPecehFae0/eps0hkZ3b4Zc/PezUMOpYuHFQbA7FxHZxa305EhmjLj4g==",
-              "dev": true,
-              "requires": {
-                "debug": "^2.2.0",
-                "heimdalljs": "^0.2.6"
-              }
-            }
-          }
-        },
-        "ensure-posix-path": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
-          "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
-          "dev": true
-        },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "dev": true,
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "hash-for-dep": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/hash-for-dep/-/hash-for-dep-1.5.1.tgz",
-          "integrity": "sha512-/dQ/A2cl7FBPI2pO0CANkvuuVi/IFS5oTyJ0PsOb6jW6WbVW1js5qJXMJTNbWHXBIPdFTWFbabjB+mE0d+gelw==",
-          "dev": true,
-          "requires": {
-            "broccoli-kitchen-sink-helpers": "^0.3.1",
-            "heimdalljs": "^0.2.3",
-            "heimdalljs-logger": "^0.1.7",
-            "path-root": "^0.1.1",
-            "resolve": "^1.10.0",
-            "resolve-package-path": "^1.0.11"
-          }
-        },
-        "matcher-collection": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
-          "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
-          "dev": true,
-          "requires": {
-            "minimatch": "^3.0.2"
-          }
-        },
-        "path-parse": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "rsvp": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-          "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-          "dev": true
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-          "dev": true
-        },
-        "walk-sync": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.1.0.tgz",
-          "integrity": "sha512-KpH9Xw64LNSx7/UI+3guRZvJWlDxVA4+KKb/4puRoVrG8GkvZRxnF3vhxdjgpoKJGL2TVg1OrtkXIE/VuGPLHQ==",
-          "dev": true,
-          "requires": {
-            "@types/minimatch": "^3.0.3",
-            "ensure-posix-path": "^1.1.0",
-            "matcher-collection": "^2.0.0"
-          },
-          "dependencies": {
-            "matcher-collection": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
-              "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
-              "dev": true,
-              "requires": {
-                "@types/minimatch": "^3.0.3",
-                "minimatch": "^3.0.2"
-              }
-            }
-          }
-        }
-      }
     },
     "ember-cli-code-coverage": {
       "version": "1.0.0-beta.9",
@@ -40320,6 +40056,7 @@
       "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
       "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
       "dev": true,
+      "optional": true,
       "requires": {
         "delegate": "^3.1.2"
       }
@@ -46369,7 +46106,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
       "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "semver": {
       "version": "7.3.2",
@@ -48012,7 +47750,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.1.tgz",
       "integrity": "sha1-5lkZ2R5Ijip49+voJ6VsaxiNUa8=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "tiny-lr": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
+    "copy-text-to-clipboard": "^2.2.0",
     "fastboot-app-server": "^2.0.0",
     "morgan": "^1.10.0",
     "pretty-bytes": "^5.3.0"
@@ -54,7 +55,6 @@
     "ember-cli": "~3.18.0",
     "ember-cli-app-version": "^3.2.0",
     "ember-cli-babel": "^7.21.0",
-    "ember-cli-clipboard": "^0.14.0",
     "ember-cli-code-coverage": "^1.0.0-beta.9",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-dependency-lint": "^1.1.3",


### PR DESCRIPTION
This PR performs a number of refactorings on the `CrateTomlCopy` component. The main changes are converting it to a Glimmer component and replacing the `ember-cli-clipboard` dependency with https://github.com/sindresorhus/copy-text-to-clipboard to save payload size and simplify the code. It also uses an ember-concurrency task now to prevent race conditions when clicking the button multiple times.

r? @locks 