### PR TITLE
Make it possible to open the search using S

### DIFF
--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -23,6 +23,7 @@
       >
       <label for="cargo-desktop-search" local-class="search-label">Search</label>
       {{on-key 's' (focus '#cargo-desktop-search')}}
+      {{on-key 'S' (focus '#cargo-desktop-search')}}
       {{on-key 'shift+s' (focus '#cargo-desktop-search')}}
     </form>
 

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -89,6 +89,10 @@ module('Acceptance | search', function (hooks) {
     assert.dom('[data-test-search-input]').isFocused();
 
     await blur('[data-test-search-input]');
+    await keyDown('S');
+    assert.dom('[data-test-search-input]').isFocused();
+
+    await blur('[data-test-search-input]');
     await keyDown('shift+s');
     assert.dom('[data-test-search-input]').isFocused();
   });


### PR DESCRIPTION
Now it's more flexible and works even if you (possibly accidentally) have Caps Lock enabled. This already works for the Rust docs too so I thought it's more consistent this way.