### PR TITLE
crate.version: Navigate to `index` route if version can't be found

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -49,6 +49,7 @@ export default class VersionRoute extends Route {
     const version = versions.find(version => version.num === params.version_num);
     if (params.version_num && !version) {
       this.notifications.error(`Version '${params.version_num}' of crate '${crate.name}' does not exist`);
+      this.replaceWith('index');
     }
 
     return {


### PR DESCRIPTION
Staying on an empty page seems bad, so let's navigate the user to the `index` route instead.

r? @locks 