### PR TITLE
models::Dependency: Replace `encodable()` method

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -247,7 +247,7 @@ pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     let (rev_deps, total) = krate.reverse_dependencies(&*conn, pagination_options)?;
     let rev_deps: Vec<_> = rev_deps
         .into_iter()
-        .map(|dep| dep.encodable(&krate.name))
+        .map(|dep| EncodableDependency::from_reverse_dep(dep, &krate.name))
         .collect();
 
     let version_ids: Vec<i32> = rev_deps.iter().map(|dep| dep.version_id).collect();

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -26,7 +26,7 @@ pub fn dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     let deps = version.dependencies(&conn)?;
     let deps = deps
         .into_iter()
-        .map(|(dep, crate_name)| dep.encodable(&crate_name, None))
+        .map(|(dep, crate_name)| EncodableDependency::from_dep(dep, &crate_name))
         .collect();
 
     #[derive(Serialize)]

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -5,7 +5,7 @@ use crate::util::errors::{cargo_err, AppResult};
 
 use crate::models::{Crate, Version};
 use crate::schema::*;
-use crate::views::{EncodableCrateDependency, EncodableDependency};
+use crate::views::EncodableCrateDependency;
 
 pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints are not allowed \
      on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-\
@@ -47,24 +47,6 @@ pub enum DependencyKind {
     Build = 1,
     Dev = 2,
     // if you add a kind here, be sure to update `from_row` below.
-}
-
-impl Dependency {
-    // `downloads` need only be specified when generating a reverse dependency
-    pub fn encodable(self, crate_name: &str, downloads: Option<i32>) -> EncodableDependency {
-        EncodableDependency {
-            id: self.id,
-            version_id: self.version_id,
-            crate_id: crate_name.into(),
-            req: self.req,
-            optional: self.optional,
-            default_features: self.default_features,
-            features: self.features,
-            target: self.target,
-            kind: self.kind,
-            downloads: downloads.unwrap_or(0),
-        }
-    }
 }
 
 pub fn add_dependencies(

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -67,13 +67,6 @@ impl Dependency {
     }
 }
 
-impl ReverseDependency {
-    pub fn encodable(self, crate_name: &str) -> EncodableDependency {
-        self.dependency
-            .encodable(crate_name, Some(self.crate_downloads))
-    }
-}
-
 pub fn add_dependencies(
     conn: &PgConnection,
     deps: &[EncodableCrateDependency],

--- a/src/views.rs
+++ b/src/views.rs
@@ -3,7 +3,8 @@ use std::collections::HashMap;
 
 use crate::github;
 use crate::models::{
-    Badge, Category, CreatedApiToken, DependencyKind, Keyword, Owner, Team, User, VersionDownload,
+    Badge, Category, CreatedApiToken, Dependency, DependencyKind, Keyword, Owner,
+    ReverseDependency, Team, User, VersionDownload,
 };
 use crate::util::rfc3339;
 
@@ -93,6 +94,17 @@ pub struct EncodableDependency {
     pub target: Option<String>,
     pub kind: DependencyKind,
     pub downloads: i32,
+}
+
+impl EncodableDependency {
+    pub fn from_dep(dependency: Dependency, crate_name: &str) -> Self {
+        dependency.encodable(crate_name, None)
+    }
+
+    pub fn from_reverse_dep(rev_dep: ReverseDependency, crate_name: &str) -> Self {
+        let dependency = rev_dep.dependency;
+        dependency.encodable(crate_name, Some(rev_dep.crate_downloads))
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -98,12 +98,28 @@ pub struct EncodableDependency {
 
 impl EncodableDependency {
     pub fn from_dep(dependency: Dependency, crate_name: &str) -> Self {
-        dependency.encodable(crate_name, None)
+        Self::encode(dependency, crate_name, None)
     }
 
     pub fn from_reverse_dep(rev_dep: ReverseDependency, crate_name: &str) -> Self {
         let dependency = rev_dep.dependency;
-        dependency.encodable(crate_name, Some(rev_dep.crate_downloads))
+        Self::encode(dependency, crate_name, Some(rev_dep.crate_downloads))
+    }
+
+    // `downloads` need only be specified when generating a reverse dependency
+    fn encode(dependency: Dependency, crate_name: &str, downloads: Option<i32>) -> Self {
+        Self {
+            id: dependency.id,
+            version_id: dependency.version_id,
+            crate_id: crate_name.into(),
+            req: dependency.req,
+            optional: dependency.optional,
+            default_features: dependency.default_features,
+            features: dependency.features,
+            target: dependency.target,
+            kind: dependency.kind,
+            downloads: downloads.unwrap_or(0),
+        }
     }
 }
 


### PR DESCRIPTION
This PR continues #3124 by implementing `from_dep()` and `from_reverse_dep()` methods for the `EncodableDependency` struct and removing the `encodable()` methods on `Dependency` and `ReverseDependency`. We can't use the `From` trait in these cases because the `crate_name` has to be explicitly provided. What we could do instead is implement `From<(Dependency, String)>`, but that doesn't feel right to me.

r? @pietroalbini 