### PR TITLE
Improve "external crate link" simplification logic

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -39,7 +39,7 @@
     </div>
 
     <div>
-      {{#if (and @crate.homepage (not-eq @crate.repository @crate.homepage))}}
+      {{#if this.showHomepage}}
         <CrateSidebar::Link
           @title="Homepage"
           @url={{@crate.homepage}}

--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -43,6 +43,7 @@
         <CrateSidebar::Link
           @title="Homepage"
           @url={{@crate.homepage}}
+          data-test-homepage-link
         />
       {{/if}}
 
@@ -58,6 +59,7 @@
         <CrateSidebar::Link
           @title="Repository"
           @url={{@crate.repository}}
+          data-test-repository-link
         />
       {{/if}}
     </div>

--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -2,6 +2,8 @@ import { computed } from '@ember/object';
 import { gt, readOnly } from '@ember/object/computed';
 import Component from '@glimmer/component';
 
+import { simplifyUrl } from './crate-sidebar/link';
+
 const NUM_VERSIONS = 5;
 
 export default class DownloadGraph extends Component {
@@ -15,7 +17,8 @@ export default class DownloadGraph extends Component {
   @gt('sortedVersions.length', NUM_VERSIONS) hasMoreVersions;
 
   get showHomepage() {
-    return this.args.crate.homepage && this.args.crate.repository !== this.args.crate.homepage;
+    let { repository, homepage } = this.args.crate;
+    return homepage && (!repository || simplifyUrl(repository) !== simplifyUrl(homepage));
   }
 
   get tomlSnippet() {

--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -14,6 +14,10 @@ export default class DownloadGraph extends Component {
 
   @gt('sortedVersions.length', NUM_VERSIONS) hasMoreVersions;
 
+  get showHomepage() {
+    return this.args.crate.homepage && this.args.crate.repository !== this.args.crate.homepage;
+  }
+
   get tomlSnippet() {
     return `${this.args.crate.name} = "${this.args.version.num}"`;
   }

--- a/app/components/crate-sidebar/link.js
+++ b/app/components/crate-sidebar/link.js
@@ -9,6 +9,9 @@ export default class CrateSidebarLink extends Component {
     if (url.startsWith('www.')) {
       url = url.slice('www.'.length);
     }
+    if (url.endsWith('/')) {
+      url = url.slice(0, -1);
+    }
 
     return url;
   }

--- a/app/components/crate-sidebar/link.js
+++ b/app/components/crate-sidebar/link.js
@@ -12,6 +12,9 @@ export default class CrateSidebarLink extends Component {
     if (url.endsWith('/')) {
       url = url.slice(0, -1);
     }
+    if (url.startsWith('github.com/') && url.endsWith('.git')) {
+      url = url.slice(0, -4);
+    }
 
     return url;
   }

--- a/app/components/crate-sidebar/link.js
+++ b/app/components/crate-sidebar/link.js
@@ -3,20 +3,7 @@ import Component from '@glimmer/component';
 export default class CrateSidebarLink extends Component {
   get text() {
     let { url } = this.args;
-    if (url.startsWith('https://')) {
-      url = url.slice('https://'.length);
-    }
-    if (url.startsWith('www.')) {
-      url = url.slice('www.'.length);
-    }
-    if (url.endsWith('/')) {
-      url = url.slice(0, -1);
-    }
-    if (url.startsWith('github.com/') && url.endsWith('.git')) {
-      url = url.slice(0, -4);
-    }
-
-    return url;
+    return simplifyUrl(url);
   }
 
   get isDocsRs() {
@@ -26,4 +13,21 @@ export default class CrateSidebarLink extends Component {
   get isGitHub() {
     return this.text.startsWith('github.com/');
   }
+}
+
+export function simplifyUrl(url) {
+  if (url.startsWith('https://')) {
+    url = url.slice('https://'.length);
+  }
+  if (url.startsWith('www.')) {
+    url = url.slice('www.'.length);
+  }
+  if (url.endsWith('/')) {
+    url = url.slice(0, -1);
+  }
+  if (url.startsWith('github.com/') && url.endsWith('.git')) {
+    url = url.slice(0, -4);
+  }
+
+  return url;
 }

--- a/tests/components/crate-sidebar/link-test.js
+++ b/tests/components/crate-sidebar/link-test.js
@@ -34,4 +34,9 @@ module('Component | CrateSidebar::Link', function (hooks) {
     await render(hbs`<CrateSidebar::Link @url="http://www.rust-lang.org" />`);
     assert.dom('[data-test-link]').hasAttribute('href', 'http://www.rust-lang.org').hasText('http://www.rust-lang.org');
   });
+
+  test('strips trailing slashes', async function (assert) {
+    await render(hbs`<CrateSidebar::Link @url="https://www.rust-lang.org/" />`);
+    assert.dom('[data-test-link]').hasAttribute('href', 'https://www.rust-lang.org/').hasText('rust-lang.org');
+  });
 });

--- a/tests/components/crate-sidebar/link-test.js
+++ b/tests/components/crate-sidebar/link-test.js
@@ -39,4 +39,17 @@ module('Component | CrateSidebar::Link', function (hooks) {
     await render(hbs`<CrateSidebar::Link @url="https://www.rust-lang.org/" />`);
     assert.dom('[data-test-link]').hasAttribute('href', 'https://www.rust-lang.org/').hasText('rust-lang.org');
   });
+
+  test('strips the trailing `.git` from GitHub project URLs', async function (assert) {
+    await render(hbs`<CrateSidebar::Link @url="https://github.com/rust-lang/crates.io.git" />`);
+    assert
+      .dom('[data-test-link]')
+      .hasAttribute('href', 'https://github.com/rust-lang/crates.io.git')
+      .hasText('github.com/rust-lang/crates.io');
+  });
+
+  test('does not strip the trailing `.git` from other URLs', async function (assert) {
+    await render(hbs`<CrateSidebar::Link @url="https://foo.git/" />`);
+    assert.dom('[data-test-link]').hasAttribute('href', 'https://foo.git/').hasText('foo.git');
+  });
 });

--- a/tests/routes/crate/version/crate-links-test.js
+++ b/tests/routes/crate/version/crate-links-test.js
@@ -1,0 +1,62 @@
+import { visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'cargo/tests/helpers';
+
+module('Route | crate.version | crate links', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('shows all external crate links', async function (assert) {
+    this.server.create('crate', {
+      name: 'foo',
+      homepage: 'https://crates.io/',
+      documentation: 'https://doc.rust-lang.org/cargo/getting-started/',
+      repository: 'https://github.com/rust-lang/crates.io.git',
+    });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    await visit('/crates/foo');
+
+    assert.dom('[data-test-homepage-link] a').hasText('crates.io').hasAttribute('href', 'https://crates.io/');
+
+    assert
+      .dom('[data-test-docs-link] a')
+      .hasText('doc.rust-lang.org/cargo/getting-started')
+      .hasAttribute('href', 'https://doc.rust-lang.org/cargo/getting-started/');
+
+    assert
+      .dom('[data-test-repository-link] a')
+      .hasText('github.com/rust-lang/crates.io')
+      .hasAttribute('href', 'https://github.com/rust-lang/crates.io.git');
+  });
+
+  test('shows no external crate links if none are set', async function (assert) {
+    this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    await visit('/crates/foo');
+
+    assert.dom('[data-test-homepage-link]').doesNotExist();
+    assert.dom('[data-test-docs-link]').doesNotExist();
+    assert.dom('[data-test-repository-link]').doesNotExist();
+  });
+
+  test('hide the homepage link if it is the same as the repository', async function (assert) {
+    this.server.create('crate', {
+      name: 'foo',
+      homepage: 'https://github.com/rust-lang/crates.io',
+      repository: 'https://github.com/rust-lang/crates.io',
+    });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    await visit('/crates/foo');
+
+    assert.dom('[data-test-homepage-link]').doesNotExist();
+    assert.dom('[data-test-docs-link]').doesNotExist();
+
+    assert
+      .dom('[data-test-repository-link] a')
+      .hasText('github.com/rust-lang/crates.io')
+      .hasAttribute('href', 'https://github.com/rust-lang/crates.io');
+  });
+});

--- a/tests/routes/crate/version/crate-links-test.js
+++ b/tests/routes/crate/version/crate-links-test.js
@@ -59,4 +59,23 @@ module('Route | crate.version | crate links', function (hooks) {
       .hasText('github.com/rust-lang/crates.io')
       .hasAttribute('href', 'https://github.com/rust-lang/crates.io');
   });
+
+  test('hide the homepage link if it is the same as the repository plus `.git`', async function (assert) {
+    this.server.create('crate', {
+      name: 'foo',
+      homepage: 'https://github.com/rust-lang/crates.io/',
+      repository: 'https://github.com/rust-lang/crates.io.git',
+    });
+    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+
+    await visit('/crates/foo');
+
+    assert.dom('[data-test-homepage-link]').doesNotExist();
+    assert.dom('[data-test-docs-link]').doesNotExist();
+
+    assert
+      .dom('[data-test-repository-link] a')
+      .hasText('github.com/rust-lang/crates.io')
+      .hasAttribute('href', 'https://github.com/rust-lang/crates.io.git');
+  });
 });


### PR DESCRIPTION
This PR strips trailing slashes from the displayed links, strips trailing `.git` for any github.com link, and uses the simplified URL to figure out if the homepage link matches the repository link.

https://crates.io/crates/aprs-parser for example currently shows `https://github.com/Turbo87/aprs-parser-rs/` as the homepage and `https://github.com/Turbo87/aprs-parser-rs.git` as the repository, but with this PR these links will be treated as equivalent and only the repository link will be shown.