### PR TITLE
crate/settings: Ensure that only authenticated users can visit the route

### DIFF
--- a/app/routes/crate/settings.js
+++ b/app/routes/crate/settings.js
@@ -1,6 +1,6 @@
-import Route from '@ember/routing/route';
+import AuthenticatedRoute from '../-authenticated-route';
 
-export default class SettingsRoute extends Route {
+export default class SettingsRoute extends AuthenticatedRoute {
   setupController(controller) {
     super.setupController(...arguments);
     let crate = this.modelFor('crate');


### PR DESCRIPTION
This still does not check whether the authenticated user is sufficiently privileged to perform any actions on the page, but at least it prevents unauthenticated users from accessing the page.