### PR TITLE
CrateSidebar: Move last update, license and crate size into new "Metadata" section

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -4,19 +4,37 @@
   ...attributes
 >
   <div local-class='top'>
-    <div>
-      <div local-class='last-update'>Last Updated</div>
-      <div local-class='{{if @version.crate_size 'date-with-small-margin-bot' 'date'}}'>
-        {{date-format-distance-to-now @crate.updated_at addSuffix=true}}
-      </div>
-    </div>
 
-    {{#if @version.crate_size}}
-      <div>
-        <div local-class='crate-size'>Crate Size</div>
-        <div local-class='size'>{{pretty-bytes @version.crate_size}}</div>
-      </div>
-    {{/if}}
+    <div local-class="metadata">
+      <h3>Metadata</h3>
+
+      <time
+        datetime={{date-format-iso @version.updated_at}}
+        local-class="date"
+      >
+        {{svg-jar "calendar"}}
+        <span>
+          {{date-format-distance-to-now @version.created_at addSuffix=true}}
+          <EmberTooltip @text={{date-format @version.created_at 'PPP'}} />
+        </span>
+      </time>
+
+      {{#if @version.license}}
+        <div local-class="license" data-test-license>
+          {{svg-jar "license"}}
+          <span>
+            <LicenseExpression @license={{@version.license}} />
+          </span>
+        </div>
+      {{/if}}
+
+      {{#if @version.crate_size}}
+        <div local-class="bytes">
+          {{svg-jar "weight"}}
+          {{pretty-bytes @version.crate_size}}
+        </div>
+      {{/if}}
+    </div>
 
     <div>
       <h3>Install</h3>
@@ -97,15 +115,6 @@
   </div>
 
   <div local-class='bottom'>
-    {{#if @version.license}}
-      <div>
-        <h3>License</h3>
-        <p data-test-license>
-          <LicenseExpression @license={{@version.license }} />
-        </p>
-      </div>
-    {{/if}}
-
     {{#unless @crate.categories.isPending}}
       {{#if @crate.categories}}
         <div>

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -29,30 +29,35 @@
     }
 }
 
-.last-update,
-.crate-size {
-    composes: small from '../styles/shared/typography.module.css';
-    line-height: 25px;
+.date,
+.license,
+.bytes {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+
+    svg {
+        flex-shrink: 0;
+        margin-right: 7px;
+        height: 1em;
+        width: auto;
+    }
 }
 
 .date {
-    font-weight: bold;
-    margin-bottom: 40px;
+    [title], :global(.ember-tooltip-target) {
+        cursor: help;
+    }
 }
 
-/*
-    Since crate_size is a new field, older crates won't have it.
-    Preserve behaviour for older crates. For newer ones, keep
-    `Crate Size` closer to last updated.
-*/
-.date-with-small-margin-bot {
-    font-weight: bold;
-    margin-bottom: 20px;
+.license {
+    a {
+        color: var(--main-color);
+    }
 }
 
-.size {
-    font-weight: bold;
-    margin-bottom: 40px;
+.bytes {
+    font-variant-numeric: tabular-nums;
 }
 
 .copy-help {


### PR DESCRIPTION
### Before
![Bildschirmfoto 2021-03-08 um 17 44 09](https://user-images.githubusercontent.com/141300/110352230-fa8b7e80-8035-11eb-8f25-abce9ed11520.png)

### After
![Bildschirmfoto 2021-03-08 um 17 43 57](https://user-images.githubusercontent.com/141300/110352225-f95a5180-8035-11eb-9589-801c4590c02b.png)
