### PR TITLE
Update comrak to 0.8 since 0.7.1 is yanked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,9 +404,9 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c299ee56c3914ef56247656d2d1d3e1640703dd411be80f4c063e02736c43f"
+checksum = "b818732a109eeabbe99fee28030ff8ecbd606889fcd25509ed933e6c69b7aa69"
 dependencies = [
  "entities",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ swirl = { git = "https://github.com/sgrif/swirl.git", rev = "e87cf37" }
 serde_json = "1.0.0"
 serde = { version = "1.0.0", features = ["derive"] }
 chrono = { version = "0.4.0", features = ["serde"] }
-comrak = { version = "0.7", default-features = false }
+comrak = { version = "0.8", default-features = false }
 ammonia = "3.0.0"
 docopt = "1.0"
 scheduled-thread-pool = "0.2.0"


### PR DESCRIPTION
0.7.1 is yanked as it contained a breaking change that we addressed here a while ago.
See: https://github.com/kivikakk/comrak/blob/master/changelog.txt

r? @jtgeibel 