### PR TITLE
CrateOwnerInvitation: Replace `encodable()` method

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -14,7 +14,7 @@ pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
         .load(&*conn)?;
     let crate_owner_invitations = crate_owner_invitations
         .into_iter()
-        .map(|i| i.encodable(conn))
+        .map(|i| EncodableCrateOwnerInvitation::from(i, conn))
         .collect();
 
     #[derive(Serialize)]

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -2,7 +2,6 @@ use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
 use crate::schema::{crate_owner_invitations, crates, users};
-use crate::views::EncodableCrateOwnerInvitation;
 
 /// The model representing a row in the `crate_owner_invitations` database table.
 #[derive(Clone, Debug, PartialEq, Eq, Identifiable, Queryable)]
@@ -39,14 +38,5 @@ impl CrateOwnerInvitation {
             .select(crates::name)
             .first(&*conn)
             .unwrap_or_else(|_| String::from("(unknown crate name)"))
-    }
-
-    pub fn encodable(self, conn: &PgConnection) -> EncodableCrateOwnerInvitation {
-        EncodableCrateOwnerInvitation {
-            invited_by_username: self.invited_by_username(conn),
-            crate_name: self.crate_name(conn),
-            crate_id: self.crate_id,
-            created_at: self.created_at,
-        }
     }
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,10 +1,11 @@
 use chrono::NaiveDateTime;
+use diesel::PgConnection;
 use std::collections::HashMap;
 
 use crate::github;
 use crate::models::{
-    Badge, Category, CreatedApiToken, Dependency, DependencyKind, Keyword, Owner,
-    ReverseDependency, Team, User, VersionDownload,
+    Badge, Category, CrateOwnerInvitation, CreatedApiToken, Dependency, DependencyKind, Keyword,
+    Owner, ReverseDependency, Team, User, VersionDownload,
 };
 use crate::util::rfc3339;
 
@@ -74,6 +75,12 @@ pub struct EncodableCrateOwnerInvitation {
     pub crate_id: i32,
     #[serde(with = "rfc3339")]
     pub created_at: NaiveDateTime,
+}
+
+impl EncodableCrateOwnerInvitation {
+    pub fn from(invitation: CrateOwnerInvitation, conn: &PgConnection) -> Self {
+        invitation.encodable(conn)
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Copy, Clone)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -79,7 +79,12 @@ pub struct EncodableCrateOwnerInvitation {
 
 impl EncodableCrateOwnerInvitation {
     pub fn from(invitation: CrateOwnerInvitation, conn: &PgConnection) -> Self {
-        invitation.encodable(conn)
+        Self {
+            invited_by_username: invitation.invited_by_username(conn),
+            crate_name: invitation.crate_name(conn),
+            crate_id: invitation.crate_id,
+            created_at: invitation.created_at,
+        }
     }
 }
 


### PR DESCRIPTION
This PR is similar to #3134 and brings us one step closer to removing the `models -> views` dependency by inverting the relationship for the `CrateOwnerInvitation` model and `EncodableCrateOwnerInvitation` view.

r? @pietroalbini 