### PR TITLE
Move "Copy Cargo.toml snippet" button to the sidebar

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -19,6 +19,26 @@
     {{/if}}
 
     <div>
+      <h3>Install</h3>
+
+      <p local-class="copy-help">Add the following line to your Cargo.toml file:</p>
+      {{#if (is-clipboard-supported)}}
+        <CopyButton
+          @copyText='{{@crate.name}} = "{{@version.num}}"'
+          title="Copy Cargo.toml snippet to clipboard"
+          local-class="copy-button"
+        >
+          <span>{{@crate.name}} = "{{@version.num}}"</span>
+          {{svg-jar "copy" aria-hidden="true" local-class="copy-icon"}}
+        </CopyButton>
+      {{else}}
+        <code local-class="copy-fallback">
+          {{@crate.name}} = "{{@version.num}}"
+        </code>
+      {{/if}}
+    </div>
+
+    <div>
       <h3>Owners</h3>
 
       {{#if this.isOwner}}

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -55,6 +55,50 @@
     margin-bottom: 40px;
 }
 
+.copy-help {
+    font-size: 12px;
+}
+
+.copy-button,
+.copy-fallback {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    padding: 7px 12px;
+    font-family: monospace;
+    font-size: 14px;
+    line-height: 1.5em;
+    color: var(--main-color);
+    background: transparent;
+    border-radius: 5px;
+    border: solid 2px var(--gray-border);
+}
+
+.copy-button {
+    text-align: start;
+    cursor: pointer;
+
+    &:hover {
+        background-color: white;
+    }
+}
+
+.copy-icon {
+    flex-shrink: 0;
+    height: 1.1em;
+    width: auto;
+    /* for slightly nicer alignment... */
+    margin-top: -3px;
+    margin-left: 10px;
+    opacity: 0;
+    transition: opacity 100ms;
+
+    .copy-button:hover & {
+        opacity: 1;
+    }
+}
+
 ul.owners, ul.keywords {
     display: flex;
     flex-wrap: wrap;

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -74,10 +74,13 @@ div.header {
 .about {
     line-height: 180%;
     margin-bottom: 40px;
+
+    > h3 {
+        margin-top: 0;
+    }
 }
 
 .readme {
-    margin-top: 20px;
     margin-bottom: 20px;
 }
 

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -71,48 +71,6 @@ div.header {
     }
 }
 
-.install {
-    font-size: 120%;
-    padding: 10px;
-    background-color: #dfdbc2;
-    display: flex;
-
-    code {
-        flex: 1;
-        background: var(--main-color);
-        color: white;
-        padding: 20px;
-
-        @media only screen and (min-width: 500px) {
-            flex: 8;
-        }
-    }
-}
-
-.install-action {
-    display: none;
-    text-align: center;
-    padding-top: 18px;
-    padding-right: 10px;
-
-    @media only screen and (min-width: 500px) {
-        flex: 2;
-        display: block;
-    }
-}
-
-.copy-button {
-    composes: button-reset from '../shared/buttons.module.css';
-    width: 60px;
-    color: var(--main-color);
-    background: white;
-    cursor: pointer;
-
-    &:hover {
-        background: #edebdd;
-    }
-}
-
 .about {
     line-height: 180%;
     margin-bottom: 40px;

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -52,19 +52,6 @@
         one that has not been yanked.
       </p>
     {{else}}
-      <div local-class='install'>
-        <div local-class='install-action'>Cargo.toml</div>
-        <code>{{this.crate.name}} = "{{this.currentVersion.num}}"</code>
-        {{#if (is-clipboard-supported)}}
-          <CopyButton
-            @copyText='{{this.crate.name}} = "{{this.currentVersion.num}}"'
-            title="Copy Cargo.toml snippet to clipboard"
-            local-class="copy-button"
-          >
-            {{svg-jar "copy" alt="Copy Cargo.toml snippet to clipboard"}}
-          </CopyButton>
-        {{/if}}
-      </div>
       {{#if this.readme}}
         <section aria-label="Readme">
           <RenderedHtml @html={{this.readme}} local-class="readme" />


### PR DESCRIPTION
The goal of this PR is to put all the additional metadata of a crate/version into the sidebar, and have the main section focus on the primary content. This content section currently includes the rather large "Copy Cargo.toml snippet" button, which this PR moves to the sidebar instead:

<img width="977" alt="Bildschirmfoto 2021-02-01 um 16 32 20" src="https://user-images.githubusercontent.com/141300/106479871-15089000-64ab-11eb-9002-d06e7c948894.png">

(the screenshot shows the button in the hovered state)

r? @locks 