### PR TITLE
Handle invalid docs.rs responses better (fixes #3348)

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -142,7 +142,7 @@ export default class Version extends Model {
   @computed('loadDocsBuildsTask.lastSuccessful.value')
   get hasDocsRsLink() {
     let docsBuilds = this.loadDocsBuildsTask.lastSuccessful?.value;
-    return docsBuilds && docsBuilds.length !== 0 && docsBuilds[0].build_status === true;
+    return docsBuilds?.[0]?.build_status === true;
   }
 
   get docsRsLink() {

--- a/tests/routes/crate/version/docs-link-test.js
+++ b/tests/routes/crate/version/docs-link-test.js
@@ -81,4 +81,24 @@ module('Route | crate.version | docs link', function (hooks) {
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
   });
+
+  test('null builds in docs.rs responses are ignored', async function (assert) {
+    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crateId: 'foo', num: '0.6.2' });
+
+    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [null]);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
+  });
+
+  test('empty arrays in docs.rs responses are ignored', async function (assert) {
+    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crateId: 'foo', num: '0.6.2' });
+
+    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
+  });
 });


### PR DESCRIPTION
Is running `this.server.get` in one test twice ok?

Fixes #3348