### PR TITLE
Replace `log` and `env_logger` with `tracing` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,6 @@ dependencies = [
  "lazy_static",
  "lettre",
  "license-exprs",
- "log",
  "oauth2",
  "parking_lot",
  "rand",
@@ -316,6 +315,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,7 +291,6 @@ dependencies = [
  "diesel_full_text_search",
  "diesel_migrations",
  "dotenv",
- "env_logger",
  "failure",
  "flate2",
  "futures-channel",
@@ -316,6 +324,7 @@ dependencies = [
  "toml",
  "tower-service",
  "tracing",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -810,19 +819,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
-name = "env_logger"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1007,6 +1003,19 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1238,12 +1247,6 @@ name = "httpdate"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "humantime"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
@@ -1541,6 +1544,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1602,15 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -2228,6 +2253,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2365,12 @@ checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
  "parking_lot",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -2563,6 +2604,16 @@ dependencies = [
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+dependencies = [
+ "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -3031,6 +3082,49 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "pin-project 0.4.27",
  "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec 1.5.0",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ dialoguer = "0.7.1"
 diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
 diesel_full_text_search = "1.0.0"
 dotenv = "0.15"
-env_logger = "0.8"
 failure = "0.1.1"
 flate2 = "1.0"
 futures-channel = { version = "0.3.1", default-features = false }
@@ -85,6 +84,7 @@ tempfile = "3"
 tokio = { version = "0.2", default-features = false, features = ["net", "signal", "io-std"]}
 toml = "0.5"
 tracing = "0.1"
+tracing-subscriber = "0.2"
 url = "2.1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,6 @@ indexmap = "1.0.2"
 jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "0.10.0-alpha.1", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
 license-exprs = "^1.4"
-log = "0.4"
 oauth2 = { version = "3.0.0", default-features = false, features = ["reqwest-010"] }
 parking_lot = "0.11"
 rand = "0.7"
@@ -85,6 +84,7 @@ tar = "0.4.16"
 tempfile = "3"
 tokio = { version = "0.2", default-features = false, features = ["net", "signal", "io-std"]}
 toml = "0.5"
+tracing = "0.1"
 url = "2.1"
 
 [dev-dependencies]

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
 
     // Initialize logging
-    env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let config = cargo_registry::Config::default();
     let client = Client::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@ extern crate derive_deref;
 #[macro_use]
 extern crate diesel;
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate serde_json;
+#[macro_use]
+extern crate tracing;
 
 pub use crate::{app::App, config::Config, uploaders::Uploader};
 use std::sync::Arc;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -7,11 +7,11 @@ extern crate diesel;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate serde_json;
+#[macro_use]
+extern crate tracing;
 
 use crate::util::{RequestHelper, TestApp};
 use cargo_registry::{

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -48,9 +48,10 @@ use url::Url;
 pub use conduit::{header, StatusCode};
 
 pub fn init_logger() {
-    let _ = env_logger::builder()
-        .format_timestamp(None)
-        .is_test(true)
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .without_time()
+        .with_test_writer()
         .try_init();
 }
 


### PR DESCRIPTION
This brings us closer to being able to use structured logging and properly instrumenting some of functions. The change is mostly a drop-in replacement as described by https://docs.rs/tracing/0.1.22/tracing/#for-log-users.

The only difference is the slightly changed log output format:

```
# before
[2020-12-23T21:51:50Z INFO  cargo_registry::app] test23

# after
Dec 23 22:53:48.847  INFO cargo_registry::app: test23
```

This could be massaged by using a custom `FormatEvent` implementation though, if we really need this to be formatted in a specific way. Otherwise there is also a JSON-based output format which might be beneficial in production for real structured logging.

r? @pietroalbini 