### PR TITLE
VersionList::Row: Fix tooltip alignment in narrow viewport

### DIFF
--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -161,9 +161,11 @@
     }
 
     @media only screen and (max-width: 750px) {
-        > * {
-            display: block;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
 
+        > * {
             &:not(:first-child) {
                 margin-left: 0;
                 margin-top: 10px;


### PR DESCRIPTION
### Before
<img width="669" alt="Bildschirmfoto 2021-02-27 um 09 52 14" src="https://user-images.githubusercontent.com/141300/109382602-c13e6a80-78e1-11eb-8382-ac8dd1b4b27d.png">

### After
<img width="680" alt="Bildschirmfoto 2021-02-27 um 09 52 26" src="https://user-images.githubusercontent.com/141300/109382604-c4395b00-78e1-11eb-9f56-ee10a4964dbc.png">
