### PR TITLE
package.json: Set `edition: octane` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,5 +133,8 @@
   "engines": {
     "node": "^14.9.0",
     "npm": "^7.0.0"
+  },
+  "ember": {
+    "edition": "octane"
   }
 }


### PR DESCRIPTION
Not having this flag set was deprecated in Ember 3.26