### PR TITLE
Fix missing line break

### DIFF
--- a/app/components/results-count.module.css
+++ b/app/components/results-count.module.css
@@ -1,5 +1,7 @@
 .results-count {
     composes: small from '../styles/shared/typography.module.css';
+    word-break: break-all;
+    padding-right: 20px;
 }
 
 .highlight {

--- a/app/styles/crate/version-dependencies.module.css
+++ b/app/styles/crate/version-dependencies.module.css
@@ -9,3 +9,7 @@
         }
     }
 }
+
+.no-deps {
+     word-break: break-all;
+ }

--- a/app/styles/crate/versions.module.css
+++ b/app/styles/crate/versions.module.css
@@ -11,6 +11,8 @@
 
 .page-description {
     composes: small from '../shared/typography.module.css';
+    word-break: break-all;
+    padding-right: 20px;
 
     @media only screen and (max-width: 550px) {
         display: block;


### PR DESCRIPTION
Fix missing line breaks in crates "Versions", "Dependencies" and "Dependents" page, because some long crate names made the website in a mess on small screen devices, personally that add some 'word-break' would be a simple workaround ('padding' is also needed), related to #3600, and this was a further fix.

Test on my laptop with Safari 15.0:

- Add a `word-break` to class `page-description` in "Version" page

<img width="1034" alt="121806342-0795ba80-cc82-11eb-9739-562461f97a35" src="https://user-images.githubusercontent.com/15633984/121902627-1354b000-cd5a-11eb-9a45-85210c53524b.png">


- Add a `word-break` to class `no-deps` in "Dependencies" page while there is no other dependencies

<img width="969" alt="121806351-17150380-cc82-11eb-99d6-35c2a3819771" src="https://user-images.githubusercontent.com/15633984/121902614-0fc12900-cd5a-11eb-86bd-8b4f7c7a9b35.png">

- Add a `word-break` to class `results-count` in "Dependents" page

<img width="1099" alt="121806356-1bd9b780-cc82-11eb-8822-112b2dfe5664" src="https://user-images.githubusercontent.com/15633984/121902595-0afc7500-cd5a-11eb-866a-1d320f3da641.png">

Thanks for reviewing, split PR of #3699 