### PR TITLE
Increase HTTP request timeout for background jobs

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -40,8 +40,12 @@ fn main() {
     println!("Index cloned");
 
     let build_runner = || {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(45))
+            .build()
+            .expect("Couldn't build client");
         let environment =
-            Environment::new_shared(repository.clone(), config.uploader.clone(), Client::new());
+            Environment::new_shared(repository.clone(), config.uploader.clone(), client);
         let db_config = r2d2::Pool::builder().min_idle(Some(0));
         swirl::Runner::builder(environment)
             .connection_pool_builder(&db_url, db_config)


### PR DESCRIPTION
Due to the large size of the database dumps, the upload does not complete within the default 30 second timeout.

Because the database dump job was repeatedly failing, I deleted the job for today. The current database dump on S3 is probably truncated. Hopefully we can land and deploy this before the job is queued again in about 22 hours.

r? @pietroalbini 