### PR TITLE
test-selectors: Remove obsolete `patchClassicComponent` option

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -48,10 +48,6 @@ module.exports = function (defaults) {
       components: highlightedLanguages,
     },
 
-    'ember-test-selectors': {
-      patchClassicComponent: false,
-    },
-
     cssModules: {
       extension: 'module.css',
       plugins: {


### PR DESCRIPTION
see https://github.com/simplabs/ember-test-selectors/pull/764