### PR TITLE
Parse license expressions and show links to choosealicense.com

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -82,7 +82,9 @@
     {{#if @version.license}}
       <div>
         <h3>License</h3>
-        <p data-test-license>{{ @version.license }}</p>
+        <p data-test-license>
+          <LicenseExpression @license={{@version.license }} />
+        </p>
       </div>
     {{/if}}
 

--- a/app/components/license-expression.hbs
+++ b/app/components/license-expression.hbs
@@ -1,0 +1,11 @@
+{{#each (parse-license @license) as |part|}}
+  {{#if part.isKeyword}}
+    <small>{{part.text}}</small>
+  {{else if part.link}}
+    <a href={{part.link}} rel="noreferrer">
+      {{part.text}}
+    </a>
+  {{else}}
+    {{part.text}}
+  {{/if}}
+{{/each}}

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -62,7 +62,7 @@
 
       <span local-class="license">
         {{svg-jar "license"}}
-        {{@version.license}}
+        <LicenseExpression @license={{@version.license}} />
       </span>
 
       {{#if @version.featureList}}

--- a/app/helpers/parse-license.js
+++ b/app/helpers/parse-license.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+
+import { parseLicense } from '../utils/license';
+
+export default helper(function ([expression]) {
+  if (expression) {
+    return parseLicense(expression);
+  }
+});

--- a/app/utils/license.js
+++ b/app/utils/license.js
@@ -1,0 +1,61 @@
+// see https://choosealicense.com/appendix/
+const CAL_LICENSES = [
+  '0bsd',
+  'afl-3.0',
+  'agpl-3.0',
+  'apache-2.0',
+  'artistic-2.0',
+  'bsd-2-clause',
+  'bsd-3-clause-clear',
+  'bsd-3-clause',
+  'bsd-4-clause',
+  'bsl-1.0',
+  'cc-by-4.0',
+  'cc-by-sa-4.0',
+  'cc0-1.0',
+  'cecill-2.1',
+  'ecl-2.0',
+  'epl-1.0',
+  'epl-2.0',
+  'eupl-1.1',
+  'eupl-1.2',
+  'gpl-2.0',
+  'gpl-3.0',
+  'isc',
+  'lgpl-2.1',
+  'lgpl-3.0',
+  'lppl-1.3c',
+  'mit',
+  'mpl-2.0',
+  'ms-pl',
+  'ms-rl',
+  'ncsa',
+  'odbl-1.0',
+  'ofl-1.1',
+  'osl-3.0',
+  'postgresql',
+  'unlicense',
+  'upl-1.0',
+  'vim',
+  'wtfpl',
+  'zlib',
+];
+
+const LICENSE_KEYWORDS = new Set(['OR', 'AND', 'WITH']);
+
+export function parseLicense(text) {
+  return text
+    .trim()
+    .replace('/', ' OR ')
+    .replace(/ +/g, ' ')
+    .split(' ')
+    .map(text => {
+      let lowerCaseText = text.toLowerCase();
+
+      let isKeyword = LICENSE_KEYWORDS.has(text);
+      let calLicense = CAL_LICENSES.find(it => it === lowerCaseText);
+      let link = calLicense ? `https://choosealicense.com/licenses/${calLicense}` : undefined;
+
+      return { isKeyword, text, link };
+    });
+}

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -184,7 +184,7 @@ module('Acceptance | crate page', function (hooks) {
     assert.dom('[data-test-license]').hasText('Apache-2.0');
 
     await click('[data-test-version-link="0.5.0"]');
-    assert.dom('[data-test-license]').hasText('MIT/Apache-2.0');
+    assert.dom('[data-test-license]').hasText('MIT OR Apache-2.0');
   });
 
   skip('crates can be yanked by owner', async function (assert) {

--- a/tests/utils/license-test.js
+++ b/tests/utils/license-test.js
@@ -1,0 +1,65 @@
+import { module, test } from 'qunit';
+
+import { parseLicense } from '../../utils/license';
+
+module('parseLicense()', function () {
+  const TESTS = [
+    ['MIT', [{ isKeyword: false, link: 'https://choosealicense.com/licenses/mit', text: 'MIT' }]],
+    [
+      'MIT OR Apache-2.0',
+      [
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/mit', text: 'MIT' },
+        { isKeyword: true, link: undefined, text: 'OR' },
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/apache-2.0', text: 'Apache-2.0' },
+      ],
+    ],
+    [
+      'MIT/Apache-2.0',
+      [
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/mit', text: 'MIT' },
+        { isKeyword: true, link: undefined, text: 'OR' },
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/apache-2.0', text: 'Apache-2.0' },
+      ],
+    ],
+    [
+      'LGPL-2.1-only AND MIT AND BSD-2-Clause',
+      [
+        { isKeyword: false, link: undefined, text: 'LGPL-2.1-only' },
+        { isKeyword: true, link: undefined, text: 'AND' },
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/mit', text: 'MIT' },
+        { isKeyword: true, link: undefined, text: 'AND' },
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/bsd-2-clause', text: 'BSD-2-Clause' },
+      ],
+    ],
+    [
+      'GPL-2.0-or-later WITH Bison-exception-2.2',
+      [
+        { isKeyword: false, link: undefined, text: 'GPL-2.0-or-later' },
+        { isKeyword: true, link: undefined, text: 'WITH' },
+        { isKeyword: false, link: undefined, text: 'Bison-exception-2.2' },
+      ],
+    ],
+    [
+      'Unlicense OR MIT',
+      [
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/unlicense', text: 'Unlicense' },
+        { isKeyword: true, link: undefined, text: 'OR' },
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/mit', text: 'MIT' },
+      ],
+    ],
+    [
+      'A   OR  B',
+      [
+        { isKeyword: false, link: undefined, text: 'A' },
+        { isKeyword: true, link: undefined, text: 'OR' },
+        { isKeyword: false, link: undefined, text: 'B' },
+      ],
+    ],
+  ];
+
+  for (let [input, expectation] of TESTS) {
+    test(input, function (assert) {
+      assert.deepEqual(parseLicense(input), expectation);
+    });
+  }
+});


### PR DESCRIPTION
<img width="236" alt="Bildschirmfoto 2021-02-10 um 01 00 50" src="https://user-images.githubusercontent.com/141300/107444794-8bf0f900-6b3b-11eb-8518-138361431622.png">

<img width="261" alt="Bildschirmfoto 2021-02-10 um 01 01 05" src="https://user-images.githubusercontent.com/141300/107444797-8d222600-6b3b-11eb-833c-249a2ff744be.png">

This PR is implementing a basic SPDX license expression parser and a corresponding `LicenseExpression` component, which deemphasizes keywords and adds links to https://choosealicense.com for known license IDs.