### PR TITLE
Remove outdated information about GitHub permission error

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -27,25 +27,23 @@ where
         .header(header::USER_AGENT, "crates.io (https://crates.io)")
         .send()?
         .error_for_status()
-        .map_err(|e| handle_error_response(app, &e))?
+        .map_err(|e| handle_error_response(&e))?
         .json()
         .map_err(Into::into)
 }
 
-fn handle_error_response(app: &App, error: &reqwest::Error) -> Box<dyn AppError> {
+fn handle_error_response(error: &reqwest::Error) -> Box<dyn AppError> {
     use reqwest::StatusCode as Status;
 
     match error.status() {
-        Some(Status::UNAUTHORIZED) | Some(Status::FORBIDDEN) => cargo_err(&format!(
+        Some(Status::UNAUTHORIZED) | Some(Status::FORBIDDEN) => cargo_err(
             "It looks like you don't have permission \
-             to query a necessary property from Github \
+             to query a necessary property from GitHub \
              to complete this request. \
              You may need to re-authenticate on \
              crates.io to grant permission to read \
-             github org memberships. Just go to \
-             https://{}/login",
-            app.config.domain_name,
-        )),
+             GitHub org memberships.",
+        ),
         Some(Status::NOT_FOUND) => not_found(),
         _ => internal(&format_args!(
             "didn't get a 200 result from github: {}",


### PR DESCRIPTION
https://crates.io/login is no longer valid (found in https://github.com/rust-lang/cargo/pull/9000#discussion_r547384911) and it's just enough to recommend re-authentication now, I think.