### PR TITLE
Fix owner removal error handling

### DIFF
--- a/app/controllers/crate/owners.js
+++ b/app/controllers/crate/owners.js
@@ -36,9 +36,14 @@ export default class CrateOwnersController extends Controller {
         this.notifications.success(`User ${owner.get('login')} removed as crate owner`);
         this.crate.owner_user.removeObject(owner);
       }
-    } catch {
+    } catch (error) {
       let subject = owner.kind === 'team' ? `team ${owner.get('display_name')}` : `user ${owner.get('login')}`;
-      this.notifications.error(`Failed to remove the ${subject} as crate owner`);
+      let message = `Failed to remove the ${subject} as crate owner`;
+      if (error.errors) {
+        message += `: ${error.errors[0].detail}`;
+      }
+
+      this.notifications.error(message);
     }
   })
   removeOwnerTask;

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -54,5 +54,12 @@ export default class Crate extends Model {
     before(username) {
       return { owners: [username] };
     },
+    after(response) {
+      if (response.ok) {
+        return response;
+      } else {
+        throw response;
+      }
+    },
   });
 }

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -254,7 +254,7 @@ export function register(server) {
       return notFound();
     }
 
-    return {};
+    return { ok: true, msg: 'owners successfully removed' };
   });
 
   server.delete('/api/v1/crates/:crate_id/:version/yank', (schema, request) => {

--- a/tests/acceptance/owners-test.js
+++ b/tests/acceptance/owners-test.js
@@ -90,7 +90,9 @@ module('Acceptance | /crates/:name/owners', function (hooks) {
     await visit(`/crates/${crate.name}/owners`);
     await click(`[data-test-owner-user="${user2.login}"] [data-test-remove-owner-button]`);
 
-    assert.dom('[data-test-notification-message="error"]').hasText('Failed to remove the user user-2 as crate owner');
+    assert
+      .dom('[data-test-notification-message="error"]')
+      .hasText('Failed to remove the user user-2 as crate owner: nope');
     assert.dom('[data-test-owner-user]').exists({ count: 2 });
   });
 
@@ -126,7 +128,7 @@ module('Acceptance | /crates/:name/owners', function (hooks) {
 
     assert
       .dom('[data-test-notification-message="error"]')
-      .hasText('Failed to remove the team rust-lang/team-1 as crate owner');
+      .hasText('Failed to remove the team rust-lang/team-1 as crate owner: nope');
     assert.dom('[data-test-owner-team]').exists({ count: 1 });
     assert.dom('[data-test-owner-user]').exists({ count: 1 });
   });

--- a/tests/acceptance/owners-test.js
+++ b/tests/acceptance/owners-test.js
@@ -72,6 +72,28 @@ module('Acceptance | /crates/:name/owners', function (hooks) {
     assert.dom('[data-test-owner-user]').exists({ count: 1 });
   });
 
+  test('remove a user crate owner (error behavior)', async function (assert) {
+    let user = this.server.create('user');
+    let user2 = this.server.create('user');
+
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('crate-ownership', { crate, user });
+    this.server.create('crate-ownership', { crate, user: user2 });
+
+    // we are intentionally returning a 200 response here, because is what
+    // the real backend also returns due to legacy reasons
+    this.server.delete('/api/v1/crates/nanomsg/owners', { errors: [{ detail: 'nope' }] });
+
+    this.authenticateAs(user);
+
+    await visit(`/crates/${crate.name}/owners`);
+    await click(`[data-test-owner-user="${user2.login}"] [data-test-remove-owner-button]`);
+
+    assert.dom('[data-test-notification-message="error"]').hasText('Failed to remove the user user-2 as crate owner');
+    assert.dom('[data-test-owner-user]').exists({ count: 2 });
+  });
+
   test('remove a crate owner when owner is a team', async function (assert) {
     this.server.loadFixtures();
 
@@ -82,5 +104,30 @@ module('Acceptance | /crates/:name/owners', function (hooks) {
       .dom('[data-test-notification-message="success"]')
       .hasText('Team org/thehydroimpulseteam removed as crate owner');
     assert.dom('[data-test-owner-team]').exists({ count: 1 });
+  });
+
+  test('remove a team crate owner (error behavior)', async function (assert) {
+    let user = this.server.create('user');
+    let team = this.server.create('team');
+
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('crate-ownership', { crate, user });
+    this.server.create('crate-ownership', { crate, team });
+
+    // we are intentionally returning a 200 response here, because is what
+    // the real backend also returns due to legacy reasons
+    this.server.delete('/api/v1/crates/nanomsg/owners', { errors: [{ detail: 'nope' }] });
+
+    this.authenticateAs(user);
+
+    await visit(`/crates/${crate.name}/owners`);
+    await click(`[data-test-owner-team="${team.login}"] [data-test-remove-owner-button]`);
+
+    assert
+      .dom('[data-test-notification-message="error"]')
+      .hasText('Failed to remove the team rust-lang/team-1 as crate owner');
+    assert.dom('[data-test-owner-team]').exists({ count: 1 });
+    assert.dom('[data-test-owner-user]').exists({ count: 1 });
   });
 });

--- a/tests/models/crate-test.js
+++ b/tests/models/crate-test.js
@@ -49,7 +49,7 @@ module('Model | Crate', function (hooks) {
       let crateRecord = await this.store.findRecord('crate', crate.id);
 
       let result = await crateRecord.removeOwner(user.login);
-      assert.deepEqual(result, {});
+      assert.deepEqual(result, { ok: true, msg: 'owners successfully removed' });
     });
 
     test('error handling', async function (assert) {


### PR DESCRIPTION
On the frontend we were not considering that the backend always returns 200 HTTP status codes, even for errors. This PR fixes our frontend code to only consider `{ ok: true }` responses as successful requests and shows an error message otherwise.

This PR also adds two tests to the frontend test suite to avoid regressions on this.

Resolves #2976 

r? @carols10cents 