### PR TITLE
helpers/format-num: Format numbers in the user's preferred locale

### DIFF
--- a/app/helpers/format-num.js
+++ b/app/helpers/format-num.js
@@ -1,8 +1,13 @@
 import { helper } from '@ember/component/helper';
 
-const numberFormat = new Intl.NumberFormat('en');
+import window from 'ember-window-mock';
+
+let numberFormat;
 
 export function formatNum(value) {
+  if (!numberFormat) {
+    numberFormat = new Intl.NumberFormat(window.navigator.languages || window.navigator.language);
+  }
   return numberFormat.format(value);
 }
 

--- a/tests/unit/helpers/format-num-test.js
+++ b/tests/unit/helpers/format-num-test.js
@@ -1,9 +1,16 @@
 import { module, test } from 'qunit';
 
+import window from 'ember-window-mock';
+import { setupWindowMock } from 'ember-window-mock/test-support';
+
 import { formatNum } from '../../../helpers/format-num';
 
-module('Unit | Helper | format-num', function () {
+module('Unit | Helper | format-num', function (hooks) {
+  setupWindowMock(hooks);
+
   test('it works', function (assert) {
+    window.navigator = { language: 'en' };
+
     assert.equal(formatNum(42), '42');
     assert.equal(formatNum(0), '0');
     assert.equal(formatNum(0.2), '0.2');


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation 😉 

r? @locks 