### PR TITLE
Fix missing word-break and add theme-color meta for Safari 15.0

### DIFF
--- a/app/components/header.module.css
+++ b/app/components/header.module.css
@@ -54,7 +54,7 @@ input.search {
     background-color: white;
     background-image: url('/assets/search.png');
     background-repeat: no-repeat;
-    background-position: 6px 6px;
+    background-position: 8px center;
     background-size: 14px 15px;
     border-radius: 15px;
     box-shadow: none;

--- a/app/components/results-count.module.css
+++ b/app/components/results-count.module.css
@@ -1,5 +1,7 @@
 .results-count {
     composes: small from '../styles/shared/typography.module.css';
+
+    word-break: break-all;
 }
 
 .highlight {

--- a/app/components/results-count.module.css
+++ b/app/components/results-count.module.css
@@ -2,6 +2,7 @@
     composes: small from '../styles/shared/typography.module.css';
 
     word-break: break-all;
+    padding-right: 20px;
 }
 
 .highlight {

--- a/app/index.html
+++ b/app/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="hsl(115, 31%, 31%)">
 
     <title>crates.io: Rust Package Registry</title>
 

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -23,9 +23,9 @@ export default class DesignService extends Service {
     this.useNewDesign = !this.useNewDesign;
     localStorage.setItem('use-new-design', String(this.useNewDesign));
 
-    var newDesignBaseColor = document.documentElement.getPropertyValue(
+    var newDesignHeaderColor = getComputedStyle(window?.document.documentElement).getPropertyValue(
       this.useNewDesign ? '--violet800' : '--green800',
     );
-    document.querySelector('meta[name="theme-color"]').setAttribute('content', getComputedStyle(newDesignBaseColor));
+    document.querySelector('meta[name="theme-color"]').setAttribute('content', newDesignHeaderColor);
   }
 }

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { lastValue } from 'ember-concurrency';
 
 import window from 'ember-window-mock';
 
@@ -24,13 +23,9 @@ export default class DesignService extends Service {
     this.useNewDesign = !this.useNewDesign;
     localStorage.setItem('use-new-design', String(this.useNewDesign));
 
-    document.querySelector('meta[name="theme-color"]').setAttribute(
-      "content",
-      getComputedStyle(
-        document.documentElement
-      ).getPropertyValue(
-        this.useNewDesign ? '--violet800' : '--green800'
-      )
+    var newDesignBaseColor = document.documentElement.getPropertyValue(
+      this.useNewDesign ? '--violet800' : '--green800',
     );
+    document.querySelector('meta[name="theme-color"]').setAttribute('content', getComputedStyle(newDesignBaseColor));
   }
 }

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -1,6 +1,7 @@
 import { action } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
+import { lastValue } from 'ember-concurrency';
 
 import window from 'ember-window-mock';
 
@@ -22,5 +23,14 @@ export default class DesignService extends Service {
   toggle() {
     this.useNewDesign = !this.useNewDesign;
     localStorage.setItem('use-new-design', String(this.useNewDesign));
+
+    document.querySelector('meta[name="theme-color"]').setAttribute(
+      "content",
+      getComputedStyle(
+        document.documentElement
+      ).getPropertyValue(
+        this.useNewDesign ? '--violet800' : '--green800'
+      )
+    );
   }
 }

--- a/app/styles/crate/version-dependencies.module.css
+++ b/app/styles/crate/version-dependencies.module.css
@@ -9,3 +9,7 @@
         }
     }
 }
+
+.no-deps {
+    word-break: break-all;
+}

--- a/app/styles/crate/versions.module.css
+++ b/app/styles/crate/versions.module.css
@@ -12,6 +12,8 @@
 .page-description {
     composes: small from '../shared/typography.module.css';
 
+    word-break: break-all;
+
     @media only screen and (max-width: 550px) {
         display: block;
         margin-bottom: 15px;

--- a/app/styles/crate/versions.module.css
+++ b/app/styles/crate/versions.module.css
@@ -13,6 +13,7 @@
     composes: small from '../shared/typography.module.css';
 
     word-break: break-all;
+    padding-right: 20px;
 
     @media only screen and (max-width: 550px) {
         display: block;

--- a/tests/index.html
+++ b/tests/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="theme-color" content="hsl(115, 31%, 31%)">
 
     <title>crates.io: Rust Package Registry</title>
 


### PR DESCRIPTION
Fix missing line breaks in crates "Versions", "Dependencies" and "Dependents" page, because some long crate names made the website in a mess on small screen devices, personally that add some 'word-break' would be a simple workaround, related to #3600, and this was a further fix.

Another subjective refine for upcoming Safari 15.x is add 'theme-color' meta to the `index.html` header to let the address bar color of Safari get matched with the header color of *crates.io*. Personally I choose the same color as the website header, its equals to `--green800`.

Test on my laptop with Safari 15.0:

- Add a `word-break` to class `page-description` in "Version" page

<img width="1180" alt="Screen Shot 2021-06-13 at 19 56 20" src="https://user-images.githubusercontent.com/15633984/121806342-0795ba80-cc82-11eb-9739-562461f97a35.png">

- Add a `word-break` to class `no-deps` in "Dependencies" page while there is no other dependencies

<img width="1180" alt="Screen Shot 2021-06-13 at 19 56 54" src="https://user-images.githubusercontent.com/15633984/121806351-17150380-cc82-11eb-99d6-35c2a3819771.png">

- Add a `word-break` to class `results-count` in "Dependents" page

<img width="1180" alt="Screen Shot 2021-06-13 at 19 57 22" src="https://user-images.githubusercontent.com/15633984/121806356-1bd9b780-cc82-11eb-8822-112b2dfe5664.png">

- Add `theme-color` meta to the `index.html` header for upcoming Safari 15.x (on right side, the color is changeable using "Toggle Design" button in development mode), compared with the original website (on left side)

https://user-images.githubusercontent.com/15633984/121806498-a3272b00-cc82-11eb-9e09-6f0fcfcb045e.mov

Thanks for reviewing!