### PR TITLE
utils/ajax: Throw an `Error` instance instead of a random object

### DIFF
--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -5,5 +5,17 @@ export default async function ajax(input, init) {
   if (response.ok) {
     return await response.json();
   }
-  throw response;
+  throw new HttpError(input, init, response);
+}
+
+export class HttpError extends Error {
+  constructor(url, init, response) {
+    let method = init.method ?? 'GET';
+    let message = `${method} ${url} failed with: ${response.status} ${response.statusText}`;
+    super(message);
+    this.name = 'HttpError';
+    this.method = method;
+    this.url = url;
+    this.response = response;
+  }
 }


### PR DESCRIPTION
This should make Sentry issues like https://sentry.io/organizations/rust-lang/issues/1935012204/ a little more useful

r? @jtgeibel 