### PR TITLE
DownloadGraph: Ignore missing `version` relationships

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -84,7 +84,10 @@ export default class DownloadGraph extends Component {
     }
 
     downloads.forEach(d => {
-      let version_num = d.version.num;
+      let version = d.version;
+      if (!version) return;
+
+      let version_num = version.num;
 
       versions.add(version_num);
 


### PR DESCRIPTION
Fixes https://github.com/rust-lang/crates.io/issues/3254