### PR TITLE
QUnit: Override testing container background color

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -48,5 +48,7 @@ module.exports = function (defaults) {
 
   app.import('node_modules/normalize.css/normalize.css');
 
+  app.import('vendor/qunit.css', { type: 'test' });
+
   return app.toTree();
 };

--- a/vendor/qunit.css
+++ b/vendor/qunit.css
@@ -1,0 +1,3 @@
+#ember-testing-container {
+  background-color: var(--header-bg-color);
+}


### PR DESCRIPTION
This makes the testing container have the same background color as the regular app, which makes interactive testing a little more pleasant because the top menu is actually visible on the screen 😅 

r? @pichfl 