### PR TITLE
Improve `ajax()` utility function

### DIFF
--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -1,3 +1,5 @@
+import { runInDebug } from '@ember/debug';
+
 import fetch from 'fetch';
 
 export default async function ajax(input, init) {
@@ -30,7 +32,14 @@ export class HttpError extends Error {
 
 export class AjaxError extends Error {
   constructor({ url, method, cause }) {
-    super(`${method} ${url} failed`);
+    let message = `${method} ${url} failed`;
+    runInDebug(() => {
+      if (cause?.stack) {
+        message += `\n\ncaused by: ${cause.stack}`;
+      }
+    });
+
+    super(message);
     this.name = 'AjaxError';
     this.method = method;
     this.url = url;

--- a/app/utils/ajax.js
+++ b/app/utils/ajax.js
@@ -45,4 +45,12 @@ export class AjaxError extends Error {
     this.url = url;
     this.cause = cause;
   }
+
+  async json() {
+    try {
+      return await this.cause.response.json();
+    } catch {
+      // ignore errors and implicitly return `undefined`
+    }
+  }
 }

--- a/tests/utils/ajax-test.js
+++ b/tests/utils/ajax-test.js
@@ -93,6 +93,34 @@ module('ajax()', function (hooks) {
       return true;
     });
   });
+
+  module('json()', function () {
+    test('resolves with the JSON payload', async function (assert) {
+      this.server.get('/foo', { foo: 42 }, 500);
+
+      let error;
+      await assert.rejects(ajax('/foo'), function (_error) {
+        error = _error;
+        return true;
+      });
+
+      let json = await error.json();
+      assert.deepEqual(json, { foo: 42 });
+    });
+
+    test('resolves with `undefined` if there is no JSON payload', async function (assert) {
+      this.server.get('/foo', () => '{ foo: 42', 500);
+
+      let error;
+      await assert.rejects(ajax('/foo'), function (_error) {
+        error = _error;
+        return true;
+      });
+
+      let json = await error.json();
+      assert.strictEqual(json, undefined);
+    });
+  });
 });
 
 function setupFetchRestore(hooks) {

--- a/tests/utils/ajax-test.js
+++ b/tests/utils/ajax-test.js
@@ -29,9 +29,11 @@ module('ajax()', function (hooks) {
     this.server.get('/foo', { foo: 42 }, 500);
 
     await assert.rejects(ajax('/foo'), function (error) {
+      let expectedMessage = 'GET /foo failed\n\ncaused by: HttpError: GET /foo failed with: 500 Internal Server Error';
+
       assert.ok(error instanceof AjaxError);
       assert.equal(error.name, 'AjaxError');
-      assert.equal(error.message, 'GET /foo failed');
+      assert.ok(error.message.startsWith(expectedMessage), error.message);
       assert.equal(error.method, 'GET');
       assert.equal(error.url, '/foo');
       assert.ok(error.cause);
@@ -52,9 +54,11 @@ module('ajax()', function (hooks) {
     this.server.get('/foo', () => '{ foo: 42');
 
     await assert.rejects(ajax('/foo'), function (error) {
+      let expectedMessage = 'GET /foo failed\n\ncaused by: SyntaxError';
+
       assert.ok(error instanceof AjaxError);
       assert.equal(error.name, 'AjaxError');
-      assert.equal(error.message, 'GET /foo failed');
+      assert.ok(error.message.startsWith(expectedMessage), error.message);
       assert.equal(error.method, 'GET');
       assert.equal(error.url, '/foo');
       assert.ok(error.cause);
@@ -73,9 +77,11 @@ module('ajax()', function (hooks) {
     };
 
     await assert.rejects(ajax('/foo'), function (error) {
+      let expectedMessage = 'GET /foo failed\n\ncaused by: TypeError';
+
       assert.ok(error instanceof AjaxError);
       assert.equal(error.name, 'AjaxError');
-      assert.equal(error.message, 'GET /foo failed');
+      assert.ok(error.message.startsWith(expectedMessage), error.message);
       assert.equal(error.method, 'GET');
       assert.equal(error.url, '/foo');
       assert.ok(error.cause);


### PR DESCRIPTION
This PR improves the `ajax()` function in two ways:

- it adds the nested `cause` to the `message` in debug mode (production is handled by Sentry automatically)
- it adds a `json()` method for easy access to the error response payload if one exists

The second part will be used in an upcoming feature, and the first part turned out useful during the development of that feature.

r? @pichfl 