### PR TITLE
reverse-dependencies: Remove unused CSS class

### DIFF
--- a/app/styles/crate/reverse-dependencies.module.css
+++ b/app/styles/crate/reverse-dependencies.module.css
@@ -1,7 +1,3 @@
-.back-link {
-    margin-bottom: 20px;
-}
-
 .results-meta {
     margin-bottom: 25px;
 }


### PR DESCRIPTION
The back link on this page does not exist anymore 😉 