### PR TITLE
Use new conduit API when computing elapsed time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-middleware"
-version = "0.9.0-alpha.3"
+version = "0.9.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11aae989fb790857867a76d27cc02304d7ca743b49667e711fdb6b1ee6a5f1f"
+checksum = "ddc5fb08579847c817024b06fb144f6ef39f66588f2cd4df1e300c1fd4769d1b"
 dependencies = [
  "conduit",
 ]
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-test"
-version = "0.9.0-alpha.3"
+version = "0.9.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b2f3bd0554c5ca215e78d8569b093a9dea8e384c0f2497a30dd0cccafe1ef5"
+checksum = "3c4cfaa2c193186237c6b7dd18b2511f36f4bb0926d8fe54cc27746a7ed394d2"
 dependencies = [
  "conduit",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "civet"
-version = "0.12.0-alpha.4"
+version = "0.12.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adfa9a0117908b89125b42475fa45da5cbfae6a32f06ef67043918ad054587a"
+checksum = "7b38e18226401dff3e26aa36d5128707af657649a56f134fb29b465daa3bd6d1"
 dependencies = [
  "civet-sys",
  "conduit",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.9.0-alpha.3"
+version = "0.9.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f55ff2e3601329f850eaa86fe6dff2cd66a58ac1df26188e850162126a0432"
+checksum = "6ce8954d399f2fcb0900b06973b4624538b8d8e46d38c12be237dd3cc8e95cfc"
 dependencies = [
  "http 0.2.2",
 ]
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-hyper"
-version = "0.3.0-alpha.5"
+version = "0.3.0-alpha.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f2fc542431a2f71cdf7897594e180efe0deda7044a52c3bd1e31f12356b4eb"
+checksum = "1b49a5700d37b4304284964370b5cd7ee50f413c425f306596294dffaf515bd8"
 dependencies = [
  "conduit",
  "http 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,15 +34,15 @@ anyhow = "1.0"
 base64 = "0.13"
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 chrono = { version = "0.4.0", features = ["serde"] }
-civet = "0.12.0-alpha.4"
+civet = "0.12.0-alpha.5"
 clap = "=3.0.0-beta.2"
 comrak = { version = "0.9", default-features = false }
 
-conduit = "0.9.0-alpha.3"
+conduit = "0.9.0-alpha.5"
 conduit-conditional-get = "0.9.0-alpha.3"
 conduit-cookie = "0.9.0-alpha.4"
 conduit-git-http-backend = "0.9.0-alpha.2"
-conduit-hyper = "=0.3.0-alpha.5"
+conduit-hyper = "=0.3.0-alpha.5.1"
 conduit-middleware = "0.9.0-alpha.3"
 conduit-router = "0.9.0-alpha.3"
 conduit-static = "0.9.0-alpha.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ conduit-conditional-get = "0.9.0-alpha.3"
 conduit-cookie = "0.9.0-alpha.4"
 conduit-git-http-backend = "0.9.0-alpha.2"
 conduit-hyper = "=0.3.0-alpha.5.1"
-conduit-middleware = "0.9.0-alpha.3"
+conduit-middleware = "0.9.0-alpha.4"
 conduit-router = "0.9.0-alpha.3"
 conduit-static = "0.9.0-alpha.3"
 
@@ -89,7 +89,7 @@ url = "2.1"
 
 [dev-dependencies]
 claim = "0.4.0"
-conduit-test = "0.9.0-alpha.3"
+conduit-test = "0.9.0-alpha.4"
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }
 hyper-tls = "0.4"
 lazy_static = "1.0"


### PR DESCRIPTION
The request start time is now captured by a `conduit` based server. This
ensures that the logged elapsed time is accurate, even if the request
queues waiting for a background thread to run on.

Relevent upstream changes:

* https://github.com/conduit-rust/conduit/compare/v0.9.0-alpha.3...v0.9.0-alpha.5
* https://github.com/conduit-rust/rust-civet/compare/v0.12.0-alpha.4...v0.12.0-alpha.5
* https://github.com/jtgeibel/conduit-hyper/compare/v0.3.0-alpha.5...v0.3.0-alpha.5.1

Unrelated upstream changes (minor API cleanup):

* https://github.com/conduit-rust/conduit-test/compare/v0.9.0-alpha.3...v0.9.0-alpha.4
* https://github.com/conduit-rust/conduit-middleware/compare/v0.9.0-alpha.3...v0.9.0-alpha.4

r? @Turbo87
cc @pietroalbini 