### PR TITLE
services/google-charts: Ensure that `loadScript()` rejects with an `Error` instance

### DIFF
--- a/app/services/google-charts.js
+++ b/app/services/google-charts.js
@@ -26,9 +26,20 @@ async function loadScript(src) {
     const script = document.createElement('script');
     script.src = src;
     script.onload = resolve;
-    script.onerror = reject;
+    script.onerror = event => {
+      reject(new ExternalScriptError(event.target.src));
+    };
     document.body.appendChild(script);
   });
+}
+
+class ExternalScriptError extends Error {
+  constructor(url) {
+    let message = `Failed to load script at ${url}`;
+    super(message);
+    this.name = 'ExternalScriptError';
+    this.url = url;
+  }
 }
 
 async function loadJsApi() {


### PR DESCRIPTION
Up until now the function would have rejected with an `Event` instance, which shows up in a non-useful way on Sentry. https://developer.mozilla.org/de/docs/Web/API/HTMLScriptElement suggests to use `event.target.src` instead to convert the event to an `Error` instance.

r? @jtgeibel 