### PR TITLE
models/version: Add `published_by` relationship

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -19,6 +19,7 @@ export default class Version extends Model {
 
   @belongsTo('crate', { async: false }) crate;
 
+  @belongsTo('user', { async: false }) published_by;
   @hasMany('users', { async: true }) authors;
   @hasMany('dependency', { async: true }) dependencies;
   @hasMany('version-download', { async: true }) version_downloads;

--- a/app/serializers/version.js
+++ b/app/serializers/version.js
@@ -1,0 +1,9 @@
+import { EmbeddedRecordsMixin } from '@ember-data/serializer/rest';
+
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend(EmbeddedRecordsMixin, {
+  attrs: {
+    published_by: { embedded: 'always' },
+  },
+});

--- a/mirage/models/version.js
+++ b/mirage/models/version.js
@@ -2,4 +2,5 @@ import { belongsTo, Model } from 'ember-cli-mirage';
 
 export default Model.extend({
   crate: belongsTo(),
+  publishedBy: belongsTo('user'),
 });

--- a/mirage/serializers/version.js
+++ b/mirage/serializers/version.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/avoid-leaking-state-in-ember-objects */
+
 import BaseSerializer from './application';
 
 export default BaseSerializer.extend({
@@ -15,6 +17,8 @@ export default BaseSerializer.extend({
     'crate_size',
   ],
 
+  include: ['publishedBy'],
+
   links(version) {
     return {
       authors: `/api/v1/crates/${version.crateId}/${version.num}/authors`,
@@ -28,18 +32,29 @@ export default BaseSerializer.extend({
 
     if (Array.isArray(hash)) {
       for (let resource of hash) {
-        this._adjust(resource);
+        this._adjust(resource, addToIncludes);
       }
     } else {
-      this._adjust(hash);
+      this._adjust(hash, addToIncludes);
     }
+
+    addToIncludes = addToIncludes.filter(it => it.modelName !== 'user');
 
     return [hash, addToIncludes];
   },
 
-  _adjust(hash) {
+  _adjust(hash, includes) {
     hash.dl_path = `/api/v1/crates/${hash.crate_id}/${hash.num}/download`;
     hash.crate = hash.crate_id;
+
+    if (hash.published_by_id) {
+      let user = includes.find(it => it.modelName === 'user' && it.id === hash.published_by_id);
+      hash.published_by = this.getHashForIncludedResource(user)[0].users[0];
+    } else {
+      hash.published_by = null;
+    }
+
     delete hash.crate_id;
+    delete hash.published_by_id;
   },
 });

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -270,6 +270,7 @@ module('Mirage | Crates', function (hooks) {
               version_downloads: '/api/v1/crates/rand/1.0.0-beta.1/downloads',
             },
             num: '1.0.0-beta.1',
+            published_by: null,
             updated_at: '2017-02-24T12:34:56Z',
             yanked: false,
           },
@@ -303,6 +304,7 @@ module('Mirage | Crates', function (hooks) {
             version_downloads: '/api/v1/crates/rand/1.0.0/downloads',
           },
           num: '1.0.0',
+          published_by: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
         },
@@ -320,6 +322,7 @@ module('Mirage | Crates', function (hooks) {
             version_downloads: '/api/v1/crates/rand/1.1.0/downloads',
           },
           num: '1.1.0',
+          published_by: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
         },
@@ -337,6 +340,7 @@ module('Mirage | Crates', function (hooks) {
             version_downloads: '/api/v1/crates/rand/1.2.0/downloads',
           },
           num: '1.2.0',
+          published_by: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
         },
@@ -540,9 +544,10 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns all versions belonging to the specified crate', async function (assert) {
+      let user = this.server.create('user');
       this.server.create('crate', { name: 'rand' });
       this.server.create('version', { crateId: 'rand', num: '1.0.0' });
-      this.server.create('version', { crateId: 'rand', num: '1.1.0' });
+      this.server.create('version', { crateId: 'rand', num: '1.1.0', publishedBy: user });
       this.server.create('version', { crateId: 'rand', num: '1.2.0' });
 
       let response = await fetch('/api/v1/crates/rand/versions');
@@ -565,6 +570,7 @@ module('Mirage | Crates', function (hooks) {
               version_downloads: '/api/v1/crates/rand/1.0.0/downloads',
             },
             num: '1.0.0',
+            published_by: null,
             updated_at: '2017-02-24T12:34:56Z',
             yanked: false,
           },
@@ -582,6 +588,13 @@ module('Mirage | Crates', function (hooks) {
               version_downloads: '/api/v1/crates/rand/1.1.0/downloads',
             },
             num: '1.1.0',
+            published_by: {
+              id: 1,
+              avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
+              login: 'user-1',
+              name: 'User 1',
+              url: 'https://github.com/user-1',
+            },
             updated_at: '2017-02-24T12:34:56Z',
             yanked: false,
           },
@@ -599,6 +612,7 @@ module('Mirage | Crates', function (hooks) {
               version_downloads: '/api/v1/crates/rand/1.2.0/downloads',
             },
             num: '1.2.0',
+            published_by: null,
             updated_at: '2017-02-24T12:34:56Z',
             yanked: false,
           },
@@ -995,6 +1009,7 @@ module('Mirage | Crates', function (hooks) {
               version_downloads: '/api/v1/crates/bar/1.0.0/downloads',
             },
             num: '1.0.0',
+            published_by: null,
             updated_at: '2017-02-24T12:34:56Z',
             yanked: false,
           },
@@ -1012,6 +1027,7 @@ module('Mirage | Crates', function (hooks) {
               version_downloads: '/api/v1/crates/baz/1.0.1/downloads',
             },
             num: '1.0.1',
+            published_by: null,
             updated_at: '2017-02-24T12:34:56Z',
             yanked: false,
           },

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -241,6 +241,7 @@ module('Mirage | /me', function (hooks) {
               version_downloads: '/api/v1/crates/foo/1.2.3/downloads',
             },
             num: '1.2.3',
+            published_by: null,
             updated_at: '2017-02-24T12:34:56Z',
             yanked: false,
           },

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -1,0 +1,28 @@
+import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
+
+import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
+
+module('Model | Version', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+  });
+
+  test('`published_by` relationship is assigned correctly', async function (assert) {
+    let user = this.server.create('user', { name: 'JD' });
+
+    let crate = this.server.create('crate');
+    this.server.create('version', { crate, publishedBy: user });
+
+    let crateRecord = await this.store.findRecord('crate', crate.id);
+    assert.ok(crateRecord);
+    let versions = (await crateRecord.versions).toArray();
+    assert.equal(versions.length, 1);
+    let version = versions[0];
+    assert.ok(version.published_by);
+    assert.equal(version.published_by.name, 'JD');
+  });
+});


### PR DESCRIPTION
For the more recent releases the crates.io backend now records who published the release and returns that information on the API. It would be useful to eventually show this data either in the versions list or on the version details page.

This PR adds a corresponding `published_by` relationship to the `version` model to make this data generally available in the frontend.