### PR TITLE
reverse-dependencies: Show "no results" message instead of empty list

### DIFF
--- a/app/styles/crate/reverse-dependencies.module.css
+++ b/app/styles/crate/reverse-dependencies.module.css
@@ -42,3 +42,8 @@
 .rev-dep-downloads {
     padding-left: 7px
 }
+
+.no-results {
+    text-align: center;
+    margin: 20px;
+}

--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -1,29 +1,35 @@
 <CrateHeader @crate={{this.crate}} />
 
-<div local-class="results-meta">
-  <ResultsCount
-    @start={{this.pagination.currentPageStart}}
-    @end={{this.pagination.currentPageEnd}}
-    @total={{this.totalItems}}
-    @name="reverse dependencies of {{this.crate.name}}"
-  />
-</div>
+{{#if this.model}}
+  <div local-class="results-meta">
+    <ResultsCount
+      @start={{this.pagination.currentPageStart}}
+      @end={{this.pagination.currentPageEnd}}
+      @total={{this.totalItems}}
+      @name="reverse dependencies of {{this.crate.name}}"
+    />
+  </div>
 
-<div local-class="list" data-test-list>
-  {{#each this.model as |dependency index|}}
-    <div local-class="row" data-test-row={{index}}>
-      <div>
-        <LinkTo @route="crate" @model={{dependency.version.crateName}} data-test-crate-name>
-          {{dependency.version.crateName}}
-        </LinkTo>
-        requires {{dependency.req}}
+  <div local-class="list" data-test-list>
+    {{#each this.model as |dependency index|}}
+      <div local-class="row" data-test-row={{index}}>
+        <div>
+          <LinkTo @route="crate" @model={{dependency.version.crateName}} data-test-crate-name>
+            {{dependency.version.crateName}}
+          </LinkTo>
+          requires {{dependency.req}}
+        </div>
+        <div local-class="stats downloads">
+          {{svg-jar "download-arrow" local-class="download-icon"}}
+          <span local-class="rev-dep-downloads">{{ format-num dependency.downloads }}</span>
+        </div>
       </div>
-      <div local-class="stats downloads">
-        {{svg-jar "download-arrow" local-class="download-icon"}}
-        <span local-class="rev-dep-downloads">{{ format-num dependency.downloads }}</span>
-      </div>
-    </div>
-  {{/each}}
-</div>
+    {{/each}}
+  </div>
 
-<Pagination @pagination={{this.pagination}} />
+  <Pagination @pagination={{this.pagination}} />
+{{else}}
+  <div local-class="no-results">
+    This crate is not used as a dependency in any other crate on crates.io.
+  </div>
+{{/if}}


### PR DESCRIPTION

### Before
<img width="1159" alt="Bildschirmfoto 2021-03-13 um 00 24 57" src="https://user-images.githubusercontent.com/141300/111008935-8f71dd00-8392-11eb-891b-4fafbb31a0bc.png">

### After
<img width="1157" alt="Bildschirmfoto 2021-03-13 um 00 24 33" src="https://user-images.githubusercontent.com/141300/111008921-82ed8480-8392-11eb-9432-5ac8c7e5577b.png">

