### PR TITLE
ember-test-selectors: Disable obsolete/deprecated `Component.reopen()` call

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -43,6 +43,11 @@ module.exports = function (defaults) {
       theme: 'twilight',
       components: highlightedLanguages,
     },
+
+    'ember-test-selectors': {
+      patchClassicComponent: false,
+    },
+
     cssModules: {
       extension: 'module.css',
       plugins: {


### PR DESCRIPTION


see https://github.com/simplabs/ember-test-selectors/pull/721