### PR TITLE
Handle docs.rs request errors

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -27,7 +27,7 @@
       <li><a href="{{this.crate.mailing_list}}">Mailing list</a></li>
     {{/if}}
     {{#if this.documentationLink}}
-      <li><a href="{{this.documentationLink}}">Documentation</a></li>
+      <li><a href="{{this.documentationLink}}" data-test-docs-link>Documentation</a></li>
     {{/if}}
     {{#if this.crate.repository}}
       <li><a href="{{this.crate.repository}}">Repository</a></li>

--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -5,12 +5,11 @@ export default async function ajax(input, init) {
   if (response.ok) {
     return await response.json();
   }
-  throw new HttpError(input, init, response);
+  throw new HttpError({ url: input, method: init?.method ?? 'GET', response });
 }
 
 export class HttpError extends Error {
-  constructor(url, init, response) {
-    let method = init?.method ?? 'GET';
+  constructor({ url, method, response }) {
     let message = `${method} ${url} failed with: ${response.status} ${response.statusText}`;
     super(message);
     this.name = 'HttpError';

--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -1,11 +1,20 @@
 import fetch from 'fetch';
 
 export default async function ajax(input, init) {
-  let response = await fetch(input, init);
-  if (response.ok) {
-    return await response.json();
+  let method = init?.method ?? 'GET';
+
+  let cause;
+  try {
+    let response = await fetch(input, init);
+    if (response.ok) {
+      return await response.json();
+    }
+    cause = new HttpError({ url: input, method, response });
+  } catch (error) {
+    cause = error;
   }
-  throw new HttpError({ url: input, method: init?.method ?? 'GET', response });
+
+  throw new AjaxError({ url: input, method, cause });
 }
 
 export class HttpError extends Error {
@@ -16,5 +25,15 @@ export class HttpError extends Error {
     this.method = method;
     this.url = url;
     this.response = response;
+  }
+}
+
+export class AjaxError extends Error {
+  constructor({ url, method, cause }) {
+    super(`${method} ${url} failed`);
+    this.name = 'AjaxError';
+    this.method = method;
+    this.url = url;
+    this.cause = cause;
   }
 }

--- a/tests/routes/crate/version/docs-link-test.js
+++ b/tests/routes/crate/version/docs-link-test.js
@@ -1,0 +1,76 @@
+import { visit } from '@ember/test-helpers';
+import { setupApplicationTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from '../../../helpers/setup-mirage';
+
+module('Route | crate.version | docs link', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test('shows regular documentation link', async function (assert) {
+    this.server.create('crate', { name: 'foo', documentation: 'https://foo.io/docs' });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link]').hasAttribute('href', 'https://foo.io/docs');
+  });
+
+  test('show no docs link if `documentation` is unspecified and there are no related docs.rs builds', async function (assert) {
+    this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link]').doesNotExist();
+  });
+
+  test('show docs link if `documentation` is unspecified and there are related docs.rs builds', async function (assert) {
+    this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [
+      {
+        id: 42,
+        rustc_version: 'rustc 1.50.0-nightly (1c389ffef 2020-11-24)',
+        docsrs_version: 'docsrs 0.6.0 (31c864e 2020-11-22)',
+        build_status: true,
+        build_time: '2020-12-06T09:04:36.610302Z',
+        output: null,
+      },
+    ]);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link]').hasAttribute('href', 'https://docs.rs/foo/1.0.0');
+  });
+
+  test('show original docs link if `documentation` points to docs.rs and there are no related docs.rs builds', async function (assert) {
+    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link]').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
+  });
+
+  test('show updated docs link if `documentation` points to docs.rs and there are related docs.rs builds', async function (assert) {
+    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [
+      {
+        id: 42,
+        rustc_version: 'rustc 1.50.0-nightly (1c389ffef 2020-11-24)',
+        docsrs_version: 'docsrs 0.6.0 (31c864e 2020-11-22)',
+        build_status: true,
+        build_time: '2020-12-06T09:04:36.610302Z',
+        output: null,
+      },
+    ]);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link]').hasAttribute('href', 'https://docs.rs/foo/1.0.0');
+  });
+});

--- a/tests/routes/crate/version/docs-link-test.js
+++ b/tests/routes/crate/version/docs-link-test.js
@@ -73,4 +73,14 @@ module('Route | crate.version | docs link', function (hooks) {
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link]').hasAttribute('href', 'https://docs.rs/foo/1.0.0');
   });
+
+  test('ajax errors are ignored', async function (assert) {
+    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', {}, 500);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link]').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
+  });
 });

--- a/tests/utils/ajax-test.js
+++ b/tests/utils/ajax-test.js
@@ -1,0 +1,76 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import ajax, { HttpError } from 'cargo/utils/ajax';
+
+import setupMirage from '../helpers/setup-mirage';
+
+module('ajax()', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+  setupFetchRestore(hooks);
+
+  test('fetches a JSON document from the server', async function (assert) {
+    this.server.get('/foo', { foo: 42 });
+
+    let response = await ajax('/foo');
+    assert.deepEqual(response, { foo: 42 });
+  });
+
+  test('passes additional options to `fetch()`', async function (assert) {
+    this.server.get('/foo', { foo: 42 });
+    this.server.put('/foo', { foo: 'bar' });
+
+    let response = await ajax('/foo', { method: 'PUT' });
+    assert.deepEqual(response, { foo: 'bar' });
+  });
+
+  test('throws an `HttpError` for non-2xx responses', async function (assert) {
+    this.server.get('/foo', { foo: 42 }, 500);
+
+    await assert.rejects(ajax('/foo'), function (error) {
+      assert.ok(error instanceof HttpError);
+      assert.equal(error.name, 'HttpError');
+      assert.equal(error.message, 'GET /foo failed with: 500 Internal Server Error');
+      assert.equal(error.method, 'GET');
+      assert.equal(error.url, '/foo');
+      assert.ok(error.response);
+      assert.equal(error.response.url, '/foo');
+      return true;
+    });
+  });
+
+  test('throws an error for invalid JSON responses', async function (assert) {
+    this.server.get('/foo', () => '{ foo: 42');
+
+    await assert.rejects(ajax('/foo'), function (error) {
+      assert.ok(!(error instanceof HttpError));
+      assert.equal(error.name, 'SyntaxError');
+      assert.equal(error.message, 'Unexpected token f in JSON at position 2');
+      return true;
+    });
+  });
+
+  test('throws an error when there is a network issue', async function (assert) {
+    window.fetch = async function () {
+      throw new TypeError('NetworkError when attempting to fetch resource.');
+    };
+
+    await assert.rejects(ajax('/foo'), function (error) {
+      assert.ok(!(error instanceof HttpError));
+      assert.equal(error.name, 'TypeError');
+      assert.equal(error.message, 'NetworkError when attempting to fetch resource.');
+      return true;
+    });
+  });
+});
+
+function setupFetchRestore(hooks) {
+  let oldFetch;
+  hooks.beforeEach(function () {
+    oldFetch = window.fetch;
+  });
+  hooks.afterEach(function () {
+    window.fetch = oldFetch;
+  });
+}


### PR DESCRIPTION
The primary goal of this PR is to correctly handle errors when requesting the `builds.json` files from docs.rs.

We first add tests for our `ajax()` utility function, then refactor it to always reject with `AjaxError` instances. We then use this specific error class on the error handler to only send errors to Sentry that are **not** `AjaxError`.

Since the result from docs.rs is not mission-critical we can simply ignore a missing response and treat it as if the result was `[]`. This part was already implemented in the `documentationLink` computed property.

This should hopefully reduce the number of issues like https://sentry.io/organizations/rust-lang/issues/1946426065/ and will fix another `ember-concurrency/no-perform-without-catch` ESLint issue.

r? @locks