### PR TITLE
Revert "Update dependency ember-source to v3.27.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ember-resolver": "8.0.2",
     "ember-router-scroll": "4.0.3",
     "ember-set-body-class": "1.0.2",
-    "ember-source": "3.27.0",
+    "ember-source": "3.26.1",
     "ember-svg-jar": "2.3.3",
     "ember-template-lint": "3.3.1",
     "ember-test-selectors": "5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1570,10 +1570,10 @@
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
-"@glimmer/vm-babel-plugins@0.78.2":
-  version "0.78.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.78.2.tgz#b530a19f54da385c7099a22cf348e9062d186838"
-  integrity sha512-GSEf16h6OCtKx7PsSvD21cLXZuVc6swW2rSOAvfLeZco1DEWMRgYTwkCkColydKZcQ3gvwbPBeYwTC2K6tlnjg==
+"@glimmer/vm-babel-plugins@0.77.5":
+  version "0.77.5"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.77.5.tgz#daffb6507aa6b08ec36f69d652897d339fdd0007"
+  integrity sha512-jTBM7fJMrIEy4/bCeI8e7ypR+AuWYzLA+KORCGbnTJtL/NYg4G8qwhQAZBtg1d3KmoqyqaCsyqE6f4/tzJO4eQ==
   dependencies:
     babel-plugin-debug-macros "^0.3.4"
 
@@ -7078,16 +7078,16 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@3.27.0:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.27.0.tgz#7e746e0e22e49ad7dacb654ba79183e83d7b6bb2"
-  integrity sha512-DGVJv5GJjdHhDcJl6oCgZuH7nmM32g+TD8IB5xcU1Z2VkYGViBl+Xn9Eo1CL19M7y9sNdQd375sO+3U/IySZPw==
+ember-source@3.26.1:
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.26.1.tgz#8c9e8a314fb0da447b944d64f9d92a80a628d7b5"
+  integrity sha512-5/NATBo5h9m1N52ITVksmjtGlYhGHLl4lDErAWv5/DC9zYe9ZR93NtymR6PEqrRilXc2x0KWd3NlOsWUoJRUOw==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
     "@babel/plugin-transform-object-assign" "^7.8.3"
     "@ember/edition-utils" "^1.2.0"
-    "@glimmer/vm-babel-plugins" "0.78.2"
+    "@glimmer/vm-babel-plugins" "0.77.5"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     broccoli-concat "^4.2.4"


### PR DESCRIPTION
Reverts rust-lang/crates.io#3580

This has been causing the following error in production builds:

> Could not find module `ember-testing` imported from `@ember/test/index`

Detailed investigation is still pending, but in the meantime we should revert this update for now.