### PR TITLE
Switch to hyper as the default web server

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         });
 
-    let server = if dotenv::var("USE_HYPER").is_ok() {
+    let server = if dotenv::var("WEB_USE_CIVET").is_err() {
         use tokio::io::AsyncWriteExt;
         use tokio::signal::unix::{signal, SignalKind};
 


### PR DESCRIPTION
This is changed so that running `cargo run --bin server` locally uses
the same web server that we are running in production. The `civet`
server can be selected by setting the `WEB_USE_CIVET` environment
variable to any value (including an empty string).

r? @JohnTitor 
cc #2204