### PR TITLE
User: Replace `encodable_private()` method

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -10,7 +10,7 @@ use crate::models::{
     CrateOwner, Email, Follow, NewEmail, OwnerKind, User, Version, VersionOwnerAction,
 };
 use crate::schema::{crate_owners, crates, emails, follows, users, versions};
-use crate::views::{EncodableMe, EncodableVersion, OwnedCrate};
+use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
 pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
@@ -46,7 +46,7 @@ pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
     let verified = verified.unwrap_or(false);
     let verification_sent = verified || verification_sent;
     Ok(req.json(&EncodableMe {
-        user: user.encodable_private(email, verified, verification_sent),
+        user: EncodablePrivateUser::from(user, email, verified, verification_sent),
         owned_crates,
     }))
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -7,7 +7,6 @@ use crate::util::errors::AppResult;
 
 use crate::models::{ApiToken, Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};
 use crate::schema::{crate_owners, emails, users};
-use crate::views::EncodablePrivateUser;
 
 /// The model representing a row in the `users` database table.
 #[derive(Clone, Debug, PartialEq, Eq, Queryable, Identifiable, AsChangeset, Associations)]
@@ -166,34 +165,6 @@ impl User {
             .filter(emails::verified.eq(true))
             .first(&*conn)
             .optional()?)
-    }
-
-    /// Converts this `User` model into an `EncodablePrivateUser` for JSON serialization.
-    pub fn encodable_private(
-        self,
-        email: Option<String>,
-        email_verified: bool,
-        email_verification_sent: bool,
-    ) -> EncodablePrivateUser {
-        let User {
-            id,
-            name,
-            gh_login,
-            gh_avatar,
-            ..
-        } = self;
-        let url = format!("https://github.com/{}", gh_login);
-
-        EncodablePrivateUser {
-            id,
-            email,
-            email_verified,
-            email_verification_sent,
-            avatar: gh_avatar,
-            login: gh_login,
-            name,
-            url: Some(url),
-        }
     }
 
     /// Queries for the email belonging to a particular user

--- a/src/views.rs
+++ b/src/views.rs
@@ -353,13 +353,32 @@ pub struct EncodablePrivateUser {
 }
 
 impl EncodablePrivateUser {
+    /// Converts this `User` model into an `EncodablePrivateUser` for JSON serialization.
     pub fn from(
         user: User,
         email: Option<String>,
         email_verified: bool,
         email_verification_sent: bool,
     ) -> Self {
-        user.encodable_private(email, email_verified, email_verification_sent)
+        let User {
+            id,
+            name,
+            gh_login,
+            gh_avatar,
+            ..
+        } = user;
+        let url = format!("https://github.com/{}", gh_login);
+
+        EncodablePrivateUser {
+            id,
+            email,
+            email_verified,
+            email_verification_sent,
+            avatar: gh_avatar,
+            login: gh_login,
+            name,
+            url: Some(url),
+        }
     }
 }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -352,6 +352,17 @@ pub struct EncodablePrivateUser {
     pub url: Option<String>,
 }
 
+impl EncodablePrivateUser {
+    pub fn from(
+        user: User,
+        email: Option<String>,
+        email_verified: bool,
+        email_verification_sent: bool,
+    ) -> Self {
+        user.encodable_private(email, email_verified, email_verification_sent)
+    }
+}
+
 /// The serialization format for the `User` model.
 /// Same as private user, except no email field
 #[derive(Deserialize, Serialize, Debug)]


### PR DESCRIPTION
This PR is similar to #3168 and brings us one step closer to removing the `models -> views` dependency by inverting the relationship for the `User` model and `EncodablePrivateUser` view.

r? @pietroalbini