### PR TITLE
Recreate the BRIN index on `version_downloads` with `pages_per_range=1`

### DIFF
--- a/migrations/2021-05-05-081208_recreate_version_downloads_date_index_with_brin_pages_per_range_1/down.sql
+++ b/migrations/2021-05-05-081208_recreate_version_downloads_date_index_with_brin_pages_per_range_1/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX index_version_downloads_date;
+CREATE INDEX IF NOT EXISTS index_version_downloads_by_date ON version_downloads USING brin (date);

--- a/migrations/2021-05-05-081208_recreate_version_downloads_date_index_with_brin_pages_per_range_1/up.sql
+++ b/migrations/2021-05-05-081208_recreate_version_downloads_date_index_with_brin_pages_per_range_1/up.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS index_version_downloads_by_date;
+CREATE INDEX IF NOT EXISTS index_version_downloads_date ON version_downloads USING brin (date) WITH (pages_per_range = 1);


### PR DESCRIPTION
The `recent_crate_downloads` materialized view currently takes a lot of time to regenerate (in the order of multiple minutes), and that's impacting the performance of our database server. I looked at the query backing the materialized view and noticed it was using a BRIN index over the date column to discard historical data stored in the table. Our write patterns are similar to the ones where BRIN indexes works best.

I tried tweaking the parameters of the index, and these are the results:

| kind   | pages_per_range | data read | index size |
|--------|-----------------|-----------|------------|
| BRIN   |             128 |   3.29 GB |    0.16 MB |
| BRIN   |              16 |   2.13 GB |    1.12 MB |
| BRIN   |               1 |   1.34 GB |   17.00 MB |
| |
| B-TREE |                 |   1.34 GB |    1.32 GB |

Right now we're using the default `pages_per_range=128`, but switching to `pages_per_range=1` cuts the amount of data we're reading by 60%. The increased disk size of the index is still negligible. Notably, with our workloads `pages_per_size=1` reads the same amount of data as a B-TREE index over the same column, while using way less storage for the index itself.

Because of all of that, this PR recreates the index on `version_downloads` using `pages_per_size=1`. The index has a different name to allow us to pre-create it in production with `CONCURRENTLY` before deploying this.

r? @jtgeibel 