### PR TITLE
script/ember: Use locally installed ember-cli executable

### DIFF
--- a/script/ember.sh
+++ b/script/ember.sh
@@ -9,4 +9,4 @@ else
     unset FASTBOOT_DISABLED
 fi
 
-ember "$@"
+./node_modules/.bin/ember "$@"


### PR DESCRIPTION
It shouldn't be necessary to globally install `ember-cli` just so that our wrapper script can run properly. Instead we can refer to the locally installed `node_modules/.bin/ember` executable.

Closes https://github.com/rust-lang/crates.io/pull/2752

r? @locks 