### PR TITLE
Fix search icon position to vertical center

### DIFF
--- a/app/components/header.module.css
+++ b/app/components/header.module.css
@@ -54,7 +54,7 @@ input.search {
     background-color: white;
     background-image: url('/assets/search.png');
     background-repeat: no-repeat;
-    background-position: 6px 6px;
+    background-position: 8px center;
     background-size: 14px 15px;
     border-radius: 15px;
     box-shadow: none;


### PR DESCRIPTION
Fix search icon position to vertical center, compared in attached image:

<img width="535" alt="Screen Shot 2021-06-14 at 21 38 57" src="https://user-images.githubusercontent.com/15633984/121901541-1307e500-cd59-11eb-879f-29ec40102763.png">

*split PR in #3699 