### PR TITLE
Avoid logging request_id for successful download redirects

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -206,7 +206,19 @@ impl Display for RequestLine<'_> {
         line.add_field("at", at)?;
         line.add_field("method", self.req.method())?;
         line.add_quoted_field("path", FullPath(self.req))?;
-        line.add_field("request_id", request_header(self.req, "x-request-id"))?;
+
+        // The request_id is not logged for successful download requests
+        if !(self.req.path().ends_with("/download")
+            && self
+                .res
+                .as_ref()
+                .ok()
+                .map(|ok| ok.status().is_redirection())
+                == Some(true))
+        {
+            line.add_field("request_id", request_header(self.req, "x-request-id"))?;
+        }
+
         line.add_quoted_field("fwd", request_header(self.req, "x-real-ip"))?;
         line.add_field("service", TimeMs(self.response_time))?;
         line.add_field("status", status.as_str())?;


### PR DESCRIPTION
The request ID is provided to the user in a few error cases to help us
locate the log line. However, the ID is not provided to the user for
successful requests in general, and in particular for download requests
that make up the vast majority of our traffic.

Removing this from the logs will save 48 bytes in log traffic per
download, and should reduce our log output by about 15%.

r? @pietroalbini 