### PR TITLE
Bump to the latest emberjs buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/emk/heroku-buildpack-rust#578d630
-https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz
+https://jtgeibel.com/emberjs.tgz
 https://github.com/heroku/heroku-buildpack-nginx.git#fbc49cd
 https://github.com/sgrif/heroku-buildpack-diesel#f605edd


### PR DESCRIPTION
It appears that the buildpack we were grabbing from S3 is very stale.
That version pins `heroku/nodejs-v98` which is also old (the current
version is v174).

This is causing deploys to fail and has already been [reported]
upstream. This commit pins to a custom built version based on
jtgeibel/heroku-buildpack-emberjs@34f4175.

I'm trying a staging deploy of this now, and will merge once that succeeds.

r? @ghost

[reported]: https://github.com/heroku/heroku-buildpack-emberjs/issues/61