### PR TITLE
Add COM0 and LPT0 to the list of reserved crate names

### DIFF
--- a/migrations/2021-02-10-141019_reserve_com0_lpt0/down.sql
+++ b/migrations/2021-02-10-141019_reserve_com0_lpt0/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM reserved_crate_names WHERE name IN ('com0', 'lpt0');

--- a/migrations/2021-02-10-141019_reserve_com0_lpt0/up.sql
+++ b/migrations/2021-02-10-141019_reserve_com0_lpt0/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO reserved_crate_names (name) VALUES ('com0'), ('lpt0') ON CONFLICT DO NOTHING;


### PR DESCRIPTION
In #695 we added all the documented reserved Windows file names to the list of reserved crate names, to prevent people from registering crates named that way and breaking all Windows users in the process.

Unfortunately it turns out that COM0 and LPT0 are *also* reserved on Windows systems, but they're not documented in Microsoft's docs. This PR adds both names to the reserved crate names list.

Note that the migration here is a no-op on the production crates.io instance, as both names were manually added to the database before opening this PR.

r? @jtgeibel 