### PR TITLE
Refactor some test code

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -357,7 +357,7 @@ mod tests {
     // in comrak 0.1.8 but was fixed in 0.1.9.
     #[test]
     fn text_with_fancy_single_quotes() {
-        let text = r#"wb’"#;
+        let text = "wb’";
         let result = markdown_to_html(text, None);
         assert_eq!(result, "<p>wb’</p>\n");
     }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -105,10 +105,6 @@ pub struct OkBool {
     ok: bool,
 }
 
-fn app() -> (Arc<App>, conduit_middleware::MiddlewareBuilder) {
-    build_app(simple_config(), None)
-}
-
 fn simple_config() -> Config {
     let uploader = Uploader::S3 {
         bucket: s3::Bucket::new(
@@ -265,11 +261,15 @@ fn new_category<'a>(category: &'a str, slug: &'a str, description: &'a str) -> N
     }
 }
 
+// This reflects the configuration of our test environment. In the production application, this
+// does not hold true.
 #[test]
 fn multiple_live_references_to_the_same_connection_can_be_checked_out() {
     use std::ptr;
 
-    let (app, _) = app();
+    let (app, _) = TestApp::init().empty();
+    let app = app.as_inner();
+
     let conn1 = app.primary_database.get().unwrap();
     let conn2 = app.primary_database.get().unwrap();
     let conn1_ref: &PgConnection = &conn1;

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -17,7 +17,6 @@ use crate::util::{RequestHelper, TestApp};
 use cargo_registry::{
     models::{Crate, CrateOwner, Dependency, NewCategory, NewTeam, NewUser, Team, User, Version},
     schema::crate_owners,
-    util::AppResponse,
     views::{
         EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
         EncodableOwner, EncodableVersion, GoodCrate,
@@ -32,7 +31,6 @@ use std::{
     },
 };
 
-use conduit::Body;
 use diesel::prelude::*;
 use reqwest::{blocking::Client, Proxy};
 
@@ -171,27 +169,6 @@ fn env(var: &str) -> String {
             "environment variable `{}` must be defined and valid unicode",
             var
         ),
-    }
-}
-
-fn json<T>(r: &mut AppResponse) -> T
-where
-    for<'de> T: serde::Deserialize<'de>,
-{
-    use conduit::Body::*;
-
-    let mut body = Body::empty();
-    std::mem::swap(r.body_mut(), &mut body);
-    let body: std::borrow::Cow<'static, [u8]> = match body {
-        Static(slice) => slice.into(),
-        Owned(vec) => vec.into(),
-        File(_) => unimplemented!(),
-    };
-
-    let s = std::str::from_utf8(&body).unwrap();
-    match serde_json::from_str(s) {
-        Ok(t) => t,
-        Err(e) => panic!("failed to decode: {:?}\n{}", e, s),
     }
 }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -15,7 +15,7 @@ extern crate tracing;
 
 use crate::util::{RequestHelper, TestApp};
 use cargo_registry::{
-    models::{Crate, CrateOwner, Dependency, NewCategory, NewTeam, NewUser, Team, User, Version},
+    models::{Crate, CrateOwner, NewCategory, NewTeam, NewUser, Team, User},
     schema::crate_owners,
     views::{
         EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
@@ -150,23 +150,6 @@ fn add_team_to_crate(t: &Team, krate: &Crate, u: &User, conn: &PgConnection) -> 
         .execute(conn)?;
 
     Ok(())
-}
-
-fn new_dependency(conn: &PgConnection, version: &Version, krate: &Crate) -> Dependency {
-    use cargo_registry::schema::dependencies::dsl::*;
-    use diesel::insert_into;
-
-    insert_into(dependencies)
-        .values((
-            version_id.eq(version.id),
-            crate_id.eq(krate.id),
-            req.eq(">= 0"),
-            optional.eq(false),
-            default_features.eq(false),
-            features.eq(Vec::<String>::new()),
-        ))
-        .get_result(conn)
-        .unwrap()
 }
 
 fn new_category<'a>(category: &'a str, slug: &'a str, description: &'a str) -> NewCategory<'a> {

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -1,44 +1,32 @@
-use crate::{util::RequestHelper, TestApp};
+use crate::util::{RequestHelper, Response};
+use crate::TestApp;
 
 use crate::util::encode_session_header;
-use conduit::{header, Handler, HandlerResult, Method, StatusCode};
-use conduit_test::MockRequest;
+use conduit::{header, Body, Method, StatusCode};
 
 static URL: &str = "/api/v1/me/updates";
 static MUST_LOGIN: &[u8] = br#"{"errors":[{"detail":"must be logged in to perform that action"}]}"#;
 static INTERNAL_ERROR_NO_USER: &str =
     "user_id from cookie not found in database caused by NotFound";
 
-fn call(app: &TestApp, mut request: MockRequest) -> HandlerResult {
-    app.as_middleware().call(&mut request)
-}
-
-fn into_parts(response: HandlerResult) -> (StatusCode, std::borrow::Cow<'static, [u8]>) {
-    use conduit_test::ResponseExt;
-
-    let response = response.unwrap();
-    (response.status(), response.into_cow())
-}
-
 #[test]
 fn anonymous_user_unauthorized() {
-    let (app, anon) = TestApp::init().empty();
-    let request = anon.request_builder(Method::GET, URL);
+    let (_, anon) = TestApp::init().empty();
+    let response: Response<Body> = anon.get(URL);
 
-    let (status, body) = into_parts(call(&app, request));
-    assert_eq!(status, StatusCode::FORBIDDEN);
-    assert_eq!(body, MUST_LOGIN);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.json().to_string().as_bytes(), MUST_LOGIN);
 }
 
 #[test]
 fn token_auth_cannot_find_token() {
-    let (app, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty();
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::AUTHORIZATION, "cio1tkfake-token");
+    let response: Response<Body> = anon.run(request);
 
-    let (status, body) = into_parts(call(&app, request));
-    assert_eq!(status, StatusCode::FORBIDDEN);
-    assert_eq!(body, MUST_LOGIN);
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.json().to_string().as_bytes(), MUST_LOGIN);
 }
 
 // Ensure that an unexpected authentication error is available for logging.  The user would see
@@ -54,7 +42,6 @@ fn cookie_auth_cannot_find_user() {
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::COOKIE, &cookie);
 
-    let response = call(&app, request);
-    let log_message = response.map(|_| ()).unwrap_err().to_string();
-    assert_eq!(log_message, INTERNAL_ERROR_NO_USER);
+    let error = anon.run_err(request);
+    assert_eq!(error.to_string(), INTERNAL_ERROR_NO_USER);
 }

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -5,8 +5,7 @@ use conduit::{header, Handler, HandlerResult, Method, StatusCode};
 use conduit_test::MockRequest;
 
 static URL: &str = "/api/v1/me/updates";
-static MUST_LOGIN: &[u8] =
-    b"{\"errors\":[{\"detail\":\"must be logged in to perform that action\"}]}";
+static MUST_LOGIN: &[u8] = br#"{"errors":[{"detail":"must be logged in to perform that action"}]}"#;
 static INTERNAL_ERROR_NO_USER: &str =
     "user_id from cookie not found in database caused by NotFound";
 

--- a/src/tests/krate/dependencies.rs
+++ b/src/tests/krate/dependencies.rs
@@ -1,5 +1,4 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
-use crate::new_dependency;
 use crate::util::{RequestHelper, TestApp};
 use cargo_registry::views::EncodableDependency;
 use http::StatusCode;
@@ -16,9 +15,10 @@ fn dependencies() {
 
     app.db(|conn| {
         let c1 = CrateBuilder::new("foo_deps", user.id).expect_build(conn);
-        let v = VersionBuilder::new("1.0.0").expect_build(c1.id, user.id, conn);
         let c2 = CrateBuilder::new("bar_deps", user.id).expect_build(conn);
-        new_dependency(conn, &v, &c2);
+        VersionBuilder::new("1.0.0")
+            .dependency(&c2, None)
+            .expect_build(c1.id, user.id, conn);
     });
 
     let deps: Deps = anon

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -222,7 +222,7 @@ fn new_krate_with_broken_dependency_requirement() {
 
     // create a request body with `version_req: "broken"`
     let (json, tarball) = crate_to_publish.build();
-    let new_json = json.replace("\"version_req\":\"1.2.3\"", "\"version_req\":\"broken\"");
+    let new_json = json.replace(r#""version_req":"1.2.3""#, r#""version_req":"broken""#);
     assert_ne!(json, new_json);
     let body = PublishBuilder::create_publish_body(&new_json, &tarball);
 

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -1,7 +1,7 @@
-use conduit::{header, Method};
-
 use crate::builders::*;
 use crate::util::*;
+
+use conduit::{header, Method, StatusCode};
 
 #[test]
 fn user_agent_is_required() {

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,8 +1,4 @@
-use crate::{
-    user::UserShowPrivateResponse,
-    util::{header, StatusCode},
-    RequestHelper, TestApp,
-};
+use crate::{user::UserShowPrivateResponse, RequestHelper, TestApp};
 use cargo_registry::{
     models::ApiToken,
     schema::api_tokens,
@@ -11,6 +7,7 @@ use cargo_registry::{
 };
 use std::collections::HashSet;
 
+use conduit::{header, StatusCode};
 use diesel::prelude::*;
 
 #[derive(Deserialize)]

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,7 +1,7 @@
 use crate::{
     builders::{CrateBuilder, VersionBuilder},
     new_user,
-    util::{MockCookieUser, RequestHelper, Response, StatusCode},
+    util::{MockCookieUser, RequestHelper, Response},
     OkBool, TestApp,
 };
 use cargo_registry::{
@@ -10,6 +10,7 @@ use cargo_registry::{
     views::{EncodablePrivateUser, EncodablePublicUser, EncodableVersion, OwnedCrate},
 };
 
+use conduit::StatusCode;
 use diesel::prelude::*;
 
 #[derive(Deserialize)]

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -34,7 +34,7 @@ use conduit::{BoxError, Handler, HandlerResult, Method};
 use conduit_cookie::SessionMiddleware;
 use conduit_test::MockRequest;
 
-pub use conduit::{header, StatusCode};
+use conduit::{header, StatusCode};
 use cookie::Cookie;
 use std::collections::HashMap;
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -23,23 +23,20 @@ use crate::{
     builders::PublishBuilder, CategoryListResponse, CategoryResponse, CrateList, CrateResponse,
     GoodCrate, OkBool, OwnersResponse, VersionResponse,
 };
-use cargo_registry::{
-    models::{ApiToken, CreatedApiToken, User},
-    util::AppResponse,
-};
-use serde_json::Value;
-use std::marker::PhantomData;
+use cargo_registry::models::{ApiToken, CreatedApiToken, User};
 
-use conduit::{BoxError, Handler, HandlerResult, Method};
+use conduit::{BoxError, Handler, Method};
 use conduit_cookie::SessionMiddleware;
 use conduit_test::MockRequest;
 
-use conduit::{header, StatusCode};
+use conduit::header;
 use cookie::Cookie;
 use std::collections::HashMap;
 
+mod response;
 mod test_app;
 
+pub use response::Response;
 pub use test_app::TestApp;
 
 /// This function can be used to create a `Cookie` header for mock requests that
@@ -323,80 +320,4 @@ impl MockTokenUser {
 #[derive(Deserialize, Debug)]
 pub struct Error {
     pub detail: String,
-}
-
-/// A type providing helper methods for working with responses
-#[must_use]
-pub struct Response<T> {
-    response: AppResponse,
-    return_type: PhantomData<T>,
-}
-
-impl<T> Response<T>
-where
-    for<'de> T: serde::Deserialize<'de>,
-{
-    /// Assert that the response is good and deserialize the message
-    #[track_caller]
-    pub fn good(mut self) -> T {
-        if !self.status().is_success() {
-            panic!("bad response: {:?}", self.status());
-        }
-        crate::json(&mut self.response)
-    }
-}
-
-impl<T> Response<T> {
-    #[track_caller]
-    fn new(response: HandlerResult) -> Self {
-        Self {
-            response: assert_ok!(response),
-            return_type: PhantomData,
-        }
-    }
-
-    /// Consume the response body and convert it to a JSON value
-    #[track_caller]
-    // TODO: Rename to into_json()
-    pub fn json(mut self) -> Value {
-        assert_eq!(
-            self.response
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .expect("Missing content-type header"),
-            "application/json; charset=utf-8"
-        );
-        crate::json(&mut self.response)
-    }
-
-    pub fn status(&self) -> StatusCode {
-        self.response.status()
-    }
-
-    #[track_caller]
-    pub fn assert_redirect_ends_with(&self, target: &str) -> &Self {
-        assert!(self
-            .response
-            .headers()
-            .get(header::LOCATION)
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .ends_with(target));
-        self
-    }
-}
-
-impl Response<()> {
-    /// Assert that the status code is 404
-    #[track_caller]
-    pub fn assert_not_found(&self) {
-        assert_eq!(StatusCode::NOT_FOUND, self.status());
-    }
-
-    /// Assert that the status code is 403
-    #[track_caller]
-    pub fn assert_forbidden(&self) {
-        assert_eq!(StatusCode::FORBIDDEN, self.status());
-    }
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -20,196 +20,27 @@
 //! to the underlying database model value (`User` and `ApiToken` respectively).
 
 use crate::{
-    builders::PublishBuilder, record, CategoryListResponse, CategoryResponse, CrateList,
-    CrateResponse, GoodCrate, OkBool, OwnersResponse, VersionResponse,
+    builders::PublishBuilder, CategoryListResponse, CategoryResponse, CrateList, CrateResponse,
+    GoodCrate, OkBool, OwnersResponse, VersionResponse,
 };
 use cargo_registry::{
-    background_jobs::Environment,
-    db::DieselPool,
-    git::{Credentials, RepositoryConfig},
     models::{ApiToken, CreatedApiToken, User},
     util::AppResponse,
-    App, Config,
 };
-use diesel::PgConnection;
 use serde_json::Value;
-use std::{marker::PhantomData, rc::Rc, sync::Arc, time::Duration};
-use swirl::Runner;
+use std::marker::PhantomData;
 
 use conduit::{BoxError, Handler, HandlerResult, Method};
 use conduit_cookie::SessionMiddleware;
 use conduit_test::MockRequest;
 
-use cargo_registry::git::Repository as WorkerRepository;
-use git2::Repository as UpstreamRepository;
-
-use url::Url;
-
 pub use conduit::{header, StatusCode};
 use cookie::Cookie;
 use std::collections::HashMap;
 
-pub fn init_logger() {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .without_time()
-        .with_test_writer()
-        .try_init();
-}
+mod test_app;
 
-struct TestAppInner {
-    app: Arc<App>,
-    // The bomb (if created) needs to be held in scope until the end of the test.
-    _bomb: Option<record::Bomb>,
-    middle: conduit_middleware::MiddlewareBuilder,
-    index: Option<UpstreamRepository>,
-    runner: Option<Runner<Environment, DieselPool>>,
-}
-
-impl Drop for TestAppInner {
-    fn drop(&mut self) {
-        use diesel::prelude::*;
-        use swirl::schema::background_jobs::dsl::*;
-
-        // Avoid a double-panic if the test is already failing
-        if std::thread::panicking() {
-            return;
-        }
-
-        // Lazily run any remaining jobs
-        if let Some(runner) = &self.runner {
-            runner.run_all_pending_jobs().expect("Could not run jobs");
-            runner.check_for_failed_jobs().expect("Failed jobs remain");
-        }
-
-        // Manually verify that all jobs have completed successfully
-        // This will catch any tests that enqueued a job but forgot to initialize the runner
-        let conn = self.app.primary_database.get().unwrap();
-        let job_count: i64 = background_jobs.count().get_result(&*conn).unwrap();
-        assert_eq!(
-            0, job_count,
-            "Unprocessed or failed jobs remain in the queue"
-        );
-
-        // TODO: If a runner was started, obtain the clone from it and ensure its HEAD matches the upstream index HEAD
-    }
-}
-
-/// A representation of the app and its database transaction
-#[derive(Clone)]
-pub struct TestApp(Rc<TestAppInner>);
-
-impl TestApp {
-    /// Initialize an application with an `Uploader` that panics
-    pub fn init() -> TestAppBuilder {
-        init_logger();
-
-        TestAppBuilder {
-            config: crate::simple_config(),
-            proxy: None,
-            bomb: None,
-            index: None,
-            build_job_runner: false,
-        }
-    }
-
-    /// Initialize the app and a proxy that can record and playback outgoing HTTP requests
-    pub fn with_proxy() -> TestAppBuilder {
-        Self::init().with_proxy()
-    }
-
-    /// Initialize a full application, with a proxy, index, and background worker
-    pub fn full() -> TestAppBuilder {
-        Self::with_proxy().with_git_index().with_job_runner()
-    }
-
-    /// Obtain the database connection and pass it to the closure
-    ///
-    /// Within each test, the connection pool only has 1 connection so it is necessary to drop the
-    /// connection before making any API calls.  Once the closure returns, the connection is
-    /// dropped, ensuring it is returned to the pool and available for any future API calls.
-    pub fn db<T, F: FnOnce(&PgConnection) -> T>(&self, f: F) -> T {
-        let conn = self.0.app.primary_database.get().unwrap();
-        f(&conn)
-    }
-
-    /// Create a new user with a verified email address in the database and return a mock user
-    /// session
-    ///
-    /// This method updates the database directly
-    pub fn db_new_user(&self, username: &str) -> MockCookieUser {
-        use cargo_registry::schema::emails;
-        use diesel::prelude::*;
-
-        let user = self.db(|conn| {
-            let email = "something@example.com";
-
-            let user = crate::new_user(username)
-                .create_or_update(None, conn)
-                .unwrap();
-            diesel::insert_into(emails::table)
-                .values((
-                    emails::user_id.eq(user.id),
-                    emails::email.eq(email),
-                    emails::verified.eq(true),
-                ))
-                .execute(conn)
-                .unwrap();
-            user
-        });
-        MockCookieUser {
-            app: TestApp(Rc::clone(&self.0)),
-            user,
-        }
-    }
-
-    /// Obtain a reference to the upstream repository ("the index")
-    pub fn upstream_repository(&self) -> &UpstreamRepository {
-        self.0.index.as_ref().unwrap()
-    }
-
-    /// Obtain a list of crates from the index HEAD
-    pub fn crates_from_index_head(&self, path: &str) -> Vec<cargo_registry::git::Crate> {
-        let path = std::path::Path::new(path);
-        let index = self.upstream_repository();
-        let tree = index.head().unwrap().peel_to_tree().unwrap();
-        let blob = tree
-            .get_path(path)
-            .unwrap()
-            .to_object(&index)
-            .unwrap()
-            .peel_to_blob()
-            .unwrap();
-        let content = blob.content();
-
-        // The index format consists of one JSON object per line
-        // It is not a JSON array
-        let lines = std::str::from_utf8(content).unwrap().lines();
-        lines
-            .map(|line| serde_json::from_str(line).unwrap())
-            .collect()
-    }
-
-    pub fn run_pending_background_jobs(&self) {
-        let runner = &self.0.runner;
-        let runner = runner.as_ref().expect("Index has not been initialized");
-
-        runner.run_all_pending_jobs().expect("Could not run jobs");
-        runner
-            .check_for_failed_jobs()
-            .expect("Could not determine if jobs failed");
-    }
-
-    /// Obtain a reference to the inner `App` value
-    pub fn as_inner(&self) -> &App {
-        &self.0.app
-    }
-
-    /// Obtain a reference to the inner middleware builder
-    pub fn as_middleware(&self) -> &conduit_middleware::MiddlewareBuilder {
-        &self.0.middle
-    }
-}
+pub use test_app::TestApp;
 
 /// This function can be used to create a `Cookie` header for mock requests that
 /// include cookie-based authentication.
@@ -239,111 +70,6 @@ pub fn encode_session_header(session_key: &str, user_id: i32) -> String {
 
     // read the raw cookie from the cookie jar
     jar.get(&cookie_name).unwrap().to_string()
-}
-
-pub struct TestAppBuilder {
-    config: Config,
-    proxy: Option<String>,
-    bomb: Option<record::Bomb>,
-    index: Option<UpstreamRepository>,
-    build_job_runner: bool,
-}
-
-impl TestAppBuilder {
-    /// Create a `TestApp` with an empty database
-    pub fn empty(self) -> (TestApp, MockAnonymousUser) {
-        use crate::git;
-
-        let (app, middle) = crate::build_app(self.config, self.proxy);
-
-        let runner = if self.build_job_runner {
-            let repository_config = RepositoryConfig {
-                index_location: Url::from_file_path(&git::bare()).unwrap(),
-                credentials: Credentials::Missing,
-            };
-            let index = WorkerRepository::open(&repository_config).expect("Could not clone index");
-            let environment = Environment::new(
-                index,
-                app.config.uploader.clone(),
-                app.http_client().clone(),
-            );
-
-            Some(
-                Runner::builder(environment)
-                    // We only have 1 connection in tests, so trying to run more than
-                    // 1 job concurrently will just block
-                    .thread_count(1)
-                    .connection_pool(app.primary_database.clone())
-                    .job_start_timeout(Duration::from_secs(5))
-                    .build(),
-            )
-        } else {
-            None
-        };
-
-        let test_app_inner = TestAppInner {
-            app,
-            _bomb: self.bomb,
-            middle,
-            index: self.index,
-            runner,
-        };
-        let test_app = TestApp(Rc::new(test_app_inner));
-        let anon = MockAnonymousUser {
-            app: test_app.clone(),
-        };
-        (test_app, anon)
-    }
-
-    /// Create a proxy for use with this app
-    pub fn with_proxy(mut self) -> Self {
-        let (proxy, bomb) = record::proxy();
-        self.proxy = Some(proxy);
-        self.bomb = Some(bomb);
-        self
-    }
-
-    // Create a `TestApp` with a database including a default user
-    pub fn with_user(self) -> (TestApp, MockAnonymousUser, MockCookieUser) {
-        let (app, anon) = self.empty();
-        let user = app.db_new_user("foo");
-        (app, anon, user)
-    }
-
-    /// Create a `TestApp` with a database including a default user and its token
-    pub fn with_token(self) -> (TestApp, MockAnonymousUser, MockCookieUser, MockTokenUser) {
-        let (app, anon) = self.empty();
-        let user = app.db_new_user("foo");
-        let token = user.db_new_token("bar");
-        (app, anon, user, token)
-    }
-
-    pub fn with_config(mut self, f: impl FnOnce(&mut Config)) -> Self {
-        f(&mut self.config);
-        self
-    }
-
-    pub fn with_publish_rate_limit(self, rate: Duration, burst: i32) -> Self {
-        self.with_config(|config| {
-            config.publish_rate_limit.rate = rate;
-            config.publish_rate_limit.burst = burst;
-        })
-    }
-
-    pub fn with_git_index(mut self) -> Self {
-        use crate::git;
-
-        git::init();
-
-        let thread_local_path = git::bare();
-        self.index = Some(UpstreamRepository::open_bare(thread_local_path).unwrap());
-        self
-    }
-
-    pub fn with_job_runner(mut self) -> Self {
-        self.build_job_runner = true;
-        self
-    }
 }
 
 /// A collection of helper methods for the 3 authentication types
@@ -507,7 +233,7 @@ impl MockCookieUser {
     /// Creates an instance from a database `User` instance
     pub fn new(app: &TestApp, user: User) -> Self {
         Self {
-            app: TestApp(Rc::clone(&app.0)),
+            app: app.clone(),
             user,
         }
     }
@@ -525,7 +251,7 @@ impl MockCookieUser {
             .app
             .db(|conn| ApiToken::insert(conn, self.user.id, name).unwrap());
         MockTokenUser {
-            app: TestApp(Rc::clone(&self.app.0)),
+            app: self.app.clone(),
             token,
         }
     }

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -1,0 +1,83 @@
+use cargo_registry::util::AppResponse;
+use serde_json::Value;
+use std::marker::PhantomData;
+
+use conduit::HandlerResult;
+
+use conduit::{header, StatusCode};
+
+/// A type providing helper methods for working with responses
+#[must_use]
+pub struct Response<T> {
+    response: AppResponse,
+    return_type: PhantomData<T>,
+}
+
+impl<T> Response<T>
+where
+    for<'de> T: serde::Deserialize<'de>,
+{
+    /// Assert that the response is good and deserialize the message
+    #[track_caller]
+    pub fn good(mut self) -> T {
+        if !self.status().is_success() {
+            panic!("bad response: {:?}", self.status());
+        }
+        crate::json(&mut self.response)
+    }
+}
+
+impl<T> Response<T> {
+    #[track_caller]
+    pub(super) fn new(response: HandlerResult) -> Self {
+        Self {
+            response: assert_ok!(response),
+            return_type: PhantomData,
+        }
+    }
+
+    /// Consume the response body and convert it to a JSON value
+    #[track_caller]
+    // TODO: Rename to into_json()
+    pub fn json(mut self) -> Value {
+        assert_eq!(
+            self.response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .expect("Missing content-type header"),
+            "application/json; charset=utf-8"
+        );
+        crate::json(&mut self.response)
+    }
+
+    pub fn status(&self) -> StatusCode {
+        self.response.status()
+    }
+
+    #[track_caller]
+    pub fn assert_redirect_ends_with(&self, target: &str) -> &Self {
+        assert!(self
+            .response
+            .headers()
+            .get(header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .ends_with(target));
+        self
+    }
+}
+
+impl Response<()> {
+    /// Assert that the status code is 404
+    #[track_caller]
+    pub fn assert_not_found(&self) {
+        assert_eq!(StatusCode::NOT_FOUND, self.status());
+    }
+
+    /// Assert that the status code is 403
+    #[track_caller]
+    pub fn assert_forbidden(&self) {
+        assert_eq!(StatusCode::FORBIDDEN, self.status());
+    }
+}

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -40,13 +40,6 @@ impl<T> Response<T> {
     #[track_caller]
     // TODO: Rename to into_json()
     pub fn json(mut self) -> Value {
-        assert_eq!(
-            self.response
-                .headers()
-                .get(header::CONTENT_TYPE)
-                .expect("Missing content-type header"),
-            "application/json; charset=utf-8"
-        );
         json(&mut self.response)
     }
 
@@ -95,6 +88,23 @@ where
         Owned(vec) => vec.into(),
         File(_) => unimplemented!(),
     };
+
+    assert_eq!(
+        r.headers()
+            .get(header::CONTENT_TYPE)
+            .expect("Missing content-type header"),
+        "application/json; charset=utf-8"
+    );
+
+    assert_eq!(
+        r.headers()
+            .get(header::CONTENT_LENGTH)
+            .expect("Missing content-length header")
+            .to_str()
+            .unwrap()
+            .parse(),
+        Ok(body.len())
+    );
 
     let s = std::str::from_utf8(&body).unwrap();
     match serde_json::from_str(s) {

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -106,9 +106,8 @@ where
         Ok(body.len())
     );
 
-    let s = std::str::from_utf8(&body).unwrap();
-    match serde_json::from_str(s) {
+    match serde_json::from_slice(&*body) {
         Ok(t) => t,
-        Err(e) => panic!("failed to decode: {:?}\n{}", e, s),
+        Err(e) => panic!("failed to decode: {:?}", e),
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -1,0 +1,283 @@
+use super::{MockAnonymousUser, MockCookieUser, MockTokenUser};
+use crate::record;
+use cargo_registry::{
+    background_jobs::Environment,
+    db::DieselPool,
+    git::{Credentials, RepositoryConfig},
+    App, Config,
+};
+use diesel::PgConnection;
+use std::{rc::Rc, sync::Arc, time::Duration};
+use swirl::Runner;
+
+use cargo_registry::git::Repository as WorkerRepository;
+use git2::Repository as UpstreamRepository;
+
+use url::Url;
+
+struct TestAppInner {
+    app: Arc<App>,
+    // The bomb (if created) needs to be held in scope until the end of the test.
+    _bomb: Option<record::Bomb>,
+    middle: conduit_middleware::MiddlewareBuilder,
+    index: Option<UpstreamRepository>,
+    runner: Option<Runner<Environment, DieselPool>>,
+}
+
+impl Drop for TestAppInner {
+    fn drop(&mut self) {
+        use diesel::prelude::*;
+        use swirl::schema::background_jobs::dsl::*;
+
+        // Avoid a double-panic if the test is already failing
+        if std::thread::panicking() {
+            return;
+        }
+
+        // Lazily run any remaining jobs
+        if let Some(runner) = &self.runner {
+            runner.run_all_pending_jobs().expect("Could not run jobs");
+            runner.check_for_failed_jobs().expect("Failed jobs remain");
+        }
+
+        // Manually verify that all jobs have completed successfully
+        // This will catch any tests that enqueued a job but forgot to initialize the runner
+        let conn = self.app.primary_database.get().unwrap();
+        let job_count: i64 = background_jobs.count().get_result(&*conn).unwrap();
+        assert_eq!(
+            0, job_count,
+            "Unprocessed or failed jobs remain in the queue"
+        );
+
+        // TODO: If a runner was started, obtain the clone from it and ensure its HEAD matches the upstream index HEAD
+    }
+}
+
+/// A representation of the app and its database transaction
+#[derive(Clone)]
+pub struct TestApp(Rc<TestAppInner>);
+
+impl TestApp {
+    /// Initialize an application with an `Uploader` that panics
+    pub fn init() -> TestAppBuilder {
+        init_logger();
+
+        TestAppBuilder {
+            config: crate::simple_config(),
+            proxy: None,
+            bomb: None,
+            index: None,
+            build_job_runner: false,
+        }
+    }
+
+    /// Initialize the app and a proxy that can record and playback outgoing HTTP requests
+    pub fn with_proxy() -> TestAppBuilder {
+        Self::init().with_proxy()
+    }
+
+    /// Initialize a full application, with a proxy, index, and background worker
+    pub fn full() -> TestAppBuilder {
+        Self::with_proxy().with_git_index().with_job_runner()
+    }
+
+    /// Obtain the database connection and pass it to the closure
+    ///
+    /// Within each test, the connection pool only has 1 connection so it is necessary to drop the
+    /// connection before making any API calls.  Once the closure returns, the connection is
+    /// dropped, ensuring it is returned to the pool and available for any future API calls.
+    pub fn db<T, F: FnOnce(&PgConnection) -> T>(&self, f: F) -> T {
+        let conn = self.0.app.primary_database.get().unwrap();
+        f(&conn)
+    }
+
+    /// Create a new user with a verified email address in the database and return a mock user
+    /// session
+    ///
+    /// This method updates the database directly
+    pub fn db_new_user(&self, username: &str) -> MockCookieUser {
+        use cargo_registry::schema::emails;
+        use diesel::prelude::*;
+
+        let user = self.db(|conn| {
+            let email = "something@example.com";
+
+            let user = crate::new_user(username)
+                .create_or_update(None, conn)
+                .unwrap();
+            diesel::insert_into(emails::table)
+                .values((
+                    emails::user_id.eq(user.id),
+                    emails::email.eq(email),
+                    emails::verified.eq(true),
+                ))
+                .execute(conn)
+                .unwrap();
+            user
+        });
+        MockCookieUser {
+            app: self.clone(),
+            user,
+        }
+    }
+
+    /// Obtain a reference to the upstream repository ("the index")
+    pub fn upstream_repository(&self) -> &UpstreamRepository {
+        self.0.index.as_ref().unwrap()
+    }
+
+    /// Obtain a list of crates from the index HEAD
+    pub fn crates_from_index_head(&self, path: &str) -> Vec<cargo_registry::git::Crate> {
+        let path = std::path::Path::new(path);
+        let index = self.upstream_repository();
+        let tree = index.head().unwrap().peel_to_tree().unwrap();
+        let blob = tree
+            .get_path(path)
+            .unwrap()
+            .to_object(&index)
+            .unwrap()
+            .peel_to_blob()
+            .unwrap();
+        let content = blob.content();
+
+        // The index format consists of one JSON object per line
+        // It is not a JSON array
+        let lines = std::str::from_utf8(content).unwrap().lines();
+        lines
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    pub fn run_pending_background_jobs(&self) {
+        let runner = &self.0.runner;
+        let runner = runner.as_ref().expect("Index has not been initialized");
+
+        runner.run_all_pending_jobs().expect("Could not run jobs");
+        runner
+            .check_for_failed_jobs()
+            .expect("Could not determine if jobs failed");
+    }
+
+    /// Obtain a reference to the inner `App` value
+    pub fn as_inner(&self) -> &App {
+        &self.0.app
+    }
+
+    /// Obtain a reference to the inner middleware builder
+    pub fn as_middleware(&self) -> &conduit_middleware::MiddlewareBuilder {
+        &self.0.middle
+    }
+}
+
+pub struct TestAppBuilder {
+    config: Config,
+    proxy: Option<String>,
+    bomb: Option<record::Bomb>,
+    index: Option<UpstreamRepository>,
+    build_job_runner: bool,
+}
+
+impl TestAppBuilder {
+    /// Create a `TestApp` with an empty database
+    pub fn empty(self) -> (TestApp, MockAnonymousUser) {
+        use crate::git;
+
+        let (app, middle) = crate::build_app(self.config, self.proxy);
+
+        let runner = if self.build_job_runner {
+            let repository_config = RepositoryConfig {
+                index_location: Url::from_file_path(&git::bare()).unwrap(),
+                credentials: Credentials::Missing,
+            };
+            let index = WorkerRepository::open(&repository_config).expect("Could not clone index");
+            let environment = Environment::new(
+                index,
+                app.config.uploader.clone(),
+                app.http_client().clone(),
+            );
+
+            Some(
+                Runner::builder(environment)
+                    // We only have 1 connection in tests, so trying to run more than
+                    // 1 job concurrently will just block
+                    .thread_count(1)
+                    .connection_pool(app.primary_database.clone())
+                    .job_start_timeout(Duration::from_secs(5))
+                    .build(),
+            )
+        } else {
+            None
+        };
+
+        let test_app_inner = TestAppInner {
+            app,
+            _bomb: self.bomb,
+            middle,
+            index: self.index,
+            runner,
+        };
+        let test_app = TestApp(Rc::new(test_app_inner));
+        let anon = MockAnonymousUser {
+            app: test_app.clone(),
+        };
+        (test_app, anon)
+    }
+
+    /// Create a proxy for use with this app
+    pub fn with_proxy(mut self) -> Self {
+        let (proxy, bomb) = record::proxy();
+        self.proxy = Some(proxy);
+        self.bomb = Some(bomb);
+        self
+    }
+
+    // Create a `TestApp` with a database including a default user
+    pub fn with_user(self) -> (TestApp, MockAnonymousUser, MockCookieUser) {
+        let (app, anon) = self.empty();
+        let user = app.db_new_user("foo");
+        (app, anon, user)
+    }
+
+    /// Create a `TestApp` with a database including a default user and its token
+    pub fn with_token(self) -> (TestApp, MockAnonymousUser, MockCookieUser, MockTokenUser) {
+        let (app, anon) = self.empty();
+        let user = app.db_new_user("foo");
+        let token = user.db_new_token("bar");
+        (app, anon, user, token)
+    }
+
+    pub fn with_config(mut self, f: impl FnOnce(&mut Config)) -> Self {
+        f(&mut self.config);
+        self
+    }
+
+    pub fn with_publish_rate_limit(self, rate: Duration, burst: i32) -> Self {
+        self.with_config(|config| {
+            config.publish_rate_limit.rate = rate;
+            config.publish_rate_limit.burst = burst;
+        })
+    }
+
+    pub fn with_git_index(mut self) -> Self {
+        use crate::git;
+
+        git::init();
+
+        let thread_local_path = git::bare();
+        self.index = Some(UpstreamRepository::open_bare(thread_local_path).unwrap());
+        self
+    }
+
+    pub fn with_job_runner(mut self) -> Self {
+        self.build_job_runner = true;
+        self
+    }
+}
+
+pub fn init_logger() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .without_time()
+        .with_test_writer()
+        .try_init();
+}


### PR DESCRIPTION
It is best to review per-commit, as some logic is split into sub-modules under `util` which obscures the smaller diffs within. The individual commits should all be straightforward.

In particular, many `T: serde::Deserialize` bounds are removed from various test helper methods, which allowed some remaining on-off tests to switch over to the test helpers.

r? @Turbo87 