### PR TITLE
controllers/crate.version: Move reverse dependencies link into the sidebar

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -127,6 +127,10 @@
           {{/if}}
         {{/each}}
       </ul>
+
+      <LinkTo @route="crate.reverse-dependencies" local-class="reverse-deps-link" data-test-reverse-deps-link>
+        Show dependent crates
+      </LinkTo>
     </div>
 
     {{#if @version.buildDependencies}}

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -71,6 +71,7 @@ ul.owners, ul.keywords {
     composes: yanked from '../styles/shared/typography.module.css';
 }
 
-.more-versions-link {
+.more-versions-link,
+.reverse-deps-link {
     composes: small from '../styles/shared/typography.module.css';
 }

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -32,11 +32,6 @@
     {{#if this.crate.repository}}
       <li><a href="{{this.crate.repository}}">Repository</a></li>
     {{/if}}
-    <li>
-      <LinkTo @route="crate.reverse-dependencies" data-test-reverse-deps-link>
-        Dependent crates
-      </LinkTo>
-    </li>
   </ul>
 </PageHeader>
 


### PR DESCRIPTION
In the quicklinks section at the top the link is a bit hard to find. This PR moves it to the sidebar under the list of "Dependencies".

The long-term goal is to move the remaining links to the sidebar too.

r? @locks 