### PR TITLE
Fix "Edge for Android" compatibility

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -9,5 +9,11 @@ module.exports = {
     'last 1 Edge version',
     'last 1 UCAndroid version',
     'last 1 years',
+    // Edge for Android is currently (2021-08-18) using an outdated Chromium version (v77),
+    // which is not recognized by `browserslist` and `caniuse`. This can be removed once
+    // Edge for Android has promoted their "Edge for Android Beta" app to production, which
+    // is using a more up-to-date Chromium version.
+    // (see https://github.com/rust-lang/crates.io/issues/3838)
+    'Chrome 77',
   ],
 };


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/3838 by explicitly adding "Chrome 77" to our browser targets list for now.

/cc @zkat