### PR TITLE
Update comrak to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.10.1-rc.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65096990371e2f853754ef064756d67e8f97d9334109420572b9c03406fcbb13"
+checksum = "b423acba50d5016684beaf643f9991e622633a4c858be6885653071c2da2b0c6"
 dependencies = [
  "entities",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ base64 = "0.13"
 cargo-registry-s3 = { path = "src/s3", version = "0.2.0" }
 chrono = { version = "0.4.0", features = ["serde"] }
 clap = "=3.0.0-beta.2"
-comrak = { version = "0.10.1-rc.1", default-features = false }
+comrak = { version = "0.10.1", default-features = false }
 
 conduit = "0.9.0-alpha.5"
 conduit-conditional-get = "0.9.0-alpha.3"


### PR DESCRIPTION
An XSS vulnerability has been reported in comrak < 0.10.1 (including 0.10.1-rc.1); see https://github.com/kivikakk/comrak/issues/187.

crates.io is **unaffected** due to our use of `ammonia` (which is best practice :+1:), but it's probably not ideal to be using a version with a known bug either way.