### PR TITLE
Double nginx worker connections

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -23,7 +23,7 @@ worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
 events {
 	use epoll;
 	accept_mutex on;
-	worker_connections 1024;
+	worker_connections 2048;
 }
 
 http {

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -33,32 +33,48 @@ http {
 	real_ip_recursive on;
 
 	# CloudFront IP addresses from http://d7uri8nf7uskq.cloudfront.net/tools/list-cloudfront-ips
-	# Last updated: 2020-05-22
+	# Last updated: 2020-09-12
+	set_real_ip_from 3.10.17.128/25;
+	set_real_ip_from 3.11.53.0/24;
+	set_real_ip_from 3.128.93.0/24;
+	set_real_ip_from 3.134.215.0/24;
 	set_real_ip_from 3.231.2.0/25;
 	set_real_ip_from 3.234.232.224/27;
+	set_real_ip_from 3.236.48.0/23;
+	set_real_ip_from 3.236.169.192/26;
 	set_real_ip_from 13.32.0.0/15;
 	set_real_ip_from 13.35.0.0/16;
+	set_real_ip_from 13.48.32.0/24;
 	set_real_ip_from 13.54.63.128/26;
 	set_real_ip_from 13.59.250.0/26;
+	set_real_ip_from 13.113.196.64/26;
 	set_real_ip_from 13.113.203.0/24;
 	set_real_ip_from 13.124.199.0/24;
 	set_real_ip_from 13.210.67.128/26;
 	set_real_ip_from 13.224.0.0/14;
 	set_real_ip_from 13.228.69.0/24;
+	set_real_ip_from 13.233.177.192/26;
 	set_real_ip_from 13.249.0.0/16;
+	set_real_ip_from 15.188.184.0/24;
+	set_real_ip_from 15.207.13.128/25;
+	set_real_ip_from 15.207.213.128/25;
+	set_real_ip_from 18.192.142.0/23;
 	set_real_ip_from 18.200.212.0/23;
 	set_real_ip_from 18.216.170.128/25;
+	set_real_ip_from 18.229.220.192/26;
 	set_real_ip_from 34.195.252.0/24;
 	set_real_ip_from 34.216.51.0/25;
 	set_real_ip_from 34.223.12.224/27;
 	set_real_ip_from 34.223.80.192/26;
 	set_real_ip_from 34.226.14.0/24;
-	set_real_ip_from 34.232.163.208/29;
 	set_real_ip_from 35.158.136.0/24;
 	set_real_ip_from 35.162.63.192/26;
 	set_real_ip_from 35.167.191.128/26;
 	set_real_ip_from 36.103.232.0/25;
 	set_real_ip_from 36.103.232.128/26;
+	set_real_ip_from 44.227.178.0/24;
+	set_real_ip_from 44.234.90.252/30;
+	set_real_ip_from 44.234.108.128/25;
 	set_real_ip_from 52.15.127.128/26;
 	set_real_ip_from 52.46.0.0/18;
 	set_real_ip_from 52.47.139.0/24;

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -19,7 +19,8 @@ impl AroundMiddleware for RequireUserAgent {
 
 impl Handler for RequireUserAgent {
     fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
-        let has_user_agent = request_header(req, header::USER_AGENT) != "";
+        let agent = request_header(req, header::USER_AGENT);
+        let has_user_agent = agent != "" && agent != "Amazon CloudFront";
         let is_download = req.path().ends_with("download");
         if !has_user_agent && !is_download {
             super::log_request::add_custom_metadata(req, "cause", "no user agent");

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -1,6 +1,14 @@
 //! Middleware that blocks requests with no user-agent header
+//!
+//! By default the middleware will treat "" and "Amazon CloudFront" as a missing user-agent. To
+//! change the 2nd value, set `WEB_CDN_USER_AGENT` to the appropriate string. To disable the CDN
+//! check, set `WEB_CDN_USER_AGENT` to the empty string.
+//!
+//! Requests to the download endpoint are always allowed, to support versions of cargo older than
+//! 0.17 (released alongside rustc 1.17).
 
 use super::prelude::*;
+use std::env;
 
 use crate::util::request_header;
 
@@ -8,11 +16,14 @@ use crate::util::request_header;
 #[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct RequireUserAgent {
+    cdn_user_agent: String,
     handler: Option<Box<dyn Handler>>,
 }
 
 impl AroundMiddleware for RequireUserAgent {
     fn with_handler(&mut self, handler: Box<dyn Handler>) {
+        self.cdn_user_agent =
+            env::var("WEB_CDN_USER_AGENT").unwrap_or_else(|_| "Amazon CloudFront".into());
         self.handler = Some(handler);
     }
 }
@@ -20,7 +31,7 @@ impl AroundMiddleware for RequireUserAgent {
 impl Handler for RequireUserAgent {
     fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
         let agent = request_header(req, header::USER_AGENT);
-        let has_user_agent = agent != "" && agent != "Amazon CloudFront";
+        let has_user_agent = agent != "" && agent != self.cdn_user_agent;
         let is_download = req.path().ends_with("download");
         if !has_user_agent && !is_download {
             super::log_request::add_custom_metadata(req, "cause", "no user agent");


### PR DESCRIPTION
This should double our burst capacity during large influxes of download
traffic and reduce the occurance of H13 errors due to hitting the worker
connection limit.

With more queued connections we could potentially bump into limits on
the number of open file handles. It looks like Heroku dynos have a
ulimit on open files of:
* 10,000 for Standard-1X dynos
* 1,048,576 for Performance-M dynos

Based on these numbers, we have a margin of 1,808 file handles for
database connections, serving static files, etc. even on a Standard-1X
dyno.

r? @pietroalbini 