### PR TITLE
crate.version: Fix `latestUnyankedVersion` bug

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -32,7 +32,7 @@ export default Route.extend({
           // Find the latest version that not yanked.
           const latestUnyankedVersion = versions.find(version => !version.yanked);
 
-          if (latestStableVersion == null) {
+          if (latestUnyankedVersion == null) {
             // There's not even any unyanked version...
             params.version_num = maxVersion;
           } else {


### PR DESCRIPTION
`latestStableVersion` is already guaranteed to be `null` because of the previous condition. I assume the original intention here was to check for `latestUnyankedVersion` instead.

It looks like this bug was already present in the original implementation in https://github.com/rust-lang/crates.io/pull/1857

r? @jtgeibel 