### PR TITLE
Catch exceptions thrown when an anchor in a readme is invalid

### DIFF
--- a/app/initializers/hashchange.js
+++ b/app/initializers/hashchange.js
@@ -13,7 +13,8 @@ function findElementByFragmentName(document, name) {
 
   try {
     return document.querySelector(`#${name}`) || document.getElementsByName(name)[0];
-  } catch { //catches execptions thrown when an anchor in a readme was invalid (see issue #3108)
+  } catch {
+    // Catches execptions thrown when an anchor in a readme was invalid (see issue #3108)
     return;
   }
 }

--- a/app/initializers/hashchange.js
+++ b/app/initializers/hashchange.js
@@ -11,7 +11,11 @@ function findElementByFragmentName(document, name) {
     return;
   }
 
-  return document.querySelector(`#${name}`) || document.getElementsByName(name)[0];
+  try {
+    return document.querySelector(`#${name}`) || document.getElementsByName(name)[0];
+  } catch { //catches execptions thrown when an anchor in a readme was invalid (see issue #3108)
+    return;
+  }
 }
 
 function hashchange() {


### PR DESCRIPTION
Implements a fix to #3108