### PR TITLE
Obtain allowed origin list from the environment

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,10 @@
 # `postgres://postgres@localhost/cargo_registry`.
 export DATABASE_URL=
 
+# Allowed origins - any origins for which you want to allow browser
+# access to authenticated endpoints.
+export WEB_ALLOWED_ORIGINS=http://localhost:8888,http://localhost:4200
+
 # If you are running a mirror of crates.io, uncomment this line.
 # export MIRROR=1
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub publish_rate_limit: PublishRateLimit,
     pub blocked_traffic: Vec<(String, Vec<String>)>,
     pub domain_name: String,
+    pub allowed_origins: Vec<String>,
 }
 
 impl Default for Config {
@@ -121,6 +122,10 @@ impl Default for Config {
                 }
             }
         };
+        let allowed_origins = env("WEB_ALLOWED_ORIGINS")
+            .split(',')
+            .map(ToString::to_string)
+            .collect();
         Config {
             uploader,
             session_key: env("SESSION_KEY"),
@@ -136,6 +141,7 @@ impl Default for Config {
             publish_rate_limit: Default::default(),
             blocked_traffic: blocked_traffic(),
             domain_name: domain_name(),
+            allowed_origins,
         }
     }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -145,6 +145,7 @@ fn simple_config() -> Config {
         publish_rate_limit: Default::default(),
         blocked_traffic: Default::default(),
         domain_name: "crates.io".into(),
+        allowed_origins: Vec::new(),
     }
 }
 


### PR DESCRIPTION
This adapts the scheme added in #2627. When operating behind
CloudFront, the Host received by nginx is the Heroku instance and does
not match the user facing crates.io origin. Therefore it is necessary to
obtain a list of allowed origins at boot time.

If this header is not set, the server will panic and will not boot.

r? @JohnTitor 
cc @jsha 