### PR TITLE
Docker: Improve `postgres` setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     volumes:
       - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       - postgres-data:/var/lib/postgresql/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,12 @@ services:
   postgres:
     image: postgres:9.6
     environment:
-      POSTGRES_DB: cargo_registry
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     ports:
       - 5432:5432
     volumes:
+      - ./docker/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       - postgres-data:/var/lib/postgresql/data
 
   backend:

--- a/docker/docker-entrypoint-initdb.d/create-databases.sql
+++ b/docker/docker-entrypoint-initdb.d/create-databases.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE cargo_registry;
+CREATE DATABASE cargo_registry_test;


### PR DESCRIPTION
This PR allows us to use the docker-compose setup to run `cargo test` with the Dockerized Postgres server. It also adjusts the docker-compose setup a little bit to not expose the `postgres` container on *all* host interfaces, but instead only makes it available on 127.0.0.1.

To run just the database container you can use:

```
docker-compose up -d postgres
```

(`-d` runs it in daemon mode)

/cc @plaets

r? @pietroalbini 