### PR TITLE
feat(footer): update link to privacy policy

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -10,7 +10,7 @@
     <span local-class="sep">|</span>
     <a href='https://github.com/rust-lang/crates.io'>Fork on GitHub</a>
     <span local-class="sep">|</span>
-    <a href='https://www.rust-lang.org/policies/privacy'>Privacy notice</a>
+    <a href='https://foundation.rust-lang.org/policies/privacy-policy/'>Privacy policy</a>
     <span local-class="sep">|</span>
     <LinkTo @route="policies">Policies</LinkTo>
   </div>


### PR DESCRIPTION
this PR updates the website footer to link to the (updated) privacy policy, which now lives on the Rust Foundation website: https://foundation.rust-lang.org/policies/privacy-policy/.