### PR TITLE
tests/settings: Replace `loadFixtures()` calls

### DIFF
--- a/mirage/factories/team.js
+++ b/mirage/factories/team.js
@@ -4,13 +4,14 @@ const ORGS = ['rust-lang', 'emberjs', 'rust-random', 'georust', 'actix'];
 
 export default Factory.extend({
   name: i => `team-${i + 1}`,
+  org: i => ORGS[i % ORGS.length],
 
-  login(i) {
-    return `github:${ORGS[i % ORGS.length]}:${this.name}`;
+  login() {
+    return `github:${this.org}:${this.name}`;
   },
 
-  url(i) {
-    return `https://github.com/${ORGS[i % ORGS.length]}`;
+  url() {
+    return `https://github.com/${this.org}`;
   },
 
   avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',

--- a/mirage/serializers/team.js
+++ b/mirage/serializers/team.js
@@ -17,5 +17,6 @@ export default BaseSerializer.extend({
 
   _adjust(hash) {
     hash.id = Number(hash.id);
+    delete hash.org;
   },
 });


### PR DESCRIPTION
The fixtures are inconsistent, slow and hard to maintain. We can create only what we need instead, similar to how we already do it in plenty of other test cases.