### PR TITLE
CrateSidebar::Link: Use ellipsis suffix for long URLs

### DIFF
--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -1,7 +1,6 @@
 .sidebar {
     .top, .bottom {
         display: flex;
-        flex-wrap: wrap;
     }
 
     .top > * { flex: 1 }

--- a/app/components/crate-sidebar/link.hbs
+++ b/app/components/crate-sidebar/link.hbs
@@ -9,7 +9,7 @@
       {{svg-jar "link" local-class="icon" data-test-icon="link"}}
     {{/if}}
 
-    <a href={{@url}} data-test-link>
+    <a href={{@url}} local-class="link" data-test-link>
       {{this.text}}
     </a>
   </div>

--- a/app/components/crate-sidebar/link.module.css
+++ b/app/components/crate-sidebar/link.module.css
@@ -9,3 +9,9 @@
     width: auto;
     margin-right: 7px;
 }
+
+.link {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -1,10 +1,7 @@
 .crate-info {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-
     @media only screen and (min-width: 890px) {
-        flex-direction: row;
+        display: grid;
+        grid-template-columns: minmax(0, 7fr) minmax(0, 3fr);
     }
 }
 
@@ -24,8 +21,6 @@
     }
 
     @media only screen and (min-width: 890px) {
-        flex: 7;
-        max-width: 640px;
         margin-bottom: 0;
     }
 }
@@ -58,7 +53,6 @@
 
 .sidebar {
     @media only screen and (min-width: 890px) {
-        flex: 3;
         margin-top: 20px;
         margin-left: 20px;
     }


### PR DESCRIPTION
This is an alternative for https://github.com/rust-lang/crates.io/pull/3395, which uses `text-overflow: ellipsis` instead. This shortens the URLs and uses an `…` suffix instead, if they get too long. The downside is that the full URL is not displayed if the URL is too long, but it looks like GitHub and npm use the same pattern in their UIs, so it might not be so bad 😅 

I also had to convert the README/Sidebar container element to use CSS grid instead of flexbox to make the ellipsis work properly. Maybe I missed something but I couldn't get it to work when using all of the nested flexbox elements.

### Before

<img width="369" alt="Bildschirmfoto 2021-03-11 um 18 00 59" src="https://user-images.githubusercontent.com/141300/110830711-cadcb080-8299-11eb-8665-1deb21ac809e.png">

### After

<img width="301" alt="Bildschirmfoto 2021-03-11 um 18 44 05" src="https://user-images.githubusercontent.com/141300/110830723-cdd7a100-8299-11eb-8dce-7ec211f4c144.png">
