### PR TITLE
models/version: Add `features/featureList` properties

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -13,6 +13,7 @@ export default class Version extends Model {
   @attr('date') created_at;
   @attr('date') updated_at;
   @attr downloads;
+  @attr features;
   @attr yanked;
   @attr license;
   @attr crate_size;
@@ -28,6 +29,19 @@ export default class Version extends Model {
     return this.belongsTo('crate').id();
   })
   crateName;
+
+  get featureList() {
+    let { features } = this;
+    if (typeof features !== 'object' || features === null) {
+      return [];
+    }
+
+    let defaultFeatures = features.default ?? [];
+    return Object.keys(features)
+      .filter(name => name !== 'default')
+      .sort()
+      .map(name => ({ name, isDefault: defaultFeatures.includes(name), dependencies: features[name] }));
+  }
 
   @alias('loadAuthorsTask.last.value') authorNames;
 

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -11,6 +11,87 @@ module('Model | Version', function (hooks) {
     this.store = this.owner.lookup('service:store');
   });
 
+  module('featuresList', function () {
+    async function prepare(context, { features }) {
+      let { server, store } = context;
+
+      let crate = server.create('crate');
+      server.create('version', { crate, features });
+
+      let crateRecord = await store.findRecord('crate', crate.id);
+      let versions = (await crateRecord.versions).toArray();
+      return versions[0];
+    }
+
+    test('`features: {}` results in empty list', async function (assert) {
+      let version = await prepare(this, { features: {} });
+      assert.deepEqual(version.featureList, []);
+    });
+
+    test('`features: null` results in empty list', async function (assert) {
+      let version = await prepare(this, { features: null });
+      assert.deepEqual(version.featureList, []);
+    });
+
+    test('real world case', async function (assert) {
+      let features = {
+        alloc: ['rand_core/alloc'],
+        default: ['std', 'std_rng'],
+        getrandom: ['rand_core/getrandom'],
+        nightly: [],
+        serde1: ['serde'],
+        simd_support: ['packed_simd'],
+        small_rng: [],
+        std: ['rand_core/std', 'rand_chacha/std', 'alloc', 'getrandom', 'libc'],
+        std_rng: ['rand_chacha', 'rand_hc'],
+      };
+
+      let version = await prepare(this, { features });
+      assert.deepEqual(version.featureList, [
+        {
+          dependencies: ['rand_core/alloc'],
+          isDefault: false,
+          name: 'alloc',
+        },
+        {
+          dependencies: ['rand_core/getrandom'],
+          isDefault: false,
+          name: 'getrandom',
+        },
+        {
+          dependencies: [],
+          isDefault: false,
+          name: 'nightly',
+        },
+        {
+          dependencies: ['serde'],
+          isDefault: false,
+          name: 'serde1',
+        },
+        {
+          dependencies: ['packed_simd'],
+          isDefault: false,
+          name: 'simd_support',
+        },
+        {
+          dependencies: [],
+          isDefault: false,
+          name: 'small_rng',
+        },
+        {
+          dependencies: ['rand_core/std', 'rand_chacha/std', 'alloc', 'getrandom', 'libc'],
+          isDefault: true,
+          name: 'std',
+        },
+        {
+          dependencies: ['rand_chacha', 'rand_hc'],
+          isDefault: true,
+          name: 'std_rng',
+        },
+      ]);
+    });
+  });
+
   test('`published_by` relationship is assigned correctly', async function (assert) {
     let user = this.server.create('user', { name: 'JD' });
 


### PR DESCRIPTION
Each published `version` can have different optional `features` and it would be nice to see when a feature has been introduced. This PR prepares for showing this information in the versions list by adding `features` and `featureList` properties to the `version` model.
