### PR TITLE
Cleanup crate version downloads processing code

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -59,11 +59,11 @@ export default class CrateVersionController extends Controller {
     }
 
     downloads.forEach(d => {
-      let version_id = d.get('version.id');
+      let version_id = d.version.id;
       let key = d.date;
       if (dates[key]) {
         let prev = dates[key].cnt[version_id] || 0;
-        dates[key].cnt[version_id] = prev + d.get('downloads');
+        dates[key].cnt[version_id] = prev + d.downloads;
       }
     });
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -55,12 +55,12 @@ export default class CrateVersionController extends Controller {
     let versions = [];
     for (let i = 0; i < 90; i++) {
       let now = moment().subtract(i, 'days');
-      dates[now.format('MMM D')] = { date: now, cnt: {} };
+      dates[now.toISOString().slice(0, 10)] = { date: now, cnt: {} };
     }
 
     downloads.forEach(d => {
       let version_id = d.get('version.id');
-      let key = moment(d.get('date')).utc().format('MMM D');
+      let key = d.date;
       if (dates[key]) {
         let prev = dates[key].cnt[version_id] || 0;
         dates[key].cnt[version_id] = prev + d.get('downloads');
@@ -68,7 +68,7 @@ export default class CrateVersionController extends Controller {
     });
 
     extra.forEach(d => {
-      let key = moment(d.date).utc().format('MMM D');
+      let key = d.date;
       if (dates[key]) {
         let prev = dates[key].cnt[null] || 0;
         dates[key].cnt[null] = prev + d.downloads;

--- a/app/models/version-download.js
+++ b/app/models/version-download.js
@@ -2,7 +2,7 @@ import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class VersionDownload extends Model {
   @attr downloads;
-  @attr('date') date;
+  @attr date;
 
   @belongsTo('version', { async: false }) version;
 }

--- a/app/models/version-download.js
+++ b/app/models/version-download.js
@@ -1,7 +1,9 @@
 import Model, { belongsTo, attr } from '@ember-data/model';
 
 export default class VersionDownload extends Model {
+  /** @type number */
   @attr downloads;
+  /** @type string */
   @attr date;
 
   @belongsTo('version', { async: false }) version;


### PR DESCRIPTION
This gets rid of a few instances of unnecessary `Date` parsing. In most cases we can just use the ISO8601 string directly, without having to convert to `Date` and back to a string all the time.

r? @locks 