### PR TITLE
Migrate "Fork me" from ribbon to footer

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -2,7 +2,7 @@
   <div local-class='after-main-links'>
     <a href='https://doc.rust-lang.org/cargo/getting-started/installation.html'>Install</a>
     <span local-class="sep">|</span>
-    <a href='https://doc.rust-lang.org/cargo/'>Getting Started</a>
+    <a href='https://doc.rust-lang.org/cargo/'>Getting started</a>
     <span local-class="sep">|</span>
     <a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a>
     <span local-class="sep">|</span>

--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -1,7 +1,5 @@
 <footer local-class="footer">
   <div local-class='after-main-links'>
-    <a href='https://doc.rust-lang.org/cargo/getting-started/installation.html'>Install</a>
-    <span local-class="sep">|</span>
     <a href='https://doc.rust-lang.org/cargo/'>Getting started</a>
     <span local-class="sep">|</span>
     <a href='https://doc.rust-lang.org/cargo/guide/'>Guide</a>
@@ -9,6 +7,8 @@
     <a href='mailto:help@crates.io'>Send us an email</a>
     <span local-class="sep">|</span>
     <a href='https://www.rust-lang.org/policies/security'>Report a security issue</a>
+    <span local-class="sep">|</span>
+    <a href='https://github.com/rust-lang/crates.io'>Fork on GitHub</a>
     <span local-class="sep">|</span>
     <a href='https://www.rust-lang.org/policies/privacy'>Privacy notice</a>
     <span local-class="sep">|</span>

--- a/app/components/footer.module.css
+++ b/app/components/footer.module.css
@@ -6,7 +6,7 @@
 }
 
 .sep {
-    margin: 0 10px;
+    margin: 0 5px;
     color: var(--separator-color);
 }
 

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -112,16 +112,6 @@ noscript {
     padding: 0 15px;
 }
 
-.fork-me {
-    position: absolute;
-    top: 0;
-    right: 0;
-
-    @media only screen and (max-width: 1180px) {
-        display: none;
-    }
-}
-
 .toggle-design-button {
     position: fixed;
     bottom: 30px;

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -15,10 +15,6 @@
 
 <Footer/>
 
-<a href='https://github.com/rust-lang/crates.io' local-class='fork-me'>
-  <img src='/assets/forkme.png' alt="Fork me on GitHub">
-</a>
-
 {{#if this.design.showToggleButton}}
   <button type="button" local-class="toggle-design-button" {{on "click" this.design.toggle}}>
     Toggle Design


### PR DESCRIPTION
This moves the "Fork me on GitHub" link from a prominent corner ribbon to a footer link, and rewords it to "Fork crates.io on GitHub", removing the ambiguous "me". This is meant to address the confusion between accessing the source of a crate, and accessing the source of crates.io itself.

Without this change the source link for crates.io is much more prominent than the source link for the crate itself. Personally I've been bitten by this many times: I click on the ribbon intending to see the source for a crate. See #596 for some prior discussion. 

To prevent the footer from becoming too crowded and wrapping, I removed the "Install" link, with the idea that "Getting Started" is sufficient. If you click "Getting Started" you quickly land on "Install" instructions.

The corner ribbon is gone. Footer before:

<img width="855" alt="Screen Shot 2020-09-10 at 7 55 34 PM" src="https://user-images.githubusercontent.com/920838/92849587-584d4f80-f3a0-11ea-9d1c-056fd3bad3a2.png">

With this change:

<img width="855" alt="Screen Shot 2020-09-10 at 7 56 03 PM" src="https://user-images.githubusercontent.com/920838/92849607-5d120380-f3a0-11ea-84a6-ee15892b47cd.png">
