### PR TITLE
Enable JS sourcemap output

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -39,6 +39,11 @@ module.exports = function (defaults) {
     fingerprint: {
       extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'ttf', 'woff', 'woff2'],
     },
+
+    sourcemaps: {
+      enabled: true,
+      extensions: ['js'],
+    },
   });
 
   app.import('node_modules/normalize.css/normalize.css');


### PR DESCRIPTION
This is needed to take advantage of proper stacktraces in Sentry

r? @jtgeibel 