### PR TITLE
crate.reverse-dependencies: Show error notification if data loading fails

### DIFF
--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -11,11 +11,14 @@
   />
 </div>
 
-<div local-class="list">
-  {{#each this.model as |dependency|}}
-    <div local-class="row">
+<div local-class="list" data-test-list>
+  {{#each this.model as |dependency index|}}
+    <div local-class="row" data-test-row={{index}}>
       <div>
-        <LinkTo @route="crate" @model={{dependency.version.crateName}}>{{dependency.version.crateName}}</LinkTo> requires {{dependency.req}}
+        <LinkTo @route="crate" @model={{dependency.version.crateName}} data-test-crate-name>
+          {{dependency.version.crateName}}
+        </LinkTo>
+        requires {{dependency.req}}
       </div>
       <div local-class="stats downloads">
         {{svg-jar "download-arrow" local-class="download-icon"}}

--- a/tests/acceptance/reverse-dependencies-test.js
+++ b/tests/acceptance/reverse-dependencies-test.js
@@ -1,0 +1,64 @@
+import { click, currentURL, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from '../helpers/setup-mirage';
+
+module('Acceptance | /crates/:crate_id/reverse_dependencies', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  function prepare({ server }) {
+    let foo = server.create('crate', { name: 'foo' });
+    server.create('version', { crate: foo });
+
+    let bar = server.create('crate', { name: 'bar' });
+    server.create('version', { crate: bar });
+
+    let baz = server.create('crate', { name: 'baz' });
+    server.create('version', { crate: baz });
+
+    server.create('dependency', { crate: foo, version: bar.versions.models[0] });
+    server.create('dependency', { crate: foo, version: baz.versions.models[0] });
+
+    return { foo, bar, baz };
+  }
+
+  test('shows a list of crates depending on the selected crate', async function (assert) {
+    let { foo, bar, baz } = prepare(this);
+
+    await visit(`/crates/${foo.name}/reverse_dependencies`);
+    assert.equal(currentURL(), `/crates/${foo.name}/reverse_dependencies`);
+    assert.dom('[data-test-row]').exists({ count: 2 });
+    assert.dom('[data-test-row="0"] [data-test-crate-name]').hasText(bar.name);
+    assert.dom('[data-test-row="1"] [data-test-crate-name]').hasText(baz.name);
+  });
+
+  test('supports pagination', async function (assert) {
+    let { foo } = prepare(this);
+
+    for (let i = 0; i < 20; i++) {
+      let crate = this.server.create('crate');
+      let version = this.server.create('version', { crate });
+      this.server.create('dependency', { crate: foo, version });
+    }
+
+    await visit(`/crates/${foo.name}/reverse_dependencies`);
+    assert.equal(currentURL(), `/crates/${foo.name}/reverse_dependencies`);
+    assert.dom('[data-test-row]').exists({ count: 10 });
+    assert.dom('[data-test-current-rows]').hasText('1-10');
+    assert.dom('[data-test-total-rows]').hasText('22');
+
+    await click('[data-test-pagination-next]');
+    assert.equal(currentURL(), `/crates/${foo.name}/reverse_dependencies?page=2`);
+    assert.dom('[data-test-row]').exists({ count: 10 });
+    assert.dom('[data-test-current-rows]').hasText('11-20');
+    assert.dom('[data-test-total-rows]').hasText('22');
+
+    await click('[data-test-pagination-next]');
+    assert.equal(currentURL(), `/crates/${foo.name}/reverse_dependencies?page=3`);
+    assert.dom('[data-test-row]').exists({ count: 2 });
+    assert.dom('[data-test-current-rows]').hasText('21-22');
+    assert.dom('[data-test-total-rows]').hasText('22');
+  });
+});


### PR DESCRIPTION
Instead of showing an empty error page, this PR adjusts the code to show an error message popup through our regular `notifications` service system:

<img width="633" alt="Bildschirmfoto 2020-10-21 um 16 16 52" src="https://user-images.githubusercontent.com/141300/96732693-ea417280-13b8-11eb-96fc-b7aa5dae0042.png">


Related to https://github.com/rust-lang/crates.io/issues/187

r? @locks 