### PR TITLE
Use `claim` to simplify assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "cargo-registry-s3",
  "chrono",
  "civet",
+ "claim",
  "comrak",
  "conduit",
  "conduit-conditional-get",
@@ -390,6 +391,15 @@ name = "civet-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958d15372bf28b7983cb35e1d4bf36dd843b0d42e507c1c73aad7150372c5936"
+
+[[package]]
+name = "claim"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ad37958d55b29a7088909368968d2fe876a24c203f8441195130f3b15194b9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "cloudabi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ toml = "0.5"
 url = "2.1"
 
 [dev-dependencies]
+claim = "0.4.0"
 conduit-test = "0.9.0-alpha.3"
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }
 hyper-tls = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -187,5 +187,5 @@ fn parse_traffic_patterns_splits_on_comma_and_looks_for_equal_sign() {
     let patterns_2 = parse_traffic_patterns(pattern_string_2).collect::<Vec<_>>();
     assert_eq!(vec![("Baz", "QUX")], patterns_2);
 
-    assert!(parse_traffic_patterns(pattern_string_3).next().is_none());
+    assert_none!(parse_traffic_patterns(pattern_string_3).next());
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -141,12 +141,12 @@ mod tests {
             "test",
             "test",
         );
-        assert!(result.is_err());
+        assert_err!(result);
     }
 
     #[test]
     fn sending_to_valid_email_succeeds() {
         let result = send_email("someone@example.com", "test", "test");
-        assert!(result.is_ok());
+        assert_ok!(result);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@
 #![warn(clippy::all, rust_2018_idioms)]
 #![warn(missing_debug_implementations, missing_copy_implementations)]
 
+#[cfg(test)]
+#[macro_use]
+extern crate claim;
 #[macro_use]
 extern crate derive_deref;
 #[macro_use]

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -564,7 +564,7 @@ mod tests {
             repository: None,
             max_upload_size: None,
         };
-        assert!(krate.validate().is_err());
+        assert_err!(krate.validate());
     }
 
     #[test]

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -133,14 +133,12 @@ mod tests {
             last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
         };
         let json = serde_json::to_string(&tok).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
-        assert!(json
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
+        assert_some!(json
             .as_str()
-            .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
-            .is_some());
+            .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#));
     }
 
     #[test]
@@ -154,13 +152,11 @@ mod tests {
             last_used_at: Some(NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 12)),
         };
         let json = serde_json::to_string(&tok).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
-        assert!(json
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
+        assert_some!(json
             .as_str()
-            .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#)
-            .is_some());
+            .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#));
     }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -1,6 +1,8 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 #[macro_use]
+extern crate claim;
+#[macro_use]
 extern crate diesel;
 #[macro_use]
 extern crate lazy_static;
@@ -32,15 +34,6 @@ use conduit::{header, Body};
 use conduit_test::MockRequest;
 use diesel::prelude::*;
 use reqwest::{blocking::Client, Proxy};
-
-macro_rules! t {
-    ($e:expr) => {
-        match $e {
-            Ok(e) => e,
-            Err(m) => panic!("{} failed with: {}", stringify!($e), m),
-        }
-    };
-}
 
 mod account_lock;
 mod authentication;
@@ -164,7 +157,7 @@ fn build_app(
     };
 
     let app = App::new(config, client);
-    t!(t!(app.primary_database.get()).begin_test_transaction());
+    assert_ok!(assert_ok!(app.primary_database.get()).begin_test_transaction());
     let app = Arc::new(app);
     let handler = cargo_registry::build_handler(Arc::clone(&app));
     (app, handler)

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -14,7 +14,7 @@ lazy_static! {
         {
             let mut ar =
                 tar::Builder::new(GzEncoder::new(&mut empty_tarball, Compression::default()));
-            t!(ar.finish());
+            assert_ok!(ar.finish());
         }
         empty_tarball
     };
@@ -88,12 +88,12 @@ impl PublishBuilder {
             let mut ar = tar::Builder::new(GzEncoder::new(&mut tarball, Compression::default()));
             for &mut (name, ref mut data, size) in files {
                 let mut header = tar::Header::new_gnu();
-                t!(header.set_path(name));
+                assert_ok!(header.set_path(name));
                 header.set_size(size);
                 header.set_cksum();
-                t!(ar.append(&header, data));
+                assert_ok!(ar.append(&header, data));
             }
-            t!(ar.finish());
+            assert_ok!(ar.finish());
         }
 
         self.tarball = tarball;

--- a/src/tests/category.rs
+++ b/src/tests/category.rs
@@ -44,8 +44,10 @@ fn show() {
 
     // Create a category and a subcategory
     app.db(|conn| {
-        t!(new_category("Foo Bar", "foo-bar", "Foo Bar crates").create_or_update(conn));
-        t!(new_category("Foo Bar::Baz", "foo-bar::baz", "Baz crates").create_or_update(conn));
+        assert_ok!(new_category("Foo Bar", "foo-bar", "Foo Bar crates").create_or_update(conn));
+        assert_ok!(
+            new_category("Foo Bar::Baz", "foo-bar::baz", "Baz crates").create_or_update(conn)
+        );
     });
 
     // The category and its subcategories should be in the json
@@ -69,8 +71,10 @@ fn update_crate() {
     let user = user.as_model();
 
     app.db(|conn| {
-        t!(new_category("cat1", "cat1", "Category 1 crates").create_or_update(conn));
-        t!(new_category("Category 2", "category-2", "Category 2 crates").create_or_update(conn));
+        assert_ok!(new_category("cat1", "cat1", "Category 1 crates").create_or_update(conn));
+        assert_ok!(
+            new_category("Category 2", "category-2", "Category 2 crates").create_or_update(conn)
+        );
         let krate = CrateBuilder::new("foo_crate", user.id).expect_build(&conn);
 
         // Updating with no categories has no effect
@@ -122,7 +126,7 @@ fn update_crate() {
         assert_eq!(count(&anon, "category-2"), 0);
 
         // Add a category and its subcategory
-        t!(new_category("cat1::bar", "cat1::bar", "bar crates").create_or_update(conn));
+        assert_ok!(new_category("cat1::bar", "cat1::bar", "bar crates").create_or_update(conn));
         Category::update_crate(&conn, &krate, &["cat1", "cat1::bar"]).unwrap();
 
         assert_eq!(count(&anon, "cat1"), 1);

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -164,7 +164,7 @@ fn show_latest_user_case_insensitively() {
         // should be used for uniquely identifying GitHub accounts whenever possible. For the
         // crates.io/user/:username pages, the best we can do is show the last crates.io account
         // created with that username.
-        t!(NewUser::new(
+        assert_ok!(NewUser::new(
             1,
             "foobar",
             Some("I was first then deleted my github account"),
@@ -172,7 +172,7 @@ fn show_latest_user_case_insensitively() {
             "bar"
         )
         .create_or_update(None, conn));
-        t!(NewUser::new(
+        assert_ok!(NewUser::new(
             2,
             "FOOBAR",
             Some("I was second, I took the foobar username on github"),
@@ -270,7 +270,7 @@ fn following() {
         .iter()
         .find(|v| v.krate == "foo_fighters")
         .unwrap();
-    assert!(foo_version.published_by.is_none());
+    assert_none!(&foo_version.published_by);
     let bar_version = r
         .versions
         .iter()
@@ -357,13 +357,16 @@ fn updating_existing_user_doesnt_change_api_token() {
     let gh_id = user.as_model().gh_id;
     let token = token.plaintext();
 
-    let user = app.db(|conn| {
-        // Reuse gh_id but use new gh_login and gh_access_token
-        t!(NewUser::new(gh_id, "bar", None, None, "bar_token").create_or_update(None, conn));
+    let user =
+        app.db(|conn| {
+            // Reuse gh_id but use new gh_login and gh_access_token
+            assert_ok!(
+                NewUser::new(gh_id, "bar", None, None, "bar_token").create_or_update(None, conn)
+            );
 
-        // Use the original API token to find the now updated user
-        t!(User::find_by_api_token(conn, token))
-    });
+            // Use the original API token to find the now updated user
+            assert_ok!(User::find_by_api_token(conn, token))
+        });
 
     assert_eq!("bar", user.gh_login);
     assert_eq!("bar_token", user.gh_access_token);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -594,7 +594,7 @@ where
 {
     fn new(response: HandlerResult) -> Self {
         Self {
-            response: t!(response),
+            response: assert_ok!(response),
             callback_on_good: None,
         }
     }

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -99,7 +99,7 @@ fn show_by_crate_name_and_semver_no_published_by() {
     });
 
     let json: VersionResponse = anon.show_version("foo_vers_show_no_pb", "1.0.0");
-    assert!(json.version.published_by.is_none());
+    assert_none!(json.version.published_by);
 }
 
 #[test]

--- a/src/views.rs
+++ b/src/views.rs
@@ -261,10 +261,9 @@ mod tests {
             created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
         };
         let json = serde_json::to_string(&cat).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
     }
 
     #[test]
@@ -280,10 +279,9 @@ mod tests {
             parent_categories: vec![],
         };
         let json = serde_json::to_string(&cat).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
     }
 
     #[test]
@@ -295,10 +293,9 @@ mod tests {
             crates_cnt: 0,
         };
         let json = serde_json::to_string(&key).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
     }
 
     #[test]
@@ -335,18 +332,13 @@ mod tests {
             }],
         };
         let json = serde_json::to_string(&ver).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
-        assert!(json
+            .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#));
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
-            .is_some());
-        assert!(json
-            .as_str()
-            .find(r#""time":"2017-01-06T14:23:12+00:00""#)
-            .is_some());
+            .find(r#""created_at":"2017-01-06T14:23:12+00:00""#));
+        assert_some!(json.as_str().find(r#""time":"2017-01-06T14:23:12+00:00""#));
     }
 
     #[test]
@@ -379,14 +371,12 @@ mod tests {
             exact_match: false,
         };
         let json = serde_json::to_string(&crt).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
-        assert!(json
+            .find(r#""updated_at":"2017-01-06T14:23:11+00:00""#));
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:12+00:00""#)
-            .is_some());
+            .find(r#""created_at":"2017-01-06T14:23:12+00:00""#));
     }
 
     #[test]
@@ -398,9 +388,8 @@ mod tests {
             created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
         };
         let json = serde_json::to_string(&inv).unwrap();
-        assert!(json
+        assert_some!(json
             .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#)
-            .is_some());
+            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
     }
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -233,10 +233,10 @@ impl ToSql<Text, Pg> for EncodableFeature {
 fn feature_deserializes_for_valid_features() {
     use serde_json as json;
 
-    assert!(json::from_str::<EncodableFeature>("\"foo\"").is_ok());
-    assert!(json::from_str::<EncodableFeature>("\"\"").is_err());
-    assert!(json::from_str::<EncodableFeature>("\"/\"").is_err());
-    assert!(json::from_str::<EncodableFeature>("\"%/%\"").is_err());
-    assert!(json::from_str::<EncodableFeature>("\"a/a\"").is_ok());
-    assert!(json::from_str::<EncodableFeature>("\"32-column-tables\"").is_ok());
+    assert_ok!(json::from_str::<EncodableFeature>("\"foo\""));
+    assert_err!(json::from_str::<EncodableFeature>("\"\""));
+    assert_err!(json::from_str::<EncodableFeature>("\"/\""));
+    assert_err!(json::from_str::<EncodableFeature>("\"%/%\""));
+    assert_ok!(json::from_str::<EncodableFeature>("\"a/a\""));
+    assert_ok!(json::from_str::<EncodableFeature>("\"32-column-tables\""));
 }


### PR DESCRIPTION
This PR introduces https://github.com/svartalf/rust-claim/ for our tests to replace our custom `t!()` macro and simplify/improve a few other `assert!()` usages.

`t!()` is certainly shorter than `assert_ok!()`, but I think the latter expresses the intent way better than the former. With `t!()` is was always thinking that this might have something to do with translations... 😅 

r? @jtgeibel 