### PR TITLE
Start background-worker from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,19 +35,11 @@ services:
       - 5432:5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
-    healthcheck:
-      test: pg_isready -U postgres
-      interval: 5s
-      start_period: 30s
 
   backend:
     <<: *backend
     ports:
       - 8888:8888
-    healthcheck:
-      test: curl http://backend:8888/api/v1/site_metadata
-      interval: 5s
-      start_period: 300s
     depends_on:
       - postgres
 
@@ -69,10 +61,6 @@ services:
     volumes:
       # Mount the app/ directory so live reload works
       - ./app:/app/app:ro
-    healthcheck:
-      test: wget http://frontend:4200/ -O /dev/null
-      interval: 5s
-      start_period: 120s
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - 5432:5432
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 5s
+      start_period: 30s
 
   backend:
     build:
@@ -36,6 +40,10 @@ services:
       - index:/app/tmp
       - cargo-cache:/usr/local/cargo/registry
       - target-cache:/app/target
+    healthcheck:
+      test: curl http://backend:8888/api/v1/site_metadata
+      interval: 5s
+      start_period: 300s
 
   frontend:
     build:
@@ -49,6 +57,10 @@ services:
     volumes:
       # Mount the app/ directory so live reload works
       - ./app:/app/app:ro
+    healthcheck:
+      test: wget http://frontend:4200/ -O /dev/null
+      interval: 5s
+      start_period: 120s
 
 volumes:
   postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,28 @@
 version: "3"
 
+x-backend: &backend
+  build:
+    context: .
+    dockerfile: backend.Dockerfile
+  environment:
+    DEV_DOCKER: "true"
+    DATABASE_URL: postgres://postgres:password@postgres/cargo_registry
+    SESSION_KEY: badkeyabcdefghijklmnopqrstuvwxyzabcdef
+    GIT_REPO_URL: file://./tmp/index-bare
+    GH_CLIENT_ID: ""
+    GH_CLIENT_SECRET: ""
+    WEB_ALLOWED_ORIGINS: http://localhost:8888,http://localhost:4200
+  links:
+    - postgres
+  volumes:
+    # Mount the src/ directory so we don't have to rebuild the Docker image
+    # when we want to change some code
+    - ./src:/app/src:ro
+
+    - index:/app/tmp
+    - cargo-cache:/usr/local/cargo/registry
+    - target-cache:/app/target
+
 services:
   postgres:
     image: postgres:9.6
@@ -17,29 +40,9 @@ services:
       start_period: 30s
 
   backend:
-    build:
-      context: .
-      dockerfile: backend.Dockerfile
-    environment:
-      DEV_DOCKER: "true"
-      DATABASE_URL: postgres://postgres:password@postgres/cargo_registry
-      SESSION_KEY: badkeyabcdefghijklmnopqrstuvwxyzabcdef
-      GIT_REPO_URL: file://./tmp/index-bare
-      GH_CLIENT_ID: ""
-      GH_CLIENT_SECRET: ""
-      WEB_ALLOWED_ORIGINS: http://localhost:8888,http://localhost:4200
-    links:
-      - postgres
+    <<: *backend
     ports:
       - 8888:8888
-    volumes:
-      # Mount the src/ directory so we don't have to rebuild the Docker image
-      # when we want to change some code
-      - ./src:/app/src:ro
-
-      - index:/app/tmp
-      - cargo-cache:/usr/local/cargo/registry
-      - target-cache:/app/target
     healthcheck:
       test: curl http://backend:8888/api/v1/site_metadata
       interval: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,13 @@ services:
       interval: 5s
       start_period: 300s
 
+  worker:
+    <<: *backend
+    entrypoint: cargo run --bin background-worker
+    depends_on:
+      backend:
+        condition: service_healthy
+
   frontend:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 x-backend: &backend
   build:
@@ -8,7 +8,7 @@ x-backend: &backend
     DEV_DOCKER: "true"
     DATABASE_URL: postgres://postgres:password@postgres/cargo_registry
     SESSION_KEY: badkeyabcdefghijklmnopqrstuvwxyzabcdef
-    GIT_REPO_URL: file://./tmp/index-bare
+    GIT_REPO_URL: file:///app/tmp/index-bare
     GH_CLIENT_ID: ""
     GH_CLIENT_SECRET: ""
     WEB_ALLOWED_ORIGINS: http://localhost:8888,http://localhost:4200
@@ -22,6 +22,7 @@ x-backend: &backend
     - index:/app/tmp
     - cargo-cache:/usr/local/cargo/registry
     - target-cache:/app/target
+    - local-uploads:/app/local_uploads
 
 services:
   postgres:
@@ -47,13 +48,14 @@ services:
       test: curl http://backend:8888/api/v1/site_metadata
       interval: 5s
       start_period: 300s
+    depends_on:
+      - postgres
 
   worker:
     <<: *backend
     entrypoint: cargo run --bin background-worker
     depends_on:
-      backend:
-        condition: service_healthy
+      - backend
 
   frontend:
     build:
@@ -77,3 +79,4 @@ volumes:
   cargo-cache:
   target-cache:
   index:
+  local-uploads:


### PR DESCRIPTION
Pasting the detailed list of my changes on top of @Turbo87's branch:
* change GIT_REPO_URL to an absolute path to the repo, otherwise the background worker fails with 
  `thread 'main' panicked at 'Failed to clone index: Error { code: -1, klass: 2, message: "failed to resolve path \'file://./tmp/index-bare\': No such file or directory" }', src/bin/background-worker.rs:38:46`
* add a new volume for the `local_uploads` directory, otherwise
  backend won't be able to read readmes rendered by the background worker.
  I'm not aware of any other directories that should be shared between these two services.
* remove the `depends_on` condition for the worker - this syntax is not
  supported anymore according to the official docs
  https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on
  If it's necessary that the background worker starts after the backend, a startup
  script for the worker that polls the backend if it's ready will probably be needed
  https://docs.docker.com/compose/startup-order/
* update `docker-compose.yml` version to `3.4`, `start_period` is
  not supported in earlier versions
  https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck

