### PR TITLE
Upgrade `oauth2` to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.0.0-beta.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64828351c656346fb1b8cb0622b4170c4bb5a382bf4c19666ce395722d08594"
+checksum = "10ad4d0136960353683efa6160b9c867088b4b8f567b762cd37420a10ce32703"
 dependencies = [
  "base64 0.12.3",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ indexmap = "1.0.2"
 jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "0.10.0-beta.3", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
 license-exprs = "1.6"
-oauth2 = { version = "4.0.0-beta.1", default-features = false, features = ["reqwest"] }
+oauth2 = { version = "4.0.0", default-features = false, features = ["reqwest"] }
 parking_lot = "0.11"
 prometheus = "0.12.0"
 rand = "0.8"


### PR DESCRIPTION
There's no functional change from the beta: https://github.com/ramosbugs/oauth2-rs/compare/4.0.0-beta.1...4.0.0