### PR TITLE
Upgrade `lettre` to 0.10.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1360,9 +1360,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lettre"
-version = "0.10.0-alpha.5"
+version = "0.10.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34f3dd8d917156976a47ef421a2e771423d6da95e93696f1814e76768625c162"
+checksum = "0f060515ec950723c5482163457b3faad8c088810c4a01a42523bc98e15bcb3e"
 dependencies = [
  "base64 0.13.0",
  "hostname",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1"] }
 indexmap = "1.0.2"
 jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
-lettre = { version = "0.10.0-alpha.1", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
+lettre = { version = "=0.10.0-beta.1", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
 license-exprs = "1.6"
 oauth2 = { version = "4.0.0-alpha.3", default-features = false, features = ["reqwest"] }
 parking_lot = "0.11"


### PR DESCRIPTION
The changes between alpha.5 and beta.1: https://github.com/lettre/lettre/compare/v0.10.0-alpha.5...v0.10.0-beta.1

This release contains a lot of refactorings and a few new features. The default features have also changed but it won't affect here as we have `default-features = false`. Other changes also don't, at a glance.

(Separating PRs from oauth2's in case we find an issue.)