### PR TITLE
util/errors: Fix "trait objects without an explicit `dyn`" deprecation warning/error

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -202,7 +202,7 @@ impl<E: Error + Send + 'static> AppError for E {
 
 impl<E: Error + Send + 'static> From<E> for Box<dyn AppError> {
     fn from(err: E) -> Box<dyn AppError> {
-        AppError::try_convert(&err).unwrap_or_else(|| Box::new(err))
+        <dyn AppError>::try_convert(&err).unwrap_or_else(|| Box::new(err))
     }
 }
 // =============================================================================


### PR DESCRIPTION
This deprecation warning in the new Rust v1.52 beta is currently breaking our CI.

@jtgeibel I guess that's the reason why I usually prefer pinned versions in the CI configs 😉 