### PR TITLE
Log `in_flight_total` when the request count exceeds a threshold

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -55,7 +55,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if config.env == Env::Development {
                 5
             } else {
-                50
+                // A large default because this can be easily changed via env and in production we
+                // want the logging middleware to accurately record the start time.
+                500
             }
         });
 


### PR DESCRIPTION
The parent of this PR is what is currently deployed so we should be able to merge this and deploy `843a975` (not the merge commit) without deploying untested changes on master.

r? @pietroalbini 