### PR TITLE
tests/front-page: Override locale to make download count test pass

### DIFF
--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -17,6 +17,8 @@ module('Acceptance | front page', function (hooks) {
   setupMirage(hooks);
 
   test('visiting /', async function (assert) {
+    this.owner.lookup('service:intl').locale = 'en';
+
     this.server.loadFixtures();
 
     await visit('/');


### PR DESCRIPTION
When running the testsuite locally, this test was failing due to my browser using the German locale for formatting instead. This PR forces the `intl` service in the test to explicitly use the `en` locale for formatting instead.

r? @pichfl 