### PR TITLE
Adds tests for DownloadsCounter

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -172,8 +172,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     println!("Persisting remaining downloads counters");
-    if let Err(err) = app.downloads_counter.persist_all_shards(&app) {
-        println!("downloads_counter error: {}", err);
+    match app.downloads_counter.persist_all_shards(&app) {
+        Ok(stats) => stats.log(),
+        Err(err) => println!("downloads_counter error: {}", err),
     }
 
     println!("Server has gracefully shutdown!");
@@ -205,8 +206,9 @@ fn downloads_counter_thread(app: Arc<App>) {
     std::thread::spawn(move || loop {
         std::thread::sleep(interval);
 
-        if let Err(err) = app.downloads_counter.persist_next_shard(&app) {
-            println!("downloads_counter error: {}", err);
+        match app.downloads_counter.persist_next_shard(&app) {
+            Ok(stats) => stats.log(),
+            Err(err) => println!("downloads_counter error: {}", err),
         }
     });
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -130,3 +130,10 @@ impl CustomizeConnection<PgConnection, r2d2::Error> for ConnectionConfig {
         Ok(())
     }
 }
+
+#[cfg(test)]
+pub(crate) fn test_conn() -> PgConnection {
+    let conn = PgConnection::establish(&crate::env("TEST_DATABASE_URL")).unwrap();
+    conn.begin_test_transaction().unwrap();
+    conn
+}

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -66,7 +66,15 @@ impl DownloadsCounter {
 
     pub fn persist_all_shards(&self, app: &App) -> Result<PersistStats, Error> {
         let conn = app.primary_database.get()?;
+        self.persist_all_shards_with_conn(&conn)
+    }
 
+    pub fn persist_next_shard(&self, app: &App) -> Result<PersistStats, Error> {
+        let conn = app.primary_database.get()?;
+        self.persist_next_shard_with_conn(&conn)
+    }
+
+    fn persist_all_shards_with_conn(&self, conn: &PgConnection) -> Result<PersistStats, Error> {
         let mut stats = PersistStats::default();
         for shard in self.inner.shards() {
             let shard = std::mem::take(&mut *shard.write());
@@ -76,9 +84,7 @@ impl DownloadsCounter {
         Ok(stats)
     }
 
-    pub fn persist_next_shard(&self, app: &App) -> Result<PersistStats, Error> {
-        let conn = app.primary_database.get()?;
-
+    fn persist_next_shard_with_conn(&self, conn: &PgConnection) -> Result<PersistStats, Error> {
         // Replace the next shard in the ring with an empty HashMap (clearing it), and return the
         // previous contents for processing. The fetch_add method wraps around on overflow, so it's
         // fine to keep incrementing it without resetting.

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -162,7 +162,7 @@ impl DownloadsCounter {
     }
 }
 
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct PersistStats {
     shard: Option<usize>,
     counted_downloads: usize,
@@ -192,5 +192,190 @@ impl PersistStats {
             self.counted_downloads,
             self.pending_downloads,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{Crate, NewCrate, NewUser, NewVersion, User};
+    use diesel::PgConnection;
+    use semver::Version;
+
+    #[test]
+    fn test_increment_and_persist_all() {
+        let counter = DownloadsCounter::new();
+        let conn = crate::db::test_conn();
+        let mut state = State::new(&conn);
+
+        let v1 = state.new_version(&conn);
+        let v2 = state.new_version(&conn);
+        let v3 = state.new_version(&conn);
+
+        // Add 15 downloads between v1 and v2, and no downloads for v3.
+        for _ in 0..10 {
+            counter.increment(v1);
+        }
+        for _ in 0..5 {
+            counter.increment(v2);
+        }
+        assert_eq!(15, counter.pending_count.load(Ordering::SeqCst));
+
+        // Persist everything to the database
+        let stats = counter
+            .persist_all_shards_with_conn(&conn)
+            .expect("failed to persist all shards");
+
+        // Ensure the stats are accurate
+        assert_eq!(
+            stats,
+            PersistStats {
+                shard: None,
+                counted_downloads: 15,
+                counted_versions: 2,
+                pending_downloads: 0,
+            }
+        );
+
+        // Ensure the download counts in the database are what we expect.
+        state.assert_downloads_count(&conn, v1, 10);
+        state.assert_downloads_count(&conn, v2, 5);
+        state.assert_downloads_count(&conn, v3, 0);
+    }
+
+    #[test]
+    fn test_increment_and_persist_shard() {
+        let counter = DownloadsCounter::new();
+        let conn = crate::db::test_conn();
+        let mut state = State::new(&conn);
+
+        let v1 = state.new_version(&conn);
+        let v1_shard = counter.inner.determine_map(&v1);
+
+        // For this test to work we need the two versions to be stored in different shards.
+        let mut v2 = state.new_version(&conn);
+        while counter.inner.determine_map(&v2) == v1_shard {
+            v2 = state.new_version(&conn);
+        }
+        let v2_shard = counter.inner.determine_map(&v2);
+
+        // Add 15 downloads between v1 and v2.
+        for _ in 0..10 {
+            counter.increment(v1);
+        }
+        for _ in 0..5 {
+            counter.increment(v2);
+        }
+        assert_eq!(15, counter.pending_count.load(Ordering::SeqCst));
+
+        // Persist one shard at the time and ensure the stats returned for each shard are expected.
+        let mut pending = 15;
+        for shard in 0..counter.shards_count() {
+            let stats = counter
+                .persist_next_shard_with_conn(&conn)
+                .expect("failed to persist shard");
+
+            if shard == v1_shard {
+                pending -= 10;
+                assert_eq!(
+                    stats,
+                    PersistStats {
+                        shard: Some(shard),
+                        counted_downloads: 10,
+                        counted_versions: 1,
+                        pending_downloads: pending,
+                    }
+                );
+                state.assert_downloads_count(&conn, v1, 10);
+            } else if shard == v2_shard {
+                pending -= 5;
+                assert_eq!(
+                    stats,
+                    PersistStats {
+                        shard: Some(shard),
+                        counted_downloads: 5,
+                        counted_versions: 1,
+                        pending_downloads: pending,
+                    }
+                );
+                state.assert_downloads_count(&conn, v2, 5);
+            } else {
+                assert_eq!(
+                    stats,
+                    PersistStats {
+                        shard: Some(shard),
+                        counted_downloads: 0,
+                        counted_versions: 0,
+                        pending_downloads: pending,
+                    }
+                );
+            };
+        }
+        assert_eq!(pending, 0);
+
+        // Finally ensure that the download counts in the database are what we expect.
+        state.assert_downloads_count(&conn, v1, 10);
+        state.assert_downloads_count(&conn, v2, 5);
+    }
+
+    struct State {
+        user: User,
+        krate: Crate,
+        next_version: u32,
+    }
+
+    impl State {
+        fn new(conn: &PgConnection) -> Self {
+            let user = NewUser {
+                gh_id: 0,
+                gh_login: "ghost",
+                ..NewUser::default()
+            }
+            .create_or_update(None, conn)
+            .expect("failed to create user");
+
+            let krate = NewCrate {
+                name: "foo",
+                ..NewCrate::default()
+            }
+            .create_or_update(conn, user.id, None)
+            .expect("failed to create crate");
+
+            Self {
+                user,
+                krate,
+                next_version: 1,
+            }
+        }
+
+        fn new_version(&mut self, conn: &PgConnection) -> i32 {
+            let version = NewVersion::new(
+                self.krate.id,
+                &Version::parse(&format!("{}.0.0", self.next_version)).unwrap(),
+                &HashMap::new(),
+                None,
+                None,
+                0,
+                self.user.id,
+            )
+            .expect("failed to create version")
+            .save(conn, &[], "ghost@example.com")
+            .expect("failed to save version");
+
+            self.next_version += 1;
+            version.id
+        }
+
+        fn assert_downloads_count(&self, conn: &PgConnection, version: i32, expected: i64) {
+            use crate::schema::version_downloads::dsl::*;
+            use diesel::dsl::*;
+
+            let actual: Option<i64> = version_downloads
+                .select(sum(downloads))
+                .filter(version_id.eq(version))
+                .first(conn)
+                .unwrap();
+            assert_eq!(actual.unwrap_or(0), expected);
+        }
     }
 }

--- a/src/tasks/update_downloads.rs
+++ b/src/tasks/update_downloads.rs
@@ -83,17 +83,8 @@ fn collect(conn: &PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{
-        env,
-        models::{Crate, NewCrate, NewUser, NewVersion, User, Version},
-    };
+    use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
     use std::collections::HashMap;
-
-    fn conn() -> PgConnection {
-        let conn = PgConnection::establish(&env("TEST_DATABASE_URL")).unwrap();
-        conn.begin_test_transaction().unwrap();
-        conn
-    }
 
     fn user(conn: &PgConnection) -> User {
         NewUser::new(2, "login", None, None, "access_token")
@@ -126,7 +117,7 @@ mod test {
     fn increment() {
         use diesel::dsl::*;
 
-        let conn = conn();
+        let conn = crate::db::test_conn();
         let user = user(&conn);
         let (krate, version) = crate_and_version(&conn, user.id);
         insert_into(version_downloads::table)
@@ -165,7 +156,7 @@ mod test {
     fn set_processed_true() {
         use diesel::dsl::*;
 
-        let conn = conn();
+        let conn = crate::db::test_conn();
         let user = user(&conn);
         let (_, version) = crate_and_version(&conn, user.id);
         insert_into(version_downloads::table)
@@ -189,7 +180,7 @@ mod test {
     #[test]
     fn dont_process_recent_row() {
         use diesel::dsl::*;
-        let conn = conn();
+        let conn = crate::db::test_conn();
         let user = user(&conn);
         let (_, version) = crate_and_version(&conn, user.id);
         insert_into(version_downloads::table)
@@ -215,7 +206,7 @@ mod test {
         use diesel::dsl::*;
         use diesel::update;
 
-        let conn = conn();
+        let conn = crate::db::test_conn();
         let user = user(&conn);
         let (krate, version) = crate_and_version(&conn, user.id);
         update(versions::table)
@@ -269,7 +260,7 @@ mod test {
         use diesel::dsl::*;
         use diesel::update;
 
-        let conn = conn();
+        let conn = crate::db::test_conn();
         let user = user(&conn);
         let (_, version) = crate_and_version(&conn, user.id);
         update(versions::table)

--- a/src/tests/krate/downloads.rs
+++ b/src/tests/krate/downloads.rs
@@ -46,7 +46,8 @@ fn download() {
         app.as_inner()
             .downloads_counter
             .persist_all_shards(app.as_inner())
-            .expect("failed to persist downloads count");
+            .expect("failed to persist downloads count")
+            .log();
     };
 
     download("foo_download/1.0.0");


### PR DESCRIPTION
This fixes https://github.com/rust-lang/crates.io/issues/3416 by adding tests for `DownloadsCounter`. There are a few notable things in this PR I'd like to highlight.

First off, the tests are not implemented in `src/tests`, but are implemented in a `#[cfg(test)] mod tests {}` in the same source file. While this resulted in some code duplication I had to do this because testing `persist_next_shard` requires access to the internals of `DownloadsCounter` and I'd prefer not to expose them.

This PR also fixes a bug I discovered while writing the test for incrementing a missing version. Inserting a missing version ID in the `version_downloads` table doesn't work thanks to the foreign key, and aborts the whole `INSERT` statement (losing all the downloads in that shard). This could happen in production if a version is deleted between calling `increment()` and persisting that shard.

To fix that bug I changed the code to do a `SELECT FOR SHARE` from the `versions` table of the version IDs we're about to persist, discarding the versions that are not returned by the query. The `FOR SHARE` clause does the equivalent of `RwLock::read`, preventing other transactions from updating or deleting the selected rows while allowing other `SELECT`s and `SELECT FOR SHARE`s. 

There were also some refactorings to make the tests better to write.

This PR is best reviewed commit-by-commit.
r? @jtgeibel 