### PR TITLE
Add "compilers" category.

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -285,27 +285,6 @@ description = """
 Compilers, interpreters, transpilers implemented for particular programming languages.\
 """
 
-[language-implementations.categories.transpilers]
-name = "Transpiler implementations"
-description = """
-Transpilers deal with source to source translations, such as\
-Python <-> Rust
-"""
-
-[language-implementations.categories.compilers]
-name = "Compiler implementations"
-description = """
-Compilers deal with source to machine translations, like compiling\
-Rust for x86 architectures.
-"""
-
-[language-implementations.categories.interpreters]
-name = "Interpreter implementations"
-description = """
-Interpreters deal with source to some IR translations, such as AST or\
-bytecode based interpreters like CPython or Rust's MIRI.
-"""
-
 [localization]
 name = "Localization (L10n)"
 description = """

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -64,7 +64,7 @@ the results.\
 [compilers]
 name = "Compilers"
 description = """
-Compiler implementations, for translating high-level languages into lower level ones.\
+Compiler implementations, including interpreters and transpilers.\
 """
 
 [command-line-interface]
@@ -283,13 +283,6 @@ name = "Internationalization (i18n)"
 description = """
 Crates to help develop software capable of adapting to various \
 languages and regions.\
-"""
-
-[interpreters]
-name = "Interpreters"
-description = """
-Interpreter implementations, without requiring them previously to have been compiled \
-into a machine language program.\
 """
 
 [localization]

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -279,6 +279,33 @@ Crates to help develop software capable of adapting to various \
 languages and regions.\
 """
 
+[language-implementations]
+name = "Language implementations"
+description = """
+Compilers, interpreters, transpilers implemented for particular programming languages.\
+"""
+
+[language-implementations.categories.transpilers]
+name = "Transpiler implementations"
+description = """
+Transpilers deal with source to source translations, such as\
+Python <-> Rust
+"""
+
+[language-implementations.categories.compilers]
+name = "Compiler implementations"
+description = """
+Compilers deal with source to machine translations, like compiling\
+Rust for x86 architectures.
+"""
+
+[language-implementations.categories.interpreters]
+name = "Interpreter implementations"
+description = """
+Interpreters deal with source to some IR translations, such as AST or\
+bytecode based interpreters like CPython or Rust's MIRI.
+"""
+
 [localization]
 name = "Localization (L10n)"
 description = """

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -61,6 +61,12 @@ Crates to store the results of previous computations in order to reuse \
 the results.\
 """
 
+[compilers]
+name = "Compilers"
+description = """
+Compiler implementations, for translating high-level languages into lower level ones.\
+"""
+
 [command-line-interface]
 name = "Command-line interface"
 description = """
@@ -279,10 +285,11 @@ Crates to help develop software capable of adapting to various \
 languages and regions.\
 """
 
-[language-implementations]
-name = "Language implementations"
+[interpreters]
+name = "Interpreters"
 description = """
-Compilers, interpreters, transpilers implemented for particular programming languages.\
+Interpreter implementations, without requiring them previously to have been compiled \
+into a machine language program.\
 """
 
 [localization]


### PR DESCRIPTION
Sub categories include: transpilers, interpreters, and compilers.

I decided to follow the precedence set by `"parser-implementations"` and `"parsing"` for these categories since they felt appropriately related.

Resolves #1412 