### PR TITLE
Keep only latest search API request

### DIFF
--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -59,6 +59,6 @@ export default class SearchController extends Controller {
     }
 
     return yield this.store.query('crate', { all_keywords, page, per_page, q, sort });
-  }).drop())
+  }).restartable())
   dataTask;
 }


### PR DESCRIPTION
We are currently using the `drop` modifier for the data task, which means that subsequent requests are ignored while the first request is in flight.
Changing the modifier to `restartable` will take the data task drop all but the latest request. This should help with showing the correct search results when paginating and using the browser's back button.

Partially addresses https://github.com/rust-lang/crates.io/issues/3041.