### PR TITLE
renovatebot: Enable `rust` updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,6 @@
     "docker": {
         "enabled": false
     },
-    "rust": {
-        "enabled": false
-    },
     "postUpdateOptions": ["npmDedupe"],
     "packageRules": [{
         "groupName": "embroider",


### PR DESCRIPTION
Since it seems to have been working well for the frontend dependencies I guess we could also give it a try for the backend. If we figure out that it doesn't work as well we can always disable it again.

r? @jtgeibel 