### PR TITLE
Add `DB_OFFLINE` as a failsafe during outages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ extern crate serde_json;
 #[macro_use]
 extern crate tracing;
 
-pub use crate::{app::App, config::Config, email::Emails, uploaders::Uploader};
+pub use crate::config::{Config, DbPoolConfig};
+pub use crate::{app::App, email::Emails, uploaders::Uploader};
 use std::sync::Arc;
 
 use conduit_middleware::MiddlewareBuilder;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -4,7 +4,7 @@ use cargo_registry::{
     background_jobs::Environment,
     db::DieselPool,
     git::{Credentials, RepositoryConfig},
-    App, Config, Emails, Env, Replica, Uploader,
+    App, Config, DbPoolConfig, Emails, Env, Replica, Uploader,
 };
 use std::{rc::Rc, sync::Arc, time::Duration};
 
@@ -302,8 +302,11 @@ fn simple_config() -> Config {
         gh_client_id: dotenv::var("GH_CLIENT_ID").unwrap_or_default(),
         gh_client_secret: dotenv::var("GH_CLIENT_SECRET").unwrap_or_default(),
         gh_base_url: "http://api.github.com".to_string(),
-        db_url: env("TEST_DATABASE_URL"),
-        replica_db_url: None,
+        db_primary_config: DbPoolConfig {
+            url: env("TEST_DATABASE_URL"),
+            read_only_mode: false,
+        },
+        db_replica_config: None,
         env: Env::Test,
         max_upload_size: 3000,
         max_unpack_size: 2000,


### PR DESCRIPTION
If set to `leader` then the follower credentials are used in read-only
mode for all connections. The background-worker will log a message every
minute as a reminder to scale down its instance until the leader is
restored. To operate the server in this mode, a value must be provided
for `READ_ONLY_REPLICA_URL`.

If set to `follower` then no follower connection pool is initialized, as
if `READ_ONLY_REPLICA_URL` was not set.

r? @pietroalbini 