### PR TITLE
sentry: Ignore `TransitionAborted` errors

### DIFF
--- a/app/sentry.js
+++ b/app/sentry.js
@@ -17,5 +17,17 @@ export function init() {
     environment,
     ...config.sentry,
     integrations,
+
+    beforeSend(event, hint) {
+      let error = hint?.originalException;
+
+      // Ignoring these errors due to https://github.com/emberjs/ember.js/issues/12505
+      // and https://github.com/emberjs/ember.js/issues/18416
+      if (error && error.name === 'TransitionAborted') {
+        return null;
+      }
+
+      return event;
+    },
   });
 }


### PR DESCRIPTION
According to https://github.com/emberjs/ember.js/issues/18416 it looks like changing query params that have `refreshModel: true` causes an internal `TransitionAborted` error. This error is being ignored by Ember itself (see https://github.com/emberjs/ember.js/blob/v3.21.3/packages/@ember/-internals/runtime/lib/ext/rsvp.js#L40-L42), but Sentry also hooks into `RSVP.on('error')` and unfortunately reports these false positives (see https://github.com/emberjs/ember.js/issues/12505)

This PR actively ignores `TransitionAborted` errors in the `beforeSend()` hook of Sentry.

r? @jtgeibel 