### PR TITLE
router: Remove unused/empty `crate.download` route

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -11,7 +11,6 @@ Router.map(function () {
   this.route('github-authorize', { path: '/authorize/github' });
   this.route('crates');
   this.route('crate', { path: '/crates/:crate_id' }, function () {
-    this.route('download');
     this.route('versions');
     this.route('version', { path: '/:version_num' });
 


### PR DESCRIPTION
This route does not seem to be used anywhere and it has neither controller, nor template, nor route file.

r? @pichfl 