### PR TITLE
Bump to latest route-recognizer and cookie crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,11 +463,11 @@ dependencies = [
 
 [[package]]
 name = "conduit-cookie"
-version = "0.9.0-alpha.4"
+version = "0.9.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae03deb30e24d1dbcbb39cfb1c4a8ec4b584935aa928cf59fd93bb4b37099d68"
+checksum = "6df0d72704718f2206dc4d50d65fffedc461bc946d39239643086b8429727f4b"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.0",
  "conduit",
  "conduit-middleware",
  "cookie",
@@ -521,9 +521,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-router"
-version = "0.9.0-alpha.5"
+version = "0.9.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bbff14b0e1fb1c7a0f7f0991baeb6fbfb3b6e1c478b960a38b2abcb6e9e10b"
+checksum = "c17affd4f27912a18866139ff22cfb011b5c7e9fd7546e5bfef29fb7cba60173"
 dependencies = [
  "conduit",
  "route-recognizer",
@@ -574,16 +574,17 @@ checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "cookie"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784ad0fbab4f3e9cef09f20e0aea6000ae08d2cb98ac4c0abc53df18803d702f"
+checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
 dependencies = [
  "aes-gcm",
- "base64 0.12.3",
+ "base64 0.13.0",
  "hkdf",
  "hmac",
- "rand 0.7.3",
+ "rand 0.8.3",
  "sha2",
+ "subtle",
  "time 0.2.25",
  "version_check",
 ]
@@ -2221,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "route-recognizer"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56770675ebc04927ded3e60633437841581c285dc6236109ea25fbf3beb7b59e"
+checksum = "824172f0afccf3773c3905f5550ac94572144efe0deaf49a1f22bbca188d193e"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,14 @@ comrak = { version = "0.9", default-features = false }
 
 conduit = "0.9.0-alpha.5"
 conduit-conditional-get = "0.9.0-alpha.3"
-conduit-cookie = "0.9.0-alpha.4"
+conduit-cookie = "0.9.0-alpha.5"
 conduit-git-http-backend = "0.9.0-alpha.2"
 conduit-hyper = "0.3.0-alpha.7"
 conduit-middleware = "0.9.0-alpha.4"
-conduit-router = "0.9.0-alpha.3"
+conduit-router = "0.9.0-alpha.6"
 conduit-static = "0.9.0-alpha.3"
 
-cookie = { version = "0.14", features = ["secure"] }
+cookie = { version = "0.15", features = ["secure"] }
 ctrlc = { version = "3.0", features = ["termination"] }
 derive_deref = "1.1.1"
 dialoguer = "0.7.1"

--- a/src/router.rs
+++ b/src/router.rs
@@ -175,8 +175,8 @@ impl Handler for R404 {
         let R404(ref router) = *self;
         match router.recognize(&req.method(), req.path()) {
             Ok(m) => {
-                req.mut_extensions().insert(m.params.clone());
-                m.handler.call(req)
+                req.mut_extensions().insert(m.params().clone());
+                m.handler().call(req)
             }
             Err(..) => Ok(NotFound.into()),
         }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -230,13 +230,12 @@ pub fn encode_session_header(session_key: &str, user_id: i32) -> String {
     map.insert("user_id".into(), user_id.to_string());
 
     // encode the map into a cookie value string
-    let session_middleware = SessionMiddleware::new(cookie_name, cookie_key.clone(), false);
-    let encoded = session_middleware.encode(&map);
+    let encoded = SessionMiddleware::encode(&map);
 
     // put the cookie into a signed cookie jar
     let cookie = Cookie::build(cookie_name, encoded).finish();
     let mut jar = cookie::CookieJar::new();
-    jar.signed(&cookie_key).add(cookie);
+    jar.signed_mut(&cookie_key).add(cookie);
 
     // read the raw cookie from the cookie jar
     jar.get(&cookie_name).unwrap().to_string()


### PR DESCRIPTION
This bumps a few conduit crates to pull in the latest version of these dependencies.

r? @Turbo87 