### PR TITLE
CI: Run tests via `cargo-tarpaulin`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,10 +197,8 @@ jobs:
           cargo fmt -- --check
           cargo clippy --all-targets --all-features --all
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1.3
-        with:
-          version: '0.17.0'
+      - run: cargo install cargo-tarpaulin
+      - run: cargo tarpaulin
 
       - name: Prune unnecessary cache
         run: script/ci/prune-cache.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,17 @@ jobs:
           cargo fmt -- --check
           cargo clippy --all-targets --all-features --all
 
-      - run: cargo install cargo-tarpaulin
-      - run: cargo tarpaulin
+      - name: Install cargo-tarpaulin
+        if: matrix.rust == 'stable'
+        run: which cargo-tarpaulin || cargo install cargo-tarpaulin
+
+      - name: Run tests (with coverage report)
+        if: matrix.rust == 'stable'
+        run: cargo tarpaulin
+
+      - name: Run tests
+        if: matrix.rust != 'stable'
+        run: cargo test
 
       - name: Prune unnecessary cache
         run: script/ci/prune-cache.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost/cargo_registry_test
       TEST_DATABASE_URL: postgres://postgres:postgres@localhost/cargo_registry_test
       CARGO_INCREMENTAL: 0
-      RUSTFLAGS: "-C debuginfo=0 -D warnings"
+      RUSTFLAGS: "-D warnings"
       MALLOC_CONF: "background_thread:true,abort_conf:true,abort:true,junk:true"
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,10 @@ jobs:
           cargo fmt -- --check
           cargo clippy --all-targets --all-features --all
 
-      - name: Test
-        run: cargo test
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1.3
+        with:
+          version: '0.17.0'
 
       - name: Prune unnecessary cache
         run: script/ci/prune-cache.sh


### PR DESCRIPTION
This PR adds https://github.com/actions-rs/tarpaulin to our CI pipeline to display a test coverage report.

Resolves https://github.com/rust-lang/crates.io/issues/1162