### PR TITLE
Add more histograms

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -19,7 +19,6 @@ mod prelude {
 
     pub use crate::db::RequestTransaction;
     pub use crate::middleware::app::RequestApp;
-    pub use crate::middleware::log_request::TimingRecorder;
     pub use crate::util::errors::{cargo_err, AppError, AppResult, ChainError}; // TODO: Remove cargo_err from here
     pub use crate::util::{AppResponse, EndpointResult};
 
@@ -39,7 +38,6 @@ mod prelude {
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
 
         fn log_metadata<V: std::fmt::Display>(&mut self, key: &'static str, value: V);
-        fn timing_recorder(&mut self) -> TimingRecorder;
     }
 
     impl<'a> RequestUtils for dyn RequestExt + 'a {
@@ -79,17 +77,6 @@ mod prelude {
 
         fn log_metadata<V: std::fmt::Display>(&mut self, key: &'static str, value: V) {
             crate::middleware::log_request::add_custom_metadata(self, key, value);
-        }
-
-        fn timing_recorder(&mut self) -> TimingRecorder {
-            if let Some(recorder) = self.extensions().find::<TimingRecorder>() {
-                recorder.clone()
-            } else {
-                let recorder = TimingRecorder::new();
-                self.mut_extensions()
-                    .insert::<TimingRecorder>(recorder.clone());
-                recorder
-            }
         }
     }
 }

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -20,7 +20,7 @@
 use crate::util::errors::AppResult;
 use crate::{app::App, db::DieselPool};
 use prometheus::{
-    proto::MetricFamily, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
+    proto::MetricFamily, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
 
 metrics! {
@@ -46,6 +46,8 @@ metrics! {
         pub downloads_unconditional_redirects_total: IntCounter,
         /// Number of download requests with a non-canonical crate name.
         pub downloads_non_canonical_crate_name_total: IntCounter,
+        /// How long it takes to execute the SELECT query in the download endpoint.
+        pub downloads_select_query_execution_time: Histogram,
         /// Number of download requests that are not counted yet.
         downloads_not_counted_total: IntGauge,
     }

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -29,6 +29,8 @@ metrics! {
         database_idle_conns: IntGaugeVec["pool"],
         /// Number of used database connections in the pool
         database_used_conns: IntGaugeVec["pool"],
+        /// Amount of time required to obtain a database connection
+        pub database_time_to_obtain_connection: HistogramVec["pool"],
 
         /// Number of requests processed by this instance
         pub requests_total: IntCounter,


### PR DESCRIPTION
This PR adds more histograms to the metrics we collect, exposing information that could be useful when we get paged. Two metrics were added:

* `cratesio_instance_database_time_to_obtain_connection`: how long it takes to obtain a database connection
* `cratesio_instance_downloads_select_query_execution_time`: how long the `SELECT` in the download endpoint takes

A side effect of this is that `TimingRecorder` is not needed anymore: we used it to measure those two things, appending them in the logs for slow requests, but now that we have metrics there is no need to have it. If we need to measure more timings in the future we can just add more histograms. This PR thus removes `TimingRecorder` from the codebase.

r? @jtgeibel or @Turbo87
This can be reviewed commit-by-commit.