### PR TITLE
Update to the latest semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,7 @@ dependencies = [
  "rand",
  "reqwest",
  "scheduled-thread-pool",
- "semver 0.10.0",
+ "semver 0.11.0",
  "sentry",
  "serde",
  "serde_json",
@@ -2377,17 +2377,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
 ]
 
 [[package]]
 name = "semver"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "diesel",
- "semver-parser",
+ "semver-parser 0.10.1",
  "serde",
 ]
 
@@ -2396,6 +2396,15 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ef146c2ad5e5f4b037cd6ce2ebb775401729b19a82040c1beac9d36c7d1428"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "sentry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ parse_link_header = "0.2.0"
 rand = "0.7"
 reqwest = { version = "0.10", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "0.2.0"
-semver = { version = "0.10", features = ["diesel", "serde"] }
+semver = { version = "0.11", features = ["diesel", "serde"] }
 sentry = "0.21.0"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -92,7 +92,7 @@ pub fn add_dependencies(
                 .map_err(|_| cargo_err(&format_args!("no known crate named `{}`", &*dep.name)))?;
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {
                 return Err(cargo_err(
-                    "wildcard (`*`) dependency constraints are not allowed \
+                    "wildcard (`*` or `>= 0`) dependency constraints are not allowed \
                      on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-\
                      libraries-use--as-a-version-for-their-dependencies for more \
                      information",

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -190,6 +190,7 @@ fn bad_resp(r: &mut AppResponse) -> Option<Bad> {
     Some(bad)
 }
 
+#[track_caller]
 fn json<T>(r: &mut AppResponse) -> T
 where
     for<'de> T: serde::Deserialize<'de>,

--- a/src/tests/builders/dependency.rs
+++ b/src/tests/builders/dependency.rs
@@ -15,7 +15,7 @@ impl DependencyBuilder {
             explicit_name_in_toml: None,
             name: name.to_string(),
             registry: None,
-            version_req: u::EncodableCrateVersionReq(semver::VersionReq::parse(">= 0").unwrap()),
+            version_req: u::EncodableCrateVersionReq(semver::VersionReq::parse("> 0").unwrap()),
         }
     }
 


### PR DESCRIPTION
The new release of semver treats `>= 0` the same as the `*` wildcard.
It makes sense that these are equivalent, but this did break 3 tests
and will technically reject syntax in `Cargo.toml` that was previously
accepted.

r? @ghost