### PR TITLE
tests: Use `assert_eq!()` to check error response payload content

### DIFF
--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -26,12 +26,17 @@ fn account_locked_indefinitely() {
     let (app, _anon, user) = TestApp::init().with_user();
     lock_account(&app, user.as_model().id, None);
 
-    user.get::<()>(URL)
-        .bad_with_status(StatusCode::FORBIDDEN)
-        .assert_error(&format!(
-            "This account is indefinitely locked. Reason: {}",
-            LOCK_REASON
-        ));
+    let response = user.get::<()>(URL);
+    response.assert_status(StatusCode::FORBIDDEN);
+
+    let error_message = format!(
+        "This account is indefinitely locked. Reason: {}",
+        LOCK_REASON
+    );
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": error_message }] })
+    );
 }
 
 #[test]
@@ -42,12 +47,17 @@ fn account_locked_with_future_expiry() {
     lock_account(&app, user.as_model().id, Some(until));
 
     let until = until.format("%Y-%m-%d at %H:%M:%S UTC");
-    user.get::<()>(URL)
-        .bad_with_status(StatusCode::FORBIDDEN)
-        .assert_error(&format!(
-            "This account is locked until {}. Reason: {}",
-            until, LOCK_REASON,
-        ));
+    let response = user.get::<()>(URL);
+    response.assert_status(StatusCode::FORBIDDEN);
+
+    let error_message = format!(
+        "This account is locked until {}. Reason: {}",
+        until, LOCK_REASON,
+    );
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": error_message }] })
+    );
 }
 
 #[test]

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -11,7 +11,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_json;
 
-use crate::util::{Bad, RequestHelper, TestApp};
+use crate::util::{RequestHelper, TestApp};
 use cargo_registry::{
     models::{Crate, CrateOwner, Dependency, NewCategory, NewTeam, NewUser, Team, User, Version},
     schema::crate_owners,
@@ -180,14 +180,6 @@ fn req(method: conduit::Method, path: &str) -> MockRequest {
     let mut request = MockRequest::new(method, path);
     request.header(header::USER_AGENT, "conduit-test");
     request
-}
-
-fn bad_resp(r: &mut AppResponse) -> Option<Bad> {
-    let bad = json::<Bad>(r);
-    if bad.errors.is_empty() {
-        return None;
-    }
-    Some(bad)
 }
 
 fn json<T>(r: &mut AppResponse) -> T

--- a/src/tests/krate/dependencies.rs
+++ b/src/tests/krate/dependencies.rs
@@ -26,6 +26,10 @@ fn dependencies() {
         .good();
     assert_eq!(deps.dependencies[0].crate_id, "bar_deps");
 
-    anon.get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies")
-        .bad_with_status(StatusCode::OK);
+    let response = anon.get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies");
+    response.assert_status(StatusCode::OK);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": "crate `foo_deps` does not have a version `1.0.2`" }] })
+    );
 }

--- a/src/tests/krate/search.rs
+++ b/src/tests/krate/search.rs
@@ -676,19 +676,19 @@ fn pagination_parameters_only_accept_integers() {
         CrateBuilder::new("pagination_links_3", user.id).expect_build(conn);
     });
 
-    let invalid_per_page_json = anon
-        .get_with_query::<()>("/api/v1/crates", "page=1&per_page=100%22%EF%BC%8Cexception")
-        .bad_with_status(StatusCode::BAD_REQUEST);
+    let response =
+        anon.get_with_query::<()>("/api/v1/crates", "page=1&per_page=100%22%EF%BC%8Cexception");
+    response.assert_status(StatusCode::BAD_REQUEST);
     assert_eq!(
-        invalid_per_page_json.errors[0].detail,
-        "invalid digit found in string"
+        response.json(),
+        json!({ "errors": [{ "detail": "invalid digit found in string" }] })
     );
 
-    let invalid_page_json = anon
-        .get_with_query::<()>("/api/v1/crates", "page=100%22%EF%BC%8Cexception&per_page=1")
-        .bad_with_status(StatusCode::BAD_REQUEST);
+    let response =
+        anon.get_with_query::<()>("/api/v1/crates", "page=100%22%EF%BC%8Cexception&per_page=1");
+    response.assert_status(StatusCode::BAD_REQUEST);
     assert_eq!(
-        invalid_page_json.errors[0].detail,
-        "invalid digit found in string"
+        response.json(),
+        json!({ "errors": [{ "detail": "invalid digit found in string" }] })
     );
 }

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -109,12 +109,11 @@ fn yank_by_a_non_owner_fails() {
             .expect_build(conn);
     });
 
-    let json = token
-        .yank("foo_not", "1.0.0")
-        .bad_with_status(StatusCode::OK);
+    let response = token.yank("foo_not", "1.0.0");
+    response.assert_status(StatusCode::OK);
     assert_eq!(
-        json.errors[0].detail,
-        "must already be an owner to yank or unyank"
+        response.json(),
+        json!({ "errors": [{ "detail": "must already be an owner to yank or unyank" }] })
     );
 }
 

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -29,14 +29,6 @@ struct NewResponse {
 #[derive(Deserialize)]
 struct RevokedResponse {}
 
-macro_rules! assert_contains {
-    ($e:expr, $f:expr) => {
-        if !$e.contains($f) {
-            panic!(format!("expected '{}' to contain '{}'", $e, $f));
-        }
-    };
-}
-
 // Default values used by many tests
 static URL: &str = "/api/v1/me/tokens";
 static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -6,6 +6,7 @@ use crate::{
 use cargo_registry::{
     models::ApiToken,
     schema::api_tokens,
+    util::errors::TOKEN_FORMAT_ERROR,
     views::{EncodableApiTokenWithToken, EncodableMe},
 };
 use std::collections::HashSet;
@@ -118,33 +119,36 @@ fn create_token_logged_out() {
 fn create_token_invalid_request() {
     let (_, _, user) = TestApp::init().with_user();
     let invalid = br#"{ "name": "" }"#;
-    let json = user
-        .put::<()>(URL, invalid)
-        .bad_with_status(StatusCode::BAD_REQUEST);
-
-    assert_contains!(json.errors[0].detail, "invalid new token request");
+    let response = user.put::<()>(URL, invalid);
+    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": "invalid new token request: Error(\"missing field `api_token`\", line: 1, column: 14)" }] })
+    );
 }
 
 #[test]
 fn create_token_no_name() {
     let (_, _, user) = TestApp::init().with_user();
     let empty_name = br#"{ "api_token": { "name": "" } }"#;
-    let json = user
-        .put::<()>(URL, empty_name)
-        .bad_with_status(StatusCode::BAD_REQUEST);
-
-    assert_eq!(json.errors[0].detail, "name must have a value");
+    let response = user.put::<()>(URL, empty_name);
+    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": "name must have a value" }] })
+    );
 }
 
 #[test]
 fn create_token_long_body() {
     let (_, _, user) = TestApp::init().with_user();
     let too_big = &[5; 5192]; // Send a request with a 5kB body of 5's
-    let json = user
-        .put::<()>(URL, too_big)
-        .bad_with_status(StatusCode::BAD_REQUEST);
-
-    assert_contains!(json.errors[0].detail, "max content length");
+    let response = user.put::<()>(URL, too_big);
+    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": "max content length is: 2000" }] })
+    );
 }
 
 #[test]
@@ -156,11 +160,12 @@ fn create_token_exceeded_tokens_per_user() {
             assert_ok!(ApiToken::insert(conn, id, &format!("token {}", i)));
         }
     });
-    let json = user
-        .put::<()>(URL, NEW_BAR)
-        .bad_with_status(StatusCode::BAD_REQUEST);
-
-    assert_contains!(json.errors[0].detail, "maximum tokens per user");
+    let response = user.put::<()>(URL, NEW_BAR);
+    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": "maximum tokens per user is: 500" }] })
+    );
 }
 
 #[test]
@@ -202,16 +207,14 @@ fn create_token_multiple_users_have_different_values() {
 #[test]
 fn cannot_create_token_with_token() {
     let (_, _, _, token) = TestApp::init().with_token();
-    let json = token
-        .put::<()>(
-            "/api/v1/me/tokens",
-            br#"{ "api_token": { "name": "baz" } }"#,
-        )
-        .bad_with_status(StatusCode::BAD_REQUEST);
-
-    assert_contains!(
-        json.errors[0].detail,
-        "cannot use an API token to create a new API token"
+    let response = token.put::<()>(
+        "/api/v1/me/tokens",
+        br#"{ "api_token": { "name": "baz" } }"#,
+    );
+    response.assert_status(StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": "cannot use an API token to create a new API token" }] })
     );
 }
 
@@ -313,9 +316,10 @@ fn old_tokens_give_specific_error_message() {
 
     let mut request = anon.get_request(url);
     request.header(header::AUTHORIZATION, "oldtoken");
-    let json = anon
-        .run::<()>(request)
-        .bad_with_status(StatusCode::UNAUTHORIZED);
-
-    assert_contains!(json.errors[0].detail, "revoked");
+    let response = anon.run::<()>(request);
+    response.assert_status(StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": TOKEN_FORMAT_ERROR }] })
+    );
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -554,11 +554,6 @@ pub struct Error {
     pub detail: String,
 }
 
-#[derive(Deserialize)]
-pub struct Bad {
-    pub errors: Vec<Error>,
-}
-
 /// A type providing helper methods for working with responses
 #[must_use]
 pub struct Response<T> {
@@ -589,18 +584,6 @@ where
             panic!("bad response: {:?}", self.response.status());
         }
         crate::json(&mut self.response)
-    }
-
-    /// Assert the response status code and deserialze into a list of errors
-    ///
-    /// Cargo endpoints return a status 200 on error instead of 400.
-    #[track_caller]
-    pub fn bad_with_status(&mut self, expected: StatusCode) -> Bad {
-        assert_eq!(self.response.status(), expected);
-        match crate::bad_resp(&mut self.response) {
-            None => panic!("ok response: {:?}", self.response.status()),
-            Some(b) => b,
-        }
     }
 
     #[track_caller]

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -559,17 +559,6 @@ pub struct Bad {
     pub errors: Vec<Error>,
 }
 
-impl Bad {
-    pub fn assert_error(&self, expected: &str) {
-        assert_eq!(
-            1,
-            self.errors.len(),
-            "the number of errors in this response is not 1"
-        );
-        assert_eq!(expected, self.errors[0].detail);
-    }
-}
-
 /// A type providing helper methods for working with responses
 #[must_use]
 pub struct Response<T> {

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -24,6 +24,7 @@ use crate::util::AppResponse;
 
 mod json;
 
+pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{InsecurelyGeneratedTokenRevoked, NotFound, ReadOnlyMode, TooManyRequests};
 
 /// Returns an error with status 200 and the provided description as JSON

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -181,19 +181,20 @@ impl AppError for InsecurelyGeneratedTokenRevoked {
     }
 }
 
+pub const TOKEN_FORMAT_ERROR: &str =
+    "The given API token does not match the format used by crates.io. \
+    \
+    Tokens generated before 2020-07-14 were generated with an insecure \
+    random number generator, and have been revoked. You can generate a \
+    new token at https://crates.io/me. \
+    \
+    For more information please see \
+    https://blog.rust-lang.org/2020/07/14/crates-io-security-advisory.html. \
+    We apologize for any inconvenience.";
+
 impl fmt::Display for InsecurelyGeneratedTokenRevoked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(
-            "The given API token does not match the format used by crates.io. \
-            \
-            Tokens generated before 2020-07-14 were generated with an insecure \
-            random number generator, and have been revoked. You can generate a \
-            new token at https://crates.io/me. \
-            \
-            For more information please see \
-            https://blog.rust-lang.org/2020/07/14/crates-io-security-advisory.html. \
-            We apologize for any inconvenience.",
-        )?;
+        f.write_str(TOKEN_FORMAT_ERROR)?;
         Result::Ok(())
     }
 }


### PR DESCRIPTION
This PR continues #3066 and converts the remaining tests to use the same pattern of using `assert_eq!()` and the `json!()` macro to assert on the exact structure and content of the error responses.

r? @jtgeibel 