### PR TITLE
models::Version: Change `num` field to a plain `String`

### DIFF
--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -23,7 +23,7 @@ pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
 
     let mut versions: Vec<Version> = krate.all_versions().load(&*conn)?;
-    versions.sort_by(|a, b| b.num.cmp(&a.num));
+    versions.sort_by_cached_key(|version| cmp::Reverse(semver::Version::parse(&version.num).ok()));
     let (latest_five, rest) = versions.split_at(cmp::min(5, versions.len()));
 
     let downloads = VersionDownload::belonging_to(latest_five)

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -4,6 +4,8 @@
 //! index or cached metadata which was extracted (client side) from the
 //! `Cargo.toml` file.
 
+use std::cmp::Reverse;
+
 use crate::controllers::frontend_prelude::*;
 use crate::controllers::helpers::pagination::PaginationOptions;
 
@@ -128,7 +130,10 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
         .left_outer_join(users::table)
         .select((versions::all_columns, users::all_columns.nullable()))
         .load(&*conn)?;
-    versions_and_publishers.sort_by(|a, b| b.0.num.cmp(&a.0.num));
+
+    versions_and_publishers
+        .sort_by_cached_key(|(version, _)| Reverse(semver::Version::parse(&version.num).ok()));
+
     let versions = versions_and_publishers
         .iter()
         .map(|(v, _)| v)
@@ -224,7 +229,10 @@ pub fn versions(req: &mut dyn RequestExt) -> EndpointResult {
         .left_outer_join(users::table)
         .select((versions::all_columns, users::all_columns.nullable()))
         .load(&*conn)?;
-    versions_and_publishers.sort_by(|a, b| b.0.num.cmp(&a.0.num));
+
+    versions_and_publishers
+        .sort_by_cached_key(|(version, _)| Reverse(semver::Version::parse(&version.num).ok()));
+
     let versions = versions_and_publishers
         .iter()
         .map(|(v, _)| v)

--- a/src/git.rs
+++ b/src/git.rs
@@ -328,13 +328,12 @@ pub fn yank(
         }
 
         let prev = fs::read_to_string(&dst)?;
-        let version_num = version.num.to_string();
         let new = prev
             .lines()
             .map(|line| {
                 let mut git_crate = serde_json::from_str::<Crate>(line)
                     .map_err(|_| format!("couldn't decode: `{}`", line))?;
-                if git_crate.name != krate || git_crate.vers != version_num {
+                if git_crate.name != krate || git_crate.vers != version.num {
                     return Ok(line.to_string());
                 }
                 git_crate.yanked = Some(yanked);

--- a/src/views.rs
+++ b/src/views.rs
@@ -607,12 +607,15 @@ impl EncodableVersion {
             ..
         } = version;
 
-        let num = num.to_string();
+        let links = EncodableVersionLinks {
+            dependencies: format!("/api/v1/crates/{}/{}/dependencies", crate_name, num),
+            version_downloads: format!("/api/v1/crates/{}/{}/downloads", crate_name, num),
+        };
 
         Self {
             dl_path: format!("/api/v1/crates/{}/{}/download", crate_name, num),
             readme_path: format!("/api/v1/crates/{}/{}/readme", crate_name, num),
-            num: num.clone(),
+            num,
             id,
             krate: crate_name.to_string(),
             updated_at,
@@ -621,10 +624,7 @@ impl EncodableVersion {
             features,
             yanked,
             license,
-            links: EncodableVersionLinks {
-                dependencies: format!("/api/v1/crates/{}/{}/dependencies", crate_name, num),
-                version_downloads: format!("/api/v1/crates/{}/{}/downloads", crate_name, num),
-            },
+            links,
             crate_size,
             published_by: published_by.map(User::into),
             audit_actions: audit_actions


### PR DESCRIPTION
This PR prepares for `semver` v1.x no longer having a `diesel` feature, which would make it much more complicated for us to directly deserialize the SQL column into a `semver::Version` field. We can deserialize it to a `String` instead, and only parse it into a `semver::Version` on demand.
