### PR TITLE
Simplify and modernize the `EmailInput` component

### DIFF
--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -13,7 +13,7 @@
       <div local-class="label">
         <dt>Email</dt>
       </div>
-      <form local-class="email-form" {{action 'saveEmail' on='submit'}}>
+      <form local-class="email-form" {{on "submit" this.saveEmail}}>
         <Input
           @type="email"
           @value={{this.value}}
@@ -61,7 +61,7 @@
           type="button"
           local-class="edit-button"
           data-test-edit-button
-          {{action 'editEmail'}}
+          {{on "click" this.editEmail}}
         >
           Edit
         </button>
@@ -79,9 +79,9 @@
           <button
             type="button"
             local-class="resend-button"
-            {{action (perform this.resendEmailTask)}}
             disabled={{this.disableResend}}
             data-test-resend-button
+            {{on "click" (perform this.resendEmailTask)}}
           >
             {{#if this.disableResend}}
               Sent!

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -88,13 +88,6 @@
         </div>
       </div>
     {{/if}}
-    {{#if this.isError}}
-      <div local-class="row">
-        <div local-class="label">
-          <p data-test-error>{{this.emailError}}</p>
-        </div>
-      </div>
-    {{/if}}
   {{/if}}
 
 </div>

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -22,12 +22,6 @@
           data-test-input
         />
 
-        {{#if this.notValidEmail }}
-          <div data-test-invalid-email-warning>
-            <p>Whoops, that email format is invalid</p>
-          </div>
-        {{/if}}
-
         <div local-class="actions">
           <button
             type='submit'

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -50,8 +50,8 @@
       </div>
       <div local-class="email-column" data-test-email-address>
         <dd>
-          {{ this.user.email }}
-          {{#if this.user.email_verified}}
+          {{ @user.email }}
+          {{#if @user.email_verified}}
             <span local-class="verified" data-test-verified>Verified!</span>
           {{/if}}
         </dd>
@@ -70,7 +70,7 @@
     {{#if this.emailNotVerified }}
       <div local-class="row">
         <div local-class="label">
-          {{#if this.user.email_verification_sent}}
+          {{#if @user.email_verification_sent}}
             <p data-test-verification-sent>We have sent a verification email to your address.</p>
           {{/if}}
           <p data-test-not-verified>Your email has not yet been verified.</p>

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -83,7 +83,13 @@
             disabled={{this.disableResend}}
             data-test-resend-button
           >
-            {{this.resendButtonText}}
+            {{#if this.disableResend}}
+              Sent!
+            {{else if @user.email_verification_sent}}
+              Resend
+            {{else}}
+              Send verification email
+            {{/if}}
           </button>
         </div>
       </div>

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -13,7 +13,7 @@
       <div local-class="label">
         <dt>Email</dt>
       </div>
-      <form local-class="email-form" {{on "submit" this.saveEmail}}>
+      <form local-class="email-form" {{on "submit" (perform this.saveEmailTask)}}>
         <Input
           @type="email"
           @value={{this.value}}

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -67,7 +67,7 @@
         </button>
       </div>
     </div>
-    {{#if this.emailNotVerified }}
+    {{#if (and @user.email (not @user.email_verified))}}
       <div local-class="row">
         <div local-class="label">
           {{#if @user.email_verification_sent}}

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -15,7 +15,7 @@
       </div>
       <form local-class="email-form" {{action 'saveEmail' on='submit'}}>
         <Input
-          @type={{this.type}}
+          @type="email"
           @value={{this.value}}
           placeholder="Email"
           local-class="input"

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -26,7 +26,7 @@
           <button
             type='submit'
             local-class="save-button"
-            disabled={{this.disableSave}}
+            disabled={{not this.value}}
             data-test-save-button
           >
             Save

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -36,7 +36,7 @@
             type="button"
             local-class="cancel-button"
             data-test-cancel-button
-            {{action 'cancelEdit'}}
+            {{on "click" (fn (mut this.isEditing) false)}}
           >
             Cancel
           </button>

--- a/app/components/email-input.hbs
+++ b/app/components/email-input.hbs
@@ -1,12 +1,12 @@
 <div ...attributes>
-  {{#if this.emailIsNull }}
+  {{#unless @user.email}}
     <div local-class="friendly-message" data-test-no-email>
       <p>
         Please add your email address. We will only use
         it to contact you about your account. We promise we'll never share it!
       </p>
     </div>
-  {{/if}}
+  {{/unless}}
 
   {{#if this.isEditing }}
     <div local-class="row">

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -8,7 +8,7 @@ import { task } from 'ember-concurrency';
 export default class EmailInput extends Component {
   tagName = '';
 
-  value = '';
+  @tracked value;
   @tracked isEditing = false;
   user = null;
 
@@ -55,7 +55,7 @@ export default class EmailInput extends Component {
 
   @action
   editEmail() {
-    this.set('value', this.user.email);
+    this.value = this.user.email;
     this.isEditing = true;
   }
 

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,24 +1,20 @@
-import Component from '@ember/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
 
 export default class EmailInput extends Component {
-  tagName = '';
-
   @service notifications;
 
   @tracked value;
   @tracked isEditing = false;
   @tracked disableResend = false;
 
-  user = null;
-
   @task(function* () {
     try {
-      yield this.user.resendVerificationEmail();
+      yield this.args.user.resendVerificationEmail();
       this.disableResend = true;
     } catch (error) {
       if (error.errors) {
@@ -32,7 +28,7 @@ export default class EmailInput extends Component {
 
   @action
   editEmail() {
-    this.value = this.user.email;
+    this.value = this.args.user.email;
     this.isEditing = true;
   }
 
@@ -40,7 +36,7 @@ export default class EmailInput extends Component {
     event.preventDefault();
 
     let userEmail = this.value;
-    let user = this.user;
+    let user = this.args.user;
 
     try {
       yield user.changeEmail(userEmail);

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -37,7 +37,9 @@ export default class EmailInput extends Component {
   }
 
   @action
-  saveEmail() {
+  saveEmail(event) {
+    event.preventDefault();
+
     let userEmail = this.value;
     let user = this.user;
 

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { empty } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
@@ -18,17 +18,6 @@ export default class EmailInput extends Component {
   user = null;
 
   @empty('value') disableSave;
-
-  @computed('disableResend', 'user.email_verification_sent')
-  get resendButtonText() {
-    if (this.disableResend) {
-      return 'Sent!';
-    } else if (this.get('user.email_verification_sent')) {
-      return 'Resend';
-    } else {
-      return 'Send verification email';
-    }
-  }
 
   @task(function* () {
     try {

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -63,6 +63,7 @@ export default class EmailInput extends Component {
 
   @action
   editEmail() {
+    this.set('value', this.user.email);
     let email = this.value;
     this.set('emailIsNull', email == null);
     this.isEditing = true;

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,6 +1,5 @@
 import Component from '@ember/component';
 import { action } from '@ember/object';
-import { empty } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
@@ -16,8 +15,6 @@ export default class EmailInput extends Component {
   @tracked disableResend = false;
 
   user = null;
-
-  @empty('value') disableSave;
 
   @task(function* () {
     try {

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -44,6 +44,9 @@ export default class EmailInput extends Component {
 
     try {
       yield user.changeEmail(userEmail);
+
+      this.isEditing = false;
+      this.disableResend = false;
     } catch (err) {
       let msg;
       if (err.errors && err.errors[0] && err.errors[0].detail) {
@@ -53,9 +56,6 @@ export default class EmailInput extends Component {
       }
       this.notifications.error(`Error in saving email: ${msg}`);
     }
-
-    this.isEditing = false;
-    this.disableResend = false;
   })
   saveEmailTask;
 }

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -12,7 +12,7 @@ export default class EmailInput extends Component {
   @tracked isEditing = false;
   user = null;
 
-  @empty('user.email') disableSave;
+  @empty('value') disableSave;
 
   prevEmail = '';
 

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -14,7 +14,6 @@ export default class EmailInput extends Component {
 
   @empty('user.email') disableSave;
 
-  notValidEmail = false;
   prevEmail = '';
 
   @computed('user.email')
@@ -75,16 +74,6 @@ export default class EmailInput extends Component {
     let userEmail = this.value;
     let user = this.user;
 
-    let emailIsProperFormat = function (userEmail) {
-      let regExp = /^\S+@\S+\.\S+$/;
-      return regExp.test(userEmail);
-    };
-
-    if (!emailIsProperFormat(userEmail)) {
-      this.set('notValidEmail', true);
-      return;
-    }
-
     user
       .changeEmail(userEmail)
       .then(() => {
@@ -104,7 +93,6 @@ export default class EmailInput extends Component {
       });
 
     this.isEditing = false;
-    this.set('notValidEmail', false);
     this.set('disableResend', false);
   }
 

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -76,9 +76,4 @@ export default class EmailInput extends Component {
     this.isEditing = false;
     this.disableResend = false;
   }
-
-  @action
-  cancelEdit() {
-    this.isEditing = false;
-  }
 }

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -65,11 +65,7 @@ export default class EmailInput extends Component {
   @action
   editEmail() {
     let email = this.value;
-    let isEmailNull = function (email) {
-      return email == null;
-    };
-
-    this.set('emailIsNull', isEmailNull(email));
+    this.set('emailIsNull', email == null);
     this.isEditing = true;
     this.set('prevEmail', this.value);
   }

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,12 +1,15 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { empty } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
 
 export default class EmailInput extends Component {
   tagName = '';
+
+  @service notifications;
 
   @tracked value;
   @tracked isEditing = false;
@@ -22,8 +25,6 @@ export default class EmailInput extends Component {
     return email != null && !verified;
   }
 
-  isError = false;
-  emailError = '';
   disableResend = false;
 
   @computed('disableResend', 'user.email_verification_sent')
@@ -43,11 +44,9 @@ export default class EmailInput extends Component {
       this.set('disableResend', true);
     } catch (error) {
       if (error.errors) {
-        this.set('isError', true);
-        this.set('emailError', `Error in resending message: ${error.errors[0].detail}`);
+        this.notifications.error(`Error in resending message: ${error.errors[0].detail}`);
       } else {
-        this.set('isError', true);
-        this.set('emailError', 'Unknown error in resending message');
+        this.notifications.error('Unknown error in resending message');
       }
     }
   })
@@ -71,8 +70,7 @@ export default class EmailInput extends Component {
       } else {
         msg = 'An unknown error occurred while saving this email.';
       }
-      this.set('isError', true);
-      this.set('emailError', `Error in saving email: ${msg}`);
+      this.notifications.error(`Error in saving email: ${msg}`);
     });
 
     this.isEditing = false;

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -74,23 +74,17 @@ export default class EmailInput extends Component {
     let userEmail = this.value;
     let user = this.user;
 
-    user
-      .changeEmail(userEmail)
-      .then(() => {
-        this.set('serverError', null);
-      })
-      .catch(err => {
-        let msg;
-        if (err.errors && err.errors[0] && err.errors[0].detail) {
-          msg = `An error occurred while saving this email, ${err.errors[0].detail}`;
-        } else {
-          msg = 'An unknown error occurred while saving this email.';
-        }
-        user.set('email', this.prevEmail);
-        this.set('serverError', msg);
-        this.set('isError', true);
-        this.set('emailError', `Error in saving email: ${msg}`);
-      });
+    user.changeEmail(userEmail).catch(err => {
+      let msg;
+      if (err.errors && err.errors[0] && err.errors[0].detail) {
+        msg = `An error occurred while saving this email, ${err.errors[0].detail}`;
+      } else {
+        msg = 'An unknown error occurred while saving this email.';
+      }
+      user.set('email', this.prevEmail);
+      this.set('isError', true);
+      this.set('emailError', `Error in saving email: ${msg}`);
+    });
 
     this.isEditing = false;
     this.set('disableResend', false);

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -7,7 +7,6 @@ import { task } from 'ember-concurrency';
 export default class EmailInput extends Component {
   tagName = '';
 
-  type = '';
   value = '';
   isEditing = false;
   user = null;

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -13,6 +13,8 @@ export default class EmailInput extends Component {
 
   @tracked value;
   @tracked isEditing = false;
+  @tracked disableResend = false;
+
   user = null;
 
   @empty('value') disableSave;
@@ -24,8 +26,6 @@ export default class EmailInput extends Component {
 
     return email != null && !verified;
   }
-
-  disableResend = false;
 
   @computed('disableResend', 'user.email_verification_sent')
   get resendButtonText() {
@@ -41,7 +41,7 @@ export default class EmailInput extends Component {
   @task(function* () {
     try {
       yield this.user.resendVerificationEmail();
-      this.set('disableResend', true);
+      this.disableResend = true;
     } catch (error) {
       if (error.errors) {
         this.notifications.error(`Error in resending message: ${error.errors[0].detail}`);
@@ -74,7 +74,7 @@ export default class EmailInput extends Component {
     });
 
     this.isEditing = false;
-    this.set('disableResend', false);
+    this.disableResend = false;
   }
 
   @action

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -14,8 +14,6 @@ export default class EmailInput extends Component {
 
   @empty('value') disableSave;
 
-  prevEmail = '';
-
   @computed('user.email')
   get emailIsNull() {
     let email = this.get('user.email');
@@ -67,7 +65,6 @@ export default class EmailInput extends Component {
     let email = this.value;
     this.set('emailIsNull', email == null);
     this.isEditing = true;
-    this.set('prevEmail', this.value);
   }
 
   @action
@@ -82,7 +79,6 @@ export default class EmailInput extends Component {
       } else {
         msg = 'An unknown error occurred while saving this email.';
       }
-      user.set('email', this.prevEmail);
       this.set('isError', true);
       this.set('emailError', `Error in saving email: ${msg}`);
     });
@@ -94,6 +90,5 @@ export default class EmailInput extends Component {
   @action
   cancelEdit() {
     this.isEditing = false;
-    this.set('value', this.prevEmail);
   }
 }

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -14,12 +14,6 @@ export default class EmailInput extends Component {
 
   @empty('value') disableSave;
 
-  @computed('user.email')
-  get emailIsNull() {
-    let email = this.get('user.email');
-    return email == null;
-  }
-
   @computed('user.{email,email_verified}')
   get emailNotVerified() {
     let email = this.get('user.email');

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,6 +1,7 @@
 import Component from '@ember/component';
 import { action, computed } from '@ember/object';
 import { empty } from '@ember/object/computed';
+import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
 
@@ -8,7 +9,7 @@ export default class EmailInput extends Component {
   tagName = '';
 
   value = '';
-  isEditing = false;
+  @tracked isEditing = false;
   user = null;
 
   @empty('user.email') disableSave;
@@ -69,7 +70,7 @@ export default class EmailInput extends Component {
     };
 
     this.set('emailIsNull', isEmailNull(email));
-    this.set('isEditing', true);
+    this.isEditing = true;
     this.set('prevEmail', this.value);
   }
 
@@ -106,14 +107,14 @@ export default class EmailInput extends Component {
         this.set('emailError', `Error in saving email: ${msg}`);
       });
 
-    this.set('isEditing', false);
+    this.isEditing = false;
     this.set('notValidEmail', false);
     this.set('disableResend', false);
   }
 
   @action
   cancelEdit() {
-    this.set('isEditing', false);
+    this.isEditing = false;
     this.set('value', this.prevEmail);
   }
 }

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -62,8 +62,6 @@ export default class EmailInput extends Component {
   @action
   editEmail() {
     this.set('value', this.user.email);
-    let email = this.value;
-    this.set('emailIsNull', email == null);
     this.isEditing = true;
   }
 

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -36,14 +36,15 @@ export default class EmailInput extends Component {
     this.isEditing = true;
   }
 
-  @action
-  saveEmail(event) {
+  @task(function* (event) {
     event.preventDefault();
 
     let userEmail = this.value;
     let user = this.user;
 
-    user.changeEmail(userEmail).catch(err => {
+    try {
+      yield user.changeEmail(userEmail);
+    } catch (err) {
       let msg;
       if (err.errors && err.errors[0] && err.errors[0].detail) {
         msg = `An error occurred while saving this email, ${err.errors[0].detail}`;
@@ -51,9 +52,10 @@ export default class EmailInput extends Component {
         msg = 'An unknown error occurred while saving this email.';
       }
       this.notifications.error(`Error in saving email: ${msg}`);
-    });
+    }
 
     this.isEditing = false;
     this.disableResend = false;
-  }
+  })
+  saveEmailTask;
 }

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -19,14 +19,6 @@ export default class EmailInput extends Component {
 
   @empty('value') disableSave;
 
-  @computed('user.{email,email_verified}')
-  get emailNotVerified() {
-    let email = this.get('user.email');
-    let verified = this.get('user.email_verified');
-
-    return email != null && !verified;
-  }
-
   @computed('disableResend', 'user.email_verification_sent')
   get resendButtonText() {
     if (this.disableResend) {

--- a/app/templates/me/index.hbs
+++ b/app/templates/me/index.hbs
@@ -20,7 +20,6 @@
 <div local-class="me-email">
   <h2>User Email</h2>
   <EmailInput
-    @type="email"
     @value={{this.model.user.email}}
     @user={{this.model.user}}
     data-test-email-input

--- a/app/templates/me/index.hbs
+++ b/app/templates/me/index.hbs
@@ -20,7 +20,6 @@
 <div local-class="me-email">
   <h2>User Email</h2>
   <EmailInput
-    @value={{this.model.user.email}}
     @user={{this.model.user}}
     data-test-email-input
   />

--- a/tests/acceptance/email-change-test.js
+++ b/tests/acceptance/email-change-test.js
@@ -126,7 +126,7 @@ module('Acceptance | Email Change', function (hooks) {
     assert.dom('[data-test-email-input] [data-test-not-verified]').doesNotExist();
     assert.dom('[data-test-email-input] [data-test-verification-sent]').doesNotExist();
     assert
-      .dom('[data-test-email-input] [data-test-error]')
+      .dom('[data-test-notification-message="error"]')
       .includesText('Error in saving email: An error occurred while saving this email');
 
     user.reload();
@@ -172,7 +172,7 @@ module('Acceptance | Email Change', function (hooks) {
 
       await click('[data-test-email-input] [data-test-resend-button]');
       assert.dom('[data-test-email-input] [data-test-resend-button]').isEnabled().hasText('Resend');
-      assert.dom('[data-test-email-input] [data-test-error]').hasText('Error in resending message: [object Object]');
+      assert.dom('[data-test-notification-message="error"]').hasText('Error in resending message: [object Object]');
     });
   });
 });

--- a/tests/acceptance/email-change-test.js
+++ b/tests/acceptance/email-change-test.js
@@ -86,20 +86,6 @@ module('Acceptance | Email Change', function (hooks) {
     assert.ok(user.emailVerificationToken);
   });
 
-  test('invalid email address', async function (assert) {
-    let user = this.server.create('user', { email: 'old@email.com' });
-
-    this.authenticateAs(user);
-
-    await visit('/me');
-    await click('[data-test-email-input] [data-test-edit-button]');
-    await fillIn('[data-test-email-input] [data-test-input]', 'foo@bar');
-    assert.dom('[data-test-email-input] [data-test-invalid-email-warning]').doesNotExist();
-
-    await click('[data-test-email-input] [data-test-save-button]');
-    assert.dom('[data-test-email-input] [data-test-invalid-email-warning]').exists();
-  });
-
   test('cancel button', async function (assert) {
     let user = this.server.create('user', { email: 'old@email.com' });
 

--- a/tests/acceptance/email-change-test.js
+++ b/tests/acceptance/email-change-test.js
@@ -74,6 +74,7 @@ module('Acceptance | Email Change', function (hooks) {
     assert.dom('[data-test-email-input] [data-test-save-button]').isEnabled();
 
     await click('[data-test-email-input] [data-test-save-button]');
+    assert.dom('[data-test-email-input] [data-test-no-email]').doesNotExist();
     assert.dom('[data-test-email-input] [data-test-email-address]').includesText('new@email.com');
     assert.dom('[data-test-email-input] [data-test-verified]').doesNotExist();
     assert.dom('[data-test-email-input] [data-test-not-verified]').exists();

--- a/tests/acceptance/email-change-test.js
+++ b/tests/acceptance/email-change-test.js
@@ -121,10 +121,8 @@ module('Acceptance | Email Change', function (hooks) {
     await fillIn('[data-test-email-input] [data-test-input]', 'new@email.com');
 
     await click('[data-test-email-input] [data-test-save-button]');
-    assert.dom('[data-test-email-input] [data-test-email-address]').includesText('old@email.com');
-    assert.dom('[data-test-email-input] [data-test-verified]').exists();
-    assert.dom('[data-test-email-input] [data-test-not-verified]').doesNotExist();
-    assert.dom('[data-test-email-input] [data-test-verification-sent]').doesNotExist();
+    assert.dom('[data-test-email-input] [data-test-input]').hasValue('new@email.com');
+    assert.dom('[data-test-email-input] [data-test-email-address]').doesNotExist();
     assert
       .dom('[data-test-notification-message="error"]')
       .includesText('Error in saving email: An error occurred while saving this email');


### PR DESCRIPTION
The primary user-facing change in this PR is replacing the custom error display with usage of our regular `notifications` service. Other than that the input should work and look essentially the same as before, but is now based on a Glimmer component.

This PR converts our last remaining Ember component to Glimmer! 🎉 

r? @locks 