### PR TITLE
Use `clap` for CLI argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,6 @@ dependencies = [
  "diesel",
  "diesel_full_text_search",
  "diesel_migrations",
- "docopt",
  "dotenv",
  "env_logger",
  "failure",
@@ -414,7 +413,7 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "os_str_bytes",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap",
  "unicode-width",
@@ -750,18 +749,6 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
-name = "docopt"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f525a586d310c87df72ebcd98009e57f1cc030c8c268305287a476beb653969"
-dependencies = [
- "lazy_static",
- "regex",
- "serde",
- "strsim 0.9.3",
-]
 
 [[package]]
 name = "dotenv"
@@ -2701,12 +2688,6 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
-
-[[package]]
-name = "strsim"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "chrono",
  "civet",
  "claim",
+ "clap",
  "comrak",
  "conduit",
  "conduit-conditional-get",
@@ -399,6 +400,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ad37958d55b29a7088909368968d2fe876a24c203f8441195130f3b15194b9"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "clap"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd1061998a501ee7d4b6d449020df3266ca3124b941ec56cf2005c3779ca142"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "indexmap",
+ "lazy_static",
+ "os_str_bytes",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "370f715b81112975b1b69db93e0b56ea4cd4e5002ac43b2da8474106a54096a1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -727,7 +760,7 @@ dependencies = [
  "lazy_static",
  "regex",
  "serde",
- "strsim",
+ "strsim 0.9.3",
 ]
 
 [[package]]
@@ -1050,6 +1083,15 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1804,6 +1846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac6fe3538f701e339953a3ebbe4f39941aababa8a3f6964635b24ab526daeac"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1994,6 +2042,30 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -2637,6 +2709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +2811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2993,6 +3080,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3146,12 @@ name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ base64 = "0.13"
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 chrono = { version = "0.4.0", features = ["serde"] }
 civet = "0.12.0-alpha.4"
+clap = "=3.0.0-beta.2"
 comrak = { version = "0.8", default-features = false }
 
 conduit = "0.9.0-alpha.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ ctrlc = { version = "3.0", features = ["termination"] }
 derive_deref = "1.1.1"
 diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
 diesel_full_text_search = "1.0.0"
-docopt = "1.0"
 dotenv = "0.15"
 env_logger = "0.8"
 failure = "0.1.1"

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -1,10 +1,3 @@
-// Purge all references to a crate's version from the database.
-//
-// Please be super sure you want to do this before running this.
-//
-// Usage:
-//      cargo run --bin delete-version crate-name version-number
-
 #![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{
@@ -12,12 +5,22 @@ use cargo_registry::{
     models::{Crate, Version},
     schema::versions,
 };
-use std::{
-    env,
-    io::{self, prelude::*},
-};
+use std::io::{self, prelude::*};
 
+use clap::Clap;
 use diesel::prelude::*;
+
+#[derive(Clap, Debug)]
+#[clap(
+    name = "delete-version",
+    about = "Purge all references to a crate's version from the database.\n\nPlease be super sure you want to do this before running this."
+)]
+struct Opts {
+    /// Name of the crate
+    crate_name: String,
+    /// Version number that should be deleted
+    version: String,
+}
 
 fn main() {
     let conn = db::connect_now().unwrap();
@@ -29,29 +32,16 @@ fn main() {
 }
 
 fn delete(conn: &PgConnection) {
-    let name = match env::args().nth(1) {
-        None => {
-            println!("needs a crate-name argument");
-            return;
-        }
-        Some(s) => s,
-    };
-    let version = match env::args().nth(2) {
-        None => {
-            println!("needs a version argument");
-            return;
-        }
-        Some(s) => s,
-    };
+    let opts: Opts = Opts::parse();
 
-    let krate: Crate = Crate::by_name(&name).first(conn).unwrap();
+    let krate: Crate = Crate::by_name(&opts.crate_name).first(conn).unwrap();
     let v: Version = Version::belonging_to(&krate)
-        .filter(versions::num.eq(&version))
+        .filter(versions::num.eq(&opts.version))
         .first(conn)
         .unwrap();
     print!(
         "Are you sure you want to delete {}#{} ({}) [y/N]: ",
-        name, version, v.id
+        opts.crate_name, opts.version, v.id
     );
     io::stdout().flush().unwrap();
     let mut line = String::new();

--- a/src/bin/populate.rs
+++ b/src/bin/populate.rs
@@ -1,16 +1,20 @@
-// Populate a set of dummy download statistics for a specific version in the
-// database.
-//
-// Usage:
-//      cargo run --bin populate version_id1 version_id2 ...
-
 #![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{db, schema::version_downloads};
-use std::env;
 
+use clap::Clap;
 use diesel::prelude::*;
 use rand::{thread_rng, Rng};
+
+#[derive(Clap, Debug)]
+#[clap(
+    name = "populate",
+    about = "Populate a set of dummy download statistics for a specific version in the database."
+)]
+struct Opts {
+    #[clap(required = true)]
+    version_ids: Vec<i32>,
+}
 
 fn main() {
     let conn = db::connect_now().unwrap();
@@ -20,10 +24,9 @@ fn main() {
 fn update(conn: &PgConnection) -> QueryResult<()> {
     use diesel::dsl::*;
 
-    let ids = env::args()
-        .skip(1)
-        .filter_map(|arg| arg.parse::<i32>().ok());
-    for id in ids {
+    let opts: Opts = Opts::parse();
+
+    for id in opts.version_ids {
         let mut rng = thread_rng();
         let mut dls = rng.gen_range(5_000i32, 10_000);
 

--- a/src/bin/verify-token.rs
+++ b/src/bin/verify-token.rs
@@ -1,14 +1,23 @@
-// Look up a username by API token. Used by staff to verify someone's identity
-// by having an API token given. If an error occurs, including being unable to
-// find a user with that API token, the error will be displayed.
-
 use cargo_registry::{db, models::User, util::errors::AppResult};
-use std::env;
+
+use clap::Clap;
+
+#[derive(Clap, Debug)]
+#[clap(
+    name = "verify-token",
+    about = "Look up a username by API token. Used by staff to verify someone's identity \
+        by having an API token given. If an error occurs, including being unable to \
+        find a user with that API token, the error will be displayed."
+)]
+struct Opts {
+    api_token: String,
+}
 
 fn main() -> AppResult<()> {
+    let opts: Opts = Opts::parse();
+
     let conn = db::connect_now()?;
-    let token = env::args().nth(1).expect("API token argument required");
-    let user = User::find_by_api_token(&conn, &token)?;
+    let user = User::find_by_api_token(&conn, &opts.api_token)?;
     println!("The token belongs to user {}", user.gh_login);
     Ok(())
 }


### PR DESCRIPTION
This should make it easier to convert these binaries to clap subcommands in a follow-up PR. It also simplifies our argument parsing code and generates help messages and proper errors if the passed arguments don't match our expectations.

r? @jtgeibel 