### PR TITLE
Convert remaining components to ES6 classes

### DIFF
--- a/app/components/api-token-row.js
+++ b/app/components/api-token-row.js
@@ -3,19 +3,20 @@ import { empty, or } from '@ember/object/computed';
 
 import { task } from 'ember-concurrency';
 
-export default Component.extend({
-  emptyName: empty('api_token.name'),
-  disableCreate: or('api_token.isSaving', 'emptyName'),
-  serverError: null,
+export default class ApiTokenRow extends Component {
+  @empty('api_token.name') emptyName;
+  @or('api_token.isSaving', 'emptyName') disableCreate;
+
+  serverError = null;
 
   didInsertElement() {
     let input = this.element.querySelector('input');
     if (input && input.focus) {
       input.focus();
     }
-  },
+  }
 
-  saveTokenTask: task(function* () {
+  @task(function* () {
     try {
       yield this.api_token.save();
       this.set('serverError', null);
@@ -28,9 +29,10 @@ export default Component.extend({
       }
       this.set('serverError', msg);
     }
-  }),
+  })
+  saveTokenTask;
 
-  revokeTokenTask: task(function* () {
+  @task(function* () {
     try {
       yield this.api_token.destroyRecord();
     } catch (err) {
@@ -42,5 +44,6 @@ export default Component.extend({
       }
       this.set('serverError', msg);
     }
-  }),
-});
+  })
+  revokeTokenTask;
+}

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,38 +1,44 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { empty } from '@ember/object/computed';
 
 import { task } from 'ember-concurrency';
 
 import ajax from '../utils/ajax';
 
-export default Component.extend({
-  tagName: '',
-  type: '',
-  value: '',
-  isEditing: false,
-  user: null,
-  disableSave: empty('user.email'),
-  notValidEmail: false,
-  prevEmail: '',
+export default class EmailInput extends Component {
+  tagName = '';
 
-  emailIsNull: computed('user.email', function () {
+  type = '';
+  value = '';
+  isEditing = false;
+  user = null;
+
+  @empty('user.email') disableSave;
+
+  notValidEmail = false;
+  prevEmail = '';
+
+  @computed('user.email')
+  get emailIsNull() {
     let email = this.get('user.email');
     return email == null;
-  }),
+  }
 
-  emailNotVerified: computed('user.{email,email_verified}', function () {
+  @computed('user.{email,email_verified}')
+  get emailNotVerified() {
     let email = this.get('user.email');
     let verified = this.get('user.email_verified');
 
     return email != null && !verified;
-  }),
+  }
 
-  isError: false,
-  emailError: '',
-  disableResend: false,
+  isError = false;
+  emailError = '';
+  disableResend = false;
 
-  resendButtonText: computed('disableResend', 'user.email_verification_sent', function () {
+  @computed('disableResend', 'user.email_verification_sent')
+  get resendButtonText() {
     if (this.disableResend) {
       return 'Sent!';
     } else if (this.get('user.email_verification_sent')) {
@@ -40,9 +46,9 @@ export default Component.extend({
     } else {
       return 'Send verification email';
     }
-  }),
+  }
 
-  resendEmailTask: task(function* () {
+  @task(function* () {
     let user = this.user;
 
     try {
@@ -57,62 +63,64 @@ export default Component.extend({
         this.set('emailError', 'Unknown error in resending message');
       }
     }
-  }),
+  })
+  resendEmailTask;
 
-  actions: {
-    editEmail() {
-      let email = this.value;
-      let isEmailNull = function (email) {
-        return email == null;
-      };
+  @action
+  editEmail() {
+    let email = this.value;
+    let isEmailNull = function (email) {
+      return email == null;
+    };
 
-      this.set('emailIsNull', isEmailNull(email));
-      this.set('isEditing', true);
-      this.set('prevEmail', this.value);
-    },
+    this.set('emailIsNull', isEmailNull(email));
+    this.set('isEditing', true);
+    this.set('prevEmail', this.value);
+  }
 
-    saveEmail() {
-      let userEmail = this.value;
-      let user = this.user;
+  @action
+  saveEmail() {
+    let userEmail = this.value;
+    let user = this.user;
 
-      let emailIsProperFormat = function (userEmail) {
-        let regExp = /^\S+@\S+\.\S+$/;
-        return regExp.test(userEmail);
-      };
+    let emailIsProperFormat = function (userEmail) {
+      let regExp = /^\S+@\S+\.\S+$/;
+      return regExp.test(userEmail);
+    };
 
-      if (!emailIsProperFormat(userEmail)) {
-        this.set('notValidEmail', true);
-        return;
-      }
+    if (!emailIsProperFormat(userEmail)) {
+      this.set('notValidEmail', true);
+      return;
+    }
 
-      user.set('email', userEmail);
-      user
-        .save()
-        .then(() => {
-          this.set('serverError', null);
-          this.set('user.email_verification_sent', true);
-          this.set('user.email_verified', false);
-        })
-        .catch(err => {
-          let msg;
-          if (err.errors && err.errors[0] && err.errors[0].detail) {
-            msg = `An error occurred while saving this email, ${err.errors[0].detail}`;
-          } else {
-            msg = 'An unknown error occurred while saving this email.';
-          }
-          this.set('serverError', msg);
-          this.set('isError', true);
-          this.set('emailError', `Error in saving email: ${msg}`);
-        });
+    user.set('email', userEmail);
+    user
+      .save()
+      .then(() => {
+        this.set('serverError', null);
+        this.set('user.email_verification_sent', true);
+        this.set('user.email_verified', false);
+      })
+      .catch(err => {
+        let msg;
+        if (err.errors && err.errors[0] && err.errors[0].detail) {
+          msg = `An error occurred while saving this email, ${err.errors[0].detail}`;
+        } else {
+          msg = 'An unknown error occurred while saving this email.';
+        }
+        this.set('serverError', msg);
+        this.set('isError', true);
+        this.set('emailError', `Error in saving email: ${msg}`);
+      });
 
-      this.set('isEditing', false);
-      this.set('notValidEmail', false);
-      this.set('disableResend', false);
-    },
+    this.set('isEditing', false);
+    this.set('notValidEmail', false);
+    this.set('disableResend', false);
+  }
 
-    cancelEdit() {
-      this.set('isEditing', false);
-      this.set('value', this.prevEmail);
-    },
-  },
-});
+  @action
+  cancelEdit() {
+    this.set('isEditing', false);
+    this.set('value', this.prevEmail);
+  }
+}

--- a/app/components/owned-crate-row.js
+++ b/app/components/owned-crate-row.js
@@ -1,19 +1,21 @@
 import Component from '@ember/component';
-import { computed } from '@ember/object';
+import { action, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 
-export default Component.extend({
-  tagName: '',
+export default class OwnedCrateRow extends Component {
+  tagName = '';
 
-  name: alias('ownedCrate.name'),
-  controlId: computed('ownedCrate.id', function () {
+  @alias('ownedCrate.name') name;
+
+  @computed('ownedCrate.id')
+  get controlId() {
     return `${this.ownedCrate.id}-email-notifications`;
-  }),
-  emailNotifications: alias('ownedCrate.email_notifications'),
+  }
 
-  actions: {
-    toggleEmailNotifications() {
-      this.set('emailNotifications', !this.emailNotifications);
-    },
-  },
-});
+  @alias('ownedCrate.email_notifications') emailNotifications;
+
+  @action
+  toggleEmailNotifications() {
+    this.set('emailNotifications', !this.emailNotifications);
+  }
+}

--- a/app/components/pending-owner-invite-row.js
+++ b/app/components/pending-owner-invite-row.js
@@ -2,14 +2,15 @@ import Component from '@ember/component';
 
 import { task } from 'ember-concurrency';
 
-export default Component.extend({
-  tagName: '',
-  isAccepted: false,
-  isDeclined: false,
-  isError: false,
-  inviteError: 'default error message',
+export default class PendingOwnerInviteRow extends Component {
+  tagName = '';
 
-  acceptInvitationTask: task(function* () {
+  isAccepted = false;
+  isDeclined = false;
+  isError = false;
+  inviteError = 'default error message';
+
+  @task(function* () {
     this.invite.set('accepted', true);
 
     try {
@@ -23,9 +24,10 @@ export default Component.extend({
         this.set('inviteError', 'Error in accepting invite');
       }
     }
-  }),
+  })
+  acceptInvitationTask;
 
-  declineInvitationTask: task(function* () {
+  @task(function* () {
     this.invite.set('accepted', false);
 
     try {
@@ -39,5 +41,6 @@ export default Component.extend({
         this.set('inviteError', 'Error in declining invite');
       }
     }
-  }),
-});
+  })
+  declineInvitationTask;
+}


### PR DESCRIPTION
This PR ports the remaining files using `Component.extend({...})` to use `class ... extends Component { ... }` instead.

r? @locks 