### PR TITLE
categories: Add os::linux-apis

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -349,6 +349,12 @@ description = """
 Bindings to operating system-specific APIs.\
 """
 
+[os.categories.linux-apis]
+name = "Linux APIs"
+description = """
+Bindings to Linux-specific APIs.\
+"""
+
 [os.categories.macos-apis]
 name = "mac OS APIs"
 description = """


### PR DESCRIPTION
First of all, thank you to the crates.io team! The service and work you provide is invaluable.

I'm opening this PR to propose a new category slug: `os::linux-apis`. My rationale:

Linux has a large API surface that isn't shared with other
members of the Unix/Unix-like family, so having a separate
category for it allows crate authors to better distinguish
when writing bindings for Linux-specific interfaces.

This is consistent with the availability of `os::macos-apis`,
as macOS is another member of the Unix/Unix-like family with
its own large and discrete API surface.