### PR TITLE
mirage: Untangle `crate.id` and `crate.name`

### DIFF
--- a/mirage/factories/crate.js
+++ b/mirage/factories/crate.js
@@ -3,10 +3,6 @@ import { Factory } from 'ember-cli-mirage';
 export default Factory.extend({
   name: i => `crate-${i}`,
 
-  id() {
-    return this.name;
-  },
-
   description() {
     return `This is the description for the crate called "${this.name}"`;
   },

--- a/mirage/serializers/crate.js
+++ b/mirage/serializers/crate.js
@@ -28,11 +28,11 @@ export default BaseSerializer.extend({
 
   links(crate) {
     return {
-      owner_user: `/api/v1/crates/${crate.id}/owner_user`,
-      owner_team: `/api/v1/crates/${crate.id}/owner_team`,
-      reverse_dependencies: `/api/v1/crates/${crate.id}/reverse_dependencies`,
-      version_downloads: `/api/v1/crates/${crate.id}/downloads`,
-      versions: `/api/v1/crates/${crate.id}/versions`,
+      owner_user: `/api/v1/crates/${crate.name}/owner_user`,
+      owner_team: `/api/v1/crates/${crate.name}/owner_team`,
+      reverse_dependencies: `/api/v1/crates/${crate.name}/reverse_dependencies`,
+      version_downloads: `/api/v1/crates/${crate.name}/downloads`,
+      versions: `/api/v1/crates/${crate.name}/versions`,
     };
   },
 
@@ -52,7 +52,7 @@ export default BaseSerializer.extend({
 
   _adjust(hash) {
     let versions = this.schema.versions.where({ crateId: hash.id });
-    assert(`crate \`${hash.id}\` has no associated versions`, versions.length !== 0);
+    assert(`crate \`${hash.name}\` has no associated versions`, versions.length !== 0);
     versions = versions.filter(it => !it.yanked);
 
     let versionNums = versions.models.map(it => it.num);
@@ -62,6 +62,8 @@ export default BaseSerializer.extend({
 
     let newestVersions = versions.models.sort((a, b) => compareIsoDates(b.updated_at, a.updated_at));
     hash.newest_version = newestVersions[0]?.num ?? '0.0.0';
+
+    hash.id = hash.name;
 
     hash.categories = hash.category_ids;
     delete hash.category_ids;

--- a/mirage/serializers/dependency.js
+++ b/mirage/serializers/dependency.js
@@ -1,0 +1,22 @@
+import BaseSerializer from './application';
+
+export default BaseSerializer.extend({
+  getHashForResource() {
+    let [hash, addToIncludes] = BaseSerializer.prototype.getHashForResource.apply(this, arguments);
+
+    if (Array.isArray(hash)) {
+      for (let resource of hash) {
+        this._adjust(resource);
+      }
+    } else {
+      this._adjust(hash);
+    }
+
+    return [hash, addToIncludes];
+  },
+
+  _adjust(hash) {
+    let crate = this.schema.crates.find(hash.crate_id);
+    hash.crate_id = crate.name;
+  },
+});

--- a/mirage/serializers/version.js
+++ b/mirage/serializers/version.js
@@ -21,8 +21,8 @@ export default BaseSerializer.extend({
 
   links(version) {
     return {
-      dependencies: `/api/v1/crates/${version.crateId}/${version.num}/dependencies`,
-      version_downloads: `/api/v1/crates/${version.crateId}/${version.num}/downloads`,
+      dependencies: `/api/v1/crates/${version.crate.name}/${version.num}/dependencies`,
+      version_downloads: `/api/v1/crates/${version.crate.name}/${version.num}/downloads`,
     };
   },
 
@@ -43,8 +43,10 @@ export default BaseSerializer.extend({
   },
 
   _adjust(hash, includes) {
-    hash.dl_path = `/api/v1/crates/${hash.crate_id}/${hash.num}/download`;
-    hash.crate = hash.crate_id;
+    let crate = this.schema.crates.find(hash.crate_id);
+
+    hash.dl_path = `/api/v1/crates/${crate.name}/${hash.num}/download`;
+    hash.crate = crate.name;
 
     if (hash.published_by_id) {
       let user = includes.find(it => it.modelName === 'user' && it.id === hash.published_by_id);

--- a/tests/acceptance/crate-dependencies-test.js
+++ b/tests/acceptance/crate-dependencies-test.js
@@ -28,8 +28,8 @@ module('Acceptance | crate dependencies page', function (hooks) {
   });
 
   test('empty list case', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     await visit('/crates/nanomsg/dependencies');
 
@@ -53,16 +53,16 @@ module('Acceptance | crate dependencies page', function (hooks) {
   });
 
   test('hides description if loading of dependency details fails', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    let version = this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    let version = this.server.create('version', { crate, num: '0.6.1' });
 
-    this.server.create('crate', { name: 'foo', description: 'This is the foo crate' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
-    this.server.create('dependency', { crateId: 'foo', version, req: '^1.0.0', kind: 'normal' });
+    let foo = this.server.create('crate', { name: 'foo', description: 'This is the foo crate' });
+    this.server.create('version', { crate: foo, num: '1.0.0' });
+    this.server.create('dependency', { crate: foo, version, req: '^1.0.0', kind: 'normal' });
 
-    this.server.create('crate', { name: 'bar', description: 'This is the bar crate' });
-    this.server.create('version', { crateId: 'bar', num: '2.3.4' });
-    this.server.create('dependency', { crateId: 'bar', version, req: '^2.0.0', kind: 'normal' });
+    let bar = this.server.create('crate', { name: 'bar', description: 'This is the bar crate' });
+    this.server.create('version', { crate: bar, num: '2.3.4' });
+    this.server.create('dependency', { crate: bar, version, req: '^2.0.0', kind: 'normal' });
 
     this.server.get('/api/v1/crates', {}, 500);
 

--- a/tests/acceptance/crate-navtabs-test.js
+++ b/tests/acceptance/crate-navtabs-test.js
@@ -13,8 +13,8 @@ module('Acceptance | crate navigation tabs', function (hooks) {
   setupApplicationTest(hooks);
 
   test('basic navigation between tabs works as expected', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     await visit('/crates/nanomsg');
     assert.equal(currentURL(), '/crates/nanomsg');

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -14,8 +14,8 @@ module('Acceptance | crate page', function (hooks) {
   setupApplicationTest(hooks);
 
   test('visiting a crate page from the front page', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg', newest_version: '0.6.1' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg', newest_version: '0.6.1' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     await visit('/');
     await click('[data-test-just-updated] [data-test-crate-link="0"]');
@@ -28,9 +28,9 @@ module('Acceptance | crate page', function (hooks) {
   });
 
   test('visiting /crates/nanomsg', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '0.6.0' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     await visit('/crates/nanomsg');
 
@@ -47,9 +47,9 @@ module('Acceptance | crate page', function (hooks) {
   });
 
   test('visiting /crates/nanomsg/', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '0.6.0' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     await visit('/crates/nanomsg/');
 
@@ -63,9 +63,9 @@ module('Acceptance | crate page', function (hooks) {
   });
 
   test('visiting /crates/nanomsg/0.6.0', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '0.6.0' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     await visit('/crates/nanomsg/0.6.0');
 
@@ -98,9 +98,9 @@ module('Acceptance | crate page', function (hooks) {
   });
 
   test('unknown versions fall back to latest version and show an error message', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '0.6.0' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     await visit('/crates/nanomsg/0.7.0');
 
@@ -111,9 +111,9 @@ module('Acceptance | crate page', function (hooks) {
   });
 
   test('other versions loading error shows an error message', async function (assert) {
-    this.server.create('crate', { name: 'nanomsg' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.0' });
-    this.server.create('version', { crateId: 'nanomsg', num: '0.6.1' });
+    let crate = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate, num: '0.6.0' });
+    this.server.create('version', { crate, num: '0.6.1' });
 
     this.server.get('/api/v1/crates/:crate_name/versions', {}, 500);
 

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -108,8 +108,8 @@ module('Acceptance | search', function (hooks) {
   });
 
   test('error handling when searching from the frontpage', async function (assert) {
-    this.server.create('crate', { name: 'rust' });
-    this.server.create('version', { crateId: 'rust', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'rust' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     this.server.get('/api/v1/crates', {}, 500);
 
@@ -140,8 +140,8 @@ module('Acceptance | search', function (hooks) {
   });
 
   test('error handling when searching from the search page', async function (assert) {
-    this.server.create('crate', { name: 'rust' });
-    this.server.create('version', { crateId: 'rust', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'rust' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     await visit('/search?q=rust');
     assert.dom('[data-test-crate-row]').exists({ count: 1 });

--- a/tests/adapters/crate-test.js
+++ b/tests/adapters/crate-test.js
@@ -9,10 +9,10 @@ module('Adapter | crate', function (hooks) {
   setupMirage(hooks);
 
   test('findRecord requests are coalesced', async function (assert) {
-    this.server.create('crate', { name: 'foo' });
-    this.server.create('version', { crateId: 'foo' });
-    this.server.create('crate', { name: 'bar' });
-    this.server.create('version', { crateId: 'bar' });
+    let _foo = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate: _foo });
+    let _bar = this.server.create('crate', { name: 'bar' });
+    this.server.create('version', { crate: _bar });
 
     // if request coalescing works correctly, then this regular API endpoint
     // should not be hit in this case

--- a/tests/mirage/crates-test.js
+++ b/tests/mirage/crates-test.js
@@ -25,15 +25,15 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns a paginated crates list', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
+      let crate = this.server.create('crate', { name: 'rand' });
       this.server.create('version', {
-        crateId: 'rand',
+        crate,
         created_at: '2020-11-06T12:34:56Z',
         num: '1.0.0',
         updated_at: '2020-11-06T12:34:56Z',
       });
       this.server.create('version', {
-        crateId: 'rand',
+        crate,
         created_at: '2020-12-25T12:34:56Z',
         num: '2.0.0-beta.1',
         updated_at: '2020-12-25T12:34:56Z',
@@ -108,12 +108,12 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('supports a `letter` parameter', async function (assert) {
-      this.server.create('crate', { name: 'foo' });
-      this.server.create('version', { crateId: 'foo' });
-      this.server.create('crate', { name: 'bar' });
-      this.server.create('version', { crateId: 'bar' });
-      this.server.create('crate', { name: 'BAZ' });
-      this.server.create('version', { crateId: 'BAZ' });
+      let foo = this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crate: foo });
+      let bar = this.server.create('crate', { name: 'bar' });
+      this.server.create('version', { crate: bar });
+      let baz = this.server.create('crate', { name: 'BAZ' });
+      this.server.create('version', { crate: baz });
 
       let response = await fetch('/api/v1/crates?letter=b');
       assert.equal(response.status, 200);
@@ -128,12 +128,12 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('supports a `q` parameter', async function (assert) {
-      this.server.create('crate', { name: '123456' });
-      this.server.create('version', { crateId: '123456' });
-      this.server.create('crate', { name: '00123' });
-      this.server.create('version', { crateId: '00123' });
-      this.server.create('crate', { name: '87654' });
-      this.server.create('version', { crateId: '87654' });
+      let crate1 = this.server.create('crate', { name: '123456' });
+      this.server.create('version', { crate: crate1 });
+      let crate2 = this.server.create('crate', { name: '00123' });
+      this.server.create('version', { crate: crate2 });
+      let crate3 = this.server.create('crate', { name: '87654' });
+      this.server.create('version', { crate: crate3 });
 
       let response = await fetch('/api/v1/crates?q=123');
       assert.equal(response.status, 200);
@@ -151,14 +151,14 @@ module('Mirage | Crates', function (hooks) {
       let user1 = this.server.create('user');
       let user2 = this.server.create('user');
 
-      this.server.create('crate', { name: 'foo' });
-      this.server.create('version', { crateId: 'foo' });
+      let foo = this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crate: foo });
       let bar = this.server.create('crate', { name: 'bar' });
       this.server.create('crate-ownership', { crate: bar, user: user1 });
-      this.server.create('version', { crateId: 'bar' });
+      this.server.create('version', { crate: bar });
       let baz = this.server.create('crate', { name: 'baz' });
       this.server.create('crate-ownership', { crate: baz, user: user2 });
-      this.server.create('version', { crateId: 'baz' });
+      this.server.create('version', { crate: baz });
 
       let response = await fetch(`/api/v1/crates?user_id=${user1.id}`);
       assert.equal(response.status, 200);
@@ -173,14 +173,14 @@ module('Mirage | Crates', function (hooks) {
       let team1 = this.server.create('team');
       let team2 = this.server.create('team');
 
-      this.server.create('crate', { name: 'foo' });
-      this.server.create('version', { crateId: 'foo' });
+      let foo = this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crate: foo });
       let bar = this.server.create('crate', { name: 'bar' });
       this.server.create('crate-ownership', { crate: bar, team: team1 });
-      this.server.create('version', { crateId: 'bar' });
+      this.server.create('version', { crate: bar });
       let baz = this.server.create('crate', { name: 'baz' });
       this.server.create('crate-ownership', { crate: baz, team: team2 });
-      this.server.create('version', { crateId: 'baz' });
+      this.server.create('version', { crate: baz });
 
       let response = await fetch(`/api/v1/crates?team_id=${team1.id}`);
       assert.equal(response.status, 200);
@@ -192,12 +192,12 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('supports a `following` parameter', async function (assert) {
-      this.server.create('crate', { name: 'foo' });
-      this.server.create('version', { crateId: 'foo' });
-      this.server.create('crate', { name: 'bar' });
-      this.server.create('version', { crateId: 'bar' });
+      let foo = this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crate: foo });
+      let bar = this.server.create('crate', { name: 'bar' });
+      this.server.create('version', { crate: bar });
 
-      let user = this.server.create('user', { followedCrateIds: ['bar'] });
+      let user = this.server.create('user', { followedCrates: [bar] });
       this.authenticateAs(user);
 
       let response = await fetch(`/api/v1/crates?following=1`);
@@ -210,14 +210,14 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('supports multiple `ids[]` parameters', async function (assert) {
-      this.server.create('crate', { name: 'foo' });
-      this.server.create('version', { crateId: 'foo' });
-      this.server.create('crate', { name: 'bar' });
-      this.server.create('version', { crateId: 'bar' });
-      this.server.create('crate', { name: 'baz' });
-      this.server.create('version', { crateId: 'baz' });
-      this.server.create('crate', { name: 'other' });
-      this.server.create('version', { crateId: 'other' });
+      let foo = this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crate: foo });
+      let bar = this.server.create('crate', { name: 'bar' });
+      this.server.create('version', { crate: bar });
+      let baz = this.server.create('crate', { name: 'baz' });
+      this.server.create('version', { crate: baz });
+      let other = this.server.create('crate', { name: 'other' });
+      this.server.create('version', { crate: other });
 
       let response = await fetch(`/api/v1/crates?ids[]=foo&ids[]=bar&ids[]=baz&ids[]=baz&ids[]=unknown`);
       assert.equal(response.status, 200);
@@ -241,8 +241,8 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns a crate object for known crates', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      this.server.create('version', { crateId: 'rand', num: '1.0.0-beta.1' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '1.0.0-beta.1' });
 
       let response = await fetch('/api/v1/crates/rand');
       assert.equal(response.status, 200);
@@ -299,10 +299,10 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('includes related versions', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      this.server.create('version', { crateId: 'rand', num: '1.0.0' });
-      this.server.create('version', { crateId: 'rand', num: '1.1.0' });
-      this.server.create('version', { crateId: 'rand', num: '1.2.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '1.0.0' });
+      this.server.create('version', { crate, num: '1.1.0' });
+      this.server.create('version', { crate, num: '1.2.0' });
 
       let response = await fetch('/api/v1/crates/rand');
       assert.equal(response.status, 200);
@@ -367,8 +367,8 @@ module('Mirage | Crates', function (hooks) {
     test('includes related categories', async function (assert) {
       this.server.create('category', { category: 'no-std' });
       this.server.create('category', { category: 'cli' });
-      this.server.create('crate', { name: 'rand', categoryIds: ['no-std'] });
-      this.server.create('version', { crateId: 'rand' });
+      let crate = this.server.create('crate', { name: 'rand', categoryIds: ['no-std'] });
+      this.server.create('version', { crate });
 
       let response = await fetch('/api/v1/crates/rand');
       assert.equal(response.status, 200);
@@ -390,8 +390,8 @@ module('Mirage | Crates', function (hooks) {
     test('includes related keywords', async function (assert) {
       this.server.create('keyword', { keyword: 'no-std' });
       this.server.create('keyword', { keyword: 'cli' });
-      this.server.create('crate', { name: 'rand', keywordIds: ['no-std'] });
-      this.server.create('version', { crateId: 'rand' });
+      let crate = this.server.create('crate', { name: 'rand', keywordIds: ['no-std'] });
+      this.server.create('version', { crate });
 
       let response = await fetch('/api/v1/crates/rand');
       assert.equal(response.status, 200);
@@ -562,10 +562,10 @@ module('Mirage | Crates', function (hooks) {
 
     test('returns all versions belonging to the specified crate', async function (assert) {
       let user = this.server.create('user');
-      this.server.create('crate', { name: 'rand' });
-      this.server.create('version', { crateId: 'rand', num: '1.0.0' });
-      this.server.create('version', { crateId: 'rand', num: '1.1.0', publishedBy: user });
-      this.server.create('version', { crateId: 'rand', num: '1.2.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '1.0.0' });
+      this.server.create('version', { crate, num: '1.1.0', publishedBy: user });
+      this.server.create('version', { crate, num: '1.2.0' });
 
       let response = await fetch('/api/v1/crates/rand/versions');
       assert.equal(response.status, 200);
@@ -657,8 +657,8 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('empty case', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      this.server.create('version', { crateId: 'rand', num: '1.0.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '1.0.0' });
 
       let response = await fetch('/api/v1/crates/rand/1.0.0/authors');
       assert.equal(response.status, 200);
@@ -673,8 +673,8 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns a list of authors belonging to the specified crate version', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      this.server.create('version', { crateId: 'rand', num: '1.0.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '1.0.0' });
 
       let response = await fetch('/api/v1/crates/rand/1.0.0/authors');
       assert.equal(response.status, 200);
@@ -711,8 +711,8 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('empty case', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      this.server.create('version', { crateId: 'rand', num: '1.0.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '1.0.0' });
 
       let response = await fetch('/api/v1/crates/rand/1.0.0/dependencies');
       assert.equal(response.status, 200);
@@ -724,15 +724,15 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns a list of dependencies belonging to the specified crate version', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      let version = this.server.create('version', { crateId: 'rand', num: '1.0.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      let version = this.server.create('version', { crate, num: '1.0.0' });
 
-      this.server.create('crate', { name: 'foo' });
-      this.server.create('dependency', { crateId: 'foo', versionId: version.id });
-      this.server.create('crate', { name: 'bar' });
-      this.server.create('dependency', { crateId: 'bar', versionId: version.id });
-      this.server.create('crate', { name: 'baz' });
-      this.server.create('dependency', { crateId: 'baz', versionId: version.id });
+      let foo = this.server.create('crate', { name: 'foo' });
+      this.server.create('dependency', { crate: foo, version });
+      let bar = this.server.create('crate', { name: 'bar' });
+      this.server.create('dependency', { crate: bar, version });
+      let baz = this.server.create('crate', { name: 'baz' });
+      this.server.create('dependency', { crate: baz, version });
 
       let response = await fetch('/api/v1/crates/rand/1.0.0/dependencies');
       assert.equal(response.status, 200);
@@ -800,8 +800,8 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('empty case', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      this.server.create('version', { crateId: 'rand', num: '1.0.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      this.server.create('version', { crate, num: '1.0.0' });
 
       let response = await fetch('/api/v1/crates/rand/1.0.0/downloads');
       assert.equal(response.status, 200);
@@ -813,8 +813,8 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns a list of version downloads belonging to the specified crate version', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      let version = this.server.create('version', { crateId: 'rand', num: '1.0.0' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      let version = this.server.create('version', { crate, num: '1.0.0' });
       this.server.create('version-download', { version, date: '2020-01-13' });
       this.server.create('version-download', { version, date: '2020-01-14' });
       this.server.create('version-download', { version, date: '2020-01-15' });
@@ -961,20 +961,20 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns a paginated list of crate versions depending to the specified crate', async function (assert) {
-      this.server.create('crate', { name: 'foo' });
+      let crate = this.server.create('crate', { name: 'foo' });
 
       this.server.create('dependency', {
-        crateId: 'foo',
-        versionId: this.server.create('version', {
+        crate,
+        version: this.server.create('version', {
           crate: this.server.create('crate', { name: 'bar' }),
-        }).id,
+        }),
       });
 
       this.server.create('dependency', {
-        crateId: 'foo',
-        versionId: this.server.create('version', {
+        crate,
+        version: this.server.create('version', {
           crate: this.server.create('crate', { name: 'baz' }),
-        }).id,
+        }),
       });
 
       let response = await fetch('/api/v1/crates/foo/reverse_dependencies');
@@ -1049,14 +1049,14 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('never returns more than 10 results', async function (assert) {
-      this.server.create('crate', { name: 'foo' });
+      let crate = this.server.create('crate', { name: 'foo' });
 
       this.server.createList('dependency', 25, {
-        crateId: 'foo',
-        versionId: () =>
+        crate,
+        version: () =>
           this.server.create('version', {
             crate: () => this.server.create('crate', { name: 'bar' }),
-          }).id,
+          }),
       });
 
       let response = await fetch('/api/v1/crates/foo/reverse_dependencies');
@@ -1069,7 +1069,7 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('supports `page` and `per_page` parameters', async function (assert) {
-      this.server.create('crate', { name: 'foo' });
+      let crate = this.server.create('crate', { name: 'foo' });
 
       let crates = this.server.createList('crate', 25, {
         name: i => `crate-${String(i + 1).padStart(2, '0')}`,
@@ -1078,7 +1078,7 @@ module('Mirage | Crates', function (hooks) {
         crate: i => crates[i],
       });
       this.server.createList('dependency', versions.length, {
-        crateId: 'foo',
+        crate,
         versionId: i => versions[i].id,
       });
 
@@ -1121,8 +1121,8 @@ module('Mirage | Crates', function (hooks) {
     });
 
     test('returns a list of version downloads belonging to the specified crate version', async function (assert) {
-      this.server.create('crate', { name: 'rand' });
-      let versions = this.server.createList('version', 2, { crateId: 'rand' });
+      let crate = this.server.create('crate', { name: 'rand' });
+      let versions = this.server.createList('version', 2, { crate });
       this.server.create('version-download', { version: versions[0], date: '2020-01-13' });
       this.server.create('version-download', { version: versions[1], date: '2020-01-14' });
       this.server.create('version-download', { version: versions[1], date: '2020-01-15' });

--- a/tests/mirage/me-test.js
+++ b/tests/mirage/me-test.js
@@ -49,8 +49,8 @@ module('Mirage | /me', function (hooks) {
 
       let responsePayload = await response.json();
       assert.deepEqual(responsePayload.owned_crates, [
-        { id: 'crate-0', name: 'crate-0', email_notifications: true },
-        { id: 'crate-2', name: 'crate-2', email_notifications: true },
+        { id: crate1.id, name: 'crate-0', email_notifications: true },
+        { id: crate3.id, name: 'crate-2', email_notifications: true },
       ]);
     });
 
@@ -208,17 +208,13 @@ module('Mirage | /me', function (hooks) {
     });
 
     test('returns latest versions of followed crates', async function (assert) {
-      {
-        let crate = this.server.create('crate', { name: 'foo' });
-        this.server.create('version', { crate, num: '1.2.3' });
-      }
+      let foo = this.server.create('crate', { name: 'foo' });
+      this.server.create('version', { crate: foo, num: '1.2.3' });
 
-      {
-        let crate = this.server.create('crate', { name: 'bar' });
-        this.server.create('version', { crate, num: '0.8.6' });
-      }
+      let bar = this.server.create('crate', { name: 'bar' });
+      this.server.create('version', { crate: bar, num: '0.8.6' });
 
-      let user = this.server.create('user', { followedCrateIds: ['foo'] });
+      let user = this.server.create('user', { followedCrates: [foo] });
       this.authenticateAs(user);
 
       let response = await fetch('/api/v1/me/updates');

--- a/tests/models/crate-test.js
+++ b/tests/models/crate-test.js
@@ -21,7 +21,7 @@ module('Model | Crate', function (hooks) {
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 
-      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let crateRecord = await this.store.findRecord('crate', crate.name);
 
       let result = await crateRecord.inviteOwner(user.login);
       assert.deepEqual(result, { ok: true });
@@ -31,7 +31,7 @@ module('Model | Crate', function (hooks) {
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 
-      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let crateRecord = await this.store.findRecord('crate', crate.name);
 
       await assert.rejects(crateRecord.inviteOwner('unknown'), function (error) {
         assert.deepEqual(error.errors, [{ detail: 'could not find user with login `unknown`' }]);
@@ -47,7 +47,7 @@ module('Model | Crate', function (hooks) {
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 
-      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let crateRecord = await this.store.findRecord('crate', crate.name);
 
       let result = await crateRecord.removeOwner(user.login);
       assert.deepEqual(result, { ok: true, msg: 'owners successfully removed' });
@@ -57,7 +57,7 @@ module('Model | Crate', function (hooks) {
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 
-      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let crateRecord = await this.store.findRecord('crate', crate.name);
 
       await assert.rejects(crateRecord.removeOwner('unknown'), function (error) {
         assert.deepEqual(error.errors, [{ detail: 'Not Found' }]);

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -18,7 +18,7 @@ module('Model | Version', function (hooks) {
     let crate = server.create('crate');
     server.create('version', { crate, created_at: '2010-06-16T21:30:45Z' });
 
-    let crateRecord = await store.findRecord('crate', crate.id);
+    let crateRecord = await store.findRecord('crate', crate.name);
     let versions = (await crateRecord.versions).toArray();
 
     timekeeper.travel(new Date('2010-06-16T21:40:45Z'));
@@ -41,7 +41,7 @@ module('Model | Version', function (hooks) {
       let crate = server.create('crate');
       server.create('version', { crate, num });
 
-      let crateRecord = await store.findRecord('crate', crate.id);
+      let crateRecord = await store.findRecord('crate', crate.name);
       let versions = (await crateRecord.versions).toArray();
       return versions[0];
     }
@@ -133,7 +133,7 @@ module('Model | Version', function (hooks) {
         this.server.create('version', { crate, num });
       }
 
-      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let crateRecord = await this.store.findRecord('crate', crate.name);
       let versions = (await crateRecord.versions).toArray();
 
       assert.deepEqual(
@@ -164,7 +164,7 @@ module('Model | Version', function (hooks) {
       this.server.create('version', { crate, num: '0.4.1' });
       this.server.create('version', { crate, num: '0.4.2', yanked: true });
 
-      let crateRecord = await this.store.findRecord('crate', crate.id);
+      let crateRecord = await this.store.findRecord('crate', crate.name);
       let versions = (await crateRecord.versions).toArray();
 
       assert.deepEqual(
@@ -185,7 +185,7 @@ module('Model | Version', function (hooks) {
       let crate = server.create('crate');
       server.create('version', { crate, features });
 
-      let crateRecord = await store.findRecord('crate', crate.id);
+      let crateRecord = await store.findRecord('crate', crate.name);
       let versions = (await crateRecord.versions).toArray();
       return versions[0];
     }
@@ -265,7 +265,7 @@ module('Model | Version', function (hooks) {
     let crate = this.server.create('crate');
     this.server.create('version', { crate, publishedBy: user });
 
-    let crateRecord = await this.store.findRecord('crate', crate.id);
+    let crateRecord = await this.store.findRecord('crate', crate.name);
     assert.ok(crateRecord);
     let versions = (await crateRecord.versions).toArray();
     assert.equal(versions.length, 1);

--- a/tests/routes/crate/version/crate-links-test.js
+++ b/tests/routes/crate/version/crate-links-test.js
@@ -7,13 +7,13 @@ module('Route | crate.version | crate links', function (hooks) {
   setupApplicationTest(hooks);
 
   test('shows all external crate links', async function (assert) {
-    this.server.create('crate', {
+    let crate = this.server.create('crate', {
       name: 'foo',
       homepage: 'https://crates.io/',
       documentation: 'https://doc.rust-lang.org/cargo/getting-started/',
       repository: 'https://github.com/rust-lang/crates.io.git',
     });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     await visit('/crates/foo');
 
@@ -31,8 +31,8 @@ module('Route | crate.version | crate links', function (hooks) {
   });
 
   test('shows no external crate links if none are set', async function (assert) {
-    this.server.create('crate', { name: 'foo' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     await visit('/crates/foo');
 
@@ -42,12 +42,12 @@ module('Route | crate.version | crate links', function (hooks) {
   });
 
   test('hide the homepage link if it is the same as the repository', async function (assert) {
-    this.server.create('crate', {
+    let crate = this.server.create('crate', {
       name: 'foo',
       homepage: 'https://github.com/rust-lang/crates.io',
       repository: 'https://github.com/rust-lang/crates.io',
     });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     await visit('/crates/foo');
 
@@ -61,12 +61,12 @@ module('Route | crate.version | crate links', function (hooks) {
   });
 
   test('hide the homepage link if it is the same as the repository plus `.git`', async function (assert) {
-    this.server.create('crate', {
+    let crate = this.server.create('crate', {
       name: 'foo',
       homepage: 'https://github.com/rust-lang/crates.io/',
       repository: 'https://github.com/rust-lang/crates.io.git',
     });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     await visit('/crates/foo');
 

--- a/tests/routes/crate/version/docs-link-test.js
+++ b/tests/routes/crate/version/docs-link-test.js
@@ -7,16 +7,16 @@ module('Route | crate.version | docs link', function (hooks) {
   setupApplicationTest(hooks);
 
   test('shows regular documentation link', async function (assert) {
-    this.server.create('crate', { name: 'foo', documentation: 'https://foo.io/docs' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'foo', documentation: 'https://foo.io/docs' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://foo.io/docs');
   });
 
   test('show no docs link if `documentation` is unspecified and there are no related docs.rs builds', async function (assert) {
-    this.server.create('crate', { name: 'foo' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
 
@@ -25,8 +25,8 @@ module('Route | crate.version | docs link', function (hooks) {
   });
 
   test('show docs link if `documentation` is unspecified and there are related docs.rs builds', async function (assert) {
-    this.server.create('crate', { name: 'foo' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [
       {
@@ -44,8 +44,8 @@ module('Route | crate.version | docs link', function (hooks) {
   });
 
   test('show original docs link if `documentation` points to docs.rs and there are no related docs.rs builds', async function (assert) {
-    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
 
@@ -54,8 +54,8 @@ module('Route | crate.version | docs link', function (hooks) {
   });
 
   test('show updated docs link if `documentation` points to docs.rs and there are related docs.rs builds', async function (assert) {
-    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [
       {
@@ -73,8 +73,8 @@ module('Route | crate.version | docs link', function (hooks) {
   });
 
   test('ajax errors are ignored', async function (assert) {
-    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
-    this.server.create('version', { crateId: 'foo', num: '1.0.0' });
+    let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crate, num: '1.0.0' });
 
     this.server.get('https://docs.rs/crate/:crate/:version/builds.json', {}, 500);
 
@@ -83,8 +83,8 @@ module('Route | crate.version | docs link', function (hooks) {
   });
 
   test('null builds in docs.rs responses are ignored', async function (assert) {
-    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
-    this.server.create('version', { crateId: 'foo', num: '0.6.2' });
+    let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crate, num: '0.6.2' });
 
     this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [null]);
 
@@ -93,8 +93,8 @@ module('Route | crate.version | docs link', function (hooks) {
   });
 
   test('empty arrays in docs.rs responses are ignored', async function (assert) {
-    this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
-    this.server.create('version', { crateId: 'foo', num: '0.6.2' });
+    let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
+    this.server.create('version', { crate, num: '0.6.2' });
 
     this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
 


### PR DESCRIPTION
The `id` is rarely used and exposed on the API, but there are a few cases where it is indeed used. The `id` is meant to be a `i32` though, so having it equal to the `name` of the crate was wrong. This PR fixes the issue by having the `id` as a regular numeric ID and using `name` everywhere else.

This PR is a prerequisite for implementing `crate-owner-invitation` support into our mirage setup.