### PR TITLE
fix server error when adding renamed github team as owner

### DIFF
--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -62,7 +62,7 @@ impl<'a> NewTeam<'a> {
 
         insert_into(teams)
             .values(self)
-            .on_conflict(login)
+            .on_conflict(github_id)
             .do_update()
             .set(self)
             .get_result(conn)

--- a/src/tests/http-data/team_add_renamed_team
+++ b/src/tests/http-data/team_add_renamed_team
@@ -128,7 +128,7 @@
   },
   {
     "request": {
-      "uri": "http://api.github.com/organizations/13804222/team/1699377/memberships/crates-tester-2",
+      "uri": "http://api.github.com/organizations/13804222/team/1699377/memberships/foo",
       "method": "GET",
       "headers": [
         [
@@ -183,7 +183,7 @@
         ],
         [
           "content-length",
-          "111"
+          "99"
         ],
         [
           "X-OAuth-Client-Id",
@@ -250,7 +250,7 @@
           "admin:org, read:org, repo, write:org"
         ]
       ],
-      "body": "eyJzdGF0ZSI6ImFjdGl2ZSIsInJvbGUiOiJtYWludGFpbmVyIiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS90ZWFtcy8xNjk5Mzc3L21lbWJlcnNoaXBzL2NyYXRlcy10ZXN0ZXItMiJ9"
+      "body": "eyJzdGF0ZSI6ImFjdGl2ZSIsInJvbGUiOiJtYWludGFpbmVyIiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS90ZWFtcy8xNjk5Mzc3L21lbWJlcnNoaXBzL2ZvbyJ9"
     }
   },
   {

--- a/src/tests/http-data/team_add_renamed_team
+++ b/src/tests/http-data/team_add_renamed_team
@@ -1,0 +1,387 @@
+[
+  {
+    "request": {
+      "uri": "http://api.github.com/orgs/crates-test-org/teams/core",
+      "method": "GET",
+      "headers": [
+        [
+          "authorization",
+          "token 7534f8b996e3a3f800f0a324f619adba12a74532"
+        ],
+        [
+          "host",
+          "api.github.com"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "accept",
+          "application/vnd.github.v3+json"
+        ]
+      ],
+      "body": ""
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "Cache-Control",
+          "private, max-age=60, s-maxage=60"
+        ],
+        [
+          "Access-Control-Expose-Headers",
+          "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-accepted-OAuth-Scopes, X-Poll-Interval"
+        ],
+        [
+          "X-content-type-Options",
+          "nosniff"
+        ],
+        [
+          "X-OAuth-Scopes",
+          "read:org"
+        ],
+        [
+          "content-type",
+          "application/json; charset=utf-8"
+        ],
+        [
+          "Access-Control-Allow-Origin",
+          "*"
+        ],
+        [
+          "date",
+          "Wed, 04 Oct 2017 14:52:58 GMT"
+        ],
+        [
+          "X-RateLimit-Limit",
+          "5000"
+        ],
+        [
+          "X-Runtime-rack",
+          "0.035631"
+        ],
+        [
+          "X-OAuth-Client-Id",
+          "89b6afdeaa6c6c7506ec"
+        ],
+        [
+          "X-RateLimit-Reset",
+          "1507132377"
+        ],
+        [
+          "Strict-Transport-Security",
+          "max-age=31536000; includeSubdomains; preload"
+        ],
+        [
+          "X-accepted-OAuth-Scopes",
+          "admin:org, read:org, repo, user, write:org"
+        ],
+        [
+          "ETag",
+          "\"168464471f229c2bec917d1c95ad86ff\""
+        ],
+        [
+          "Server",
+          "GitHub.com"
+        ],
+        [
+          "content-length",
+          "362"
+        ],
+        [
+          "Status",
+          "200 OK"
+        ],
+        [
+          "X-Frame-Options",
+          "deny"
+        ],
+        [
+          "Vary",
+          "accept, authorization, Cookie, X-GitHub-OTP"
+        ],
+        [
+          "X-GitHub-Media-Type",
+          "github.v3; format=json"
+        ],
+        [
+          "X-GitHub-Request-Id",
+          "CA9C:6F2F:8060D6:FB015A:59D4F5CA"
+        ],
+        [
+          "Content-Security-Policy",
+          "default-src 'none'"
+        ],
+        [
+          "X-XSS-Protection",
+          "1; mode=block"
+        ],
+        [
+          "X-RateLimit-Remaining",
+          "4995"
+        ]
+      ],
+      "body": "ewogICJuYW1lIjogImNvcmUiLAogICJpZCI6IDE2OTkzNzcsCiAgInNsdWciOiAiY29yZSIsCiAgImRlc2NyaXB0aW9uIjogbnVsbCwKICAicHJpdmFjeSI6ICJzZWNyZXQiLAogICJ1cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS90ZWFtcy8xNjk5Mzc3IiwKICAibWVtYmVyc191cmwiOiAiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS90ZWFtcy8xNjk5Mzc3L21lbWJlcnN7L21lbWJlcn0iLAogICJyZXBvc2l0b3JpZXNfdXJsIjogImh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vdGVhbXMvMTY5OTM3Ny9yZXBvcyIsCiAgInBlcm1pc3Npb24iOiAiYWRtaW4iLAogICJvcmdhbml6YXRpb24iOiB7CiAgICAiaWQiOiAxMzgwNDIyMgogIH0KfQo="
+    }
+  },
+  {
+    "request": {
+      "uri": "http://api.github.com/organizations/13804222/team/1699377/memberships/crates-tester-2",
+      "method": "GET",
+      "headers": [
+        [
+          "authorization",
+          "token 7534f8b996e3a3f800f0a324f619adba12a74532"
+        ],
+        [
+          "accept",
+          "application/vnd.github.v3+json"
+        ],
+        [
+          "host",
+          "api.github.com"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ]
+      ],
+      "body": ""
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "X-Frame-Options",
+          "deny"
+        ],
+        [
+          "Access-Control-Expose-Headers",
+          "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-accepted-OAuth-Scopes, X-Poll-Interval"
+        ],
+        [
+          "X-Runtime-rack",
+          "0.030002"
+        ],
+        [
+          "X-GitHub-Media-Type",
+          "github.v3; format=json"
+        ],
+        [
+          "ETag",
+          "\"a004da562b1c421613f0ca38f7a9bf2f\""
+        ],
+        [
+          "X-GitHub-Request-Id",
+          "CA9C:6F2F:8060E2:FB016C:59D4F5CA"
+        ],
+        [
+          "Vary",
+          "accept, authorization, Cookie, X-GitHub-OTP"
+        ],
+        [
+          "content-length",
+          "111"
+        ],
+        [
+          "X-OAuth-Client-Id",
+          "89b6afdeaa6c6c7506ec"
+        ],
+        [
+          "content-type",
+          "application/json; charset=utf-8"
+        ],
+        [
+          "Content-Security-Policy",
+          "default-src 'none'"
+        ],
+        [
+          "Access-Control-Allow-Origin",
+          "*"
+        ],
+        [
+          "X-XSS-Protection",
+          "1; mode=block"
+        ],
+        [
+          "X-content-type-Options",
+          "nosniff"
+        ],
+        [
+          "X-RateLimit-Limit",
+          "5000"
+        ],
+        [
+          "Server",
+          "GitHub.com"
+        ],
+        [
+          "Cache-Control",
+          "private, max-age=60, s-maxage=60"
+        ],
+        [
+          "Strict-Transport-Security",
+          "max-age=31536000; includeSubdomains; preload"
+        ],
+        [
+          "X-RateLimit-Reset",
+          "1507132377"
+        ],
+        [
+          "Status",
+          "200 OK"
+        ],
+        [
+          "date",
+          "Wed, 04 Oct 2017 14:52:58 GMT"
+        ],
+        [
+          "X-RateLimit-Remaining",
+          "4994"
+        ],
+        [
+          "X-OAuth-Scopes",
+          "read:org"
+        ],
+        [
+          "X-accepted-OAuth-Scopes",
+          "admin:org, read:org, repo, write:org"
+        ]
+      ],
+      "body": "eyJzdGF0ZSI6ImFjdGl2ZSIsInJvbGUiOiJtYWludGFpbmVyIiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS90ZWFtcy8xNjk5Mzc3L21lbWJlcnNoaXBzL2NyYXRlcy10ZXN0ZXItMiJ9"
+    }
+  },
+  {
+    "request": {
+      "uri": "http://api.github.com/orgs/crates-test-org",
+      "method": "GET",
+      "headers": [
+        [
+          "accept",
+          "application/vnd.github.v3+json"
+        ],
+        [
+          "host",
+          "api.github.com"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "authorization",
+          "token 7534f8b996e3a3f800f0a324f619adba12a74532"
+        ]
+      ],
+      "body": ""
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "content-type",
+          "application/json; charset=utf-8"
+        ],
+        [
+          "Cache-Control",
+          "private, max-age=60, s-maxage=60"
+        ],
+        [
+          "Vary",
+          "accept, authorization, Cookie, X-GitHub-OTP"
+        ],
+        [
+          "X-content-type-Options",
+          "nosniff"
+        ],
+        [
+          "Content-Security-Policy",
+          "default-src 'none'"
+        ],
+        [
+          "X-GitHub-Request-Id",
+          "CA9C:6F2F:8060E5:FB0178:59D4F5CA"
+        ],
+        [
+          "Server",
+          "GitHub.com"
+        ],
+        [
+          "date",
+          "Wed, 04 Oct 2017 14:52:58 GMT"
+        ],
+        [
+          "Access-Control-Allow-Origin",
+          "*"
+        ],
+        [
+          "X-RateLimit-Remaining",
+          "4993"
+        ],
+        [
+          "Status",
+          "200 OK"
+        ],
+        [
+          "X-RateLimit-Limit",
+          "5000"
+        ],
+        [
+          "X-accepted-OAuth-Scopes",
+          "admin:org, read:org, repo, user, write:org"
+        ],
+        [
+          "X-OAuth-Client-Id",
+          "89b6afdeaa6c6c7506ec"
+        ],
+        [
+          "X-OAuth-Scopes",
+          "read:org"
+        ],
+        [
+          "Last-Modified",
+          "Tue, 18 Aug 2015 17:37:08 GMT"
+        ],
+        [
+          "X-XSS-Protection",
+          "1; mode=block"
+        ],
+        [
+          "X-Runtime-rack",
+          "0.052093"
+        ],
+        [
+          "X-Frame-Options",
+          "deny"
+        ],
+        [
+          "content-length",
+          "1168"
+        ],
+        [
+          "X-GitHub-Media-Type",
+          "github.v3; format=json"
+        ],
+        [
+          "X-RateLimit-Reset",
+          "1507132377"
+        ],
+        [
+          "Strict-Transport-Security",
+          "max-age=31536000; includeSubdomains; preload"
+        ],
+        [
+          "ETag",
+          "\"164b3fa13f1e681dc06cab6811749c2f\""
+        ],
+        [
+          "Access-Control-Expose-Headers",
+          "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-accepted-OAuth-Scopes, X-Poll-Interval"
+        ]
+      ],
+      "body": "eyJsb2dpbiI6ImNyYXRlcy10ZXN0LW9yZyIsImlkIjoxMzgwNDIyMiwidXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9vcmdzL2NyYXRlcy10ZXN0LW9yZyIsInJlcG9zX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vb3Jncy9jcmF0ZXMtdGVzdC1vcmcvcmVwb3MiLCJldmVudHNfdXJsIjoiaHR0cHM6Ly9hcGkuZ2l0aHViLmNvbS9vcmdzL2NyYXRlcy10ZXN0LW9yZy9ldmVudHMiLCJob29rc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL29yZ3MvY3JhdGVzLXRlc3Qtb3JnL2hvb2tzIiwiaXNzdWVzX3VybCI6Imh0dHBzOi8vYXBpLmdpdGh1Yi5jb20vb3Jncy9jcmF0ZXMtdGVzdC1vcmcvaXNzdWVzIiwibWVtYmVyc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL29yZ3MvY3JhdGVzLXRlc3Qtb3JnL21lbWJlcnN7L21lbWJlcn0iLCJwdWJsaWNfbWVtYmVyc191cmwiOiJodHRwczovL2FwaS5naXRodWIuY29tL29yZ3MvY3JhdGVzLXRlc3Qtb3JnL3B1YmxpY19tZW1iZXJzey9tZW1iZXJ9IiwiYXZhdGFyX3VybCI6Imh0dHBzOi8vYXZhdGFyczIuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3UvMTM4MDQyMjI/dj00IiwiZGVzY3JpcHRpb24iOm51bGwsImhhc19vcmdhbml6YXRpb25fcHJvamVjdHMiOnRydWUsImhhc19yZXBvc2l0b3J5X3Byb2plY3RzIjp0cnVlLCJwdWJsaWNfcmVwb3MiOjAsInB1YmxpY19naXN0cyI6MCwiZm9sbG93ZXJzIjowLCJmb2xsb3dpbmciOjAsImh0bWxfdXJsIjoiaHR0cHM6Ly9naXRodWIuY29tL2NyYXRlcy10ZXN0LW9yZyIsImNyZWF0ZWRfYXQiOiIyMDE1LTA4LTE1VDAwOjA3OjMwWiIsInVwZGF0ZWRfYXQiOiIyMDE1LTA4LTE4VDE3OjM3OjA4WiIsInR5cGUiOiJPcmdhbml6YXRpb24iLCJ0b3RhbF9wcml2YXRlX3JlcG9zIjowLCJvd25lZF9wcml2YXRlX3JlcG9zIjowLCJwcml2YXRlX2dpc3RzIjpudWxsLCJkaXNrX3VzYWdlIjpudWxsLCJjb2xsYWJvcmF0b3JzIjpudWxsLCJiaWxsaW5nX2VtYWlsIjpudWxsLCJwbGFuIjp7Im5hbWUiOiJmcmVlIiwic3BhY2UiOjk3NjU2MjQ5OSwicHJpdmF0ZV9yZXBvcyI6MCwiZmlsbGVkX3NlYXRzIjoyLCJzZWF0cyI6MH0sImRlZmF1bHRfcmVwb3NpdG9yeV9wZXJtaXNzaW9uIjpudWxsLCJtZW1iZXJzX2Nhbl9jcmVhdGVfcmVwb3NpdG9yaWVzIjpudWxsfQ=="
+    }
+  }
+]

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -122,7 +122,7 @@ fn add_renamed_team() {
         CrateBuilder::new("foo_renamed_team", user.as_model().id).expect_build(conn);
 
         // create team with same ID and different name compared to http mock
-        // used for `add_renamed_owner`
+        // used for `add_named_owner`
         NewTeam::new(
             "github:crates-test-org:not_core", // different team name
             13804222,                          // same org ID

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -112,14 +112,13 @@ fn nonexistent_team() {
 // Test adding a renamed team
 #[test]
 fn add_renamed_team() {
-    let (app, anon) = TestApp::with_proxy().empty();
-    let user = app.db_new_user(mock_user_on_both_teams().gh_login);
-    let token = user.db_new_token("arbitrary token name");
+    let (app, anon, user, token) = TestApp::with_proxy().with_token();
+    let owner_id = user.as_model().id;
 
     app.db(|conn| {
         use cargo_registry::schema::teams::dsl::*;
 
-        CrateBuilder::new("foo_renamed_team", user.as_model().id).expect_build(conn);
+        CrateBuilder::new("foo_renamed_team", owner_id).expect_build(conn);
 
         // create team with same ID and different name compared to http mock
         // used for `add_named_owner`

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -5,7 +5,7 @@ use crate::{
     record::GhUser,
     OwnerTeamsResponse, RequestHelper, TestApp,
 };
-use cargo_registry::models::{Crate, NewUser};
+use cargo_registry::models::{Crate, NewTeam, NewUser};
 use std::sync::Once;
 
 use conduit::StatusCode;
@@ -107,6 +107,42 @@ fn nonexistent_team() {
         response.json(),
         json!({ "errors": [{ "detail": "could not find the github team crates-test-org/this-does-not-exist" }] })
     );
+}
+
+// Test adding a renamed team
+#[test]
+fn add_renamed_team() {
+    let (app, anon) = TestApp::with_proxy().empty();
+    let user = app.db_new_user(mock_user_on_both_teams().gh_login);
+    let token = user.db_new_token("arbitrary token name");
+
+    app.db(|conn| {
+        use cargo_registry::schema::teams::dsl::*;
+
+        CrateBuilder::new("foo_renamed_team", user.as_model().id).expect_build(conn);
+
+        // create team with same ID and different name compared to http mock
+        // used for `add_renamed_owner`
+        NewTeam::new(
+            "github:crates-test-org:not_core", // different team name
+            13804222,                          // same org ID
+            1699377,                           // same team id as `core` team
+            None,
+            None,
+        )
+        .create_or_update(conn)
+        .unwrap();
+
+        assert_eq!(teams.count().get_result::<i64>(conn).unwrap(), 1);
+    });
+
+    token
+        .add_named_owner("foo_renamed_team", "github:crates-test-org:core")
+        .good();
+
+    let json = anon.crate_owner_teams("foo_renamed_team").good();
+    assert_eq!(json.teams.len(), 1);
+    assert_eq!(json.teams[0].login, "github:crates-test-org:core");
 }
 
 // Test adding team names with mixed case, when on the team
@@ -324,9 +360,10 @@ fn crates_by_team_id_not_including_deleted_owners() {
     let user = user.as_model();
 
     let team = app.db(|conn| {
-        let t = new_team("github:crates-test-org:core")
+        let t = NewTeam::new("github:crates-test-org:core", 13804222, 1699377, None, None)
             .create_or_update(conn)
             .unwrap();
+
         let krate = CrateBuilder::new("foo", user.id).expect_build(conn);
         add_team_to_crate(&t, &krate, user, conn).unwrap();
         krate


### PR DESCRIPTION
This should fix #2957 and fix #2687, as I understood these bugs.

I made the changes as I thought I understood the project design, but I'm happy to implement any changes that will get this to match standards and design. 

IMHO the change from checking `login` to checking `github_id` only is fine. We always get current data from github for the name that the user requested to add. And there we always get the id from github and can treat it as PK. 

The change to `crates_by_team_id_not_including_deleted_owners` is needed because the `github:crates-test-org:core`  now is not allowed to be created with a new, different ID, which it would get from `new_team` 