### PR TITLE
Fixes #3448 Handle cargo-style semver in `/range`

### DIFF
--- a/app/routes/crate/range.js
+++ b/app/routes/crate/range.js
@@ -3,6 +3,10 @@ import { inject as service } from '@ember/service';
 
 import maxSatisfying from 'semver/ranges/max-satisfying';
 
+function cargoRangeToNpm(range) {
+  return range.replace(',', ' ');
+}
+
 export default class VersionRoute extends Route {
   @service notifications;
   @service router;
@@ -14,8 +18,9 @@ export default class VersionRoute extends Route {
     let allVersionNums = versions.map(it => it.num);
     let unyankedVersionNums = versions.filter(it => !it.yanked).map(it => it.num);
 
+    let npmRange = cargoRangeToNpm(range);
     // find a version that matches the specified range
-    let versionNum = maxSatisfying(unyankedVersionNums, range) ?? maxSatisfying(allVersionNums, range);
+    let versionNum = maxSatisfying(unyankedVersionNums, npmRange) ?? maxSatisfying(allVersionNums, npmRange);
     if (!versionNum) {
       this.notifications.error(`No matching version of crate '${crate.name}' found for: ${range}`);
       this.replaceWith('crate.index');

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -34,6 +34,20 @@ module('Route | crate.range', function (hooks) {
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 
+  test('happy path with cargo style and', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.4.2' });
+    this.server.create('version', { crate, num: '1.3.4' });
+    this.server.create('version', { crate, num: '1.3.3' });
+    this.server.create('version', { crate, num: '1.2.6' });
+
+    await visit('/crates/foo/range/>=1.3.0, <1.4.0');
+    assert.equal(currentURL(), `/crates/foo/1.3.4`);
+    assert.dom('[data-test-crate-name]').hasText('foo');
+    assert.dom('[data-test-crate-version]').hasText('1.3.4');
+    assert.dom('[data-test-notification-message]').doesNotExist();
+  });
+
   test('ignores yanked versions if possible', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0' });


### PR DESCRIPTION
Fixes #3448

It took this long because I started overthinking and went back and forth on some decisions. In the end, I decided to just replace all ',' with spaces... It should be enough for ranges that are valid for cargo (as of 0.53.0). I'm assuming that I don't need to handle the implicit caret (like renovate does) because it's inserted automatically somewhere in the backend.   
I also wanted to note that `/range/` will happily accept  ranges that are not supported by cargo (`||`, `-`, ...). Code in this commit does not handle these cases in any way. But then, cargo is currently using semver v0.10.0, meanwhile v0.11.0 implements `||`... 

For future reference:
* [Npm semver docs, section 'Advanced Range Syntax'](https://www.npmjs.com/package/semver)
* [Semver ranges in cargo docs](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio)
* [Semver parsing in cargo starts here](https://github.com/rust-lang/cargo/tree/525c5b6239eba82a03ab560402cfb48bbc2b7794/src/cargo/core/dependency.rs#L101)

