### PR TITLE
notifications: Increase `clearDuration` to 10 sec

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -32,6 +32,7 @@ module.exports = function (environment) {
     },
     'ember-cli-notifications': {
       autoClear: true,
+      clearDuration: 10000,
     },
     emberKeyboard: {
       disableInputsInitializer: true,


### PR DESCRIPTION
Having the notifications on the screen for only 3 sec by default is far too fast for most cases. Having it on the screen for too long is far better than the opposite. :)

r? @pichfl 