### PR TITLE
test: add more tests for format-num

### DIFF
--- a/tests/unit/helpers/format-num-test.js
+++ b/tests/unit/helpers/format-num-test.js
@@ -6,6 +6,8 @@ module('Unit | Helper | format-num', function () {
   test('it works', function (assert) {
     assert.equal(formatNum(42), '42');
     assert.equal(formatNum(0), '0');
+    assert.equal(formatNum(0.2), '0.2');
     assert.equal(formatNum(1000), '1,000');
+    assert.equal(formatNum(1000000), '1,000,000');
   });
 });


### PR DESCRIPTION
- added more tests for format-num
- currently format-num test does not cover larger values and decimal values. 
- Some countries, such as India use this format `12,34,567`. However, we want to use the format like `1,234,567`. 
- That's why I added a larger value test.
