### PR TITLE
Set the default r2d2::Pool::max_size to 3

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -59,7 +59,7 @@ impl App {
         let db_pool_size = match (dotenv::var("DB_POOL_SIZE"), config.env) {
             (Ok(num), _) => num.parse().expect("couldn't parse DB_POOL_SIZE"),
             (_, Env::Production) => 10,
-            _ => 1,
+            _ => 3,
         };
 
         let db_min_idle = match (dotenv::var("DB_MIN_IDLE"), config.env) {


### PR DESCRIPTION
While working locally with the crates.io backend I got stuck for some time. Requests to `/api/v1/crates/new` would hang for 30 seconds and then a 500 error would be returned. The error was from r2d2, which timed out while trying to acquire a database connection from the pool. I finally figured out the default max pool size had been set to 1. Strangely this seems to have been this way for 3 years now, so I don't know if I'm doing something wrong here, but this fixed the issue for me.