### PR TITLE
Capture request start time in nginx for calculating response times

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -224,8 +224,10 @@ http {
 
 		add_header Strict-Transport-Security "max-age=31536000" always;
 		add_header Vary 'Accept, Accept-Encoding, Cookie';
+
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Real-Ip $remote_addr;
+		proxy_set_header X-Request-Start $msec;
 		proxy_redirect off;
 		if ($http_x_forwarded_proto != 'https') {
 			rewrite ^ https://$host$request_uri? permanent;


### PR DESCRIPTION
This works because the nginx proxy and application are running on the
same machine. For local development, which is not typically run behind
nginx, the previous calculation based on the in-app web server is used
as a fallback.

r? @pietroalbini