### PR TITLE
README: Remove broken "What's Deployed" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # crates.io
 
-[![What's Deployed](https://img.shields.io/badge/whatsdeployed-prod-green.svg)](https://whatsdeployed.io/s-9IG)
-
 Source code for the default [Cargo](http://doc.crates.io) registry. Viewable
 online at [crates.io](https://crates.io).
 


### PR DESCRIPTION
This page only shows "HTTPError" so the value that this badge brings is currently rather questionable 😉

r? @jtgeibel 