### PR TITLE
Remove unused `parse_link_header` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,6 @@ dependencies = [
  "log",
  "oauth2",
  "parking_lot",
- "parse_link_header",
  "rand",
  "reqwest",
  "scheduled-thread-pool",
@@ -1889,16 +1888,6 @@ dependencies = [
  "redox_syscall",
  "smallvec 1.5.0",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "parse_link_header"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b09f37bc2b55b5237baf3139b9e6304aea937baf38e8f43207b41cc3934b3a1"
-dependencies = [
- "http 0.2.1",
- "regex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,6 @@ license-exprs = "^1.4"
 log = "0.4"
 oauth2 = { version = "3.0.0", default-features = false, features = ["reqwest-010"] }
 parking_lot = "0.11"
-parse_link_header = "0.2.0"
 rand = "0.7"
 reqwest = { version = "0.10", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "0.2.0"


### PR DESCRIPTION
https://github.com/est31/cargo-udeps indicated that this dependency might be unused, and indeed I couldn't find any references to it anywhere in our code.

r? @jtgeibel 