### PR TITLE
tests/util: Remove crate name check from `enqueue_publish()`

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -397,10 +397,7 @@ pub trait RequestHelper {
     /// Any pending jobs are run when the `TestApp` is dropped to ensure that the test fails unless
     /// all background tasks complete successfully.
     fn enqueue_publish(&self, publish_builder: PublishBuilder) -> Response<GoodCrate> {
-        let krate_name = publish_builder.krate_name.clone();
-        let response = self.put("/api/v1/crates/new", &publish_builder.body());
-        let callback_on_good = move |json: &GoodCrate| assert_eq!(json.krate.name, krate_name);
-        response.with_callback(Box::new(callback_on_good))
+        self.put("/api/v1/crates/new", &publish_builder.body())
     }
 
     /// Request the JSON used for a crate's page

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -596,13 +596,6 @@ where
         }
     }
 
-    fn with_callback(self, callback_on_good: Box<dyn Fn(&T)>) -> Self {
-        Self {
-            response: self.response,
-            callback_on_good: Some(callback_on_good),
-        }
-    }
-
     /// Assert that the response is good and deserialize the message
     #[track_caller]
     pub fn good(mut self) -> T {


### PR DESCRIPTION
We have enough tests that explicitly assert the crate name already. Removing this code path allows us to slightly simplify the test code a little more.

r? @jtgeibel 
