### PR TITLE
Log user id and token id when applicable.

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -26,7 +26,7 @@ mod prelude {
     use serde::Serialize;
 
     pub trait UserAuthenticationExt {
-        fn authenticate(&self, conn: &PgConnection) -> AppResult<super::util::AuthenticatedUser>;
+        fn authenticate(&mut self) -> AppResult<super::util::AuthenticatedUser>;
     }
 
     pub trait RequestUtils {

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -6,7 +6,7 @@ use crate::views::{EncodableCrateOwnerInvitation, InvitationResponse};
 
 /// Handles the `GET /me/crate_owner_invitations` route.
 pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
-    let user_id = { req.authenticate()? }.user_id();
+    let user_id = req.authenticate()?.user_id();
     let conn = &*req.db_conn()?;
 
     let crate_owner_invitations = crate_owner_invitations::table

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -6,8 +6,8 @@ use crate::views::{EncodableCrateOwnerInvitation, InvitationResponse};
 
 /// Handles the `GET /me/crate_owner_invitations` route.
 pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
+    let user_id = { req.authenticate()? }.user_id();
     let conn = &*req.db_conn()?;
-    let user_id = req.authenticate(conn)?.user_id();
 
     let crate_owner_invitations = crate_owner_invitations::table
         .filter(crate_owner_invitations::invited_user_id.eq(user_id))
@@ -35,18 +35,17 @@ pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
     let mut body = String::new();
     req.body().read_to_string(&mut body)?;
 
-    let conn = &*req.db_conn()?;
-
     let crate_invite: OwnerInvitation =
         serde_json::from_str(&body).map_err(|_| bad_request("invalid json request"))?;
 
     let crate_invite = crate_invite.crate_owner_invite;
-    let user_id = req.authenticate(conn)?.user_id();
+    let user_id = req.authenticate()?.user_id();
+    let conn = &*req.db_conn()?;
 
     if crate_invite.accepted {
         accept_invite(req, conn, crate_invite, user_id)
     } else {
-        decline_invite(req, conn, crate_invite)
+        decline_invite(req, conn, crate_invite, user_id)
     }
 }
 
@@ -113,10 +112,10 @@ fn decline_invite(
     req: &dyn RequestExt,
     conn: &PgConnection,
     crate_invite: InvitationResponse,
+    user_id: i32,
 ) -> EndpointResult {
     use diesel::delete;
 
-    let user_id = req.authenticate(conn)?.user_id();
     delete(crate_owner_invitations::table.find((user_id, crate_invite.crate_id))).execute(conn)?;
 
     #[derive(Serialize)]

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -88,12 +88,13 @@ fn parse_owners_request(req: &mut dyn RequestExt) -> AppResult<Vec<String>> {
 }
 
 fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
+    let authenticated_user = req.authenticate()?;
     let logins = parse_owners_request(req)?;
     let app = req.app();
     let crate_name = &req.params()["crate_id"];
 
     let conn = req.db_conn()?;
-    let user = req.authenticate(&conn)?.find_user(&conn)?;
+    let user = authenticated_user.find_user(&conn)?;
 
     conn.transaction(|| {
         let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -45,7 +45,7 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
     req.log_metadata("crate_version", new_crate.vers.to_string());
 
     let conn = app.primary_database.get()?;
-    let ids = req.authenticate(&conn)?;
+    let ids = req.authenticate()?;
     let user = ids.find_user(&conn)?;
 
     let verified_email_address = user.verified_email(&conn)?;

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,6 +1,7 @@
 use super::prelude::*;
 
 use crate::middleware::current_user::TrustedUserId;
+use crate::middleware::log_request;
 use crate::models::{ApiToken, User};
 use crate::util::errors::{
     forbidden, internal, AppError, AppResult, ChainError, InsecurelyGeneratedTokenRevoked,
@@ -29,28 +30,40 @@ impl AuthenticatedUser {
 
 impl<'a> UserAuthenticationExt for dyn RequestExt + 'a {
     /// Obtain `AuthenticatedUser` for the request or return an `Forbidden` error
-    fn authenticate(&self, conn: &PgConnection) -> AppResult<AuthenticatedUser> {
-        if let Some(id) = self.extensions().find::<TrustedUserId>() {
-            // A trusted user_id was provided by a signed cookie (or a test `MockCookieUser`)
+    fn authenticate(&mut self) -> AppResult<AuthenticatedUser> {
+        if let Some(id) = self.extensions().find::<TrustedUserId>().map(|x| x.0) {
+            log_request::add_custom_metadata(self, "uid", id);
             Ok(AuthenticatedUser {
-                user_id: id.0,
+                user_id: id,
                 token_id: None,
             })
         } else {
             // Otherwise, look for an `Authorization` header on the request
-            if let Some(headers) = self.headers().get(header::AUTHORIZATION) {
-                ApiToken::find_by_api_token(conn, headers.to_str().unwrap_or_default())
-                    .map(|token| AuthenticatedUser {
-                        user_id: token.user_id,
-                        token_id: Some(token.id),
-                    })
-                    .map_err(|e| {
-                        if e.is::<InsecurelyGeneratedTokenRevoked>() {
-                            e
-                        } else {
-                            e.chain(internal("invalid token")).chain(forbidden())
-                        }
-                    })
+            let maybe_authorization: Option<String> = {
+                self.headers()
+                    .get(header::AUTHORIZATION)
+                    .and_then(|h| h.to_str().ok())
+                    .map(|h| h.to_string())
+            };
+            if let Some(header_value) = maybe_authorization {
+                let user = {
+                    let conn = self.db_conn()?;
+                    ApiToken::find_by_api_token(&conn, &header_value)
+                        .map(|token| AuthenticatedUser {
+                            user_id: token.user_id,
+                            token_id: Some(token.id),
+                        })
+                        .map_err(|e| {
+                            if e.is::<InsecurelyGeneratedTokenRevoked>() {
+                                e
+                            } else {
+                                e.chain(internal("invalid token")).chain(forbidden())
+                            }
+                        })?
+                };
+                log_request::add_custom_metadata(self, "uid", user.user_id);
+                log_request::add_custom_metadata(self, "tokenid", user.token_id.unwrap_or(0));
+                Ok(user)
             } else {
                 // Unable to authenticate the user
                 Err(internal("no cookie session or auth header found")).chain_error(forbidden)

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -28,9 +28,9 @@ pub fn unyank(req: &mut dyn RequestExt) -> EndpointResult {
 
 /// Changes `yanked` flag on a crate version record
 fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
+    let authenticated_user = req.authenticate()?;
     let (conn, version, krate) = version_and_crate(req)?;
-    let ids = req.authenticate(&conn)?;
-    let user = ids.find_user(&conn)?;
+    let user = authenticated_user.find_user(&conn)?;
     let owners = krate.owners(&conn)?;
 
     if user.rights(req.app(), &owners)? < Rights::Publish {
@@ -42,7 +42,13 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
         VersionAction::Unyank
     };
 
-    insert_version_owner_action(&conn, version.id, user.id, ids.api_token_id(), action)?;
+    insert_version_owner_action(
+        &conn,
+        version.id,
+        user.id,
+        authenticated_user.api_token_id(),
+        action,
+    )?;
 
     git::yank(krate.name, version, yanked).enqueue(&conn)?;
 


### PR DESCRIPTION
In https://github.com/rust-lang/rfcs/pull/2947#discussion_r456525127,
@pietroalbini says, with regards to restricting the default
authorization of API tokens:
> this would break everyone using the token to authenticate to endpoints
> not used by Cargo. Even though we're not providing stability guarantees
> for them I'd be wary of blindly breaking them. At least I'd like some
> stats on which endpoints are accessed with the cookie and which are used
> with tokens.

This change attempts to provide those stats via the logs. All
authenticated requests receive a `uid` field in the log output. If the
request was authenticated via an API token, the log output additionally
contains a `tokenid` field.

Because the method I used, log_request::add_custom_metadata, requires a
mutable request, I had to make req.authenticate() take a mutable ref.
Since that conflicted with many call sites that were already holding an
immutable ref to the request's DB connection, I moved the taking of the
DB connection reference after the authenticate call.

In crate_owner_invitations.rs and follow.rs, this also meant removing
duplicate authenticate calls and passing through the
already-authenticated user ID from a calling function instead.

In a few places, `req.authenticate(&conn)?.find_user(&conn)?` has been
replaced with two lines, one to do the authentication, and one to do the
database lookup for the user object, after `let conn = req.db_conn()?`