### PR TITLE
DownloadGraph: Set `maintainAspectRatio: false` and use `min-height` instead

### DIFF
--- a/app/components/download-graph.hbs
+++ b/app/components/download-graph.hbs
@@ -1,8 +1,5 @@
 <div
-  local-class="
-    wrapper
-    {{if this.chartjs.loadTask.lastSuccessful.value "auto-height"}}
-  "
+  local-class="wrapper"
   data-test-download-graph
   ...attributes
   {{did-insert this.loadChartJs}}

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -25,6 +25,7 @@ export default class DownloadGraph extends Component {
       type: 'line',
       data: this.data,
       options: {
+        maintainAspectRatio: false,
         layout: {
           padding: 10,
         },

--- a/app/components/download-graph.module.css
+++ b/app/components/download-graph.module.css
@@ -4,10 +4,6 @@
     border: solid 1px var(--gray-border);
     border-radius: 5px;
     min-height: 400px;
-
-    &.auto-height {
-        min-height: auto;
-    }
 }
 
 .spinner {


### PR DESCRIPTION


Without this the graph looks very pressed together on mobile devices

r? @pichfl 