### PR TITLE
DownloadsCounter: Ignore flaky `test_increment_missing_version()` test for now

### DIFF
--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -357,7 +357,9 @@ mod tests {
         state.assert_downloads_count(&conn, v2, 5);
     }
 
+    // TODO: temporarily ignored due to https://github.com/rust-lang/crates.io/issues/3462
     #[test]
+    #[ignore]
     fn test_increment_missing_version() {
         let counter = DownloadsCounter::new();
         let conn = crate::db::test_conn();


### PR DESCRIPTION
This PR is related to #3462 and uses `#[ignore]` to ignore the broken test for now. This should unblock our CI runs and allows us to keep merging unrelated PRs until the test is fixed.