### PR TITLE
EncodableCrate: Add `max_stable_version` field

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -357,6 +357,8 @@ impl Crate {
             .map(|v| v.to_string())
             .unwrap_or_else(|| "0.0.0".to_string());
 
+        let max_stable_version = top_versions.highest_stable.as_ref().map(|v| v.to_string());
+
         EncodableCrate {
             id: name.clone(),
             name: name.clone(),
@@ -370,6 +372,7 @@ impl Crate {
             badges,
             max_version,
             newest_version,
+            max_stable_version,
             documentation,
             homepage,
             exact_match,

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -43,8 +43,7 @@ pub struct NewVersion {
 pub struct TopVersions {
     /// The "highest" version in terms of semver
     pub highest: Option<semver::Version>,
-    /// The "highest" non-prerelease version, or, if only
-    /// prereleases exist, the "highest" version
+    /// The "highest" non-prerelease version
     pub highest_stable: Option<semver::Version>,
     /// The "newest" version in terms of publishing date
     pub newest: Option<semver::Version>,
@@ -70,8 +69,7 @@ impl TopVersions {
             .into_iter()
             .map(|(_, v)| v)
             .filter(|v| !v.is_prerelease())
-            .max()
-            .or_else(|| highest.clone());
+            .max();
 
         Self {
             newest,
@@ -302,7 +300,7 @@ mod tests {
             TopVersions::from_date_version_pairs(versions),
             TopVersions {
                 highest: Some(version("1.0.0-beta.5")),
-                highest_stable: Some(version("1.0.0-beta.5")),
+                highest_stable: None,
                 newest: Some(version("1.0.0-beta.5")),
             }
         );

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -43,6 +43,9 @@ pub struct NewVersion {
 pub struct TopVersions {
     /// The "highest" version in terms of semver
     pub highest: Option<semver::Version>,
+    /// The "highest" non-prerelease version, or, if only
+    /// prereleases exist, the "highest" version
+    pub highest_stable: Option<semver::Version>,
     /// The "newest" version in terms of publishing date
     pub newest: Option<semver::Version>,
 }
@@ -61,9 +64,20 @@ impl TopVersions {
         T: Clone + IntoIterator<Item = (NaiveDateTime, semver::Version)>,
     {
         let newest = pairs.clone().into_iter().max().map(|(_, v)| v);
-        let highest = pairs.into_iter().map(|(_, v)| v).max();
+        let highest = pairs.clone().into_iter().map(|(_, v)| v).max();
 
-        Self { newest, highest }
+        let highest_stable = pairs
+            .into_iter()
+            .map(|(_, v)| v)
+            .filter(|v| !v.is_prerelease())
+            .max()
+            .or_else(|| highest.clone());
+
+        Self {
+            newest,
+            highest,
+            highest_stable,
+        }
     }
 }
 
@@ -262,6 +276,7 @@ mod tests {
             TopVersions::from_date_version_pairs(versions),
             TopVersions {
                 highest: None,
+                highest_stable: None,
                 newest: None,
             }
         );
@@ -274,7 +289,21 @@ mod tests {
             TopVersions::from_date_version_pairs(versions),
             TopVersions {
                 highest: Some(version("1.0.0")),
+                highest_stable: Some(version("1.0.0")),
                 newest: Some(version("1.0.0")),
+            }
+        );
+    }
+
+    #[test]
+    fn top_versions_prerelease() {
+        let versions = vec![(date("2020-12-03T12:34:56"), version("1.0.0-beta.5"))];
+        assert_eq!(
+            TopVersions::from_date_version_pairs(versions),
+            TopVersions {
+                highest: Some(version("1.0.0-beta.5")),
+                highest_stable: Some(version("1.0.0-beta.5")),
+                newest: Some(version("1.0.0-beta.5")),
             }
         );
     }
@@ -285,12 +314,14 @@ mod tests {
             (date("2018-12-03T12:34:56"), version("1.0.0")),
             (date("2019-12-03T12:34:56"), version("2.0.0-alpha.1")),
             (date("2020-12-03T12:34:56"), version("1.1.0")),
+            (date("2020-12-31T12:34:56"), version("1.0.4")),
         ];
         assert_eq!(
             TopVersions::from_date_version_pairs(versions),
             TopVersions {
                 highest: Some(version("2.0.0-alpha.1")),
-                newest: Some(version("1.1.0")),
+                highest_stable: Some(version("1.1.0")),
+                newest: Some(version("1.0.4")),
             }
         );
     }

--- a/src/views.rs
+++ b/src/views.rs
@@ -156,6 +156,7 @@ pub struct EncodableCrate {
     // NOTE: Used by shields.io, altering `max_version` requires a PR with shields.io
     pub max_version: String,
     pub newest_version: String, // Most recently updated version, which may not be max
+    pub max_stable_version: Option<String>,
     pub description: Option<String>,
     pub homepage: Option<String>,
     pub documentation: Option<String>,
@@ -510,6 +511,7 @@ mod tests {
             recent_downloads: None,
             max_version: "".to_string(),
             newest_version: "".to_string(),
+            max_stable_version: None,
             description: None,
             homepage: None,
             documentation: None,


### PR DESCRIPTION
This PR resolves the API part of https://github.com/rust-lang/crates.io/issues/654 by adding a `max_stable_version` field for the `krate` resource. Since naming is hard, it is called `highest_stable` internally on the `TopVersions` struct. Contrary to `newest_version` and `max_version` this field will be `null` (not `"0.0.0"`) if all available versions have been yanked.

r? @jtgeibel 