### PR TITLE
Add `crate` adapter that coalesces `findRecord()` requests

### DIFF
--- a/app/adapters/crate.js
+++ b/app/adapters/crate.js
@@ -1,0 +1,15 @@
+import ApplicationAdapter from './application';
+
+const BULK_REQUEST_GROUP_SIZE = 10;
+
+export default class CrateAdapter extends ApplicationAdapter {
+  coalesceFindRequests = true;
+
+  groupRecordsForFindMany(store, snapshots) {
+    let result = [];
+    for (let i = 0; i < snapshots.length; i += BULK_REQUEST_GROUP_SIZE) {
+      result.push(snapshots.slice(i, i + BULK_REQUEST_GROUP_SIZE));
+    }
+    return result;
+  }
+}

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -37,6 +37,11 @@ export function list(schema, request) {
     crates = crates.filter(crate => schema.crateOwnerships.findBy({ crateId: crate.id, teamId }));
   }
 
+  let { ids } = request.queryParams;
+  if (ids) {
+    crates = crates.filter(crate => ids.includes(crate.id));
+  }
+
   if (request.queryParams.sort === 'alpha') {
     crates = crates.sort((a, b) => compareStrings(a.id.toLowerCase(), b.id.toLowerCase()));
   }

--- a/tests/adapters/crate-test.js
+++ b/tests/adapters/crate-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+import { setupTest } from 'cargo/tests/helpers';
+
+module('Adapter | crate', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('findRecord requests are coalesced', async function (assert) {
+    this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crateId: 'foo' });
+    this.server.create('crate', { name: 'bar' });
+    this.server.create('version', { crateId: 'bar' });
+
+    // if request coalescing works correctly, then this regular API endpoint
+    // should not be hit in this case
+    this.server.get('/api/v1/crates/:crate_name', {}, 500);
+
+    let store = this.owner.lookup('service:store');
+
+    let [foo, bar] = await Promise.all([store.findRecord('crate', 'foo'), store.findRecord('crate', 'bar')]);
+    assert.equal(foo?.name, 'foo');
+    assert.equal(bar?.name, 'bar');
+  });
+});

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -208,6 +208,27 @@ module('Mirage | Crates', function (hooks) {
       assert.equal(responsePayload.crates[0].id, 'bar');
       assert.equal(responsePayload.meta.total, 1);
     });
+
+    test('supports multiple `ids[]` parameters', async function (assert) {
+      this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crateId: 'foo' });
+      this.server.create('crate', { name: 'bar' });
+      this.server.create('version', { crateId: 'bar' });
+      this.server.create('crate', { name: 'baz' });
+      this.server.create('version', { crateId: 'baz' });
+      this.server.create('crate', { name: 'other' });
+      this.server.create('version', { crateId: 'other' });
+
+      let response = await fetch(`/api/v1/crates?ids[]=foo&ids[]=bar&ids[]=baz&ids[]=baz&ids[]=unknown`);
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.equal(responsePayload.crates.length, 3);
+      assert.equal(responsePayload.crates[0].id, 'foo');
+      assert.equal(responsePayload.crates[1].id, 'bar');
+      assert.equal(responsePayload.crates[2].id, 'baz');
+      assert.equal(responsePayload.meta.total, 3);
+    });
   });
 
   module('GET /api/v1/crates/:id', function () {


### PR DESCRIPTION
This PR is based on #3445 and #3426 and allows `findRecord('crate', ...)` calls to be grouped into a single network request if they are started within the same runloop tick. This helps to prevent unintended N+1 request situations and enables us to implement #3405 in a more efficient way.