### PR TITLE
Add index `version_downloads_not_processed`

### DIFF
--- a/migrations/2021-05-03-174624_add_index_version_downloads_not_processed/down.sql
+++ b/migrations/2021-05-03-174624_add_index_version_downloads_not_processed/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX index_version_downloads_not_processed;

--- a/migrations/2021-05-03-174624_add_index_version_downloads_not_processed/up.sql
+++ b/migrations/2021-05-03-174624_add_index_version_downloads_not_processed/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS index_version_downloads_not_processed ON version_downloads (processed) WHERE NOT processed;


### PR DESCRIPTION
:warning: **Please let me manually deploy this PR to production instead of batching it with other deploys.** :warning: 

To avoid impairing workloads running in production we'll want to run `CREATE INDEX CONCURRENTLY ...` manually when the background job is not running, instead of relying on the migration in the PR. The migration will still succeed thanks to `IF NOT EXISTS`.

---

While investigating issues with the load on our primary database I noticed that all the load spikes happened when the background job updating the download counts was running. After analyzing the queries executed by that job I noticed two queries that were doing a sequential scan of the whole version_downloads table.

The version_downloads table serves two purposes: storing historical download stats (with one row per version per day) and storing the data collected in the current day that still needs to be processed. Due to the nature of the data, the amount of historical information far exceeds the number of unprocessed rows.

The background job updating download counts only needs to interact with the unprocessed rows, but before this commit there was no index that allowed PostgreSQL to easily ignore historical rows. This resulted in the database having to do sequential scans over the whole table, which as of 2021-05-03 contains 61 million rows. On the production database, each sequential scan took around 55 seconds.

This commit creates a partial index on rows that are not processed yet, greatly improving the performance of the background job and improving the reliability of our database.

The index is a partial index on `processed` for rows matching `WHERE NOT processed`. Compared to a regular index, the partial index only indexes rows matching the `WHERE` clause instead of all the rows in the table. This greatly reduces the size on disk of the index (1.6 MB compared to 1.3 GB) and encourages PostgreSQL to actually use it.

r? @jtgeibel 