### PR TITLE
Load `Intl` polyfills, if needed

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -2,12 +2,18 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
+import { shouldPolyfill as shouldPolyfillGetCanonicalLocales } from '@formatjs/intl-getcanonicallocales/should-polyfill';
+import { shouldPolyfill as shouldPolyfillLocale } from '@formatjs/intl-locale/should-polyfill';
+import { shouldPolyfill as shouldPolyfillNumberFormat } from '@formatjs/intl-numberformat/should-polyfill';
+import { shouldPolyfill as shouldPolyfillPluralRules } from '@formatjs/intl-pluralrules/should-polyfill';
+
 export default class ApplicationRoute extends Route {
   @service googleCharts;
+  @service notifications;
   @service progress;
   @service session;
 
-  beforeModel() {
+  async beforeModel() {
     // trigger the task, but don't wait for the result here
     this.session.loadUserTask.perform();
 
@@ -16,6 +22,35 @@ export default class ApplicationRoute extends Route {
     // anyway when we call `load()` from the `DownloadGraph`
     // component
     this.googleCharts.load().catch(() => {});
+
+    // load `Intl` polyfills if necessary
+    let polyfillImports = [];
+    if (shouldPolyfillGetCanonicalLocales()) {
+      console.debug('Loading Intl.getCanonicalLocales() polyfill…');
+      polyfillImports.push(import('@formatjs/intl-getcanonicallocales/polyfill'));
+    }
+    if (shouldPolyfillLocale()) {
+      console.debug('Loading Intl.Locale polyfill…');
+      polyfillImports.push(import('@formatjs/intl-locale/polyfill'));
+    }
+    if (shouldPolyfillPluralRules()) {
+      console.debug('Loading Intl.PluralRules polyfill…');
+      polyfillImports.push(import('@formatjs/intl-pluralrules/polyfill'));
+      polyfillImports.push(import('@formatjs/intl-pluralrules/locale-data/en'));
+    }
+    if (shouldPolyfillNumberFormat()) {
+      console.debug('Loading Intl.NumberFormat polyfill…');
+      polyfillImports.push(import('@formatjs/intl-numberformat/polyfill'));
+      polyfillImports.push(import('@formatjs/intl-numberformat/locale-data/en'));
+    }
+
+    try {
+      await Promise.all(polyfillImports);
+    } catch {
+      let message =
+        'We tried to load some polyfill code for your browser, but network issues caused the request to fail. If you notice any issues please try to reload the page.';
+      this.notifications.warning(message);
+    }
   }
 
   @action loading(transition) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,8 +25,8 @@ module.exports = function (defaults) {
   ];
 
   let app = new EmberApp(defaults, {
-    babel6: {
-      plugins: ['transform-object-rest-spread'],
+    babel: {
+      plugins: [require.resolve('ember-auto-import/babel-plugin')],
     },
     'ember-fetch': {
       preferNative: true,

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
     "trailingComma": "all"
   },
   "dependencies": {
+    "@formatjs/intl-getcanonicallocales": "^1.5.3",
+    "@formatjs/intl-locale": "^2.4.11",
+    "@formatjs/intl-numberformat": "^6.1.1",
+    "@formatjs/intl-pluralrules": "^4.0.1",
     "@sentry/browser": "5.29.2",
     "@sentry/integrations": "5.29.2",
     "copy-text-to-clipboard": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1356,6 +1356,47 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@formatjs/ecma402-abstract@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.0.tgz#759c8f11ff45e96f8fb58741e7fbdb41096d5ddd"
+  integrity sha512-wXv36yo+mfWllweN0Fq7sUs7PUiNopn7I0JpLTe3hGu6ZMR4CV7LqK1llhB18pndwpKoafQKb1et2DCJAOW20Q==
+  dependencies:
+    tslib "^2.0.1"
+
+"@formatjs/intl-getcanonicallocales@1.5.3", "@formatjs/intl-getcanonicallocales@^1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.5.3.tgz#b5978462340da1502502c3fde1c4abccff8f3b8e"
+  integrity sha512-QVBnSPZ32Y80wkXbf36hP9VbyklbOb8edppxFcgO9Lbd47zagllw65Y81QOHEn/j11JcTn2OhW0vea95LHvQmA==
+  dependencies:
+    cldr-core "38"
+    tslib "^2.0.1"
+
+"@formatjs/intl-locale@^2.4.11":
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-locale/-/intl-locale-2.4.11.tgz#bd0f23d5c30410e9e7a336b9fbc44e502bcf190f"
+  integrity sha512-Rus5jUOHWKKX17ZbyNa8tjghMPc3WWXnC8SSqNWWtUIaPkkKvBEfKEcRivzrGEr56NyZa86dcsDzSUb8ldjcsA==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.5.0"
+    "@formatjs/intl-getcanonicallocales" "1.5.3"
+    cldr-core "38"
+    tslib "^2.0.1"
+
+"@formatjs/intl-numberformat@^6.1.1":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-numberformat/-/intl-numberformat-6.1.1.tgz#43f021d1ea241e5cef883221ee2eaf454d5dfebd"
+  integrity sha512-ne+xoNAYHLvOQTzZ6WPaREDo3VVP2mds9j2NAzoVUn3ozPU2yXRTxPX3Z1hKK5rfMJTq4dBfKL+suhYRpwdB6Q==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.5.0"
+    tslib "^2.0.1"
+
+"@formatjs/intl-pluralrules@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-pluralrules/-/intl-pluralrules-4.0.1.tgz#a1d3222f11647ca3222d91c52482c7f7411cc940"
+  integrity sha512-FIFSP1N0ZRPdhe2pnV4psKb34RD9Ci6ISYgsluAZsPzaR8UERb46oz7jag/OXlMcAPU4BoiZ2EHRGy++CePQtw==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.5.0"
+    tslib "^2.0.1"
+
 "@glimmer/component@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@glimmer/component/-/component-1.0.3.tgz#38c26fc4855fd7ad0e0816d18d80d32c578e5140"
@@ -4842,6 +4883,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+cldr-core@38:
+  version "38.0.0"
+  resolved "https://registry.yarnpkg.com/cldr-core/-/cldr-core-38.0.0.tgz#f54a5dfd222c79a050f1fe8e87ad9764f16fb840"
+  integrity sha512-WkjA4zo5rLT/BWTZAxHJ0lJXwI33gCYucEz1+CpoI8Wu+rr5IrC57wyNXyrNNMdxfDE5RsWi/JCQ9qnG8sHTiw==
 
 clean-base-url@^1.0.0:
   version "1.0.0"
@@ -14183,7 +14229,7 @@ tslib@^1, tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0:
+tslib@^2.0.0, tslib@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
   integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==


### PR DESCRIPTION
It turns out a few Chinese browsers don't ship with an `Intl` API, and that causes several issues on Sentry.

This PR adds optional polyfills for the `Intl` APIs that are loaded if necessary before the app boots.

