### PR TITLE
backend: Implement sending notification email when a new version is published

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -8,6 +8,7 @@ use swirl::PerformError;
 use crate::db::{DieselPool, DieselPooledConn};
 use crate::git::Repository;
 use crate::uploaders::Uploader;
+use crate::email::Emails;
 
 impl<'a> swirl::db::BorrowedConnection<'a> for DieselPool {
     type Connection = DieselPooledConn<'a>;
@@ -26,6 +27,7 @@ pub struct Environment {
     index: Arc<Mutex<Repository>>,
     pub uploader: Uploader,
     http_client: AssertUnwindSafe<Client>,
+    pub emails: Arc<Emails>,
 }
 
 impl Clone for Environment {
@@ -34,24 +36,27 @@ impl Clone for Environment {
             index: self.index.clone(),
             uploader: self.uploader.clone(),
             http_client: AssertUnwindSafe(self.http_client.0.clone()),
+            emails: self.emails.clone(),
         }
     }
 }
 
 impl Environment {
-    pub fn new(index: Repository, uploader: Uploader, http_client: Client) -> Self {
-        Self::new_shared(Arc::new(Mutex::new(index)), uploader, http_client)
+    pub fn new(index: Repository, uploader: Uploader, http_client: Client, emails: Emails) -> Self {
+        Self::new_shared(Arc::new(Mutex::new(index)), uploader, http_client, Arc::new(emails))
     }
 
     pub fn new_shared(
         index: Arc<Mutex<Repository>>,
         uploader: Uploader,
         http_client: Client,
+        emails: Arc<Emails>,
     ) -> Self {
         Self {
             index,
             uploader,
             http_client: AssertUnwindSafe(http_client),
+            emails,
         }
     }
 

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -6,9 +6,9 @@ use diesel::r2d2::PoolError;
 use swirl::PerformError;
 
 use crate::db::{DieselPool, DieselPooledConn};
+use crate::email::Emails;
 use crate::git::Repository;
 use crate::uploaders::Uploader;
-use crate::email::Emails;
 
 impl<'a> swirl::db::BorrowedConnection<'a> for DieselPool {
     type Connection = DieselPooledConn<'a>;
@@ -43,7 +43,12 @@ impl Clone for Environment {
 
 impl Environment {
     pub fn new(index: Repository, uploader: Uploader, http_client: Client, emails: Emails) -> Self {
-        Self::new_shared(Arc::new(Mutex::new(index)), uploader, http_client, Arc::new(emails))
+        Self::new_shared(
+            Arc::new(Mutex::new(index)),
+            uploader,
+            http_client,
+            Arc::new(emails),
+        )
     }
 
     pub fn new_shared(

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -12,6 +12,7 @@
 
 #![warn(clippy::all, rust_2018_idioms)]
 
+use cargo_registry::email::Emails;
 use cargo_registry::git::{Repository, RepositoryConfig};
 use cargo_registry::{background_jobs::*, db};
 use diesel::r2d2;
@@ -39,9 +40,16 @@ fn main() {
     ));
     println!("Index cloned");
 
+    let emails = Emails::from_environment();
+    let emails = Arc::new(emails);
+
     let build_runner = || {
-        let environment =
-            Environment::new_shared(repository.clone(), config.uploader.clone(), Client::new());
+        let environment = Environment::new_shared(
+            repository.clone(),
+            config.uploader.clone(),
+            Client::new(),
+            emails.clone(),
+        );
         let db_config = r2d2::Pool::builder().min_idle(Some(0));
         swirl::Runner::builder(environment)
             .connection_pool_builder(&db_url, db_config)

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -204,7 +204,8 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
 
         let hex_cksum = cksum.encode_hex::<String>();
 
-        // Register this crate in our local git repo.
+        // Register this crate in our local git repo and send notification emails
+        // to owners who haven't opted out of them.
         let git_crate = git::Crate {
             name: name.0,
             vers: vers.to_string(),
@@ -214,7 +215,8 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
             yanked: Some(false),
             links,
         };
-        git::add_crate(git_crate).enqueue(&conn)?;
+        let emails = krate.owners_with_notification_email(&conn)?;
+        git::add_crate(git_crate, emails, user.name, verified_email_address).enqueue(&conn)?;
 
         // The `other` field on `PublishWarnings` was introduced to handle a temporary warning
         // that is no longer needed. As such, crates.io currently does not return any `other`

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -319,6 +319,17 @@ impl Crate {
         Ok(users.chain(teams).collect())
     }
 
+    pub fn owners_with_notification_email(&self, conn: &PgConnection) -> QueryResult<Vec<String>> {
+        CrateOwner::by_owner_kind(OwnerKind::User)
+            .filter(crate_owners::crate_id.eq(self.id))
+            .filter(crate_owners::email_notifications.eq(true))
+            .inner_join(emails::table.on(crate_owners::owner_id.eq(emails::user_id)))
+            .filter(emails::verified.eq(true))
+            .select(emails::email)
+            .distinct()
+            .load(conn)
+    }
+
     pub fn owner_add(
         &self,
         app: &App,

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -630,7 +630,7 @@ fn new_krate_records_verified_email() {
             .select(versions_published_by::email)
             .first(conn)
             .unwrap();
-        assert_eq!(email, "something@example.com");
+        assert_eq!(email, "something+foo@example.com");
     });
 }
 

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -464,7 +464,7 @@ fn test_email_get_and_put() {
     let (_app, _anon, user) = TestApp::init().with_user();
 
     let json = user.show_me();
-    assert_eq!(json.user.email.unwrap(), "something@example.com");
+    assert_eq!(json.user.email.unwrap(), "something+foo@example.com");
 
     user.update_email("mango@mangos.mango");
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -194,6 +194,7 @@ impl TestAppBuilder {
                 index,
                 app.config.uploader.clone(),
                 app.http_client().clone(),
+                Emails::new_in_memory(),
             );
 
             Some(

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -100,7 +100,7 @@ impl TestApp {
         use diesel::prelude::*;
 
         let user = self.db(|conn| {
-            let email = "something@example.com";
+            let email = format!("something+{}@example.com", username);
 
             let user = crate::new_user(username)
                 .create_or_update(None, &self.0.app.emails, conn)


### PR DESCRIPTION
I believe this should complete the last task in #1895

A few notes on the implementation:

* I decided to write a custom query for this task, since listing owners and then retrieving the email one by one didn't feel clean and would have been an N+1 query
* I didn't use an HashSet to deduplicate emails, instead I used the [DISTINCT](https://docs.rs/diesel/1.4.5/diesel/query_dsl/trait.QueryDsl.html#method.distinct) keyword in the SQL query
* I had to change the `db_new_user` implementation to generate a different email based on the username, otherwise I wouldn't be able to test if all of the owners would be counted in by `owners_with_notification_email`
* ~~I put all emails in the `To` header since crate owners are public anyway~~

I manually tested this locally by setting [this](https://github.com/rust-lang/crates.io/blob/99a0162e2890d112daf9176cd91a4a68b336d105/app/controllers/me/index.js#L27) to `true`.

Rendered email:
![Rendered email screenshot](https://user-images.githubusercontent.com/6215781/90415134-f22b2080-e0b0-11ea-93b7-78f77ad30de1.png)
