### PR TITLE
Update license-exprs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "license-exprs"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb374efe4669153b6bb170a7c5063a4e570a4eb45e5daf0dab4c1543d4d6f197"
+checksum = "a577c3a5f3982766dd577c4440b86c53c6ffd42007e4c1d83d2da3ce9f99cc3d"
 
 [[package]]
 name = "lock_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ hyper = { version = "0.14", features = ["client", "http1"] }
 indexmap = "1.0.2"
 jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "0.10.0-alpha.1", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
-license-exprs = "^1.4"
+license-exprs = "1.6"
 oauth2 = { version = "4.0.0-alpha.3", default-features = false, features = ["reqwest"] }
 parking_lot = "0.11"
 rand = "0.7"


### PR DESCRIPTION
Updates license-exprs to 1.6 which brings in updates to validate with SPDX 3.11.