### PR TITLE
tests/krate/publish: Use `assert_eq!()` to check response payload content

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -16,6 +16,12 @@ use crate::render;
 use crate::util::{read_fill, read_le_u32, Maximums};
 use crate::views::{EncodableCrateUpload, GoodCrate, PublishWarnings};
 
+pub const MISSING_RIGHTS_ERROR_MESSAGE: &str =
+    "this crate exists but you don't seem to be an owner. \
+     If you believe this is a mistake, perhaps you need \
+     to accept an invitation to be an owner before \
+     publishing.";
+
 /// Handles the `PUT /crates/new` route.
 /// Used by `cargo publish` to publish a new crate or to publish a new version of an
 /// existing crate.
@@ -98,12 +104,7 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
 
         let owners = krate.owners(&conn)?;
         if user.rights(req.app(), &owners)? < Rights::Publish {
-            return Err(cargo_err(
-                "this crate exists but you don't seem to be an owner. \
-                 If you believe this is a mistake, perhaps you need \
-                 to accept an invitation to be an owner before \
-                 publishing.",
-            ));
+            return Err(cargo_err(MISSING_RIGHTS_ERROR_MESSAGE));
         }
 
         if krate.name != *name {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -261,13 +261,30 @@ fn parse_new_headers(req: &mut dyn RequestExt) -> AppResult<EncodableCrateUpload
         missing.push("authors");
     }
     if !missing.is_empty() {
-        return Err(cargo_err(&format_args!(
-            "missing or empty metadata fields: {}. Please \
-             see https://doc.rust-lang.org/cargo/reference/manifest.html for \
-             how to upload metadata",
-            missing.join(", ")
-        )));
+        let message = missing_metadata_error_message(&missing);
+        return Err(cargo_err(&message));
     }
 
     Ok(new)
+}
+
+pub fn missing_metadata_error_message(missing: &[&str]) -> String {
+    format!(
+        "missing or empty metadata fields: {}. Please \
+         see https://doc.rust-lang.org/cargo/reference/manifest.html for \
+         how to upload metadata",
+        missing.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::missing_metadata_error_message;
+
+    #[test]
+    fn missing_metadata_error_message_test() {
+        assert_eq!(missing_metadata_error_message(&["a"]), "missing or empty metadata fields: a. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
+        assert_eq!(missing_metadata_error_message(&["a", "b"]), "missing or empty metadata fields: a, b. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
+        assert_eq!(missing_metadata_error_message(&["a", "b", "c"]), "missing or empty metadata fields: a, b, c. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
+    }
 }

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -7,6 +7,11 @@ use crate::models::{Crate, Version};
 use crate::schema::*;
 use crate::views::{EncodableCrateDependency, EncodableDependency};
 
+pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints are not allowed \
+     on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-\
+     libraries-use--as-a-version-for-their-dependencies for more \
+     information";
+
 #[derive(Identifiable, Associations, Debug, Queryable, QueryableByName)]
 #[belongs_to(Version)]
 #[belongs_to(Crate)]
@@ -91,12 +96,7 @@ pub fn add_dependencies(
                 .first(&*conn)
                 .map_err(|_| cargo_err(&format_args!("no known crate named `{}`", &*dep.name)))?;
             if dep.version_req == semver::VersionReq::parse("*").unwrap() {
-                return Err(cargo_err(
-                    "wildcard (`*`) dependency constraints are not allowed \
-                     on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-\
-                     libraries-use--as-a-version-for-their-dependencies for more \
-                     information",
-                ));
+                return Err(cargo_err(WILDCARD_ERROR_MESSAGE));
             }
 
             // If this dependency has an explicit name in `Cargo.toml` that

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -33,6 +33,7 @@ use cargo_registry::{
     App, Config,
 };
 use diesel::PgConnection;
+use serde_json::Value;
 use std::{marker::PhantomData, rc::Rc, sync::Arc, time::Duration};
 use swirl::Runner;
 
@@ -585,6 +586,11 @@ where
             response: assert_ok!(response),
             return_type: PhantomData,
         }
+    }
+
+    #[track_caller]
+    pub fn json(mut self) -> Value {
+        crate::json(&mut self.response)
     }
 
     /// Assert that the response is good and deserialize the message


### PR DESCRIPTION
Using the `json!()` macro makes it quite straight forward to assert against the exact response payload expectation and is ultimately less verbose than checking against `json.errors[0].detail` like we currently do.

r? @jtgeibel 