### PR TITLE
Add support for logging instance-level metrics to stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ hex = "0.4"
 htmlescape = "0.3.1"
 http = "0.2"
 hyper = { version = "0.14", features = ["client", "http1"] }
-indexmap = "1.0.2"
+indexmap = { version = "1.0.2", features = ["serde-1"] }
 jemallocator = { version = "0.3", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "0.10.0-beta.3", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
 license-exprs = "1.6"

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub ownership_invitations_expiration_days: u64,
     pub metrics_authorization_token: Option<String>,
     pub use_test_database_pool: bool,
+    pub instance_metrics_log_every_seconds: Option<u64>,
 }
 
 #[derive(Debug)]
@@ -70,6 +71,8 @@ impl Default for Config {
     ///   be blocked if `WEB_MAX_ALLOWED_PAGE_OFFSET` is exceeded. Including an empty string in the
     ///   list will block *all* user-agents exceeding the offset. If not set or empty, no blocking
     ///   will occur.
+    /// - `INSTANCE_METRICS_LOG_EVERY_SECONDS`: How frequently should instance metrics be logged.
+    ///   If the environment variable is not present instance metrics are not logged.
     ///
     /// # Panics
     ///
@@ -229,6 +232,7 @@ impl Default for Config {
             ownership_invitations_expiration_days: 30,
             metrics_authorization_token: dotenv::var("METRICS_AUTHORIZATION_TOKEN").ok(),
             use_test_database_pool: false,
+            instance_metrics_log_every_seconds: env_optional("INSTANCE_METRICS_LOG_EVERY_SECONDS"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod downloads_counter;
 pub mod email;
 pub mod git;
 pub mod github;
-mod metrics;
+pub mod metrics;
 pub mod middleware;
 mod publish_rate_limit;
 pub mod render;

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -44,7 +44,7 @@ metrics! {
 }
 
 impl InstanceMetrics {
-    pub(crate) fn gather(&self, app: &App) -> AppResult<Vec<MetricFamily>> {
+    pub fn gather(&self, app: &App) -> AppResult<Vec<MetricFamily>> {
         // Database pool stats
         self.refresh_pool_stats("primary", &app.primary_database)?;
         if let Some(follower) = &app.read_only_replica_database {

--- a/src/metrics/log_encoder.rs
+++ b/src/metrics/log_encoder.rs
@@ -1,0 +1,237 @@
+use base64::write::EncoderWriter;
+use indexmap::IndexMap;
+use prometheus::proto::{MetricFamily, MetricType};
+use prometheus::{Encoder, Error};
+use std::io::Write;
+
+/// The `LogEncoder` struct encodes Prometheus metrics in the format [`crates-io-heroku-metrics`]
+/// expects metrics to be logged. This can be used to forward instance metrics to it, allowing them
+/// to be scraped by the Rust infrastructure monitoring system.
+///
+/// The metrics are encoded in the format [Vector expects them][vector], and the list of metrics is
+/// json-encoded and then base64-encoded. The whole thing is prefixed with a predefined string to
+/// let [`crates-io-heroku-metrics`] find it easily.
+///
+/// This is needed mostly for crates.io hosted on Heroku. Deployments of crates.io on other
+/// platforms shouldn't need this.
+///
+/// [`crates-io-heroku-metrics`]: https://github.com/rust-lang/crates-io-heroku-metrics
+/// [vector]: https://vector.dev/docs/about/under-the-hood/architecture/data-model/metric/
+#[derive(Debug, Clone, Copy)]
+pub struct LogEncoder(());
+
+impl LogEncoder {
+    pub fn new() -> Self {
+        Self(())
+    }
+}
+
+impl Encoder for LogEncoder {
+    fn encode<W: Write>(
+        &self,
+        families: &[MetricFamily],
+        mut dest: &mut W,
+    ) -> prometheus::Result<()> {
+        let events = families_to_json_events(families);
+
+        dest.write_all(b"crates-io-heroku-metrics:ingest ")?;
+        let base64_dest = EncoderWriter::new(&mut dest, base64::STANDARD);
+        serde_json::to_writer(base64_dest, &events).map_err(|e| Error::Msg(e.to_string()))?;
+        dest.write_all(b"\n")?;
+
+        Ok(())
+    }
+
+    fn format_type(&self) -> &str {
+        "crates-io-heroku-metrics log encoding"
+    }
+}
+
+fn families_to_json_events(families: &[MetricFamily]) -> Vec<VectorEvent<'_>> {
+    let mut events = Vec::new();
+    for family in families {
+        for metric in family.get_metric() {
+            let data = match family.get_field_type() {
+                MetricType::COUNTER => VectorMetricData::Counter {
+                    value: metric.get_counter().get_value(),
+                },
+                MetricType::GAUGE => VectorMetricData::Gauge {
+                    value: metric.get_gauge().get_value(),
+                },
+                other => {
+                    panic!("unsupported metric type: {:?}", other)
+                }
+            };
+            events.push(VectorEvent {
+                metric: VectorMetric {
+                    data,
+                    kind: "absolute",
+                    name: family.get_name(),
+                    tags: metric
+                        .get_label()
+                        .iter()
+                        .map(|p| (p.get_name(), p.get_value()))
+                        .collect(),
+                },
+            });
+        }
+    }
+    events
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+struct VectorEvent<'a> {
+    metric: VectorMetric<'a>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+struct VectorMetric<'a> {
+    #[serde(flatten)]
+    data: VectorMetricData,
+    kind: &'a str,
+    name: &'a str,
+    tags: IndexMap<&'a str, &'a str>,
+}
+
+#[derive(Serialize, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum VectorMetricData {
+    Counter { value: f64 },
+    Gauge { value: f64 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::Error;
+    use prometheus::{IntCounter, IntGauge, IntGaugeVec, Opts, Registry};
+
+    #[test]
+    fn test_counter_to_json() -> Result<(), Error> {
+        let counter =
+            IntCounter::with_opts(Opts::new("sample_counter", "sample_counter help message"))?;
+        let registry = Registry::new();
+        registry.register(Box::new(counter.clone()))?;
+
+        assert_eq!(
+            vec![VectorEvent {
+                metric: VectorMetric {
+                    data: VectorMetricData::Counter { value: 0.0 },
+                    kind: "absolute",
+                    name: "sample_counter",
+                    tags: IndexMap::new(),
+                }
+            }],
+            families_to_json_events(&registry.gather())
+        );
+
+        counter.inc_by(42);
+        assert_eq!(
+            vec![VectorEvent {
+                metric: VectorMetric {
+                    data: VectorMetricData::Counter { value: 42.0 },
+                    kind: "absolute",
+                    name: "sample_counter",
+                    tags: IndexMap::new(),
+                }
+            }],
+            families_to_json_events(&registry.gather())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_gauge_to_json() -> Result<(), Error> {
+        let gauge = IntGauge::with_opts(Opts::new("sample_gauge", "sample_gauge help message"))?;
+        let registry = Registry::new();
+        registry.register(Box::new(gauge.clone()))?;
+
+        assert_eq!(
+            vec![VectorEvent {
+                metric: VectorMetric {
+                    data: VectorMetricData::Gauge { value: 0.0 },
+                    kind: "absolute",
+                    name: "sample_gauge",
+                    tags: IndexMap::new(),
+                }
+            }],
+            families_to_json_events(&registry.gather())
+        );
+
+        gauge.set(42);
+        assert_eq!(
+            vec![VectorEvent {
+                metric: VectorMetric {
+                    data: VectorMetricData::Gauge { value: 42.0 },
+                    kind: "absolute",
+                    name: "sample_gauge",
+                    tags: IndexMap::new(),
+                }
+            }],
+            families_to_json_events(&registry.gather())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_metric_with_tags_to_json() -> Result<(), Error> {
+        let gauge_vec = IntGaugeVec::new(
+            Opts::new("sample_gauge", "sample_gauge help message"),
+            &["label1", "label2"],
+        )?;
+        let registry = Registry::new();
+        registry.register(Box::new(gauge_vec.clone()))?;
+
+        gauge_vec.with_label_values(&["foo", "1"]).set(42);
+        gauge_vec.with_label_values(&["bar", "2"]).set(98);
+
+        assert_eq!(
+            vec![
+                VectorEvent {
+                    metric: VectorMetric {
+                        data: VectorMetricData::Gauge { value: 98.0 },
+                        kind: "absolute",
+                        name: "sample_gauge",
+                        tags: [("label1", "bar"), ("label2", "2")]
+                            .iter()
+                            .copied()
+                            .collect(),
+                    }
+                },
+                VectorEvent {
+                    metric: VectorMetric {
+                        data: VectorMetricData::Gauge { value: 42.0 },
+                        kind: "absolute",
+                        name: "sample_gauge",
+                        tags: [("label1", "foo"), ("label2", "1")]
+                            .iter()
+                            .copied()
+                            .collect(),
+                    }
+                },
+            ],
+            families_to_json_events(&registry.gather())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encoding() -> Result<(), Error> {
+        let gauge = IntGauge::with_opts(Opts::new("sample_gauge", "sample_gauge help message"))?;
+        let registry = Registry::new();
+        registry.register(Box::new(gauge.clone()))?;
+
+        let mut output = Vec::new();
+        LogEncoder::new().encode(&registry.gather(), &mut output)?;
+
+        assert_eq!(
+            b"crates-io-heroku-metrics:ingest W3sibWV0cmljIjp7ImdhdWdlIjp7InZhbHVlIjowLjB9LCJraW5kIjoiYWJzb2x1dGUiLCJuYW1lIjoic2FtcGxlX2dhdWdlIiwidGFncyI6e319fV0=\n",
+            output.as_slice(),
+        );
+
+        Ok(())
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,10 +1,12 @@
 pub use self::instance::InstanceMetrics;
+pub use self::log_encoder::LogEncoder;
 pub use self::service::ServiceMetrics;
 
 #[macro_use]
 mod macros;
 
 mod instance;
+mod log_encoder;
 mod service;
 
 load_metric_type!(IntGauge as single);

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -354,6 +354,7 @@ fn simple_config() -> Config {
         ownership_invitations_expiration_days: 30,
         metrics_authorization_token: None,
         use_test_database_pool: true,
+        instance_metrics_log_every_seconds: None,
     }
 }
 


### PR DESCRIPTION
This commit implements support for [`crates-io-heroku-metrics`][1] by logging all the instance-level metrics on stdout periodically, allowing the tool to scrape them from the logs. This will finally enable us to collect instance-level metrics on Heroku! :tada: :tada: :tada: 

Support for this on the `crates-io-heroku-metrics` side is implemented in https://github.com/rust-lang/crates-io-heroku-metrics/pull/1 (no need for the crates.io team to review it, I will merge it once this PR is deployed). Note that support for logging histograms is not implemented in this PR, but we aren't using histograms right now anyway. I'll implement histograms support once this PR is merged.

We'll also want to configure Papertrail to filter out log lines starting with `crates-io-heroku-metrics:ingest`.

[1]: https://github.com/rust-lang/crates-io-heroku-metrics