### PR TITLE
Remove obsolete attributes from `crate` model

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -46,20 +46,6 @@
         />
       {{/if}}
 
-      {{#if @crate.wiki}}
-        <CrateSidebar::Link
-          @title="Wiki"
-          @url={{@crate.wiki}}
-        />
-      {{/if}}
-
-      {{#if @crate.mailing_list}}
-        <CrateSidebar::Link
-          @title="Mailing list"
-          @url={{@crate.mailing_list}}
-        />
-      {{/if}}
-
       {{#if @version.documentationLink}}
         <CrateSidebar::Link
           @title="Documentation"

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -14,9 +14,6 @@ export default class Crate extends Model {
 
   @attr description;
   @attr homepage;
-  @attr wiki;
-  @attr mailing_list;
-  @attr issues;
   @attr documentation;
   @attr repository;
   @attr exact_match;


### PR DESCRIPTION
These may have existed at some point, but these fields are no longer sent by the backend, so there is no point in us still handling them