### PR TITLE
Replace more `encodable()` methods with `From` implementations

### DIFF
--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -23,7 +23,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.db_conn()?;
     let data: Paginated<Keyword> = query.load(&*conn)?;
     let total = data.total();
-    let kws = data.into_iter().map(Keyword::encodable).collect::<Vec<_>>();
+    let kws = data.into_iter().map(Keyword::into).collect::<Vec<_>>();
 
     #[derive(Serialize)]
     struct R {
@@ -52,7 +52,5 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     struct R {
         keyword: EncodableKeyword,
     }
-    Ok(req.json(&R {
-        keyword: kw.encodable(),
-    }))
+    Ok(req.json(&R { keyword: kw.into() }))
 }

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -31,7 +31,7 @@ pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
         .order(version_downloads::date.asc())
         .load(&*conn)?
         .into_iter()
-        .map(VersionDownload::encodable)
+        .map(VersionDownload::into)
         .collect::<Vec<_>>();
 
     let sum_downloads = sql::<BigInt>("SUM(version_downloads.downloads)");

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -80,7 +80,7 @@ pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
         .limit(10)
         .load(&*conn)?
         .into_iter()
-        .map(Keyword::encodable)
+        .map(Keyword::into)
         .collect();
 
     let popular_categories = Category::toplevel(&conn, "crates", 10, 0)?
@@ -178,7 +178,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
             .into_iter()
             .map(|(v, pb, aas)| v.encodable(&krate.name, pb, aas))
             .collect(),
-        keywords: kws.into_iter().map(Keyword::encodable).collect(),
+        keywords: kws.into_iter().map(Keyword::into).collect(),
         categories: cats.into_iter().map(Category::into).collect(),
     }))
 }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -9,11 +9,7 @@ pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let conn = req.db_conn()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
-    let owners = krate
-        .owners(&conn)?
-        .into_iter()
-        .map(Owner::encodable)
-        .collect();
+    let owners = krate.owners(&conn)?.into_iter().map(Owner::into).collect();
 
     #[derive(Serialize)]
     struct R {
@@ -29,7 +25,7 @@ pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = Team::owning(&krate, &conn)?
         .into_iter()
-        .map(Owner::encodable)
+        .map(Owner::into)
         .collect();
 
     #[derive(Serialize)]
@@ -46,7 +42,7 @@ pub fn owner_user(req: &mut dyn RequestExt) -> EndpointResult {
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = User::owning(&krate, &conn)?
         .into_iter()
-        .map(Owner::encodable)
+        .map(Owner::into)
         .collect();
 
     #[derive(Serialize)]

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -16,7 +16,5 @@ pub fn show_team(req: &mut dyn RequestExt) -> EndpointResult {
     struct R {
         team: EncodableTeam,
     }
-    Ok(req.json(&R {
-        team: team.encodable(),
-    }))
+    Ok(req.json(&R { team: team.into() }))
 }

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -87,7 +87,7 @@ pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
         api_token: EncodableApiTokenWithToken,
     }
     Ok(req.json(&R {
-        api_token: api_token.encodable_with_token(),
+        api_token: api_token.into(),
     }))
 }
 

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -20,9 +20,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     struct R {
         user: EncodablePublicUser,
     }
-    Ok(req.json(&R {
-        user: user.encodable_public(),
-    }))
+    Ok(req.json(&R { user: user.into() }))
 }
 
 /// Handles the `GET /users/:user_id/stats` route.

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -94,7 +94,7 @@ pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
         .order(version_downloads::date)
         .load(&*conn)?
         .into_iter()
-        .map(VersionDownload::encodable)
+        .map(VersionDownload::into)
         .collect();
 
     #[derive(Serialize)]

--- a/src/models/download.rs
+++ b/src/models/download.rs
@@ -3,7 +3,6 @@ use diesel::prelude::*;
 
 use crate::models::Version;
 use crate::schema::version_downloads;
-use crate::views::EncodableVersionDownload;
 
 #[derive(Queryable, Identifiable, Associations, Debug, Clone, Copy)]
 #[belongs_to(Version)]
@@ -30,13 +29,5 @@ impl VersionDownload {
             .set(downloads.eq(downloads + 1))
             .execute(conn)?;
         Ok(())
-    }
-
-    pub fn encodable(self) -> EncodableVersionDownload {
-        EncodableVersionDownload {
-            version: self.version_id,
-            downloads: self.downloads,
-            date: self.date.to_string(),
-        }
     }
 }

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -3,7 +3,6 @@ use diesel::prelude::*;
 
 use crate::models::Crate;
 use crate::schema::*;
-use crate::views::EncodableKeyword;
 
 #[derive(Clone, Identifiable, Queryable, Debug)]
 pub struct Keyword {
@@ -59,21 +58,6 @@ impl Keyword {
                 .chars()
                 .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
             && name.chars().all(|c| c.is_ascii())
-    }
-
-    pub fn encodable(self) -> EncodableKeyword {
-        let Keyword {
-            crates_cnt,
-            keyword,
-            created_at,
-            ..
-        } = self;
-        EncodableKeyword {
-            id: keyword.clone(),
-            created_at,
-            crates_cnt,
-            keyword,
-        }
     }
 
     pub fn update_crate(conn: &PgConnection, krate: &Crate, keywords: &[&str]) -> QueryResult<()> {

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -2,12 +2,10 @@ use diesel::pg::Pg;
 use diesel::prelude::*;
 
 use crate::app::App;
-use crate::github;
 use crate::util::errors::{cargo_err, AppResult};
 
 use crate::models::{Crate, Team, User};
 use crate::schema::{crate_owners, users};
-use crate::views::EncodableOwner;
 
 #[derive(Insertable, Associations, Identifiable, Debug, Clone, Copy)]
 #[belongs_to(Crate)]
@@ -98,45 +96,6 @@ impl Owner {
         match *self {
             Owner::User(ref user) => user.id,
             Owner::Team(ref team) => team.id,
-        }
-    }
-
-    pub fn encodable(self) -> EncodableOwner {
-        match self {
-            Owner::User(User {
-                id,
-                name,
-                gh_login,
-                gh_avatar,
-                ..
-            }) => {
-                let url = format!("https://github.com/{}", gh_login);
-                EncodableOwner {
-                    id,
-                    login: gh_login,
-                    avatar: gh_avatar,
-                    url: Some(url),
-                    name,
-                    kind: String::from("user"),
-                }
-            }
-            Owner::Team(Team {
-                id,
-                name,
-                login,
-                avatar,
-                ..
-            }) => {
-                let url = github::team_url(&login);
-                EncodableOwner {
-                    id,
-                    login,
-                    url: Some(url),
-                    avatar,
-                    name,
-                    kind: String::from("team"),
-                }
-            }
         }
     }
 }

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -1,14 +1,13 @@
 use diesel::prelude::*;
 
 use crate::app::App;
-use crate::github::{github_api, team_url};
+use crate::github::github_api;
 use crate::util::errors::{cargo_err, AppResult, NotFound};
 
 use oauth2::AccessToken;
 
 use crate::models::{Crate, CrateOwner, Owner, OwnerKind, User};
 use crate::schema::{crate_owners, teams};
-use crate::views::EncodableTeam;
 
 /// For now, just a Github Team. Can be upgraded to other teams
 /// later if desirable.
@@ -212,25 +211,6 @@ impl Team {
             .map(Owner::Team);
 
         Ok(teams.collect())
-    }
-
-    pub fn encodable(self) -> EncodableTeam {
-        let Team {
-            id,
-            name,
-            login,
-            avatar,
-            ..
-        } = self;
-        let url = team_url(&login);
-
-        EncodableTeam {
-            id,
-            login,
-            name,
-            avatar,
-            url: Some(url),
-        }
     }
 }
 

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -6,7 +6,6 @@ use crate::models::User;
 use crate::schema::api_tokens;
 use crate::util::errors::{AppResult, InsecurelyGeneratedTokenRevoked};
 use crate::util::rfc3339;
-use crate::views::EncodableApiTokenWithToken;
 
 const TOKEN_LENGTH: usize = 32;
 const TOKEN_PREFIX: &str = "cio"; // Crates.IO
@@ -83,21 +82,6 @@ pub struct CreatedApiToken {
     pub plaintext: String,
 }
 
-impl CreatedApiToken {
-    /// Converts this `CreatedApiToken` into an `EncodableApiToken` including
-    /// the actual token value for JSON serialization.
-    pub fn encodable_with_token(self) -> EncodableApiTokenWithToken {
-        EncodableApiTokenWithToken {
-            id: self.model.id,
-            name: self.model.name,
-            token: self.plaintext,
-            revoked: self.model.revoked,
-            created_at: self.model.created_at,
-            last_used_at: self.model.last_used_at,
-        }
-    }
-}
-
 // Use a custom implementation of Debug to hide the plaintext token.
 impl std::fmt::Debug for CreatedApiToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -111,6 +95,7 @@ impl std::fmt::Debug for CreatedApiToken {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::views::EncodableApiTokenWithToken;
     use chrono::NaiveDate;
 
     #[test]

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -7,7 +7,7 @@ use crate::util::errors::AppResult;
 
 use crate::models::{ApiToken, Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};
 use crate::schema::{crate_owners, emails, users};
-use crate::views::{EncodablePrivateUser, EncodablePublicUser};
+use crate::views::EncodablePrivateUser;
 
 /// The model representing a row in the `users` database table.
 #[derive(Clone, Debug, PartialEq, Eq, Queryable, Identifiable, AsChangeset, Associations)]
@@ -202,24 +202,5 @@ impl User {
             .select(emails::email)
             .first(&*conn)
             .optional()?)
-    }
-
-    /// Converts this`User` model into an `EncodablePublicUser` for JSON serialization.
-    pub fn encodable_public(self) -> EncodablePublicUser {
-        let User {
-            id,
-            name,
-            gh_login,
-            gh_avatar,
-            ..
-        } = self;
-        let url = format!("https://github.com/{}", gh_login);
-        EncodablePublicUser {
-            id,
-            avatar: gh_avatar,
-            login: gh_login,
-            name,
-            url: Some(url),
-        }
     }
 }

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -94,12 +94,12 @@ impl Version {
                 authors: format!("/api/v1/crates/{}/{}/authors", crate_name, num),
             },
             crate_size,
-            published_by: published_by.map(User::encodable_public),
+            published_by: published_by.map(User::into),
             audit_actions: audit_actions
                 .into_iter()
                 .map(|(audit_action, user)| EncodableAuditAction {
                     action: audit_action.action.into(),
-                    user: User::encodable_public(user),
+                    user: user.into(),
                     time: audit_action.time,
                 })
                 .collect(),

--- a/src/views.rs
+++ b/src/views.rs
@@ -322,9 +322,24 @@ pub struct EncodablePublicUser {
     pub url: Option<String>,
 }
 
+/// Converts a `User` model into an `EncodablePublicUser` for JSON serialization.
 impl From<User> for EncodablePublicUser {
     fn from(user: User) -> Self {
-        user.encodable_public()
+        let User {
+            id,
+            name,
+            gh_login,
+            gh_avatar,
+            ..
+        } = user;
+        let url = format!("https://github.com/{}", gh_login);
+        EncodablePublicUser {
+            id,
+            avatar: gh_avatar,
+            login: gh_login,
+            name,
+            url: Some(url),
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
-use crate::models::{Badge, Category, DependencyKind, Keyword, VersionDownload};
+use crate::models::{Badge, Category, DependencyKind, Keyword, Owner, VersionDownload};
 use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -179,6 +179,12 @@ pub struct EncodableOwner {
     pub url: Option<String>,
     pub name: Option<String>,
     pub avatar: Option<String>,
+}
+
+impl From<Owner> for EncodableOwner {
+    fn from(owner: Owner) -> Self {
+        owner.encodable()
+    }
 }
 
 #[derive(Serialize, Debug)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -2,7 +2,9 @@ use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
 use crate::github;
-use crate::models::{Badge, Category, DependencyKind, Keyword, Owner, Team, User, VersionDownload};
+use crate::models::{
+    Badge, Category, CreatedApiToken, DependencyKind, Keyword, Owner, Team, User, VersionDownload,
+};
 use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -266,6 +268,12 @@ pub struct EncodableApiTokenWithToken {
     pub created_at: NaiveDateTime,
     #[serde(with = "rfc3339::option")]
     pub last_used_at: Option<NaiveDateTime>,
+}
+
+impl From<CreatedApiToken> for EncodableApiTokenWithToken {
+    fn from(token: CreatedApiToken) -> Self {
+        token.encodable_with_token()
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -322,6 +322,12 @@ pub struct EncodablePublicUser {
     pub url: Option<String>,
 }
 
+impl From<User> for EncodablePublicUser {
+    fn from(user: User) -> Self {
+        user.encodable_public()
+    }
+}
+
 #[derive(Deserialize, Serialize, Debug)]
 pub struct EncodableAuditAction {
     pub action: String,

--- a/src/views.rs
+++ b/src/views.rs
@@ -234,7 +234,22 @@ pub struct EncodableTeam {
 
 impl From<Team> for EncodableTeam {
     fn from(team: Team) -> Self {
-        team.encodable()
+        let Team {
+            id,
+            name,
+            login,
+            avatar,
+            ..
+        } = team;
+        let url = github::team_url(&login);
+
+        EncodableTeam {
+            id,
+            login,
+            name,
+            avatar,
+            url: Some(url),
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,7 +1,8 @@
 use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
-use crate::models::{Badge, Category, DependencyKind, Keyword, Owner, VersionDownload};
+use crate::github;
+use crate::models::{Badge, Category, DependencyKind, Keyword, Owner, Team, User, VersionDownload};
 use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -183,7 +184,42 @@ pub struct EncodableOwner {
 
 impl From<Owner> for EncodableOwner {
     fn from(owner: Owner) -> Self {
-        owner.encodable()
+        match owner {
+            Owner::User(User {
+                id,
+                name,
+                gh_login,
+                gh_avatar,
+                ..
+            }) => {
+                let url = format!("https://github.com/{}", gh_login);
+                Self {
+                    id,
+                    login: gh_login,
+                    avatar: gh_avatar,
+                    url: Some(url),
+                    name,
+                    kind: String::from("user"),
+                }
+            }
+            Owner::Team(Team {
+                id,
+                name,
+                login,
+                avatar,
+                ..
+            }) => {
+                let url = github::team_url(&login);
+                Self {
+                    id,
+                    login,
+                    url: Some(url),
+                    avatar,
+                    name,
+                    kind: String::from("team"),
+                }
+            }
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -272,7 +272,14 @@ pub struct EncodableApiTokenWithToken {
 
 impl From<CreatedApiToken> for EncodableApiTokenWithToken {
     fn from(token: CreatedApiToken) -> Self {
-        token.encodable_with_token()
+        EncodableApiTokenWithToken {
+            id: token.model.id,
+            name: token.model.name,
+            token: token.plaintext,
+            revoked: token.model.revoked,
+            created_at: token.model.created_at,
+            last_used_at: token.model.last_used_at,
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
-use crate::models::{Badge, Category, DependencyKind};
+use crate::models::{Badge, Category, DependencyKind, VersionDownload};
 use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -97,6 +97,12 @@ pub struct EncodableVersionDownload {
     pub version: i32,
     pub downloads: i32,
     pub date: String,
+}
+
+impl From<VersionDownload> for EncodableVersionDownload {
+    fn from(download: VersionDownload) -> Self {
+        download.encodable()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -120,7 +120,18 @@ pub struct EncodableKeyword {
 
 impl From<Keyword> for EncodableKeyword {
     fn from(keyword: Keyword) -> Self {
-        keyword.encodable()
+        let Keyword {
+            crates_cnt,
+            keyword,
+            created_at,
+            ..
+        } = keyword;
+        Self {
+            id: keyword.clone(),
+            created_at,
+            crates_cnt,
+            keyword,
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -232,6 +232,12 @@ pub struct EncodableTeam {
     pub url: Option<String>,
 }
 
+impl From<Team> for EncodableTeam {
+    fn from(team: Team) -> Self {
+        team.encodable()
+    }
+}
+
 /// The serialization format for the `ApiToken` model with its token value.
 /// This should only be used when initially creating a new token to minimize
 /// the chance of token leaks.

--- a/src/views.rs
+++ b/src/views.rs
@@ -101,7 +101,11 @@ pub struct EncodableVersionDownload {
 
 impl From<VersionDownload> for EncodableVersionDownload {
     fn from(download: VersionDownload) -> Self {
-        download.encodable()
+        Self {
+            version: download.version_id,
+            downloads: download.downloads,
+            date: download.date.to_string(),
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
-use crate::models::{Badge, Category, DependencyKind, VersionDownload};
+use crate::models::{Badge, Category, DependencyKind, Keyword, VersionDownload};
 use crate::util::rfc3339;
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
@@ -116,6 +116,12 @@ pub struct EncodableKeyword {
     #[serde(with = "rfc3339")]
     pub created_at: NaiveDateTime,
     pub crates_cnt: i32,
+}
+
+impl From<Keyword> for EncodableKeyword {
+    fn from(keyword: Keyword) -> Self {
+        keyword.encodable()
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
This PR continues #3124 by replacing more of our `encodable()` methods with `From` trait implementations to ultimately decouple our database models from the JSON views.

r? @pietroalbini 