### PR TITLE
Temporarily remove yank button from crate header

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -7,7 +7,7 @@
       <h1 data-test-crate-name>{{ this.crate.name }}</h1>
       <h2 data-test-crate-version>{{ this.currentVersion.num }}</h2>
       {{#if this.isOwner }}
-        <YankButton @version={{this.currentVersion}} @tan={{true}} />
+        {{!-- <YankButton @version={{this.currentVersion}} @tan={{true}} /> --}}
       {{/if}}
     </div>
 

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,6 +1,6 @@
 import { click, fillIn, currentURL, currentRouteName, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 
 import percySnapshot from '@percy/ember';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';
@@ -219,7 +219,7 @@ module('Acceptance | crate page', function (hooks) {
     assert.dom('[data-test-license]').hasText('MIT/Apache-2.0');
   });
 
-  test('crates can be yanked by owner', async function (assert) {
+  skip('crates can be yanked by owner', async function (assert) {
     this.server.loadFixtures();
 
     let user = this.server.schema.users.findBy({ login: 'thehydroimpulse' });


### PR DESCRIPTION
Temporarily remove the yank button from the crate page until we find better placement for the button. The buttons added to the all versions page in #2623 remain.

I would like to merge this as a temporary fix to unblock deploying to production. I've opened #2794 to track adding this back.

r? @locks
cc @thiagoarrais 
