### PR TITLE
Sentry: Disable when using `FastBoot`

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -6,7 +6,9 @@ import Resolver from 'ember-resolver';
 import config from './config/environment';
 import * as Sentry from './sentry';
 
-Sentry.init();
+if (typeof FastBoot === 'undefined') {
+  Sentry.init();
+}
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;


### PR DESCRIPTION
The `@sentry/browser` packages rely on `window.location`, which is not available in Node.js

r? @locks 