### PR TITLE
yarn: Remove obsolete `ember-test-waiters` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,8 +127,5 @@
   "engines": {
     "node": "^14.9.0",
     "npm": "^7.0.0"
-  },
-  "resolutions": {
-    "ember-test-waiters": "2.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7044,16 +7044,6 @@ ember-test-selectors@5.0.0:
     ember-cli-babel "^7.22.1"
     ember-cli-version-checker "^5.1.1"
 
-ember-test-waiters@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-2.1.3.tgz#40fe7b674d5ef1005f665e0e040753f88c5a2175"
-  integrity sha512-xDjvq8/1C3b9z3NGpez7aslbq5gsLrxsdjD3apyziHkImh/PTeXZr2bxo/YAUgOwGOtpZ1So0fIsppiSN0u1Ng==
-  dependencies:
-    ember-cli-babel "^7.21.0"
-    ember-cli-typescript "^3.1.3"
-    ember-cli-version-checker "^5.1.1"
-    semver "^7.1.3"
-
 ember-truth-helpers@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-truth-helpers/-/ember-truth-helpers-3.0.0.tgz#86766bdca4ac9b86bce3d262dff2aabc4a0ea384"


### PR DESCRIPTION
This should no longer be necessary since we're using `@ember/test-waiters` everywhere now.