### PR TITLE
ESLint: Enable `sort-imports` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,9 @@ module.exports = {
     // it's fine to use `return` without a value and rely on the implicit `undefined` return value
     'getter-return': 'off',
 
+    // declaration sort is taken care of by `import-helpers/order-imports`
+    'sort-imports': ['error', { ignoreDeclarationSort: true, ignoreCase: true }],
+
     'prettier/prettier': 'error',
 
     // disabled because we still use `this.set()` in a few places and it works just fine

--- a/app/adapters/category-slug.js
+++ b/app/adapters/category-slug.js
@@ -1,4 +1,4 @@
-import { underscore, decamelize } from '@ember/string';
+import { decamelize, underscore } from '@ember/string';
 
 import { pluralize } from 'ember-inflector';
 

--- a/app/components/follow-button.js
+++ b/app/components/follow-button.js
@@ -2,7 +2,7 @@ import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
-import { task, didCancel } from 'ember-concurrency';
+import { didCancel, task } from 'ember-concurrency';
 
 import ajax from '../utils/ajax';
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { computed } from '@ember/object';
-import { gt, readOnly, alias } from '@ember/object/computed';
+import { alias, gt, readOnly } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
 import { task } from 'ember-concurrency';

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action, computed } from '@ember/object';
-import { readOnly, bool } from '@ember/object/computed';
+import { bool, readOnly } from '@ember/object/computed';
 
 import { task } from 'ember-concurrency';
 

--- a/app/models/dependency.js
+++ b/app/models/dependency.js
@@ -1,4 +1,4 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 import Inflector from 'ember-inflector';
 

--- a/app/models/version-download.js
+++ b/app/models/version-download.js
@@ -1,4 +1,4 @@
-import Model, { belongsTo, attr } from '@ember-data/model';
+import Model, { attr, belongsTo } from '@ember-data/model';
 
 export default class VersionDownload extends Model {
   /** @type number */

--- a/mirage/models/api-token.js
+++ b/mirage/models/api-token.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { belongsTo, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   user: belongsTo(),

--- a/mirage/models/crate-ownership.js
+++ b/mirage/models/crate-ownership.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { belongsTo, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   crate: belongsTo(),

--- a/mirage/models/crate.js
+++ b/mirage/models/crate.js
@@ -1,4 +1,4 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { hasMany, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   categories: hasMany(),

--- a/mirage/models/dependency.js
+++ b/mirage/models/dependency.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { belongsTo, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   crate: belongsTo(),

--- a/mirage/models/mirage-session.js
+++ b/mirage/models/mirage-session.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { belongsTo, Model } from 'ember-cli-mirage';
 
 /**
  * This is a mirage-only model, that is used to keep track of the current

--- a/mirage/models/user.js
+++ b/mirage/models/user.js
@@ -1,4 +1,4 @@
-import { Model, hasMany } from 'ember-cli-mirage';
+import { hasMany, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   followedCrates: hasMany('crate'),

--- a/mirage/models/version-download.js
+++ b/mirage/models/version-download.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { belongsTo, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   version: belongsTo(),

--- a/mirage/models/version.js
+++ b/mirage/models/version.js
@@ -1,4 +1,4 @@
-import { Model, belongsTo } from 'ember-cli-mirage';
+import { belongsTo, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   crate: belongsTo(),

--- a/mirage/route-handlers/categories.js
+++ b/mirage/route-handlers/categories.js
@@ -1,4 +1,4 @@
-import { pageParams, compareStrings, withMeta, notFound } from './-utils';
+import { compareStrings, notFound, pageParams, withMeta } from './-utils';
 
 export function register(server) {
   server.get('/api/v1/categories', function (schema, request) {

--- a/mirage/route-handlers/keywords.js
+++ b/mirage/route-handlers/keywords.js
@@ -1,4 +1,4 @@
-import { pageParams, withMeta, notFound } from './-utils';
+import { notFound, pageParams, withMeta } from './-utils';
 
 export function register(server) {
   server.get('/api/v1/keywords', function (schema, request) {

--- a/tests/acceptance/404-test.js
+++ b/tests/acceptance/404-test.js
@@ -1,4 +1,4 @@
-import { fillIn, currentURL, triggerEvent, visit } from '@ember/test-helpers';
+import { currentURL, fillIn, triggerEvent, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -1,4 +1,4 @@
-import { currentURL, findAll, click, fillIn } from '@ember/test-helpers';
+import { click, currentURL, fillIn, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/crate-following-test.js
+++ b/tests/acceptance/crate-following-test.js
@@ -1,4 +1,4 @@
-import { visit, waitFor, settled, click } from '@ember/test-helpers';
+import { click, settled, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,6 +1,6 @@
-import { click, currentURL, currentRouteName, visit, waitFor } from '@ember/test-helpers';
+import { click, currentRouteName, currentURL, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
-import { module, test, skip } from 'qunit';
+import { module, skip, test } from 'qunit';
 
 import percySnapshot from '@percy/ember';
 import a11yAudit from 'ember-a11y-testing/test-support/audit';

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -1,4 +1,4 @@
-import { currentURL, visit, click, waitFor, settled } from '@ember/test-helpers';
+import { click, currentURL, settled, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -1,4 +1,4 @@
-import { currentURL, click } from '@ember/test-helpers';
+import { click, currentURL } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL, click, waitFor } from '@ember/test-helpers';
+import { click, currentURL, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/logout-test.js
+++ b/tests/acceptance/logout-test.js
@@ -1,4 +1,4 @@
-import { visit, currentURL, click } from '@ember/test-helpers';
+import { click, currentURL, visit } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -1,4 +1,4 @@
-import { click, fillIn, currentURL, triggerEvent, visit, blur, waitFor, settled } from '@ember/test-helpers';
+import { blur, click, currentURL, fillIn, settled, triggerEvent, visit, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/bugs/2329-test.js
+++ b/tests/bugs/2329-test.js
@@ -1,4 +1,4 @@
-import { currentURL, click, waitFor } from '@ember/test-helpers';
+import { click, currentURL, waitFor } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 

--- a/tests/helpers/visit-ignoring-abort.js
+++ b/tests/helpers/visit-ignoring-abort.js
@@ -1,4 +1,4 @@
-import { settled, visit as _visit } from '@ember/test-helpers';
+import { visit as _visit, settled } from '@ember/test-helpers';
 
 // see https://github.com/emberjs/ember-test-helpers/issues/332
 export async function visit(url) {


### PR DESCRIPTION
With https://github.com/Tibfib/eslint-plugin-import-helpers and prettier, this rule makes it even easier to import things and have the tooling take care of formatting things in a readable way.

r? @locks 