### PR TITLE
crate.owners: Use `notifications` service in tasks

### DIFF
--- a/app/controllers/crate/owners.js
+++ b/app/controllers/crate/owners.js
@@ -30,15 +30,13 @@ export default class CrateOwnersController extends Controller {
   @task(function* (owner) {
     try {
       yield this.crate.removeOwner(owner.get('login'));
-      switch (owner.kind) {
-        case 'user':
-          this.notifications.success(`User ${owner.get('login')} removed as crate owner`);
-          this.crate.owner_user.removeObject(owner);
-          break;
-        case 'team':
-          this.notifications.success(`Team ${owner.get('display_name')} removed as crate owner`);
-          this.crate.owner_team.removeObject(owner);
-          break;
+
+      if (owner.kind === 'team') {
+        this.notifications.success(`Team ${owner.get('display_name')} removed as crate owner`);
+        this.crate.owner_team.removeObject(owner);
+      } else {
+        this.notifications.success(`User ${owner.get('login')} removed as crate owner`);
+        this.crate.owner_user.removeObject(owner);
       }
     } catch (error) {
       let subject = owner.kind === 'team' ? `team ${owner.get('display_name')}` : `user ${owner.get('login')}`;

--- a/app/controllers/crate/owners.js
+++ b/app/controllers/crate/owners.js
@@ -7,26 +7,21 @@ export default class CrateOwnersController extends Controller {
   @service notifications;
 
   crate = null;
-  error = false;
-  invited = false;
   username = '';
 
   @task(function* (event) {
     event.preventDefault();
 
-    this.set('error', false);
-    this.set('invited', false);
-
     const username = this.username;
 
     try {
       yield this.crate.inviteOwner(username);
-      this.set('invited', `An invite has been sent to ${username}`);
+      this.notifications.success(`An invite has been sent to ${username}`);
     } catch (error) {
       if (error.errors) {
-        this.set('error', `Error sending invite: ${error.errors[0].detail}`);
+        this.notifications.error(`Error sending invite: ${error.errors[0].detail}`);
       } else {
-        this.set('error', 'Error sending invite');
+        this.notifications.error('Error sending invite');
       }
     }
   })

--- a/app/controllers/crate/owners.js
+++ b/app/controllers/crate/owners.js
@@ -19,11 +19,6 @@ export default class CrateOwnersController extends Controller {
 
     const username = this.username;
 
-    if (!username) {
-      this.set('error', 'Please enter a username');
-      return false;
-    }
-
     try {
       yield this.crate.inviteOwner(username);
       this.set('invited', `An invite has been sent to ${username}`);

--- a/app/templates/crate/owners.hbs
+++ b/app/templates/crate/owners.hbs
@@ -9,14 +9,6 @@
 <div local-class="me-email">
   <h2>Add Owner</h2>
 
-  {{#if this.error}}
-    <p data-test-error-message>{{this.error}}</p>
-  {{/if}}
-
-  {{#if this.invited}}
-    <p data-test-invited-message>{{this.invited}}</p>
-  {{/if}}
-
   <form local-class="email-form" {{on "submit" (perform this.addOwnerTask)}}>
     <label local-class="email-input-label" for='new-owner-username'>
       Username

--- a/app/templates/crate/owners.hbs
+++ b/app/templates/crate/owners.hbs
@@ -28,10 +28,6 @@
 
 <h2>Owners</h2>
 
-{{#if this.removed}}
-  <p data-test-removed-message>{{this.removed}}</p>
-{{/if}}
-
 <div local-class='list' data-test-owners>
   {{#each this.crate.owner_team as |team|}}
     <div local-class='row' data-test-owner-team={{team.login}}>

--- a/app/templates/crate/owners.hbs
+++ b/app/templates/crate/owners.hbs
@@ -22,7 +22,7 @@
       Username
     </label>
     <Input @type="text" id="new-owner-username" @value={{this.username}} placeholder="Username" local-class="email-input" @name="username" />
-    <button type="submit" local-class="submit-button" data-test-save-button>Save</button>
+    <button type="submit" disabled={{not this.username}} local-class="submit-button" data-test-save-button>Save</button>
   </form>
 </div>
 

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -298,7 +298,7 @@ module('Acceptance | crate page', function (hooks) {
     await click('[data-test-save-button]');
 
     assert
-      .dom('[data-test-error-message]')
+      .dom('[data-test-notification-message="error"]')
       .hasText('Error sending invite: could not find user with login `spookyghostboo`');
     assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
     assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
@@ -311,7 +311,7 @@ module('Acceptance | crate page', function (hooks) {
     await fillIn('input[name="username"]', 'iain8');
     await click('[data-test-save-button]');
 
-    assert.dom('[data-test-invited-message]').hasText('An invite has been sent to iain8');
+    assert.dom('[data-test-notification-message="success"]').hasText('An invite has been sent to iain8');
     assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
     assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
   });

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -325,7 +325,7 @@ module('Acceptance | crate page', function (hooks) {
     await visit('/crates/nanomsg/owners');
     await click('[data-test-owner-user="thehydroimpulse"] [data-test-remove-owner-button]');
 
-    assert.dom('[data-test-removed-message]').hasText('User thehydroimpulse removed as crate owner');
+    assert.dom('[data-test-notification-message="success"]').hasText('User thehydroimpulse removed as crate owner');
     assert.dom('[data-test-owner-user]').exists({ count: 1 });
   });
 
@@ -335,7 +335,9 @@ module('Acceptance | crate page', function (hooks) {
     await visit('/crates/nanomsg/owners');
     await click('[data-test-owner-team="github:org:thehydroimpulse"] [data-test-remove-owner-button]');
 
-    assert.dom('[data-test-removed-message]').hasText('Team org/thehydroimpulseteam removed as crate owner');
+    assert
+      .dom('[data-test-notification-message="success"]')
+      .hasText('Team org/thehydroimpulseteam removed as crate owner');
     assert.dom('[data-test-owner-team]').exists({ count: 1 });
   });
 });

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -286,11 +286,8 @@ module('Acceptance | crate page', function (hooks) {
     this.server.loadFixtures();
 
     await visit('/crates/nanomsg/owners');
-    await click('[data-test-save-button]');
-
-    assert.dom('[data-test-error-message]').hasText('Please enter a username');
-    assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
-    assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
+    await fillIn('input[name="username"]', '');
+    assert.dom('[data-test-save-button]').isDisabled();
   });
 
   test('attempting to add non-existent owner', async function (assert) {


### PR DESCRIPTION
Instead of displaying the operation result somewhere in the page, this changes the code to use our regular notification system.

r? @locks 