### PR TITLE
helpers/format-num: Fall back to `en` locale if `navigator.language` causes an error

### DIFF
--- a/app/helpers/format-num.js
+++ b/app/helpers/format-num.js
@@ -2,13 +2,16 @@ import { helper } from '@ember/component/helper';
 
 import window from 'ember-window-mock';
 
-let numberFormat;
+function newNumberFormat() {
+  try {
+    return new Intl.NumberFormat(window.navigator.languages || window.navigator.language);
+  } catch (error) {
+    return new Intl.NumberFormat('en');
+  }
+}
 
 export function formatNum(value) {
-  if (!numberFormat) {
-    numberFormat = new Intl.NumberFormat(window.navigator.languages || window.navigator.language);
-  }
-  return numberFormat.format(value);
+  return newNumberFormat().format(value);
 }
 
 export default helper(params => formatNum(params[0]));


### PR DESCRIPTION


This should resolve https://sentry.io/organizations/rust-lang/issues/1936687439/

r? @jtgeibel 