### PR TITLE
Cargo.toml: Sort dependencies alphabetically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 chrono = { version = "0.4.0", features = ["serde"] }
 civet = "0.12.0-alpha.4"
 comrak = { version = "0.8", default-features = false }
+
 conduit = "0.9.0-alpha.3"
 conduit-conditional-get = "0.9.0-alpha.3"
 conduit-cookie = "0.9.0-alpha.4"
@@ -43,6 +44,7 @@ conduit-hyper = "0.3.0-alpha.5"
 conduit-middleware = "0.9.0-alpha.3"
 conduit-router = "0.9.0-alpha.3"
 conduit-static = "0.9.0-alpha.3"
+
 cookie = { version = "0.14", features = ["secure"] }
 ctrlc = { version = "3.0", features = ["termination"] }
 derive_deref = "1.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,73 +28,69 @@ rustdoc-args = [
 ]
 
 [dependencies]
-anyhow = "1.0"
-cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
-rand = "0.7"
-git2 = "0.13.0"
-flate2 = "1.0"
-semver = { version = "0.10", features = ["diesel", "serde"] }
-url = "2.1"
-tar = "0.4.16"
-base64 = "0.12"
-
-sha2 = "0.9"
-oauth2 = { version = "3.0.0", default-features = false, features = ["reqwest-010"] }
-log = "0.4"
-env_logger = "0.7"
-hex = "0.4"
-htmlescape = "0.3.1"
-license-exprs = "^1.4"
-dotenv = "0.15"
-toml = "0.5"
-diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
-diesel_full_text_search = "1.0.0"
-swirl = { git = "https://github.com/sgrif/swirl.git", rev = "e87cf37" }
-serde_json = "1.0.0"
-serde = { version = "1.0.0", features = ["derive"] }
-chrono = { version = "0.4.0", features = ["serde"] }
-comrak = { version = "0.8", default-features = false }
 ammonia = "3.0.0"
-docopt = "1.0"
-scheduled-thread-pool = "0.2.0"
-derive_deref = "1.1.1"
-reqwest = { version = "0.10", features = ["blocking", "gzip", "json"] }
-tempfile = "3"
-parking_lot = "0.11"
-jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
-
-lettre = { version = "0.10.0-alpha.1", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
-failure = "0.1.1"
-
+anyhow = "1.0"
+base64 = "0.12"
+cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
+chrono = { version = "0.4.0", features = ["serde"] }
+civet = "0.12.0-alpha.4"
+comrak = { version = "0.8", default-features = false }
 conduit = "0.9.0-alpha.3"
 conduit-conditional-get = "0.9.0-alpha.3"
 conduit-cookie = "0.9.0-alpha.4"
-cookie = { version = "0.14", features = ["secure"] }
+conduit-git-http-backend = "0.9.0-alpha.2"
+conduit-hyper = "0.3.0-alpha.5"
 conduit-middleware = "0.9.0-alpha.3"
 conduit-router = "0.9.0-alpha.3"
 conduit-static = "0.9.0-alpha.3"
-conduit-git-http-backend = "0.9.0-alpha.2"
-civet = "0.12.0-alpha.4"
-conduit-hyper = "0.3.0-alpha.5"
-http = "0.2"
-
-futures-util = "0.3"
-futures-channel = { version = "0.3.1", default-features = false }
-tokio = { version = "0.2", default-features = false, features = ["net", "signal", "io-std"]}
-hyper = "0.13"
+cookie = { version = "0.14", features = ["secure"] }
 ctrlc = { version = "3.0", features = ["termination"] }
-indexmap = "1.0.2"
+derive_deref = "1.1.1"
+diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
+diesel_full_text_search = "1.0.0"
+docopt = "1.0"
+dotenv = "0.15"
+env_logger = "0.7"
+failure = "0.1.1"
+flate2 = "1.0"
+futures-channel = { version = "0.3.1", default-features = false }
+futures-util = "0.3"
+git2 = "0.13.0"
 handlebars = "3.0.1"
+hex = "0.4"
+htmlescape = "0.3.1"
+http = "0.2"
+hyper = "0.13"
+indexmap = "1.0.2"
+jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
+lettre = { version = "0.10.0-alpha.1", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
+license-exprs = "^1.4"
+log = "0.4"
+oauth2 = { version = "3.0.0", default-features = false, features = ["reqwest-010"] }
+parking_lot = "0.11"
+rand = "0.7"
+reqwest = { version = "0.10", features = ["blocking", "gzip", "json"] }
+scheduled-thread-pool = "0.2.0"
+semver = { version = "0.10", features = ["diesel", "serde"] }
+serde = { version = "1.0.0", features = ["derive"] }
+serde_json = "1.0.0"
+sha2 = "0.9"
+swirl = { git = "https://github.com/sgrif/swirl.git", rev = "e87cf37" }
+tar = "0.4.16"
+tempfile = "3"
+tokio = { version = "0.2", default-features = false, features = ["net", "signal", "io-std"]}
+toml = "0.5"
+url = "2.1"
 
 [dev-dependencies]
 conduit-test = "0.9.0-alpha.3"
+diesel_migrations = { version = "1.3.0", features = ["postgres"] }
 hyper-tls = "0.4"
 lazy_static = "1.0"
-diesel_migrations = { version = "1.3.0", features = ["postgres"] }
-tower-service = "0.3.0"
 tokio = { version = "0.2", default-features = false, features = ["stream"]}
+tower-service = "0.3.0"
 
 [build-dependencies]
-dotenv = "0.15"
 diesel = { version = "1.3.0", features = ["postgres"] }
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }
+dotenv = "0.15"


### PR DESCRIPTION
Having the dependencies arbitrarily grouped makes it hard to know where to put new dependencies. This PR sorts them alphabetically, which should resolve the problem.

r? @jtgeibel 