### PR TITLE
models: Remove unnecessary transforms

### DIFF
--- a/app/models/api-token.js
+++ b/app/models/api-token.js
@@ -1,8 +1,8 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class ApiToken extends Model {
-  @attr('string') name;
-  @attr('string') token;
+  @attr name;
+  @attr token;
   @attr('date') created_at;
   @attr('date') last_used_at;
 }

--- a/app/models/category-slug.js
+++ b/app/models/category-slug.js
@@ -1,6 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class CategorySlug extends Model {
-  @attr('string') slug;
-  @attr('string') description;
+  @attr slug;
+  @attr description;
 }

--- a/app/models/category.js
+++ b/app/models/category.js
@@ -1,14 +1,14 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Category extends Model {
-  @attr('string') category;
-  @attr('string') slug;
-  @attr('string') description;
+  @attr category;
+  @attr slug;
+  @attr description;
   @attr('date') created_at;
-  @attr('number') crates_cnt;
+  @attr crates_cnt;
 
-  @attr() subcategories;
-  @attr() parent_categories;
+  @attr subcategories;
+  @attr parent_categories;
 
   @hasMany('crate', { async: true }) crates;
 }

--- a/app/models/crate-owner-invite.js
+++ b/app/models/crate-owner-invite.js
@@ -1,9 +1,9 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class CrateOwnerInvite extends Model {
-  @attr('string') invited_by_username;
-  @attr('string') crate_name;
-  @attr('number') crate_id;
+  @attr invited_by_username;
+  @attr crate_name;
+  @attr crate_id;
   @attr('date') created_at;
-  @attr('boolean', { defaultValue: false }) accepted;
+  @attr accepted;
 }

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -3,22 +3,22 @@ import Model, { attr, hasMany } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
 
 export default class Crate extends Model {
-  @attr('string') name;
-  @attr('number') downloads;
-  @attr('number') recent_downloads;
+  @attr name;
+  @attr downloads;
+  @attr recent_downloads;
   @attr('date') created_at;
   @attr('date') updated_at;
-  @attr('string') max_version;
-  @attr('string') newest_version;
+  @attr max_version;
+  @attr newest_version;
 
-  @attr('string') description;
-  @attr('string') homepage;
-  @attr('string') wiki;
-  @attr('string') mailing_list;
-  @attr('string') issues;
-  @attr('string') documentation;
-  @attr('string') repository;
-  @attr('boolean') exact_match;
+  @attr description;
+  @attr homepage;
+  @attr wiki;
+  @attr mailing_list;
+  @attr issues;
+  @attr documentation;
+  @attr repository;
+  @attr exact_match;
 
   @hasMany('versions', { async: true }) versions;
 

--- a/app/models/dependency.js
+++ b/app/models/dependency.js
@@ -5,13 +5,13 @@ import Inflector from 'ember-inflector';
 Inflector.inflector.irregular('dependency', 'dependencies');
 
 export default class Dependency extends Model {
-  @attr('string') crate_id;
-  @attr('string') req;
-  @attr('boolean') optional;
-  @attr('boolean') default_features;
+  @attr crate_id;
+  @attr req;
+  @attr optional;
+  @attr default_features;
   @attr({ defaultValue: () => [] }) features;
-  @attr('string') kind;
-  @attr('number') downloads;
+  @attr kind;
+  @attr downloads;
 
   @belongsTo('version', { async: false }) version;
 }

--- a/app/models/keyword.js
+++ b/app/models/keyword.js
@@ -1,9 +1,9 @@
 import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class Keyword extends Model {
-  @attr('string') keyword;
+  @attr keyword;
   @attr('date') created_at;
-  @attr('number') crates_cnt;
+  @attr crates_cnt;
 
   @hasMany('crate', { async: true }) crates;
 }

--- a/app/models/owned-crate.js
+++ b/app/models/owned-crate.js
@@ -1,6 +1,6 @@
 import Model, { attr } from '@ember-data/model';
 
 export default class OwnedCrate extends Model {
-  @attr('string') name;
-  @attr('boolean') email_notifications;
+  @attr name;
+  @attr email_notifications;
 }

--- a/app/models/team.js
+++ b/app/models/team.js
@@ -2,13 +2,13 @@ import Model, { attr } from '@ember-data/model';
 import { computed } from '@ember/object';
 
 export default class Team extends Model {
-  @attr('string') email;
-  @attr('string') name;
-  @attr('string') login;
-  @attr('string') api_token;
-  @attr('string') avatar;
-  @attr('string') url;
-  @attr('string') kind;
+  @attr email;
+  @attr name;
+  @attr login;
+  @attr api_token;
+  @attr avatar;
+  @attr url;
+  @attr kind;
 
   @computed('login', function () {
     let login = this.login;

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,14 +3,14 @@ import Model, { attr } from '@ember-data/model';
 import { memberAction } from 'ember-api-actions';
 
 export default class User extends Model {
-  @attr('string') email;
-  @attr('boolean') email_verified;
-  @attr('boolean') email_verification_sent;
-  @attr('string') name;
-  @attr('string') login;
-  @attr('string') avatar;
-  @attr('string') url;
-  @attr('string') kind;
+  @attr email;
+  @attr email_verified;
+  @attr email_verification_sent;
+  @attr name;
+  @attr login;
+  @attr avatar;
+  @attr url;
+  @attr kind;
 
   stats = memberAction({ type: 'GET', path: 'stats' });
 }

--- a/app/models/version-download.js
+++ b/app/models/version-download.js
@@ -1,7 +1,7 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class VersionDownload extends Model {
-  @attr('number') downloads;
+  @attr downloads;
   @attr('date') date;
 
   @belongsTo('version', { async: false }) version;

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -5,15 +5,15 @@ import { alias } from '@ember/object/computed';
 import { task } from 'ember-concurrency';
 
 export default class Version extends Model {
-  @attr('string') num;
-  @attr('string') dl_path;
-  @attr('string') readme_path;
+  @attr num;
+  @attr dl_path;
+  @attr readme_path;
   @attr('date') created_at;
   @attr('date') updated_at;
-  @attr('number') downloads;
-  @attr('boolean') yanked;
-  @attr('string') license;
-  @attr('number') crate_size;
+  @attr downloads;
+  @attr yanked;
+  @attr license;
+  @attr crate_size;
 
   @belongsTo('crate', { async: false }) crate;
 


### PR DESCRIPTION
These are only needed when API fields should be transformed from one type to another (e.g. from ISO8601 string to `Date`), but for the regular cases they don't need to be used.

r? @locks 