### PR TITLE
Use notification service for the email notification success message

### DIFF
--- a/app/routes/confirm.js
+++ b/app/routes/confirm.js
@@ -19,14 +19,16 @@ export default Route.extend({
       if (this.session.currentUser) {
         this.store.pushPayload({ user: { id: this.session.currentUser.id, email_verified: true } });
       }
+
+      this.notifications.success('Thank you for confirming your email! :)');
     } catch (error) {
       if (error.errors) {
         this.notifications.error(`Error in email confirmation: ${error.errors[0].detail}`);
-        return this.replaceWith('index');
       } else {
         this.notifications.error(`Unknown error in email confirmation`);
-        return this.replaceWith('index');
       }
     }
+
+    this.replaceWith('index');
   },
 });

--- a/app/templates/confirm.hbs
+++ b/app/templates/confirm.hbs
@@ -1,1 +1,0 @@
-<h1 data-test-success-message>Thank you for confirming your email! :)</h1>

--- a/tests/acceptance/email-confirmation-test.js
+++ b/tests/acceptance/email-confirmation-test.js
@@ -14,8 +14,8 @@ module('Acceptance | Email Confirmation', function (hooks) {
     assert.strictEqual(user.emailVerified, false);
 
     await visit('/confirm/badc0ffee');
-    assert.equal(currentURL(), '/confirm/badc0ffee');
-    assert.dom('[data-test-success-message]').exists();
+    assert.equal(currentURL(), '/');
+    assert.dom('[data-test-notification-message="success"]').exists();
 
     user.reload();
     assert.strictEqual(user.emailVerified, true);
@@ -28,8 +28,8 @@ module('Acceptance | Email Confirmation', function (hooks) {
     this.authenticateAs(user);
 
     await visit('/confirm/badc0ffee');
-    assert.equal(currentURL(), '/confirm/badc0ffee');
-    assert.dom('[data-test-success-message]').exists();
+    assert.equal(currentURL(), '/');
+    assert.dom('[data-test-notification-message="success"]').exists();
 
     let { currentUser } = this.owner.lookup('service:session');
     assert.strictEqual(currentUser.email_verified, true);


### PR DESCRIPTION
The `confirm` route previously only contained a single sentence and the layout looked a little broken. This PR changes the route to redirect back to the frontpage and show a success notification using our regular notification system.

<img width="884" alt="Bildschirmfoto 2020-10-02 um 09 31 14" src="https://user-images.githubusercontent.com/141300/94898558-0d4fc500-0492-11eb-894e-c3fdcf1d91c0.png">

r? @locks 