### PR TITLE
README: Remove TravisCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # crates.io
 
-[![Build Status](https://travis-ci.com/rust-lang/crates.io.svg?branch=master)](https://travis-ci.com/rust-lang/crates.io)
 [![What's Deployed](https://img.shields.io/badge/whatsdeployed-prod-green.svg)](https://whatsdeployed.io/s-9IG)
 
 Source code for the default [Cargo](http://doc.crates.io) registry. Viewable


### PR DESCRIPTION
We use the bors bot to merge our code so the chance that this badge will ever not be green is veeery small and it doesn't give a lot of value to the readers so we should probably just get rid of it ;)

r? @jtgeibel 