### PR TITLE
Implement and use `/crates/:crate_id/range/:range` route

### DIFF
--- a/app/components/dependency-list/row.hbs
+++ b/app/components/dependency-list/row.hbs
@@ -12,8 +12,8 @@
 
   <span>
     <LinkTo
-      @route="crate"
-      @model={{@dependency.crate_id}}
+      @route="crate.range"
+      @models={{array @dependency.crate_id @dependency.req}}
       local-class="link"
       {{on "focusin" (fn this.setFocused true)}}
       {{on "focusout" (fn this.setFocused false)}}

--- a/app/router.js
+++ b/app/router.js
@@ -15,6 +15,7 @@ Router.map(function () {
     this.route('dependencies');
     this.route('version', { path: '/:version_num' });
     this.route('version-dependencies', { path: '/:version_num/dependencies' });
+    this.route('range', { path: '/range/:range' });
 
     this.route('reverse-dependencies', { path: 'reverse_dependencies' });
 

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -1,0 +1,78 @@
+import { currentURL, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'cargo/tests/helpers';
+
+module('Route | crate.range', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('happy path', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.1.0' });
+    this.server.create('version', { crate, num: '1.2.0' });
+    this.server.create('version', { crate, num: '1.2.3' });
+
+    await visit('/crates/foo/range/^1.1.0');
+    assert.equal(currentURL(), `/crates/foo/1.2.3`);
+    assert.dom('[data-test-crate-name]').hasText('foo');
+    assert.dom('[data-test-crate-version]').hasText('1.2.3');
+    assert.dom('[data-test-notification-message]').doesNotExist();
+  });
+
+  test('happy path with tilde range', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.1.0' });
+    this.server.create('version', { crate, num: '1.1.1' });
+    this.server.create('version', { crate, num: '1.2.0' });
+
+    await visit('/crates/foo/range/~1.1.0');
+    assert.equal(currentURL(), `/crates/foo/1.1.1`);
+    assert.dom('[data-test-crate-name]').hasText('foo');
+    assert.dom('[data-test-crate-version]').hasText('1.1.1');
+    assert.dom('[data-test-notification-message]').doesNotExist();
+  });
+
+  test('ignores yanked versions if possible', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.1.0' });
+    this.server.create('version', { crate, num: '1.1.1' });
+    this.server.create('version', { crate, num: '1.2.0', yanked: true });
+
+    await visit('/crates/foo/range/^1.0.0');
+    assert.equal(currentURL(), `/crates/foo/1.1.1`);
+    assert.dom('[data-test-crate-name]').hasText('foo');
+    assert.dom('[data-test-crate-version]').hasText('1.1.1');
+    assert.dom('[data-test-notification-message]').doesNotExist();
+  });
+
+  test('falls back to yanked version if necessary', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0', yanked: true });
+    this.server.create('version', { crate, num: '1.1.0', yanked: true });
+    this.server.create('version', { crate, num: '1.1.1', yanked: true });
+    this.server.create('version', { crate, num: '2.0.0' });
+
+    await visit('/crates/foo/range/^1.0.0');
+    assert.equal(currentURL(), `/crates/foo/1.1.1`);
+    assert.dom('[data-test-crate-name]').hasText('foo');
+    assert.dom('[data-test-crate-version]').hasText('1.1.1');
+    assert.dom('[data-test-notification-message]').doesNotExist();
+  });
+
+  test('redirects to main crate page if no match found', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.1.0' });
+    this.server.create('version', { crate, num: '1.1.1' });
+    this.server.create('version', { crate, num: '2.0.0' });
+
+    await visit('/crates/foo/range/^3');
+    assert.equal(currentURL(), `/crates/foo`);
+    assert.dom('[data-test-crate-name]').hasText('foo');
+    assert.dom('[data-test-crate-version]').hasText('2.0.0');
+    assert.dom('[data-test-notification-message="error"]').hasText("No matching version of crate 'foo' found for: ^3");
+  });
+});


### PR DESCRIPTION
... that redirects the user to the highest version that satisfies the specified semver range. I guess the added test cases should explain the purpose quite well :)