### PR TITLE
Avoid cloning `Config` struct

### DIFF
--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -5,7 +5,7 @@ use crate::{
     schema::{crates, readme_renderings, versions},
     Config,
 };
-use std::{io::Read, path::Path, thread};
+use std::{io::Read, path::Path, sync::Arc, thread};
 
 use chrono::{TimeZone, Utc};
 use clap::Clap;
@@ -38,7 +38,7 @@ pub struct Opts {
 }
 
 pub fn run(opts: Opts) {
-    let config = Config::default();
+    let config = Arc::new(Config::default());
     let conn = db::connect_now().unwrap();
 
     let start_time = Utc::now();

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -35,8 +35,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
     let config = cargo_registry::Config::default();
+    let env = config.env;
     let client = Client::new();
-    let app = Arc::new(App::new(config.clone(), Some(client)));
+    let app = Arc::new(App::new(config, Some(client)));
 
     // Start the background thread periodically persisting download counts to the database.
     downloads_counter_thread(app.clone());
@@ -63,7 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let threads = dotenv::var("SERVER_THREADS")
         .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"))
         .unwrap_or_else(|_| {
-            if config.env == Env::Development {
+            if env == Env::Development {
                 5
             } else {
                 // A large default because this can be easily changed via env and in production we

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use crate::publish_rate_limit::PublishRateLimit;
 use crate::{env, uploaders::Uploader, Env, Replica};
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Config {
     pub uploader: Uploader,
     pub session_key: String,
@@ -24,7 +24,7 @@ pub struct Config {
     pub metrics_authorization_token: Option<String>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct DbPoolConfig {
     pub url: String,
     pub read_only_mode: bool,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -39,8 +39,8 @@ use crate::{App, Env};
 
 pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);
-    let config = app.config.clone();
-    let env = config.env;
+    let env = app.config.env;
+    let blocked_traffic = app.config.blocked_traffic.clone();
 
     if env != Env::Test {
         m.add(ensure_well_formed_500::EnsureWellFormed500);
@@ -110,7 +110,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
 
     m.around(Head::default());
 
-    for (header, blocked_values) in config.blocked_traffic {
+    for (header, blocked_values) in blocked_traffic {
         m.around(block_traffic::BlockTraffic::new(header, blocked_values));
     }
 


### PR DESCRIPTION
This struct contains a lot of owned data and cloning the entire struct
is unnecessary.

r? @Turbo87 