### PR TITLE
Add an option for disabling the requirement to verify email before publishing

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -60,3 +60,7 @@ export GH_CLIENT_SECRET=
 # Credentials for connecting to the Sentry error reporting service.
 # export SENTRY_DSN_API=
 export SENTRY_ENV_API=local
+
+# If you don't require users to complete email verification before
+# they can publish a crate, uncomment this line.
+# export DISABLE_EMAIL_VERIFICATION_REQUIREMENT=1

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -439,11 +439,21 @@ OAuth Applications](https://github.com/settings/developers) and click on the
 - Homepage URL: `http://localhost:4200/`
 - Authorization callback URL: `http://localhost:4200/authorize/github`
 
-Create the application, then take the Client ID ad Client Secret values and use
+Create the application, then take the Client ID and Client Secret values and use
 them as the values of the `GH_CLIENT_ID` and `GH_CLIENT_SECRET` in your `.env`.
 
 Then restart your backend, and you should be able to log in to your local
 crates.io with your GitHub account.
+
+The next step is that you need to verify your email address to be able
+to publish crates. When you log in for the first time, an email will
+be sent with a verification link. In development, the sending of
+emails is simulated by a file representing the email being created in
+your local `/tmp/` directory. You need to find that email file and
+follow the link to verify your email. As an easier alternative, you
+can disable requiring a verified email in development by setting
+`DISABLE_EMAIL_VERIFICATION_REQUIREMENT` in your `.env` file and
+restart your backend.
 
 Go to http://localhost:4200/me to get your API token and run the `cargo login`
 command as directed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -155,7 +155,7 @@ pub(crate) fn domain_name() -> String {
 }
 
 fn require_email_verification() -> bool {
-    !dotenv::var("DISABLE_EMAIL_VERIFICATION_REQUIREMENT").is_ok()
+    dotenv::var("DISABLE_EMAIL_VERIFICATION_REQUIREMENT").is_err()
 }
 
 fn blocked_traffic() -> Vec<(String, Vec<String>)> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct Config {
     pub blocked_traffic: Vec<(String, Vec<String>)>,
     pub domain_name: String,
     pub allowed_origins: Vec<String>,
+    pub require_email_verification: bool,
 }
 
 impl Default for Config {
@@ -44,6 +45,8 @@ impl Default for Config {
     /// - `READ_ONLY_REPLICA_URL`: The URL of an optional postgres read-only replica database.
     /// - `BLOCKED_TRAFFIC`: A list of headers and environment variables to use for blocking
     ///.  traffic. See the `block_traffic` module for more documentation.
+    /// - `DISABLE_EMAIL_VERIFICATION_REQUIREMENT`: Disable the requirement that email must be
+    ///.  verified before publishing a crate.
     fn default() -> Config {
         let api_protocol = String::from("https");
         let mirror = if dotenv::var("MIRROR").is_ok() {
@@ -142,12 +145,17 @@ impl Default for Config {
             blocked_traffic: blocked_traffic(),
             domain_name: domain_name(),
             allowed_origins,
+            require_email_verification: require_email_verification(),
         }
     }
 }
 
 pub(crate) fn domain_name() -> String {
     dotenv::var("DOMAIN_NAME").unwrap_or_else(|_| "crates.io".into())
+}
+
+fn require_email_verification() -> bool {
+    !dotenv::var("DISABLE_EMAIL_VERIFICATION_REQUIREMENT").is_ok()
 }
 
 fn blocked_traffic() -> Vec<(String, Vec<String>)> {

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -142,6 +142,7 @@ fn simple_config() -> Config {
         blocked_traffic: Default::default(),
         domain_name: "crates.io".into(),
         allowed_origins: Vec::new(),
+        require_email_verification: true,
     }
 }
 

--- a/src/tests/http-data/krate_publish_new_krate_records_with_unverified_email_if_email_verification_disabled
+++ b/src/tests/http-data/krate_publish_new_krate_records_with_unverified_email_if_email_verification_disabled
@@ -1,0 +1,69 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_unverified_email/foo_unverified_email-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "host",
+          "alexcrichton-test.s3.amazonaws.com"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-type",
+          "application/x-tar"
+        ],
+        [
+          "authorization",
+          "AWS AKIAICL5IWUZYWWKA7JA:uDc39eNdF6CcwB+q+JwKsoDLQc4="
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 07:53:06 -0700"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "x-amz-request-id",
+          "26589A5E52F8395C"
+        ],
+        [
+          "ETag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 14:53:07 GMT"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "x-amz-id-2",
+          "JdIvnNTw53aqXjBIqBLNuN4kxf/w1XWX+xuIiGBDYy7yzOSDuAMtBSrTW4ZWetcCIdqCUHuQ51A="
+        ],
+        [
+          "Server",
+          "AmazonS3"
+        ]
+      ],
+      "body": ""
+    }
+  }
+]


### PR DESCRIPTION
Needing to verify your email before publishing can be a pain while running crates.io locally during development.

This PR adds a new environment variable to the config flag, DISABLE_EMAIL_VERIFICATION_REQUIREMENT. If this is set, then you can publish a crate even if your email has not been verified.

I've also updated the "contributing" docs around "Publishing a crate to your local crates.io", both to mention the email verification that you need to do, and how to disable it with the new flag.
