### PR TITLE
me.index: Remove unnecessary `created_at` assignment

### DIFF
--- a/app/controllers/me/index.js
+++ b/app/controllers/me/index.js
@@ -62,9 +62,7 @@ export default Controller.extend({
       this.setAllEmailNotifications(false);
     },
     startNewToken() {
-      this.store.createRecord('api-token', {
-        created_at: new Date(Date.now() + 2000),
-      });
+      this.store.createRecord('api-token');
     },
   },
 });


### PR DESCRIPTION
This attribute isn't read by the backend code, and there is no reason for us to explicitly set it.

r? @locks 