### PR TITLE
CrateRow: Use `defaultVersion` for crate version display

### DIFF
--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -11,6 +11,7 @@
         @copyText='{{@crate.name}} = "{{@crate.max_version}}"'
         title="Copy Cargo.toml snippet to clipboard"
         local-class="copy-button"
+        data-test-copy-toml-button
       >
         {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
       </CopyButton>

--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -6,15 +6,17 @@
           {{@crate.name}}
         </a>
       {{/let}}
-      <span local-class="version" data-test-version>v{{@crate.max_version}}</span>
-      <CopyButton
-        @copyText='{{@crate.name}} = "{{@crate.max_version}}"'
-        title="Copy Cargo.toml snippet to clipboard"
-        local-class="copy-button"
-        data-test-copy-toml-button
-      >
-        {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
-      </CopyButton>
+      {{#if @crate.defaultVersion}}
+        <span local-class="version" data-test-version>v{{@crate.defaultVersion}}</span>
+        <CopyButton
+          @copyText='{{@crate.name}} = "{{@crate.defaultVersion}}"'
+          title="Copy Cargo.toml snippet to clipboard"
+          local-class="copy-button"
+          data-test-copy-toml-button
+        >
+          {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
+        </CopyButton>
+      {{/if}}
     </div>
     <div local-class="description" data-test-description>
       {{ truncate-text @crate.description }}

--- a/tests/components/crate-row-test.js
+++ b/tests/components/crate-row-test.js
@@ -1,0 +1,42 @@
+import { render } from '@ember/test-helpers';
+import { setupRenderingTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import { hbs } from 'ember-cli-htmlbars';
+
+import setupMirage from '../helpers/setup-mirage';
+
+module('Component | CrateRow', function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  test('shows crate name and highest version', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.2.3', yanked: true });
+    this.server.create('version', { crate, num: '2.0.0-beta.1' });
+    this.server.create('version', { crate, num: '1.1.2' });
+
+    let store = this.owner.lookup('service:store');
+    this.crate = await store.findRecord('crate', crate.name);
+
+    await render(hbs`<CrateRow @crate={{this.crate}} />`);
+    assert.dom('[data-test-crate-link]').hasText('foo');
+    assert.dom('[data-test-version]').hasText('v2.0.0-beta.1');
+    assert.dom('[data-test-copy-toml-button]').exists();
+  });
+
+  test('shows crate name and `0.0.0` version if all versions are yanked', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0', yanked: true });
+    this.server.create('version', { crate, num: '1.2.3', yanked: true });
+
+    let store = this.owner.lookup('service:store');
+    this.crate = await store.findRecord('crate', crate.name);
+
+    await render(hbs`<CrateRow @crate={{this.crate}} />`);
+    assert.dom('[data-test-crate-link]').hasText('foo');
+    assert.dom('[data-test-version]').hasText('v0.0.0');
+    assert.dom('[data-test-copy-toml-button]').exists();
+  });
+});

--- a/tests/components/crate-row-test.js
+++ b/tests/components/crate-row-test.js
@@ -10,7 +10,7 @@ module('Component | CrateRow', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
-  test('shows crate name and highest version', async function (assert) {
+  test('shows crate name and highest stable version', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0' });
     this.server.create('version', { crate, num: '1.2.3', yanked: true });
@@ -22,11 +22,26 @@ module('Component | CrateRow', function (hooks) {
 
     await render(hbs`<CrateRow @crate={{this.crate}} />`);
     assert.dom('[data-test-crate-link]').hasText('foo');
-    assert.dom('[data-test-version]').hasText('v2.0.0-beta.1');
+    assert.dom('[data-test-version]').hasText('v1.1.2');
     assert.dom('[data-test-copy-toml-button]').exists();
   });
 
-  test('shows crate name and `0.0.0` version if all versions are yanked', async function (assert) {
+  test('shows crate name and highest version, if there is no stable version available', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0-beta.1' });
+    this.server.create('version', { crate, num: '1.0.0-beta.3' });
+    this.server.create('version', { crate, num: '1.0.0-beta.2' });
+
+    let store = this.owner.lookup('service:store');
+    this.crate = await store.findRecord('crate', crate.name);
+
+    await render(hbs`<CrateRow @crate={{this.crate}} />`);
+    assert.dom('[data-test-crate-link]').hasText('foo');
+    assert.dom('[data-test-version]').hasText('v1.0.0-beta.3');
+    assert.dom('[data-test-copy-toml-button]').exists();
+  });
+
+  test('shows crate name and no version if all versions are yanked', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0', yanked: true });
     this.server.create('version', { crate, num: '1.2.3', yanked: true });
@@ -36,7 +51,7 @@ module('Component | CrateRow', function (hooks) {
 
     await render(hbs`<CrateRow @crate={{this.crate}} />`);
     assert.dom('[data-test-crate-link]').hasText('foo');
-    assert.dom('[data-test-version]').hasText('v0.0.0');
-    assert.dom('[data-test-copy-toml-button]').exists();
+    assert.dom('[data-test-version]').doesNotExist();
+    assert.dom('[data-test-copy-toml-button]').doesNotExist();
   });
 });


### PR DESCRIPTION
This PR resolves https://github.com/rust-lang/crates.io/issues/654 by using the new `defaultVersion` property of the `crate` model in the `CrateRow` component which is used by the search page.

Closes #2751

r? @pichfl 