### PR TITLE
CrateSidebar: Move Playground explanation to a tooltip

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -139,11 +139,17 @@
         data-test-playground-button
       >
         Try on Rust Playground
+
+        {{#if this.canHover}}
+          <EmberTooltip @text="The top 100 crates are available on the Rust Playground for you to try out directly in your browser." />
+        {{/if}}
       </a>
-      <p local-class="playground-help" data-test-playground-help>
-        The top 100 crates are available on the Rust Playground for you to
-        try out directly in your browser.
-      </p>
+      {{#unless this.canHover}}
+        <p local-class="playground-help" data-test-playground-help>
+          The top 100 crates are available on the Rust Playground for you to
+          try out directly in your browser.
+        </p>
+      {{/unless}}
     </div>
   {{/if}}
 </section>

--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -41,6 +41,10 @@ export default class DownloadGraph extends Component {
     return `https://play.rust-lang.org/?code=use%20${playgroundCrate.id}%3B%0A%0Afn%20main()%20%7B%0A%20%20%20%20%2F%2F%20try%20using%20the%20%60${playgroundCrate.id}%60%20crate%20here%0A%7D`;
   }
 
+  get canHover() {
+    return window?.matchMedia('(hover: hover)').matches;
+  }
+
   constructor() {
     super(...arguments);
 

--- a/tests/components/crate-sidebar/playground-button-test.js
+++ b/tests/components/crate-sidebar/playground-button-test.js
@@ -37,7 +37,6 @@ module('Component | CrateSidebar | Playground Button', function (hooks) {
 
     await render(hbs`<CrateSidebar @crate={{this.crate}} @version={{this.version}} />`);
     assert.dom('[data-test-playground-button]').doesNotExist();
-    assert.dom('[data-test-playground-help]').doesNotExist();
   });
 
   test('button is visible for available crates', async function (assert) {
@@ -53,7 +52,6 @@ module('Component | CrateSidebar | Playground Button', function (hooks) {
 
     await render(hbs`<CrateSidebar @crate={{this.crate}} @version={{this.version}} />`);
     assert.dom('[data-test-playground-button]').hasAttribute('href', expectedHref);
-    assert.dom('[data-test-playground-help]').exists();
   });
 
   test('button is hidden while Playground request is pending', async function (assert) {
@@ -70,7 +68,6 @@ module('Component | CrateSidebar | Playground Button', function (hooks) {
     render(hbs`<CrateSidebar @crate={{this.crate}} @version={{this.version}} />`);
     await waitFor('[data-test-owners]');
     assert.dom('[data-test-playground-button]').doesNotExist();
-    assert.dom('[data-test-playground-help]').doesNotExist();
 
     deferred.resolve({ crates: [] });
     await settled();
@@ -88,6 +85,5 @@ module('Component | CrateSidebar | Playground Button', function (hooks) {
 
     await render(hbs`<CrateSidebar @crate={{this.crate}} @version={{this.version}} />`);
     assert.dom('[data-test-playground-button]').doesNotExist();
-    assert.dom('[data-test-playground-help]').doesNotExist();
   });
 });


### PR DESCRIPTION
### Before
<img width="353" alt="Bildschirmfoto 2021-03-05 um 22 56 58" src="https://user-images.githubusercontent.com/141300/110178003-1c9eba00-7e06-11eb-907d-10f2ef2a0c37.png">

### After
<img width="403" alt="Bildschirmfoto 2021-03-05 um 22 53 25" src="https://user-images.githubusercontent.com/141300/110177903-f842dd80-7e05-11eb-8538-93de3b9874d3.png">

This move a bit of noise from the sidebar into a tooltip that is shown when hovering over the button.