### PR TITLE
Include only the last 90 days of downloads in our database dumps

### DIFF
--- a/src/tasks/dump_db/dump-db.toml
+++ b/src/tasks/dump_db/dump-db.toml
@@ -188,6 +188,7 @@ name = "public"
 
 [version_downloads]
 dependencies = ["versions"]
+filter = "date > current_date - interval '90 day'"
 [version_downloads.columns]
 version_id = "public"
 downloads = "public"


### PR DESCRIPTION
In #3479 we plan to drop old entries and archive them in some other way, so old entries will eventually disappear from dumps anyway. This should make use of the database dumps much more practical for daily use. I think it would be reasonable to even limit this to the past week of data.

r? @pietroalbini 
cc @kornelski, #2078