### PR TITLE
ApiTokenRow: Replace custom error display with notification

### DIFF
--- a/app/components/api-token-row.hbs
+++ b/app/components/api-token-row.hbs
@@ -59,14 +59,6 @@
   </div>
 </div>
 
-{{#if this.serverError}}
-  <div local-class="row error" data-test-error>
-    <div>
-      {{ this.serverError }}
-    </div>
-  </div>
-{{/if}}
-
 {{#if @token.token}}
   <div local-class="row new-token" data-test-token>
     <div>

--- a/app/components/api-token-row.js
+++ b/app/components/api-token-row.js
@@ -1,18 +1,18 @@
 import Component from '@ember/component';
 import { empty, or } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
 
 export default class ApiTokenRow extends Component {
+  @service notifications;
+
   @empty('token.name') emptyName;
   @or('token.isSaving', 'emptyName') disableCreate;
-
-  serverError = null;
 
   @task(function* () {
     try {
       yield this.token.save();
-      this.set('serverError', null);
     } catch (err) {
       let msg;
       if (err.errors && err.errors[0] && err.errors[0].detail) {
@@ -20,7 +20,7 @@ export default class ApiTokenRow extends Component {
       } else {
         msg = 'An unknown error occurred while saving this token';
       }
-      this.set('serverError', msg);
+      this.notifications.error(msg);
     }
   })
   saveTokenTask;
@@ -35,7 +35,7 @@ export default class ApiTokenRow extends Component {
       } else {
         msg = 'An unknown error occurred while revoking this token';
       }
-      this.set('serverError', msg);
+      this.notifications.error(msg);
     }
   })
   revokeTokenTask;

--- a/app/components/api-token-row.module.css
+++ b/app/components/api-token-row.module.css
@@ -64,10 +64,3 @@
     flex-direction: column;
     justify-content: stretch;
 }
-
-.error {
-    border-top-width: 0;
-    font-weight: bold;
-    color: rgb(216, 0, 41);
-    padding: 0 10px 10px 20px;
-}

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -94,7 +94,7 @@ module('Acceptance | api-tokens', function (hooks) {
     assert.dom('[data-test-api-token]').exists({ count: 2 });
     assert.dom('[data-test-api-token="2"]').exists();
     assert.dom('[data-test-api-token="1"]').exists();
-    assert.dom('[data-test-error]').includesText('An error occurred while revoking this token');
+    assert.dom('[data-test-notification-message="error"]').includesText('An error occurred while revoking this token');
   });
 
   test('new API tokens can be created', async function (assert) {


### PR DESCRIPTION
This changes API token creation or revocation errors to use the regular notification system instead of displaying in a custom way.

r? @locks 