### PR TITLE
Add support for testing emails

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,6 +4,7 @@ use crate::{db, Config, Env};
 use std::{sync::Arc, time::Duration};
 
 use crate::downloads_counter::DownloadsCounter;
+use crate::email::Emails;
 use crate::github::GitHubClient;
 use diesel::r2d2;
 use oauth2::basic::BasicClient;
@@ -35,6 +36,9 @@ pub struct App {
 
     /// Count downloads and periodically persist them in the database
     pub downloads_counter: DownloadsCounter,
+
+    /// Backend used to send emails
+    pub emails: Emails,
 
     /// A configured client for outgoing HTTP requests
     ///
@@ -136,6 +140,7 @@ impl App {
             session_key: config.session_key.clone(),
             config,
             downloads_counter: DownloadsCounter::new(),
+            emails: Emails::from_environment(),
             http_client,
         }
     }

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -4,6 +4,7 @@ use conduit_cookie::RequestSession;
 use oauth2::reqwest::http_client;
 use oauth2::{AuthorizationCode, Scope, TokenResponse};
 
+use crate::email::Emails;
 use crate::github::GithubUser;
 use crate::models::{NewUser, User};
 use crate::schema::users;
@@ -102,7 +103,12 @@ pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
 
     // Fetch the user info from GitHub using the access token we just got and create a user record
     let ghuser = req.app().github.current_user(token)?;
-    let user = save_user_to_database(&ghuser, &token.secret(), &*req.db_conn()?)?;
+    let user = save_user_to_database(
+        &ghuser,
+        &token.secret(),
+        &req.app().emails,
+        &*req.db_conn()?,
+    )?;
 
     // Log in by setting a cookie and the middleware authentication
     req.session_mut()
@@ -114,6 +120,7 @@ pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
 fn save_user_to_database(
     user: &GithubUser,
     access_token: &str,
+    emails: &Emails,
     conn: &PgConnection,
 ) -> AppResult<User> {
     NewUser::new(
@@ -123,7 +130,7 @@ fn save_user_to_database(
         user.avatar_url.as_deref(),
         access_token,
     )
-    .create_or_update(user.email.as_deref(), conn)
+    .create_or_update(user.email.as_deref(), emails, conn)
     .map_err(Into::into)
     .or_else(|e: Box<dyn AppError>| {
         // If we're in read only mode, we can't update their details
@@ -158,6 +165,7 @@ mod tests {
 
     #[test]
     fn gh_user_with_invalid_email_doesnt_fail() {
+        let emails = Emails::new_in_memory();
         let conn = pg_connection();
         let gh_user = GithubUser {
             email: Some("String.Format(\"{0}.{1}@live.com\", FirstName, LastName)".into()),
@@ -166,7 +174,7 @@ mod tests {
             id: -1,
             avatar_url: None,
         };
-        let result = save_user_to_database(&gh_user, "arbitrary_token", &conn);
+        let result = save_user_to_database(&gh_user, "arbitrary_token", &emails, &conn);
 
         assert!(
             result.is_ok(),

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -237,6 +237,7 @@ impl PersistStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::email::Emails;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User};
     use diesel::PgConnection;
     use semver::Version;
@@ -423,7 +424,7 @@ mod tests {
                 gh_login: "ghost",
                 ..NewUser::default()
             }
-            .create_or_update(None, conn)
+            .create_or_update(None, &Emails::new_in_memory(), conn)
             .expect("failed to create user");
 
             let krate = NewCrate {

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
 
 use crate::util::errors::{server_error, AppResult};
 
@@ -8,126 +9,175 @@ use lettre::transport::smtp::SmtpTransport;
 use lettre::{Message, Transport};
 
 #[derive(Debug)]
-pub struct MailgunConfigVars {
-    pub smtp_login: String,
-    pub smtp_password: String,
-    pub smtp_server: String,
+pub struct Emails {
+    backend: EmailBackend,
 }
 
-pub fn init_config_vars() -> Option<MailgunConfigVars> {
-    match (
-        dotenv::var("MAILGUN_SMTP_LOGIN"),
-        dotenv::var("MAILGUN_SMTP_PASSWORD"),
-        dotenv::var("MAILGUN_SMTP_SERVER"),
-    ) {
-        (Ok(login), Ok(password), Ok(server)) => Some(MailgunConfigVars {
-            smtp_login: login,
-            smtp_password: password,
-            smtp_server: server,
-        }),
-        _ => None,
+impl Emails {
+    /// Create a new instance detecting the backend from the environment. This will either connect
+    /// to a SMTP server or store the emails on the local filesystem.
+    pub fn from_environment() -> Self {
+        let backend = match (
+            dotenv::var("MAILGUN_SMTP_LOGIN"),
+            dotenv::var("MAILGUN_SMTP_PASSWORD"),
+            dotenv::var("MAILGUN_SMTP_SERVER"),
+        ) {
+            (Ok(login), Ok(password), Ok(server)) => EmailBackend::Smtp {
+                server,
+                login,
+                password,
+            },
+            _ => EmailBackend::FileSystem {
+                path: "/tmp".into(),
+            },
+        };
+
+        Self { backend }
     }
-}
 
-fn build_email(
-    recipient: &str,
-    subject: &str,
-    body: String,
-    mailgun_config: &Option<MailgunConfigVars>,
-) -> AppResult<Message> {
-    let sender = mailgun_config
-        .as_ref()
-        .map(|s| s.smtp_login.as_str())
-        .unwrap_or("test@localhost");
+    /// Create a new test backend that stores all the outgoing emails in memory, allowing for tests
+    /// to later assert the mails were sent.
+    pub fn new_in_memory() -> Self {
+        Self {
+            backend: EmailBackend::Memory {
+                mails: Mutex::new(Vec::new()),
+            },
+        }
+    }
 
-    let email = Message::builder()
-        .to(recipient.parse()?)
-        .from(sender.parse()?)
-        .subject(subject)
-        .body(body)?;
+    /// Attempts to send a confirmation email.
+    pub fn send_user_confirm(&self, email: &str, user_name: &str, token: &str) -> AppResult<()> {
+        // Create a URL with token string as path to send to user
+        // If user clicks on path, look email/user up in database,
+        // make sure tokens match
 
-    Ok(email)
-}
-
-/// Attempts to send a confirmation email. Swallows all errors.
-///
-/// This function swallows any errors that occur while attempting to send the email. Some users
-/// have an invalid email set in their GitHub profile, and we should let them sign in even though
-/// we're trying to silently use their invalid address during signup and can't send them an email.
-/// Use `try_send_user_confirm_email` when the user is directly trying to set their email.
-pub fn send_user_confirm_email(email: &str, user_name: &str, token: &str) {
-    let _ = try_send_user_confirm_email(email, user_name, token);
-}
-
-/// Attempts to send a confirmation email and returns errors.
-///
-/// For use in cases where we want to fail if an email is bad because the user is directly trying
-/// to set their email correctly, as opposed to us silently trying to use the email from their
-/// GitHub profile during signup.
-pub fn try_send_user_confirm_email(email: &str, user_name: &str, token: &str) -> AppResult<()> {
-    // Create a URL with token string as path to send to user
-    // If user clicks on path, look email/user up in database,
-    // make sure tokens match
-
-    let subject = "Please confirm your email address";
-    let body = format!(
-        "Hello {}! Welcome to Crates.io. Please click the
+        let subject = "Please confirm your email address";
+        let body = format!(
+            "Hello {}! Welcome to Crates.io. Please click the
 link below to verify your email address. Thank you!\n
 https://{}/confirm/{}",
-        user_name,
-        crate::config::domain_name(),
-        token
-    );
+            user_name,
+            crate::config::domain_name(),
+            token
+        );
 
-    send_email(email, subject, body)
-}
+        self.send(email, subject, &body)
+    }
 
-/// Attempts to send a crate owner invitation email. Swallows all errors.
-///
-/// Whether or not the email is sent, the invitation entry will be created in
-/// the database and the user will see the invitation when they visit
-/// https://crates.io/me/pending-invites/.
-pub fn send_owner_invite_email(email: &str, user_name: &str, crate_name: &str, token: &str) {
-    let subject = "Crate ownership invitation";
-    let body = format!(
-        "{} has invited you to become an owner of the crate {}!\n
+    /// Attempts to send an ownership invitation.
+    pub fn send_owner_invite(
+        &self,
+        email: &str,
+        user_name: &str,
+        crate_name: &str,
+        token: &str,
+    ) -> AppResult<()> {
+        let subject = "Crate ownership invitation";
+        let body = format!(
+            "{} has invited you to become an owner of the crate {}!\n
 Visit https://{domain}/accept-invite/{} to accept this invitation,
 or go to https://{domain}/me/pending-invites to manage all of your crate ownership invitations.",
-        user_name,
-        crate_name,
-        token,
-        domain = crate::config::domain_name()
-    );
+            user_name,
+            crate_name,
+            token,
+            domain = crate::config::domain_name()
+        );
 
-    let _ = send_email(email, subject, body);
-}
+        self.send(email, subject, &body)
+    }
 
-fn send_email(recipient: &str, subject: &str, body: String) -> AppResult<()> {
-    let mailgun_config = init_config_vars();
-    let email = build_email(recipient, subject, body, &mailgun_config)?;
-
-    match mailgun_config {
-        Some(mailgun_config) => {
-            let transport = SmtpTransport::relay(&mailgun_config.smtp_server)
-                .unwrap()
-                .credentials(Credentials::new(
-                    mailgun_config.smtp_login,
-                    mailgun_config.smtp_password,
-                ))
-                .authentication(vec![Mechanism::Plain])
-                .build();
-
-            let result = transport.send(&email);
-            result.map_err(|_| server_error("Error in sending email"))?;
-        }
-        None => {
-            let sender = FileTransport::new(Path::new("/tmp"));
-            let result = sender.send(&email);
-            result.map_err(|_| server_error("Email file could not be generated"))?;
+    /// This is supposed to be used only during tests, to retrieve the messages stored in the
+    /// "memory" backend. It's not cfg'd away because our integration tests need to access this.
+    pub fn mails_in_memory(&self) -> Option<Vec<StoredEmail>> {
+        if let EmailBackend::Memory { mails } = &self.backend {
+            Some(mails.lock().unwrap().clone())
+        } else {
+            None
         }
     }
 
-    Ok(())
+    fn send(&self, recipient: &str, subject: &str, body: &str) -> AppResult<()> {
+        let email = Message::builder()
+            .to(recipient.parse()?)
+            .from(self.sender_address().parse()?)
+            .subject(subject)
+            .body(body.to_string())?;
+
+        match &self.backend {
+            EmailBackend::Smtp {
+                server,
+                login,
+                password,
+            } => {
+                SmtpTransport::relay(&server)?
+                    .credentials(Credentials::new(login.clone(), password.clone()))
+                    .authentication(vec![Mechanism::Plain])
+                    .build()
+                    .send(&email)
+                    .map_err(|_| server_error("Error in sending email"))?;
+            }
+            EmailBackend::FileSystem { path } => {
+                FileTransport::new(&path)
+                    .send(&email)
+                    .map_err(|_| server_error("Email file could not be generated"))?;
+            }
+            EmailBackend::Memory { mails } => mails.lock().unwrap().push(StoredEmail {
+                to: recipient.into(),
+                subject: subject.into(),
+                body: body.into(),
+            }),
+        }
+
+        Ok(())
+    }
+
+    fn sender_address(&self) -> &str {
+        match &self.backend {
+            EmailBackend::Smtp { login, .. } => login,
+            EmailBackend::FileSystem { .. } => "test@localhost",
+            EmailBackend::Memory { .. } => "test@localhost",
+        }
+    }
+}
+
+enum EmailBackend {
+    /// Backend used in production to send mails using SMTP.
+    Smtp {
+        server: String,
+        login: String,
+        password: String,
+    },
+    /// Backend used locally during development, will store the emails in the provided directory.
+    FileSystem { path: PathBuf },
+    /// Backend used during tests, will keep messages in memory to allow tests to retrieve them.
+    Memory { mails: Mutex<Vec<StoredEmail>> },
+}
+
+// Custom Debug implementation to avoid showing the SMTP password.
+impl std::fmt::Debug for EmailBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EmailBackend::Smtp { server, login, .. } => {
+                // The password field is *intentionally* not included
+                f.debug_struct("Smtp")
+                    .field("server", server)
+                    .field("login", login)
+                    .finish()?;
+            }
+            EmailBackend::FileSystem { path } => {
+                f.debug_struct("FileSystem").field("path", path).finish()?;
+            }
+            EmailBackend::Memory { .. } => f.write_str("Memory")?,
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredEmail {
+    pub to: String,
+    pub subject: String,
+    pub body: String,
 }
 
 #[cfg(test)]
@@ -136,17 +186,19 @@ mod tests {
 
     #[test]
     fn sending_to_invalid_email_fails() {
-        let result = send_email(
+        let emails = Emails::new_in_memory();
+
+        assert_err!(emails.send(
             "String.Format(\"{0}.{1}@live.com\", FirstName, LastName)",
             "test",
-            "test".to_string(),
-        );
-        assert_err!(result);
+            "test",
+        ));
     }
 
     #[test]
     fn sending_to_valid_email_succeeds() {
-        let result = send_email("someone@example.com", "test", "test".to_string());
-        assert_ok!(result);
+        let emails = Emails::new_in_memory();
+
+        assert_ok!(emails.send("someone@example.com", "test", "test"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ extern crate serde_json;
 #[macro_use]
 extern crate tracing;
 
-pub use crate::{app::App, config::Config, uploaders::Uploader};
+pub use crate::{app::App, config::Config, email::Emails, uploaders::Uploader};
 use std::sync::Arc;
 
 use conduit_middleware::MiddlewareBuilder;

--- a/src/publish_rate_limit.rs
+++ b/src/publish_rate_limit.rs
@@ -104,6 +104,7 @@ impl PublishRateLimit {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::email::Emails;
     use crate::test_util::*;
 
     #[test]
@@ -325,7 +326,7 @@ mod tests {
             gh_login,
             ..NewUser::default()
         }
-        .create_or_update(None, conn)?;
+        .create_or_update(None, &Emails::new_in_memory(), conn)?;
         Ok(user.id)
     }
 

--- a/src/tasks/update_downloads.rs
+++ b/src/tasks/update_downloads.rs
@@ -83,12 +83,13 @@ fn collect(conn: &PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::email::Emails;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
     use std::collections::HashMap;
 
     fn user(conn: &PgConnection) -> User {
         NewUser::new(2, "login", None, None, "access_token")
-            .create_or_update(None, conn)
+            .create_or_update(None, &Emails::new_in_memory(), conn)
             .unwrap()
     }
 

--- a/src/tests/krate/search.rs
+++ b/src/tests/krate/search.rs
@@ -14,7 +14,9 @@ fn index() {
     assert_eq!(json.meta.total, 0);
 
     let krate = app.db(|conn| {
-        let u = new_user("foo").create_or_update(None, conn).unwrap();
+        let u = new_user("foo")
+            .create_or_update(None, &app.as_inner().emails, conn)
+            .unwrap();
         CrateBuilder::new("fooindex", u.id).expect_build(conn)
     });
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -2,12 +2,13 @@ use crate::{
     add_team_to_crate,
     builders::{CrateBuilder, PublishBuilder},
     new_team,
-    util::{MockCookieUser, MockTokenUser, RequestHelper},
+    util::{MockAnonymousUser, MockCookieUser, MockTokenUser, RequestHelper},
     TestApp,
 };
 use cargo_registry::{
     models::Crate,
     views::{EncodableCrateOwnerInvitation, EncodableOwner, InvitationResponse},
+    Emails,
 };
 
 use conduit::StatusCode;
@@ -81,6 +82,19 @@ impl MockCookieUser {
     /// As the currently logged in user, list my pending invitations.
     fn list_invitations(&self) -> InvitationListResponse {
         self.get("/api/v1/me/crate_owner_invitations").good()
+    }
+}
+
+impl MockAnonymousUser {
+    fn accept_ownership_invitation_by_token(&self, token: &str) {
+        #[derive(Deserialize)]
+        struct Response {
+            crate_owner_invitation: InvitationResponse,
+        }
+
+        let url = format!("/api/v1/me/crate_owner_invitations/accept/{}", token);
+        let response: Response = self.put(&url, &[]).good();
+        assert!(response.crate_owner_invitation.accepted);
     }
 }
 
@@ -382,6 +396,31 @@ fn test_decline_invitation() {
 }
 
 #[test]
+fn test_accept_invitation_by_mail() {
+    let (app, anon, owner, owner_token) = TestApp::init().with_token();
+    let owner = owner.as_model();
+    let invited_user = app.db_new_user("user_bar");
+    let _krate = app.db(|conn| CrateBuilder::new("accept_invitation", owner.id).expect_build(conn));
+
+    // Invite a new owner
+    owner_token.add_user_owner("accept_invitation", "user_bar");
+
+    // Retrieve the ownership invitation
+    let invite_token = extract_token_from_invite_email(&app.as_inner().emails);
+
+    // Accept the invitation anonymously with a token
+    anon.accept_ownership_invitation_by_token(&invite_token);
+
+    // New owner's invitation list should now be empty
+    let json = invited_user.list_invitations();
+    assert_eq!(json.crate_owner_invitations.len(), 0);
+
+    // New owner is now listed as an owner, so the crate has two owners
+    let json = anon.show_crate_owners("accept_invitation");
+    assert_eq!(json.users.len(), 2);
+}
+
+#[test]
 fn inactive_users_dont_get_invitations() {
     use cargo_registry::models::NewUser;
     use std::borrow::Cow;
@@ -436,4 +475,21 @@ fn highest_gh_id_is_most_recent_account_we_know_of() {
 
     let json = invited_user.list_invitations();
     assert_eq!(json.crate_owner_invitations.len(), 1);
+}
+
+fn extract_token_from_invite_email(emails: &Emails) -> String {
+    let message = emails
+        .mails_in_memory()
+        .unwrap()
+        .into_iter()
+        .find(|m| m.subject.contains("invitation"))
+        .expect("missing email");
+
+    // Simple (but kinda fragile) parser to extract the token.
+    let before_token = "/accept-invite/";
+    let after_token = " ";
+    let body = message.body.as_str();
+    let before_pos = body.find(before_token).unwrap() + before_token.len();
+    let after_pos = before_pos + (&body[before_pos..]).find(after_token).unwrap();
+    body[before_pos..after_pos].to_string()
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -401,7 +401,7 @@ fn inactive_users_dont_get_invitations() {
             gh_avatar: None,
             gh_access_token: Cow::Borrowed("some random token"),
         }
-        .create_or_update(None, conn)
+        .create_or_update(None, &app.as_inner().emails, conn)
         .unwrap();
         CrateBuilder::new(krate_name, owner.id).expect_build(conn);
     });


### PR DESCRIPTION
Before this PR there wasn't really a practical way to test what the content of an email is, which makes it harder for example to test that the token included in the ownership confirmation email works with the relevant APIs.

The main thing this PR does is refactoring the email handling code, moving from standalone functions to an `Emails` struct (an instance of it is stored in the `App`). This allows to configure which email backend is used at startup instead of automatically detecting it every time we happen to send an email address. It will also allow to persist other email-related information when we'll need to.

Thanks to the new email backends support this PR also adds a "memory" backend, used during tests. Instead of sending the email via SMTP or storing it into a file, the "memory" backend stores it in a `Mutex<Vec<_>>` which can be inspected by any test.

Finally, to test the new email testing capabilities this PR adds a test to ensure a user can accept an ownership invitation with the token included in the email.

This PR is best reviewed commit-by-commit.
r? @jtgeibel or @Turbo87 