### PR TITLE
Fix version logic when there are only pre-releases

### DIFF
--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -36,7 +36,7 @@ export default class VersionRoute extends Route {
             // There's not even any unyanked version...
             params.version_num = maxVersion;
           } else {
-            params.version_num = latestUnyankedVersion;
+            params.version_num = latestUnyankedVersion.num;
           }
         } else {
           params.version_num = latestStableVersion.num;


### PR DESCRIPTION
It looks like fixing the bug in #2894 exposed this bug. When there are
only pre-release versions of a crate, the version number needs to be
extracted so that the version object can be located again a few lines
later. This could probably be refactored, but for now this removes the
spurious error notification shown in the UI.

r? @Turbo87 