### PR TITLE
Improve backend integration with Sentry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,3 +100,4 @@ tower-service = "0.3.0"
 diesel = { version = "1.3.0", features = ["postgres"] }
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }
 dotenv = "0.15"
+git2 = "0.13.0"

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,13 @@
 use diesel::prelude::*;
 use diesel_migrations::run_pending_migrations;
 use std::env;
+use std::error::Error;
 
 fn main() {
+    if let Err(err) = load_git_commit() {
+        println!("cargo:warning=failed to load git commit: {}", err);
+    }
+
     println!("cargo:rerun-if-env-changed=TEST_DATABASE_URL");
     println!("cargo:rerun-if-changed=.env");
     println!("cargo:rerun-if-changed=migrations/");
@@ -13,4 +18,23 @@ fn main() {
             run_pending_migrations(&connection).expect("Error running migrations");
         }
     }
+}
+
+fn load_git_commit() -> Result<(), Box<dyn Error>> {
+    let repo = git2::Repository::open(env::current_dir()?)?;
+    let head = repo.head()?;
+
+    // Ensure the build script is re-run if the current commit changes.
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    if let Some(name) = head.name() {
+        println!("cargo:rerun-if-changed=.git/{}", name);
+    }
+
+    if let Some(hash) = head.target() {
+        let mut hash = hash.to_string();
+        hash.truncate(7);
+        println!("cargo:rustc-env=CRATES_IO_GIT_COMMIT={}", hash);
+    }
+
+    Ok(())
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -38,6 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     .map(Cow::Owned)
                     .expect("SENTRY_ENV_API must be set when using SENTRY_DSN_API"),
             );
+            opts.release = option_env!("CRATES_IO_GIT_COMMIT").map(Into::into);
 
             sentry::init(opts)
         });

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -69,14 +69,7 @@ pub fn add_custom_metadata<V: Display>(req: &mut dyn RequestExt, key: &'static s
 fn report_to_sentry(req: &dyn RequestExt, res: &AfterResult, response_time: u64) {
     let (message, level) = match res {
         Err(e) => (e.to_string(), Level::Error),
-        Ok(_) => {
-            if response_time <= SLOW_REQUEST_THRESHOLD_MS {
-                return;
-            }
-
-            let message = format!("Slow Request: {} {}", req.method(), req.path());
-            (message, Level::Info)
-        }
+        Ok(_) => return,
     };
 
     let config = |scope: &mut sentry::Scope| {

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 const SLOW_REQUEST_THRESHOLD_MS: u64 = 1000;
 
-const FILTERED_HEADERS: [&str; 3] = ["Authorization", "Cookie", "X-Real-Ip"];
+const FILTERED_HEADERS: &[&str] = &["Authorization", "Cookie", "X-Real-Ip", "X-Forwarded-For"];
 
 #[derive(Default)]
 pub(super) struct LogRequests();


### PR DESCRIPTION
This PR introduces multiple improvements to our backend Sentry integration:

* The `X-Forwarded-For` header is stripped before sending an event, as that contains PII.
* Slow requests are not sent to Sentry anymore, as those alerts are not really actionable.
* The current git commit is included in every event sent to Sentry, to be able to identify releases.

r? @Turbo87 