### PR TITLE
More aggressively rate limit reserving new package names

### DIFF
--- a/src/publish_rate_limit.rs
+++ b/src/publish_rate_limit.rs
@@ -14,9 +14,19 @@ pub struct PublishRateLimit {
 
 impl Default for PublishRateLimit {
     fn default() -> Self {
+        let minutes = dotenv::var("WEB_NEW_PKG_RATE_LIMIT_RATE_MINUTES")
+            .unwrap_or_default()
+            .parse()
+            .ok()
+            .unwrap_or(10);
+        let burst = dotenv::var("WEB_NEW_PKG_RATE_LIMIT_BURST")
+            .unwrap_or_default()
+            .parse()
+            .ok()
+            .unwrap_or(5);
         Self {
-            rate: Duration::from_secs(60) * 10,
-            burst: 30,
+            rate: Duration::from_secs(60) * minutes,
+            burst,
         }
     }
 }


### PR DESCRIPTION
Larger burst limits can be applied on a per-user basis if they contact
us ahead of time.

r? @pietroalbini 