### PR TITLE
Display crate description in the `CrateHeader` component

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -12,6 +12,11 @@
       <FollowButton @crate={{@crate}}/>
     {{/if}}
   </div>
+  {{#if @crate.description}}
+    <div local-class="description">
+      {{@crate.description}}
+    </div>
+  {{/if}}
 </PageHeader>
 
 <NavTabs aria-label="{{@crate.name}} crate subpages" local-class="nav" as |nav|>

--- a/app/components/crate-header.module.css
+++ b/app/components/crate-header.module.css
@@ -30,6 +30,11 @@
     height: 32px;
 }
 
+.description {
+    margin-top: 15px;
+    line-height: 1.35;
+}
+
 .nav {
     margin-bottom: 20px;
 }

--- a/app/components/loading-spinner.module.css
+++ b/app/components/loading-spinner.module.css
@@ -1,19 +1,20 @@
 .spinner {
     --spinner-color: black;
     --spinner-bg-color: rgba(0, 0, 0, .2);
+    --spinner-size: 16px;
 
     display: inline-block;
-    height: 16px;
-    width: 16px;
+    height: var(--spinner-size);
+    width: var(--spinner-size);
 
     &:after {
         content: " ";
         display: block;
         box-sizing: border-box;
-        width: 16px;
-        height: 16px;
+        width: var(--spinner-size);
+        height: var(--spinner-size);
         border-radius: 50%;
-        border: 3px solid var(--spinner-color);
+        border: calc(var(--spinner-size) / 5.5) solid var(--spinner-color);
         border-color: var(--spinner-bg-color) var(--spinner-bg-color) var(--spinner-color) var(--spinner-bg-color);
         animation: spinner 1.2s linear infinite;
     }

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -31,6 +31,22 @@
     margin-bottom: 20px;
 }
 
+.readme-spinner {
+    padding: 40px 15px;
+    text-align: center;
+    font-size: 20px;
+    font-weight: 300;
+
+    code {
+        font-size: 18px;
+        font-weight: 500;
+    }
+}
+
+.readme-spinner > div {
+    --spinner-size: 35px;
+}
+
 .crate-downloads {
     display: flex;
     flex-wrap: wrap;

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -31,7 +31,8 @@
     margin-bottom: 20px;
 }
 
-.readme-spinner {
+.readme-spinner,
+.no-readme {
     padding: 40px 15px;
     text-align: center;
     font-size: 20px;

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -23,12 +23,9 @@
           <RenderedHtml @html={{this.readme}} local-class="readme" />
         </article>
       {{else}}
-        {{#if this.crate.description}}
-          <div local-class='about'>
-            <h3>About This Package</h3>
-            <p>{{ this.crate.description }}</p>
-          </div>
-        {{/if}}
+        <div local-class="no-readme">
+          {{this.crate.name}} v{{this.currentVersion.num}} appears to have no <code>README.md</code> file
+        </div>
       {{/if}}
     {{/if}}
   </div>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -14,7 +14,11 @@
         one that has not been yanked.
       </p>
     {{else}}
-      {{#if this.readme}}
+      {{#if this.loadReadmeTask.isRunning}}
+        <div local-class="readme-spinner">
+          <LoadingSpinner/>
+        </div>
+      {{else if this.readme}}
         <article aria-label="Readme">
           <RenderedHtml @html={{this.readme}} local-class="readme" />
         </article>


### PR DESCRIPTION
<img width="1127" alt="Bildschirmfoto 2021-02-25 um 18 52 09" src="https://user-images.githubusercontent.com/141300/109195299-a4e3e600-779a-11eb-9211-724bf0b37fd7.png">

This makes it easier to figure out on first glance what a crate does, without having to wait for and read through the README text.

