### PR TITLE
Fix button alignment on mobile / narrow widths

### DIFF
--- a/app/styles/index.module.css
+++ b/app/styles/index.module.css
@@ -21,6 +21,7 @@
 
 .hero-button {
     composes: yellow-button from '../styles/shared/buttons.module.css';
+    vertical-align: initial;
 }
 
 .blurb {


### PR DESCRIPTION
Hello,

This PR aims to fix the alignment issue on the two main button, on mobile and narrow widths.

This issue was due to [a media query](https://github.com/rust-lang/crates.io/blob/master/app/styles/index.module.css#L17) and [a `vertical-align`](https://github.com/rust-lang/crates.io/blob/master/app/styles/shared/buttons.module.css#L43) rule conflict between `570px` and `447px`, highlighted by the second link margin-top.

Note that the `yellow-button` class is extended 9 times in the app, that's why I've preferred a `vertical-align` "reset" on the `hero-button` definition.

Didn't found a better way. Let me know if you think about something else.

BEFORE: 

<img width="447" alt="image" src="https://user-images.githubusercontent.com/5517077/89797636-6f8fe780-db2b-11ea-9796-787ccab4c7c8.png">

AFTER:

<img width="448" alt="image" src="https://user-images.githubusercontent.com/5517077/89797660-79194f80-db2b-11ea-968f-c1eda7dbb674.png">



Fixes #2654 