### PR TITLE
Extract `sentry` service

### DIFF
--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -3,7 +3,6 @@ import { gt, readOnly } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import * as Sentry from '@sentry/browser';
 import { didCancel } from 'ember-concurrency';
 
 import { simplifyUrl } from './crate-sidebar/link';
@@ -12,6 +11,7 @@ const NUM_VERSIONS = 5;
 
 export default class DownloadGraph extends Component {
   @service playground;
+  @service sentry;
 
   @readOnly('args.crate.versions') sortedVersions;
 
@@ -53,7 +53,7 @@ export default class DownloadGraph extends Component {
       this.playground.loadCratesTask.perform().catch(error => {
         if (!(didCancel(error) || error.isServerError || error.isNetworkError)) {
           // report unexpected errors to Sentry
-          Sentry.captureException(error);
+          this.sentry.captureException(error);
         }
       });
     }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-import * as Sentry from '@sentry/browser';
 import { rawTimeout, task } from 'ember-concurrency';
 
 export default class ApplicationRoute extends Route {
@@ -10,10 +9,11 @@ export default class ApplicationRoute extends Route {
   @service router;
   @service session;
   @service playground;
+  @service sentry;
 
   beforeModel() {
     this.router.on('routeDidChange', () => {
-      Sentry.configureScope(scope => {
+      this.sentry.configureScope(scope => {
         scope.setTag('routeName', this.router.currentRouteName);
       });
     });

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -1,13 +1,13 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-import * as Sentry from '@sentry/browser';
 import { didCancel } from 'ember-concurrency';
 
 import { AjaxError } from '../../utils/ajax';
 
 export default class VersionRoute extends Route {
   @service notifications;
+  @service sentry;
 
   async model(params) {
     let crate = this.modelFor('crate');
@@ -41,7 +41,7 @@ export default class VersionRoute extends Route {
       version.loadDocsBuildsTask.perform().catch(error => {
         // report unexpected errors to Sentry and ignore `ajax()` errors
         if (!didCancel(error) && !(error instanceof AjaxError)) {
-          Sentry.captureException(error);
+          this.sentry.captureException(error);
         }
       });
     }

--- a/app/services/progress.js
+++ b/app/services/progress.js
@@ -3,13 +3,13 @@ import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
 import Ember from 'ember';
 
-import * as Sentry from '@sentry/browser';
 import { didCancel, rawTimeout, task } from 'ember-concurrency';
 
 const SPEED = 200;
 
 export default class ProgressService extends Service {
   @service router;
+  @service sentry;
 
   @tracked _style = '';
 
@@ -28,7 +28,7 @@ export default class ProgressService extends Service {
     this.updateTask.perform().catch(error => {
       if (!didCancel(error)) {
         // this task shouldn't be able to fail, but if it does we'll let Sentry know
-        Sentry.captureException(error);
+        this.sentry.captureException(error);
       }
     });
 

--- a/app/services/sentry.js
+++ b/app/services/sentry.js
@@ -1,0 +1,17 @@
+import Service from '@ember/service';
+
+import * as Sentry from '@sentry/browser';
+
+export default class SentryService extends Service {
+  captureException(error, captureContext) {
+    Sentry.captureException(error, captureContext);
+  }
+
+  configureScope(callback) {
+    Sentry.configureScope(callback);
+  }
+
+  setUser(user) {
+    Sentry.setUser(user);
+  }
+}

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,7 +1,6 @@
 import { alias } from '@ember/object/computed';
 import Service, { inject as service } from '@ember/service';
 
-import * as Sentry from '@sentry/browser';
 import { race, rawTimeout, task, waitForEvent } from 'ember-concurrency';
 import window from 'ember-window-mock';
 
@@ -12,6 +11,7 @@ export default class SessionService extends Service {
   @service store;
   @service notifications;
   @service router;
+  @service sentry;
 
   savedTransition = null;
 
@@ -129,7 +129,7 @@ export default class SessionService extends Service {
     this.isLoggedIn = false;
 
     yield this.loadUserTask.cancelAll({ resetState: true });
-    Sentry.setUser(null);
+    this.sentry.setUser(null);
 
     this.router.transitionTo('index');
   })
@@ -149,7 +149,7 @@ export default class SessionService extends Service {
     let ownedCrates = response.owned_crates.map(c => this.store.push(this.store.normalize('owned-crate', c)));
 
     let { id } = currentUser;
-    Sentry.setUser({ id });
+    this.sentry.setUser({ id });
 
     return { currentUser, ownedCrates };
   }).drop())

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -1,5 +1,6 @@
 import { setupApplicationTest as upstreamSetupApplicationTest } from 'ember-qunit';
 
+import { setupSentryMock } from './sentry';
 import setupMirage from './setup-mirage';
 
 export { setupTest, setupRenderingTest } from 'ember-qunit';
@@ -8,4 +9,5 @@ export { setupTest, setupRenderingTest } from 'ember-qunit';
 export function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
   setupMirage(hooks);
+  setupSentryMock(hooks);
 }

--- a/tests/helpers/sentry.js
+++ b/tests/helpers/sentry.js
@@ -1,0 +1,35 @@
+import Service from '@ember/service';
+
+class MockSentryService extends Service {
+  events = [];
+  scope = new MockScope();
+
+  captureException(error) {
+    let { scope, user } = this;
+    let { tags } = scope;
+    let event = { error, tags, user };
+    this.events.push(event);
+  }
+
+  configureScope(callback) {
+    callback(this.scope);
+  }
+
+  setUser(user) {
+    this.user = user;
+  }
+}
+
+class MockScope {
+  tags = {};
+
+  setTag(key, value) {
+    this.tags[key] = value;
+  }
+}
+
+export function setupSentryMock(hooks) {
+  hooks.beforeEach(function () {
+    this.owner.register('service:sentry', MockSentryService);
+  });
+}


### PR DESCRIPTION
This makes it easier to mock the Sentry code during tests to ensure that whether we send certain types of errors to Sentry or not.