### PR TITLE
Boot nginx from the backend app to fix graceful shutdown in production

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: bin/diesel migration run
-web: ./script/start-web.sh
+web: ./target/release/server
 background_worker: ./target/release/background-worker

--- a/script/start-web.sh
+++ b/script/start-web.sh
@@ -1,12 +1,15 @@
 #! /bin/bash
 set -ue
 
+# Since this script is launched from our app, we tell the nginx
+# buildpack (`bin/start-nginx`) that `cat` is our server.
+
 if [[ -z "${USE_FASTBOOT-}" ]]; then
     unset USE_FASTBOOT
-    bin/start-nginx ./target/release/server
+    bin/start-nginx cat
 else
     export USE_FASTBOOT
     node --optimize_for_size --max_old_space_size=200 fastboot.js &
-    bin/start-nginx ./target/release/server &
+    bin/start-nginx cat &
     wait -n
 fi

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -80,7 +80,7 @@ impl DownloadsCounter {
         }
 
         println!(
-            "download_counter all_shards counted_versions={} counted_downloads={} pending_downloads={}",
+            "downloads_counter all_shards counted_versions={} counted_downloads={} pending_downloads={}",
             counted_versions,
             counted_downloads,
             pending_downloads,
@@ -101,7 +101,7 @@ impl DownloadsCounter {
 
         let stats = self.persist_shard(&conn, shard)?;
         println!(
-            "download_counter shard={} counted_versions={} counted_downloads={} pending_downloads={}",
+            "downloads_counter shard={} counted_versions={} counted_downloads={} pending_downloads={}",
             idx,
             stats.counted_versions,
             stats.counted_downloads,


### PR DESCRIPTION
In production we aren't gracefully shutting down as expected. nginx
does a quick shutdown when receiving a `SIGTERM` and once it exits, it
appears that our process is aborted.

Instead of spawning the backend from the shell script, the backend
process is now responsible for spawning the shell script. This allows
the backend to finish its shutdown work even if the script has already
exited.

`cat` is passed to the nginx buildpack script as our "server", which
will block on `STDIN` so that `nginx` will run until receiving
`SIGTERM`.

r? @pietroalbini 