### PR TITLE
services/session: Add user ids to Sentry context

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,6 +1,7 @@
 import { alias } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
+import * as Sentry from '@sentry/browser';
 import { race, rawTimeout, task, waitForEvent } from 'ember-concurrency';
 import window from 'ember-window-mock';
 
@@ -128,6 +129,7 @@ export default class SessionService extends Service {
     this.isLoggedIn = false;
 
     this.loadUserTask.cancelAll({ resetState: true });
+    Sentry.setUser(null);
 
     this.router.transitionTo('index');
   })
@@ -145,6 +147,9 @@ export default class SessionService extends Service {
 
     let currentUser = this.store.push(this.store.normalize('user', response.user));
     let ownedCrates = response.owned_crates.map(c => this.store.push(this.store.normalize('owned-crate', c)));
+
+    let { id } = currentUser;
+    Sentry.setUser({ id });
 
     return { currentUser, ownedCrates };
   }).drop())


### PR DESCRIPTION
This will make it easier to associate backend errors with frontend errors on Sentry.

r? @pietroalbini 