### PR TITLE
Add an expiration to owner invitations

### DIFF
--- a/app/components/pending-owner-invite-row.js
+++ b/app/components/pending-owner-invite-row.js
@@ -17,7 +17,7 @@ export default class PendingOwnerInviteRow extends Component {
       yield this.args.invite.save();
       this.isAccepted = true;
     } catch (error) {
-      if (error.errors) {
+      if (error.errors?.[0]?.detail && error.errors[0].detail !== '[object Object]') {
         this.notifications.error(`Error in accepting invite: ${error.errors[0].detail}`);
       } else {
         this.notifications.error('Error in accepting invite');
@@ -33,7 +33,7 @@ export default class PendingOwnerInviteRow extends Component {
       yield this.args.invite.save();
       this.isDeclined = true;
     } catch (error) {
-      if (error.errors) {
+      if (error.errors?.[0]?.detail && error.errors[0].detail !== '[object Object]') {
         this.notifications.error(`Error in declining invite: ${error.errors[0].detail}`);
       } else {
         this.notifications.error('Error in declining invite');

--- a/app/routes/accept-invite.js
+++ b/app/routes/accept-invite.js
@@ -6,11 +6,9 @@ export default class AcceptInviteRoute extends Route {
   async model(params) {
     try {
       await ajax(`/api/v1/me/crate_owner_invitations/accept/${params.token}`, { method: 'PUT', body: '{}' });
-      this.set('response', { accepted: true });
-      return { response: this.response };
+      return { response: { accepted: true } };
     } catch {
-      this.set('response', { accepted: false });
-      return { response: this.response };
+      return { response: { accepted: false } };
     }
   }
 }

--- a/app/routes/accept-invite.js
+++ b/app/routes/accept-invite.js
@@ -6,9 +6,11 @@ export default class AcceptInviteRoute extends Route {
   async model(params) {
     try {
       await ajax(`/api/v1/me/crate_owner_invitations/accept/${params.token}`, { method: 'PUT', body: '{}' });
-      return { response: { accepted: true } };
-    } catch {
-      return { response: { accepted: false } };
+      return { ok: true };
+    } catch (error) {
+      let json = await error.json?.();
+      let errorText = json?.errors?.[0]?.detail;
+      return { ok: false, errorText };
     }
   }
 }

--- a/app/templates/accept-invite.hbs
+++ b/app/templates/accept-invite.hbs
@@ -1,7 +1,13 @@
-{{#if this.model.response.accepted}}
+{{#if @model.ok}}
   <h1>You've been added as a crate owner!</h1>
   <p data-test-success-message>Visit your <a href="/dashboard">dashboard</a> to view all of your crates, or <a href="/me">account settings</a> to manage email notification preferences for all of your crates.</p>
 {{else}}
   <h1>Error in accepting crate ownership.</h1>
-  <p data-test-error-message>You may want to visit <a href="/me/pending-invites">crates.io/me/pending-invites</a> to try again.</p>
+  <p data-test-error-message>
+    {{#if @model.errorText}}
+      {{@model.errorText}}
+    {{else}}
+      You may want to visit <a href="/me/pending-invites">crates.io/me/pending-invites</a> to try again.
+    {{/if}}
+  </p>
 {{/if}}

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,7 @@ pub struct Config {
     pub domain_name: String,
     pub allowed_origins: Vec<String>,
     pub downloads_persist_interval_ms: usize,
+    pub ownership_invitations_expiration_days: u64,
 }
 
 impl Default for Config {
@@ -29,6 +30,7 @@ impl Default for Config {
     ///
     /// - `Config::max_upload_size`: 10MiB
     /// - `Config::api_protocol`: `https`
+    /// - `Config::ownership_invitations_expiration_days`: 30
     ///
     /// Pulls values from the following environment variables:
     ///
@@ -153,6 +155,7 @@ impl Default for Config {
                         .expect("invalid DOWNLOADS_PERSIST_INTERVAL_MS")
                 })
                 .unwrap_or(60_000), // 1 minute
+            ownership_invitations_expiration_days: 30,
         }
     }
 }

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -61,7 +61,8 @@ pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
                 .map(|name| name.clone())
                 .unwrap_or_else(|| String::from("(unknown crate name)"));
 
-            EncodableCrateOwnerInvitation::from(invitation, inviter_name, crate_name)
+            let expires_at = invitation.expires_at(&config);
+            EncodableCrateOwnerInvitation::from(invitation, inviter_name, crate_name, expires_at)
         })
         .collect();
 

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -96,10 +96,11 @@ pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_invite = crate_invite.crate_owner_invite;
     let user_id = req.authenticate()?.user_id();
     let conn = &*req.db_conn()?;
+    let config = &req.app().config;
 
     let invitation = CrateOwnerInvitation::find_by_id(user_id, crate_invite.crate_id, &conn)?;
     if crate_invite.accepted {
-        invitation.accept(&conn)?;
+        invitation.accept(&conn, config)?;
     } else {
         invitation.decline(&conn)?;
     }
@@ -115,12 +116,13 @@ pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
 
 /// Handles the `PUT /me/crate_owner_invitations/accept/:token` route.
 pub fn handle_invite_with_token(req: &mut dyn RequestExt) -> EndpointResult {
+    let config = &req.app().config;
     let conn = req.db_conn()?;
     let req_token = &req.params()["token"];
 
     let invitation = CrateOwnerInvitation::find_by_token(req_token, &conn)?;
     let crate_id = invitation.crate_id;
-    invitation.accept(&conn)?;
+    invitation.accept(&conn, config)?;
 
     #[derive(Serialize)]
     struct R {

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -45,8 +45,10 @@ pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
     let crates: HashMap<i32, String> = crates.into_iter().collect();
 
     // Turn `CrateOwnerInvitation` list into `EncodableCrateOwnerInvitation` list
+    let config = &req.app().config;
     let crate_owner_invitations = crate_owner_invitations
         .into_iter()
+        .filter(|i| !i.is_expired(config))
         .map(|invitation| {
             let inviter_id = invitation.invited_by_user_id;
             let inviter_name = users

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,7 @@
 pub use self::action::{insert_version_owner_action, VersionAction, VersionOwnerAction};
 pub use self::badge::{Badge, CrateBadge, MaintenanceStatus};
 pub use self::category::{Category, CrateCategory, NewCategory};
-pub use self::crate_owner_invitation::{CrateOwnerInvitation, NewCrateOwnerInvitation};
+pub use self::crate_owner_invitation::{CrateOwnerInvitation, NewCrateOwnerInvitationOutcome};
 pub use self::dependency::{Dependency, DependencyKind, ReverseDependency};
 pub use self::download::VersionDownload;
 pub use self::email::{Email, NewEmail};

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -111,7 +111,7 @@ impl CrateOwnerInvitation {
         self.expires_at(config) <= Utc::now().naive_utc()
     }
 
-    fn expires_at(&self, config: &Config) -> NaiveDateTime {
+    pub fn expires_at(&self, config: &Config) -> NaiveDateTime {
         let days = chrono::Duration::days(config.ownership_invitations_expiration_days as i64);
         self.created_at + days
     }

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -107,7 +107,7 @@ impl CrateOwnerInvitation {
         Ok(())
     }
 
-    fn is_expired(&self, config: &Config) -> bool {
+    pub fn is_expired(&self, config: &Config) -> bool {
         self.expires_at(config) <= Utc::now().naive_utc()
     }
 

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -1,6 +1,9 @@
 use chrono::NaiveDateTime;
 
-use crate::schema::crate_owner_invitations;
+use crate::models::{CrateOwner, OwnerKind};
+use crate::schema::{crate_owner_invitations, crate_owners};
+use crate::util::errors::AppResult;
+use diesel::prelude::*;
 
 /// The model representing a row in the `crate_owner_invitations` database table.
 #[derive(Clone, Debug, PartialEq, Eq, Identifiable, Queryable)]
@@ -20,4 +23,44 @@ pub struct NewCrateOwnerInvitation {
     pub invited_user_id: i32,
     pub invited_by_user_id: i32,
     pub crate_id: i32,
+}
+
+impl CrateOwnerInvitation {
+    pub fn find_by_id(user_id: i32, crate_id: i32, conn: &PgConnection) -> AppResult<Self> {
+        Ok(crate_owner_invitations::table
+            .find((user_id, crate_id))
+            .first::<Self>(&*conn)?)
+    }
+
+    pub fn find_by_token(token: &str, conn: &PgConnection) -> AppResult<Self> {
+        Ok(crate_owner_invitations::table
+            .filter(crate_owner_invitations::token.eq(token))
+            .first::<Self>(&*conn)?)
+    }
+
+    pub fn accept(self, conn: &PgConnection) -> AppResult<()> {
+        conn.transaction(|| {
+            diesel::insert_into(crate_owners::table)
+                .values(&CrateOwner {
+                    crate_id: self.crate_id,
+                    owner_id: self.invited_user_id,
+                    created_by: self.invited_by_user_id,
+                    owner_kind: OwnerKind::User as i32,
+                    email_notifications: true,
+                })
+                .on_conflict(crate_owners::table.primary_key())
+                .do_update()
+                .set(crate_owners::deleted.eq(false))
+                .execute(conn)?;
+
+            diesel::delete(&self).execute(conn)?;
+
+            Ok(())
+        })
+    }
+
+    pub fn decline(self, conn: &PgConnection) -> AppResult<()> {
+        diesel::delete(&self).execute(conn)?;
+        Ok(())
+    }
 }

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -333,7 +333,8 @@ impl Crate {
         match owner {
             // Users are invited and must accept before being added
             Owner::User(user) => {
-                match CrateOwnerInvitation::create(user.id, req_user.id, self.id, conn)? {
+                let config = &app.config;
+                match CrateOwnerInvitation::create(user.id, req_user.id, self.id, conn, config)? {
                     NewCrateOwnerInvitationOutcome::InviteCreated { plaintext_token } => {
                         if let Ok(Some(email)) = user.verified_email(&conn) {
                             // Swallow any error. Whether or not the email is sent, the invitation

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -9,7 +9,7 @@ use crate::app::App;
 use crate::controllers::helpers::pagination::*;
 use crate::models::version::TopVersions;
 use crate::models::{
-    Badge, CrateOwner, CrateOwnerInvitation, NewCrateOwnerInvitation, Owner, OwnerKind,
+    Badge, CrateOwner, CrateOwnerInvitation, NewCrateOwnerInvitationOutcome, Owner, OwnerKind,
     ReverseDependency, User, Version,
 };
 use crate::util::errors::{cargo_err, AppResult};
@@ -333,35 +333,30 @@ impl Crate {
         match owner {
             // Users are invited and must accept before being added
             Owner::User(user) => {
-                let maybe_inserted: Option<CrateOwnerInvitation> =
-                    insert_into(crate_owner_invitations::table)
-                        .values(&NewCrateOwnerInvitation {
-                            invited_user_id: user.id,
-                            invited_by_user_id: req_user.id,
-                            crate_id: self.id,
-                        })
-                        .on_conflict_do_nothing()
-                        .get_result(conn)
-                        .optional()?;
+                match CrateOwnerInvitation::create(user.id, req_user.id, self.id, conn)? {
+                    NewCrateOwnerInvitationOutcome::InviteCreated { plaintext_token } => {
+                        if let Ok(Some(email)) = user.verified_email(&conn) {
+                            // Swallow any error. Whether or not the email is sent, the invitation
+                            // entry will be created in the database and the user will see the
+                            // invitation when they visit https://crates.io/me/pending-invites/.
+                            let _ = app.emails.send_owner_invite(
+                                &email,
+                                &req_user.gh_login,
+                                &self.name,
+                                &plaintext_token,
+                            );
+                        }
 
-                if let Some(ownership_invitation) = maybe_inserted {
-                    if let Ok(Some(email)) = user.verified_email(&conn) {
-                        // Swallow any error. Whether or not the email is sent, the invitation
-                        // entry will be created in the database and the user will see the
-                        // invitation when they visit https://crates.io/me/pending-invites/.
-                        let _ = app.emails.send_owner_invite(
-                            &email,
-                            &req_user.gh_login,
-                            &self.name,
-                            &ownership_invitation.token,
-                        );
+                        Ok(format!(
+                            "user {} has been invited to be an owner of crate {}",
+                            user.gh_login, self.name
+                        ))
                     }
+                    NewCrateOwnerInvitationOutcome::AlreadyExists => Ok(format!(
+                        "user {} already has a pending invitation to be an owner of crate {}",
+                        user.gh_login, self.name
+                    )),
                 }
-
-                Ok(format!(
-                    "user {} has been invited to be an owner of crate {}",
-                    user.gh_login, self.name
-                ))
             }
             // Teams are added as owners immediately
             owner @ Owner::Team(_) => {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -404,6 +404,8 @@ fn invitations_list() {
                 inviter_id: owner.id,
                 // This value changes with each test run so we can't use a fixed value here
                 created_at: invitations.crate_owner_invitations[0].created_at,
+                // This value changes with each test run so we can't use a fixed value here
+                expires_at: invitations.crate_owner_invitations[0].expires_at,
             }],
             users: vec![owner.clone().into()],
         }
@@ -437,6 +439,8 @@ fn invitations_list_does_not_include_expired_invites() {
                 inviter_id: owner.id,
                 // This value changes with each test run so we can't use a fixed value here
                 created_at: invitations.crate_owner_invitations[0].created_at,
+                // This value changes with each test run so we can't use a fixed value here
+                expires_at: invitations.crate_owner_invitations[0].expires_at,
             }],
             users: vec![owner.clone().into()],
         }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -316,6 +316,7 @@ fn simple_config() -> Config {
         domain_name: "crates.io".into(),
         allowed_origins: Vec::new(),
         downloads_persist_interval_ms: 1000,
+        ownership_invitations_expiration_days: 30,
     }
 }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -25,7 +25,10 @@ use crate::util::AppResponse;
 mod json;
 
 pub use json::TOKEN_FORMAT_ERROR;
-pub(crate) use json::{InsecurelyGeneratedTokenRevoked, NotFound, ReadOnlyMode, TooManyRequests};
+pub(crate) use json::{
+    InsecurelyGeneratedTokenRevoked, NotFound, OwnershipInvitationExpired, ReadOnlyMode,
+    TooManyRequests,
+};
 
 /// Returns an error with status 200 and the provided description as JSON
 ///

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -229,3 +229,25 @@ impl fmt::Display for AccountLocked {
         }
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct OwnershipInvitationExpired {
+    pub(crate) crate_name: String,
+}
+
+impl AppError for OwnershipInvitationExpired {
+    fn response(&self) -> Option<AppResponse> {
+        Some(json_error(&self.to_string(), StatusCode::GONE))
+    }
+}
+
+impl fmt::Display for OwnershipInvitationExpired {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "The invitation to become an owner of the {} crate expired. \
+             Please reach out to an owner of the crate to request a new invitation.",
+            self.crate_name
+        )
+    }
+}

--- a/src/views.rs
+++ b/src/views.rs
@@ -2,6 +2,7 @@ use chrono::NaiveDateTime;
 use std::collections::HashMap;
 use url::Url;
 
+use crate::config::Config;
 use crate::github;
 use crate::models::{
     Badge, Category, Crate, CrateOwnerInvitation, CreatedApiToken, Dependency, DependencyKind,

--- a/src/views.rs
+++ b/src/views.rs
@@ -2,7 +2,6 @@ use chrono::NaiveDateTime;
 use std::collections::HashMap;
 use url::Url;
 
-use crate::config::Config;
 use crate::github;
 use crate::models::{
     Badge, Category, Crate, CrateOwnerInvitation, CreatedApiToken, Dependency, DependencyKind,
@@ -83,6 +82,8 @@ pub struct EncodableCrateOwnerInvitation {
     pub crate_id: i32,
     #[serde(with = "rfc3339")]
     pub created_at: NaiveDateTime,
+    #[serde(with = "rfc3339")]
+    pub expires_at: NaiveDateTime,
 }
 
 impl EncodableCrateOwnerInvitation {
@@ -90,6 +91,7 @@ impl EncodableCrateOwnerInvitation {
         invitation: CrateOwnerInvitation,
         inviter_name: String,
         crate_name: String,
+        expires_at: NaiveDateTime,
     ) -> Self {
         Self {
             invitee_id: invitation.invited_user_id,
@@ -98,6 +100,7 @@ impl EncodableCrateOwnerInvitation {
             crate_name,
             crate_id: invitation.crate_id,
             created_at: invitation.created_at,
+            expires_at,
         }
     }
 }
@@ -805,11 +808,15 @@ mod tests {
             crate_name: "".to_string(),
             crate_id: 123,
             created_at: NaiveDate::from_ymd(2017, 1, 6).and_hms(14, 23, 11),
+            expires_at: NaiveDate::from_ymd(2020, 10, 24).and_hms(16, 30, 00),
         };
         let json = serde_json::to_string(&inv).unwrap();
         assert_some!(json
             .as_str()
             .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
+        assert_some!(json
+            .as_str()
+            .find(r#""expires_at":"2020-10-24T16:30:00+00:00""#));
     }
 
     #[test]

--- a/src/views.rs
+++ b/src/views.rs
@@ -73,7 +73,7 @@ pub struct EncodableCategoryWithSubcategories {
 }
 
 /// The serialization format for the `CrateOwnerInvitation` model.
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct EncodableCrateOwnerInvitation {
     pub invitee_id: i32,
     pub inviter_id: i32,
@@ -521,7 +521,7 @@ impl EncodablePrivateUser {
 
 /// The serialization format for the `User` model.
 /// Same as private user, except no email field
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
 pub struct EncodablePublicUser {
     pub id: i32,
     pub login: String,

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -165,7 +165,24 @@ module('Acceptance | /me/pending-invites', function (hooks) {
     assert.equal(currentURL(), '/me/pending-invites');
 
     await click('[data-test-invite="nanomsg"] [data-test-accept-button]');
-    assert.dom('[data-test-notification-message="error"]').containsText('Error in accepting invite');
+    assert.dom('[data-test-notification-message="error"]').hasText('Error in accepting invite');
+    assert.dom('[data-test-accepted-message]').doesNotExist();
+    assert.dom('[data-test-declined-message]').doesNotExist();
+  });
+
+  test('specific error message is shown if accept request fails', async function (assert) {
+    prepare(this);
+
+    let errorMessage =
+      'The invitation to become an owner of the demo_crate crate expired. Please reach out to an owner of the crate to request a new invitation.';
+    let payload = { errors: [{ detail: errorMessage }] };
+    this.server.put('/api/v1/me/crate_owner_invitations/:crate', payload, 410);
+
+    await visit('/me/pending-invites');
+    assert.equal(currentURL(), '/me/pending-invites');
+
+    await click('[data-test-invite="nanomsg"] [data-test-accept-button]');
+    assert.dom('[data-test-notification-message="error"]').hasText('Error in accepting invite: ' + errorMessage);
     assert.dom('[data-test-accepted-message]').doesNotExist();
     assert.dom('[data-test-declined-message]').doesNotExist();
   });

--- a/tests/acceptance/token-invites-test.js
+++ b/tests/acceptance/token-invites-test.js
@@ -36,6 +36,17 @@ module('Acceptance | /accept-invite/:token', function (hooks) {
     assert.dom('[data-test-error-message]').hasText('You may want to visit crates.io/me/pending-invites to try again.');
   });
 
+  test('shows error for expired token', async function (assert) {
+    let errorMessage =
+      'The invitation to become an owner of the demo_crate crate expired. Please reach out to an owner of the crate to request a new invitation.';
+    let payload = { errors: [{ detail: errorMessage }] };
+    this.server.put('/api/v1/me/crate_owner_invitations/accept/:token', payload, 410);
+
+    await visit('/accept-invite/secret123');
+    assert.equal(currentURL(), '/accept-invite/secret123');
+    assert.dom('[data-test-error-message]').hasText(errorMessage);
+  });
+
   test('shows success for known token', async function (assert) {
     assert.expect(3);
 


### PR DESCRIPTION
This PR fixes #2869 by implementing a 30 days expiration for all ownership invitations.

Once an invite gets past its expiration date it will disappear from the [pending invites page](https://crates.io/me/pending-invites), and trying to accept it with the email link will display a message saying the invite expired and that the user needs to request a new one from the crate owner. Technically it's possible to decline an invite after it's expired through the API, but declining just deletes the row from the database so it's fine.

The new expiration rules will apply to existing invites too, and invites created more than 30 days before the deploy will instantly be treated as expired. The expiration check is entirely done on the application side, and the database schema is not changed: rolling back the PR will revert to the previous behavior of invites never expiring for invites generated both before and after the deploy.

Note that trying to send another invite to the same user before the expiration date will *not* extend the expiration date.

There are full tests for the whole functionality, and some refactors are included as part of this PR. Thanks @Turbo87 for authoring the first three commits handling a frontend bug when accepting expired invites via email!

r? @jtgeibel 
This PR is best reviewed commit by commit.