### PR TITLE
Backfill GitHub organization IDs for teams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,9 @@ dependencies = [
  "log",
  "oauth2",
  "parking_lot",
+ "parse_link_header",
  "rand",
+ "regex",
  "reqwest",
  "scheduled-thread-pool",
  "semver 0.10.0",
@@ -1764,6 +1766,16 @@ dependencies = [
  "redox_syscall",
  "smallvec 1.4.2",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "parse_link_header"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b09f37bc2b55b5237baf3139b9e6304aea937baf38e8f43207b41cc3934b3a1"
+dependencies = [
+ "http 0.2.1",
+ "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,9 @@ license-exprs = "^1.4"
 log = "0.4"
 oauth2 = { version = "3.0.0", default-features = false, features = ["reqwest-010"] }
 parking_lot = "0.11"
+parse_link_header = "0.2.0"
 rand = "0.7"
+regex = "1.3.9"
 reqwest = { version = "0.10", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "0.2.0"
 semver = { version = "0.10", features = ["diesel", "serde"] }

--- a/src/bin/backfill-org-ids.rs
+++ b/src/bin/backfill-org-ids.rs
@@ -1,0 +1,119 @@
+// Queries GitHub and backfills organization IDs for all teams without one
+//
+// Usage:
+//      cargo run --bin backfill-org-ids
+
+#![warn(clippy::all, rust_2018_idioms)]
+
+use cargo_registry::{db, models::Team, schema::teams};
+
+use diesel::prelude::*;
+use regex::Regex;
+use reqwest::blocking::{Client, Response};
+use serde::Deserialize;
+use std::env;
+
+fn main() {
+    let conn = db::connect_now().unwrap();
+    let client = Client::new();
+    conn.transaction::<_, diesel::result::Error, _>(|| {
+        backfill_org_ids(&conn, &client);
+        Ok(())
+    })
+    .unwrap()
+}
+
+fn backfill_org_ids(conn: &PgConnection, client: &Client) {
+    let teams = teams::table
+        .filter(teams::org_id.is_null())
+        .load::<Team>(conn)
+        .unwrap();
+
+    let mut found = 0;
+    for team in &teams {
+        let option_org_id = query_for_org_id(client, team);
+        match option_org_id {
+            Some(org_id) => {
+                found += 1;
+                let update_result = diesel::update(teams::table)
+                    .filter(teams::github_id.eq(team.github_id))
+                    .set(teams::org_id.eq(org_id))
+                    .execute(conn);
+                if let Err(msg) = update_result {
+                    println!(
+                        "problem when updating record for team '{}': {}",
+                        team.login, msg
+                    );
+                }
+            }
+            None => println!("could not find org id for team '{}'", team.login),
+        }
+    }
+
+    println!(
+        "Recorded organization ids for {} of {} teams",
+        found,
+        teams.len()
+    );
+}
+
+fn query_for_org_id(client: &Client, team: &Team) -> Option<i32> {
+    query_using_team_id(client, team).or_else(|| query_using_org_name(client, team))
+}
+
+fn query_using_team_id(client: &Client, team: &Team) -> Option<i32> {
+    // GET https://api.github.com/teams/2874034
+    let res = github_http_get(
+        client,
+        &format!("https://api.github.com/teams/{}", team.github_id),
+    )?;
+
+    // HTTP/1.1 404 Not Found
+    // link: <https://docs.github.com/changes/2020-01-21-moving-the-team-api-endpoints/>; rel="deprecation"; type="text/html", <https://api.github.com/organizations/14631425/team/2874034>; rel="alternate"
+    let link = res.headers().get("Link")?.to_str().ok()?;
+    let links = parse_link_header::parse(link).ok()?;
+    let re = Regex::new(r"/organizations/(\d+)/team").ok()?;
+    let re_captures = re.captures(&links.get(&Some("alternate".into()))?.raw_uri)?;
+    let org_id_str = re_captures.get(1)?.as_str();
+    let org_id = i32::from_str_radix(&org_id_str, 10).ok()?;
+
+    if org_id == 0 {
+        None
+    } else {
+        Some(org_id)
+    }
+}
+
+fn query_using_org_name(client: &Client, team: &Team) -> Option<i32> {
+    let re = Regex::new(r":([^:]+):").unwrap();
+    let org_name = re.captures(&team.login)?.get(1)?.as_str();
+
+    // GET https://api.github.com/orgs/rust-lang-nursery
+    let res = github_http_get(client, &format!("https://api.github.com/orgs/{}", org_name))?;
+    if !res.status().is_success() {
+        return None;
+    }
+
+    #[derive(Deserialize)]
+    struct GithubOrganization {
+        id: i32,
+    }
+
+    let org = res.json::<GithubOrganization>().ok()?;
+
+    Some(org.id)
+}
+
+fn github_http_get(client: &Client, url: &str) -> Option<Response> {
+    let gh_client_id = env::var("GH_CLIENT_ID").expect("must set GH_CLIENT_ID");
+    let gh_client_secret = env::var("GH_CLIENT_SECRET").expect("must set GH_CLIENT_SECRET");
+
+    let resp_result = client
+        .get(url)
+        .header(reqwest::header::ACCEPT, "application/vnd.github.v3+json")
+        .header(reqwest::header::USER_AGENT, "crates.io (https://crates.io)")
+        .basic_auth(&gh_client_id, Some(&gh_client_secret))
+        .send();
+
+    resp_result.ok()
+}

--- a/src/bin/backfill-org-ids.rs
+++ b/src/bin/backfill-org-ids.rs
@@ -11,7 +11,7 @@ use diesel::prelude::*;
 use regex::Regex;
 use reqwest::blocking::{Client, Response};
 use serde::Deserialize;
-use std::env;
+use std::{env, thread, time};
 
 fn main() {
     let conn = db::connect_now().unwrap();
@@ -44,6 +44,7 @@ fn backfill_org_ids(conn: &PgConnection, client: &Client) {
             }
             None => println!("could not find org id for team '{}'", team.login),
         }
+        thread::sleep(time::Duration::from_secs(1));
     }
 
     println!(

--- a/src/bin/backfill-org-ids.rs
+++ b/src/bin/backfill-org-ids.rs
@@ -16,11 +16,7 @@ use std::env;
 fn main() {
     let conn = db::connect_now().unwrap();
     let client = Client::new();
-    conn.transaction::<_, diesel::result::Error, _>(|| {
-        backfill_org_ids(&conn, &client);
-        Ok(())
-    })
-    .unwrap()
+    backfill_org_ids(&conn, &client);
 }
 
 fn backfill_org_ids(conn: &PgConnection, client: &Client) {


### PR DESCRIPTION
~~_This builds upon https://github.com/rust-lang/crates.io/pull/2725. I've created multiple PRs for us to focus review on specific issues. Feel free to close the [previous one](https://github.com/rust-lang/crates.io/pull/2725) if you folks prefer to review this as one big PR instead._~~

I've added a small program for backfilling the current database with the organization IDs for the existing teams.

It goes over all the teams in the database that don't have an org id (assuming that #2725 has been online for some time) and tries to query the [`/teams/:team_id`][team_legacy_ep] endpoint. Failing that, it parses the org name from the `login` field and queries [`/orgs/:org_name`][org_ep]. For the first part, I took advantage of the fact that I described in https://github.com/rust-lang/crates.io/issues/2619#issuecomment-689668261 about the `Link` header in GitHub's API.

The GitHub API calls are intended to run with crates.io's credentials. This assumes those will be available at `GH_CLIENT_ID` and `GH_CLIENT_SECRET`. There is no rate limiting on the client side. We have (at the time of writing) ~300 org ids to query. Since the GitHub limit is 5000 calls per hour per app and all requests are sequential, I've assumed that we wouldn't need to buffer calls on the client.

**Questions:**

1. Is `src/bin` the right place to add this? I don't think so, but couldn't find a better one.
2. Do you folks think we should do some buffering on the requests?
3. I couldn't find how to add dependencies for this binary only and included `parse_link_header` and `regex` to `Cargo.toml`. Is that OK?
4. We can detect future GitHub deprecation notices via this `Link` header. Should we integrate this into the main app (as a future issue/PR) and trigger some kind of automated warning?

Related: #2619

[team_legacy_ep]: https://docs.github.com/en/rest/reference/teams#get-a-team-legacy
[org_ep]: https://docs.github.com/en/rest/reference/orgs#get-an-organization