### PR TITLE
models/version: Shorten `releaseTrack` for high major versions

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -66,7 +66,7 @@ export default class Version extends Model {
     }
 
     let { semver } = this;
-    return `${semver.major}.${semver.major === 0 ? semver.minor : 'x'}`;
+    return semver.major >= 100 ? String(semver.major) : `${semver.major}.${semver.major === 0 ? semver.minor : 'x'}`;
   }
 
   @cached get isHighestOfReleaseTrack() {

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -79,6 +79,17 @@ module('Model | Version', function (hooks) {
       assert.strictEqual(releaseTrack, '0.0');
     });
 
+    test('123.0.0 has 123 release track', async function (assert) {
+      let { semver, releaseTrack, isPrerelease } = await prepare(this, { num: '123.0.0' });
+      assert.strictEqual(semver.major, 123);
+      assert.strictEqual(semver.minor, 0);
+      assert.strictEqual(semver.patch, 0);
+      assert.deepEqual(semver.prerelease, []);
+      assert.deepEqual(semver.build, []);
+      assert.false(isPrerelease);
+      assert.strictEqual(releaseTrack, '123');
+    });
+
     test('parses 0.3.0-alpha.01 (non-standard) correctly', async function (assert) {
       let { semver, releaseTrack, isPrerelease } = await prepare(this, { num: '0.3.0-alpha.01' });
       assert.strictEqual(semver.major, 0);


### PR DESCRIPTION
Example: https://crates.io/crates/rustc-ap-rustc_arena/versions

Having `706.x` as the release track barely fits in the release track indicator, so let's shorten this value for major versions above 100.