### PR TITLE
Drop crates.textsearchable_index_col from the export

### DIFF
--- a/src/tasks/dump_db/dump-db.toml
+++ b/src/tasks/dump_db/dump-db.toml
@@ -82,7 +82,7 @@ description = "public"
 homepage = "public"
 documentation = "public"
 readme = "public"
-textsearchable_index_col = "public"
+textsearchable_index_col = "private" # This Postgres specific and can be derived from exported data
 repository = "public"
 max_upload_size = "public"
 

--- a/src/tasks/dump_db/dump-import.sql.hbs
+++ b/src/tasks/dump_db/dump-import.sql.hbs
@@ -16,6 +16,9 @@ BEGIN;
     TRUNCATE "{{this.name}}" RESTART IDENTITY CASCADE;
 {{~/each}}
 
+    -- Enable this trigger so that `crates.textsearchable_index_col` can be excluded from the export
+    ALTER TABLE "crates" ENABLE TRIGGER "trigger_crates_tsvector_update";
+
     -- Import the CSV data.
 {{~#each tables}}
     \copy "{{this.name}}" ({{this.columns}}) FROM 'data/{{this.name}}.csv' WITH CSV HEADER


### PR DESCRIPTION
This column is postgres specific and is normally populated via a
trigger. The trigger is now enabled during the import so that the column
can be dropped from the export.

This addresses part of what was raised in bullet point 2 of #2078. The large readme column remains because there could be people using that data, but the text search column is redundant.

r? @smarnach 
cc @kornelski 