### PR TITLE
Refactor login code to use `postMessage()` instead of polling loop

### DIFF
--- a/app/routes/github-authorize.js
+++ b/app/routes/github-authorize.js
@@ -22,14 +22,12 @@ export default Route.extend({
       let { code, state } = transition.to.queryParams;
       let resp = await fetch(`/api/private/session/authorize?code=${code}&state=${state}`);
       let json = await resp.json();
-      let item = JSON.stringify({ ok: resp.ok, data: json });
       if (window.opener) {
-        window.opener.github_response = item;
+        window.opener.postMessage({ ok: resp.ok, data: json }, window.location.origin);
       }
     } catch (d) {
-      let item = JSON.stringify({ ok: false, data: d });
       if (window.opener) {
-        window.opener.github_response = item;
+        window.opener.postMessage({ ok: false, data: d }, window.location.origin);
       }
     } finally {
       window.close();

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -12,9 +12,9 @@ import * as localStorage from '../utils/local-storage';
  *
  * @see `github-authorize` route
  */
-export default Route.extend({
-  notifications: service(),
-  session: service(),
+export default class LoginRoute extends Route {
+  @service notifications;
+  @service session;
 
   beforeModel(transition) {
     localStorage.removeItem('github_response');
@@ -67,5 +67,5 @@ export default Route.extend({
     }, 200);
 
     transition.abort();
-  },
-});
+  }
+}

--- a/tests/bugs/2329-test.js
+++ b/tests/bugs/2329-test.js
@@ -35,7 +35,7 @@ module('Bug #2329', function (hooks) {
 
     this.server.get('/api/v1/me/tokens', { api_tokens: [] });
 
-    let fakeWindow = { closed: false };
+    let fakeWindow = {};
     window.open = () => fakeWindow;
 
     // 1. Sign out.
@@ -53,10 +53,7 @@ module('Bug #2329', function (hooks) {
     // 5. Complete the authentication workflow if necessary.
 
     // simulate the response from the `github-authorize` route
-    window.github_response = JSON.stringify({ ok: true, data: { user } });
-
-    // simulate that the window has been closed by the `github-authorize` route
-    fakeWindow.closed = true;
+    window.postMessage({ ok: true, data: { user } }, window.location.origin);
 
     // wait for the user menu to show up after the successful login
     await waitFor('[data-test-user-menu]');


### PR DESCRIPTION
I got nerd-sniped by the following comment in the codebase:

> For the life of me I cannot figure out how to do this other than polling

This PR simplifies the implementation and now uses the recommended way to communicate between parent and child window: `window.postMessage()`

see https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage for more information

r? @jtgeibel 