### PR TITLE
CrateHeader: Link to `crate.settings` so that tab gets "active" state

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -64,7 +64,7 @@
   </nav.Tab>
 
   {{#if this.isOwner}}
-    <nav.Tab @link={{link "crate.owners" @crate}} data-test-settings-tab>
+    <nav.Tab @link={{link "crate.settings" @crate}} data-test-settings-tab>
       Settings
     </nav.Tab>
   {{/if}}


### PR DESCRIPTION
`crate.owners` redirects to `crate.settings` these days, so the "Settings" tab would never receive the "active" state with the current implementation.