### PR TITLE
fix: prevent yarn usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
   },
   "engines": {
     "node": "^12.9.1",
-    "npm": "^6.10.2"
+    "npm": "^6.10.2",
+    "yarn": "please_use_npm"
   }
 }


### PR DESCRIPTION
- prevent to use yarn instead of npm
- these days, many people use yarn, so it can be possible to make a mistake to use yarn instead of npm
- in order to avoid the annoying mistake, I created this PR.