### PR TITLE
tests/krate/publish: Fix `new_krate_tarball_with_hard_links()`

### DIFF
--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -859,9 +859,9 @@ fn new_krate_tarball_with_hard_links() {
         let mut header = tar::Header::new_gnu();
         assert_ok!(header.set_path("foo-1.1.0/bar"));
         header.set_size(0);
-        header.set_cksum();
         header.set_entry_type(tar::EntryType::hard_link());
         assert_ok!(header.set_link_name("foo-1.1.0/another"));
+        header.set_cksum();
         assert_ok!(ar.append(&header, &[][..]));
         assert_ok!(ar.finish());
     }
@@ -872,7 +872,7 @@ fn new_krate_tarball_with_hard_links() {
     response.assert_status(StatusCode::OK);
     assert_eq!(
         response.json(),
-        json!({ "errors": [{ "detail": "uploaded tarball is malformed or too large when decompressed" }] })
+        json!({ "errors": [{ "detail": "invalid tarball uploaded" }] })
     );
 }
 


### PR DESCRIPTION
The test was receiving "too large when decompressed" because of a broken header checksum, which was mistakenly converted into this error message, because we assume that every `entries()` error is coming from our `LimitErrorReader`.  This commit moves the checksum calculation to the right place, which causes the test to now test the correct condition in our `verify_tarball()` function.

r? @pietroalbini 