### PR TITLE
Fix typo in env sample: github -> GitHub

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,7 +12,7 @@ export WEB_ALLOWED_ORIGINS=http://localhost:8888,http://localhost:4200
 
 # If you're running an instance of the application on a domain different than
 # crates.io, uncomment this line and set the variable to your domain name.
-#export DOMAIN_NAME=staging.crates.io
+# export DOMAIN_NAME=staging.crates.io
 
 # Key to sign and encrypt cookies with. Must be at least 32 bytes. Change this
 # to a long, random string for production.
@@ -38,9 +38,9 @@ export TEST_DATABASE_URL=
 # Run `./script/init-local-index.sh` to initialize this repo.
 export GIT_REPO_URL=file://$PWD/tmp/index-bare
 
-# Credentials for talking to github. You can leave these blank if you're
+# Credentials for talking to GitHub. You can leave these blank if you're
 # not logging into your crates.io instance.
-# When registering a new application on github for use with your local
+# When registering a new application on GitHub for use with your local
 # crates.io instance, be sure to set the callback url for that application
 # to the address `http://localhost:4200/authorize/github`.
 export GH_CLIENT_ID=


### PR DESCRIPTION
github -> GitHub