### PR TITLE
tests: Initialize env_logger in `TestApp::init()`

### DIFF
--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -7,6 +7,8 @@ extern crate diesel;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
+extern crate log;
+#[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate serde_json;

--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -292,6 +292,7 @@ fn replay_http(
 ) -> impl Future<Output = Result<Response<Body>, Error>> + Send {
     static IGNORED_HEADERS: &[&str] = &["authorization", "date", "cache-control"];
 
+    debug!("<- {:?}", req);
     assert_eq!(req.uri().to_string(), exchange.request.uri);
     assert_eq!(req.method().to_string(), exchange.request.method);
     assert_ok!(writeln!(
@@ -337,6 +338,7 @@ fn replay_http(
         let status = StatusCode::from_u16(exchange.response.status).unwrap();
         let response = builder.status(status).body(body.into()).unwrap();
 
+        debug!("-> {:?}", response);
         Ok(response)
     }
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -47,6 +47,13 @@ use url::Url;
 
 pub use conduit::{header, StatusCode};
 
+pub fn init_logger() {
+    let _ = env_logger::builder()
+        .format_timestamp(None)
+        .is_test(true)
+        .try_init();
+}
+
 struct TestAppInner {
     app: Arc<App>,
     // The bomb (if created) needs to be held in scope until the end of the test.
@@ -92,6 +99,8 @@ pub struct TestApp(Rc<TestAppInner>);
 impl TestApp {
     /// Initialize an application with an `Uploader` that panics
     pub fn init() -> TestAppBuilder {
+        init_logger();
+
         TestAppBuilder {
             config: crate::simple_config(),
             proxy: None,


### PR DESCRIPTION
This allows us to use e.g. `debug!()` in test utilities and run `cargo test` with `RUST_LOG=debug`.

This PR also adds `debug!()` calls to our HTTP proxy replay code, to make it easier to see what requests have been intercepted by the proxy.

r? @pietroalbini 