### PR TITLE
Fix missing line breaks for crate name and refine sidebar layout

### DIFF
--- a/app/components/crate-header.module.css
+++ b/app/components/crate-header.module.css
@@ -17,6 +17,10 @@
         padding: 0;
     }
 
+    h1 {
+        word-break: break-word;
+    }
+
     h2 {
         color: var(--main-color-light);
         margin-left: 10px;

--- a/app/components/crate-row.module.css
+++ b/app/components/crate-row.module.css
@@ -22,6 +22,7 @@
     font-weight: bold;
     text-decoration: none;
     font-size: 120%;
+    overflow-wrap: break-word;
 }
 
 .version {

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -15,7 +15,7 @@
         }
     }
 
-    @media only screen and (max-width: 480px) {
+    @media only screen and (max-width: 890px) {
         .top, .bottom {
             flex-direction: column;
         }

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -71,6 +71,12 @@
     background: transparent;
     border-radius: 5px;
     border: solid 2px var(--gray-border);
+
+    span {
+        flex: auto;
+        display: block;
+        word-break: break-word;
+    }
 }
 
 .copy-button {

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -39,6 +39,7 @@
     text-align: center;
     font-size: 20px;
     font-weight: 300;
+    overflow-wrap: break-word;
 
     code {
         font-size: 18px;


### PR DESCRIPTION
Notified that *crates.io* seems not optimized for small screen devices while I was finding crates on my phone, some long crate names made the website in a mess due to missing line breaks, in my opinion a simple workaround would apply to it by adding line breaks.

Test on my laptop with Safari 14.1:

- Add overflow wrap to the names of crates

  ![1](https://user-images.githubusercontent.com/15633984/117532847-24542800-b01c-11eb-8eb1-6e97f80be5c1.png)

- Add word-break to the header name and no-readme texts in detailed crate pages

  ![2](https://user-images.githubusercontent.com/15633984/117532993-b2c8a980-b01c-11eb-930d-c7b5a3d31a8b.png)

- Add word-break to texts inside the sidebar copy button 

  ![3](https://user-images.githubusercontent.com/15633984/117533113-7d708b80-b01d-11eb-8761-ae2c77c3bba9.png)

- Change the flex layout wrap to column when window width is less than `890px` to avoid warp overflow in row

  ![4](https://user-images.githubusercontent.com/15633984/117533412-4b602900-b01f-11eb-8dc8-4b7f3f9d30e8.png)

This would not be the best workaround, it only provides a better experience while surfing the *crates.io* on the phone, on small screen devices or on a split window view. 


