### PR TITLE
Run the Rust buildpack last

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/emk/heroku-buildpack-rust#cfa0f06
 https://github.com/heroku/heroku-buildpack-nodejs#v176
 https://github.com/heroku/heroku-buildpack-nginx#53b03b0
+https://github.com/emk/heroku-buildpack-rust#cfa0f06


### PR DESCRIPTION
We currently use heroku-buildpack-multi which is no longer actively
maintained. Heroku supports multiple buildpacks natively and it makes
sense to follow their recommendation even if our config is a bit
different. (Heroku is currently detecting the framework as
`nginx-buildpack`.)

https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app#adding-a-buildpack

> The buildpack for the primary language of your app should always be
> the last buildpack in the list. This ensures that defaults for that
> primary language are applied instead of those for another language,
> and allows Heroku to correctly detect the primary language of your app.

r? @pietroalbini 