### PR TITLE
Simplify `authenticate_user()` function

### DIFF
--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -66,14 +66,13 @@ fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
         (id, None)
     } else {
         // Otherwise, look for an `Authorization` header on the request
-        let maybe_authorization: Option<String> = {
-            req.headers()
-                .get(header::AUTHORIZATION)
-                .and_then(|h| h.to_str().ok())
-                .map(|h| h.to_string())
-        };
+        let maybe_authorization = req
+            .headers()
+            .get(header::AUTHORIZATION)
+            .and_then(|h| h.to_str().ok());
+
         if let Some(header_value) = maybe_authorization {
-            let token = ApiToken::find_by_api_token(&conn, &header_value).map_err(|e| {
+            let token = ApiToken::find_by_api_token(&conn, header_value).map_err(|e| {
                 if e.is::<InsecurelyGeneratedTokenRevoked>() {
                     e
                 } else {

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -62,11 +62,14 @@ fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
     let session = req.session();
     let user_id_from_session = session.get("user_id").and_then(|s| s.parse::<i32>().ok());
 
-    let (user, token_id) = if let Some(id) = user_id_from_session {
+    if let Some(id) = user_id_from_session {
         let user = User::find(&conn, id)
             .chain_error(|| internal("user_id from cookie not found in database"))?;
 
-        (user, None)
+        return Ok(AuthenticatedUser {
+            user,
+            token_id: None,
+        });
     } else {
         // Otherwise, look for an `Authorization` header on the request
         let maybe_authorization = req
@@ -86,14 +89,15 @@ fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
             let user = User::find(&conn, token.user_id)
                 .chain_error(|| internal("user_id from token not found in database"))?;
 
-            (user, Some(token.id))
+            return Ok(AuthenticatedUser {
+                user,
+                token_id: Some(token.id),
+            });
         } else {
             // Unable to authenticate the user
             return Err(internal("no cookie session or auth header found")).chain_error(forbidden);
         }
-    };
-
-    Ok(AuthenticatedUser { user, token_id })
+    }
 }
 
 impl<'a> UserAuthenticationExt for dyn RequestExt + 'a {

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -8,7 +8,7 @@ static URL: &str = "/api/v1/me/updates";
 static MUST_LOGIN: &[u8] =
     b"{\"errors\":[{\"detail\":\"must be logged in to perform that action\"}]}";
 static INTERNAL_ERROR_NO_USER: &str =
-    "user_id from cookie or token not found in database caused by NotFound";
+    "user_id from cookie not found in database caused by NotFound";
 
 fn call(app: &TestApp, mut request: MockRequest) -> HandlerResult {
     app.as_middleware().call(&mut request)


### PR DESCRIPTION
The function was a bit hard to read and difficult to extend (see #3307). This PR simplifies it a little bit by returning early if a suitable authentication method was found.

r? @jtgeibel 