### PR TITLE
Block page offset user-agents based on substring, instead of full UA

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -66,8 +66,8 @@ impl Default for Config {
     /// - `READ_ONLY_MODE`: If defined (even as empty) then force all connections to be read-only.
     /// - `WEB_MAX_ALLOWED_PAGE_OFFSET`: Page offsets larger than this value are rejected. Defaults
     ///   to 200.
-    /// - `WEB_PAGE_OFFSET_UA_BLOCKLIST`: A comma seperated list of user-agents that will be
-    ///   blocked if `WEB_MAX_ALLOWED_PAGE_OFFSET` is exceeded.
+    /// - `WEB_PAGE_OFFSET_UA_BLOCKLIST`: A comma seperated list of user-agent substrings that will
+    ///   be blocked if `WEB_MAX_ALLOWED_PAGE_OFFSET` is exceeded.
     ///
     /// # Panics
     ///

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -41,7 +41,7 @@ impl Page {
                 && config
                     .page_offset_ua_blocklist
                     .iter()
-                    .any(|blocked| user_agent == blocked)
+                    .any(|blocked| user_agent.contains(blocked))
             {
                 add_custom_metadata(req, "cause", "large page offset");
                 return Err(bad_request("requested page offset is too large"));


### PR DESCRIPTION
Because UA strings can contain commas, we test
`user_agent.contains(blocked)`. This is in contrast to the `BlockTraffic`
middleware, which only matches identical/full strings.