### PR TITLE
Ensure the release succeeds when the primary database is read-only

### DIFF
--- a/src/admin/migrate.rs
+++ b/src/admin/migrate.rs
@@ -4,11 +4,33 @@ static CATEGORIES_TOML: &'static str = include_str!("../boot/categories.toml");
 diesel_migrations::embed_migrations!("./migrations");
 
 #[derive(clap::Clap, Debug, Copy, Clone)]
-#[clap(name = "migrate", about = "Migrate the database.")]
+#[clap(
+    name = "migrate",
+    about = "Verify config, migrate the database, and other release tasks."
+)]
 pub struct Opts;
 
 pub fn run(_opts: Opts) -> Result<(), Error> {
+    let config = crate::Config::default();
+
+    // TODO: Refactor logic so that we can also check things from App::new() here.
+    // If the app will panic due to bad configuration, it is better to error in the release phase
+    // to avoid launching dynos that will fail.
+
+    if config.db_primary_config.read_only_mode {
+        // TODO: Check `any_pending_migrations()` with a read-only connection and error if true.
+        // It looks like this requires changes upstream to make this pub in `migration_macros`.
+
+        println!("==> Skipping migrations and category sync (read-only mode)");
+
+        // The service is undergoing maintenance or mitigating an outage.
+        // Exit with success to ensure configuration changes can be made.
+        // Heroku will not launch new dynos if the release phase fails.
+        return Ok(());
+    }
+
     println!("==> migrating the database");
+    // The primary is online, access directly via `DATABASE_URL`.
     let conn = crate::db::connect_now()?;
     embedded_migrations::run_with_output(&conn, &mut std::io::stdout())?;
 

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -26,17 +26,17 @@ enum SubCommand {
     Migrate(migrate::Opts),
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let opts: Opts = Opts::parse();
 
-    match opts.command {
+    Ok(match opts.command {
         SubCommand::DeleteCrate(opts) => delete_crate::run(opts),
         SubCommand::DeleteVersion(opts) => delete_version::run(opts),
         SubCommand::Populate(opts) => populate::run(opts),
         SubCommand::RenderReadmes(opts) => render_readmes::run(opts),
-        SubCommand::TestPagerduty(opts) => test_pagerduty::run(opts).unwrap(),
+        SubCommand::TestPagerduty(opts) => test_pagerduty::run(opts)?,
         SubCommand::TransferCrates(opts) => transfer_crates::run(opts),
         SubCommand::VerifyToken(opts) => verify_token::run(opts).unwrap(),
-        SubCommand::Migrate(opts) => migrate::run(opts).unwrap(),
-    }
+        SubCommand::Migrate(opts) => migrate::run(opts)?,
+    })
 }


### PR DESCRIPTION
If the primary is in read-only mode then the leader database in
`DATABASE_URL` may be unavailable. To avoid blocking configuration
changes, the command exits immediately claiming success.

r? @pietroalbini 