### PR TITLE
Update `semver` to v1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
  "rand 0.8.3",
  "reqwest",
  "scheduled-thread-pool",
- "semver 0.10.0",
+ "semver 1.0.3",
  "sentry",
  "serde",
  "serde_json",
@@ -2243,22 +2243,20 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
-dependencies = [
- "diesel",
- "semver-parser 0.7.0",
- "serde",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser 0.10.2",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ prometheus = "0.12.0"
 rand = "0.8"
 reqwest = { version = "0.11", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "0.2.0"
-semver = { version = "0.10", features = ["diesel", "serde"] }
+semver = { version = "1.0.3", features = ["serde"] }
 sentry = "0.22"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -303,8 +303,11 @@ pub fn add_dependencies(
             let krate:Crate = Crate::by_exact_name(&dep.name)
                 .first(&*conn)
                 .map_err(|_| cargo_err(&format_args!("no known crate named `{}`", &*dep.name)))?;
-            if semver::VersionReq::parse(&dep.version_req.0) == semver::VersionReq::parse("*") {
-                return Err(cargo_err(WILDCARD_ERROR_MESSAGE));
+
+            if let Ok(version_req) = semver::VersionReq::parse(&dep.version_req.0) {
+                if version_req == semver::VersionReq::STAR {
+                    return Err(cargo_err(WILDCARD_ERROR_MESSAGE));
+                }
             }
 
             // If this dependency has an explicit name in `Cargo.toml` that

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -76,7 +76,7 @@ impl TopVersions {
         let highest_stable = pairs
             .iter()
             .map(|(_, v)| v)
-            .filter(|v| !v.is_prerelease())
+            .filter(|v| v.pre.is_empty())
             .max()
             .map(|v| v.clone());
 


### PR DESCRIPTION
This PR updates the `semver` crate to the new v1.0.0 release, which is basically a complete rewrite. The `diesel` feature no longer exists, but due to #3650 we don't need it anymore.

Closes https://github.com/rust-lang/crates.io/pull/3338