### PR TITLE
CrateOwnerInvite: Avoid "missing `id`" issue

### DIFF
--- a/app/serializers/crate-owner-invite.js
+++ b/app/serializers/crate-owner-invite.js
@@ -10,4 +10,12 @@ export default class CrateOwnerInviteSerializer extends ApplicationSerializer {
   payloadKeyFromModelName() {
     return 'crate_owner_invite';
   }
+
+  normalizeResponse(store, schema, payload, id, requestType) {
+    if (payload.users) {
+      delete payload.users;
+    }
+
+    return super.normalizeResponse(store, schema, payload, id, requestType);
+  }
 }

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -15,21 +15,32 @@ module('Acceptance | /me/pending-invites', function (hooks) {
     let user = context.server.create('user');
     context.authenticateAs(user);
 
-    context.server.get('/api/v1/me/crate_owner_invitations', {
-      crate_owner_invitations: [
-        {
-          invited_by_username: 'janed',
-          crate_name: 'nanomsg',
-          crate_id: 42,
-          created_at: '2016-12-24T12:34:56Z',
-        },
-        {
-          invited_by_username: 'wycats',
-          crate_name: 'ember-rs',
-          crate_id: 1,
-          created_at: '2020-12-31T12:34:56Z',
-        },
-      ],
+    let inviter = context.server.create('user', { name: 'janed' });
+    let inviter2 = context.server.create('user', { name: 'wycats' });
+    context.server.get('/api/v1/me/crate_owner_invitations', function () {
+      let users = [this.serialize(inviter, 'user').user, this.serialize(inviter2, 'user').user];
+
+      return {
+        crate_owner_invitations: [
+          {
+            invited_by_username: 'janed',
+            crate_name: 'nanomsg',
+            crate_id: 42,
+            created_at: '2016-12-24T12:34:56Z',
+            invitee_id: parseInt(user.id, 10),
+            inviter_id: parseInt(inviter.id, 10),
+          },
+          {
+            invited_by_username: 'wycats',
+            crate_name: 'ember-rs',
+            crate_id: 1,
+            created_at: '2020-12-31T12:34:56Z',
+            invitee_id: parseInt(user.id, 10),
+            inviter_id: parseInt(inviter2.id, 10),
+          },
+        ],
+        users,
+      };
     });
   }
 


### PR DESCRIPTION
Ember Data expects all resources to have an `id`. In this serializer we are renaming that expectation to `crate_id` for questionable reasons. This worked fine as long as only `CrateOwnerInvite` resources were contained in the response, but now we also have `User` resources, and those don't have a `crate_id` attribute, which is causing issues.

This commit removes the `users` array from the response for now to fix this problem. In the future we should look into either responding with a proper ID or generating it based on `crate_id` and `invitee_id`.

