### PR TITLE
tests/util: Replace `Response::assert_status()` with `Response::status()`

### DIFF
--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -27,7 +27,7 @@ fn account_locked_indefinitely() {
     lock_account(&app, user.as_model().id, None);
 
     let response = user.get::<()>(URL);
-    response.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
     let error_message = format!(
         "This account is indefinitely locked. Reason: {}",
@@ -48,7 +48,7 @@ fn account_locked_with_future_expiry() {
 
     let until = until.format("%Y-%m-%d at %H:%M:%S UTC");
     let response = user.get::<()>(URL);
-    response.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
     let error_message = format!(
         "This account is locked until {}. Reason: {}",

--- a/src/tests/krate/dependencies.rs
+++ b/src/tests/krate/dependencies.rs
@@ -27,7 +27,7 @@ fn dependencies() {
     assert_eq!(deps.dependencies[0].crate_id, "bar_deps");
 
     let response = anon.get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies");
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "crate `foo_deps` does not have a version `1.0.2`" }] })

--- a/src/tests/krate/downloads.rs
+++ b/src/tests/krate/downloads.rs
@@ -37,7 +37,8 @@ fn download() {
 
     let download = |name_and_version: &str| {
         let url = format!("/api/v1/crates/{}/download", name_and_version);
-        anon.get::<()>(&url).assert_status(StatusCode::FOUND);
+        let response = anon.get::<()>(&url);
+        assert_eq!(response.status(), StatusCode::FOUND);
         // TODO: test the with_json code path
     };
 

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -57,7 +57,7 @@ fn new_wrong_token() {
     // Try to publish without a token
     let crate_to_publish = PublishBuilder::new("foo");
     let response = anon.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -73,7 +73,7 @@ fn new_wrong_token() {
 
     let crate_to_publish = PublishBuilder::new("foo");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -87,7 +87,7 @@ fn invalid_names() {
     let bad_name = |name: &str, error_message: &str| {
         let crate_to_publish = PublishBuilder::new(name).version("1.0.0");
         let response = token.enqueue_publish(crate_to_publish);
-        response.assert_status(StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::OK);
 
         let json = response.json();
         let json = json.as_object().unwrap();
@@ -253,7 +253,7 @@ fn reject_new_krate_with_non_exact_dependency() {
         .dependency(dependency);
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "no known crate named `foo_dep`" }] })
@@ -282,7 +282,7 @@ fn reject_new_crate_with_alternative_registry_dependency() {
 
     let crate_to_publish = PublishBuilder::new("depends-on-alt-registry").dependency(dependency);
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "Dependency `dep` is hosted on another registry. Cross-registry dependencies are not permitted on crates.io." }] })
@@ -305,7 +305,7 @@ fn new_krate_with_wildcard_dependency() {
         .dependency(dependency);
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": WILDCARD_ERROR_MESSAGE }] })
@@ -344,7 +344,7 @@ fn new_krate_wrong_user() {
     let crate_to_publish = PublishBuilder::new("foo_wrong").version("2.0.0");
 
     let response = another_user.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": MISSING_RIGHTS_ERROR_MESSAGE }] })
@@ -359,7 +359,7 @@ fn new_krate_too_big() {
     let builder = PublishBuilder::new("foo_big").files(&files);
 
     let response = user.enqueue_publish(builder);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "uploaded tarball is malformed or too large when decompressed" }] })
@@ -392,7 +392,7 @@ fn new_krate_wrong_files() {
     let builder = PublishBuilder::new("foo").files(&files);
 
     let response = user.enqueue_publish(builder);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid tarball uploaded" }] })
@@ -411,7 +411,7 @@ fn new_krate_gzip_bomb() {
         .files_with_io(&mut [("foo-1.1.0/a", &mut body, len)]);
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "uploaded tarball is malformed or too large when decompressed" }] })
@@ -431,7 +431,7 @@ fn new_krate_duplicate_version() {
 
     let crate_to_publish = PublishBuilder::new("foo_dupe").version("1.0.0");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "crate version `1.0.0` is already uploaded" }] })
@@ -450,7 +450,7 @@ fn new_crate_similar_name() {
 
     let crate_to_publish = PublishBuilder::new("foo_similar").version("1.1.0");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "crate was previously named `Foo_similar`" }] })
@@ -469,7 +469,7 @@ fn new_crate_similar_name_hyphen() {
 
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen").version("1.1.0");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "crate was previously named `foo_bar_hyphen`" }] })
@@ -488,7 +488,7 @@ fn new_crate_similar_name_underscore() {
 
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore").version("1.1.0");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "crate was previously named `foo-bar-underscore`" }] })
@@ -561,7 +561,7 @@ fn new_krate_dependency_missing() {
     let crate_to_publish = PublishBuilder::new("foo_missing").dependency(dependency);
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "no known crate named `bar_missing`" }] })
@@ -590,7 +590,7 @@ fn new_krate_without_any_email_fails() {
     let crate_to_publish = PublishBuilder::new("foo_no_email");
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "A verified email address is required to publish crates to crates.io. Visit https://crates.io/me to set and verify your email address." }] })
@@ -611,7 +611,7 @@ fn new_krate_with_unverified_email_fails() {
     let crate_to_publish = PublishBuilder::new("foo_unverified_email");
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "A verified email address is required to publish crates to crates.io. Visit https://crates.io/me to set and verify your email address." }] })
@@ -701,7 +701,7 @@ fn bad_keywords() {
     let crate_to_publish =
         PublishBuilder::new("foo_bad_key").keyword("super-long-keyword-name-oh-no");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid upload request: invalid length 29, expected a keyword with less than 20 characters at line 1 column 221" }] })
@@ -709,7 +709,7 @@ fn bad_keywords() {
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key").keyword("?@?%");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid upload request: invalid value: string \"?@?%\", expected a valid keyword specifier at line 1 column 196" }] })
@@ -717,7 +717,7 @@ fn bad_keywords() {
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key").keyword("áccênts");
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid keyword specifier at line 1 column 201" }] })
@@ -829,7 +829,7 @@ fn author_license_and_description_required() {
         .unset_authors();
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": missing_metadata_error_message(&["description", "license", "authors"]) }] })
@@ -842,7 +842,7 @@ fn author_license_and_description_required() {
         .author("");
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": missing_metadata_error_message(&["description", "authors"]) }] })
@@ -855,7 +855,7 @@ fn author_license_and_description_required() {
         .unset_description();
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": missing_metadata_error_message(&["description"]) }] })
@@ -882,7 +882,7 @@ fn new_krate_tarball_with_hard_links() {
     let crate_to_publish = PublishBuilder::new("foo").version("1.1.0").tarball(tarball);
 
     let response = token.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid tarball uploaded" }] })
@@ -901,13 +901,12 @@ fn publish_new_crate_rate_limited() {
 
     // Uploading a second crate is limited
     let crate_to_publish = PublishBuilder::new("rate_limited2");
-    token
-        .enqueue_publish(crate_to_publish)
-        .assert_status(StatusCode::TOO_MANY_REQUESTS);
+    let response = token.enqueue_publish(crate_to_publish);
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     app.run_pending_background_jobs();
 
-    anon.get::<()>("/api/v1/crates/rate_limited2")
-        .assert_status(StatusCode::NOT_FOUND);
+    let response = anon.get::<()>("/api/v1/crates/rate_limited2");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // Wait for the limit to be up
     thread::sleep(Duration::from_millis(500));

--- a/src/tests/krate/search.rs
+++ b/src/tests/krate/search.rs
@@ -699,7 +699,7 @@ fn pagination_parameters_only_accept_integers() {
 
     let response =
         anon.get_with_query::<()>("/api/v1/crates", "page=1&per_page=100%22%EF%BC%8Cexception");
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid digit found in string" }] })
@@ -707,7 +707,7 @@ fn pagination_parameters_only_accept_integers() {
 
     let response =
         anon.get_with_query::<()>("/api/v1/crates", "page=100%22%EF%BC%8Cexception&per_page=1");
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid digit found in string" }] })

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -110,7 +110,7 @@ fn yank_by_a_non_owner_fails() {
     });
 
     let response = token.yank("foo_not", "1.0.0");
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "must already be an owner to yank or unyank" }] })

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -136,7 +136,7 @@ fn owners_can_remove_self() {
 
     // Deleting yourself when you're the only owner isn't allowed.
     let response = token.remove_named_owner("owners_selfremove", username);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required." }] })
@@ -146,7 +146,7 @@ fn owners_can_remove_self() {
 
     // Deleting yourself when there are other owners is allowed.
     let response = token.remove_named_owner("owners_selfremove", username);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "msg": "owners successfully removed", "ok": true })
@@ -154,7 +154,7 @@ fn owners_can_remove_self() {
 
     // After you delete yourself, you no longer have permisions to manage the crate.
     let response = token.remove_named_owner("owners_selfremove", username);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "only owners have permission to modify owners" }] })
@@ -175,7 +175,7 @@ fn modify_multiple_owners() {
 
     // Deleting all owners is not allowed.
     let response = token.remove_named_owners("owners_multiple", &[username, "user2", "user3"]);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required." }] })
@@ -184,7 +184,7 @@ fn modify_multiple_owners() {
 
     // Deleting two owners at once is allowed.
     let response = token.remove_named_owners("owners_multiple", &["user2", "user3"]);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "msg": "owners successfully removed", "ok": true })
@@ -193,7 +193,7 @@ fn modify_multiple_owners() {
 
     // Adding multiple users fails if one of them already is an owner.
     let response = token.add_named_owners("owners_multiple", &["user2", username]);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "`foo` is already an owner" }] })
@@ -202,7 +202,7 @@ fn modify_multiple_owners() {
 
     // Adding multiple users at once succeeds.
     let response = token.add_named_owners("owners_multiple", &["user2", "user3"]);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -10,7 +10,7 @@ fn user_agent_is_required() {
     let mut req = anon.request_builder(Method::GET, "/api/v1/crates");
     req.header(header::USER_AGENT, "");
     let resp = anon.run::<()>(req);
-    resp.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn user_agent_is_not_required_for_download() {
     let mut req = anon.request_builder(Method::GET, "/api/v1/crates/dl_no_ua/0.99.0/download");
     req.header(header::USER_AGENT, "");
     let resp = anon.run::<()>(req);
-    resp.assert_status(StatusCode::FOUND);
+    assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
 #[test]
@@ -42,7 +42,7 @@ fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
     let mut req = anon.request_builder(Method::GET, "/api/v1/crates/dl_no_ua/0.99.0/download");
     req.header(header::USER_AGENT, "");
     let resp = anon.run::<()>(req);
-    resp.assert_status(StatusCode::FOUND);
+    assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn block_traffic_via_arbitrary_header_and_value() {
         "abcd",
     );
     let resp = anon.run::<()>(req);
-    resp.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     let mut req = anon.request_builder(Method::GET, "/api/v1/crates/dl_no_ua/0.99.0/download");
     // A request with a header value we don't want to block is allowed, even though there might
@@ -77,5 +77,5 @@ fn block_traffic_via_arbitrary_header_and_value() {
         "1value-must-match-exactly-this-is-allowed",
     );
     let resp = anon.run::<()>(req);
-    resp.assert_status(StatusCode::FOUND);
+    assert_eq!(resp.status(), StatusCode::FOUND);
 }

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -50,7 +50,7 @@ fn not_github() {
     });
 
     let response = token.add_named_owner("foo_not_github", "dropbox:foo:foo");
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "unknown organization handler, only 'github:org:team' is supported" }] })
@@ -66,7 +66,7 @@ fn weird_name() {
     });
 
     let response = token.add_named_owner("foo_weird_name", "github:foo/../bar:wut");
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "organization cannot contain special characters like /" }] })
@@ -83,7 +83,7 @@ fn one_colon() {
     });
 
     let response = token.add_named_owner("foo_one_colon", "github:foo");
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "missing github team argument; format is github:org:team" }] })
@@ -102,7 +102,7 @@ fn nonexistent_team() {
         "foo_nonexistent",
         "github:crates-test-org:this-does-not-exist",
     );
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "could not find the github team crates-test-org/this-does-not-exist" }] })
@@ -152,7 +152,7 @@ fn add_team_as_non_member() {
         "foo_team_non_member",
         "github:crates-test-org:just-for-crates-2",
     );
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "only members of a team can add it as an owner" }] })
@@ -177,7 +177,7 @@ fn remove_team_as_named_owner() {
     // Removing the individual owner is not allowed, since team members don't
     // have permission to manage ownership
     let response = token_on_both_teams.remove_named_owner("foo_remove_team", username);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required." }] })
@@ -190,7 +190,7 @@ fn remove_team_as_named_owner() {
     let user_on_one_team = app.db_new_user(mock_user_on_only_one_team().gh_login);
     let crate_to_publish = PublishBuilder::new("foo_remove_team").version("2.0.0");
     let response = user_on_one_team.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing." }] })
@@ -217,7 +217,7 @@ fn remove_team_as_team_owner() {
 
     let response = token_on_one_team
         .remove_named_owner("foo_remove_team_owner", "github:crates-test-org:core");
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "team members don't have permission to modify owners" }] })
@@ -243,7 +243,7 @@ fn publish_not_owned() {
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned").version("2.0.0");
     let response = user_on_one_team.enqueue_publish(crate_to_publish);
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing." }] })
@@ -290,7 +290,7 @@ fn add_owners_as_team_owner() {
     let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
 
     let response = token_on_one_team.add_named_owner("foo_add_owner", "arbitrary_username");
-    response.assert_status(StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "team members don't have permission to modify owners" }] })

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -112,7 +112,7 @@ fn create_token_invalid_request() {
     let (_, _, user) = TestApp::init().with_user();
     let invalid = br#"{ "name": "" }"#;
     let response = user.put::<()>(URL, invalid);
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid new token request: Error(\"missing field `api_token`\", line: 1, column: 14)" }] })
@@ -124,7 +124,7 @@ fn create_token_no_name() {
     let (_, _, user) = TestApp::init().with_user();
     let empty_name = br#"{ "api_token": { "name": "" } }"#;
     let response = user.put::<()>(URL, empty_name);
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "name must have a value" }] })
@@ -136,7 +136,7 @@ fn create_token_long_body() {
     let (_, _, user) = TestApp::init().with_user();
     let too_big = &[5; 5192]; // Send a request with a 5kB body of 5's
     let response = user.put::<()>(URL, too_big);
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "max content length is: 2000" }] })
@@ -153,7 +153,7 @@ fn create_token_exceeded_tokens_per_user() {
         }
     });
     let response = user.put::<()>(URL, NEW_BAR);
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "maximum tokens per user is: 500" }] })
@@ -203,7 +203,7 @@ fn cannot_create_token_with_token() {
         "/api/v1/me/tokens",
         br#"{ "api_token": { "name": "baz" } }"#,
     );
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "cannot use an API token to create a new API token" }] })
@@ -309,7 +309,7 @@ fn old_tokens_give_specific_error_message() {
     let mut request = anon.get_request(url);
     request.header(header::AUTHORIZATION, "oldtoken");
     let response = anon.run::<()>(request);
-    response.assert_status(StatusCode::UNAUTHORIZED);
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": TOKEN_FORMAT_ERROR }] })

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -114,7 +114,7 @@ fn auth_gives_a_token() {
 fn access_token_needs_data() {
     let (_, anon) = TestApp::init().empty();
     let response = anon.get::<()>("/api/private/session/authorize");
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid state parameter" }] })
@@ -298,7 +298,7 @@ fn following() {
     assert_eq!(r.meta.more, false);
 
     let response = user.get_with_query::<()>("/api/v1/me/updates", "page=0");
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "page indexing starts from 1, page 0 is invalid" }] })
@@ -494,14 +494,14 @@ fn test_empty_email_not_added() {
     let model = user.as_model();
 
     let response = user.update_email_more_control(model.id, Some(""));
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "empty email rejected" }] })
     );
 
     let response = user.update_email_more_control(model.id, None);
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "empty email rejected" }] })
@@ -524,7 +524,7 @@ fn test_other_users_cannot_change_my_email() {
         another_user_model.id,
         Some("pineapple@pineapples.pineapple"),
     );
-    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "current user does not match requested user" }] })
@@ -534,7 +534,7 @@ fn test_other_users_cannot_change_my_email() {
         another_user_model.id,
         Some("pineapple@pineapples.pineapple"),
     );
-    response.assert_status(StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -590,16 +590,14 @@ where
     /// Assert that the response is good and deserialize the message
     #[track_caller]
     pub fn good(mut self) -> T {
-        if !self.response.status().is_success() {
-            panic!("bad response: {:?}", self.response.status());
+        if !self.status().is_success() {
+            panic!("bad response: {:?}", self.status());
         }
         crate::json(&mut self.response)
     }
 
-    #[track_caller]
-    pub fn assert_status(&self, status: StatusCode) -> &Self {
-        assert_eq!(status, self.response.status());
-        self
+    pub fn status(&self) -> StatusCode {
+        self.response.status()
     }
 
     #[track_caller]
@@ -620,12 +618,12 @@ impl Response<()> {
     /// Assert that the status code is 404
     #[track_caller]
     pub fn assert_not_found(&self) {
-        assert_eq!(StatusCode::NOT_FOUND, self.response.status());
+        assert_eq!(StatusCode::NOT_FOUND, self.status());
     }
 
     /// Assert that the status code is 403
     #[track_caller]
     pub fn assert_forbidden(&self) {
-        assert_eq!(StatusCode::FORBIDDEN, self.response.status());
+        assert_eq!(StatusCode::FORBIDDEN, self.status());
     }
 }


### PR DESCRIPTION
`Response::status()` seems easier to use to me and doesn't hide the actual assertion. It also allows us to access things like `StatusCode::is_success()` directly.

r? @jtgeibel 