### PR TITLE
Improve tests for DownloadsCounter

### DIFF
--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -192,7 +192,7 @@ impl DownloadsCounter {
             shard: None,
             counted_downloads,
             counted_versions,
-            pending_downloads: old_pending - counted_downloads as i64,
+            pending_downloads: old_pending - counted_downloads as i64 - discarded_downloads as i64,
         })
     }
 


### PR DESCRIPTION
This fixes #3462, and while we're at it duplicates `test_increment_missing_version` in two separate tests, one checking when the two versions are in the same shard and one where they're in different shards.

r? @Turbo87 