### PR TITLE
Add `token_count` to `GET /api/v1/me` response

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -10,7 +10,7 @@ use crate::models::{
     ApiToken, CrateOwner, Email, Follow, NewEmail, OwnerKind, User, Version, VersionOwnerAction,
 };
 use crate::schema::{api_tokens, crate_owners, crates, emails, follows, users, versions};
-use crate::views::{EncodableMe, EncodableVersion, OwnedCrate};
+use crate::views::{EncodableMe, EncodableMeMeta, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
 pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
@@ -52,8 +52,9 @@ pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
     let verified = verified.unwrap_or(false);
     let verification_sent = verified || verification_sent;
     Ok(req.json(&EncodableMe {
-        user: user.encodable_private(email, verified, verification_sent, has_tokens),
+        user: user.encodable_private(email, verified, verification_sent),
         owned_crates,
+        meta: EncodableMeMeta { has_tokens },
     }))
 }
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -33,7 +33,8 @@ pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
     let tokens: Vec<ApiToken> = ApiToken::belonging_to(&user)
         .filter(api_tokens::revoked.eq(false))
         .load(&*conn)?;
-    let has_tokens = !tokens.is_empty();
+
+    let token_count = tokens.len() as i64;
 
     let owned_crates = CrateOwner::by_owner_kind(OwnerKind::User)
         .inner_join(crates::table)
@@ -54,7 +55,7 @@ pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
     Ok(req.json(&EncodableMe {
         user: user.encodable_private(email, verified, verification_sent),
         owned_crates,
-        meta: EncodableMeMeta { has_tokens },
+        meta: EncodableMeMeta { token_count },
     }))
 }
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -30,11 +30,10 @@ pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
             ))
             .first(&*conn)?;
 
-    let tokens: Vec<ApiToken> = ApiToken::belonging_to(&user)
+    let token_count = ApiToken::belonging_to(&user)
         .filter(api_tokens::revoked.eq(false))
-        .load(&*conn)?;
-
-    let token_count = tokens.len() as i64;
+        .count()
+        .get_result(&*conn)?;
 
     let owned_crates = CrateOwner::by_owner_kind(OwnerKind::User)
         .inner_join(crates::table)

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -174,6 +174,7 @@ impl User {
         email: Option<String>,
         email_verified: bool,
         email_verification_sent: bool,
+        has_tokens: bool,
     ) -> EncodablePrivateUser {
         let User {
             id,
@@ -189,6 +190,7 @@ impl User {
             email,
             email_verified,
             email_verification_sent,
+            has_tokens,
             avatar: gh_avatar,
             login: gh_login,
             name,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -174,7 +174,6 @@ impl User {
         email: Option<String>,
         email_verified: bool,
         email_verification_sent: bool,
-        has_tokens: bool,
     ) -> EncodablePrivateUser {
         let User {
             id,
@@ -190,7 +189,6 @@ impl User {
             email,
             email_verified,
             email_verification_sent,
-            has_tokens,
             avatar: gh_avatar,
             login: gh_login,
             name,

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -753,6 +753,9 @@ fn test_update_email_notifications_not_owned() {
 fn shows_that_user_has_tokens() {
     let (app, _, user) = TestApp::init().with_user();
 
+    let json = user.show_me();
+    assert!(!json.user.has_tokens);
+
     let user_id = user.as_model().id;
     app.db(|conn| {
         vec![

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -5,7 +5,7 @@ use crate::{
     OkBool, TestApp,
 };
 use cargo_registry::{
-    models::{Email, NewUser, User},
+    models::{ApiToken, Email, NewUser, User},
     schema::crate_owners,
     views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion, OwnedCrate},
 };
@@ -747,4 +747,20 @@ fn test_update_email_notifications_not_owned() {
 
     // There should be no change to the `email_notifications` value for a crate not belonging to me
     assert!(email_notifications);
+}
+
+#[test]
+fn shows_that_user_has_tokens() {
+    let (app, _, user) = TestApp::init().with_user();
+
+    let user_id = user.as_model().id;
+    app.db(|conn| {
+        vec![
+            assert_ok!(ApiToken::insert(conn, user_id, "bar")),
+            assert_ok!(ApiToken::insert(conn, user_id, "baz")),
+        ]
+    });
+
+    let json = user.show_me();
+    assert!(json.user.has_tokens);
 }

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -757,7 +757,7 @@ fn shows_that_user_has_tokens() {
     let (app, _, user) = TestApp::init().with_user();
 
     let json = user.show_me();
-    assert!(!json.meta.has_tokens);
+    assert_eq!(json.meta.token_count, 0);
 
     let user_id = user.as_model().id;
     app.db(|conn| {
@@ -768,5 +768,5 @@ fn shows_that_user_has_tokens() {
     });
 
     let json = user.show_me();
-    assert!(json.meta.has_tokens);
+    assert_eq!(json.meta.token_count, 2);
 }

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -7,7 +7,9 @@ use crate::{
 use cargo_registry::{
     models::{ApiToken, Email, NewUser, User},
     schema::crate_owners,
-    views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion, OwnedCrate},
+    views::{
+        EncodableMeMeta, EncodablePrivateUser, EncodablePublicUser, EncodableVersion, OwnedCrate,
+    },
 };
 
 use diesel::prelude::*;
@@ -27,6 +29,7 @@ pub struct UserShowPublicResponse {
 pub struct UserShowPrivateResponse {
     pub user: EncodablePrivateUser,
     pub owned_crates: Vec<OwnedCrate>,
+    pub meta: EncodableMeMeta,
 }
 
 #[derive(Deserialize)]
@@ -754,7 +757,7 @@ fn shows_that_user_has_tokens() {
     let (app, _, user) = TestApp::init().with_user();
 
     let json = user.show_me();
-    assert!(!json.user.has_tokens);
+    assert!(!json.meta.has_tokens);
 
     let user_id = user.as_model().id;
     app.db(|conn| {
@@ -765,5 +768,5 @@ fn shows_that_user_has_tokens() {
     });
 
     let json = user.show_me();
-    assert!(json.user.has_tokens);
+    assert!(json.meta.has_tokens);
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -176,6 +176,7 @@ pub struct EncodablePrivateUser {
     pub email: Option<String>,
     pub avatar: Option<String>,
     pub url: Option<String>,
+    pub has_tokens: bool,
 }
 
 /// The serialization format for the `User` model.

--- a/src/views.rs
+++ b/src/views.rs
@@ -166,7 +166,7 @@ pub struct EncodableMe {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 pub struct EncodableMeMeta {
-    pub has_tokens: bool,
+    pub token_count: i64,
 }
 
 /// The serialization format for the `User` model.

--- a/src/views.rs
+++ b/src/views.rs
@@ -161,6 +161,12 @@ pub struct OwnedCrate {
 pub struct EncodableMe {
     pub user: EncodablePrivateUser,
     pub owned_crates: Vec<OwnedCrate>,
+    pub meta: EncodableMeMeta,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct EncodableMeMeta {
+    pub has_tokens: bool,
 }
 
 /// The serialization format for the `User` model.
@@ -176,7 +182,6 @@ pub struct EncodablePrivateUser {
     pub email: Option<String>,
     pub avatar: Option<String>,
     pub url: Option<String>,
-    pub has_tokens: bool,
 }
 
 /// The serialization format for the `User` model.


### PR DESCRIPTION
This PR is partly extracted from https://github.com/rust-lang/crates.io/pull/1952 to finally resolve issue #19.

The PR adds a `meta: { token_count: 42 }` object to the `GET /api/v1/me` response, which can be used to display a banner, flash message, or other indicator on the frontend to signal to the user that he has not created an API token yet. The exact implementation for the frontend will follow in another PR and does not need to be discussed here.

r? @carols10cents since you did the original review on https://github.com/rust-lang/crates.io/pull/1952. let me know if you don't currently have time for the review :)