### PR TITLE
Display username instead if they don't have the "name" field

### DIFF
--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -15,7 +15,9 @@ export default class UserAvatar extends Component {
   @readOnly('width') height;
 
   get alt() {
-    return `${this.args.user.name} (${this.args.user.login})`;
+    return this.args.user.name !== null
+      ? `${this.args.user.name} (${this.args.user.login})`
+      : `(${this.args.user.login})`;
   }
 
   get title() {

--- a/app/templates/crate/owners.hbs
+++ b/app/templates/crate/owners.hbs
@@ -37,7 +37,11 @@
         <UserAvatar @user={{user}} @size="medium-small" />
       </LinkTo>
       <LinkTo @route={{user.kind}} @model={{user.login}}>
-        {{ user.name }}
+        {{#if user.name}}
+          {{user.name}}
+        {{else}}
+          {{user.login}}
+        {{/if}}
       </LinkTo>
       <div local-class="email-column">
         {{user.email}}


### PR DESCRIPTION
Let's take https://crates.io/crates/libc/owners as an example. It currently looks like:

![image](https://user-images.githubusercontent.com/25030997/111022128-47939a00-8414-11eb-8d24-73fc3f1e3a4d.png)

The problem is that the name field doesn't display anything if the account name is empty (e.g. https://github.com/rust-lang-owner).
This PR fixes that behavior to show their username (`user.login`) instead.
This also fixes the alt attribute for the avatar image by just removing `null` (it still doesn't ideal but should be better).