### PR TITLE
Add registries mirror section to .cargo/config template in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -494,7 +494,8 @@ index = "file:///path/to/your/crates.io/tmp/index-bare"
 ```
 
 Then add the crate you published to your local crates.io as a dependency in
-this crate's `Cargo.toml`, and `cargo build` should display output like this:
+this crate's `Cargo.toml` (`yourcrate = { version = "0.1.0", registry = "mirror" }`),
+and `cargo build` should display output like this:
 
 ```
     Updating registry `file:///path/to/your/crates.io/tmp/index-bare`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -488,6 +488,9 @@ registry = "file:///path/to/your/crates.io/tmp/index-bare"
 
 [source.crates-io]
 replace-with = "mirror"
+
+[registries.mirror]
+index = "file:///path/to/your/crates.io/tmp/index-bare"
 ```
 
 Then add the crate you published to your local crates.io as a dependency in


### PR DESCRIPTION
Add registries mirror section to .cargo/config template in CONTRIBUTING.md.

Without this, you will have `source = "registry+https://github.com/rust-lang/crates.io-index"` 
in your Cargo.lock file, and then publishing the dependent (second) crate will fail with 
`api errors (status 200 OK): Dependency yourcrate is hosted on another registry.
Cross-registry dependencies are not permitted on crates.io.` error.

With this change, you will have `source = "registry+file:///path/to/your/crates.io/tmp/index-bare"`
in your Cargo.lock for the upstream crate (yourcrate in this example).

Thanks to @Nemo157 for helping me to figure this out on Discord.