### PR TITLE
separate doc heading from body

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -1,5 +1,6 @@
-//! This module implements several error types and traits.  The suggested usage in returned results
-//! is as follows:
+//! This module implements several error types and traits.
+//!
+//! The suggested usage in returned results is as follows:
 //!
 //! * The concrete `util::concrete::Error` type (re-exported as `util::Error`) is great for code
 //!   that is not part of the request/response lifecycle.  It avoids pulling in the unnecessary


### PR DESCRIPTION
If you look at target/doc/cargo_registry/util/index.html, you will see this heading after *errors*:
> This module implements several error types and traits. The suggested usage in returned results is as follows: 

The first line is taken as a heading, so should remain separate, so that it's readable as a summary.