### PR TITLE
Add an index on version_owner_actions.version_id

### DIFF
--- a/migrations/2021-02-09-133314_add_version_owner_actions_index/down.sql
+++ b/migrations/2021-02-09-133314_add_version_owner_actions_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS index_version_owner_actions_by_version_id;

--- a/migrations/2021-02-09-133314_add_version_owner_actions_index/up.sql
+++ b/migrations/2021-02-09-133314_add_version_owner_actions_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS index_version_owner_actions_by_version_id ON version_owner_actions (version_id);


### PR DESCRIPTION
The `api/v1/crates/:name` endpoint includes the `audit_actions` field in the response for each of the crate's versions, and it fetches that data from the `version_owner_actions table`. The query providing that data was unreasonably slow though. Here is its `EXPLAIN ANALYZE`:

                                                               QUERY PLAN
    ---------------------------------------------------------------------------------------------------------------------------------
     Sort  (cost=1655.59..1655.59 rows=3 width=244) (actual time=15.114..15.115 rows=3 loops=1)
       Sort Key: version_owner_actions.id
       Sort Method: quicksort  Memory: 25kB
       ->  Nested Loop  (cost=0.06..1655.58 rows=3 width=244) (actual time=13.514..15.107 rows=3 loops=1)
             ->  Seq Scan on version_owner_actions  (cost=0.00..1643.40 rows=3 width=28) (actual time=13.500..15.084 rows=3 loops=1)
                   Filter: (version_id = ANY ('{331918,326822,322376}'::integer[]))
                   Rows Removed by Filter: 148898
             ->  Index Scan using users_pkey on users  (cost=0.06..4.06 rows=1 width=216) (actual time=0.005..0.005 rows=1 loops=3)
                   Index Cond: (id = version_owner_actions.user_id)
     Planning Time: 0.220 ms
     Execution Time: 15.142 ms

The query plan shows that PostgreSQL was forced to do a sequential scan over the `version_owner_actions` table, considerably slowing down the performance of that endpoint. This PR fixes the problem by adding an index on the `version_id` column, allowing PostgreSQL to more efficiently execute the query.