### PR TITLE
Remove turbofishes from diesel calls

### DIFF
--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -33,7 +33,7 @@ fn delete(conn: &PgConnection) {
         Some(s) => s,
     };
 
-    let krate = Crate::by_name(&name).first::<Crate>(conn).unwrap();
+    let krate: Crate = Crate::by_name(&name).first(conn).unwrap();
     print!(
         "Are you sure you want to delete {} ({}) [y/N]: ",
         name, krate.id

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -44,10 +44,10 @@ fn delete(conn: &PgConnection) {
         Some(s) => s,
     };
 
-    let krate = Crate::by_name(&name).first::<Crate>(conn).unwrap();
-    let v = Version::belonging_to(&krate)
+    let krate: Crate = Crate::by_name(&name).first(conn).unwrap();
+    let v: Version = Version::belonging_to(&krate)
         .filter(versions::num.eq(&version))
-        .first::<Version>(conn)
+        .first(conn)
         .unwrap();
     print!(
         "Are you sure you want to delete {}#{} ({}) [y/N]: ",

--- a/src/bin/render-readmes.rs
+++ b/src/bin/render-readmes.rs
@@ -80,7 +80,7 @@ fn main() {
         query = query.filter(crates::name.eq(crate_name));
     }
 
-    let version_ids = query.load::<i32>(&conn).expect("error loading version ids");
+    let version_ids: Vec<i32> = query.load(&conn).expect("error loading version ids");
 
     let total_versions = version_ids.len();
     println!("Rendering {} versions", total_versions);
@@ -103,11 +103,11 @@ fn main() {
             total_pages
         );
 
-        let versions = versions::table
+        let versions: Vec<(Version, String)> = versions::table
             .inner_join(crates::table)
             .filter(versions::id.eq(any(version_ids_chunk)))
             .select((versions::all_columns, crates::name))
-            .load::<(Version, String)>(&conn)
+            .load(&conn)
             .expect("error loading versions");
 
         let mut tasks = Vec::with_capacity(page_size as usize);

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -43,13 +43,13 @@ fn transfer(conn: &PgConnection) {
         Some(s) => s,
     };
 
-    let from = users::table
+    let from: User = users::table
         .filter(users::gh_login.eq(from))
-        .first::<User>(conn)
+        .first(conn)
         .unwrap();
-    let to = users::table
+    let to: User = users::table
         .filter(users::gh_login.eq(to))
-        .first::<User>(conn)
+        .first(conn)
         .unwrap();
 
     if from.gh_id != to.gh_id {

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -73,9 +73,9 @@ fn transfer(conn: &PgConnection) {
     let crate_owners = crate_owners::table
         .filter(crate_owners::owner_id.eq(from.id))
         .filter(crate_owners::owner_kind.eq(OwnerKind::User as i32));
-    let crates = Crate::all()
+    let crates: Vec<Crate> = Crate::all()
         .filter(crates::id.eq_any(crate_owners.select(crate_owners::crate_id)))
-        .load::<Crate>(conn)
+        .load(conn)
         .unwrap();
 
     for krate in crates {

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -103,7 +103,7 @@ pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> Result<()> {
         .collect::<Vec<_>>();
 
     conn.transaction(|| {
-        let slugs = diesel::insert_into(categories)
+        let slugs: Vec<String> = diesel::insert_into(categories)
             .values(&to_insert)
             .on_conflict(slug)
             .do_update()
@@ -112,7 +112,7 @@ pub fn sync_with_connection(toml_str: &str, conn: &PgConnection) -> Result<()> {
                 description.eq(excluded(description)),
             ))
             .returning(slug)
-            .get_results::<String>(&*conn)?;
+            .get_results(&*conn)?;
 
         diesel::delete(categories)
             .filter(slug.ne(all(slugs)))

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -43,7 +43,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let slug = &req.params()["category_id"];
     let conn = req.db_conn()?;
-    let cat = Category::by_slug(slug).first::<Category>(&*conn)?;
+    let cat: Category = Category::by_slug(slug).first(&*conn)?;
     let subcats = cat
         .subcategories(&conn)?
         .into_iter()

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -9,9 +9,10 @@ pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = req.authenticate()?.user_id();
     let conn = &*req.db_conn()?;
 
-    let crate_owner_invitations = crate_owner_invitations::table
+    let crate_owner_invitations: Vec<CrateOwnerInvitation> = crate_owner_invitations::table
         .filter(crate_owner_invitations::invited_user_id.eq(user_id))
-        .load::<CrateOwnerInvitation>(&*conn)?
+        .load(&*conn)?;
+    let crate_owner_invitations = crate_owner_invitations
         .into_iter()
         .map(|i| i.encodable(conn))
         .collect();

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -56,7 +56,7 @@ pub fn handle_invite_with_token(req: &mut dyn RequestExt) -> EndpointResult {
 
     let crate_owner_invite: CrateOwnerInvitation = crate_owner_invitations::table
         .filter(crate_owner_invitations::token.eq(req_token))
-        .first::<CrateOwnerInvitation>(&*conn)?;
+        .first(&*conn)?;
 
     let invite_reponse = InvitationResponse {
         crate_id: crate_owner_invite.crate_id,
@@ -79,9 +79,9 @@ fn accept_invite(
     use diesel::{delete, insert_into};
 
     conn.transaction(|| {
-        let pending_crate_owner = crate_owner_invitations::table
+        let pending_crate_owner: CrateOwnerInvitation = crate_owner_invitations::table
             .find((user_id, crate_invite.crate_id))
-            .first::<CrateOwnerInvitation>(&*conn)?;
+            .first(&*conn)?;
 
         insert_into(crate_owners::table)
             .values(&CrateOwner {

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 
-use crate::controllers::helpers::Paginate;
+use crate::controllers::helpers::{pagination::Paginated, Paginate};
 use crate::models::Keyword;
 use crate::views::EncodableKeyword;
 
@@ -20,7 +20,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
         query = query.order(keywords::keyword.asc());
     }
 
-    let data = query.paginate(&req.query())?.load::<Keyword>(&*conn)?;
+    let data: Paginated<Keyword> = query.paginate(&req.query())?.load(&*conn)?;
     let total = data.total();
     let kws = data.into_iter().map(Keyword::encodable).collect::<Vec<_>>();
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -20,7 +20,7 @@ pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
 
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_read_only()?;
-    let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
 
     let mut versions = krate.all_versions().load::<Version>(&*conn)?;
     versions.sort_by(|a, b| b.num.cmp(&a.num));

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -114,7 +114,7 @@ pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["crate_id"];
     let conn = req.db_read_only()?;
-    let krate = Crate::by_name(name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(name).first(&*conn)?;
 
     let mut versions_and_publishers = krate
         .all_versions()
@@ -210,7 +210,7 @@ pub fn readme(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn versions(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_read_only()?;
-    let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
         .all_versions()
         .left_outer_join(users::table)
@@ -241,7 +241,7 @@ pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
 
     let name = &req.params()["crate_id"];
     let conn = req.db_read_only()?;
-    let krate = Crate::by_name(name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(name).first(&*conn)?;
     let (rev_deps, total) = krate.reverse_dependencies(&*conn, &req.query())?;
     let rev_deps: Vec<_> = rev_deps
         .into_iter()

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -8,7 +8,7 @@ use crate::views::EncodableOwner;
 pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
-    let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = krate
         .owners(&conn)?
         .into_iter()
@@ -26,7 +26,7 @@ pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
-    let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = Team::owning(&krate, &conn)?
         .into_iter()
         .map(Owner::encodable)
@@ -43,7 +43,7 @@ pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn owner_user(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
-    let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = User::owning(&krate, &conn)?
         .into_iter()
         .map(Owner::encodable)
@@ -97,7 +97,7 @@ fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
     let user = authenticated_user.user();
 
     conn.transaction(|| {
-        let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
+        let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
         let owners = krate.owners(&conn)?;
 
         match user.rights(app, &owners)? {

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -10,7 +10,7 @@ pub fn show_team(req: &mut dyn RequestExt) -> EndpointResult {
 
     let name = &req.params()["team_id"];
     let conn = req.db_conn()?;
-    let team = teams.filter(login.eq(name)).first::<Team>(&*conn)?;
+    let team: Team = teams.filter(login.eq(name)).first(&*conn)?;
 
     #[derive(Serialize)]
     struct R {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -72,9 +72,7 @@ pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
     let user = authenticated_user.user();
 
     let max_token_per_user = 500;
-    let count = ApiToken::belonging_to(&user)
-        .count()
-        .get_result::<i64>(&*conn)?;
+    let count: i64 = ApiToken::belonging_to(&user).count().get_result(&*conn)?;
     if count >= max_token_per_user {
         return Err(bad_request(&format!(
             "maximum tokens per user is: {}",

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -16,16 +16,17 @@ pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = req.authenticate()?.user_id();
     let conn = req.db_conn()?;
 
-    let (user, verified, email, verification_sent) = users::table
-        .find(user_id)
-        .left_join(emails::table)
-        .select((
-            users::all_columns,
-            emails::verified.nullable(),
-            emails::email.nullable(),
-            emails::token_generated_at.nullable().is_not_null(),
-        ))
-        .first::<(User, Option<bool>, Option<String>, bool)>(&*conn)?;
+    let (user, verified, email, verification_sent): (User, Option<bool>, Option<String>, bool) =
+        users::table
+            .find(user_id)
+            .left_join(emails::table)
+            .select((
+                users::all_columns,
+                emails::verified.nullable(),
+                emails::email.nullable(),
+                emails::token_generated_at.nullable().is_not_null(),
+            ))
+            .first(&*conn)?;
 
     let owned_crates = CrateOwner::by_owner_kind(OwnerKind::User)
         .inner_join(crates::table)

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -11,10 +11,10 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
 
     let name = &req.params()["user_id"].to_lowercase();
     let conn = req.db_conn()?;
-    let user = users
+    let user: User = users
         .filter(crate::lower(gh_login).eq(name))
         .order(id.desc())
-        .first::<User>(&*conn)?;
+        .first(&*conn)?;
 
     #[derive(Serialize)]
     struct R {
@@ -34,7 +34,7 @@ pub fn stats(req: &mut dyn RequestExt) -> EndpointResult {
         .chain_error(|| bad_request("invalid user_id"))?;
     let conn = req.db_conn()?;
 
-    let data = CrateOwner::by_owner_kind(OwnerKind::User)
+    let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)
         .inner_join(crates::table)
         .filter(crate_owners::owner_id.eq(user_id))
         .select(sum(crates::downloads))

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -13,7 +13,7 @@ fn version_and_crate(req: &dyn RequestExt) -> AppResult<(DieselPooledConn<'_>, V
     let semver = extract_semver(req)?;
 
     let conn = req.db_conn()?;
-    let krate = Crate::by_name(crate_name).first::<Crate>(&*conn)?;
+    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let version = krate.find_version(&conn, semver)?;
 
     Ok((conn, version, krate))

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -22,7 +22,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
         .filter_map(|(ref a, ref b)| if *a == "ids[]" { b.parse().ok() } else { None })
         .collect::<Vec<i32>>();
 
-    let versions_and_publishers = versions::table
+    let versions_and_publishers: Vec<(Version, String, Option<User>)> = versions::table
         .inner_join(crates::table)
         .left_outer_join(users::table)
         .select((
@@ -31,7 +31,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
             users::all_columns.nullable(),
         ))
         .filter(versions::id.eq(any(ids)))
-        .load::<(Version, String, Option<User>)>(&*conn)?;
+        .load(&*conn)?;
     let versions = versions_and_publishers
         .iter()
         .map(|(v, _, _)| v)

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -73,9 +73,8 @@ pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     let semver = extract_semver(req)?;
 
     let conn = req.db_read_only()?;
-    let version = Crate::by_name(crate_name)
-        .first::<Crate>(&*conn)?
-        .find_version(&conn, semver)?;
+    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
+    let version = krate.find_version(&conn, semver)?;
 
     let cutoff_end_date = req
         .query()

--- a/src/git.rs
+++ b/src/git.rs
@@ -301,11 +301,11 @@ pub fn yank(
     let dst = repo.index_file(&krate);
 
     conn.transaction(|| {
-        let yanked_in_db = versions::table
+        let yanked_in_db: bool = versions::table
             .find(version.id)
             .select(versions::yanked)
             .for_update()
-            .first::<bool>(&*conn)?;
+            .first(&*conn)?;
 
         if yanked_in_db == yanked {
             // The crate is alread in the state requested, nothing to do

--- a/src/models/action.rs
+++ b/src/models/action.rs
@@ -91,7 +91,7 @@ impl VersionOwnerAction {
         Ok(Self::belonging_to(versions)
             .inner_join(users::table)
             .order(version_owner_actions::dsl::id)
-            .load::<(VersionOwnerAction, User)>(conn)?
+            .load(conn)?
             .grouped_by(versions))
     }
 }

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -395,9 +395,7 @@ mod tests {
             .execute(&conn)
             .unwrap();
 
-        let cat = Category::by_slug("cat1::sub1")
-            .first::<Category>(&conn)
-            .unwrap();
+        let cat: Category = Category::by_slug("cat1::sub1").first(&conn).unwrap();
         let subcats = cat.subcategories(&conn).unwrap();
         let parents = cat.parent_categories(&conn).unwrap();
 

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -82,7 +82,7 @@ impl Category {
         slugs: &[&str],
     ) -> QueryResult<Vec<String>> {
         conn.transaction(|| {
-            let categories = Category::by_slugs_case_sensitive(slugs).load::<Category>(conn)?;
+            let categories: Vec<Category> = Category::by_slugs_case_sensitive(slugs).load(conn)?;
             let invalid_categories = slugs
                 .iter()
                 .cloned()

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -87,8 +87,8 @@ pub fn add_dependencies(
             }
 
             // Match only identical names to ensure the index always references the original crate name
-            let krate = Crate::by_exact_name(&dep.name)
-                .first::<Crate>(&*conn)
+            let krate:Crate = Crate::by_exact_name(&dep.name)
+                .first(&*conn)
                 .map_err(|_| cargo_err(&format_args!("no known crate named `{}`", &*dep.name)))?;
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {
                 return Err(cargo_err(

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -163,10 +163,10 @@ impl<'a> NewCrate<'a> {
         use diesel::dsl::exists;
         use diesel::select;
 
-        let reserved_name = select(exists(
+        let reserved_name: bool = select(exists(
             reserved_crate_names.filter(canon_crate_name(name).eq(canon_crate_name(self.name))),
         ))
-        .get_result::<bool>(conn)?;
+        .get_result(conn)?;
         if reserved_name {
             Err(cargo_err("cannot upload a crate with a reserved name"))
         } else {
@@ -178,11 +178,11 @@ impl<'a> NewCrate<'a> {
         use crate::schema::crates::dsl::*;
 
         conn.transaction(|| {
-            let maybe_inserted = diesel::insert_into(crates)
+            let maybe_inserted: Option<Crate> = diesel::insert_into(crates)
                 .values(self)
                 .on_conflict_do_nothing()
                 .returning(ALL_COLUMNS)
-                .get_result::<Crate>(conn)
+                .get_result(conn)
                 .optional()?;
 
             if let Some(ref krate) = maybe_inserted {
@@ -445,15 +445,16 @@ impl Crate {
         match owner {
             // Users are invited and must accept before being added
             Owner::User(user) => {
-                let maybe_inserted = insert_into(crate_owner_invitations::table)
-                    .values(&NewCrateOwnerInvitation {
-                        invited_user_id: user.id,
-                        invited_by_user_id: req_user.id,
-                        crate_id: self.id,
-                    })
-                    .on_conflict_do_nothing()
-                    .get_result::<CrateOwnerInvitation>(conn)
-                    .optional()?;
+                let maybe_inserted: Option<CrateOwnerInvitation> =
+                    insert_into(crate_owner_invitations::table)
+                        .values(&NewCrateOwnerInvitation {
+                            invited_user_id: user.id,
+                            invited_by_user_id: req_user.id,
+                            crate_id: self.id,
+                        })
+                        .on_conflict_do_nothing()
+                        .get_result(conn)
+                        .optional()?;
 
                 if let Some(ownership_invitation) = maybe_inserted {
                     if let Ok(Some(email)) = user.verified_email(&conn) {

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -408,9 +408,7 @@ impl Crate {
         use crate::schema::versions::dsl::*;
 
         Ok(Version::top(
-            self.versions()
-                .select((updated_at, num))
-                .load::<(NaiveDateTime, semver::Version)>(conn)?,
+            self.versions().select((updated_at, num)).load(conn)?,
         ))
     }
 
@@ -535,11 +533,12 @@ impl Crate {
         // or `QueryableByName` to load things?"
         let options = PaginationOptions::new(params)?;
         let offset = options.offset().unwrap_or_default();
-        let rows = sql_query(include_str!("krate_reverse_dependencies.sql"))
-            .bind::<Integer, _>(self.id)
-            .bind::<BigInt, _>(i64::from(offset))
-            .bind::<BigInt, _>(i64::from(options.per_page))
-            .load::<WithCount<ReverseDependency>>(conn)?;
+        let rows: Vec<WithCount<ReverseDependency>> =
+            sql_query(include_str!("krate_reverse_dependencies.sql"))
+                .bind::<Integer, _>(self.id)
+                .bind::<BigInt, _>(i64::from(offset))
+                .bind::<BigInt, _>(i64::from(options.per_page))
+                .load(conn)?;
 
         Ok(rows.records_and_total())
     }

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -43,13 +43,13 @@ impl ApiToken {
             crate::util::generate_secure_alphanumeric_string(TOKEN_LENGTH)
         );
 
-        let model = diesel::insert_into(api_tokens::table)
+        let model: ApiToken = diesel::insert_into(api_tokens::table)
             .values((
                 api_tokens::user_id.eq(user_id),
                 api_tokens::name.eq(name),
                 api_tokens::token.eq(digest(&plaintext, "sha256")),
             ))
-            .get_result::<ApiToken>(conn)?;
+            .get_result(conn)?;
 
         Ok(CreatedApiToken { plaintext, model })
     }
@@ -71,7 +71,7 @@ impl ApiToken {
         conn.transaction(|| {
             update(tokens)
                 .set(last_used_at.eq(now.nullable()))
-                .get_result::<ApiToken>(conn)
+                .get_result(conn)
         })
         .or_else(|_| tokens.first(conn))
         .map_err(Into::into)

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -164,7 +164,7 @@ impl User {
         Ok(Email::belonging_to(self)
             .select(emails::email)
             .filter(emails::verified.eq(true))
-            .first::<String>(&*conn)
+            .first(&*conn)
             .optional()?)
     }
 
@@ -200,7 +200,7 @@ impl User {
     pub fn email(&self, conn: &PgConnection) -> AppResult<Option<String>> {
         Ok(Email::belonging_to(self)
             .select(emails::email)
-            .first::<String>(&*conn)
+            .first(&*conn)
             .optional()?)
     }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -63,7 +63,7 @@ impl<'a> NewUser<'a> {
         use diesel::sql_types::Integer;
 
         conn.transaction(|| {
-            let user = insert_into(users)
+            let user: User = insert_into(users)
                 .values(self)
                 // We need the `WHERE gh_id > 0` condition here because `gh_id` set
                 // to `-1` indicates that we were unable to find a GitHub ID for
@@ -81,7 +81,7 @@ impl<'a> NewUser<'a> {
                     gh_avatar.eq(excluded(gh_avatar)),
                     gh_access_token.eq(excluded(gh_access_token)),
                 ))
-                .get_result::<User>(conn)?;
+                .get_result(conn)?;
 
             // To send the user an account verification email
             if let Some(user_email) = email {
@@ -90,11 +90,11 @@ impl<'a> NewUser<'a> {
                     email: user_email,
                 };
 
-                let token = insert_into(emails::table)
+                let token: Option<String> = insert_into(emails::table)
                     .values(&new_email)
                     .on_conflict_do_nothing()
                     .returning(emails::token)
-                    .get_result::<String>(conn)
+                    .get_result(conn)
                     .optional()?;
 
                 if let Some(token) = token {

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -210,9 +210,7 @@ impl NewVersion {
                 )));
             }
 
-            let version = insert_into(versions)
-                .values(self)
-                .get_result::<Version>(conn)?;
+            let version: Version = insert_into(versions).values(self).get_result(conn)?;
 
             insert_into(versions_published_by::table)
                 .values((

--- a/src/publish_rate_limit.rs
+++ b/src/publish_rate_limit.rs
@@ -68,10 +68,10 @@ impl PublishRateLimit {
         sql_function!(fn greatest<T>(x: T, y: T) -> T);
         sql_function!(fn least<T>(x: T, y: T) -> T);
 
-        let burst = publish_rate_overrides::table
+        let burst: i32 = publish_rate_overrides::table
             .find(uploader)
             .select(publish_rate_overrides::burst)
-            .first::<i32>(conn)
+            .first(conn)
             .optional()?
             .unwrap_or(self.burst);
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -276,11 +276,11 @@ pub fn render_and_upload_readme(
 
     conn.transaction(|| {
         Version::record_readme_rendering(version_id, &conn)?;
-        let (crate_name, vers) = versions::table
+        let (crate_name, vers): (String, String) = versions::table
             .find(version_id)
             .inner_join(crates::table)
             .select((crates::name, versions::num))
-            .first::<(String, String)>(&*conn)?;
+            .first(&*conn)?;
         env.uploader
             .upload_readme(env.http_client(), &crate_name, &vers, rendered)?;
         Ok(())

--- a/src/tasks/update_downloads.rs
+++ b/src/tasks/update_downloads.rs
@@ -244,32 +244,23 @@ mod test {
             .execute(&conn)
             .unwrap();
 
-        let version_before = versions::table
-            .find(version.id)
-            .first::<Version>(&conn)
-            .unwrap();
-        let krate_before = Crate::all()
+        let version_before: Version = versions::table.find(version.id).first(&conn).unwrap();
+        let krate_before: Crate = Crate::all()
             .filter(crates::id.eq(krate.id))
-            .first::<Crate>(&conn)
+            .first(&conn)
             .unwrap();
         super::update(&conn).unwrap();
-        let version2 = versions::table
-            .find(version.id)
-            .first::<Version>(&conn)
-            .unwrap();
+        let version2: Version = versions::table.find(version.id).first(&conn).unwrap();
         assert_eq!(version2.downloads, 2);
         assert_eq!(version2.updated_at, version_before.updated_at);
-        let krate2 = Crate::all()
+        let krate2: Crate = Crate::all()
             .filter(crates::id.eq(krate.id))
-            .first::<Crate>(&conn)
+            .first(&conn)
             .unwrap();
         assert_eq!(krate2.downloads, 2);
         assert_eq!(krate2.updated_at, krate_before.updated_at);
         super::update(&conn).unwrap();
-        let version3 = versions::table
-            .find(version.id)
-            .first::<Version>(&conn)
-            .unwrap();
+        let version3: Version = versions::table.find(version.id).first(&conn).unwrap();
         assert_eq!(version3.downloads, 2);
     }
 

--- a/src/tasks/update_downloads.rs
+++ b/src/tasks/update_downloads.rs
@@ -51,10 +51,10 @@ fn collect(conn: &PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
 
         conn.transaction::<_, diesel::result::Error, _>(|| {
             // Update the total number of version downloads
-            let crate_id = update(versions::table.find(download.version_id))
+            let crate_id: i32 = update(versions::table.find(download.version_id))
                 .set(versions::downloads.eq(versions::downloads + amt))
                 .returning(versions::crate_id)
-                .get_result::<i32>(conn)?;
+                .get_result(conn)?;
 
             // Update the total number of crate downloads
             update(crates::table.find(crate_id))

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -49,7 +49,7 @@ fn select_slugs(conn: &PgConnection) -> Vec<String> {
     categories::table
         .select(categories::slug)
         .order(categories::slug)
-        .load::<String>(conn)
+        .load(conn)
         .unwrap()
 }
 

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -1319,9 +1319,9 @@ fn new_krate_records_verified_email() {
     token.enqueue_publish(crate_to_publish).good();
 
     app.db(|conn| {
-        let email = versions_published_by::table
+        let email: String = versions_published_by::table
             .select(versions_published_by::email)
-            .first::<String>(conn)
+            .first(conn)
             .unwrap();
         assert_eq!(email, "something@example.com");
     });

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -97,8 +97,8 @@ fn new_crate_owner() {
     token.add_user_owner("foo_owner", user2.as_model());
 
     // accept invitation for user to be added as owner
-    let crate_id = app.db(|conn| Crate::by_name("foo_owner").first::<Crate>(conn).unwrap().id);
-    user2.accept_ownership_invitation("foo_owner", crate_id);
+    let krate: Crate = app.db(|conn| Crate::by_name("foo_owner").first(conn).unwrap());
+    user2.accept_ownership_invitation("foo_owner", krate.id);
 
     // Make sure this shows up as one of their crates.
     let crates = user2.search_by_user_id(user2.as_model().id);

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -52,9 +52,8 @@ fn can_download_crate_in_read_only_mode() {
         use cargo_registry::schema::version_downloads::dsl::*;
         use diesel::dsl::sum;
 
-        let dl_count = version_downloads
-            .select(sum(downloads))
-            .get_result::<Option<i64>>(conn);
+        let dl_count: Result<Option<i64>, _> =
+            version_downloads.select(sum(downloads)).get_result(conn);
         assert_eq!(Ok(None), dl_count);
     })
 }

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -141,9 +141,7 @@ fn add_team_mixed_case() {
         .good();
 
     app.db(|conn| {
-        let krate = Crate::by_name("foo_mixed_case")
-            .first::<Crate>(conn)
-            .unwrap();
+        let krate: Crate = Crate::by_name("foo_mixed_case").first(conn).unwrap();
         let owners = krate.owners(conn).unwrap();
         assert_eq!(owners.len(), 2);
         let owner = &owners[1];

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -296,7 +296,7 @@ fn using_token_updates_last_used_at() {
     // Use the token once
     token.get::<EncodableMe>("/api/v1/me").good();
 
-    let token = app.db(|conn| t!(ApiToken::belonging_to(user.as_model()).first::<ApiToken>(conn)));
+    let token: ApiToken = app.db(|conn| t!(ApiToken::belonging_to(user.as_model()).first(conn)));
     assert!(token.last_used_at.is_some());
 
     // Would check that it updates the timestamp here, but the timestamp is

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -171,7 +171,8 @@ fn create_token_success() {
     assert_eq!(json.api_token.name, "bar");
     assert!(!json.api_token.token.is_empty());
 
-    let tokens = app.db(|conn| t!(ApiToken::belonging_to(user.as_model()).load::<ApiToken>(conn)));
+    let tokens: Vec<ApiToken> =
+        app.db(|conn| t!(ApiToken::belonging_to(user.as_model()).load(conn)));
     assert_eq!(tokens.len(), 1);
     assert_eq!(tokens[0].name, "bar");
     assert_eq!(tokens[0].revoked, false);
@@ -229,7 +230,7 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 
     // List tokens for first user contains the token
     app.db(|conn| {
-        let tokens = t!(ApiToken::belonging_to(user1).load::<ApiToken>(conn));
+        let tokens: Vec<ApiToken> = t!(ApiToken::belonging_to(user1).load(conn));
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].name, token.name);
     });
@@ -241,7 +242,7 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 
     // List tokens for first user still contains the token
     app.db(|conn| {
-        let tokens = t!(ApiToken::belonging_to(user1).load::<ApiToken>(conn));
+        let tokens: Vec<ApiToken> = t!(ApiToken::belonging_to(user1).load(conn));
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].name, token.name);
     });
@@ -253,7 +254,7 @@ fn revoke_token_success() {
 
     // List tokens contains the token
     app.db(|conn| {
-        let tokens = t!(ApiToken::belonging_to(user.as_model()).load::<ApiToken>(conn));
+        let tokens: Vec<ApiToken> = t!(ApiToken::belonging_to(user.as_model()).load(conn));
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].name, token.as_model().name);
     });

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -425,10 +425,10 @@ fn github_with_email_does_not_overwrite_email() {
 
     let (app, _, user) = TestApp::init().with_user();
     let model = user.as_model();
-    let original_email = app.db(|conn| {
+    let original_email: String = app.db(|conn| {
         Email::belonging_to(model)
             .select(emails::email)
-            .first::<String>(&*conn)
+            .first(&*conn)
             .unwrap()
     });
 
@@ -562,10 +562,10 @@ fn test_confirm_user_email() {
     });
     let user_model = user.as_model();
 
-    let email_token = app.db(|conn| {
+    let email_token: String = app.db(|conn| {
         Email::belonging_to(user_model)
             .select(emails::token)
-            .first::<String>(&*conn)
+            .first(&*conn)
             .unwrap()
     });
 
@@ -733,12 +733,12 @@ fn test_update_email_notifications_not_owned() {
         email_notifications: false,
     }]);
 
-    let email_notifications = app
+    let email_notifications: bool = app
         .db(|conn| {
             crate_owners::table
                 .select(crate_owners::email_notifications)
                 .filter(crate_owners::crate_id.eq(not_my_crate.id))
-                .first::<bool>(&*conn)
+                .first(&*conn)
         })
         .unwrap();
 

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -26,10 +26,7 @@ fn index() {
             .version(VersionBuilder::new("2.0.0").license(Some("MIT")))
             .version(VersionBuilder::new("2.0.1").license(Some("MIT/Apache-2.0")))
             .expect_build(conn);
-        let ids = versions::table
-            .select(versions::id)
-            .load::<i32>(conn)
-            .unwrap();
+        let ids: Vec<i32> = versions::table.select(versions::id).load(conn).unwrap();
         (ids[0], ids[1])
     });
 


### PR DESCRIPTION
This makes the code a little more readable and helps e.g. `intellij-rust` in understanding the types of the variables better

r? @jtgeibel 
