### PR TITLE
CI: Disable `yarn test` command for `embroider` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
           node-version: '14.x'
 
       - run: yarn install
-      - run: yarn test
+
+      # `yarn test` currently does not work due to https://github.com/embroider-build/embroider/issues/677
+      - run: yarn build
         continue-on-error: true
 
   backend:


### PR DESCRIPTION
We are running into a similar issue to what is described at https://github.com/embroider-build/embroider/issues/677. We currently allow the CI step to fail, but since it waits until it times out it keeps the PRs in "running" state for an unnecessarily long time.

This PR is changing the CI to only build, but not run the tests, with embroider to avoid the above issue. Once https://github.com/embroider-build/embroider/issues/677 is addressed we can revert this change again.

r? @locks 