### PR TITLE
Convert `encodable()` methods to `From` implementations

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -18,7 +18,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let categories =
         Category::toplevel(&conn, sort, i64::from(options.per_page), i64::from(offset))?;
-    let categories = categories.into_iter().map(Category::encodable).collect();
+    let categories = categories.into_iter().map(Category::into).collect();
 
     // Query for the total count of categories
     let total = Category::count_toplevel(&conn)?;
@@ -47,15 +47,15 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let subcats = cat
         .subcategories(&conn)?
         .into_iter()
-        .map(Category::encodable)
+        .map(Category::into)
         .collect();
     let parents = cat
         .parent_categories(&conn)?
         .into_iter()
-        .map(Category::encodable)
+        .map(Category::into)
         .collect();
 
-    let cat = cat.encodable();
+    let cat = EncodableCategory::from(cat);
     let cat_with_subcats = EncodableCategoryWithSubcategories {
         id: cat.id,
         category: cat.category,

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -85,7 +85,7 @@ pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
 
     let popular_categories = Category::toplevel(&conn, "crates", 10, 0)?
         .into_iter()
-        .map(Category::encodable)
+        .map(Category::into)
         .collect();
 
     #[derive(Serialize)]
@@ -179,7 +179,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
             .map(|(v, pb, aas)| v.encodable(&krate.name, pb, aas))
             .collect(),
         keywords: kws.into_iter().map(Keyword::encodable).collect(),
-        categories: cats.into_iter().map(Category::encodable).collect(),
+        categories: cats.into_iter().map(Category::into).collect(),
     }))
 }
 

--- a/src/models/badge.rs
+++ b/src/models/badge.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 
 use crate::models::Crate;
 use crate::schema::badges;
-use crate::views::EncodableBadge;
 
 /// A combination of a `Badge` and a crate ID.
 ///
@@ -108,11 +107,6 @@ impl Queryable<badges::SqlType, Pg> for Badge {
 }
 
 impl Badge {
-    pub fn encodable(self) -> EncodableBadge {
-        // The serde attributes on Badge ensure it can be deserialized to EncodableBadge
-        serde_json::from_value(serde_json::to_value(self).unwrap()).unwrap()
-    }
-
     pub fn update_crate(
         conn: &PgConnection,
         krate: &Crate,

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -3,7 +3,6 @@ use diesel::{self, *};
 
 use crate::models::Crate;
 use crate::schema::*;
-use crate::views::EncodableCategory;
 
 #[derive(Clone, Identifiable, Queryable, QueryableByName, Debug)]
 #[table_name = "categories"]
@@ -55,25 +54,6 @@ impl Category {
 
     pub fn by_slugs_case_sensitive<'a>(slugs: &'a [&'a str]) -> BySlugsCaseSensitive<'a> {
         categories::table.filter(Self::with_slugs_case_sensitive(slugs))
-    }
-
-    pub fn encodable(self) -> EncodableCategory {
-        let Category {
-            crates_cnt,
-            category,
-            slug,
-            description,
-            created_at,
-            ..
-        } = self;
-        EncodableCategory {
-            id: slug.clone(),
-            slug,
-            description,
-            created_at,
-            crates_cnt,
-            category: category.rsplit("::").collect::<Vec<_>>()[0].to_string(),
-        }
     }
 
     pub fn update_crate(

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -342,7 +342,7 @@ impl Crate {
         };
         let keyword_ids = keywords.map(|kws| kws.iter().map(|kw| kw.keyword.clone()).collect());
         let category_ids = categories.map(|cats| cats.iter().map(|cat| cat.slug.clone()).collect());
-        let badges = badges.map(|bs| bs.into_iter().map(Badge::encodable).collect());
+        let badges = badges.map(|bs| bs.into_iter().map(Badge::into).collect());
         let documentation = Crate::remove_blocked_documentation_urls(documentation);
 
         EncodableCrate {

--- a/src/views.rs
+++ b/src/views.rs
@@ -30,7 +30,22 @@ pub struct EncodableCategory {
 
 impl From<Category> for EncodableCategory {
     fn from(category: Category) -> Self {
-        category.encodable()
+        let Category {
+            crates_cnt,
+            category,
+            slug,
+            description,
+            created_at,
+            ..
+        } = category;
+        Self {
+            id: slug.clone(),
+            slug,
+            description,
+            created_at,
+            crates_cnt,
+            category: category.rsplit("::").collect::<Vec<_>>()[0].to_string(),
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,13 +1,19 @@
 use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
-use crate::models::DependencyKind;
+use crate::models::{Badge, DependencyKind};
 use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct EncodableBadge {
     pub badge_type: String,
     pub attributes: HashMap<String, Option<String>>,
+}
+
+impl From<Badge> for EncodableBadge {
+    fn from(badge: Badge) -> Self {
+        badge.encodable()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -12,7 +12,8 @@ pub struct EncodableBadge {
 
 impl From<Badge> for EncodableBadge {
     fn from(badge: Badge) -> Self {
-        badge.encodable()
+        // The serde attributes on Badge ensure it can be deserialized to EncodableBadge
+        serde_json::from_value(serde_json::to_value(badge).unwrap()).unwrap()
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
-use crate::models::{Badge, DependencyKind};
+use crate::models::{Badge, Category, DependencyKind};
 use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -26,6 +26,12 @@ pub struct EncodableCategory {
     #[serde(with = "rfc3339")]
     pub created_at: NaiveDateTime,
     pub crates_cnt: i32,
+}
+
+impl From<Category> for EncodableCategory {
+    fn from(category: Category) -> Self {
+        category.encodable()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Our JSON `views` and the database `models` are currently tightly coupled through the `encodable()` methods on almost all models. 

Instead of having the database models depend on the JSON views it would be better to reverse this relationship, so that the database models can live on their own, and only the JSON views are depending on the database models. This would eventually allow us to extract the database models and schema into a dedicated crate, which would then allow us to cut down the dependency tree of some second-level binaries like `monitor` and `background-worker`

This PR starts the process of moving away from `encodable()` by implementing the `From` trait for two of our JSON views. This allows us to call `.into()` on the models to automatically convert it to the JSON view form.

r? @pietroalbini 