### PR TITLE
Import `htmlSafe` from `@ember/template`

### DIFF
--- a/app/helpers/format-email.js
+++ b/app/helpers/format-email.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import Ember from 'ember';
 
 const escape = Ember.Handlebars.Utils.escapeExpression;

--- a/app/services/progress.js
+++ b/app/services/progress.js
@@ -1,5 +1,5 @@
 import Service, { inject as service } from '@ember/service';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
 import Ember from 'ember';
 


### PR DESCRIPTION
This should resolve a few of the deprecation warnings that got introduced with Ember 3.25
