### PR TITLE
Log a message if the background worker resets HEAD

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -252,12 +252,18 @@ impl Repository {
 
     pub fn reset_head(&self) -> Result<(), PerformError> {
         let mut origin = self.repository.find_remote("origin")?;
+        let original_head = self.head_oid()?;
         origin.fetch(
             &["refs/heads/*:refs/heads/*"],
             Some(&mut Self::fetch_options(&self.credentials)),
             None,
         )?;
         let head = self.head_oid()?;
+
+        if head != original_head {
+            println!("Resetting index from {} to {}", original_head, head);
+        }
+
         let obj = self.repository.find_object(head, None)?;
         self.repository.reset(&obj, git2::ResetType::Hard, None)?;
         Ok(())


### PR DESCRIPTION
The first commit refactors some background job logic for the index repository.

The second commit logs a message if the background worker sees a different upstream `HEAD` than the currently expected commit. Background workers obtain a lock on the registry index so a reset should only occur if the last job modified the index but failed to push its commit, or the index was mutated externally (ex: to delete crates).

r? @Turbo87 