### PR TITLE
Block the ironframework.io documentation domain

### DIFF
--- a/src/views.rs
+++ b/src/views.rs
@@ -13,7 +13,7 @@ use crate::util::rfc3339;
 
 /// Hosts in this list are known to not be hosting documentation,
 /// and are possibly of malicious intent e.g. ad tracking networks, etc.
-const DOCUMENTATION_BLOCKLIST: [&str; 2] = ["rust-ci.org", "rustless.org"];
+const DOCUMENTATION_BLOCKLIST: &[&str] = &["rust-ci.org", "rustless.org", "ironframework.io"];
 
 #[derive(PartialEq, Debug, Serialize, Deserialize)]
 pub struct EncodableBadge {


### PR DESCRIPTION
As of 2021-01-21 the domain is serving advertising on every page. The domain likely expired and then got picked up by squatters.