### PR TITLE
Add a background job for squashing the index

### DIFF
--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 use anyhow::{anyhow, Result};
-use cargo_registry::{db, env, tasks};
+use cargo_registry::{db, env, git, tasks};
 use diesel::prelude::*;
 use swirl::schema::background_jobs::dsl::*;
 use swirl::Job;
@@ -36,6 +36,7 @@ fn main() -> Result<()> {
             Ok(tasks::dump_db(database_url, target_name).enqueue(&conn)?)
         }
         "daily_db_maintenance" => Ok(tasks::daily_db_maintenance().enqueue(&conn)?),
+        "squash_index" => Ok(git::squash_index().enqueue(&conn)?),
         other => Err(anyhow!("Unrecognized job type `{}`", other)),
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -384,7 +384,7 @@ pub fn squash_index(env: &Environment) -> Result<(), PerformError> {
     println!("Squashing the index into a single commit.");
 
     let now = Utc::now().format("%Y-%m-%d");
-    let original_head = repo.head_oid()?;
+    let original_head = repo.head_oid()?.to_string();
     let msg = format!("Collapse index into one commit\n\n\
 
         Previous HEAD was {}, now on the `snapshot-{}` branch\n\n\
@@ -393,9 +393,6 @@ pub fn squash_index(env: &Environment) -> Result<(), PerformError> {
 
         [online]: https://internals.rust-lang.org/t/cargos-crate-index-upcoming-squash-into-one-commit/8440\n\
         [this issue]: https://github.com/rust-lang/crates-io-cargo-teams/issues/47", original_head, now);
-
-    // Create a snapshot branch of current `HEAD`.
-    repo.push(&format!("HEAD:refs/heads/snapshot-{}", now))?;
 
     repo.squash_to_single_commit(&msg)?;
 
@@ -431,9 +428,15 @@ pub fn squash_index(env: &Environment) -> Result<(), PerformError> {
         )
         .args(&[
             "push",
+            // Both updates should succeed or fail together
+            "--atomic",
             "origin",
-            "HEAD:refs/heads/master",
+            // Overwrite master, but only if it server matches the expected value
             &format!("--force-with-lease=refs/heads/master:{}", original_head),
+            // The new squashed commit is pushed to master
+            "HEAD:refs/heads/master",
+            // The previous value of HEAD is pushed to a snapshot branch
+            &format!("{}:refs/heads/snapshot-{}", original_head, now),
         ])
         .output()?;
 


### PR DESCRIPTION
This adds a background job that squashes the index into a single commit.
The current plan is to manually enqueue this job on a 6 week schedule,
roughly aligning with new `rustc` releases. Before deploying this, will
need to make sure that the SSH key is allowed to do a force push to the
protected master branch.

This job is derived from a [script] that was periodically run by the
cargo team. Relative to the original script, the push of the snapshot
branch is no longer forced. The job will fail if run more than once on
the same day. (If the first attempt fails before pushing a new root
commit upstream, then retries should succeed as long as the snapshot
can be fast-forwarded.)

[script]: https://github.com/rust-lang/crates-io-cargo-teams/issues/47#issuecomment-506236036