### PR TITLE
Remove use of deprecated `set-env` and `add-path`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,10 @@ jobs:
         if: github.repository == 'rust-lang/crates.io'
         run: npx percy exec -- npm run test-coverage
 
+      - name: test-coverage
+        if: github.repository != 'rust-lang/crates.io'
+        run: npm run test-coverage
+
   backend:
     name: Backend
     runs-on: ubuntu-16.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,10 @@ jobs:
           npm run lint:deps
 
       - name: Add nonce for parallel tests
-        run: echo ::set-env name=PERCY_PARALLEL_NONCE::`date +%s`
+        run: echo "PERCY_PARALLEL_NONCE=`date +%s`" >> $GITHUB_ENV
 
-      - uses: percy/exec-action@v0.3.0
-        with:
-          command: npm run test-coverage
+      - name: Run percy exec
+        run: npx percy exec -- npm run test-coverage
 
   backend:
     name: Backend
@@ -98,7 +97,7 @@ jobs:
               rm -v "$HOME/.rustup"
               rm -v "$HOME/.cargo"
           fi
-          echo "::add-path::$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       # Cache `diesel` binary
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
           npm run lint:js
           npm run lint:deps
 
-      - name: Add nonce for parallel tests
-        run: echo "PERCY_PARALLEL_NONCE=`date +%s`" >> $GITHUB_ENV
-
       - name: Run percy exec
         if: github.repository == 'rust-lang/crates.io'
         run: npx percy exec -- npm run test-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         run: echo "PERCY_PARALLEL_NONCE=`date +%s`" >> $GITHUB_ENV
 
       - name: Run percy exec
+        if: github.repository == 'rust-lang/crates.io'
         run: npx percy exec -- npm run test-coverage
 
   backend:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         - npm run lint:hbs
         - npm run lint:js
         - npm run lint:deps
-        - percy exec -- npm run test-coverage
+        - if [ "$TRAVIS_REPO_SLUG" == "rust-lang/crates.io" ]; then percy exec -- npm run test-coverage; fi
     - rust: beta
       script:
         - cargo test


### PR DESCRIPTION
GitHub now warns about the use of `set-env` and `add-path`: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
This replaces them with new commands and just run `npx percy` directly instead of using percy's action since they haven't updated it (https://github.com/percy/exec-action/pull/18).
Also, I noticed the current config uploads snapshots even if it comes from a forked repo during debugging. 45866ff prevents it.

r? @jtgeibel