### PR TITLE
Show generic flash message if crate data fails to load 

### DIFF
--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -10,10 +10,11 @@ export default class CrateRoute extends Route {
     } catch (error) {
       if (error.errors?.some(e => e.detail === 'Not Found')) {
         this.notifications.error(`Crate '${params.crate_id}' does not exist`);
-        this.replaceWith('index');
       } else {
-        throw error;
+        this.notifications.error(`Loading data for the '${params.crate_id}' crate failed. Please try again later!`);
       }
+
+      this.replaceWith('index');
     }
   }
 

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -11,7 +11,15 @@ export default class VersionRoute extends Route {
 
   async model(params) {
     let crate = this.modelFor('crate');
-    let versions = await crate.get('versions');
+
+    let versions;
+    try {
+      versions = await crate.get('versions');
+    } catch {
+      this.notifications.error(`Loading data for the '${crate.name}' crate failed. Please try again later!`);
+      this.replaceWith('index');
+      return;
+    }
 
     let version;
     let requestedVersion = params.version_num;

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,4 +1,4 @@
-import { click, currentRouteName, currentURL, visit, waitFor } from '@ember/test-helpers';
+import { click, currentRouteName, currentURL, waitFor } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 
 import percySnapshot from '@percy/ember';
@@ -8,6 +8,7 @@ import { getPageTitle } from 'ember-page-title/test-support';
 import { setupApplicationTest } from 'cargo/tests/helpers';
 
 import axeConfig from '../axe-config';
+import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | crate page', function (hooks) {
   setupApplicationTest(hooks);
@@ -78,6 +79,12 @@ module('Acceptance | crate page', function (hooks) {
 
     await percySnapshot(assert);
     await a11yAudit(axeConfig);
+  });
+
+  test('unknown crate shows an error message', async function (assert) {
+    await visit('/crates/nanomsg');
+    assert.equal(currentURL(), '/');
+    assert.dom('[data-test-notification-message]').hasText("Crate 'nanomsg' does not exist");
   });
 
   test('unknown versions fall back to latest version and show an error message', async function (assert) {

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -110,6 +110,21 @@ module('Acceptance | crate page', function (hooks) {
     assert.dom('[data-test-notification-message]').hasText("Version '0.7.0' of crate 'nanomsg' does not exist");
   });
 
+  test('other versions loading error shows an error message', async function (assert) {
+    this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
+    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+
+    this.server.get('/api/v1/crates/:crate_name/versions', {}, 500);
+
+    await visit('/');
+    await click('[data-test-just-updated] [data-test-crate-link="0"]');
+    assert.equal(currentURL(), '/');
+    assert
+      .dom('[data-test-notification-message]')
+      .hasText("Loading data for the 'nanomsg' crate failed. Please try again later!");
+  });
+
   test('navigating to the all versions page', async function (assert) {
     this.server.loadFixtures();
 

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -87,6 +87,16 @@ module('Acceptance | crate page', function (hooks) {
     assert.dom('[data-test-notification-message]').hasText("Crate 'nanomsg' does not exist");
   });
 
+  test('other crate loading error shows an error message', async function (assert) {
+    this.server.get('/api/v1/crates/:crate_name', {}, 500);
+
+    await visit('/crates/nanomsg');
+    assert.equal(currentURL(), '/');
+    assert
+      .dom('[data-test-notification-message]')
+      .hasText("Loading data for the 'nanomsg' crate failed. Please try again later!");
+  });
+
   test('unknown versions fall back to latest version and show an error message', async function (assert) {
     this.server.create('crate', { name: 'nanomsg' });
     this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });


### PR DESCRIPTION
Rethrowing the error means that it ends up creating noise on Sentry even for regular network errors.

Resolves https://github.com/rust-lang/crates.io/issues/240