### PR TITLE
Load and show crate descriptions for dependency lists

### DIFF
--- a/app/adapters/crate.js
+++ b/app/adapters/crate.js
@@ -1,0 +1,15 @@
+import ApplicationAdapter from './application';
+
+const BULK_REQUEST_GROUP_SIZE = 10;
+
+export default class CrateAdapter extends ApplicationAdapter {
+  coalesceFindRequests = true;
+
+  groupRecordsForFindMany(store, snapshots) {
+    let result = [];
+    for (let i = 0; i < snapshots.length; i += BULK_REQUEST_GROUP_SIZE) {
+      result.push(snapshots.slice(i, i + BULK_REQUEST_GROUP_SIZE));
+    }
+    return result;
+  }
+}

--- a/app/components/dependency-list/row.hbs
+++ b/app/components/dependency-list/row.hbs
@@ -4,28 +4,45 @@
     {{if @dependency.optional "optional"}}
     {{if this.focused "focused"}}
   "
+  data-test-dependency={{@dependency.crate_id}}
   ...attributes
 >
-  <span local-class="range" data-test-range>
+  <span local-class="range-lg" data-test-range>
     {{format-req @dependency.req}}
   </span>
 
-  <span>
-    <LinkTo
-      @route="crate.range"
-      @models={{array @dependency.crate_id @dependency.req}}
-      local-class="link"
-      {{on "focusin" (fn this.setFocused true)}}
-      {{on "focusout" (fn this.setFocused false)}}
-      data-test-release-track-link
-    >
-      {{@dependency.crate_id}}
-    </LinkTo>
+  <div local-class="right">
+    <div local-class="name-and-metadata">
+      <span local-class="range-sm">
+        {{format-req @dependency.req}}
+      </span>
 
-    <span local-class="metadata">
-      {{#if @dependency.optional}}
-        optional
-      {{/if}}
-    </span>
-  </span>
+      <LinkTo
+        @route="crate.range"
+        @models={{array @dependency.crate_id @dependency.req}}
+        local-class="link"
+        {{on "focusin" (fn this.setFocused true)}}
+        {{on "focusout" (fn this.setFocused false)}}
+        data-test-crate-name
+      >
+        {{@dependency.crate_id}}
+      </LinkTo>
+
+      <span local-class="metadata" data-test-metadata>
+        {{#if @dependency.optional}}
+          optional
+        {{/if}}
+      </span>
+    </div>
+
+    {{#if (or this.description this.loadCrateTask.isRunning)}}
+      <div local-class="description" data-test-description>
+        {{#if this.loadCrateTask.isRunning}}
+          <Placeholder local-class="description-placeholder" data-test-placeholder />
+        {{else}}
+          {{this.description}}
+        {{/if}}
+      </div>
+    {{/if}}
+  </div>
 </div>

--- a/app/components/dependency-list/row.js
+++ b/app/components/dependency-list/row.js
@@ -1,11 +1,33 @@
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import { task } from 'ember-concurrency';
+
 export default class VersionRow extends Component {
+  @service store;
+
   @tracked focused = false;
 
   @action setFocused(value) {
     this.focused = value;
+  }
+
+  constructor() {
+    super(...arguments);
+
+    this.loadCrateTask.perform().catch(() => {
+      // ignore all errors and just don't display a description if the request fails
+    });
+  }
+
+  get description() {
+    return this.loadCrateTask.lastSuccessful?.value?.description;
+  }
+
+  @task *loadCrateTask() {
+    let { dependency } = this.args;
+    return yield this.store.findRecord('crate', dependency.crate_id);
   }
 }

--- a/app/components/dependency-list/row.module.css
+++ b/app/components/dependency-list/row.module.css
@@ -3,6 +3,7 @@
     --hover-bg-color: hsl(217, 37%, 98%);
     --range-color: var(--grey900);
     --crate-color: var(--grey700);
+    --placeholder-opacity: 0.35;
     --shadow: 0 1px 3px hsla(51, 90%, 42%, .35);
 
     display: flex;
@@ -27,6 +28,7 @@
     &.optional {
         --range-color: var(--grey600);
         --crate-color: var(--grey600);
+        --placeholder-opacity: 0.15;
     }
 
     [title], :global(.ember-tooltip-target) {
@@ -44,11 +46,27 @@
     }
 }
 
-.range {
+.range-lg, .range-sm {
     margin-right: 15px;
     min-width: 100px;
     color: var(--range-color);
     font-variant: tabular-nums;
+}
+
+.range-lg {
+    @media only screen and (max-width: 550px) {
+        display: none;
+    }
+}
+
+.range-sm {
+    @media only screen and (min-width: 551px) {
+        display: none;
+    }
+}
+
+.right {
+    flex-grow: 1;
 }
 
 .link {
@@ -97,4 +115,17 @@
         text-transform: none;
         letter-spacing: normal;
     }
+}
+
+.description {
+    margin-top: 10px;
+    color: var(--crate-color);
+    font-size: 90%;
+}
+
+.description-placeholder {
+    height: 1em;
+    width: 70%;
+    border-radius: 5px;
+    opacity: var(--placeholder-opacity);
 }

--- a/app/components/rev-dep-row.hbs
+++ b/app/components/rev-dep-row.hbs
@@ -1,21 +1,33 @@
 <div local-class="row {{if this.focused "focused"}}" ...attributes>
-  <div local-class="left">
-    <LinkTo
-      @route="crate"
-      @model={{@dependency.version.crateName}}
-      local-class="link"
-      data-test-crate-name
-      {{on "focusin" (fn this.setFocused true)}}
-      {{on "focusout" (fn this.setFocused false)}}
-    >
-      {{@dependency.version.crateName}}
-    </LinkTo>
-    <span local-class="range">
-      depends on {{@dependency.req}}
-    </span>
+  <div local-class="top">
+    <div local-class="left">
+      <LinkTo
+        @route="crate"
+        @model={{@dependency.version.crateName}}
+        local-class="link"
+        data-test-crate-name
+        {{on "focusin" (fn this.setFocused true)}}
+        {{on "focusout" (fn this.setFocused false)}}
+      >
+        {{@dependency.version.crateName}}
+      </LinkTo>
+      <span local-class="range">
+        depends on {{@dependency.req}}
+      </span>
+    </div>
+    <div local-class="downloads">
+      {{svg-jar "download-arrow" local-class="download-icon"}}
+      {{format-num @dependency.downloads}}
+    </div>
   </div>
-  <div local-class="downloads">
-    {{svg-jar "download-arrow" local-class="download-icon"}}
-    {{format-num @dependency.downloads}}
-  </div>
+
+  {{#if (or this.description this.loadCrateTask.isRunning)}}
+    <div local-class="description" data-test-description>
+      {{#if this.loadCrateTask.isRunning}}
+        <Placeholder local-class="description-placeholder" data-test-placeholder />
+      {{else}}
+        {{this.description}}
+      {{/if}}
+    </div>
+  {{/if}}
 </div>

--- a/app/components/rev-dep-row.js
+++ b/app/components/rev-dep-row.js
@@ -1,11 +1,33 @@
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import { task } from 'ember-concurrency';
+
 export default class VersionRow extends Component {
+  @service store;
+
   @tracked focused = false;
 
   @action setFocused(value) {
     this.focused = value;
+  }
+
+  constructor() {
+    super(...arguments);
+
+    this.loadCrateTask.perform().catch(() => {
+      // ignore all errors and just don't display a description if the request fails
+    });
+  }
+
+  get description() {
+    return this.loadCrateTask.lastSuccessful?.value?.description;
+  }
+
+  @task *loadCrateTask() {
+    let { dependency } = this.args;
+    return yield this.store.findRecord('crate', dependency.version.crateName);
   }
 }

--- a/app/components/rev-dep-row.module.css
+++ b/app/components/rev-dep-row.module.css
@@ -1,12 +1,9 @@
 .row {
     --hover-bg-color: hsl(217, 37%, 98%);
     --crate-color: var(--grey700);
+    --placeholder-opacity: 0.35;
     --shadow: 0 1px 3px hsla(51, 90%, 42%, .35);
 
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
     position: relative;
     font-size: 18px;
     padding: 15px 25px;
@@ -23,6 +20,13 @@
     &.focused {
         box-shadow: 0 0 0 3px var(--yellow500), var(--shadow);
     }
+}
+
+.top {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
 
     @media only screen and (max-width: 550px) {
         display: block
@@ -70,7 +74,7 @@
     font-variant: tabular-nums;
 
     @media only screen and (max-width: 550px) {
-        margin-top: 5px;
+        margin-top: 10px;
     }
 }
 
@@ -79,4 +83,17 @@
     height: 16px;
     flex-shrink: 0;
     margin-right: 7px;
+}
+
+.description {
+    margin-top: 10px;
+    color: var(--crate-color);
+    font-size: 90%;
+}
+
+.description-placeholder {
+    height: 1em;
+    width: 70%;
+    border-radius: 5px;
+    opacity: var(--placeholder-opacity);
 }

--- a/mirage/fixtures/crates.js
+++ b/mirage/fixtures/crates.js
@@ -334,7 +334,7 @@ export default [
     name: 'unicorn-rpc',
     repository: 'https://github.com/nicolas-cherel/rustlex',
     updated_at: '2015-08-25T19:15:35Z',
-    versionIds: [],
+    versionIds: [28674],
   },
   {
     created_at: '2015-01-17T17:47:52Z',

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -37,6 +37,11 @@ export function list(schema, request) {
     crates = crates.filter(crate => schema.crateOwnerships.findBy({ crateId: crate.id, teamId }));
   }
 
+  let { ids } = request.queryParams;
+  if (ids) {
+    crates = crates.filter(crate => ids.includes(crate.id));
+  }
+
   if (request.queryParams.sort === 'alpha') {
     crates = crates.sort((a, b) => compareStrings(a.id.toLowerCase(), b.id.toLowerCase()));
   }

--- a/tests/acceptance/reverse-dependencies-test.js
+++ b/tests/acceptance/reverse-dependencies-test.js
@@ -31,7 +31,9 @@ module('Acceptance | /crates/:crate_id/reverse_dependencies', function (hooks) {
     assert.equal(currentURL(), `/crates/${foo.name}/reverse_dependencies`);
     assert.dom('[data-test-row]').exists({ count: 2 });
     assert.dom('[data-test-row="0"] [data-test-crate-name]').hasText(bar.name);
+    assert.dom('[data-test-row="0"] [data-test-description]').hasText(bar.description);
     assert.dom('[data-test-row="1"] [data-test-crate-name]').hasText(baz.name);
+    assert.dom('[data-test-row="1"] [data-test-description]').hasText(baz.description);
   });
 
   test('supports pagination', async function (assert) {

--- a/tests/adapters/crate-test.js
+++ b/tests/adapters/crate-test.js
@@ -1,0 +1,27 @@
+import { module, test } from 'qunit';
+
+import { setupMirage } from 'ember-cli-mirage/test-support';
+
+import { setupTest } from 'cargo/tests/helpers';
+
+module('Adapter | crate', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('findRecord requests are coalesced', async function (assert) {
+    this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crateId: 'foo' });
+    this.server.create('crate', { name: 'bar' });
+    this.server.create('version', { crateId: 'bar' });
+
+    // if request coalescing works correctly, then this regular API endpoint
+    // should not be hit in this case
+    this.server.get('/api/v1/crates/:crate_name', {}, 500);
+
+    let store = this.owner.lookup('service:store');
+
+    let [foo, bar] = await Promise.all([store.findRecord('crate', 'foo'), store.findRecord('crate', 'bar')]);
+    assert.equal(foo?.name, 'foo');
+    assert.equal(bar?.name, 'bar');
+  });
+});

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -208,6 +208,27 @@ module('Mirage | Crates', function (hooks) {
       assert.equal(responsePayload.crates[0].id, 'bar');
       assert.equal(responsePayload.meta.total, 1);
     });
+
+    test('supports multiple `ids[]` parameters', async function (assert) {
+      this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crateId: 'foo' });
+      this.server.create('crate', { name: 'bar' });
+      this.server.create('version', { crateId: 'bar' });
+      this.server.create('crate', { name: 'baz' });
+      this.server.create('version', { crateId: 'baz' });
+      this.server.create('crate', { name: 'other' });
+      this.server.create('version', { crateId: 'other' });
+
+      let response = await fetch(`/api/v1/crates?ids[]=foo&ids[]=bar&ids[]=baz&ids[]=baz&ids[]=unknown`);
+      assert.equal(response.status, 200);
+
+      let responsePayload = await response.json();
+      assert.equal(responsePayload.crates.length, 3);
+      assert.equal(responsePayload.crates[0].id, 'foo');
+      assert.equal(responsePayload.crates[1].id, 'bar');
+      assert.equal(responsePayload.crates[2].id, 'baz');
+      assert.equal(responsePayload.meta.total, 3);
+    });
   });
 
   module('GET /api/v1/crates/:id', function () {


### PR DESCRIPTION
This PR adds the crate descriptions to the dependency and reverse dependency lists:

<img width="1191" alt="Bildschirmfoto 2021-03-21 um 21 24 01" src="https://user-images.githubusercontent.com/141300/111919749-dbf0a300-8a8b-11eb-841f-5a9fef19d30f.png">
<img width="1156" alt="Bildschirmfoto 2021-03-21 um 21 23 30" src="https://user-images.githubusercontent.com/141300/111919753-e01cc080-8a8b-11eb-9fb1-a3465a3db6be.png">
<img width="1170" alt="Bildschirmfoto 2021-03-21 um 21 23 22" src="https://user-images.githubusercontent.com/141300/111919756-e0b55700-8a8b-11eb-9e1e-198042890d4a.png">

The descriptions (and other `crate` details) are loaded async, so I've added a description placeholder that is replaced once the request has returned. If the request fails the row is simply displayed without a description.

The PR is based on https://github.com/rust-lang/crates.io/pull/3447 to avoid unnecessary N+1 requests.

Closes #2790