### PR TITLE
config/targets: Support all browser versions released within the past year

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -8,5 +8,6 @@ module.exports = {
     'last 1 iOS version',
     'last 1 Edge version',
     'last 1 UCAndroid version',
+    'last 1 years',
   ],
 };


### PR DESCRIPTION
It looks like https://github.com/browserslist/browserslist currently does not support something like `last 2 Firefox ESR versions`, because `ESR` is essentially treated as an alias for a specific version.

Instead, this PR proposes to add the `last 1 years` specifier which covers all of the browsers listed below:

```
❯ browserslist "last 1 years"
and_chr 85
and_ff 79
and_qq 10.4
android 81
chrome 86
chrome 85
chrome 84
chrome 83
chrome 81
chrome 80
chrome 79
edge 86
edge 85
edge 84
edge 83
edge 81
edge 80
edge 79
firefox 82
firefox 81
firefox 80
firefox 79
firefox 78
firefox 77
firefox 76
firefox 75
firefox 74
firefox 73
firefox 72
firefox 71
ios_saf 14
ios_saf 13.4-13.7
ios_saf 13.3
op_mob 59
opera 71
opera 70
opera 69
opera 68
opera 67
opera 66
opera 65
safari 14
safari 13.1
samsung 12.0
samsung 11.1-11.2
```

Resolves #2984 