### PR TITLE
Log how much each step takes on slow downloads

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -8,7 +8,11 @@ use conduit::{header, Host, RequestExt, Scheme, StatusCode};
 use conduit_cookie::RequestSession;
 use sentry::Level;
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
+use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 const SLOW_REQUEST_THRESHOLD_MS: u64 = 1000;
 
@@ -59,6 +63,28 @@ pub fn add_custom_metadata<V: Display>(req: &mut dyn RequestExt, key: &'static s
         };
         metadata.entries.push((key, value.to_string()));
         req.mut_extensions().insert(metadata);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TimingRecorder {
+    sections: Rc<RefCell<HashMap<&'static str, Duration>>>,
+}
+
+impl TimingRecorder {
+    pub fn new() -> Self {
+        Self {
+            sections: Rc::new(RefCell::new(HashMap::new())),
+        }
+    }
+
+    pub fn record<R>(&self, name: &'static str, f: impl FnOnce() -> R) -> R {
+        let start = Instant::now();
+        let res = f();
+        self.sections
+            .borrow_mut()
+            .insert(name, Instant::now() - start);
+        res
     }
 }
 
@@ -195,6 +221,17 @@ impl Display for RequestLine<'_> {
 
         if self.response_time > SLOW_REQUEST_THRESHOLD_MS {
             line.add_marker("SLOW REQUEST")?;
+
+            if let Some(timings) = self.req.extensions().find::<TimingRecorder>() {
+                for (section, duration) in timings.sections.borrow().iter() {
+                    line.add_quoted_field(
+                        format!("timing_{}", section),
+                        // Debug formatting rounds the duration to the most useful unit and adds
+                        // the unit suffix. For example: 1.20s, 10.00ms, 8.35ns
+                        format!("{:.2?}", duration),
+                    )?;
+                }
+            }
         }
 
         Ok(())


### PR DESCRIPTION
We're getting increasingly frequent pages about quick bursts of really slow download requests. Unfortunately the amount of logging and monitoring we currently have available is not enough to properly pin down what's causing this.

This PR adds instrumentation to the download endpoint to log how much each potentially slow step (getting a db connection, getting the version info and updating the download count) takes, and the infrastructure to support such instrumentation.

To avoid outputting too much stuff into the log lines, the detailed timings are only shown on slow requests.

r? @jtgeibel 