### PR TITLE
Log a flag for downloads with non-canonical crate names

### DIFF
--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -20,7 +20,7 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
     let version = &req.params()["version"];
 
-    let (version_id, crate_name): (_, String) = {
+    let (version_id, canonical_crate_name): (_, String) = {
         use self::versions::dsl::*;
 
         let conn = recorder.record("get_conn", || req.db_conn())?;
@@ -45,7 +45,11 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
         .app()
         .config
         .uploader
-        .crate_location(&crate_name, version);
+        .crate_location(&canonical_crate_name, version);
+
+    if &canonical_crate_name != crate_name {
+        req.log_metadata("bot", "dl");
+    }
 
     if req.wants_json() {
         #[derive(Serialize)]


### PR DESCRIPTION
We could instead include the corrected name, but that doesn't seem very
useful and this is already something I search the logs for occasionally.

This change will allow us to collect some data to see if it would be
practical to blindly redirect the request if there is an issue obtaining
a database connection from the pool.

r? @pietroalbini 