### PR TITLE
styles: Prepend `normalize.css` code

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -49,7 +49,7 @@ module.exports = function (defaults) {
     },
   });
 
-  app.import('node_modules/normalize.css/normalize.css');
+  app.import('node_modules/normalize.css/normalize.css', { prepend: true });
 
   app.import('vendor/qunit.css', { type: 'test' });
 


### PR DESCRIPTION
This should be included as the very first part of our CSS code so that the following code can override it if necessary

r? @locks 