### PR TITLE
CI: Bump cargo binaries cache version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo/bin
-          key: ${{ runner.os }}-cargo-bin-${{ matrix.rust }}-${{ hashFiles('.diesel_version') }}
+          key: ${{ runner.os }}-cargo-bin-${{ matrix.rust }}-${{ hashFiles('.diesel_version') }}-v2
 
       # Current size as of 2019-12-23: ~77 MB
       - name: Cache cargo registry cache


### PR DESCRIPTION
This should hopefully allow cargo-tarpaulin to be cached correctly