### PR TITLE
Convert `on_call` module to dedicated `cargo_on_call` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,12 +245,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "cargo-on-call"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "dotenv",
+ "reqwest",
+ "serde",
+]
+
+[[package]]
 name = "cargo-registry"
 version = "0.2.2"
 dependencies = [
  "ammonia",
  "anyhow",
  "base64 0.13.0",
+ "cargo-on-call",
  "cargo-registry-s3",
  "chrono",
  "civet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rustdoc-args = [
 ammonia = "3.0.0"
 anyhow = "1.0"
 base64 = "0.13"
+cargo-on-call = { path = "src/on_call" }
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 chrono = { version = "0.4.0", features = ["serde"] }
 civet = "0.12.0-alpha.5"

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,7 +1,6 @@
 pub mod delete_crate;
 pub mod delete_version;
 pub mod dialoguer;
-pub mod on_call;
 pub mod populate;
 pub mod render_readmes;
 pub mod test_pagerduty;

--- a/src/admin/test_pagerduty.rs
+++ b/src/admin/test_pagerduty.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
+use cargo_on_call::Event;
 use clap::Clap;
 use std::str::FromStr;
-
-use crate::admin::on_call;
 
 #[derive(Debug, Copy, Clone)]
 pub enum EventType {
@@ -34,15 +33,15 @@ pub struct Opts {
 
 pub fn run(opts: Opts) -> Result<()> {
     let event = match opts.event_type {
-        EventType::Trigger => on_call::Event::Trigger {
+        EventType::Trigger => Event::Trigger {
             incident_key: Some("test".into()),
             description: opts.description.unwrap_or_else(|| "Test event".into()),
         },
-        EventType::Acknowledge => on_call::Event::Acknowledge {
+        EventType::Acknowledge => Event::Acknowledge {
             incident_key: "test".into(),
             description: opts.description,
         },
-        EventType::Resolve => on_call::Event::Resolve {
+        EventType::Resolve => Event::Resolve {
             incident_key: "test".into(),
             description: opts.description,
         },

--- a/src/on_call/Cargo.toml
+++ b/src/on_call/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+
+name = "cargo-on-call"
+version = "0.0.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rust-lang/crates.io"
+description = "PagerDuty integration code for crates.io"
+edition = "2018"
+
+[lib]
+name = "cargo_on_call"
+path = "lib.rs"
+
+[dependencies]
+anyhow = "1.0"
+dotenv = "0.15"
+reqwest = { version = "0.11", features = ["blocking", "gzip", "json"] }
+serde = { version = "1.0.0", features = ["derive"] }

--- a/src/on_call/lib.rs
+++ b/src/on_call/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::all, rust_2018_idioms)]
+
 use anyhow::{anyhow, Result};
 use reqwest::{blocking::Client, header, StatusCode as Status};
 


### PR DESCRIPTION
This will eventually allow the `monitor` binary to link much faster, since it won't have to link all of the `cargo_registry` dependencies anymore.

r? @jtgeibel 