### PR TITLE
Improve reverse dependency list styling

### DIFF
--- a/app/components/rev-dep-row.hbs
+++ b/app/components/rev-dep-row.hbs
@@ -10,7 +10,9 @@
     >
       {{@dependency.version.crateName}}
     </LinkTo>
-    requires {{@dependency.req}}
+    <span local-class="range">
+      depends on {{@dependency.req}}
+    </span>
   </div>
   <div local-class="downloads">
     {{svg-jar "download-arrow" local-class="download-icon"}}

--- a/app/components/rev-dep-row.hbs
+++ b/app/components/rev-dep-row.hbs
@@ -1,0 +1,12 @@
+<div local-class="row" ...attributes>
+  <div>
+    <LinkTo @route="crate" @model={{@dependency.version.crateName}} data-test-crate-name>
+      {{@dependency.version.crateName}}
+    </LinkTo>
+    requires {{@dependency.req}}
+  </div>
+  <div local-class="stats downloads">
+    {{svg-jar "download-arrow" local-class="download-icon"}}
+    <span local-class="rev-dep-downloads">{{ format-num @dependency.downloads }}</span>
+  </div>
+</div>

--- a/app/components/rev-dep-row.hbs
+++ b/app/components/rev-dep-row.hbs
@@ -5,7 +5,7 @@
     </LinkTo>
     requires {{@dependency.req}}
   </div>
-  <div local-class="stats downloads">
+  <div local-class="downloads">
     {{svg-jar "download-arrow" local-class="download-icon"}}
     <span local-class="rev-dep-downloads">{{ format-num @dependency.downloads }}</span>
   </div>

--- a/app/components/rev-dep-row.hbs
+++ b/app/components/rev-dep-row.hbs
@@ -1,6 +1,13 @@
-<div local-class="row" ...attributes>
+<div local-class="row {{if this.focused "focused"}}" ...attributes>
   <div>
-    <LinkTo @route="crate" @model={{@dependency.version.crateName}} data-test-crate-name>
+    <LinkTo
+      @route="crate"
+      @model={{@dependency.version.crateName}}
+      local-class="link"
+      data-test-crate-name
+      {{on "focusin" (fn this.setFocused true)}}
+      {{on "focusout" (fn this.setFocused false)}}
+    >
       {{@dependency.version.crateName}}
     </LinkTo>
     requires {{@dependency.req}}

--- a/app/components/rev-dep-row.hbs
+++ b/app/components/rev-dep-row.hbs
@@ -16,6 +16,6 @@
   </div>
   <div local-class="downloads">
     {{svg-jar "download-arrow" local-class="download-icon"}}
-    <span local-class="rev-dep-downloads">{{ format-num @dependency.downloads }}</span>
+    {{format-num @dependency.downloads}}
   </div>
 </div>

--- a/app/components/rev-dep-row.hbs
+++ b/app/components/rev-dep-row.hbs
@@ -1,5 +1,5 @@
 <div local-class="row {{if this.focused "focused"}}" ...attributes>
-  <div>
+  <div local-class="left">
     <LinkTo
       @route="crate"
       @model={{@dependency.version.crateName}}

--- a/app/components/rev-dep-row.js
+++ b/app/components/rev-dep-row.js
@@ -1,0 +1,11 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class VersionRow extends Component {
+  @tracked focused = false;
+
+  @action setFocused(value) {
+    this.focused = value;
+  }
+}

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -23,6 +23,7 @@
     width: 25%;
     padding-bottom: 5px;
     color: var(--main-color-light);
+    font-variant: tabular-nums;
 }
 
 .download-icon {

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -48,6 +48,13 @@
     }
 }
 
+.range {
+    color: var(--grey600);
+    text-transform: uppercase;
+    letter-spacing: .7px;
+    font-size: 13px;
+}
+
 .downloads {
     display: flex;
     align-items: center;

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -58,17 +58,19 @@
 .downloads {
     display: flex;
     align-items: center;
-    width: 25%;
-    padding-bottom: 5px;
-    color: var(--main-color-light);
+    color: var(--grey600);
+    font-size: 16px;
+    font-weight: 500;
     font-variant: tabular-nums;
+
+    @media only screen and (max-width: 550px) {
+        margin-top: 5px;
+    }
 }
 
 .download-icon {
+    width: auto;
+    height: 16px;
     flex-shrink: 0;
-    color: #b13b89;
-}
-
-.rev-dep-downloads {
-    padding-left: 7px;
+    margin-right: 7px;
 }

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -6,6 +6,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-wrap: wrap;
     position: relative;
     font-size: 18px;
     padding: 15px 25px;
@@ -26,6 +27,11 @@
     @media only screen and (max-width: 550px) {
         display: block
     }
+}
+
+.left {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .link {

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -1,0 +1,25 @@
+.row {
+    padding: 20px 0;
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.stats {
+    width: 25%;
+    color: var(--main-color-light);
+}
+
+.downloads {
+    display: flex;
+    align-items: center;
+    padding-bottom: 5px;
+}
+
+.download-icon {
+    color: #b13b89;
+}
+
+.rev-dep-downloads {
+    padding-left: 7px
+}

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -17,15 +17,12 @@
     }
 }
 
-.stats {
-    width: 25%;
-    color: var(--main-color-light);
-}
-
 .downloads {
     display: flex;
     align-items: center;
+    width: 25%;
     padding-bottom: 5px;
+    color: var(--main-color-light);
 }
 
 .download-icon {

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -1,4 +1,6 @@
 .row {
+    --hover-bg-color: hsl(217, 37%, 98%);
+    --crate-color: var(--grey700);
     --shadow: 0 1px 3px hsla(51, 90%, 42%, .35);
 
     display: flex;
@@ -12,8 +14,37 @@
     box-shadow: var(--shadow);
     transition: all 300ms;
 
+    &:hover, &.focused {
+        background-color: var(--hover-bg-color);
+        transition: all 0ms;
+    }
+
+    &.focused {
+        box-shadow: 0 0 0 3px var(--yellow500), var(--shadow);
+    }
+
     @media only screen and (max-width: 550px) {
         display: block
+    }
+}
+
+.link {
+    color: var(--crate-color);
+    font-weight: 500;
+    margin-right: 15px;
+    outline: none;
+
+    &:hover {
+        color: var(--crate-color);
+    }
+
+    &::after {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        right: 0;
+        bottom: 0;
     }
 }
 
@@ -32,5 +63,5 @@
 }
 
 .rev-dep-downloads {
-    padding-left: 7px
+    padding-left: 7px;
 }

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -1,8 +1,20 @@
 .row {
-    padding: 20px 0;
+    --shadow: 0 1px 3px hsla(51, 90%, 42%, .35);
+
     display: flex;
+    align-items: center;
     justify-content: space-between;
-    flex-wrap: wrap;
+    position: relative;
+    font-size: 18px;
+    padding: 15px 25px;
+    background-color: white;
+    border-radius: 5px;
+    box-shadow: var(--shadow);
+    transition: all 300ms;
+
+    @media only screen and (max-width: 550px) {
+        display: block
+    }
 }
 
 .stats {
@@ -17,6 +29,7 @@
 }
 
 .download-icon {
+    flex-shrink: 0;
     color: #b13b89;
 }
 

--- a/app/styles/crate/reverse-dependencies.module.css
+++ b/app/styles/crate/reverse-dependencies.module.css
@@ -8,16 +8,13 @@
 
 .list {
     list-style: none;
-    background-color: white;
-    padding: 0 20px;
     margin: 0 0 20px;
-}
+    padding: 0;
 
-.row {
-    border-bottom: 2px solid var(--gray-border);
-
-    &:last-of-type {
-        border: none;
+    li {
+        &:not(:first-child) {
+            margin-top: 10px;
+        }
     }
 }
 

--- a/app/styles/crate/reverse-dependencies.module.css
+++ b/app/styles/crate/reverse-dependencies.module.css
@@ -7,9 +7,10 @@
 }
 
 .list {
+    list-style: none;
     background-color: white;
     padding: 0 20px;
-    margin-bottom: 20px;
+    margin: 0 0 20px;
 }
 
 .row {

--- a/app/styles/crate/reverse-dependencies.module.css
+++ b/app/styles/crate/reverse-dependencies.module.css
@@ -15,33 +15,10 @@
 
 .row {
     border-bottom: 2px solid var(--gray-border);
-    padding: 20px 0;
-    display: flex;
-    justify-content: space-between;
-    flex-wrap: wrap;
 
     &:last-of-type {
         border: none;
     }
-}
-
-.stats {
-    width: 25%;
-    color: var(--main-color-light);
-}
-
-.downloads {
-    display: flex;
-    align-items: center;
-    padding-bottom: 5px;
-}
-
-.download-icon {
-    color: #b13b89;
-}
-
-.rev-dep-downloads {
-    padding-left: 7px
 }
 
 .no-results {

--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -10,9 +10,9 @@
     />
   </div>
 
-  <div local-class="list" data-test-list>
+  <ul local-class="list" data-test-list>
     {{#each this.model as |dependency index|}}
-      <div local-class="row" data-test-row={{index}}>
+      <li local-class="row" data-test-row={{index}}>
         <div>
           <LinkTo @route="crate" @model={{dependency.version.crateName}} data-test-crate-name>
             {{dependency.version.crateName}}
@@ -23,9 +23,9 @@
           {{svg-jar "download-arrow" local-class="download-icon"}}
           <span local-class="rev-dep-downloads">{{ format-num dependency.downloads }}</span>
         </div>
-      </div>
+      </li>
     {{/each}}
-  </div>
+  </ul>
 
   <Pagination @pagination={{this.pagination}} />
 {{else}}

--- a/app/templates/crate/reverse-dependencies.hbs
+++ b/app/templates/crate/reverse-dependencies.hbs
@@ -12,17 +12,8 @@
 
   <ul local-class="list" data-test-list>
     {{#each this.model as |dependency index|}}
-      <li local-class="row" data-test-row={{index}}>
-        <div>
-          <LinkTo @route="crate" @model={{dependency.version.crateName}} data-test-crate-name>
-            {{dependency.version.crateName}}
-          </LinkTo>
-          requires {{dependency.req}}
-        </div>
-        <div local-class="stats downloads">
-          {{svg-jar "download-arrow" local-class="download-icon"}}
-          <span local-class="rev-dep-downloads">{{ format-num dependency.downloads }}</span>
-        </div>
+      <li local-class="row">
+        <RevDepRow @dependency={{dependency}} data-test-row={{index}} />
       </li>
     {{/each}}
   </ul>


### PR DESCRIPTION
### Before

<img width="1113" alt="Bildschirmfoto 2021-03-18 um 15 54 45" src="https://user-images.githubusercontent.com/141300/111646894-55756080-8802-11eb-8980-3806de71d4df.png">

### After
<img width="1120" alt="Bildschirmfoto 2021-03-18 um 15 54 31" src="https://user-images.githubusercontent.com/141300/111646950-602ff580-8802-11eb-9899-94d20518dd6f.png">
