### PR TITLE
Update `comrak` to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d325e4f2ffff52ca77d995bb675494d5364aa332499d5f7c7fbb28c25e671f6"
+checksum = "bcfb8008d04126b176c76cbfdecf9a2ccb4bacc70af87c8da6136d63d7b7292a"
 dependencies = [
  "entities",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 chrono = { version = "0.4.0", features = ["serde"] }
 civet = "0.12.0-alpha.4"
 clap = "=3.0.0-beta.2"
-comrak = { version = "0.8", default-features = false }
+comrak = { version = "0.9", default-features = false }
 
 conduit = "0.9.0-alpha.3"
 conduit-conditional-get = "0.9.0-alpha.3"


### PR DESCRIPTION
Changes between 0.8.2 and 0.9.0: https://github.com/kivikakk/comrak/compare/0.8.2...0.9.0
This shouldn't affect our codebase.