### PR TITLE
crate.version: Remove unnecessary `@query` from "Dependent crates" link

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -33,7 +33,7 @@
       <li><a href="{{this.crate.repository}}">Repository</a></li>
     {{/if}}
     <li>
-      <LinkTo @route="crate.reverse-dependencies" @query={{hash dependency=this.crate.crate_id}} data-test-reverse-deps-link>
+      <LinkTo @route="crate.reverse-dependencies" data-test-reverse-deps-link>
         Dependent crates
       </LinkTo>
     </li>


### PR DESCRIPTION
There is no `crate_id` on `this.crate`, so this was never quite working as intended. well... actually it was working as intended but not because of the `@query`... 😆 

r? @locks 