### PR TITLE
controllers::util: Clean up `verify_origin()` function

### DIFF
--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -30,11 +30,11 @@ impl AuthenticatedUser {
     }
 }
 
-// The Origin header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
-// is sent with CORS requests and POST requests, and indicates where the request comes from.
-// We don't want to accept authenticated requests that originated from other sites, so this
-// function returns an error if the Origin header doesn't match what we expect "this site" to
-// be: https://crates.io in production, or http://localhost:port/ in development.
+/// The Origin header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
+/// is sent with CORS requests and POST requests, and indicates where the request comes from.
+/// We don't want to accept authenticated requests that originated from other sites, so this
+/// function returns an error if the Origin header doesn't match what we expect "this site" to
+/// be: https://crates.io in production, or http://localhost:port/ in development.
 fn verify_origin(req: &dyn RequestExt) -> AppResult<()> {
     let headers = req.headers();
     let allowed_origins = &req.app().config.allowed_origins;

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -37,18 +37,14 @@ impl AuthenticatedUser {
 // be: https://crates.io in production, or http://localhost:port/ in development.
 fn verify_origin(req: &dyn RequestExt) -> AppResult<()> {
     let headers = req.headers();
-    let allowed_origins = req
-        .app()
-        .config
-        .allowed_origins
-        .iter()
-        .map(|s| &**s)
-        .collect::<Vec<_>>();
+    let allowed_origins = &req.app().config.allowed_origins;
 
     let bad_origin = headers
         .get_all(header::ORIGIN)
         .iter()
-        .find(|h| !allowed_origins.contains(&h.to_str().unwrap_or_default()));
+        .filter_map(|value| value.to_str().ok())
+        .find(|value| !allowed_origins.iter().any(|it| it == value));
+
     if let Some(bad_origin) = bad_origin {
         let error_message = format!(
             "only same-origin requests can be authenticated. got {:?}",


### PR DESCRIPTION
This PR simplifies the code of the `verify_origin()` function by removing the additional `Vec` allocation. It also converts the function comment to a doc comment.

r? @jtgeibel 