### PR TITLE
Create `crates-admin migrate` to sync categories and migrate the db

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,3 @@
 https://github.com/emk/heroku-buildpack-rust#cfa0f06
 https://github.com/heroku/heroku-buildpack-nodejs#v176
 https://github.com/heroku/heroku-buildpack-nginx#53b03b0
-https://github.com/sgrif/heroku-buildpack-diesel#f605edd

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ derive_deref = "1.1.1"
 dialoguer = "0.8"
 diesel = { version = "1.4.0", features = ["postgres", "serde_json", "chrono", "r2d2"] }
 diesel_full_text_search = "1.0.0"
+diesel_migrations = { version = "1.3.0", features = ["postgres"] }
 dotenv = "0.15"
 flate2 = "1.0"
 futures-channel = { version = "0.3.1", default-features = false }
@@ -88,7 +89,6 @@ url = "2.1"
 [dev-dependencies]
 claim = "0.5"
 conduit-test = "0.9.0-alpha.4"
-diesel_migrations = { version = "1.3.0", features = ["postgres"] }
 hyper-tls = "0.5"
 lazy_static = "1.0"
 tokio = "1"

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-release: bin/diesel migration run
+release: ./target/release/crates-admin migrate
 web: ./target/release/server
 background_worker: ./target/release/background-worker

--- a/src/admin/migrate.rs
+++ b/src/admin/migrate.rs
@@ -1,0 +1,19 @@
+use anyhow::Error;
+
+static CATEGORIES_TOML: &'static str = include_str!("../boot/categories.toml");
+diesel_migrations::embed_migrations!("./migrations");
+
+#[derive(clap::Clap, Debug, Copy, Clone)]
+#[clap(name = "migrate", about = "Migrate the database.")]
+pub struct Opts;
+
+pub fn run(_opts: Opts) -> Result<(), Error> {
+    println!("==> migrating the database");
+    let conn = crate::db::connect_now()?;
+    embedded_migrations::run_with_output(&conn, &mut std::io::stdout())?;
+
+    println!("==> synchronizing crate categories");
+    crate::boot::categories::sync(CATEGORIES_TOML).unwrap();
+
+    Ok(())
+}

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,6 +1,7 @@
 pub mod delete_crate;
 pub mod delete_version;
 pub mod dialoguer;
+pub mod migrate;
 pub mod on_call;
 pub mod populate;
 pub mod render_readmes;

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -1,8 +1,8 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::admin::{
-    delete_crate, delete_version, populate, render_readmes, test_pagerduty, transfer_crates,
-    verify_token,
+    delete_crate, delete_version, migrate, populate, render_readmes, test_pagerduty,
+    transfer_crates, verify_token,
 };
 
 use clap::Clap;
@@ -23,6 +23,7 @@ enum SubCommand {
     TestPagerduty(test_pagerduty::Opts),
     TransferCrates(transfer_crates::Opts),
     VerifyToken(verify_token::Opts),
+    Migrate(migrate::Opts),
 }
 
 fn main() {
@@ -36,5 +37,6 @@ fn main() {
         SubCommand::TestPagerduty(opts) => test_pagerduty::run(opts).unwrap(),
         SubCommand::TransferCrates(opts) => transfer_crates::run(opts),
         SubCommand::VerifyToken(opts) => verify_token::run(opts).unwrap(),
+        SubCommand::Migrate(opts) => migrate::run(opts).unwrap(),
     }
 }

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all, rust_2018_idioms)]
 #![allow(unknown_lints)]
 
-use cargo_registry::{boot, App, Env};
+use cargo_registry::{App, Env};
 use std::{borrow::Cow, fs::File, process::Command, sync::Arc, time::Duration};
 
 use conduit_hyper::Service;
@@ -42,11 +42,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     downloads_counter_thread(app.clone());
 
     let handler = cargo_registry::build_handler(app.clone());
-
-    // On every server restart, ensure the categories available in the database match
-    // the information in *src/categories.toml*.
-    let categories_toml = include_str!("../boot/categories.toml");
-    boot::categories::sync(categories_toml).unwrap();
 
     let heroku = dotenv::var("HEROKU").is_ok();
     let fastboot = dotenv::var("USE_FASTBOOT").is_ok();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@ extern crate derive_deref;
 #[macro_use]
 extern crate diesel;
 #[macro_use]
+extern crate diesel_migrations;
+#[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate serde_json;


### PR DESCRIPTION
The new command will be used in production to run migrations instead of installing the Diesel CLI and running migrations through it. In addition to that, synchronizing categories has been moved to the `crates-admin migrate` command instead of being executed every time the application starts.

The main advantage of this is, booting the server will not *require* a fully working database connection anymore. A connection is still needed, but this removes all the blockers for removing that limit.

r? @jtgeibel 
Part of #3541 