### PR TITLE
Added Accessibility category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -26,6 +26,12 @@
 #   `@`, `:`, or `.`. They should be all lowercase.
 #
 
+[accessibility]
+name = "Accessibility"
+description = """
+Crates that implement features for the convenience of disabled people. \
+"""
+
 [algorithms]
 name = "Algorithms"
 description = """

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -29,7 +29,7 @@
 [accessibility]
 name = "Accessibility"
 description = """
-Crates that implement features for the convenience of disabled people. \
+Tools for making your creations usable by as many people as possible. \
 """
 
 [algorithms]


### PR DESCRIPTION
I've added the `accessibility` category to cover crates that implement features for the convenience of disabled people.

I wanted to start a project that translates given colour codes to colours colorblind people can distinguish more easily, but I haven't found a category to fit it. What else belongs in this category could be crates that interoperate with peoples screenreaders, new screenreader implementations or other assistive technology.