### PR TITLE
CrateSidebar::Link: Fix missing line breaks in long URLs

### DIFF
--- a/app/components/crate-sidebar/link.hbs
+++ b/app/components/crate-sidebar/link.hbs
@@ -9,7 +9,7 @@
       {{svg-jar "link" local-class="icon" data-test-icon="link"}}
     {{/if}}
 
-    <a href={{@url}} data-test-link>
+    <a href={{@url}} local-class="link" data-test-link>
       {{this.text}}
     </a>
   </div>

--- a/app/components/crate-sidebar/link.js
+++ b/app/components/crate-sidebar/link.js
@@ -1,17 +1,23 @@
 import Component from '@glimmer/component';
 
 export default class CrateSidebarLink extends Component {
-  get text() {
+  get simplifiedUrl() {
     let { url } = this.args;
     return simplifyUrl(url);
   }
 
+  get text() {
+    // Add zero-width space characters around `/` and `.` characters
+    // to allow more line breaks in the middle of long URLs
+    return this.simplifiedUrl.replace(/([./])/g, '\u200B$1\u200B');
+  }
+
   get isDocsRs() {
-    return this.text.startsWith('docs.rs/');
+    return this.simplifiedUrl.startsWith('docs.rs/');
   }
 
   get isGitHub() {
-    return this.text.startsWith('github.com/');
+    return this.simplifiedUrl.startsWith('github.com/');
   }
 }
 

--- a/app/components/crate-sidebar/link.module.css
+++ b/app/components/crate-sidebar/link.module.css
@@ -9,3 +9,8 @@
     width: auto;
     margin-right: 7px;
 }
+
+.link {
+    word-break: break-word;
+    hyphens: auto;
+}


### PR DESCRIPTION
Some crates use long URLs for their websites and this currently makes the sidebar look ugly, because the links don't break properly. This can be reproduced on e.g. https://crates.io/crates/criterion

This PR fixes it by 1) adjusting the CSS of the links to allow for more line breaks, and 2) inserting zero-width spaces around `/` and `.` characters in the URL to allow for more natural line breaks.

### Before

<img width="369" alt="Bildschirmfoto 2021-03-11 um 18 00 59" src="https://user-images.githubusercontent.com/141300/110824911-c57c6780-8293-11eb-965d-66d9b47b8249.png">

### After

<img width="315" alt="Bildschirmfoto 2021-03-11 um 18 00 36" src="https://user-images.githubusercontent.com/141300/110824898-c31a0d80-8293-11eb-95f3-9b758c3156b9.png">

