### PR TITLE
Update debug middleware

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -50,10 +50,6 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
         m.add(Debug);
     }
 
-    if env::var_os("DEBUG_REQUESTS").is_some() {
-        m.add(DebugRequest);
-    }
-
     if env::var_os("LOG_CONNECTION_POOL_STATUS").is_some() {
         m.add(LogConnectionPoolStatus::new(&app));
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -46,7 +46,8 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     }
 
     if env == Env::Development {
-        // Print a log for each request.
+        // Optionally print debug information for each request
+        // To enable, set the environment variable: `RUST_LOG=cargo_registry::middleware=debug`
         m.add(Debug);
     }
 

--- a/src/middleware/debug.rs
+++ b/src/middleware/debug.rs
@@ -22,7 +22,7 @@ impl Middleware for Debug {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct DebugRequest;
+struct DebugRequest;
 
 impl Middleware for DebugRequest {
     fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {

--- a/src/middleware/debug.rs
+++ b/src/middleware/debug.rs
@@ -12,9 +12,9 @@ impl Middleware for Debug {
 
     fn after(&self, _req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
         res.map(|res| {
-            println!("  <- {:?}", res.status());
+            debug!("  <- {:?}", res.status());
             for (k, v) in res.headers().iter() {
-                println!("  <- {} {:?}", k, v);
+                debug!("  <- {} {:?}", k, v);
             }
             res
         })
@@ -26,15 +26,15 @@ struct DebugRequest;
 
 impl Middleware for DebugRequest {
     fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
-        println!("  version: {:?}", req.http_version());
-        println!("  method: {:?}", req.method());
-        println!("  scheme: {:?}", req.scheme());
-        println!("  host: {:?}", req.host());
-        println!("  path: {}", req.path());
-        println!("  query_string: {:?}", req.query_string());
-        println!("  remote_addr: {:?}", req.remote_addr());
+        debug!("  version: {:?}", req.http_version());
+        debug!("  method: {:?}", req.method());
+        debug!("  scheme: {:?}", req.scheme());
+        debug!("  host: {:?}", req.host());
+        debug!("  path: {}", req.path());
+        debug!("  query_string: {:?}", req.query_string());
+        debug!("  remote_addr: {:?}", req.remote_addr());
         for (k, ref v) in req.headers().iter() {
-            println!("  hdr: {}={:?}", k, v);
+            debug!("  hdr: {}={:?}", k, v);
         }
         Ok(())
     }


### PR DESCRIPTION
The first commit drops the ability to enable this middleware on production. With current traffic levels this isn't very practical (as concurrent requests can interleave their output), and we don't want to log headers that may contain authorization cookies or tokens.

The second commit silences the debug information by default during local development. It can be re-enabled by setting the `RUST_LOG` environment variable appropriately.

r? @Turbo87 