### PR TITLE
Fix broken pluralizations

### DIFF
--- a/app/templates/categories.hbs
+++ b/app/templates/categories.hbs
@@ -27,7 +27,7 @@
           {{category.category}}
         </LinkTo>
         <span local-class="crate-count" data-test-crate-count>
-          {{ pluralize (format-num category.crates_cnt) "crate" }}
+          {{format-num category.crates_cnt}} {{if (eq category.crates_cnt 1) "crate" "crates"}}
         </span>
       </div>
       <div local-class="description">

--- a/app/templates/category/index.hbs
+++ b/app/templates/category/index.hbs
@@ -21,7 +21,7 @@
           <div>
             <LinkTo @route="category" @model={{subcategory.slug}}>{{subcategory.category}}</LinkTo>
             <span local-class="crate-count">
-              {{ pluralize (format-num subcategory.crates_cnt) "crate" }}
+              {{format-num subcategory.crates_cnt}} {{if (eq subcategory.crates_cnt 1) "crate" "crates"}}
             </span>
           </div>
           <div local-class="category-description">

--- a/app/templates/keywords.hbs
+++ b/app/templates/keywords.hbs
@@ -24,7 +24,7 @@
     <div local-class="row">
       <LinkTo @route="keyword" @model={{keyword}}>{{keyword.id}}</LinkTo>
       <span local-class="crate-count">
-        {{ pluralize (format-num keyword.crates_cnt) "crate" }}
+        {{format-num keyword.crates_cnt}} {{if (eq keyword.crates_cnt 1) "crate" "crates"}}
       </span>
     </div>
   {{/each}}

--- a/mirage/serializers/category.js
+++ b/mirage/serializers/category.js
@@ -19,6 +19,6 @@ export default BaseSerializer.extend({
     let allCrates = this.schema.crates.all();
     let associatedCrates = allCrates.filter(it => it.categoryIds.includes(hash.id));
 
-    hash.crates_cnt = associatedCrates.length;
+    hash.crates_cnt ??= associatedCrates.length;
   },
 });

--- a/mirage/serializers/keyword.js
+++ b/mirage/serializers/keyword.js
@@ -19,6 +19,6 @@ export default BaseSerializer.extend({
     let allCrates = this.schema.crates.all();
     let associatedCrates = allCrates.filter(it => it.keywordIds.includes(hash.id));
 
-    hash.crates_cnt = associatedCrates.length;
+    hash.crates_cnt ??= associatedCrates.length;
   },
 });


### PR DESCRIPTION
Passing the formatted number into the `pluralize` helper doesn't work quite as expected, and in these cases we already know the pluralization, so using the `pluralize` helper is somewhat pointless anyway.

Resolves https://github.com/rust-lang/crates.io/issues/3042

r? @jtgeibel 