### PR TITLE
Parse query params with `serde` and `serde_urlencoded`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "serde_urlencoded 0.7.0",
  "sha2 0.9.1",
  "swirl",
  "tar",
@@ -896,6 +897,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -2261,7 +2272,7 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_json",
- "serde_urlencoded",
+ "serde_urlencoded 0.6.1",
  "tokio",
  "tokio-tls",
  "url",
@@ -2511,6 +2522,18 @@ dependencies = [
  "itoa",
  "serde",
  "url",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ semver = { version = "0.10", features = ["diesel", "serde"] }
 sentry = "0.20.1"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
+serde_urlencoded = "0.7.0"
 sha2 = "0.9"
 swirl = { git = "https://github.com/sgrif/swirl.git", rev = "e87cf37" }
 tar = "0.4.16"

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -12,7 +12,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
     // to paginate this.
-    let options = PaginationOptions::new(&query)?;
+    let options = PaginationOptions::new(&req.query_string().unwrap_or(""))?;
     let offset = options.offset().unwrap_or_default();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -109,16 +109,14 @@ impl<T> Paginated<T> {
     }
 
     pub(crate) fn prev_page_params(&self) -> Option<IndexMap<String, String>> {
-        if let Page::Numeric(1) | Page::Unspecified = self.options.page {
-            return None;
-        }
-
-        let mut opts = IndexMap::new();
         match self.options.page {
-            Page::Numeric(n) => opts.insert("page".into(), (n - 1).to_string()),
-            Page::Unspecified => unreachable!(),
-        };
-        Some(opts)
+            Page::Numeric(1) | Page::Unspecified => None,
+            Page::Numeric(n) => {
+                let mut opts = IndexMap::new();
+                opts.insert("page".into(), (n - 1).to_string());
+                Some(opts)
+            }
+        }
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -177,7 +177,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Page, PaginationOptions};
+    use super::PaginationOptions;
 
     use conduit::StatusCode;
     use indexmap::IndexMap;
@@ -186,7 +186,10 @@ mod tests {
     fn page_must_be_a_number() {
         let mut params = IndexMap::new();
         params.insert(String::from("page"), String::from("not a number"));
-        let page_error = Page::new(&params).unwrap_err().response().unwrap();
+        let page_error = PaginationOptions::new(&params)
+            .unwrap_err()
+            .response()
+            .unwrap();
 
         assert_eq!(page_error.status(), StatusCode::BAD_REQUEST);
     }

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -113,23 +113,9 @@ impl<T> Paginated<T> {
         }
     }
 
-    pub(crate) fn next_page_params(&self) -> Option<IndexMap<String, String>> {
-        self.next_page().map(|page| to_page_map(page))
-    }
-
-    pub(crate) fn prev_page_params(&self) -> Option<IndexMap<String, String>> {
-        self.prev_page().map(|page| to_page_map(page))
-    }
-
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
         self.records_and_total.iter().map(|row| &row.record)
     }
-}
-
-fn to_page_map(page: u32) -> IndexMap<String, String> {
-    let mut opts = IndexMap::new();
-    opts.insert("page".into(), page.to_string());
-    opts
 }
 
 impl<T: 'static> IntoIterator for Paginated<T> {

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -95,28 +95,38 @@ impl<T> Paginated<T> {
         )
     }
 
-    pub(crate) fn next_page_params(&self) -> Option<IndexMap<String, String>> {
+    pub(crate) fn next_page(&self) -> Option<u32> {
         if self.records_and_total.len() < self.options.per_page as usize {
             return None;
         }
 
-        let mut opts = IndexMap::new();
         match self.options.page {
-            Page::Numeric(n) => opts.insert("page".into(), (n + 1).to_string()),
-            Page::Unspecified => opts.insert("page".into(), 2.to_string()),
-        };
-        Some(opts)
+            Page::Numeric(n) => Some(n + 1),
+            Page::Unspecified => Some(2),
+        }
+    }
+
+    pub(crate) fn prev_page(&self) -> Option<u32> {
+        match self.options.page {
+            Page::Numeric(1) | Page::Unspecified => None,
+            Page::Numeric(n) => Some(n - 1),
+        }
+    }
+
+    pub(crate) fn next_page_params(&self) -> Option<IndexMap<String, String>> {
+        self.next_page().map(|page| {
+            let mut opts = IndexMap::new();
+            opts.insert("page".into(), page.to_string());
+            opts
+        })
     }
 
     pub(crate) fn prev_page_params(&self) -> Option<IndexMap<String, String>> {
-        match self.options.page {
-            Page::Numeric(1) | Page::Unspecified => None,
-            Page::Numeric(n) => {
-                let mut opts = IndexMap::new();
-                opts.insert("page".into(), (n - 1).to_string());
-                Some(opts)
-            }
-        }
+        self.prev_page().map(|page| {
+            let mut opts = IndexMap::new();
+            opts.insert("page".into(), page.to_string());
+            opts
+        })
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -114,24 +114,22 @@ impl<T> Paginated<T> {
     }
 
     pub(crate) fn next_page_params(&self) -> Option<IndexMap<String, String>> {
-        self.next_page().map(|page| {
-            let mut opts = IndexMap::new();
-            opts.insert("page".into(), page.to_string());
-            opts
-        })
+        self.next_page().map(|page| to_page_map(page))
     }
 
     pub(crate) fn prev_page_params(&self) -> Option<IndexMap<String, String>> {
-        self.prev_page().map(|page| {
-            let mut opts = IndexMap::new();
-            opts.insert("page".into(), page.to_string());
-            opts
-        })
+        self.prev_page().map(|page| to_page_map(page))
     }
 
     pub(crate) fn iter(&self) -> impl Iterator<Item = &T> {
         self.records_and_total.iter().map(|row| &row.record)
     }
+}
+
+fn to_page_map(page: u32) -> IndexMap<String, String> {
+    let mut opts = IndexMap::new();
+    opts.insert("page".into(), page.to_string());
+    opts
 }
 
 impl<T: 'static> IntoIterator for Paginated<T> {

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -20,7 +20,9 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
         query = query.order(keywords::keyword.asc());
     }
 
-    let data: Paginated<Keyword> = query.paginate(&req.query())?.load(&*conn)?;
+    let data: Paginated<Keyword> = query
+        .paginate(&req.query_string().unwrap_or(""))?
+        .load(&*conn)?;
     let total = data.total();
     let kws = data.into_iter().map(Keyword::encodable).collect::<Vec<_>>();
 

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -244,7 +244,7 @@ pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_read_only()?;
     let krate: Crate = Crate::by_name(name).first(&*conn)?;
 
-    let pagination = PaginationOptions::new(&req.query())?;
+    let pagination = PaginationOptions::new(&req.query_string().unwrap_or(""))?;
 
     let (rev_deps, total) = krate.reverse_dependencies(
         &*conn,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -190,7 +190,9 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         query = query.then_order_by(crates::name.asc())
     }
 
-    let data: Paginated<(Crate, bool, Option<i64>)> = query.paginate(&req.query())?.load(&*conn)?;
+    let data: Paginated<(Crate, bool, Option<i64>)> = query
+        .paginate(&req.query_string().unwrap_or(""))?
+        .load(&*conn)?;
     let total = data.total();
 
     let next_page = data

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -72,7 +72,7 @@ pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
         ))
         .paginate(&req.query())?
         .load(&*conn)?;
-    let more = data.next_page_params().is_some();
+    let more = data.next_page().is_some();
     let versions = data.iter().map(|(v, _, _)| v).cloned().collect::<Vec<_>>();
     let data = data
         .into_iter()

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -70,7 +70,7 @@ pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
             crates::name,
             users::all_columns.nullable(),
         ))
-        .paginate(&req.query())?
+        .paginate(&req.query_string().unwrap_or(""))?
         .load(&*conn)?;
     let more = data.next_page().is_some();
     let versions = data.iter().map(|(v, _, _)| v).cloned().collect::<Vec<_>>();

--- a/src/tests/krate.rs
+++ b/src/tests/krate.rs
@@ -2491,12 +2491,12 @@ fn pagination_links_included_if_applicable() {
     let page3 = anon.search("page=3&per_page=1");
     let page4 = anon.search("page=4&per_page=1");
 
-    assert_eq!(Some("?per_page=1&page=2".to_string()), page1.meta.next_page);
-    assert_eq!(None, page1.meta.prev_page);
-    assert_eq!(Some("?page=3&per_page=1".to_string()), page2.meta.next_page);
-    assert_eq!(Some("?page=1&per_page=1".to_string()), page2.meta.prev_page);
-    assert_eq!(None, page4.meta.next_page);
-    assert_eq!(Some("?page=2&per_page=1".to_string()), page3.meta.prev_page);
+    assert_eq!(page1.meta.next_page, Some("?per_page=1&page=2".to_string()));
+    assert_eq!(page1.meta.prev_page, None);
+    assert_eq!(page2.meta.next_page, Some("?page=3&per_page=1".to_string()));
+    assert_eq!(page2.meta.prev_page, Some("?page=1&per_page=1".to_string()));
+    assert_eq!(page4.meta.next_page, None);
+    assert_eq!(page3.meta.prev_page, Some("?page=2&per_page=1".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
see https://github.com/nox/serde_urlencoded

This slightly simplifies the query param parsing code, especially when conversions to numbers are involved. The pagination code had to be refactored a little bit for this to work, so I would suggest reviewing commit-by-commit to make the changes easier to understand. :)

r? @JohnTitor 