### PR TITLE
Fix mismatch in crate versions between pages

### DIFF
--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -9,8 +9,8 @@
       >
         {{ @crate.name }}
       </LinkTo>
-      <span local-class="version" data-test-version>v{{@crate.max_version}}</span>
-      <CrateTomlCopy @copyText='{{@crate.name}} = "{{@crate.max_version}}"' @inline={{true}} local-class="copy-button" />
+      <span local-class="version" data-test-version>v{{@crate.newest_version}}</span>
+      <CrateTomlCopy @copyText='{{@crate.name}} = "{{@crate.newest_version}}"' @inline={{true}} local-class="copy-button" />
     </div>
     <div local-class="description" data-test-description>
       {{ truncate-text @crate.description }}
@@ -28,7 +28,7 @@
     <div local-class="updated-at" >
       {{svg-jar "latest-updates" height="32" width="32"}}
       <span>
-        <abbr title="The last time crate was updated">Updated:</abbr>
+        <abbr title="The last time the crate was updated">Updated:</abbr>
         <time title="Last updated: {{ @crate.updated_at }}" datetime="{{ moment-format @crate.updated_at 'YYYY-MM-DDTHH:mm:ssZ' }}" data-test-updated-at>
           {{ moment-from-now @crate.updated_at }}
         </time>


### PR DESCRIPTION
Fixes #2710.

For example with `clap`, in the search results (/search?q=clap) the
crate version was shown as `3.0.0-beta.1`, whereas on the crate's page
(/crates/clap) it was shown as `2.33.3`.

The issue was that the search results were showing the *maximum* version,
not the newest version, which I believe is what the crate page was
showing.

Also added a missing "the" in a hover title.

---

@rustbot modify labels: A-frontend A-versions C-bug