### PR TITLE
utils/ajax: Allow `init` argument of `HttpError` to be `undefined`

### DIFF
--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -10,7 +10,7 @@ export default async function ajax(input, init) {
 
 export class HttpError extends Error {
   constructor(url, init, response) {
-    let method = init.method ?? 'GET';
+    let method = init?.method ?? 'GET';
     let message = `${method} ${url} failed with: ${response.status} ${response.statusText}`;
     super(message);
     this.name = 'HttpError';


### PR DESCRIPTION
This should fix https://sentry.io/organizations/rust-lang/issues/1941994215/

r? @jtgeibel 