### PR TITLE
template-lint: Enable `a11y` preset

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,14 @@
 'use strict';
 
 module.exports = {
-  extends: 'octane',
+  extends: ['octane', 'a11y'],
+
+  pending: [
+    { moduleId: 'app/components/email-input', only: ['require-input-label'] },
+    { moduleId: 'app/components/header', only: ['no-duplicate-landmark-elements'] },
+    // see https://github.com/ember-template-lint/ember-template-lint/issues/1604
+    { moduleId: 'app/components/pagination', only: ['no-invalid-link-title'] },
+    { moduleId: 'app/templates/catch-all', only: ['require-input-label'] },
+    { moduleId: 'app/components/settings/api-tokens', only: ['require-input-label'] },
+  ],
 };


### PR DESCRIPTION
see https://github.com/ember-template-lint/ember-template-lint/blob/master/lib/config/a11y.js

r? @locks 