### PR TITLE
Normalize request paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "civet"
-version = "0.12.0-alpha.3"
+version = "0.12.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f360e1a48dd03961dfac6120d9d90a189e2274a09b00c9f536cce844d462239d"
+checksum = "2adfa9a0117908b89125b42475fa45da5cbfae6a32f06ef67043918ad054587a"
 dependencies = [
  "civet-sys",
  "conduit",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47432edd46e337326eed753ec7c9a9163a5e297f82a299d24f106221a2dee412"
+checksum = "68f55ff2e3601329f850eaa86fe6dff2cd66a58ac1df26188e850162126a0432"
 dependencies = [
  "http 0.2.1",
 ]
@@ -463,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-hyper"
-version = "0.3.0-alpha.4"
+version = "0.3.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d0c38b49434c95e0a7cd8dc805c90e3c6975cb9454e158c994c35fa1bfe641"
+checksum = "50f2fc542431a2f71cdf7897594e180efe0deda7044a52c3bd1e31f12356b4eb"
 dependencies = [
  "conduit",
  "http 0.2.1",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-middleware"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda9153060cd9c67b2f13e04c93f2f0d4f3c49c22e35763d7a700ce2a26afb04"
+checksum = "d11aae989fb790857867a76d27cc02304d7ca743b49667e711fdb6b1ee6a5f1f"
 dependencies = [
  "conduit",
 ]
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-router"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eaa68ea0121fc61e2bf515f6dce485fa7674e57d17a2201762bfbc9380f65ec"
+checksum = "4dd55e9910b2a8c0df19155a66e7b6bcb87e3abfba2ef6ff47fa1b607e63035e"
 dependencies = [
  "conduit",
  "route-recognizer",
@@ -518,9 +518,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-test"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f72c6a9f57a45242f3df7a46907d1f1983d1ee279e8d9b8c355679732122dc"
+checksum = "75b2f3bd0554c5ca215e78d8569b093a9dea8e384c0f2497a30dd0cccafe1ef5"
 dependencies = [
  "conduit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,16 +66,16 @@ lettre = "0.9"
 lettre_email = "0.9"
 failure = "0.1.1"
 
-conduit = "0.9.0-alpha.2"
+conduit = "0.9.0-alpha.3"
 conduit-conditional-get = "0.9.0-alpha.3"
 conduit-cookie = "0.9.0-alpha.4"
 cookie = { version = "0.14", features = ["secure"] }
-conduit-middleware = "0.9.0-alpha.2"
-conduit-router = "0.9.0-alpha.2"
+conduit-middleware = "0.9.0-alpha.3"
+conduit-router = "0.9.0-alpha.3"
 conduit-static = "0.9.0-alpha.3"
 conduit-git-http-backend = "0.9.0-alpha.2"
-civet = "0.12.0-alpha.3"
-conduit-hyper = "0.3.0-alpha.4"
+civet = "0.12.0-alpha.4"
+conduit-hyper = "0.3.0-alpha.5"
 http = "0.2"
 
 futures-util = "0.3"
@@ -87,7 +87,7 @@ indexmap = "1.0.2"
 handlebars = "3.0.1"
 
 [dev-dependencies]
-conduit-test = "0.9.0-alpha.2"
+conduit-test = "0.9.0-alpha.3"
 hyper-tls = "0.4"
 lazy_static = "1.0"
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -21,6 +21,7 @@ mod ensure_well_formed_500;
 mod head;
 mod log_connection_pool_status;
 pub mod log_request;
+mod normalize_path;
 mod require_user_agent;
 mod static_or_continue;
 
@@ -57,6 +58,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: R404) -> MiddlewareBuilder {
         m.add(LogConnectionPoolStatus::new(&app));
     }
 
+    m.add(normalize_path::NormalizePath);
     m.add(ConditionalGet);
 
     m.add(Cookie::new());

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -11,7 +11,7 @@
 use super::prelude::*;
 use std::fmt::Write;
 
-use crate::util::{errors::NotFound, AppResponse, Error, RequestProxy};
+use crate::util::{errors::NotFound, AppResponse, Error};
 
 use conduit::{Body, HandlerResult};
 use conduit_static::Static;
@@ -66,8 +66,8 @@ impl Handler for EmberHtml {
                 .any(|val| val.to_str().unwrap_or_default().contains("html"))
             {
                 // Serve static Ember page to bootstrap the frontend
-                self.static_handler
-                    .call(&mut RequestProxy::rewrite_path(req, "/index.html"))
+                *req.path_mut() = String::from("/index.html");
+                self.static_handler.call(req)
             } else {
                 // Return a 404 to crawlers that don't send `Accept: text/hml`.
                 // This is to preserve legacy behavior and will likely change.

--- a/src/middleware/normalize_path.rs
+++ b/src/middleware/normalize_path.rs
@@ -1,0 +1,71 @@
+//! Normalize request path if necessary
+
+use super::prelude::*;
+
+use std::path::{Component, Path, PathBuf};
+
+pub struct NormalizePath;
+
+impl Middleware for NormalizePath {
+    fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
+        let path = req.path();
+        if !(path.contains("//") || path.contains("/.")) {
+            // Avoid allocations if rewriting is unnecessary
+            return Ok(());
+        }
+
+        let original = path.to_string();
+        let length = path.len();
+        let path = Path::new(path);
+
+        let path = path
+            .components()
+            .fold(PathBuf::with_capacity(length), |mut result, p| match p {
+                Component::Normal(x) => {
+                    if x != "" {
+                        result.push(x)
+                    };
+                    result
+                }
+                Component::ParentDir => {
+                    result.pop();
+                    result
+                }
+                Component::RootDir => {
+                    result.push(Component::RootDir);
+                    result
+                }
+                _ => result,
+            })
+            .to_string_lossy()
+            .to_string(); // non-Unicode is replaced with U+FFFD REPLACEMENT CHARACTER
+
+        super::log_request::add_custom_metadata(req, "original_path", original);
+        *req.path_mut() = path;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NormalizePath;
+
+    use conduit::RequestExt;
+    use conduit_middleware::Middleware;
+    use conduit_test::MockRequest;
+
+    #[test]
+    fn path_normalization() {
+        let mut req = MockRequest::new(::conduit::Method::GET, "/api/v1/.");
+        let _ = NormalizePath.before(&mut req);
+        assert_eq!(req.path(), "/api/v1");
+
+        let mut req = MockRequest::new(::conduit::Method::GET, "/api/./v1");
+        let _ = NormalizePath.before(&mut req);
+        assert_eq!(req.path(), "/api/v1");
+
+        let mut req = MockRequest::new(::conduit::Method::GET, "//api/v1/../v2");
+        let _ = NormalizePath.before(&mut req);
+        assert_eq!(req.path(), "/api/v2");
+    }
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,7 +5,7 @@ use conduit_router::{RequestParams, RouteBuilder};
 
 use crate::controllers::*;
 use crate::util::errors::{std_error, AppError, NotFound};
-use crate::util::{EndpointResult, RequestProxy};
+use crate::util::EndpointResult;
 use crate::{App, Env};
 
 pub fn build_router(app: &App) -> R404 {
@@ -160,9 +160,9 @@ struct R<H>(pub Arc<H>);
 
 impl<H: Handler> Handler for R<H> {
     fn call(&self, req: &mut dyn RequestExt) -> HandlerResult {
-        let path = req.params()["path"].to_string();
+        *req.path_mut() = req.params()["path"].to_string();
         let R(ref sub_router) = *self;
-        sub_router.call(&mut RequestProxy::rewrite_path(req, &path))
+        sub_router.call(req)
     }
 }
 


### PR DESCRIPTION
The first commit bumps conduit dependencies to add path rewriting support. Here are the full upstream diffs for the releases:

* https://github.com/conduit-rust/conduit/compare/v0.9.0-alpha.2...v0.9.0-alpha.3
* https://github.com/conduit-rust/conduit-test/compare/v0.9.0-alpha.2...v0.9.0-alpha.3
* https://github.com/conduit-rust/conduit-router/compare/v0.9.0-alpha.2...v0.9.0-alpha.3
* https://github.com/conduit-rust/conduit-middleware/compare/v0.9.0-alpha.2...v0.9.0-alpha.3
* https://github.com/conduit-rust/rust-civet/compare/v0.9.0-alpha.3...v0.9.0-alpha.4
* https://github.com/jtgeibel/conduit-hyper/compare/v0.9.0-alpha.4...v0.9.0-alpha.5

The second commit implements path normalization. This should no longer be needed by cargo since https://github.com/rust-lang/crates.io-index/commit/0b8fd79a600db6b16954e6cd302f247f3606c3f5, but I'm seeing a few search requests from cargo clients that start with `//` and result in a 404. My guess is that some people are using mirrors that were forked from the index before that commit and still include the extra slash in their `config.json`. Some 3rd party tools may also send such URLs.

We could probably get away without support for `.` and `..` and only normalize paths with a leading `//`. That would allow for a more performant algorithm. For now, all cases are handled and if normalization takes place the original path is logged. This will allow for easier log analysis to determine if a simpler algorithm can be used.

Fixes: #2552
r? @JohnTitor 