### PR TITLE
Use `dialoguer` crate for command line confirmations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "cookie",
  "ctrlc",
  "derive_deref",
+ "dialoguer",
  "diesel",
  "diesel_full_text_search",
  "diesel_migrations",
@@ -568,6 +569,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50aab2529019abfabfa93f1e6c41ef392f91fbf179b347a7e96abb524884a08"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi 0.3.9",
+ "winapi-util",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +699,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f807b2943dc90f9747497d9d65d7e92472149be0b88bf4ce1201b4ac979c26"
+dependencies = [
+ "console",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "diesel"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +790,12 @@ name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -2795,6 +2830,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3328,3 +3373,9 @@ dependencies = [
  "markup5ever",
  "time 0.1.44",
 ]
+
+[[package]]
+name = "zeroize"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ conduit-static = "0.9.0-alpha.3"
 cookie = { version = "0.14", features = ["secure"] }
 ctrlc = { version = "3.0", features = ["termination"] }
 derive_deref = "1.1.1"
+dialoguer = "0.7.1"
 diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
 diesel_full_text_search = "1.0.0"
 dotenv = "0.15"

--- a/src/bin/delete-crate.rs
+++ b/src/bin/delete-crate.rs
@@ -3,8 +3,9 @@
 use cargo_registry::{db, models::Crate, schema::crates};
 
 use clap::Clap;
-use dialoguer::Confirm;
 use diesel::prelude::*;
+
+mod dialoguer;
 
 #[derive(Clap, Debug)]
 #[clap(
@@ -34,13 +35,7 @@ fn delete(conn: &PgConnection) {
         "Are you sure you want to delete {} ({})?",
         opts.crate_name, krate.id
     );
-    if !Confirm::new()
-        .with_prompt(prompt)
-        .default(false)
-        .wait_for_newline(true)
-        .interact()
-        .unwrap()
-    {
+    if !dialoguer::confirm(&prompt) {
         return;
     }
 
@@ -50,13 +45,7 @@ fn delete(conn: &PgConnection) {
         .unwrap();
     println!("  {} deleted", n);
 
-    if !Confirm::new()
-        .with_prompt("commit?")
-        .default(false)
-        .wait_for_newline(true)
-        .interact()
-        .unwrap()
-    {
+    if !dialoguer::confirm("commit?") {
         panic!("aborting transaction");
     }
 }

--- a/src/bin/delete-version.rs
+++ b/src/bin/delete-version.rs
@@ -7,8 +7,9 @@ use cargo_registry::{
 };
 
 use clap::Clap;
-use dialoguer::Confirm;
 use diesel::prelude::*;
+
+mod dialoguer;
 
 #[derive(Clap, Debug)]
 #[clap(
@@ -44,13 +45,7 @@ fn delete(conn: &PgConnection) {
         "Are you sure you want to delete {}#{} ({})?",
         opts.crate_name, opts.version, v.id
     );
-    if !Confirm::new()
-        .with_prompt(prompt)
-        .default(false)
-        .wait_for_newline(true)
-        .interact()
-        .unwrap()
-    {
+    if !dialoguer::confirm(&prompt) {
         return;
     }
 
@@ -59,13 +54,7 @@ fn delete(conn: &PgConnection) {
         .execute(conn)
         .unwrap();
 
-    if !Confirm::new()
-        .with_prompt("commit?")
-        .default(false)
-        .wait_for_newline(true)
-        .interact()
-        .unwrap()
-    {
+    if !dialoguer::confirm("commit?") {
         panic!("aborting transaction");
     }
 }

--- a/src/bin/dialoguer/mod.rs
+++ b/src/bin/dialoguer/mod.rs
@@ -1,0 +1,32 @@
+use ::dialoguer::{theme::Theme, Confirm};
+
+pub fn confirm(msg: &str) -> bool {
+    Confirm::with_theme(&CustomTheme)
+        .with_prompt(msg)
+        .default(false)
+        .wait_for_newline(true)
+        .interact()
+        .unwrap()
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct CustomTheme;
+
+impl Theme for CustomTheme {
+    fn format_confirm_prompt(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        prompt: &str,
+        default: Option<bool>,
+    ) -> std::fmt::Result {
+        if !prompt.is_empty() {
+            write!(f, "{} ", &prompt)?;
+        }
+        match default {
+            None => write!(f, "[y/n] ")?,
+            Some(true) => write!(f, "[Y/n] yes")?,
+            Some(false) => write!(f, "[y/N] no")?,
+        }
+        Ok(())
+    }
+}

--- a/src/bin/transfer-crates.rs
+++ b/src/bin/transfer-crates.rs
@@ -8,8 +8,9 @@ use cargo_registry::{
 use std::process::exit;
 
 use clap::Clap;
-use dialoguer::Confirm;
 use diesel::prelude::*;
+
+mod dialoguer;
 
 #[derive(Clap, Debug)]
 #[clap(
@@ -87,13 +88,7 @@ fn transfer(conn: &PgConnection) {
 }
 
 fn get_confirm(msg: &str) {
-    if !Confirm::new()
-        .with_prompt(msg)
-        .default(false)
-        .wait_for_newline(true)
-        .interact()
-        .unwrap()
-    {
+    if !dialoguer::confirm(msg) {
         exit(0);
     }
 }


### PR DESCRIPTION
This simplifies our command line confirmation code in the admin tools by using https://docs.rs/dialoguer.

r? @jtgeibel 