### PR TITLE
Use `matches!` macro and rename sanitize function

### DIFF
--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -123,14 +123,11 @@ impl Team {
         // check that `team` is the `slug` in results, and grab its data
 
         // "sanitization"
-        fn whitelist(c: char) -> bool {
-            match c {
-                'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => false,
-                _ => true,
-            }
+        fn is_allowed_char(c: char) -> bool {
+            matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_')
         }
 
-        if let Some(c) = org_name.chars().find(|c| whitelist(*c)) {
+        if let Some(c) = org_name.chars().find(|c| !is_allowed_char(*c)) {
             return Err(cargo_err(&format_args!(
                 "organization cannot contain special \
                  characters like {}",


### PR DESCRIPTION
Use matches macro which is stabilized in 1.42.0. And rename it from `whitelist` to `is_allowed_char` since it's ambiguous to return true when an unexpected character comes in, even though it's "whitelist".

r? @jtgeibel just in case but feel free to r=anyone as it's a quite simple change.
