### PR TITLE
Add a big green download button.

### DIFF
--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -273,3 +273,14 @@ div.header {
 .yanked {
     composes: yanked from '../shared/typography.module.css';
 }
+
+.big-green-download-button {
+    display: inline-block;
+    float: right;
+    background-color: #0c0;
+    color: #000;
+    padding: 5px;
+    border: 1px solid #070;
+    border-radius: 20px;
+    font-size: 50px;
+}

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -8,6 +8,8 @@
       <h2 data-test-crate-version>{{ this.currentVersion.num }}</h2>
     </div>
 
+    <a target='_blank' rel='noopener noreferer' href='/api/v1/crates/{{this.crate.name}}/{{this.currentVersion.num}}/download' type='application/gzip' download='{{this.crate.name}}-{{this.currentVersion.num}}.tar.gz' local-class='big-green-download-button'>Download</a>
+
     {{#if this.session.currentUser}}
       <FollowButton @crate={{this.crate}}/>
     {{/if}}


### PR DESCRIPTION
Fixes #2113, #1592, #1219, #65.

Note that the node ember proxy is a bit broken on Firefox. The browser sends `Accept: text/html`, and ember interprets it as a request to not proxy to crates.io. No such problem was observed with Chromium.

I've not tried to make this pretty either in terms of UI or in terms of code. It is just a demonstration of an approach to solve the issue.