### PR TITLE
Add "Email Change" acceptance tests

### DIFF
--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -1,6 +1,6 @@
 <div ...attributes>
   {{#if this.emailIsNull }}
-    <div local-class="friendly-message">
+    <div local-class="friendly-message" data-test-no-email>
       <p>
         Please add your email address. We will only use
         it to contact you about your account. We promise we'll never share it!
@@ -14,15 +14,38 @@
         <dt>Email</dt>
       </div>
       <form local-class="email-form" {{action 'saveEmail' on='submit'}}>
-        <Input @type={{this.type}} @value={{this.value}} placeholder="Email" local-class="input" />
+        <Input
+          @type={{this.type}}
+          @value={{this.value}}
+          placeholder="Email"
+          local-class="input"
+          data-test-input
+        />
+
         {{#if this.notValidEmail }}
-          <div>
+          <div data-test-invalid-email-warning>
             <p>Whoops, that email format is invalid</p>
           </div>
         {{/if}}
+
         <div local-class="actions">
-          <button type='submit' local-class="save-button" disabled={{this.disableSave}}>Save</button>
-          <button type="button" local-class="cancel-button" {{action 'cancelEdit'}}>Cancel</button>
+          <button
+            type='submit'
+            local-class="save-button"
+            disabled={{this.disableSave}}
+            data-test-save-button
+          >
+            Save
+          </button>
+
+          <button
+            type="button"
+            local-class="cancel-button"
+            data-test-cancel-button
+            {{action 'cancelEdit'}}
+          >
+            Cancel
+          </button>
         </div>
       </form>
     </div>
@@ -31,28 +54,41 @@
       <div local-class="label">
         <dt>Email</dt>
       </div>
-      <div local-class="email-column">
+      <div local-class="email-column" data-test-email-address>
         <dd>
           {{ this.user.email }}
           {{#if this.user.email_verified}}
-            <span local-class="verified">Verified!</span>
+            <span local-class="verified" data-test-verified>Verified!</span>
           {{/if}}
         </dd>
       </div>
       <div local-class="actions">
-        <button type="button" local-class="edit-button" {{action 'editEmail'}}>Edit</button>
+        <button
+          type="button"
+          local-class="edit-button"
+          data-test-edit-button
+          {{action 'editEmail'}}
+        >
+          Edit
+        </button>
       </div>
     </div>
     {{#if this.emailNotVerified }}
       <div local-class="row">
         <div local-class="label">
           {{#if this.user.email_verification_sent}}
-            <p>We have sent a verification email to your address.</p>
+            <p data-test-verification-sent>We have sent a verification email to your address.</p>
           {{/if}}
-          <p>Your email has not yet been verified.</p>
+          <p data-test-not-verified>Your email has not yet been verified.</p>
         </div>
         <div local-class="actions">
-          <button type="button" local-class="resend-button" {{action (perform this.resendEmailTask)}} disabled={{this.disableResend}}>
+          <button
+            type="button"
+            local-class="resend-button"
+            {{action (perform this.resendEmailTask)}}
+            disabled={{this.disableResend}}
+            data-test-resend-button
+          >
             {{this.resendButtonText}}
           </button>
         </div>
@@ -61,7 +97,7 @@
     {{#if this.isError}}
       <div local-class="row">
         <div local-class="label">
-          <p>{{this.emailError}}</p>
+          <p data-test-error>{{this.emailError}}</p>
         </div>
       </div>
     {{/if}}

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -108,6 +108,7 @@ export default class EmailInput extends Component {
         } else {
           msg = 'An unknown error occurred while saving this email.';
         }
+        user.set('email', this.prevEmail);
         this.set('serverError', msg);
         this.set('isError', true);
         this.set('emailError', `Error in saving email: ${msg}`);

--- a/app/templates/me/index.hbs
+++ b/app/templates/me/index.hbs
@@ -19,7 +19,12 @@
 
 <div local-class="me-email">
   <h2>User Email</h2>
-  <EmailInput @type="email" @value={{this.model.user.email}} @user={{this.model.user}} />
+  <EmailInput
+    @type="email"
+    @value={{this.model.user.email}}
+    @user={{this.model.user}}
+    data-test-email-input
+  />
 </div>
 
 <form local-class="me-email-notifications" {{ action 'saveEmailNotifications' on='submit' }} >

--- a/mirage/factories/user.js
+++ b/mirage/factories/user.js
@@ -24,7 +24,7 @@ export default Factory.extend({
 
   afterCreate(model) {
     if (model.emailVerified === null) {
-      model.update({ emailVerified: !model.emailVerificationToken });
+      model.update({ emailVerified: model.email && !model.emailVerificationToken });
     }
   },
 });

--- a/mirage/route-handlers/users.js
+++ b/mirage/route-handlers/users.js
@@ -38,4 +38,21 @@ export function register(server) {
 
     return { ok: true };
   });
+
+  server.put('/api/v1/users/:user_id/resend', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      // unfortunately, it's hard to tell from the Rust code if this is the correct response
+      // in this case, but since it's used elsewhere I will assume for now that it's correct.
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
+    if (user.id !== request.params.user_id) {
+      return new Response(400, {}, { errors: [{ detail: 'current user does not match requested user' }] });
+    }
+
+    // let's pretend that we're sending an email here... :D
+
+    return { ok: true };
+  });
 }

--- a/mirage/route-handlers/users.js
+++ b/mirage/route-handlers/users.js
@@ -1,3 +1,6 @@
+import { Response } from 'ember-cli-mirage';
+
+import { getSession } from '../utils/session';
 import { notFound } from './-utils';
 
 export function register(server) {
@@ -5,5 +8,34 @@ export function register(server) {
     let login = request.params.user_id;
     let user = schema.users.findBy({ login });
     return user ? user : notFound();
+  });
+
+  server.put('/api/v1/users/:user_id', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      // unfortunately, it's hard to tell from the Rust code if this is the correct response
+      // in this case, but since it's used elsewhere I will assume for now that it's correct.
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
+    if (user.id !== request.params.user_id) {
+      return new Response(400, {}, { errors: [{ detail: 'current user does not match requested user' }] });
+    }
+
+    let json = JSON.parse(request.requestBody);
+    if (!json || !json.user || !('email' in json.user)) {
+      return new Response(400, {}, { errors: [{ detail: 'invalid json request' }] });
+    }
+    if (!json.user.email) {
+      return new Response(400, {}, { errors: [{ detail: 'empty email rejected' }] });
+    }
+
+    user.update({
+      email: json.user.email,
+      emailVerified: false,
+      emailVerificationToken: 'secret123',
+    });
+
+    return { ok: true };
   });
 }

--- a/tests/acceptance/email-change-test.js
+++ b/tests/acceptance/email-change-test.js
@@ -1,0 +1,191 @@
+import { click, currentURL, fillIn } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from '../helpers/setup-mirage';
+import { visit } from '../helpers/visit-ignoring-abort';
+
+module('Acceptance | Email Change', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('happy path', async function (assert) {
+    let user = this.server.create('user', { email: 'old@email.com' });
+
+    this.authenticateAs(user);
+
+    await visit('/me');
+    assert.equal(currentURL(), '/me');
+    assert.dom('[data-test-email-input]').exists();
+    assert.dom('[data-test-email-input] [data-test-no-email]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-email-address]').includesText('old@email.com');
+    assert.dom('[data-test-email-input] [data-test-verified]').exists();
+    assert.dom('[data-test-email-input] [data-test-not-verified]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-verification-sent]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-resend-button]').doesNotExist();
+
+    await click('[data-test-email-input] [data-test-edit-button]');
+    assert.dom('[data-test-email-input] [data-test-input]').hasValue('old@email.com');
+    assert.dom('[data-test-email-input] [data-test-save-button]').isEnabled();
+    assert.dom('[data-test-email-input] [data-test-cancel-button]').isEnabled();
+
+    await fillIn('[data-test-email-input] [data-test-input]', '');
+    assert.dom('[data-test-email-input] [data-test-input]').hasValue('');
+    assert.dom('[data-test-email-input] [data-test-save-button]').isDisabled();
+
+    await fillIn('[data-test-email-input] [data-test-input]', 'new@email.com');
+    assert.dom('[data-test-email-input] [data-test-input]').hasValue('new@email.com');
+    assert.dom('[data-test-email-input] [data-test-save-button]').isEnabled();
+
+    await click('[data-test-email-input] [data-test-save-button]');
+    assert.dom('[data-test-email-input] [data-test-email-address]').includesText('new@email.com');
+    assert.dom('[data-test-email-input] [data-test-verified]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-not-verified]').exists();
+    assert.dom('[data-test-email-input] [data-test-verification-sent]').exists();
+    assert.dom('[data-test-email-input] [data-test-resend-button]').isEnabled();
+
+    user.reload();
+    assert.strictEqual(user.email, 'new@email.com');
+    assert.strictEqual(user.emailVerified, false);
+    assert.ok(user.emailVerificationToken);
+  });
+
+  test('happy path with `email: null`', async function (assert) {
+    let user = this.server.create('user', { email: undefined });
+
+    this.authenticateAs(user);
+
+    await visit('/me');
+    assert.equal(currentURL(), '/me');
+    assert.dom('[data-test-email-input]').exists();
+    assert.dom('[data-test-email-input] [data-test-no-email]').exists();
+    assert.dom('[data-test-email-input] [data-test-email-address]').hasText('');
+    assert.dom('[data-test-email-input] [data-test-not-verified]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-verification-sent]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-resend-button]').doesNotExist();
+
+    await click('[data-test-email-input] [data-test-edit-button]');
+    assert.dom('[data-test-email-input] [data-test-input]').hasValue('');
+    assert.dom('[data-test-email-input] [data-test-save-button]').isDisabled();
+    assert.dom('[data-test-email-input] [data-test-cancel-button]').isEnabled();
+
+    await fillIn('[data-test-email-input] [data-test-input]', 'new@email.com');
+    assert.dom('[data-test-email-input] [data-test-input]').hasValue('new@email.com');
+    assert.dom('[data-test-email-input] [data-test-save-button]').isEnabled();
+
+    await click('[data-test-email-input] [data-test-save-button]');
+    assert.dom('[data-test-email-input] [data-test-email-address]').includesText('new@email.com');
+    assert.dom('[data-test-email-input] [data-test-verified]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-not-verified]').exists();
+    assert.dom('[data-test-email-input] [data-test-verification-sent]').exists();
+    assert.dom('[data-test-email-input] [data-test-resend-button]').isEnabled();
+
+    user.reload();
+    assert.strictEqual(user.email, 'new@email.com');
+    assert.strictEqual(user.emailVerified, false);
+    assert.ok(user.emailVerificationToken);
+  });
+
+  test('invalid email address', async function (assert) {
+    let user = this.server.create('user', { email: 'old@email.com' });
+
+    this.authenticateAs(user);
+
+    await visit('/me');
+    await click('[data-test-email-input] [data-test-edit-button]');
+    await fillIn('[data-test-email-input] [data-test-input]', 'foo@bar');
+    assert.dom('[data-test-email-input] [data-test-invalid-email-warning]').doesNotExist();
+
+    await click('[data-test-email-input] [data-test-save-button]');
+    assert.dom('[data-test-email-input] [data-test-invalid-email-warning]').exists();
+  });
+
+  test('cancel button', async function (assert) {
+    let user = this.server.create('user', { email: 'old@email.com' });
+
+    this.authenticateAs(user);
+
+    await visit('/me');
+    await click('[data-test-email-input] [data-test-edit-button]');
+    await fillIn('[data-test-email-input] [data-test-input]', 'new@email.com');
+    assert.dom('[data-test-email-input] [data-test-invalid-email-warning]').doesNotExist();
+
+    await click('[data-test-email-input] [data-test-cancel-button]');
+    assert.dom('[data-test-email-input] [data-test-email-address]').includesText('old@email.com');
+    assert.dom('[data-test-email-input] [data-test-verified]').exists();
+    assert.dom('[data-test-email-input] [data-test-not-verified]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-verification-sent]').doesNotExist();
+
+    user.reload();
+    assert.strictEqual(user.email, 'old@email.com');
+    assert.strictEqual(user.emailVerified, true);
+    assert.notOk(user.emailVerificationToken);
+  });
+
+  test('server error', async function (assert) {
+    let user = this.server.create('user', { email: 'old@email.com' });
+
+    this.authenticateAs(user);
+
+    this.server.put('/api/v1/users/:user_id', {}, 500);
+
+    await visit('/me');
+    await click('[data-test-email-input] [data-test-edit-button]');
+    await fillIn('[data-test-email-input] [data-test-input]', 'new@email.com');
+
+    await click('[data-test-email-input] [data-test-save-button]');
+    assert.dom('[data-test-email-input] [data-test-email-address]').includesText('old@email.com');
+    assert.dom('[data-test-email-input] [data-test-verified]').exists();
+    assert.dom('[data-test-email-input] [data-test-not-verified]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-verification-sent]').doesNotExist();
+    assert
+      .dom('[data-test-email-input] [data-test-error]')
+      .includesText('Error in saving email: An error occurred while saving this email');
+
+    user.reload();
+    assert.strictEqual(user.email, 'old@email.com');
+    assert.strictEqual(user.emailVerified, true);
+    assert.notOk(user.emailVerificationToken);
+  });
+
+  module('Resend button', function () {
+    test('happy path', async function (assert) {
+      let user = this.server.create('user', { email: 'john@doe.com', emailVerificationToken: 'secret123' });
+
+      this.authenticateAs(user);
+
+      await visit('/me');
+      assert.equal(currentURL(), '/me');
+      assert.dom('[data-test-email-input]').exists();
+      assert.dom('[data-test-email-input] [data-test-email-address]').includesText('john@doe.com');
+      assert.dom('[data-test-email-input] [data-test-verified]').doesNotExist();
+      assert.dom('[data-test-email-input] [data-test-not-verified]').exists();
+      assert.dom('[data-test-email-input] [data-test-verification-sent]').exists();
+      assert.dom('[data-test-email-input] [data-test-resend-button]').isEnabled().hasText('Resend');
+
+      await click('[data-test-email-input] [data-test-resend-button]');
+      assert.dom('[data-test-email-input] [data-test-resend-button]').isDisabled().hasText('Sent!');
+    });
+
+    test('server error', async function (assert) {
+      let user = this.server.create('user', { email: 'john@doe.com', emailVerificationToken: 'secret123' });
+
+      this.authenticateAs(user);
+
+      this.server.put('/api/v1/users/:user_id/resend', {}, 500);
+
+      await visit('/me');
+      assert.equal(currentURL(), '/me');
+      assert.dom('[data-test-email-input]').exists();
+      assert.dom('[data-test-email-input] [data-test-email-address]').includesText('john@doe.com');
+      assert.dom('[data-test-email-input] [data-test-verified]').doesNotExist();
+      assert.dom('[data-test-email-input] [data-test-not-verified]').exists();
+      assert.dom('[data-test-email-input] [data-test-verification-sent]').exists();
+      assert.dom('[data-test-email-input] [data-test-resend-button]').isEnabled().hasText('Resend');
+
+      await click('[data-test-email-input] [data-test-resend-button]');
+      assert.dom('[data-test-email-input] [data-test-resend-button]').isEnabled().hasText('Resend');
+      assert.dom('[data-test-email-input] [data-test-error]').hasText('Unknown error in resending message');
+    });
+  });
+});

--- a/tests/mirage/users-test.js
+++ b/tests/mirage/users-test.js
@@ -114,4 +114,38 @@ module('Mirage | Users', function (hooks) {
       assert.strictEqual(user.email, 'old@email.com');
     });
   });
+
+  module('PUT /api/v1/users/:id/resend', function () {
+    test('returns `ok`', async function (assert) {
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      let response = await fetch(`/api/v1/users/${user.id}/resend`, { method: 'PUT' });
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { ok: true });
+    });
+
+    test('returns 403 when not logged in', async function (assert) {
+      let user = this.server.create('user');
+
+      let response = await fetch(`/api/v1/users/${user.id}/resend`, { method: 'PUT' });
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    });
+
+    test('returns 400 when requesting the wrong user id', async function (assert) {
+      let user = this.server.create('user');
+      this.server.create('mirage-session', { user });
+
+      let response = await fetch(`/api/v1/users/wrong-id/resend`, { method: 'PUT' });
+      assert.equal(response.status, 400);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'current user does not match requested user' }] });
+    });
+  });
 });

--- a/tests/mirage/users-test.js
+++ b/tests/mirage/users-test.js
@@ -36,4 +36,82 @@ module('Mirage | Users', function (hooks) {
       });
     });
   });
+
+  module('PUT /api/v1/users/:id', function () {
+    test('updates the user with a new email address', async function (assert) {
+      let user = this.server.create('user', { email: 'old@email.com' });
+      this.server.create('mirage-session', { user });
+
+      let body = JSON.stringify({ user: { email: 'new@email.com' } });
+      let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { ok: true });
+
+      user.reload();
+      assert.strictEqual(user.email, 'new@email.com');
+      assert.strictEqual(user.emailVerified, false);
+      assert.strictEqual(user.emailVerificationToken, 'secret123');
+    });
+
+    test('returns 403 when not logged in', async function (assert) {
+      let user = this.server.create('user', { email: 'old@email.com' });
+
+      let body = JSON.stringify({ user: { email: 'new@email.com' } });
+      let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
+      assert.equal(response.status, 403);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'must be logged in to perform that action' }] });
+
+      user.reload();
+      assert.strictEqual(user.email, 'old@email.com');
+    });
+
+    test('returns 400 when requesting the wrong user id', async function (assert) {
+      let user = this.server.create('user', { email: 'old@email.com' });
+      this.server.create('mirage-session', { user });
+
+      let body = JSON.stringify({ user: { email: 'new@email.com' } });
+      let response = await fetch(`/api/v1/users/wrong-id`, { method: 'PUT', body });
+      assert.equal(response.status, 400);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'current user does not match requested user' }] });
+
+      user.reload();
+      assert.strictEqual(user.email, 'old@email.com');
+    });
+
+    test('returns 400 when sending an invalid payload', async function (assert) {
+      let user = this.server.create('user', { email: 'old@email.com' });
+      this.server.create('mirage-session', { user });
+
+      let body = JSON.stringify({});
+      let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
+      assert.equal(response.status, 400);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'invalid json request' }] });
+
+      user.reload();
+      assert.strictEqual(user.email, 'old@email.com');
+    });
+
+    test('returns 400 when sending an empty email address', async function (assert) {
+      let user = this.server.create('user', { email: 'old@email.com' });
+      this.server.create('mirage-session', { user });
+
+      let body = JSON.stringify({ user: { email: '' } });
+      let response = await fetch(`/api/v1/users/${user.id}`, { method: 'PUT', body });
+      assert.equal(response.status, 400);
+
+      let responsePayload = await response.json();
+      assert.deepEqual(responsePayload, { errors: [{ detail: 'empty email rejected' }] });
+
+      user.reload();
+      assert.strictEqual(user.email, 'old@email.com');
+    });
+  });
 });


### PR DESCRIPTION
This PR also includes a small bugfix that resets the `email` property of the user back to its original value in case the request fails.

r? @locks 