### PR TITLE
Remove obsolete `failure` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,6 @@ dependencies = [
  "diesel_full_text_search",
  "diesel_migrations",
  "dotenv",
- "failure",
  "flate2",
  "futures-channel",
  "futures-util",
@@ -797,28 +796,6 @@ name = "entities"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "fake-simd"
@@ -2803,18 +2780,6 @@ checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ dialoguer = "0.7.1"
 diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
 diesel_full_text_search = "1.0.0"
 dotenv = "0.15"
-failure = "0.1.1"
 flate2 = "1.0"
 futures-channel = { version = "0.3.1", default-features = false }
 futures-util = "0.3"

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -2,7 +2,6 @@ use crate::controllers::frontend_prelude::*;
 
 use crate::github;
 use conduit_cookie::RequestSession;
-use failure::Fail;
 use oauth2::reqwest::http_client;
 use oauth2::{AuthorizationCode, Scope, TokenResponse};
 
@@ -99,7 +98,6 @@ pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
         .github
         .exchange_code(code)
         .request(http_client)
-        .map_err(|e| e.compat())
         .chain_error(|| server_error("Error obtaining token"))?;
     let token = token.access_token();
 


### PR DESCRIPTION
The older `oauth2` release was the last thing that needed it but with our update to tokio 1.0 we also updated `oauth2`, so we can remove the `failure` dependency now. 🎉 

r? @pietroalbini 