### PR TITLE
models: Add missing `pub` declarations

### DIFF
--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -31,12 +31,12 @@ pub struct Dependency {
 #[derive(Debug, QueryableByName)]
 pub struct ReverseDependency {
     #[diesel(embed)]
-    dependency: Dependency,
+    pub dependency: Dependency,
     #[sql_type = "::diesel::sql_types::Integer"]
-    crate_downloads: i32,
+    pub crate_downloads: i32,
     #[sql_type = "::diesel::sql_types::Text"]
     #[column_name = "crate_name"]
-    name: String,
+    pub name: String,
 }
 
 #[derive(Copy, Clone, Serialize, Deserialize, Debug, FromSqlRow)]


### PR DESCRIPTION
Without these declarations it is quite hard to use these model structs outside of their files, and since the structs themselves are `pub` it makes sense for their fields to also be public.

r? @pietroalbini 