### PR TITLE
Improve Google Charts error handling

### DIFF
--- a/app/components/download-graph.hbs
+++ b/app/components/download-graph.hbs
@@ -1,5 +1,12 @@
-<div
-  {{did-insert this.renderChart}}
-  {{did-update this.renderChart @data}}
-  ...attributes
-></div>
+{{#if this.loadTask.last.error}}
+  <span data-test-google-api-error>
+    There was an error loading the Google Charts code.
+    Please try again later.
+  </span>
+{{else}}
+  <div
+    {{did-insert this.renderChart}}
+    {{did-update this.renderChart @data}}
+    ...attributes
+  ></div>
+{{/if}}

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -4,6 +4,7 @@ import Component from '@glimmer/component';
 
 import { task } from 'ember-concurrency';
 
+import { ExternalScriptError } from '../services/google-charts';
 import { ignoreCancellation } from '../utils/concurrency';
 
 // Colors by http://colorbrewer2.org/#type=diverging&scheme=RdBu&n=10
@@ -17,7 +18,15 @@ export default class DownloadGraph extends Component {
   constructor() {
     super(...arguments);
 
-    this.loadTask.perform().catch(ignoreCancellation);
+    this.loadTask
+      .perform()
+      .catch(ignoreCancellation)
+      .catch(error => {
+        // ignore `ExternalScriptError` errors since we handle those in the template
+        if (!(error instanceof ExternalScriptError)) {
+          throw error;
+        }
+      });
 
     window.addEventListener('resize', this.resizeHandler, false);
   }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -11,7 +11,10 @@ export default Route.extend({
     this.session.loadUserTask.perform();
 
     // start loading the Google Charts JS library already
-    this.googleCharts.load();
+    // and ignore any errors since we will catch them again
+    // anyway when we call `load()` from the `DownloadGraph`
+    // component
+    this.googleCharts.load().catch(() => {});
   },
 
   actions: {

--- a/app/services/google-charts.js
+++ b/app/services/google-charts.js
@@ -33,7 +33,7 @@ async function loadScript(src) {
   });
 }
 
-class ExternalScriptError extends Error {
+export class ExternalScriptError extends Error {
   constructor(url) {
     let message = `Failed to load script at ${url}`;
     super(message);


### PR DESCRIPTION
According to Sentry we have quite a few users that have trouble loading the Google Charts code. This PR improves the error handling in two ways:

1. The preloading code in the `application` route is simply ignoring any errors, since it's irrelevant for the preloading and the errors would trigger again when loaded through the `DownloadGraph` component

2. The `DownloadGraph` component is adjusted to show an error message if the loading of the Google Charts API failed, and it will no longer rethrow `ExternalScriptError` errors, which means they won't show up on Sentry anymore.

This should fix https://sentry.io/organizations/rust-lang/issues/1935278146/

r? @jtgeibel 