### PR TITLE
Add more instance-level metrics

### DIFF
--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -199,6 +199,10 @@ impl DownloadsCounter {
     pub fn shards_count(&self) -> usize {
         self.inner.shards().len()
     }
+
+    pub(crate) fn pending_count(&self) -> i64 {
+        self.pending_count.load(Ordering::SeqCst)
+    }
 }
 
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -19,7 +19,7 @@
 
 use crate::util::errors::AppResult;
 use crate::{app::App, db::DieselPool};
-use prometheus::{proto::MetricFamily, IntCounter, IntGauge, IntGaugeVec};
+use prometheus::{proto::MetricFamily, IntCounter, IntGauge, IntGaugeVec, HistogramVec};
 
 metrics! {
     pub struct InstanceMetrics {
@@ -32,6 +32,9 @@ metrics! {
         pub requests_total: IntCounter,
         /// Number of requests currently being processed
         pub requests_in_flight: IntGauge,
+
+        /// Response times of our endpoints
+        pub response_times: HistogramVec["endpoint"],
 
         /// Number of download requests that were served with an unconditional redirect.
         pub downloads_unconditional_redirects_total: IntCounter,

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -19,7 +19,9 @@
 
 use crate::util::errors::AppResult;
 use crate::{app::App, db::DieselPool};
-use prometheus::{proto::MetricFamily, IntCounter, IntGauge, IntGaugeVec, HistogramVec};
+use prometheus::{
+    proto::MetricFamily, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+};
 
 metrics! {
     pub struct InstanceMetrics {
@@ -35,6 +37,8 @@ metrics! {
 
         /// Response times of our endpoints
         pub response_times: HistogramVec["endpoint"],
+        /// Nmber of responses per status code
+        pub responses_by_status_code_total: IntCounterVec["status"],
 
         /// Number of download requests that were served with an unconditional redirect.
         pub downloads_unconditional_redirects_total: IntCounter,

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -44,6 +44,8 @@ metrics! {
         pub downloads_unconditional_redirects_total: IntCounter,
         /// Number of download requests with a non-canonical crate name.
         pub downloads_non_canonical_crate_name_total: IntCounter,
+        /// Number of download requests that are not counted yet.
+        downloads_not_counted_total: IntGauge,
     }
 
     // All instance metrics will be prefixed with this namespace.
@@ -57,6 +59,9 @@ impl InstanceMetrics {
         if let Some(follower) = &app.read_only_replica_database {
             self.refresh_pool_stats("follower", follower)?;
         }
+
+        self.downloads_not_counted_total
+            .set(app.downloads_counter.pending_count());
 
         Ok(self.registry.gather())
     }

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -59,7 +59,7 @@ macro_rules! load_metric_type {
         use prometheus::$name;
         impl crate::metrics::macros::MetricFromOpts for $name {
             fn from_opts(opts: prometheus::Opts) -> Result<Self, prometheus::Error> {
-                $name::with_opts(opts)
+                $name::with_opts(opts.into())
             }
         }
     };

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -12,3 +12,4 @@ mod service;
 load_metric_type!(IntGauge as single);
 load_metric_type!(IntCounter as single);
 load_metric_type!(IntGaugeVec as vec);
+load_metric_type!(HistogramVec as vec);

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -11,5 +11,6 @@ mod service;
 
 load_metric_type!(IntGauge as single);
 load_metric_type!(IntCounter as single);
+load_metric_type!(IntCounterVec as vec);
 load_metric_type!(IntGaugeVec as vec);
 load_metric_type!(HistogramVec as vec);

--- a/src/middleware/update_metrics.rs
+++ b/src/middleware/update_metrics.rs
@@ -1,5 +1,6 @@
 use super::app::RequestApp;
 use super::prelude::*;
+use conduit_router::RoutePattern;
 
 #[derive(Debug, Default)]
 pub(super) struct UpdateMetrics;
@@ -18,6 +19,16 @@ impl Middleware for UpdateMetrics {
 
         metrics.requests_in_flight.dec();
         metrics.requests_total.inc();
+
+        let endpoint = req
+            .extensions()
+            .find::<RoutePattern>()
+            .map(|p| p.pattern())
+            .unwrap_or("<unknown>");
+        metrics
+            .response_times
+            .with_label_values(&[endpoint])
+            .observe(req.elapsed().as_millis() as f64 / 1000.0);
 
         res
     }

--- a/src/middleware/update_metrics.rs
+++ b/src/middleware/update_metrics.rs
@@ -30,6 +30,15 @@ impl Middleware for UpdateMetrics {
             .with_label_values(&[endpoint])
             .observe(req.elapsed().as_millis() as f64 / 1000.0);
 
+        let status = match &res {
+            Ok(res) => res.status().as_u16(),
+            Err(_) => 500,
+        };
+        metrics
+            .responses_by_status_code_total
+            .with_label_values(&[&status.to_string()])
+            .inc();
+
         res
     }
 }


### PR DESCRIPTION
Now that we have support for collecting metrics this PR adds the following ones:

* `response_times`: how long preparing responses take, grouped by endpoint. Note that this does not create a metric series for each visited URL: for example all the downloads will be counted as `/crates/:crate_id/:version/download`.
* `responses_by_status_code_total` how many responses we sent, grouped by HTTP status code.
* `downloads_not_counted_total` how many download counts aren't persisted yet.

This also had to implement histograms support, needed by `response_times`.