### PR TITLE
Remove obsolete fastboot initializer override

### DIFF
--- a/fastboot/initializers/ajax.js
+++ b/fastboot/initializers/ajax.js
@@ -1,8 +1,0 @@
-export default {
-  name: 'ajax-service',
-  initialize() {
-    // This is to override Fastboot's initializer which prevents ember-fetch from working
-    // https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/fastboot/initializers/ajax.js
-    // https://github.com/ember-cli/ember-fetch#ajax-service
-  },
-};


### PR DESCRIPTION
This does not appear to be necessary anymore 🤔

r? @locks 