### PR TITLE
Implement seek-based pagination for filterless sortless crates endpoint

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -11,7 +11,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
     // to paginate this.
-    let options = PaginationOptions::new(req)?;
+    let options = PaginationOptions::builder().gather(req)?;
     let offset = options.offset().unwrap_or_default();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -4,24 +4,61 @@ use crate::models::helpers::with_count::*;
 use crate::util::errors::{bad_request, AppResult};
 use crate::util::request_header;
 
+use crate::App;
 use diesel::pg::Pg;
 use diesel::query_builder::*;
 use diesel::query_dsl::LoadQuery;
 use diesel::sql_types::BigInt;
 use indexmap::IndexMap;
+use std::sync::Arc;
 
-#[derive(Debug, Clone, Copy)]
+const MAX_PAGE_BEFORE_SUSPECTED_BOT: u32 = 10;
+const DEFAULT_PER_PAGE: u32 = 10;
+const MAX_PER_PAGE: u32 = 100;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Page {
     Numeric(u32),
     Unspecified,
 }
 
-impl Page {
-    fn new(req: &mut dyn RequestExt) -> AppResult<Self> {
-        const MAX_PAGE_BEFORE_SUSPECTED_BOT: u32 = 10;
+#[derive(Debug, Clone)]
+pub(crate) struct PaginationOptions {
+    pub(crate) page: Page,
+    pub(crate) per_page: u32,
+}
 
+impl PaginationOptions {
+    pub(crate) fn builder() -> PaginationOptionsBuilder {
+        PaginationOptionsBuilder {
+            limit_page_numbers: None,
+        }
+    }
+
+    pub(crate) fn offset(&self) -> Option<u32> {
+        if let Page::Numeric(p) = self.page {
+            Some((p - 1) * self.per_page)
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) struct PaginationOptionsBuilder {
+    limit_page_numbers: Option<Arc<App>>,
+}
+
+impl PaginationOptionsBuilder {
+    pub(crate) fn limit_page_numbers(mut self, app: Arc<App>) -> Self {
+        self.limit_page_numbers = Some(app);
+        self
+    }
+
+    pub(crate) fn gather(self, req: &mut dyn RequestExt) -> AppResult<PaginationOptions> {
         let params = req.query();
-        if let Some(s) = params.get("page") {
+        let page_param = params.get("page");
+
+        let page = if let Some(s) = page_param {
             let numeric_page = s.parse().map_err(|e| bad_request(&e))?;
             if numeric_page < 1 {
                 return Err(bad_request(&format_args!(
@@ -35,58 +72,29 @@ impl Page {
             }
 
             // Block large offsets for known violators of the crawler policy
-            let config = &req.app().config;
-            let user_agent = request_header(req, header::USER_AGENT);
-            if numeric_page > config.max_allowed_page_offset
-                && config
-                    .page_offset_ua_blocklist
-                    .iter()
-                    .any(|blocked| user_agent.contains(blocked))
-            {
-                add_custom_metadata(req, "cause", "large page offset");
-                return Err(bad_request("requested page offset is too large"));
+            if let Some(app) = self.limit_page_numbers {
+                let config = &app.config;
+                let user_agent = request_header(req, header::USER_AGENT);
+                if numeric_page > config.max_allowed_page_offset
+                    && config
+                        .page_offset_ua_blocklist
+                        .iter()
+                        .any(|blocked| user_agent.contains(blocked))
+                {
+                    add_custom_metadata(req, "cause", "large page offset");
+                    return Err(bad_request("requested page offset is too large"));
+                }
             }
 
-            Ok(Page::Numeric(numeric_page))
+            Page::Numeric(numeric_page)
         } else {
-            Ok(Page::Unspecified)
-        }
-    }
-}
+            Page::Unspecified
+        };
 
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct PaginationOptions {
-    page: Page,
-    pub(crate) per_page: u32,
-}
-
-impl PaginationOptions {
-    pub(crate) fn builder() -> PaginationOptionsBuilder {
-        PaginationOptionsBuilder
-    }
-
-    pub(crate) fn offset(&self) -> Option<u32> {
-        if let Page::Numeric(p) = self.page {
-            Some((p - 1) * self.per_page)
-        } else {
-            None
-        }
-    }
-}
-
-pub(crate) struct PaginationOptionsBuilder;
-
-impl PaginationOptionsBuilder {
-    pub(crate) fn gather(self, req: &mut dyn RequestExt) -> AppResult<PaginationOptions> {
-        const DEFAULT_PER_PAGE: u32 = 10;
-        const MAX_PER_PAGE: u32 = 100;
-
-        let params = req.query();
         let per_page = params
             .get("per_page")
             .map(|s| s.parse().map_err(|e| bad_request(&e)))
             .unwrap_or(Ok(DEFAULT_PER_PAGE))?;
-
         if per_page > MAX_PER_PAGE {
             return Err(bad_request(&format_args!(
                 "cannot request more than {} items",
@@ -94,10 +102,7 @@ impl PaginationOptionsBuilder {
             )));
         }
 
-        Ok(PaginationOptions {
-            page: Page::new(req)?,
-            per_page,
-        })
+        Ok(PaginationOptions { page, per_page })
     }
 }
 
@@ -139,14 +144,10 @@ impl<T> Paginated<T> {
     }
 
     pub(crate) fn prev_page_params(&self) -> Option<IndexMap<String, String>> {
-        if let Page::Numeric(1) | Page::Unspecified = self.options.page {
-            return None;
-        }
-
         let mut opts = IndexMap::new();
         match self.options.page {
+            Page::Numeric(1) | Page::Unspecified => return None,
             Page::Numeric(n) => opts.insert("page".into(), (n - 1).to_string()),
-            Page::Unspecified => unreachable!(),
         };
         Some(opts)
     }
@@ -176,7 +177,7 @@ impl<T> PaginatedQuery<T> {
     where
         Self: LoadQuery<PgConnection, WithCount<U>>,
     {
-        let options = self.options;
+        let options = self.options.clone();
         let records_and_total = self.internal_load(conn)?;
         Ok(Paginated {
             records_and_total,
@@ -215,10 +216,48 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Page, PaginationOptions};
-
+    use super::*;
     use conduit::StatusCode;
-    use conduit_test::MockRequest;
+    use conduit_test::{MockRequest, ResponseExt};
+
+    #[test]
+    fn no_pagination_param() {
+        let pagination = PaginationOptions::builder().gather(&mut mock("")).unwrap();
+        assert_eq!(Page::Unspecified, pagination.page);
+        assert_eq!(DEFAULT_PER_PAGE, pagination.per_page);
+    }
+
+    #[test]
+    fn page_param_parsing() {
+        let assert_error =
+            |query, msg| assert_pagination_error(PaginationOptions::builder(), query, msg);
+
+        assert_error("page=", "cannot parse integer from empty string");
+        assert_error("page=not_a_number", "invalid digit found in string");
+        assert_error("page=1.0", "invalid digit found in string");
+        assert_error("page=0", "page indexing starts from 1, page 0 is invalid");
+
+        let pagination = PaginationOptions::builder()
+            .gather(&mut mock("page=5"))
+            .unwrap();
+        assert_eq!(Page::Numeric(5), pagination.page);
+    }
+
+    #[test]
+    fn per_page_param_parsing() {
+        let assert_error =
+            |query, msg| assert_pagination_error(PaginationOptions::builder(), query, msg);
+
+        assert_error("per_page=", "cannot parse integer from empty string");
+        assert_error("per_page=not_a_number", "invalid digit found in string");
+        assert_error("per_page=1.0", "invalid digit found in string");
+        assert_error("per_page=101", "cannot request more than 100 items");
+
+        let pagination = PaginationOptions::builder()
+            .gather(&mut mock("per_page=5"))
+            .unwrap();
+        assert_eq!(5, pagination.per_page);
+    }
 
     fn mock(query: &str) -> MockRequest {
         let mut req = MockRequest::new(http::Method::GET, "");
@@ -226,48 +265,25 @@ mod tests {
         req
     }
 
-    #[test]
-    fn page_must_be_a_number() {
-        let mut req = mock("page=");
-        let page_error = Page::new(&mut req).unwrap_err().response().unwrap();
-
-        assert_eq!(page_error.status(), StatusCode::BAD_REQUEST);
-
-        let mut req = mock("page=not_a_number");
-        let page_error = Page::new(&mut req).unwrap_err().response().unwrap();
-
-        assert_eq!(page_error.status(), StatusCode::BAD_REQUEST);
-    }
-
-    #[test]
-    fn page_must_be_non_zero_positive_integer() {
-        let mut req = mock("page=0");
-        let page_error = Page::new(&mut req).unwrap_err().response().unwrap();
-
-        assert_eq!(page_error.status(), StatusCode::BAD_REQUEST);
-
-        let mut req = mock("page=1.0");
-        let page_error = Page::new(&mut req).unwrap_err().response().unwrap();
-
-        assert_eq!(page_error.status(), StatusCode::BAD_REQUEST);
-    }
-
-    #[test]
-    fn per_page_must_be_a_number() {
-        let mut req = mock("per_page=");
-        let per_page_error = PaginationOptions::builder()
-            .gather(&mut req)
+    fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {
+        let response = options
+            .gather(&mut mock(query))
             .unwrap_err()
             .response()
             .unwrap();
-        assert_eq!(per_page_error.status(), StatusCode::BAD_REQUEST);
 
-        let mut req = mock("per_page=not_a_number");
-        let per_page_error = PaginationOptions::builder()
-            .gather(&mut req)
-            .unwrap_err()
-            .response()
-            .unwrap();
-        assert_eq!(per_page_error.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(StatusCode::BAD_REQUEST, response.status());
+
+        #[derive(Deserialize)]
+        struct Parsed {
+            errors: [ParsedError; 1],
+        }
+        #[derive(Deserialize)]
+        struct ParsedError {
+            detail: String,
+        }
+
+        let parsed: Parsed = serde_json::from_slice(&response.into_cow()).unwrap();
+        assert_eq!(message, parsed.errors[0].detail);
     }
 }

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
 
+use crate::controllers::helpers::pagination::PaginationOptions;
 use crate::controllers::helpers::{pagination::Paginated, Paginate};
 use crate::models::Keyword;
 use crate::views::EncodableKeyword;
@@ -19,7 +20,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
         query = query.order(keywords::keyword.asc());
     }
 
-    let query = query.paginate(req)?;
+    let query = query.pages_pagination(PaginationOptions::builder().gather(req)?);
     let conn = req.db_read_only()?;
     let data: Paginated<Keyword> = query.load(&*conn)?;
     let total = data.total();

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -247,7 +247,7 @@ pub fn versions(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::any;
 
-    let pagination_options = PaginationOptions::new(req)?;
+    let pagination_options = PaginationOptions::builder().gather(req)?;
     let name = &req.params()["crate_id"];
     let conn = req.db_read_only()?;
     let krate: Crate = Crate::by_name(name).first(&*conn)?;

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -194,7 +194,11 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         query = query.then_order_by(crates::name.asc())
     }
 
-    let query = query.pages_pagination(PaginationOptions::builder().gather(req)?);
+    let query = query.pages_pagination(
+        PaginationOptions::builder()
+            .limit_page_numbers(req.app().clone())
+            .gather(req)?,
+    );
     let conn = req.db_read_only()?;
     let data: Paginated<(Crate, bool, Option<i64>)> = query.load(&*conn)?;
     let total = data.total();

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -12,7 +12,7 @@ use crate::schema::*;
 use crate::util::errors::{bad_request, ChainError};
 use crate::views::EncodableCrate;
 
-use crate::controllers::helpers::pagination::Paginated;
+use crate::controllers::helpers::pagination::{Paginated, PaginationOptions};
 use crate::models::krate::{canon_crate_name, ALL_COLUMNS};
 
 /// Handles the `GET /crates` route.
@@ -194,7 +194,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         query = query.then_order_by(crates::name.asc())
     }
 
-    let query = query.paginate(req)?;
+    let query = query.pages_pagination(PaginationOptions::builder().gather(req)?);
     let conn = req.db_read_only()?;
     let data: Paginated<(Crate, bool, Option<i64>)> = query.load(&*conn)?;
     let total = data.total();

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -4,7 +4,7 @@ use crate::controllers::frontend_prelude::*;
 
 use crate::controllers::helpers::*;
 
-use crate::controllers::helpers::pagination::Paginated;
+use crate::controllers::helpers::pagination::{Paginated, PaginationOptions};
 use crate::models::{
     CrateOwner, Email, Follow, NewEmail, OwnerKind, User, Version, VersionOwnerAction,
 };
@@ -68,7 +68,7 @@ pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
             crates::name,
             users::all_columns.nullable(),
         ))
-        .paginate(req)?;
+        .pages_pagination(PaginationOptions::builder().gather(req)?);
     let conn = req.db_conn()?;
     let data: Paginated<(Version, String, Option<User>)> = query.load(&*conn)?;
     let more = data.next_page_params().is_some();


### PR DESCRIPTION
This PR implements seek-based pagination for parts of the `/api/v1/crates` endpoint, and adds the infrastructure to parse `seek=` parameters in paginated APIs. The reason for this PR is that we have multiple crawlers scraping the whole `/api/v1/crates` endpoint every day, and offset-based pagination is not feasible after a high number of pages.

To keep the implementation simple seek-based pagination is only supported for requests matching these constraints:

* **No filters:** when the request is filtered the total results count is not the same as the total number of crates, so the current implementation to gather the number of results (`SELECT COUNT(*) FROM crates;`) does not work. This can be lifted in the future by refactoring how we gather the total number of results.
* **No sorting other than alphanumeric:** this is just not implemented yet, we'd need to change the condition used to seek to the correct position. Note that for anything that's not alphanumeric we'll need to sort by `($param, id)`, not just `$param`, to ensure the results are consistently ordered (there could be multiple crates with the same download count).
* **No search queries:** search queries complicate the SQL query quite a bit, introducing relevance sorting and hardcoding the exact match as the first result. Not worth implementing for the time being IMO.

When the endpoint is called with a request that supports seeking, no `meta.prev_page` will be provided and `meta.next_page` will include the `seek` parameter instead of the `page` parameter. `meta.total` will continue to be provided as usual.

The value of `seek` is a base64-encoded JSON value. The reason base64 is used is to signal to our API consumers the seek value is an implementation detail and they shouldn't manually create one. This is what other big providers do (for example GitHub). The reason to encode the value in JSON is to support more complex seek keys in the future: right now we're just encoding a bare number, and the JSON representation is the same as the ASCII representation.

This PR is fully backward compatible: if clients just rely on `meta.next_page` they will transparently start using seek-based pagination, but offset-based pagination still works. When the `page=` attribute is provided offset-based pagination will be forced, and `meta.next_page` will include `page` instead of `seek`. This way, clients manually creating `?page=` URLs will not break.

One unfortunate aspect of this PR is that we still have to provide `meta.total`, as that's required by the Cargo registries API. Getting the total count requires a full scan over the table, which right now in production is done using an index-only scan in ~20ms.

The PR is best reviewed commit-by-commit.
r? @jtgeibel 