### PR TITLE
Show features of dependencies

### DIFF
--- a/app/components/dependency-list/row.hbs
+++ b/app/components/dependency-list/row.hbs
@@ -35,6 +35,17 @@
       </span>
     </div>
 
+    {{#if (or (not @dependency.default_features) @dependency.features)}}
+      <div local-class="features" data-test-features>
+        {{#if (not @dependency.default_features)}}
+        default-features=false
+        {{/if}}
+        {{#if @dependency.features}}
+        features={{@dependency.features}}
+        {{/if}}
+      </div>
+    {{/if}}
+
     {{#if (or this.description this.loadCrateTask.isRunning)}}
       <div local-class="description" data-test-description>
         {{#if this.loadCrateTask.isRunning}}

--- a/app/components/dependency-list/row.module.css
+++ b/app/components/dependency-list/row.module.css
@@ -117,6 +117,12 @@
     }
 }
 
+.features {
+    margin-top: 10px;
+    color: var(--crate-color);
+    font-size: 80%;
+}
+
 .description {
     margin-top: 10px;
     color: var(--crate-color);


### PR DESCRIPTION
I keep getting asked why my crate depends on `tokio` besides it just needing a small subset of features: https://github.com/bikeshedder/deadpool/issues/88

This PR adds the list of features used from each dependency to the dependencies tab:

![image](https://user-images.githubusercontent.com/1112569/114195470-c5ce5800-9950-11eb-88c0-8e607a29213d.png)
