### PR TITLE
Improve metrics accuracy

### DIFF
--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -1,4 +1,19 @@
-use prometheus::Opts;
+use prometheus::{Histogram, HistogramOpts, HistogramVec, Opts};
+
+/// Prometheus's histograms work by dividing datapoints in buckets, with each bucket containing
+/// the count of datapoints equal or greater to the bucket value.
+///
+/// The buckets used by crates.io are geared towards measuring the response time of our requests,
+/// going from 0.5ms to 100ms with a higher resolution and from 100ms to 5 seconds with a slightly
+/// lower resolution. This allows us to properly measure download requests (which take around 1ms)
+/// and other requests (our 95h is around 10-20ms).
+///
+/// Histogram buckets are not an exact science, so feel free to tweak the buckets if you see that
+/// the histograms are not really accurate. Just avoid adding too many buckets as that increases
+/// the number of exported metric series.
+const HISTOGRAM_BUCKETS: &[f64] = &[
+    0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.5, 1.0, 5.0,
+];
 
 pub(super) trait MetricFromOpts: Sized {
     fn from_opts(opts: Opts) -> Result<Self, prometheus::Error>;
@@ -89,5 +104,30 @@ load_metric_type!(Gauge as single);
 load_metric_type!(GaugeVec as vec);
 load_metric_type!(IntGauge as single);
 load_metric_type!(IntGaugeVec as vec);
-load_metric_type!(Histogram as single);
-load_metric_type!(HistogramVec as vec);
+
+// Use a custom implementation for histograms to customize the buckets.
+
+impl MetricFromOpts for Histogram {
+    fn from_opts(opts: Opts) -> Result<Self, prometheus::Error> {
+        Histogram::with_opts(HistogramOpts {
+            common_opts: opts,
+            buckets: HISTOGRAM_BUCKETS.to_vec(),
+        })
+    }
+}
+
+impl MetricFromOpts for HistogramVec {
+    fn from_opts(opts: Opts) -> Result<Self, prometheus::Error> {
+        HistogramVec::new(
+            HistogramOpts {
+                common_opts: opts.clone(),
+                buckets: HISTOGRAM_BUCKETS.to_vec(),
+            },
+            opts.variable_labels
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )
+    }
+}

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -1,5 +1,7 @@
+use prometheus::Opts;
+
 pub(super) trait MetricFromOpts: Sized {
-    fn from_opts(opts: prometheus::Opts) -> Result<Self, prometheus::Error>;
+    fn from_opts(opts: Opts) -> Result<Self, prometheus::Error>;
 }
 
 #[macro_export]
@@ -53,20 +55,19 @@ macro_rules! metrics {
     };
 }
 
-#[macro_export]
 macro_rules! load_metric_type {
     ($name:ident as single) => {
         use prometheus::$name;
-        impl crate::metrics::macros::MetricFromOpts for $name {
-            fn from_opts(opts: prometheus::Opts) -> Result<Self, prometheus::Error> {
+        impl MetricFromOpts for $name {
+            fn from_opts(opts: Opts) -> Result<Self, prometheus::Error> {
                 $name::with_opts(opts.into())
             }
         }
     };
     ($name:ident as vec) => {
         use prometheus::$name;
-        impl crate::metrics::macros::MetricFromOpts for $name {
-            fn from_opts(opts: prometheus::Opts) -> Result<Self, prometheus::Error> {
+        impl MetricFromOpts for $name {
+            fn from_opts(opts: Opts) -> Result<Self, prometheus::Error> {
                 $name::new(
                     opts.clone().into(),
                     opts.variable_labels
@@ -79,3 +80,14 @@ macro_rules! load_metric_type {
         }
     };
 }
+
+load_metric_type!(Counter as single);
+load_metric_type!(CounterVec as vec);
+load_metric_type!(IntCounter as single);
+load_metric_type!(IntCounterVec as vec);
+load_metric_type!(Gauge as single);
+load_metric_type!(GaugeVec as vec);
+load_metric_type!(IntGauge as single);
+load_metric_type!(IntGaugeVec as vec);
+load_metric_type!(Histogram as single);
+load_metric_type!(HistogramVec as vec);

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -8,9 +8,3 @@ mod macros;
 mod instance;
 mod log_encoder;
 mod service;
-
-load_metric_type!(IntGauge as single);
-load_metric_type!(IntCounter as single);
-load_metric_type!(IntCounterVec as vec);
-load_metric_type!(IntGaugeVec as vec);
-load_metric_type!(HistogramVec as vec);


### PR DESCRIPTION
This should hopefully improve the accuracy of our download metrics and should stop reporting most of the downloads as taking more than 2ms (most download requests finish processing in around 1ms).