### PR TITLE
Add title with the owner's name in the owner icons

### DIFF
--- a/app/components/user-avatar.hbs
+++ b/app/components/user-avatar.hbs
@@ -3,5 +3,6 @@
   width={{this.width}}
   height={{this.height}}
   alt={{this.alt}}
+  title={{this.title}}
   ...attributes
 />

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -18,6 +18,19 @@ export default class UserAvatar extends Component {
     return `${this.args.user.name} (${this.args.user.login})`;
   }
 
+  get title() {
+    let user = this.args.user;
+
+    switch (user.kind) {
+      case 'user':
+        return user.name;
+      case 'team':
+        return `${user.name} team`;
+      default:
+        return `${user.name} (${user.kind})`;
+    }
+  }
+
   get src() {
     return `${this.args.user.avatar}&s=${this.width * 2}`;
   }


### PR DESCRIPTION
Fixes #2721

I edited the `UserAvatar` component, so the improvement will be available everywhere where users' avatars would be shown.

<img width="200" src="https://user-images.githubusercontent.com/6342851/92643371-52953280-f2ea-11ea-987b-14c6896cd9d1.png">
<img width="200" src="https://user-images.githubusercontent.com/6342851/92643341-47da9d80-f2ea-11ea-94e4-fc21b2501662.png">