### PR TITLE
Begin refactoring configuration module

### DIFF
--- a/src/admin/migrate.rs
+++ b/src/admin/migrate.rs
@@ -11,13 +11,13 @@ diesel_migrations::embed_migrations!("./migrations");
 pub struct Opts;
 
 pub fn run(_opts: Opts) -> Result<(), Error> {
-    let config = crate::Config::default();
+    let db_config = crate::config::DatabasePools::full_from_environment();
 
     // TODO: Refactor logic so that we can also check things from App::new() here.
     // If the app will panic due to bad configuration, it is better to error in the release phase
     // to avoid launching dynos that will fail.
 
-    if config.db_primary_config.read_only_mode {
+    if db_config.are_all_read_only() {
         // TODO: Check `any_pending_migrations()` with a read-only connection and error if true.
         // It looks like this requires changes upstream to make this pub in `migration_macros`.
 

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -1,10 +1,9 @@
 use crate::{
-    db,
+    config, db,
     models::Version,
     render::readme_to_html,
     schema::{crates, readme_renderings, versions},
     uploaders::Uploader,
-    Config,
 };
 use std::{io::Read, path::Path, sync::Arc, thread};
 
@@ -40,7 +39,7 @@ pub struct Opts {
 }
 
 pub fn run(opts: Opts) {
-    let config = Arc::new(Config::default());
+    let config = Arc::new(config::Server::default());
     let conn = db::connect_now().unwrap();
 
     let start_time = Utc::now();
@@ -153,7 +152,7 @@ pub fn run(opts: Opts) {
 
 /// Renders the readme of an uploaded crate version.
 fn get_readme(
-    config: &Config,
+    config: &config::Server,
     client: &Client,
     version: &Version,
     krate_name: &str,

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -124,7 +124,7 @@ pub fn run(opts: Opts) {
                 let mut extra_headers = header::HeaderMap::new();
                 extra_headers.insert(header::CACHE_CONTROL, CACHE_CONTROL_README.parse().unwrap());
                 config
-                    .uploader
+                    .uploader()
                     .upload(
                         &client,
                         &readme_path,
@@ -158,10 +158,10 @@ fn get_readme(
     krate_name: &str,
 ) -> Option<String> {
     let location = config
-        .uploader
+        .uploader()
         .crate_location(krate_name, &version.num.to_string());
 
-    let location = match config.uploader {
+    let location = match config.uploader() {
         Uploader::S3 { .. } => location,
         Uploader::Local => format!("http://localhost:8888/{}", location),
     };

--- a/src/app.rs
+++ b/src/app.rs
@@ -76,26 +76,26 @@ impl App {
             ),
         );
 
-        let db_pool_size = match (dotenv::var("DB_POOL_SIZE"), config.env) {
+        let db_pool_size = match (dotenv::var("DB_POOL_SIZE"), config.env()) {
             (Ok(num), _) => num.parse().expect("couldn't parse DB_POOL_SIZE"),
             (_, Env::Production) => 10,
             _ => 3,
         };
 
-        let db_min_idle = match (dotenv::var("DB_MIN_IDLE"), config.env) {
+        let db_min_idle = match (dotenv::var("DB_MIN_IDLE"), config.env()) {
             (Ok(num), _) => Some(num.parse().expect("couldn't parse DB_MIN_IDLE")),
             (_, Env::Production) => Some(5),
             _ => None,
         };
 
-        let db_helper_threads = match (dotenv::var("DB_HELPER_THREADS"), config.env) {
+        let db_helper_threads = match (dotenv::var("DB_HELPER_THREADS"), config.env()) {
             (Ok(num), _) => num.parse().expect("couldn't parse DB_HELPER_THREADS"),
             (_, Env::Production) => 3,
             _ => 1,
         };
 
         // Used as the connection and statement timeout value for the database pool(s)
-        let db_connection_timeout = match (dotenv::var("DB_TIMEOUT"), config.env) {
+        let db_connection_timeout = match (dotenv::var("DB_TIMEOUT"), config.env()) {
             (Ok(num), _) => num.parse().expect("couldn't parse DB_TIMEOUT"),
             (_, Env::Production) => 10,
             (_, Env::Test) => 1,

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,9 +28,6 @@ pub struct App {
     /// The GitHub OAuth2 configuration
     pub github_oauth: BasicClient,
 
-    /// A unique key used with conduit_cookie to generate cookies
-    pub session_key: String,
-
     /// The server configuration
     pub config: config::Server,
 
@@ -149,7 +146,6 @@ impl App {
             read_only_replica_database: replica_database,
             github,
             github_oauth,
-            session_key: config.session_key.clone(),
             config,
             downloads_counter: DownloadsCounter::new(),
             emails: Emails::from_environment(),
@@ -173,5 +169,10 @@ impl App {
         self.http_client
             .as_ref()
             .expect("No HTTP client is configured.  In tests, use `TestApp::with_proxy()`.")
+    }
+
+    /// A unique key used with conduit_cookie to generate signed/encrypted cookies
+    pub fn session_key(&self) -> &str {
+        &self.config.session_key
     }
 }

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -24,15 +24,9 @@ use std::time::Duration;
 fn main() {
     println!("Booting runner");
 
-    // FIXME: Break off uploader config
-    // let db_config = cargo_registry::config::Databases::from_environment();
-    // let uploader = ...;
-    let full_app = config::Server::default();
-    let config::Server {
-        db: db_config,
-        uploader,
-        ..
-    } = full_app;
+    let db_config = config::DatabasePools::full_from_environment();
+    let base_config = config::Base::from_environment();
+    let uploader = base_config.uploader();
 
     if db_config.are_all_read_only() {
         loop {

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -12,6 +12,7 @@
 
 #![warn(clippy::all, rust_2018_idioms)]
 
+use cargo_registry::config;
 use cargo_registry::git::{Repository, RepositoryConfig};
 use cargo_registry::{background_jobs::*, db};
 use diesel::r2d2;
@@ -23,9 +24,17 @@ use std::time::Duration;
 fn main() {
     println!("Booting runner");
 
-    let config = cargo_registry::Config::default();
+    // FIXME: Break off uploader config
+    // let db_config = cargo_registry::config::Databases::from_environment();
+    // let uploader = ...;
+    let full_app = config::Server::default();
+    let config::Server {
+        db: db_config,
+        uploader,
+        ..
+    } = full_app;
 
-    if config.db_primary_config.read_only_mode {
+    if db_config.are_all_read_only() {
         loop {
             println!(
                 "Cannot run background jobs with a read-only pool. Please scale background_worker \
@@ -35,7 +44,7 @@ fn main() {
         }
     }
 
-    let db_url = db::connection_url(&config.db_primary_config.url);
+    let db_url = db::connection_url(&db_config.primary.url);
 
     let job_start_timeout = dotenv::var("BACKGROUND_JOB_TIMEOUT")
         .unwrap_or_else(|_| "30".into())
@@ -55,8 +64,7 @@ fn main() {
             .timeout(Duration::from_secs(45))
             .build()
             .expect("Couldn't build client");
-        let environment =
-            Environment::new_shared(repository.clone(), config.uploader.clone(), client);
+        let environment = Environment::new_shared(repository.clone(), uploader.clone(), client);
         let db_config = r2d2::Pool::builder().min_idle(Some(0));
         swirl::Runner::builder(environment)
             .connection_pool_builder(&db_url, db_config)

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt::init();
 
     let config = cargo_registry::config::Server::default();
-    let env = config.env;
+    let env = config.env();
     let client = Client::new();
     let app = Arc::new(App::new(config, Some(client)));
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logging
     tracing_subscriber::fmt::init();
 
-    let config = cargo_registry::Config::default();
+    let config = cargo_registry::config::Server::default();
     let env = config.env;
     let client = Client::new();
     let app = Arc::new(App::new(config, Some(client)));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,21 +1,21 @@
 use crate::publish_rate_limit::PublishRateLimit;
-use crate::{env, env_optional, uploaders::Uploader, Env, Replica};
+use crate::{env, env_optional, uploaders::Uploader, Env};
 
+mod base;
 mod database_pools;
 
+pub use self::base::Base;
 pub use self::database_pools::DatabasePools;
 
 pub struct Server {
+    pub base: Base,
     pub db: DatabasePools,
-    pub uploader: Uploader,
     pub session_key: String,
     pub gh_client_id: String,
     pub gh_client_secret: String,
     pub gh_base_url: String,
-    pub env: Env,
     pub max_upload_size: u64,
     pub max_unpack_size: u64,
-    pub mirror: Replica,
     pub api_protocol: String,
     pub publish_rate_limit: PublishRateLimit,
     pub blocked_traffic: Vec<(String, Vec<String>)>,
@@ -41,13 +41,6 @@ impl Default for Server {
     ///
     /// Pulls values from the following environment variables:
     ///
-    /// - `MIRROR`: Is this instance of cargo_registry a mirror of crates.io.
-    /// - `HEROKU`: Is this instance of cargo_registry currently running on Heroku.
-    /// - `S3_BUCKET`: The S3 bucket used to store crate files. If not present during development,
-    ///    cargo_registry will fall back to a local uploader.
-    /// - `S3_REGION`: The region in which the bucket was created. Optional if US standard.
-    /// - `S3_ACCESS_KEY`: The access key to interact with S3. Optional if running a mirror.
-    /// - `S3_SECRET_KEY`: The secret key to interact with S3. Optional if running a mirror.
     /// - `SESSION_KEY`: The key used to sign and encrypt session cookies.
     /// - `GH_CLIENT_ID`: The client ID of the associated GitHub application.
     /// - `GH_CLIENT_SECRET`: The client secret of the associated GitHub application.
@@ -70,83 +63,7 @@ impl Default for Server {
     /// This function panics if the Server configuration is invalid.
     fn default() -> Self {
         let api_protocol = String::from("https");
-        let mirror = if dotenv::var("MIRROR").is_ok() {
-            Replica::ReadOnlyMirror
-        } else {
-            Replica::Primary
-        };
-        let heroku = dotenv::var("HEROKU").is_ok();
-        let cargo_env = if heroku {
-            Env::Production
-        } else {
-            Env::Development
-        };
 
-        let uploader = match (cargo_env, mirror) {
-            (Env::Production, Replica::Primary) => {
-                // `env` panics if these vars are not set, and in production for a primary instance,
-                // that's what we want since we don't want to be able to start the server if the
-                // server doesn't know where to upload crates.
-                Uploader::S3 {
-                    bucket: s3::Bucket::new(
-                        env("S3_BUCKET"),
-                        dotenv::var("S3_REGION").ok(),
-                        env("S3_ACCESS_KEY"),
-                        env("S3_SECRET_KEY"),
-                        &api_protocol,
-                    ),
-                    cdn: dotenv::var("S3_CDN").ok(),
-                }
-            }
-            (Env::Production, Replica::ReadOnlyMirror) => {
-                // Read-only mirrors don't need access key or secret key since by definition,
-                // they'll only need to read from a bucket, not upload.
-                //
-                // Read-only mirrors might have access key or secret key, so use them if those
-                // environment variables are set.
-                //
-                // Read-only mirrors definitely need bucket though, so that they know where
-                // to serve crate files from.
-                Uploader::S3 {
-                    bucket: s3::Bucket::new(
-                        env("S3_BUCKET"),
-                        dotenv::var("S3_REGION").ok(),
-                        dotenv::var("S3_ACCESS_KEY").unwrap_or_default(),
-                        dotenv::var("S3_SECRET_KEY").unwrap_or_default(),
-                        &api_protocol,
-                    ),
-                    cdn: dotenv::var("S3_CDN").ok(),
-                }
-            }
-            // In Development mode, either running as a primary instance or a read-only mirror
-            _ => {
-                if dotenv::var("S3_BUCKET").is_ok() {
-                    // If we've set the `S3_BUCKET` variable to any value, use all of the values
-                    // for the related S3 environment variables and configure the app to upload to
-                    // and read from S3 like production does. All values except for bucket are
-                    // optional, like production read-only mirrors.
-                    println!("Using S3 uploader");
-                    Uploader::S3 {
-                        bucket: s3::Bucket::new(
-                            env("S3_BUCKET"),
-                            dotenv::var("S3_REGION").ok(),
-                            dotenv::var("S3_ACCESS_KEY").unwrap_or_default(),
-                            dotenv::var("S3_SECRET_KEY").unwrap_or_default(),
-                            &api_protocol,
-                        ),
-                        cdn: dotenv::var("S3_CDN").ok(),
-                    }
-                } else {
-                    // If we don't set the `S3_BUCKET` variable, we'll use a development-only
-                    // uploader that makes it possible to run and publish to a locally-running
-                    // crates.io instance without needing to set up an account and a bucket in S3.
-                    println!(
-                        "Using local uploader, crate files will be in the local_uploads directory"
-                    );
-                    Uploader::Local
-                }
-            }
-        };
         let allowed_origins = env("WEB_ALLOWED_ORIGINS")
             .split(',')
             .map(ToString::to_string)
@@ -159,15 +76,13 @@ impl Default for Server {
         };
         Server {
             db: DatabasePools::full_from_environment(),
-            uploader,
+            base: Base::from_environment(),
             session_key: env("SESSION_KEY"),
             gh_client_id: env("GH_CLIENT_ID"),
             gh_client_secret: env("GH_CLIENT_SECRET"),
             gh_base_url: "https://api.github.com".to_string(),
-            env: cargo_env,
             max_upload_size: 10 * 1024 * 1024, // 10 MB default file upload size limit
             max_unpack_size: 512 * 1024 * 1024, // 512 MB max when decompressed
-            mirror,
             api_protocol,
             publish_rate_limit: Default::default(),
             blocked_traffic: blocked_traffic(),
@@ -187,6 +102,16 @@ impl Default for Server {
             use_test_database_pool: false,
             instance_metrics_log_every_seconds: env_optional("INSTANCE_METRICS_LOG_EVERY_SECONDS"),
         }
+    }
+}
+
+impl Server {
+    pub fn env(&self) -> Env {
+        self.base.env
+    }
+
+    pub fn uploader(&self) -> &Uploader {
+        self.base.uploader()
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,6 @@ pub struct Server {
     pub gh_base_url: String,
     pub max_upload_size: u64,
     pub max_unpack_size: u64,
-    pub api_protocol: String,
     pub publish_rate_limit: PublishRateLimit,
     pub blocked_traffic: Vec<(String, Vec<String>)>,
     pub max_allowed_page_offset: u32,
@@ -36,7 +35,6 @@ impl Default for Server {
     /// Sets the following default values:
     ///
     /// - `Config::max_upload_size`: 10MiB
-    /// - `Config::api_protocol`: `https`
     /// - `Config::ownership_invitations_expiration_days`: 30
     ///
     /// Pulls values from the following environment variables:
@@ -62,8 +60,6 @@ impl Default for Server {
     ///
     /// This function panics if the Server configuration is invalid.
     fn default() -> Self {
-        let api_protocol = String::from("https");
-
         let allowed_origins = env("WEB_ALLOWED_ORIGINS")
             .split(',')
             .map(ToString::to_string)
@@ -83,7 +79,6 @@ impl Default for Server {
             gh_base_url: "https://api.github.com".to_string(),
             max_upload_size: 10 * 1024 * 1024, // 10 MB default file upload size limit
             max_unpack_size: 512 * 1024 * 1024, // 512 MB max when decompressed
-            api_protocol,
             publish_rate_limit: Default::default(),
             blocked_traffic: blocked_traffic(),
             max_allowed_page_offset: env_optional("WEB_MAX_ALLOWED_PAGE_OFFSET").unwrap_or(200),

--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -1,0 +1,126 @@
+//! Base configuration options
+//! - `HEROKU`: Is this instance of cargo_registry currently running on Heroku.
+//! - `MIRROR`: (deprecated) Is this instance of cargo_registry a mirror of crates.io.
+//! - `S3_BUCKET`: The S3 bucket used to store crate files. If not present during development,
+//!    cargo_registry will fall back to a local uploader.
+//! - `S3_REGION`: The region in which the bucket was created. Optional if US standard.
+//! - `S3_ACCESS_KEY`: The access key to interact with S3. Optional if running a mirror.
+//! - `S3_SECRET_KEY`: The secret key to interact with S3. Optional if running a mirror.
+//! - `S3_CDN`: Optional CDN configuration for building public facing URLs.
+
+use crate::{env, uploaders::Uploader, Env, Replica};
+
+pub struct Base {
+    pub(super) env: Env,
+    uploader: Uploader,
+}
+
+impl Base {
+    pub fn from_environment() -> Self {
+        let mirror = if dotenv::var("MIRROR").is_ok() {
+            Replica::ReadOnlyMirror
+        } else {
+            Replica::Primary
+        };
+        let heroku = dotenv::var("HEROKU").is_ok();
+        let cargo_env = if heroku {
+            Env::Production
+        } else {
+            Env::Development
+        };
+
+        let uploader = match (cargo_env, mirror) {
+            (Env::Production, Replica::Primary) => {
+                // `env` panics if these vars are not set, and in production for a primary instance,
+                // that's what we want since we don't want to be able to start the server if the
+                // server doesn't know where to upload crates.
+                Uploader::S3 {
+                    bucket: s3::Bucket::new(
+                        env("S3_BUCKET"),
+                        dotenv::var("S3_REGION").ok(),
+                        env("S3_ACCESS_KEY"),
+                        env("S3_SECRET_KEY"),
+                        "https",
+                    ),
+                    cdn: dotenv::var("S3_CDN").ok(),
+                }
+            }
+            (Env::Production, Replica::ReadOnlyMirror) => {
+                // Read-only mirrors don't need access key or secret key since by definition,
+                // they'll only need to read from a bucket, not upload.
+                //
+                // Read-only mirrors might have access key or secret key, so use them if those
+                // environment variables are set.
+                //
+                // Read-only mirrors definitely need bucket though, so that they know where
+                // to serve crate files from.
+                Uploader::S3 {
+                    bucket: s3::Bucket::new(
+                        env("S3_BUCKET"),
+                        dotenv::var("S3_REGION").ok(),
+                        dotenv::var("S3_ACCESS_KEY").unwrap_or_default(),
+                        dotenv::var("S3_SECRET_KEY").unwrap_or_default(),
+                        "https",
+                    ),
+                    cdn: dotenv::var("S3_CDN").ok(),
+                }
+            }
+            // In Development mode, either running as a primary instance or a read-only mirror
+            _ => {
+                if dotenv::var("S3_BUCKET").is_ok() {
+                    // If we've set the `S3_BUCKET` variable to any value, use all of the values
+                    // for the related S3 environment variables and configure the app to upload to
+                    // and read from S3 like production does. All values except for bucket are
+                    // optional, like production read-only mirrors.
+                    println!("Using S3 uploader");
+                    Uploader::S3 {
+                        bucket: s3::Bucket::new(
+                            env("S3_BUCKET"),
+                            dotenv::var("S3_REGION").ok(),
+                            dotenv::var("S3_ACCESS_KEY").unwrap_or_default(),
+                            dotenv::var("S3_SECRET_KEY").unwrap_or_default(),
+                            "https",
+                        ),
+                        cdn: dotenv::var("S3_CDN").ok(),
+                    }
+                } else {
+                    // If we don't set the `S3_BUCKET` variable, we'll use a development-only
+                    // uploader that makes it possible to run and publish to a locally-running
+                    // crates.io instance without needing to set up an account and a bucket in S3.
+                    println!(
+                        "Using local uploader, crate files will be in the local_uploads directory"
+                    );
+                    Uploader::Local
+                }
+            }
+        };
+
+        Self {
+            env: cargo_env,
+            uploader,
+        }
+    }
+
+    pub fn test() -> Self {
+        let uploader = Uploader::S3 {
+            bucket: s3::Bucket::new(
+                String::from("alexcrichton-test"),
+                None,
+                dotenv::var("S3_ACCESS_KEY").unwrap_or_default(),
+                dotenv::var("S3_SECRET_KEY").unwrap_or_default(),
+                // When testing we route all API traffic over HTTP so we can
+                // sniff/record it, but everywhere else we use https
+                "http",
+            ),
+            cdn: None,
+        };
+        Self {
+            env: Env::Test,
+            uploader,
+        }
+    }
+
+    pub fn uploader(&self) -> &Uploader {
+        &self.uploader
+    }
+}

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -1,0 +1,85 @@
+//! Configuration for setting up database pools
+//!
+//! - `DATABASE_URL`: The URL of the postgres database to use.
+//! - `READ_ONLY_REPLICA_URL`: The URL of an optional postgres read-only replica database.
+//! - `DB_OFFLINE`: If set to `leader` then use the read-only follower as if it was the leader.
+//!   If set to `follower` then act as if `READ_ONLY_REPLICA_URL` was unset.
+//! - `READ_ONLY_MODE`: If defined (even as empty) then force all connections to be read-only.
+
+use crate::env;
+
+pub struct DatabasePools {
+    /// Settings for the primary database. This is usually writeable, but will be read-only in
+    /// some configurations.
+    pub primary: DbPoolConfig,
+    /// An optional follower database. Always read-only.
+    pub replica: Option<DbPoolConfig>,
+}
+
+#[derive(Debug)]
+pub struct DbPoolConfig {
+    pub url: String,
+    pub read_only_mode: bool,
+}
+
+impl DatabasePools {
+    pub fn are_all_read_only(&self) -> bool {
+        self.primary.read_only_mode
+    }
+}
+
+impl DatabasePools {
+    /// Load settings for one or more database pools from the environment
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `DB_OFFLINE=leader` but `READ_ONLY_REPLICA_URL` is unset.
+    pub fn full_from_environment() -> Self {
+        let leader_url = env("DATABASE_URL");
+        let follower_url = dotenv::var("READ_ONLY_REPLICA_URL").ok();
+        let read_only_mode = dotenv::var("READ_ONLY_MODE").is_ok();
+        match dotenv::var("DB_OFFLINE").as_deref() {
+            // The actual leader is down, use the follower in read-only mode as the primary and
+            // don't configure a replica.
+            Ok("leader") => Self {
+                primary: DbPoolConfig {
+                    url: follower_url
+                        .expect("Must set `READ_ONLY_REPLICA_URL` when using `DB_OFFLINE=leader`."),
+                    read_only_mode: true,
+                },
+                replica: None,
+            },
+            // The follower is down, don't configure the replica.
+            Ok("follower") => Self {
+                primary: DbPoolConfig {
+                    url: leader_url,
+                    read_only_mode,
+                },
+                replica: None,
+            },
+            _ => Self {
+                primary: DbPoolConfig {
+                    url: leader_url,
+                    read_only_mode,
+                },
+                replica: follower_url.map(|url| DbPoolConfig {
+                    url,
+                    // Always enable read-only mode for the follower. In staging, we attach the
+                    // same leader database to both environment variables and this ensures the
+                    // connection is opened read-only even when attached to a writeable database.
+                    read_only_mode: true,
+                }),
+            },
+        }
+    }
+
+    pub fn test_from_environment() -> Self {
+        DatabasePools {
+            primary: DbPoolConfig {
+                url: env("TEST_DATABASE_URL"),
+                read_only_mode: false,
+            },
+            replica: None,
+        }
+    }
+}

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -203,7 +203,7 @@ pub fn readme(req: &mut dyn RequestExt) -> EndpointResult {
     let redirect_url = req
         .app()
         .config
-        .uploader
+        .uploader()
         .readme_location(crate_name, version);
 
     if req.wants_json() {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -199,7 +199,7 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
 
         let cksum = app
             .config
-            .uploader
+            .uploader()
             .upload_crate(req, &krate, maximums, vers)?;
 
         let hex_cksum = cksum.encode_hex::<String>();

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -75,7 +75,7 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
     let redirect_url = req
         .app()
         .config
-        .uploader
+        .uploader()
         .crate_location(&crate_name, &*version);
 
     if let Some((key, value)) = log_metadata {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ extern crate serde_json;
 #[macro_use]
 extern crate tracing;
 
-pub use crate::config::{Config, DbPoolConfig};
 pub use crate::{app::App, email::Emails, uploaders::Uploader};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -37,7 +36,7 @@ pub mod admin;
 mod app;
 pub mod background_jobs;
 pub mod boot;
-mod config;
+pub mod config;
 pub mod db;
 mod downloads_counter;
 pub mod email;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -40,7 +40,7 @@ use crate::{App, Env};
 
 pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);
-    let env = app.config.env;
+    let env = app.config.env();
     let blocked_traffic = app.config.blocked_traffic.clone();
 
     if env != Env::Test {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -64,7 +64,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     m.add(Cookie::new());
     m.add(SessionMiddleware::new(
         "cargo_session",
-        cookie::Key::derive_from(app.session_key.as_bytes()),
+        cookie::Key::derive_from(app.session_key().as_bytes()),
         env == Env::Production,
     ));
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -129,7 +129,7 @@ pub fn build_router(app: &App) -> RouteBuilder {
     // Only serve the local checkout of the git index in development mode.
     // In production, for crates.io, cargo gets the index from
     // https://github.com/rust-lang/crates.io-index directly.
-    if app.config.env == Env::Development {
+    if app.config.env() == Env::Development {
         let s = conduit_git_http_backend::Serve("./tmp/index-bare".into());
         let s = Arc::new(s);
         router.get("/git/index/*path", R(Arc::clone(&s)));

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -36,7 +36,7 @@ fn token_auth_cannot_find_token() {
 fn cookie_auth_cannot_find_user() {
     let (app, anon) = TestApp::init().empty();
 
-    let session_key = &app.as_inner().session_key;
+    let session_key = &app.as_inner().session_key();
     let cookie = encode_session_header(session_key, -1);
 
     let mut request = anon.request_builder(Method::GET, URL);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -217,7 +217,7 @@ pub struct MockCookieUser {
 
 impl RequestHelper for MockCookieUser {
     fn request_builder(&self, method: Method, path: &str) -> MockRequest {
-        let session_key = &self.app.as_inner().session_key;
+        let session_key = &self.app.as_inner().session_key();
         let cookie = encode_session_header(session_key, self.user.id);
 
         let mut request = req(method, path);

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -323,9 +323,6 @@ fn simple_config() -> config::Server {
         gh_base_url: "http://api.github.com".to_string(),
         max_upload_size: 3000,
         max_unpack_size: 2000,
-        // When testing we route all API traffic over HTTP so we can
-        // sniff/record it, but everywhere else we use https
-        api_protocol: String::from("http"),
         publish_rate_limit: Default::default(),
         blocked_traffic: Default::default(),
         max_allowed_page_offset: 200,


### PR DESCRIPTION
This commit series begins refactoring the loading of configuration settings from environment variables. Unlike the main server binary, most binaries just need access to the database, and sometimes S3.

There are still some modules that access the environment directly (such as `app`, `emails`, `git`, some middleware, etc.). This should lay the groundwork for future consolidation of this logic under the `config` module.

r? @Turbo87 