### PR TITLE
Upgrade `oauth2` to 4.0.0-alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.0.0-alpha.3"
+version = "4.0.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14be0cf9da49c1a5b2909ec626949dc549e0adda4e9e7f26e4908f08a5435227"
+checksum = "10eb04b69330e2ab6d9286193a5f5318cfa1998420178b1abc51475a3a4fe18b"
 dependencies = [
  "base64 0.12.3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ indexmap = "1.0.2"
 jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "0.10.0-alpha.1", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
 license-exprs = "1.6"
-oauth2 = { version = "4.0.0-alpha.3", default-features = false, features = ["reqwest"] }
+oauth2 = { version = "=4.0.0-alpha.6", default-features = false, features = ["reqwest"] }
 parking_lot = "0.11"
 rand = "0.8"
 reqwest = { version = "0.11", features = ["blocking", "gzip", "json"] }


### PR DESCRIPTION
The changes between alpha.3 and alpha.6: https://github.com/ramosbugs/oauth2-rs/compare/4.0.0-alpha.3...4.0.0-alpha.6

All the breaking changes mentioned on https://github.com/ramosbugs/oauth2-rs/releases and the changes themselves don't seem to affect our codebase.
Also pin its version to prevent updating by accident when running `cargo update`.

r? @jtgeibel 