### PR TITLE
categories: "mac OS" -> "macOS"

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -350,9 +350,9 @@ Bindings to operating system-specific APIs.\
 """
 
 [os.categories.macos-apis]
-name = "mac OS APIs"
+name = "macOS APIs"
 description = """
-Bindings to mac OS-specific APIs.\
+Bindings to macOS-specific APIs.\
 """
 
 [os.categories.unix-apis]


### PR DESCRIPTION
This is a tiny nitpick that I noticed while opening #2662: Apple stylizes their operating system without the space, so I figured consistency with their style makes sense.