### PR TITLE
Remove unnecessary `eslint-env` declarations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
         '.eslintrc.js',
         '.template-lintrc.js',
         'ember-cli-build.js',
+        'fastboot.js',
         'testem.js',
         'blueprints/*/index.js',
         'config/**/*.js',

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,7 +1,5 @@
 'use strict';
 
-/* eslint-env node */
-
 module.exports = {
   extends: 'octane',
 

--- a/fastboot.js
+++ b/fastboot.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 'use strict';
 
 // because fastboot-app-server uses cluster, but it might change in future


### PR DESCRIPTION
Instead we'll use the `overrides` feature of ESLint

r? @locks 