### PR TITLE
Add os::freebsd-apis category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -355,6 +355,12 @@ description = """
 Bindings to Linux-specific APIs.\
 """
 
+[os.categories.freebsd-apis]
+name = "FreeBSD APIs"
+description = """
+Bindings to FreeBSD-specific APIs.\
+"""
+
 [os.categories.macos-apis]
 name = "macOS APIs"
 description = """


### PR DESCRIPTION
Added category for FreeBSD APIs: `os::freebsd-apis`