### PR TITLE
DownloadGraph: Only call `destroy` if the `Chart` instance has been created

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -59,7 +59,7 @@ export default class DownloadGraph extends Component {
   }
 
   @action destroyChart() {
-    this.chart.destroy();
+    this.chart?.destroy();
   }
 
   @action reloadPage() {


### PR DESCRIPTION


Fixes https://github.com/rust-lang/crates.io/issues/3256