### PR TITLE
models/version: Ignore yanked versions in `isHighestOfReleaseTrack` property

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -64,7 +64,9 @@ export default class Version extends Model {
     let { crate, semver, releaseTrack } = this;
     let { versions } = crate;
     // find all other non-prerelease versions on the same release track
-    let sameTrackVersions = versions.filter(it => it !== this && !it.isPrerelease && it.releaseTrack === releaseTrack);
+    let sameTrackVersions = versions.filter(
+      it => it !== this && !it.yanked && !it.isPrerelease && it.releaseTrack === releaseTrack,
+    );
     // check if we're the "highest"
     return sameTrackVersions.every(it => it.semver.compare(semver) === -1);
   }

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -80,88 +80,70 @@ module('Model | Version', function (hooks) {
     });
   });
 
-  test('isHighestOfReleaseTrack', async function (assert) {
-    let nums = [
-      '0.4.0-rc.1',
-      '0.3.23',
-      '0.3.22',
-      '0.3.21-pre.0',
-      '0.3.20',
-      '0.3.3',
-      '0.3.2',
-      '0.3.1',
-      '0.3.0',
-      '0.2.1',
-      '0.2.0',
-      '0.1.2',
-      '0.1.1',
-    ];
+  module('isHighestOfReleaseTrack', function () {
+    test('happy path', async function (assert) {
+      let nums = [
+        '0.4.0-rc.1',
+        '0.3.23',
+        '0.3.22',
+        '0.3.21-pre.0',
+        '0.3.20',
+        '0.3.3',
+        '0.3.2',
+        '0.3.1',
+        '0.3.0',
+        '0.2.1',
+        '0.2.0',
+        '0.1.2',
+        '0.1.1',
+      ];
 
-    let crate = this.server.create('crate');
-    for (let num of nums) {
-      this.server.create('version', { crate, num });
-    }
+      let crate = this.server.create('crate');
+      for (let num of nums) {
+        this.server.create('version', { crate, num });
+      }
 
-    let crateRecord = await this.store.findRecord('crate', crate.id);
-    let versions = (await crateRecord.versions).toArray();
+      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let versions = (await crateRecord.versions).toArray();
 
-    assert.deepEqual(
-      versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
-      [
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.4.0-rc.1',
-        },
-        {
-          isHighestOfReleaseTrack: true,
-          num: '0.3.23',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.3.22',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.3.21-pre.0',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.3.20',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.3.3',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.3.2',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.3.1',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.3.0',
-        },
-        {
-          isHighestOfReleaseTrack: true,
-          num: '0.2.1',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.2.0',
-        },
-        {
-          isHighestOfReleaseTrack: true,
-          num: '0.1.2',
-        },
-        {
-          isHighestOfReleaseTrack: false,
-          num: '0.1.1',
-        },
-      ],
-    );
+      assert.deepEqual(
+        versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
+        [
+          { num: '0.4.0-rc.1', isHighestOfReleaseTrack: false },
+          { num: '0.3.23', isHighestOfReleaseTrack: true },
+          { num: '0.3.22', isHighestOfReleaseTrack: false },
+          { num: '0.3.21-pre.0', isHighestOfReleaseTrack: false },
+          { num: '0.3.20', isHighestOfReleaseTrack: false },
+          { num: '0.3.3', isHighestOfReleaseTrack: false },
+          { num: '0.3.2', isHighestOfReleaseTrack: false },
+          { num: '0.3.1', isHighestOfReleaseTrack: false },
+          { num: '0.3.0', isHighestOfReleaseTrack: false },
+          { num: '0.2.1', isHighestOfReleaseTrack: true },
+          { num: '0.2.0', isHighestOfReleaseTrack: false },
+          { num: '0.1.2', isHighestOfReleaseTrack: true },
+          { num: '0.1.1', isHighestOfReleaseTrack: false },
+        ],
+      );
+    });
+
+    test('ignores yanked versions', async function (assert) {
+      let crate = this.server.create('crate');
+      this.server.create('version', { crate, num: '0.4.0' });
+      this.server.create('version', { crate, num: '0.4.1' });
+      this.server.create('version', { crate, num: '0.4.2', yanked: true });
+
+      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let versions = (await crateRecord.versions).toArray();
+
+      assert.deepEqual(
+        versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
+        [
+          { num: '0.4.0', isHighestOfReleaseTrack: false },
+          { num: '0.4.1', isHighestOfReleaseTrack: true },
+          { num: '0.4.2', isHighestOfReleaseTrack: true },
+        ],
+      );
+    });
   });
 
   module('featuresList', function () {


### PR DESCRIPTION
if there is 0.4.0, 0.4.1 and 0.4.2, and 0.4.2 is yanked then the highest of the release track should be 0.4.1.

