### PR TITLE
FollowButton: Avoid size changes

### DIFF
--- a/app/components/follow-button.module.css
+++ b/app/components/follow-button.module.css
@@ -1,3 +1,7 @@
 .button {
     composes: tan-button from '../styles/shared/buttons.module.css';
+
+    height: 48px;
+    width: 150px;
+    justify-content: center;
 }


### PR DESCRIPTION
Instead of having the button change its size depending on the content we now set a fixed size. This avoids annoying layout shifts when changing from text label to loading spinner and back, for example.