### PR TITLE
Use `std`'s items instead of `failure`'s

### DIFF
--- a/src/admin/test_pagerduty.rs
+++ b/src/admin/test_pagerduty.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Clap;
-use failure::_core::str::FromStr;
+use std::str::FromStr;
 
 use crate::admin::on_call;
 

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -9,12 +9,12 @@ use cargo_registry::models::krate::MAX_NAME_LENGTH;
 use cargo_registry::schema::{api_tokens, emails, versions_published_by};
 use cargo_registry::views::GoodCrate;
 use diesel::{delete, update, ExpressionMethods, QueryDsl, RunQueryDsl};
-use failure::_core::time::Duration;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use http::StatusCode;
 use std::collections::HashMap;
 use std::io::Read;
+use std::time::Duration;
 use std::{io, thread};
 
 #[test]


### PR DESCRIPTION
r? @Turbo87 