### PR TITLE
styles/application: Set minimum height for the `body` element

### DIFF
--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -40,6 +40,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    min-height: 100vh;
 }
 
 h1 {
@@ -95,6 +96,7 @@ noscript {
 }
 
 .main {
+    flex-grow: 1;
     display: flex;
     justify-content: center;
     width: 100%;


### PR DESCRIPTION
This causes our footer to always appear at the bottom of the page, irregardless of how long the content is:

<img width="1061" alt="Bildschirmfoto 2020-10-21 um 16 38 46" src="https://user-images.githubusercontent.com/141300/96735537-f418a500-13bb-11eb-9633-ba334dcd4be2.png">

r? @locks 
