### PR TITLE
Cleanup unneeded lints and drop unused Debug impls

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,8 +15,6 @@ use scheduled_thread_pool::ScheduledThreadPool;
 
 /// The `App` struct holds the main components of the application like
 /// the database connection pool and configurations
-// The db, oauth, and git2 types don't implement debug.
-#[allow(missing_debug_implementations)]
 pub struct App {
     /// The primary database connection pool
     pub primary_database: DieselPool,

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -20,7 +20,6 @@ impl swirl::db::DieselPool for DieselPool {
     }
 }
 
-#[allow(missing_debug_implementations)]
 pub struct Environment {
     index: Arc<Mutex<Repository>>,
     pub uploader: Uploader,

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::all)]
+#![warn(clippy::all, rust_2018_idioms)]
 
 use anyhow::{anyhow, Result};
 use cargo_registry::{db, env, tasks};

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,5 +1,4 @@
 #![warn(clippy::all, rust_2018_idioms)]
-#![allow(unknown_lints)]
 
 use cargo_registry::{metrics::LogEncoder, util::errors::AppResult, App, Env};
 use std::{borrow::Cow, fs::File, process::Command, sync::Arc, time::Duration};

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,7 +8,6 @@ use url::Url;
 
 use crate::middleware::app::RequestApp;
 
-#[allow(missing_debug_implementations)]
 #[derive(Clone)]
 pub enum DieselPool {
     Pool(r2d2::Pool<ConnectionManager<PgConnection>>),
@@ -104,7 +103,6 @@ pub struct PoolState {
     pub idle_connections: u32,
 }
 
-#[allow(missing_debug_implementations)]
 pub enum DieselPooledConn<'a> {
     Pool(r2d2::PooledConnection<ConnectionManager<PgConnection>>),
     Test(ReentrantMutexGuard<'a, PgConnection>),

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,5 +1,3 @@
-#![allow(missing_debug_implementations)]
-
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 
 #![warn(clippy::all, rust_2018_idioms)]
-#![warn(missing_debug_implementations, missing_copy_implementations)]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -4,8 +4,6 @@ use crate::App;
 use std::sync::Arc;
 
 /// Middleware that injects the `App` instance into the `Request` extensions
-// Can't derive Debug because `App` can't.
-#[allow(missing_debug_implementations)]
 pub struct AppMiddleware {
     app: Arc<App>,
 }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -12,8 +12,6 @@ use super::prelude::*;
 use crate::App;
 use std::sync::Arc;
 
-// Can't derive debug because of Handler.
-#[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct BlockTraffic {
     header_name: String,

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -5,8 +5,6 @@ use super::prelude::*;
 use crate::util::RequestProxy;
 use conduit::Method;
 
-// Can't derive debug because of Handler.
-#[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct Head {
     handler: Option<Box<dyn Handler>>,

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -12,8 +12,6 @@ use std::env;
 
 use crate::util::request_header;
 
-// Can't derive debug because of Handler.
-#[allow(missing_debug_implementations)]
 #[derive(Default)]
 pub struct RequireUserAgent {
     cdn_user_agent: String,

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -4,8 +4,6 @@ use super::prelude::*;
 
 use conduit_static::Static;
 
-// Can't derive debug because of Handler and Static.
-#[allow(missing_debug_implementations)]
 pub struct StaticOrContinue {
     fallback_handler: Option<Box<dyn Handler>>,
     static_handler: Static,

--- a/src/render.rs
+++ b/src/render.rs
@@ -12,7 +12,6 @@ use crate::background_jobs::Environment;
 use crate::models::Version;
 
 /// Context for markdown to HTML rendering.
-#[allow(missing_debug_implementations)]
 struct MarkdownRenderer<'a> {
     html_sanitizer: Builder<'a>,
 }

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -6,8 +6,6 @@ use conduit::{Method, RequestExt};
 
 type RequestMutRef<'a> = &'a mut (dyn RequestExt + 'a);
 
-// Can't derive Debug because of Request.
-#[allow(missing_debug_implementations)]
 pub struct RequestProxy<'a> {
     other: RequestMutRef<'a>,
     method: conduit::Method,


### PR DESCRIPTION
The lib crate is only used by other in-tree crates. Therefore if Debug
or Copy impls are ever needed, they can be easily added.

82 unused Debug impls are then dropped. This probably has a slight but
negligible improvement to compile/link times.

r? @Turbo87 