### PR TITLE
Remove obsolete Chart.js CSS import

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -60,8 +60,6 @@ module.exports = function (defaults) {
   });
 
   app.import('node_modules/normalize.css/normalize.css', { prepend: true });
-  app.import('node_modules/chart.js/dist/Chart.min.css');
-
   app.import('vendor/qunit.css', { type: 'test' });
 
   if (USE_EMBROIDER) {


### PR DESCRIPTION
With Chart.js v3 this is no longer needed, and the file doesn't even exist anymore 😅 