### PR TITLE
Fix error handling for errors without an `errors` property

### DIFF
--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -21,10 +21,12 @@ export default Route.extend({
 
       return { crates, team };
     } catch (e) {
-      if (e.errors.some(e => e.detail === 'Not Found')) {
+      if (e.errors?.some(e => e.detail === 'Not Found')) {
         this.notifications.error(`Team '${params.team_id}' does not exist`);
         return this.replaceWith('index');
       }
+
+      throw e;
     }
   },
 });

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -20,10 +20,12 @@ export default Route.extend({
 
       return { crates, user };
     } catch (e) {
-      if (e.errors.some(e => e.detail === 'Not Found')) {
+      if (e.errors?.some(e => e.detail === 'Not Found')) {
         this.notifications.error(`User '${params.user_id}' does not exist`);
         return this.replaceWith('index');
       }
+
+      throw e;
     }
   },
 });


### PR DESCRIPTION
These error handlers should just rethrow the original error if no `errors` propery exists.

r? @locks 