### PR TITLE
crate.version: Use `<article>` instead of `<section>` for the rendered README

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -15,9 +15,9 @@
       </p>
     {{else}}
       {{#if this.readme}}
-        <section aria-label="Readme">
+        <article aria-label="Readme">
           <RenderedHtml @html={{this.readme}} local-class="readme" />
-        </section>
+        </article>
       {{else}}
         {{#if this.crate.description}}
           <div local-class='about'>


### PR DESCRIPTION
according to https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_HTML_sections_and_outlines this appears to be a better fit for what we're doing here