### PR TITLE
Remove unused `ember-promise-helpers` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "ember-modifier": "2.1.2",
     "ember-page-title": "6.2.2",
     "ember-prism": "0.9.1",
-    "ember-promise-helpers": "1.0.9",
     "ember-qunit": "5.1.4",
     "ember-resolver": "8.0.2",
     "ember-router-scroll": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6416,7 +6416,7 @@ ember-cli-babel@7.26.6, ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cl
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.16.0:
+ember-cli-babel@^6.0.0-beta.4:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.18.0.tgz#3f6435fd275172edeff2b634ee7b29ce74318957"
   integrity sha512-7ceC8joNYxY2wES16iIBlbPSxwKDBhYwC8drU3ZEvuPDMwVv1KzxCNu1fvxyFEBWhwaRNTUxSCsEVoTd9nosGA==
@@ -7192,13 +7192,6 @@ ember-prism@0.9.1:
     ember-cli-htmlbars "^5.3.1"
     ember-cli-node-assets "^0.2.2"
     prismjs "^1.22.0"
-
-ember-promise-helpers@1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/ember-promise-helpers/-/ember-promise-helpers-1.0.9.tgz#4559dd4a09be1a2725eddd7146169d2d53a92e7a"
-  integrity sha512-BDcx2X28baEL0YMKSmDGQzvdyfiFSlx4Byf34hVrAw6W7VO17YYLjeXPebVBOXLA1BMWmUo0Bb2pZRZ09MQYYA==
-  dependencies:
-    ember-cli-babel "^6.16.0"
 
 ember-qunit@5.1.4:
   version "5.1.4"


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/pull/2403 removed the usage of the `is-pending` template helper, so this dependency is no longer used in our app! 🎉 