### PR TITLE
Cargo.toml: Specify `server` as `default-run` field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 description = "Backend of crates.io"
 edition = "2018"
+default-run = "server"
 
 [workspace]
 

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -8,4 +8,4 @@ done
 
 ./script/init-local-index.sh
 
-cargo run --bin server
+cargo run

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -348,7 +348,7 @@ Build and start the server by running this command (you'll need to stop this
 with `CTRL-C` and rerun this command every time you change the backend code):
 
 ```
-cargo run --bin server
+cargo run
 ```
 
 Then start the background worker (which will process uploaded READMEs):


### PR DESCRIPTION
This allows us to use just `cargo run` instead of `cargo run --bin server`

r? @pietroalbini 