### PR TITLE
Do unconditional redirects for downloads when the db is broken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2825,7 +2825,19 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ sha2 = "0.9"
 swirl = { git = "https://github.com/sgrif/swirl.git", rev = "e87cf37" }
 tar = "0.4.16"
 tempfile = "3"
-tokio = { version = "1", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread"]}
+tokio = { version = "1.5.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "0.5"
 tracing = "0.1"
 tracing-subscriber = "0.2"
@@ -92,7 +92,7 @@ claim = "0.5"
 conduit-test = "0.9.0-alpha.4"
 hyper-tls = "0.5"
 lazy_static = "1.0"
-tokio = "1"
+tokio = "1.5.0"
 tower-service = "0.3.0"
 
 [build-dependencies]

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -2,10 +2,9 @@ use reqwest::blocking::Client;
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
-use diesel::r2d2::PoolError;
 use swirl::PerformError;
 
-use crate::db::{DieselPool, DieselPooledConn};
+use crate::db::{DieselPool, DieselPooledConn, PoolError};
 use crate::git::Repository;
 use crate::uploaders::Uploader;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ pub struct Config {
     pub downloads_persist_interval_ms: usize,
     pub ownership_invitations_expiration_days: u64,
     pub metrics_authorization_token: Option<String>,
+    pub use_test_database_pool: bool,
 }
 
 #[derive(Debug)]
@@ -211,6 +212,7 @@ impl Default for Config {
                 .unwrap_or(60_000), // 1 minute
             ownership_invitations_expiration_days: 30,
             metrics_authorization_token: dotenv::var("METRICS_AUTHORIZATION_TOKEN").ok(),
+            use_test_database_pool: false,
         }
     }
 }

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -2,53 +2,84 @@
 //!
 //! Crate level functionality is located in `krate::downloads`.
 
+use super::{extract_crate_name_and_semver, version_and_crate};
 use crate::controllers::prelude::*;
-
-use chrono::{Duration, NaiveDate, Utc};
-
+use crate::db::PoolError;
 use crate::models::{Crate, VersionDownload};
 use crate::schema::*;
 use crate::views::EncodableVersionDownload;
-
-use super::{extract_crate_name_and_semver, version_and_crate};
+use chrono::{Duration, NaiveDate, Utc};
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
 pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
+    let app = req.app().clone();
     let recorder = req.timing_recorder();
 
-    let crate_name = &req.params()["crate_id"];
-    let version = &req.params()["version"];
+    let mut crate_name = req.params()["crate_id"].clone();
+    let version = req.params()["version"].as_str();
 
-    let (version_id, canonical_crate_name): (_, String) = {
-        use self::versions::dsl::*;
+    let mut log_metadata = None;
+    match recorder.record("get_conn", || req.db_conn()) {
+        Ok(conn) => {
+            use self::versions::dsl::*;
 
-        let conn = recorder.record("get_conn", || req.db_conn())?;
+            // Returns the crate name as stored in the database, or an error if we could
+            // not load the version ID from the database.
+            let (version_id, canonical_crate_name) = recorder.record("get_version", || {
+                versions
+                    .inner_join(crates::table)
+                    .select((id, crates::name))
+                    .filter(Crate::with_name(&crate_name))
+                    .filter(num.eq(version))
+                    .first::<(i32, String)>(&*conn)
+            })?;
 
-        // Returns the crate name as stored in the database, or an error if we could
-        // not load the version ID from the database.
-        recorder.record("get_version", || {
-            versions
-                .inner_join(crates::table)
-                .select((id, crates::name))
-                .filter(Crate::with_name(crate_name))
-                .filter(num.eq(version))
-                .first(&*conn)
-        })?
-    };
+            if canonical_crate_name != crate_name {
+                app.instance_metrics
+                    .downloads_non_canonical_crate_name_total
+                    .inc();
+                log_metadata = Some(("bot", "dl"));
+            }
+            crate_name = canonical_crate_name;
 
-    // The increment does not happen instantly, but it's deferred to be executed in a batch
-    // along with other downloads. See crate::downloads_counter for the implementation.
-    req.app().downloads_counter.increment(version_id);
+            // The increment does not happen instantly, but it's deferred to be executed in a batch
+            // along with other downloads. See crate::downloads_counter for the implementation.
+            app.downloads_counter.increment(version_id);
+        }
+        Err(PoolError::UnhealthyPool) => {
+            // The download endpoint is the most critical route in the whole crates.io application,
+            // as it's relied upon by users and automations to download crates. Keeping it working
+            // is the most important thing for us.
+            //
+            // The endpoint relies on the database to fetch the canonical crate name (with the
+            // right capitalization and hyphenation), but that's only needed to serve clients who
+            // don't call the endpoint with the crate's canonical name.
+            //
+            // Thankfully Cargo always uses the right name when calling the endpoint, and we can
+            // keep it working during a full database outage by unconditionally redirecting without
+            // checking whether the crate exists or the rigth name is used. Non-Cargo clients might
+            // get a 404 response instead of a 500, but that's worth it.
+            //
+            // Without a working database we also can't count downloads, but that's also less
+            // critical than keeping Cargo downloads operational.
+
+            app.instance_metrics
+                .downloads_unconditional_redirects_total
+                .inc();
+            log_metadata = Some(("unconditional_redirect", "true"));
+        }
+        Err(err) => return Err(err.into()),
+    }
 
     let redirect_url = req
         .app()
         .config
         .uploader
-        .crate_location(&canonical_crate_name, version);
+        .crate_location(&crate_name, &*version);
 
-    if &canonical_crate_name != crate_name {
-        req.log_metadata("bot", "dl");
+    if let Some((key, value)) = log_metadata {
+        req.log_metadata(key, value);
     }
 
     if req.wants_json() {

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -32,6 +32,11 @@ metrics! {
         pub requests_total: IntCounter,
         /// Number of requests currently being processed
         pub requests_in_flight: IntGauge,
+
+        /// Number of download requests that were served with an unconditional redirect.
+        pub downloads_unconditional_redirects_total: IntCounter,
+        /// Number of download requests with a non-canonical crate name.
+        pub downloads_non_canonical_crate_name_total: IntCounter,
     }
 
     // All instance metrics will be prefixed with this namespace.

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -47,6 +47,7 @@ mod schema_details;
 mod server;
 mod team;
 mod token;
+mod unhealthy_database;
 mod user;
 mod util;
 mod version;

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -1,8 +1,5 @@
+use crate::util::FreshSchema;
 use cargo_registry::tasks::dump_db;
-use diesel::{
-    connection::{Connection, SimpleConnection},
-    pg::PgConnection,
-};
 
 #[test]
 fn dump_db_and_reimport_dump() {
@@ -13,59 +10,10 @@ fn dump_db_and_reimport_dump() {
     let directory = dump_db::DumpDirectory::create().unwrap();
     directory.populate(&database_url).unwrap();
 
-    let schema = TemporarySchema::create(database_url, "test_db_dump");
-    schema.run_migrations();
+    let schema = FreshSchema::new(&database_url);
 
     let import_script = directory.export_dir.join("import.sql");
-    dump_db::run_psql(&import_script, &schema.database_url).unwrap();
+    dump_db::run_psql(&import_script, schema.database_url()).unwrap();
 
     // TODO: Consistency checks on the re-imported data?
-}
-
-struct TemporarySchema {
-    pub database_url: String,
-    pub schema_name: String,
-    pub connection: PgConnection,
-}
-
-impl TemporarySchema {
-    pub fn create(database_url: String, schema_name: &str) -> Self {
-        let params = &[("options", format!("--search_path={},public", schema_name))];
-        let database_url = url::Url::parse_with_params(&database_url, params)
-            .unwrap()
-            .into_string();
-        let schema_name = schema_name.to_owned();
-        let connection = PgConnection::establish(&database_url).unwrap();
-        connection
-            .batch_execute(&format!(
-                r#"DROP SCHEMA IF EXISTS "{schema_name}" CASCADE;
-                   CREATE SCHEMA "{schema_name}";"#,
-                schema_name = schema_name,
-            ))
-            .unwrap();
-        Self {
-            database_url,
-            schema_name,
-            connection,
-        }
-    }
-
-    pub fn run_migrations(&self) {
-        use diesel_migrations::{find_migrations_directory, run_pending_migrations_in_directory};
-        let migrations_dir = find_migrations_directory().unwrap();
-        run_pending_migrations_in_directory(
-            &self.connection,
-            &migrations_dir,
-            &mut std::io::sink(),
-        )
-        .unwrap();
-    }
-}
-
-impl Drop for TemporarySchema {
-    fn drop(&mut self) {
-        self.connection
-            .batch_execute(&format!(r#"DROP SCHEMA "{}" CASCADE;"#, self.schema_name))
-            .unwrap();
-    }
 }

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -1,0 +1,66 @@
+use crate::{
+    builders::CrateBuilder,
+    util::{MockAnonymousUser, RequestHelper, TestApp},
+};
+use std::time::Duration;
+
+#[test]
+fn download_crate_with_broken_networking_primary_database() {
+    let (app, anon, _, owner) = TestApp::init().with_slow_real_db_pool().with_token();
+    app.db(|conn| {
+        CrateBuilder::new("crate_name", owner.as_model().user_id)
+            .version("1.0.0")
+            .expect_build(conn)
+    });
+
+    // When the database connection is healthy downloads are redirected with the proper
+    // capitalization, and missing crates or versions return a 404.
+
+    assert_checked_redirects(&anon);
+
+    // After networking breaks, preventing new database connections, the download endpoint should
+    // do an unconditional redirect to the CDN, without checking whether the crate exists or what
+    // the exact capitalization of crate name is.
+
+    app.db_chaosproxy().break_networking();
+    assert_unconditional_redirects(&anon);
+
+    // After restoring the network and waiting for the database pool to get healthy again redirects
+    // should be checked again.
+
+    app.db_chaosproxy().restore_networking();
+    app.as_inner()
+        .primary_database
+        .wait_until_healthy(Duration::from_millis(500))
+        .expect("the database did not return healthy");
+
+    assert_checked_redirects(&anon);
+}
+
+fn assert_checked_redirects(anon: &MockAnonymousUser) {
+    anon.get::<()>("/api/v1/crates/crate_name/1.0.0/download")
+        .assert_redirect_ends_with("/crate_name/crate_name-1.0.0.crate");
+
+    anon.get::<()>("/api/v1/crates/Crate-Name/1.0.0/download")
+        .assert_redirect_ends_with("/crate_name/crate_name-1.0.0.crate");
+
+    anon.get::<()>("/api/v1/crates/crate_name/2.0.0/download")
+        .assert_not_found();
+
+    anon.get::<()>("/api/v1/crates/awesome-project/1.0.0/download")
+        .assert_not_found();
+}
+
+fn assert_unconditional_redirects(anon: &MockAnonymousUser) {
+    anon.get::<()>("/api/v1/crates/crate_name/1.0.0/download")
+        .assert_redirect_ends_with("/crate_name/crate_name-1.0.0.crate");
+
+    anon.get::<()>("/api/v1/crates/Crate-Name/1.0.0/download")
+        .assert_redirect_ends_with("/Crate-Name/Crate-Name-1.0.0.crate");
+
+    anon.get::<()>("/api/v1/crates/crate_name/2.0.0/download")
+        .assert_redirect_ends_with("/crate_name/crate_name-2.0.0.crate");
+
+    anon.get::<()>("/api/v1/crates/awesome-project/1.0.0/download")
+        .assert_redirect_ends_with("/awesome-project/awesome-project-1.0.0.crate");
+}

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -33,9 +33,11 @@ use conduit::header;
 use cookie::Cookie;
 use std::collections::HashMap;
 
+mod fresh_schema;
 mod response;
 mod test_app;
 
+pub(crate) use fresh_schema::FreshSchema;
 pub use response::Response;
 pub use test_app::TestApp;
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -33,6 +33,7 @@ use conduit::header;
 use cookie::Cookie;
 use std::collections::HashMap;
 
+mod chaosproxy;
 mod fresh_schema;
 mod response;
 mod test_app;

--- a/src/tests/util/chaosproxy.rs
+++ b/src/tests/util/chaosproxy.rs
@@ -1,0 +1,129 @@
+use anyhow::Error;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{
+        tcp::{OwnedReadHalf, OwnedWriteHalf},
+        TcpListener, TcpStream,
+    },
+    runtime::Runtime,
+    sync::broadcast::Sender,
+};
+
+pub(crate) struct ChaosProxy {
+    address: SocketAddr,
+    backend_address: SocketAddr,
+
+    runtime: Runtime,
+    listener: TcpListener,
+
+    break_networking_send: Sender<()>,
+    restore_networking_send: Sender<()>,
+}
+
+impl ChaosProxy {
+    pub(crate) fn new(backend_address: SocketAddr) -> Result<Arc<Self>, Error> {
+        let runtime = Runtime::new().expect("failed to create Tokio runtime");
+        let listener = runtime.block_on(TcpListener::bind("127.0.0.1:0"))?;
+
+        let (break_networking_send, _) = tokio::sync::broadcast::channel(16);
+        let (restore_networking_send, _) = tokio::sync::broadcast::channel(16);
+
+        let instance = Arc::new(ChaosProxy {
+            address: listener.local_addr()?,
+            backend_address,
+
+            listener,
+            runtime,
+
+            break_networking_send,
+            restore_networking_send,
+        });
+
+        let instance_clone = instance.clone();
+        instance.runtime.spawn(async move {
+            if let Err(err) = instance_clone.server_loop().await {
+                eprintln!("ChaosProxy server error: {}", err);
+            }
+        });
+
+        Ok(instance)
+    }
+
+    pub(crate) fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    pub(crate) fn break_networking(&self) {
+        self.break_networking_send
+            .send(())
+            .expect("failed to send the break_networking message");
+    }
+
+    pub(crate) fn restore_networking(&self) {
+        self.restore_networking_send
+            .send(())
+            .expect("failed to send the restore_networking message");
+    }
+
+    async fn server_loop(self: Arc<Self>) -> Result<(), Error> {
+        let mut break_networking_recv = self.break_networking_send.subscribe();
+        let mut restore_networking_recv = self.restore_networking_send.subscribe();
+
+        loop {
+            let (client_read, client_write) = tokio::select! {
+                accepted = self.listener.accept() => accepted?.0.into_split(),
+
+                // When networking is broken stop accepting connections until restore_networking()
+                _ = break_networking_recv.recv() => {
+                    let _ = restore_networking_recv.recv().await;
+                    continue;
+                },
+            };
+            let (backend_read, backend_write) = TcpStream::connect(&self.backend_address)
+                .await?
+                .into_split();
+
+            let self_clone = self.clone();
+            self.runtime.spawn(async move {
+                if let Err(err) = self_clone.proxy_data(client_read, backend_write).await {
+                    eprintln!("ChaosProxy connection error: {}", err);
+                }
+            });
+
+            let self_clone = self.clone();
+            tokio::spawn(async move {
+                if let Err(err) = self_clone.proxy_data(backend_read, client_write).await {
+                    eprintln!("ChaosProxy connection error: {}", err);
+                }
+            });
+        }
+    }
+
+    async fn proxy_data(
+        &self,
+        mut from: OwnedReadHalf,
+        mut to: OwnedWriteHalf,
+    ) -> Result<(), Error> {
+        let mut break_connections_recv = self.break_networking_send.subscribe();
+        let mut buf = [0; 1024];
+
+        loop {
+            tokio::select! {
+                len = from.read(&mut buf) => {
+                    let len = len?;
+                    if len == 0 {
+                        // EOF, the socket was closed
+                        return Ok(());
+                    }
+                    to.write(&buf[0..len]).await?;
+                }
+                _ = break_connections_recv.recv() => {
+                    to.shutdown().await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+}

--- a/src/tests/util/fresh_schema.rs
+++ b/src/tests/util/fresh_schema.rs
@@ -1,0 +1,65 @@
+use diesel::connection::SimpleConnection;
+use diesel::prelude::*;
+use diesel_migrations::{find_migrations_directory, run_pending_migrations_in_directory};
+use rand::Rng;
+
+pub(crate) struct FreshSchema {
+    database_url: String,
+    schema_name: String,
+    management_conn: PgConnection,
+}
+
+impl FreshSchema {
+    pub(crate) fn new(database_url: &str) -> Self {
+        let schema_name = generate_schema_name();
+
+        let conn = PgConnection::establish(&database_url).expect("can't connect to the test db");
+        conn.batch_execute(&format!(
+            "
+                DROP SCHEMA IF EXISTS {schema_name} CASCADE;
+                CREATE SCHEMA {schema_name};
+                SET search_path TO {schema_name}, public;
+            ",
+            schema_name = schema_name
+        ))
+        .expect("failed to initialize schema");
+
+        let migrations_dir = find_migrations_directory().unwrap();
+        run_pending_migrations_in_directory(&conn, &migrations_dir, &mut std::io::sink())
+            .expect("failed to run migrations on the test schema");
+
+        let database_url = url::Url::parse_with_params(
+            database_url,
+            &[("options", format!("--search_path={},public", schema_name))],
+        )
+        .unwrap()
+        .to_string();
+
+        Self {
+            database_url,
+            schema_name,
+            management_conn: conn,
+        }
+    }
+
+    pub(crate) fn database_url(&self) -> &str {
+        &self.database_url
+    }
+}
+
+impl Drop for FreshSchema {
+    fn drop(&mut self) {
+        self.management_conn
+            .batch_execute(&format!("DROP SCHEMA {} CASCADE;", self.schema_name))
+            .expect("failed to drop the test schema");
+    }
+}
+
+fn generate_schema_name() -> String {
+    let mut rng = rand::thread_rng();
+    let random_string: String = std::iter::repeat(())
+        .map(|_| rng.sample(rand::distributions::Alphanumeric) as char)
+        .take(16)
+        .collect();
+    format!("cratesio_test_{}", random_string)
+}

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -9,7 +9,7 @@ use cargo_registry::{
 use std::{rc::Rc, sync::Arc, time::Duration};
 
 use cargo_registry::git::Repository as WorkerRepository;
-use diesel::{Connection, PgConnection};
+use diesel::PgConnection;
 use git2::Repository as UpstreamRepository;
 use reqwest::{blocking::Client, Proxy};
 use swirl::Runner;
@@ -321,6 +321,7 @@ fn simple_config() -> Config {
         downloads_persist_interval_ms: 1000,
         ownership_invitations_expiration_days: 30,
         metrics_authorization_token: None,
+        use_test_database_pool: true,
     }
 }
 
@@ -343,7 +344,6 @@ fn build_app(
     // the application. This will also prevent cluttering the filesystem.
     app.emails = Emails::new_in_memory();
 
-    assert_ok!(assert_ok!(app.primary_database.get()).begin_test_transaction());
     let app = Arc::new(app);
     let handler = cargo_registry::build_handler(Arc::clone(&app));
     (app, handler)


### PR DESCRIPTION
We had a few database-related outages in the recent weeks, which impacted people downloading crates with Cargo. Download requests are the majority of the traffic we serve, and they're also the most critical ones. Even if the rest of crates.io stops working downloads *must* continue to be operational to reduce the impact on our users.

As a preface, the downloads endpoint used the database for two reasons: counting the downloads (which can be skipped during outages) and ensuring the crate name is canonicalized. For example, if someone tries to  `Foo-bar 1.0.0` by calling `/api/v1/crates/foo_Bar/1.0.0/download` the crates.io application canonicalizes the name and redirects the user to `https://static.crates.io/crates/Foo-bar/Foo-bar-1.0.0.crate`. If we were not to perform canonicalization the user would be redirected to `https://static.crates.io/crates/foo_Bar/foo_Bar-1.0.0.crate`, which would result in a 404.

While analyzing the outages and after investigating the traffic patterns of multiple weeks, we identified that the vast majority of downloads (including *all* downloads from Cargo) already send the canonical name to crates.io, and only a couple of third-party tools send crate names that are not canonicalized.

This PR changes the downloads endpoint to do unconditional redirects without canonicalizing the crate names **during a full database outage**. During normal operations the canonicalization will still be performed. The change will allow Cargo builds to continue functioning even without a database, and the really small percentage of requests will get a 404 instead of a 500, which in my view is an acceptable tradeoff.

This PR also adds two metrics:

* `cratesio_instance_downloads_non_canonical_crate_name_total`: how many download requests we received with a non-canonical crate name. This will allow us to revisit whether the tradeoff is still worth, and it's way easier to query than the previous method we used to extract the data.
* `cratesio_instance_downloads_unconditional_redirects_total`: how many unconditional redirects we performed. We'll want to setup an alert that pages us as soon as the metric is `> 0`.

Finally, this PR implements full tests for the changes introduced here (tests are actually the bulk of the diff). The test uses the "real" database pool instead of the dummy one used for the rest of the tests, acting on a fresh schema. Creating the fresh schema takes a second or two, so we're only doing it in this test to avoid slowing down the test suite. Also, instead of connecting directly to PostgreSQL the database the pool connects through `ChaosProxy`, a simple proxy implemented in our codebase that allows to break or restore the connection at will.

Part of #3541 
r? @jtgeibel 