### PR TITLE
Move docs.rs link code from controller to `version` model

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -123,27 +123,4 @@ export default class CrateVersionController extends Controller {
     return readme;
   })
   loadReadmeTask;
-
-  @computed('crate.{documentation,name}', 'currentVersion.{num,loadDocsBuildsTask.lastSuccessful.value}')
-  get documentationLink() {
-    // if this is *not* a docs.rs link we'll return it directly
-    if (this.crate.documentation && !this.crate.documentation.startsWith('https://docs.rs/')) {
-      return this.crate.documentation;
-    }
-
-    // if we know about a successful docs.rs build, we'll return a link to that
-    if (this.currentVersion.loadDocsBuildsTask.lastSuccessful) {
-      let docsBuilds = this.currentVersion.loadDocsBuildsTask.lastSuccessful.value;
-      if (docsBuilds.length !== 0 && docsBuilds[0].build_status === true) {
-        return `https://docs.rs/${this.crate.name}/${this.currentVersion.num}`;
-      }
-    }
-
-    // finally, we'll return the specified documentation link, whatever it is
-    if (this.crate.documentation) {
-      return this.crate.documentation;
-    }
-
-    return null;
-  }
 }

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -6,8 +6,6 @@ import { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import moment from 'moment';
 
-import ajax from '../../utils/ajax';
-
 const NUM_VERSIONS = 5;
 
 export default class CrateVersionController extends Controller {
@@ -126,7 +124,7 @@ export default class CrateVersionController extends Controller {
   })
   loadReadmeTask;
 
-  @computed('crate.{documentation,name}', 'currentVersion.num', 'loadDocsBuildsTask.lastSuccessful.value')
+  @computed('crate.{documentation,name}', 'currentVersion.{num,loadDocsBuildsTask.lastSuccessful.value}')
   get documentationLink() {
     // if this is *not* a docs.rs link we'll return it directly
     if (this.crate.documentation && !this.crate.documentation.startsWith('https://docs.rs/')) {
@@ -134,8 +132,8 @@ export default class CrateVersionController extends Controller {
     }
 
     // if we know about a successful docs.rs build, we'll return a link to that
-    if (this.loadDocsBuildsTask.lastSuccessful) {
-      let docsBuilds = this.loadDocsBuildsTask.lastSuccessful.value;
+    if (this.currentVersion.loadDocsBuildsTask.lastSuccessful) {
+      let docsBuilds = this.currentVersion.loadDocsBuildsTask.lastSuccessful.value;
       if (docsBuilds.length !== 0 && docsBuilds[0].build_status === true) {
         return `https://docs.rs/${this.crate.name}/${this.currentVersion.num}`;
       }
@@ -148,9 +146,4 @@ export default class CrateVersionController extends Controller {
 
     return null;
   }
-
-  @task(function* () {
-    return yield ajax(`https://docs.rs/crate/${this.crate.name}/${this.currentVersion.num}/builds.json`);
-  })
-  loadDocsBuildsTask;
 }

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -70,6 +70,29 @@ export default class Version extends Model {
   })
   loadDocsBuildsTask;
 
+  @computed('crate.{documentation,name}', 'num', 'loadDocsBuildsTask.lastSuccessful.value')
+  get documentationLink() {
+    // if this is *not* a docs.rs link we'll return it directly
+    if (this.crate.documentation && !this.crate.documentation.startsWith('https://docs.rs/')) {
+      return this.crate.documentation;
+    }
+
+    // if we know about a successful docs.rs build, we'll return a link to that
+    if (this.loadDocsBuildsTask.lastSuccessful) {
+      let docsBuilds = this.loadDocsBuildsTask.lastSuccessful.value;
+      if (docsBuilds.length !== 0 && docsBuilds[0].build_status === true) {
+        return `https://docs.rs/${this.crateName}/${this.num}`;
+      }
+    }
+
+    // finally, we'll return the specified documentation link, whatever it is
+    if (this.crate.documentation) {
+      return this.crate.documentation;
+    }
+
+    return null;
+  }
+
   @(task(function* () {
     let response = yield fetch(`/api/v1/crates/${this.crate.id}/${this.num}/yank`, { method: 'DELETE' });
     if (!response.ok) {

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -4,6 +4,8 @@ import { alias } from '@ember/object/computed';
 
 import { task } from 'ember-concurrency';
 
+import ajax from '../utils/ajax';
+
 export default class Version extends Model {
   @attr num;
   @attr dl_path;
@@ -62,6 +64,11 @@ export default class Version extends Model {
     }
   }).keepLatest())
   loadReadmeTask;
+
+  @task(function* () {
+    return yield ajax(`https://docs.rs/crate/${this.crateName}/${this.num}/builds.json`);
+  })
+  loadDocsBuildsTask;
 
   @(task(function* () {
     let response = yield fetch(`/api/v1/crates/${this.crate.id}/${this.num}/yank`, { method: 'DELETE' });

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -70,24 +70,35 @@ export default class Version extends Model {
   })
   loadDocsBuildsTask;
 
-  @computed('crate.{documentation,name}', 'num', 'loadDocsBuildsTask.lastSuccessful.value')
+  @computed('loadDocsBuildsTask.lastSuccessful.value')
+  get hasDocsRsLink() {
+    let docsBuilds = this.loadDocsBuildsTask.lastSuccessful?.value;
+    return docsBuilds && docsBuilds.length !== 0 && docsBuilds[0].build_status === true;
+  }
+
+  get docsRsLink() {
+    if (this.hasDocsRsLink) {
+      return `https://docs.rs/${this.crateName}/${this.num}`;
+    }
+  }
+
   get documentationLink() {
+    let crateDocsLink = this.crate.documentation;
+
     // if this is *not* a docs.rs link we'll return it directly
-    if (this.crate.documentation && !this.crate.documentation.startsWith('https://docs.rs/')) {
-      return this.crate.documentation;
+    if (crateDocsLink && !crateDocsLink.startsWith('https://docs.rs/')) {
+      return crateDocsLink;
     }
 
     // if we know about a successful docs.rs build, we'll return a link to that
-    if (this.loadDocsBuildsTask.lastSuccessful) {
-      let docsBuilds = this.loadDocsBuildsTask.lastSuccessful.value;
-      if (docsBuilds.length !== 0 && docsBuilds[0].build_status === true) {
-        return `https://docs.rs/${this.crateName}/${this.num}`;
-      }
+    let { docsRsLink } = this;
+    if (docsRsLink) {
+      return docsRsLink;
     }
 
     // finally, we'll return the specified documentation link, whatever it is
-    if (this.crate.documentation) {
-      return this.crate.documentation;
+    if (crateDocsLink) {
+      return crateDocsLink;
     }
 
     return null;

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -40,9 +40,9 @@ export default class VersionRoute extends Route {
       // ignored
     });
 
-    let { crate } = model;
+    let { crate, version } = model;
     if (!crate.documentation || crate.documentation.startsWith('https://docs.rs/')) {
-      controller.loadDocsBuildsTask.perform().catch(error => {
+      version.loadDocsBuildsTask.perform().catch(error => {
         // report unexpected errors to Sentry and ignore `ajax()` errors
         if (!(error instanceof AjaxError)) {
           Sentry.captureException(error);

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -26,8 +26,8 @@
     {{#if this.crate.mailing_list}}
       <li><a href="{{this.crate.mailing_list}}">Mailing list</a></li>
     {{/if}}
-    {{#if this.documentationLink}}
-      <li><a href="{{this.documentationLink}}" data-test-docs-link>Documentation</a></li>
+    {{#if this.currentVersion.documentationLink}}
+      <li><a href="{{this.currentVersion.documentationLink}}" data-test-docs-link>Documentation</a></li>
     {{/if}}
     {{#if this.crate.repository}}
       <li><a href="{{this.crate.repository}}">Repository</a></li>


### PR DESCRIPTION
If we want to reuse this in other places then this code should live on the model, not a specific controller.

r? @pichfl 