### PR TITLE
Add crate descriptions to dependency lists

### DIFF
--- a/app/components/dependency-list/row.hbs
+++ b/app/components/dependency-list/row.hbs
@@ -6,26 +6,42 @@
   "
   ...attributes
 >
-  <span local-class="range" data-test-range>
+  <span local-class="range-lg" data-test-range>
     {{format-req @dependency.req}}
   </span>
 
-  <span>
-    <LinkTo
-      @route="crate.range"
-      @models={{array @dependency.crate_id @dependency.req}}
-      local-class="link"
-      {{on "focusin" (fn this.setFocused true)}}
-      {{on "focusout" (fn this.setFocused false)}}
-      data-test-release-track-link
-    >
-      {{@dependency.crate_id}}
-    </LinkTo>
+  <div local-class="right">
+    <div local-class="name-and-metadata">
+      <span local-class="range-sm" data-test-range>
+        {{format-req @dependency.req}}
+      </span>
 
-    <span local-class="metadata">
-      {{#if @dependency.optional}}
-        optional
-      {{/if}}
-    </span>
-  </span>
+      <LinkTo
+        @route="crate.range"
+        @models={{array @dependency.crate_id @dependency.req}}
+        local-class="link"
+        {{on "focusin" (fn this.setFocused true)}}
+        {{on "focusout" (fn this.setFocused false)}}
+        data-test-release-track-link
+      >
+        {{@dependency.crate_id}}
+      </LinkTo>
+
+      <span local-class="metadata">
+        {{#if @dependency.optional}}
+          optional
+        {{/if}}
+      </span>
+    </div>
+
+    {{#if (or @dependency.crate.description @dependency.crate.isPending)}}
+      <div local-class="description">
+        {{#if @dependency.crate.isPending}}
+          <Placeholder local-class="description-placeholder" />
+        {{else}}
+          {{@dependency.crate.description}}
+        {{/if}}
+      </div>
+    {{/if}}
+  </div>
 </div>

--- a/app/components/dependency-list/row.module.css
+++ b/app/components/dependency-list/row.module.css
@@ -3,6 +3,7 @@
     --hover-bg-color: hsl(217, 37%, 98%);
     --range-color: var(--grey900);
     --crate-color: var(--grey700);
+    --placeholder-opacity: 0.35;
     --shadow: 0 1px 3px hsla(51, 90%, 42%, .35);
 
     display: flex;
@@ -27,6 +28,7 @@
     &.optional {
         --range-color: var(--grey600);
         --crate-color: var(--grey600);
+        --placeholder-opacity: 0.15;
     }
 
     [title], :global(.ember-tooltip-target) {
@@ -44,11 +46,27 @@
     }
 }
 
-.range {
+.range-lg, .range-sm {
     margin-right: 15px;
     min-width: 100px;
     color: var(--range-color);
     font-variant: tabular-nums;
+}
+
+.range-lg {
+    @media only screen and (max-width: 550px) {
+        display: none;
+    }
+}
+
+.range-sm {
+    @media only screen and (min-width: 551px) {
+        display: none;
+    }
+}
+
+.right {
+    flex-grow: 1;
 }
 
 .link {
@@ -97,4 +115,17 @@
         text-transform: none;
         letter-spacing: normal;
     }
+}
+
+.description {
+    margin-top: 10px;
+    color: var(--crate-color);
+    font-size: 90%;
+}
+
+.description-placeholder {
+    height: 1em;
+    width: 70%;
+    border-radius: 5px;
+    opacity: var(--placeholder-opacity);
 }

--- a/app/models/dependency.js
+++ b/app/models/dependency.js
@@ -5,7 +5,6 @@ import Inflector from 'ember-inflector';
 Inflector.inflector.irregular('dependency', 'dependencies');
 
 export default class Dependency extends Model {
-  @attr crate_id;
   @attr req;
   @attr optional;
   @attr default_features;
@@ -14,4 +13,9 @@ export default class Dependency extends Model {
   @attr downloads;
 
   @belongsTo('version', { async: false }) version;
+  @belongsTo({ async: true }) crate;
+
+  get crate_id() {
+    return this.belongsTo('crate').id();
+  }
 }

--- a/app/serializers/dependency.js
+++ b/app/serializers/dependency.js
@@ -2,6 +2,7 @@ import ApplicationSerializer from './application';
 
 export default class DependencySerializer extends ApplicationSerializer {
   attrs = {
+    crate: 'crate_id',
     version: 'version_id',
   };
 }


### PR DESCRIPTION
This PR adds the crate descriptions to the "Dependencies" tab on the crate details page. Since the descriptions are async loaded by Ember Data I've also added a loading state, based on the new `Placeholder` component.

<img width="1173" alt="Bildschirmfoto 2021-03-12 um 19 31 58" src="https://user-images.githubusercontent.com/141300/111009026-c7792000-8392-11eb-8f7c-e5106f83a6a2.png">

