### PR TITLE
FrontPageList::Item::Placeholder: Adjust styling to match `FrontPageList::Item` component

### DIFF
--- a/app/components/front-page-list/item/placeholder.module.css
+++ b/app/components/front-page-list/item/placeholder.module.css
@@ -1,11 +1,17 @@
 .link {
+    --shadow: 0 2px 3px hsla(51, 50%, 44%, .35);
+
     display: flex;
     align-items: center;
     width: 100%;
-    min-height: 60px;
+    height: 60px;
     margin: 8px 0;
-    padding: 0 10px;
-    background-color: var(--main-bg-dark);
+    padding: 0 15px;
+    background-color: white;
+    color: #525252;
+    border-radius: 7px;
+    box-shadow: var(--shadow);
+    cursor: wait;
 }
 
 .left {
@@ -17,8 +23,7 @@
     height: 16px;
     width: 150px;
     border-radius: 8px;
-    background: rgb(118, 131, 138);
-    opacity: 0.25;
+    background: hsla(59deg, 19%, 50%, 0.25);
 }
 
 .subtitle {
@@ -26,8 +31,7 @@
     width: 90px;
     margin-top: 4px;
     border-radius: 6.5px;
-    background: rgb(118, 131, 138);
-    opacity: 0.2;
+    background: hsla(59deg, 19%, 50%, 0.2);
 }
 
 .right {


### PR DESCRIPTION
I totally forgot that during https://github.com/rust-lang/crates.io/pull/3282 ... 😱 

<img width="929" alt="Bildschirmfoto 2021-02-25 um 22 13 22" src="https://user-images.githubusercontent.com/141300/109217877-b3d89180-77b6-11eb-9e9d-1bf5a71f696d.png">
