### PR TITLE
Bump to the latest stable nginx

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
 https://github.com/heroku/heroku-buildpack-nodejs#v176
-https://github.com/heroku/heroku-buildpack-nginx#53b03b0
+https://github.com/heroku/heroku-buildpack-nginx#4cd76d0
 https://github.com/emk/heroku-buildpack-rust#cfa0f06


### PR DESCRIPTION
This bumps from nginx 1.18.0 to 1.20.1. This fixes a CVE that should
not affect our configuration, as we do not use the "resolver"
directive. From the nginx release log:

> Security: 1-byte memory overwrite might occur during DNS server
> response processing if the "resolver" directive was used, allowing an
> attacker who is able to forge UDP packets from the DNS server to
> cause worker process crash or, potentially, arbitrary code execution
> (CVE-2021-23017).

r? @Turbo87 