### PR TITLE
Frontend tests cleanup

### DIFF
--- a/tests/acceptance/categories-test.js
+++ b/tests/acceptance/categories-test.js
@@ -12,30 +12,6 @@ module('Acceptance | categories', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.create('category', { category: 'API bindings' });
-    this.server.create('category', { category: 'Algorithms' });
-    this.server.create('category', { category: 'Asynchronous' });
-
-    await visit('/categories');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
-  test('category/:category_id is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.create('category', { category: 'Algorithms' });
-
-    await visit('/categories/algorithms');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
   test('listing categories', async function (assert) {
     this.server.create('category', { category: 'API bindings' });
     this.server.create('category', { category: 'Algorithms' });
@@ -48,6 +24,9 @@ module('Acceptance | categories', function (hooks) {
     assert.dom('[data-test-category="api-bindings"] [data-test-crate-count]').hasText('0 crates');
     assert.dom('[data-test-category="algorithms"] [data-test-crate-count]').hasText('1 crate');
     assert.dom('[data-test-category="asynchronous"] [data-test-crate-count]').hasText('15 crates');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('category/:category_id index default sort is recent-downloads', async function (assert) {
@@ -56,6 +35,9 @@ module('Acceptance | categories', function (hooks) {
     await visit('/categories/algorithms');
 
     assert.dom('[data-test-category-sort] [data-test-current-order]').hasText('Recent Downloads');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('listing category slugs', async function (assert) {

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -167,7 +167,7 @@ module('Acceptance | crate page', function (hooks) {
   test('crates having normal dependencies', async function (assert) {
     this.server.loadFixtures();
 
-    await visit('crates/nanomsg');
+    await visit('/crates/nanomsg');
 
     assert.dom('[data-test-dependencies] li').exists({ count: 2 });
   });
@@ -175,7 +175,7 @@ module('Acceptance | crate page', function (hooks) {
   test('crates having build dependencies', async function (assert) {
     this.server.loadFixtures();
 
-    await visit('crates/nanomsg');
+    await visit('/crates/nanomsg');
 
     assert.dom('[data-test-build-dependencies] li').exists({ count: 1 });
   });
@@ -183,7 +183,7 @@ module('Acceptance | crate page', function (hooks) {
   test('crates having dev dependencies', async function (assert) {
     this.server.loadFixtures();
 
-    await visit('crates/nanomsg');
+    await visit('/crates/nanomsg');
 
     assert.dom('[data-test-dev-dependencies] li').exists({ count: 1 });
   });

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -13,43 +13,6 @@ module('Acceptance | crate page', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('/crates/:crate is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
-
-    await visit('/crates/nanomsg');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
-  test('/crates/:crate/:version is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
-
-    await visit('/crates/nanomsg/0.6.0');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
-  test('/crates/:crate/owners is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.loadFixtures();
-
-    await visit('/crates/nanomsg/owners');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
   test('visiting a crate page from the front page', async function (assert) {
     this.server.create('crate', { name: 'nanomsg', newest_version: '0.6.1' });
     this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
@@ -78,6 +41,9 @@ module('Acceptance | crate page', function (hooks) {
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
     assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
     assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('visiting /crates/nanomsg/', async function (assert) {
@@ -110,6 +76,9 @@ module('Acceptance | crate page', function (hooks) {
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
     assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.0');
     assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview for 0.6.0 (see all)');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('unknown versions fall back to latest version and show an error message', async function (assert) {

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, currentURL, currentRouteName, visit, waitFor } from '@ember/test-helpers';
+import { click, currentURL, currentRouteName, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test, skip } from 'qunit';
 
@@ -267,74 +267,5 @@ module('Acceptance | crate page', function (hooks) {
     await click('[data-test-manage-owners-link]');
 
     assert.equal(currentURL(), '/crates/nanomsg/owners');
-  });
-
-  test('listing crate owners', async function (assert) {
-    this.server.loadFixtures();
-
-    await visit('/crates/nanomsg/owners');
-
-    assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
-    assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
-    assert.dom('a[href="/teams/github:org:thehydroimpulse"]').exists();
-    assert.dom('a[href="/teams/github:org:blabaere"]').exists();
-    assert.dom('a[href="/users/thehydroimpulse"]').exists();
-    assert.dom('a[href="/users/blabaere"]').exists();
-  });
-
-  test('attempting to add owner without username', async function (assert) {
-    this.server.loadFixtures();
-
-    await visit('/crates/nanomsg/owners');
-    await fillIn('input[name="username"]', '');
-    assert.dom('[data-test-save-button]').isDisabled();
-  });
-
-  test('attempting to add non-existent owner', async function (assert) {
-    this.server.loadFixtures();
-
-    await visit('/crates/nanomsg/owners');
-    await fillIn('input[name="username"]', 'spookyghostboo');
-    await click('[data-test-save-button]');
-
-    assert
-      .dom('[data-test-notification-message="error"]')
-      .hasText('Error sending invite: could not find user with login `spookyghostboo`');
-    assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
-    assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
-  });
-
-  test('add a new owner', async function (assert) {
-    this.server.loadFixtures();
-
-    await visit('/crates/nanomsg/owners');
-    await fillIn('input[name="username"]', 'iain8');
-    await click('[data-test-save-button]');
-
-    assert.dom('[data-test-notification-message="success"]').hasText('An invite has been sent to iain8');
-    assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
-    assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
-  });
-
-  test('remove a crate owner when owner is a user', async function (assert) {
-    this.server.loadFixtures();
-
-    await visit('/crates/nanomsg/owners');
-    await click('[data-test-owner-user="thehydroimpulse"] [data-test-remove-owner-button]');
-
-    assert.dom('[data-test-notification-message="success"]').hasText('User thehydroimpulse removed as crate owner');
-    assert.dom('[data-test-owner-user]').exists({ count: 1 });
-  });
-
-  test('remove a crate owner when owner is a team', async function (assert) {
-    this.server.loadFixtures();
-
-    await visit('/crates/nanomsg/owners');
-    await click('[data-test-owner-team="github:org:thehydroimpulse"] [data-test-remove-owner-button]');
-
-    assert
-      .dom('[data-test-notification-message="success"]')
-      .hasText('Team org/thehydroimpulseteam removed as crate owner');
-    assert.dom('[data-test-owner-team]').exists({ count: 1 });
   });
 });

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -16,17 +16,6 @@ module('Acceptance | crates page', function (hooks) {
   // should match the default set in the crates controller
   const per_page = 50;
 
-  test('/crates is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.loadFixtures();
-
-    await visit('/crates');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
   test('visiting the crates page from the front page', async function (assert) {
     this.server.loadFixtures();
 
@@ -35,6 +24,9 @@ module('Acceptance | crates page', function (hooks) {
 
     assert.equal(currentURL(), '/crates');
     assert.equal(title(), 'Crates - crates.io: Rust Package Registry');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('visiting the crates page directly', async function (assert) {

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -13,15 +13,6 @@ module('Acceptance | front page', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.loadFixtures();
-
-    await visit('/');
-    await a11yAudit(axeConfig);
-  });
-
   test('visiting /', async function (assert) {
     this.server.loadFixtures();
 
@@ -47,5 +38,6 @@ module('Acceptance | front page', function (hooks) {
     assert.dom('[data-test-just-updated] [data-test-crate-link="0"]').hasAttribute('href', '/crates/nanomsg');
 
     await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 });

--- a/tests/acceptance/keyword-test.js
+++ b/tests/acceptance/keyword-test.js
@@ -12,22 +12,14 @@ module('Acceptance | keywords', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('keyword/:keyword_id is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.create('keyword', { keyword: 'network' });
-
-    await visit('/keywords/network');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
   test('keyword/:keyword_id index default sort is recent-downloads', async function (assert) {
     this.server.create('keyword', { keyword: 'network' });
 
     await visit('/keywords/network');
 
     assert.dom('[data-test-keyword-sort] [data-test-current-order]').hasText('Recent Downloads');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 });

--- a/tests/acceptance/keyword-test.js
+++ b/tests/acceptance/keyword-test.js
@@ -17,7 +17,7 @@ module('Acceptance | keywords', function (hooks) {
 
     this.server.create('keyword', { keyword: 'network' });
 
-    await visit('keywords/network');
+    await visit('/keywords/network');
     await percySnapshot(assert);
 
     await a11yAudit(axeConfig);

--- a/tests/acceptance/owners-test.js
+++ b/tests/acceptance/owners-test.js
@@ -1,0 +1,79 @@
+import { click, fillIn, visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from '../helpers/setup-mirage';
+
+module('Acceptance | /crates/:name/owners', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('listing crate owners', async function (assert) {
+    this.server.loadFixtures();
+
+    await visit('/crates/nanomsg/owners');
+
+    assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
+    assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
+    assert.dom('a[href="/teams/github:org:thehydroimpulse"]').exists();
+    assert.dom('a[href="/teams/github:org:blabaere"]').exists();
+    assert.dom('a[href="/users/thehydroimpulse"]').exists();
+    assert.dom('a[href="/users/blabaere"]').exists();
+  });
+
+  test('attempting to add owner without username', async function (assert) {
+    this.server.loadFixtures();
+
+    await visit('/crates/nanomsg/owners');
+    await fillIn('input[name="username"]', '');
+    assert.dom('[data-test-save-button]').isDisabled();
+  });
+
+  test('attempting to add non-existent owner', async function (assert) {
+    this.server.loadFixtures();
+
+    await visit('/crates/nanomsg/owners');
+    await fillIn('input[name="username"]', 'spookyghostboo');
+    await click('[data-test-save-button]');
+
+    assert
+      .dom('[data-test-notification-message="error"]')
+      .hasText('Error sending invite: could not find user with login `spookyghostboo`');
+    assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
+    assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
+  });
+
+  test('add a new owner', async function (assert) {
+    this.server.loadFixtures();
+
+    await visit('/crates/nanomsg/owners');
+    await fillIn('input[name="username"]', 'iain8');
+    await click('[data-test-save-button]');
+
+    assert.dom('[data-test-notification-message="success"]').hasText('An invite has been sent to iain8');
+    assert.dom('[data-test-owners] [data-test-owner-team]').exists({ count: 2 });
+    assert.dom('[data-test-owners] [data-test-owner-user]').exists({ count: 2 });
+  });
+
+  test('remove a crate owner when owner is a user', async function (assert) {
+    this.server.loadFixtures();
+
+    await visit('/crates/nanomsg/owners');
+    await click('[data-test-owner-user="thehydroimpulse"] [data-test-remove-owner-button]');
+
+    assert.dom('[data-test-notification-message="success"]').hasText('User thehydroimpulse removed as crate owner');
+    assert.dom('[data-test-owner-user]').exists({ count: 1 });
+  });
+
+  test('remove a crate owner when owner is a team', async function (assert) {
+    this.server.loadFixtures();
+
+    await visit('/crates/nanomsg/owners');
+    await click('[data-test-owner-team="github:org:thehydroimpulse"] [data-test-remove-owner-button]');
+
+    assert
+      .dom('[data-test-notification-message="success"]')
+      .hasText('Team org/thehydroimpulseteam removed as crate owner');
+    assert.dom('[data-test-owner-team]').exists({ count: 1 });
+  });
+});

--- a/tests/acceptance/owners-test.js
+++ b/tests/acceptance/owners-test.js
@@ -2,6 +2,10 @@ import { click, fillIn, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
+import percySnapshot from '@percy/ember';
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+import axeConfig from '../axe-config';
 import setupMirage from '../helpers/setup-mirage';
 
 module('Acceptance | /crates/:name/owners', function (hooks) {
@@ -19,6 +23,9 @@ module('Acceptance | /crates/:name/owners', function (hooks) {
     assert.dom('a[href="/teams/github:org:blabaere"]').exists();
     assert.dom('a[href="/users/thehydroimpulse"]').exists();
     assert.dom('a[href="/users/blabaere"]').exists();
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('attempting to add owner without username', async function (assert) {

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -14,17 +14,6 @@ module('Acceptance | search', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('/search?q=rust is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.loadFixtures();
-
-    await visit('/search?q=rust');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
   test('searching for "rust"', async function (assert) {
     this.server.loadFixtures();
 
@@ -48,6 +37,9 @@ module('Acceptance | search', function (hooks) {
       .hasText('A Kinetic protocol library written in Rust');
     assert.dom('[data-test-crate-row="0"] [data-test-downloads]').hasText('All-Time: 225');
     assert.dom('[data-test-crate-row="0"] [data-test-updated-at]').exists();
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('searching for "rust" from query', async function (assert) {

--- a/tests/acceptance/team-page-test.js
+++ b/tests/acceptance/team-page-test.js
@@ -12,17 +12,6 @@ module('Acceptance | team page', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.loadFixtures();
-
-    await visit('/teams/github:org:thehydroimpulse');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
   test('has team organization display', async function (assert) {
     this.server.loadFixtures();
 
@@ -30,6 +19,9 @@ module('Acceptance | team page', function (hooks) {
 
     assert.dom('[data-test-heading] [data-test-org-name]').hasText('org');
     assert.dom('[data-test-heading] [data-test-team-name]').hasText('thehydroimpulseteam');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('has link to github in team header', async function (assert) {

--- a/tests/acceptance/user-page-test.js
+++ b/tests/acceptance/user-page-test.js
@@ -12,23 +12,15 @@ module('Acceptance | user page', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  test('is accessible', async function (assert) {
-    assert.expect(0);
-
-    this.server.loadFixtures();
-
-    await visit('/users/thehydroimpulse');
-    await percySnapshot(assert);
-
-    await a11yAudit(axeConfig);
-  });
-
   test('has user display', async function (assert) {
     this.server.loadFixtures();
 
     await visit('/users/thehydroimpulse');
 
     assert.dom('[data-test-heading] [data-test-username]').hasText('thehydroimpulse');
+
+    await percySnapshot(assert);
+    await a11yAudit(axeConfig);
   });
 
   test('has link to github in user header', async function (assert) {


### PR DESCRIPTION
This PR is best reviewed commit by commit 😉 

tl;dr it cleans up our frontend test code a little bit by splitting a file, fixing problematic `visit()` calls and merging redundant/duplicate tests into single tests.

r? @locks 