### PR TITLE
Fix discord channel name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ of the following ways:
 
 - [File a new issue](https://github.com/rust-lang/crates.io/issues/new)
 - Email [help@crates.io](mailto:help@crates.io)
-- Chat on ops > #crates-io channel on https://discord.gg/rust-lang
+- Chat on ops > #crates-io-team channel on https://discord.gg/rust-lang
 
 A volunteer will get back to you as soon as possible.
 


### PR DESCRIPTION
I just tried to follow instructions to join discord channel and noticed that there is no #crates-io channel, but rather #crates-io-team.