### PR TITLE
Run daily database maintenance tasks

### DIFF
--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -35,6 +35,7 @@ fn main() -> Result<()> {
                 .unwrap_or_else(|| String::from("db-dump.tar.gz"));
             Ok(tasks::dump_db(database_url, target_name).enqueue(&conn)?)
         }
+        "daily_db_maintenance" => Ok(tasks::daily_db_maintenance().enqueue(&conn)?),
         other => Err(anyhow!("Unrecognized job type `{}`", other)),
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,5 +1,7 @@
+mod daily_db_maintenance;
 pub mod dump_db;
 mod update_downloads;
 
+pub use daily_db_maintenance::daily_db_maintenance;
 pub use dump_db::dump_db;
 pub use update_downloads::update_downloads;

--- a/src/tasks/daily_db_maintenance.rs
+++ b/src/tasks/daily_db_maintenance.rs
@@ -1,0 +1,19 @@
+/// Run daily database maintenance tasks
+///
+/// By default PostgreSQL will run an auto-vacuum when 20% of the tuples in a table are dead.
+/// Because the `version_downloads` table includes years of historical data, we can accumulate
+/// a *lot* of garbage before an auto-vacuum is run.
+///
+/// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
+/// archive daily download counts and drop historical data, we can drop this task and rely on
+/// auto-vacuum again.
+use diesel::{sql_query, RunQueryDsl};
+use swirl::PerformError;
+
+#[swirl::background_job]
+pub fn daily_db_maintenance(conn: &PgConnection) -> Result<(), PerformError> {
+    println!("Running VACUUM on version_downloads table");
+    sql_query("VACUUM version_downloads;").execute(conn)?;
+    println!("Finished running VACUUM on version_downloads table");
+    Ok(())
+}


### PR DESCRIPTION
Run `VACUUM version_downloads;` daily. We could alternatively tweak the
auto-vacuum parameters on this table, but long term we should archive
daily download stats outside of the database and it will be easier to
pick the parameters then, once we have only 90 days of history rather
than growing daily without bound.

r? @Turbo87 