### PR TITLE
Load charts directly, without a redirect

### DIFF
--- a/app/services/google-charts.js
+++ b/app/services/google-charts.js
@@ -44,7 +44,7 @@ class ExternalScriptError extends Error {
 
 async function loadJsApi() {
   if (!window.google) {
-    await loadScript('https://www.google.com/jsapi');
+    await loadScript('https://www.gstatic.com/charts/loader.js');
   }
   return window.google;
 }

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -204,7 +204,7 @@ http {
 		add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-XSS-Protection "1; mode=block";
 
-		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' *.ingest.sentry.io https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.google.com https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.google.com https://ajax.googleapis.com https://www.gstatic.com https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
+		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' *.ingest.sentry.io https://docs.rs https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' https://www.gstatic.com; style-src 'self' 'unsafe-inline' https://www.gstatic.com https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
 		add_header Access-Control-Allow-Origin "*";
 
 		add_header Strict-Transport-Security "max-age=31536000" always;


### PR DESCRIPTION
The old URL is a permanent redirect to the new URL, maching what is
shown in the [docs].

r? @Turbo87 

[docs]: https://developers.google.com/chart/interactive/docs/quick_start