### PR TITLE
Cache the version_id for download requests

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,7 +36,7 @@ pub struct App {
     ///
     /// This is used by the download endpoint to reduce the number of database queries. The
     /// `version_id` is only cached under the canonical spelling of the crate name.
-    pub(crate) version_id_cacher: DashMap<String, i32>,
+    pub(crate) version_id_cacher: DashMap<(String, String), i32>,
 
     /// Count downloads and periodically persist them in the database
     pub downloads_counter: DownloadsCounter,

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -9,6 +9,7 @@ use crate::models::{Crate, VersionDownload};
 use crate::schema::*;
 use crate::views::EncodableVersionDownload;
 use chrono::{Duration, NaiveDate, Utc};
+use dashmap::mapref::entry::Entry;
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
@@ -18,75 +19,96 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
     let mut crate_name = req.params()["crate_id"].clone();
     let version = req.params()["version"].as_str();
 
-    // When no database connection is ready unconditional redirects will be performed. This could
-    // happen if the pool is not healthy or if an operator manually configured the application to
-    // always perform unconditional redirects (for example as part of the mitigations for an
-    // outage). See the comments below for a description of what unconditional redirects do.
-    let conn = if app.config.force_unconditional_redirects {
-        None
-    } else {
-        match req.db_conn() {
-            Ok(conn) => Some(conn),
-            Err(PoolError::UnhealthyPool) => None,
-            Err(err) => return Err(err.into()),
+    let mut log_metadata = None;
+
+    match app
+        .version_id_cacher
+        .entry(format!("{}:{}", crate_name, version))
+    {
+        // The version_id is cached. This also means that the provided crate_name is canonical
+        // and that no fixup is necessary before redirecting.
+        Entry::Occupied(entry) => {
+            let version_id = *entry.get();
+
+            // The increment does not happen instantly, but it's deferred to be executed in a batch
+            // along with other downloads. See crate::downloads_counter for the implementation.
+            app.downloads_counter.increment(version_id);
+        }
+
+        // The version_id is not cached, so either query the database or fallback to an
+        // unconditional redirect if the database pool is unhealthy.
+        Entry::Vacant(entry) => {
+            // When no database connection is ready unconditional redirects will be performed. This could
+            // happen if the pool is not healthy or if an operator manually configured the application to
+            // always perform unconditional redirects (for example as part of the mitigations for an
+            // outage). See the comments below for a description of what unconditional redirects do.
+            let conn = if app.config.force_unconditional_redirects {
+                None
+            } else {
+                match req.db_conn() {
+                    Ok(conn) => Some(conn),
+                    Err(PoolError::UnhealthyPool) => None,
+                    Err(err) => return Err(err.into()),
+                }
+            };
+
+            if let Some(conn) = &conn {
+                use self::versions::dsl::*;
+
+                // Returns the crate name as stored in the database, or an error if we could
+                // not load the version ID from the database.
+                let (version_id, canonical_crate_name) = app
+                    .instance_metrics
+                    .downloads_select_query_execution_time
+                    .observe_closure_duration(|| {
+                        versions
+                            .inner_join(crates::table)
+                            .select((id, crates::name))
+                            .filter(Crate::with_name(&crate_name))
+                            .filter(num.eq(version))
+                            .first::<(i32, String)>(&**conn)
+                    })?;
+
+                if canonical_crate_name != crate_name {
+                    app.instance_metrics
+                        .downloads_non_canonical_crate_name_total
+                        .inc();
+                    log_metadata = Some(("bot", "dl"));
+                    crate_name = canonical_crate_name;
+                } else {
+                    // The version_id is only cached if the provided crate name was canonical.
+                    // Non-canonical requests fallback to the "slow" path with a DB query, but
+                    // we typically only get a few hundred non-canonical requests in a day anyway.
+                    entry.insert(version_id);
+                }
+
+                // The increment does not happen instantly, but it's deferred to be executed in a batch
+                // along with other downloads. See crate::downloads_counter for the implementation.
+                app.downloads_counter.increment(version_id);
+            } else {
+                // The download endpoint is the most critical route in the whole crates.io application,
+                // as it's relied upon by users and automations to download crates. Keeping it working
+                // is the most important thing for us.
+                //
+                // The endpoint relies on the database to fetch the canonical crate name (with the
+                // right capitalization and hyphenation), but that's only needed to serve clients who
+                // don't call the endpoint with the crate's canonical name.
+                //
+                // Thankfully Cargo always uses the right name when calling the endpoint, and we can
+                // keep it working during a full database outage by unconditionally redirecting without
+                // checking whether the crate exists or the rigth name is used. Non-Cargo clients might
+                // get a 404 response instead of a 500, but that's worth it.
+                //
+                // Without a working database we also can't count downloads, but that's also less
+                // critical than keeping Cargo downloads operational.
+
+                app.instance_metrics
+                    .downloads_unconditional_redirects_total
+                    .inc();
+                log_metadata = Some(("unconditional_redirect", "true"));
+            }
         }
     };
-
-    let mut log_metadata = None;
-    if let Some(conn) = &conn {
-        use self::versions::dsl::*;
-
-        // Returns the crate name as stored in the database, or an error if we could
-        // not load the version ID from the database.
-        let (version_id, canonical_crate_name) = app
-            .instance_metrics
-            .downloads_select_query_execution_time
-            .observe_closure_duration(|| {
-                versions
-                    .inner_join(crates::table)
-                    .select((id, crates::name))
-                    .filter(Crate::with_name(&crate_name))
-                    .filter(num.eq(version))
-                    .first::<(i32, String)>(&**conn)
-            })?;
-
-        if canonical_crate_name != crate_name {
-            app.instance_metrics
-                .downloads_non_canonical_crate_name_total
-                .inc();
-            log_metadata = Some(("bot", "dl"));
-        }
-        crate_name = canonical_crate_name;
-
-        // The increment does not happen instantly, but it's deferred to be executed in a batch
-        // along with other downloads. See crate::downloads_counter for the implementation.
-        app.downloads_counter.increment(version_id);
-    } else {
-        // The download endpoint is the most critical route in the whole crates.io application,
-        // as it's relied upon by users and automations to download crates. Keeping it working
-        // is the most important thing for us.
-        //
-        // The endpoint relies on the database to fetch the canonical crate name (with the
-        // right capitalization and hyphenation), but that's only needed to serve clients who
-        // don't call the endpoint with the crate's canonical name.
-        //
-        // Thankfully Cargo always uses the right name when calling the endpoint, and we can
-        // keep it working during a full database outage by unconditionally redirecting without
-        // checking whether the crate exists or the rigth name is used. Non-Cargo clients might
-        // get a 404 response instead of a 500, but that's worth it.
-        //
-        // Without a working database we also can't count downloads, but that's also less
-        // critical than keeping Cargo downloads operational.
-
-        app.instance_metrics
-            .downloads_unconditional_redirects_total
-            .inc();
-        log_metadata = Some(("unconditional_redirect", "true"));
-    }
-
-    // Ensure the connection is released to the pool as soon as possible, as the download endpoint
-    // covers the majority of our traffic and we don't want it to starve other requests.
-    drop(conn);
 
     let redirect_url = req
         .app()

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -21,10 +21,8 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
 
     let mut log_metadata = None;
 
-    match app
-        .version_id_cacher
-        .entry(format!("{}:{}", crate_name, version))
-    {
+    let key = (crate_name.to_string(), version.to_string());
+    match app.version_id_cacher.entry(key) {
         // The version_id is cached. This also means that the provided crate_name is canonical
         // and that no fixup is necessary before redirecting.
         Entry::Occupied(entry) => {

--- a/src/tests/krate/downloads.rs
+++ b/src/tests/krate/downloads.rs
@@ -1,5 +1,5 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
-use crate::util::{RequestHelper, TestApp};
+use crate::util::{MockAnonymousUser, RequestHelper, TestApp};
 use cargo_registry::views::EncodableVersionDownload;
 use chrono::{Duration, Utc};
 use http::StatusCode;
@@ -7,6 +7,35 @@ use http::StatusCode;
 #[derive(Deserialize)]
 struct Downloads {
     version_downloads: Vec<EncodableVersionDownload>,
+}
+
+fn persist_downloads_count(app: &TestApp) {
+    app.as_inner()
+        .downloads_counter
+        .persist_all_shards(app.as_inner())
+        .expect("failed to persist downloads count")
+        .log();
+}
+
+#[track_caller]
+fn assert_dl_count(
+    anon: &MockAnonymousUser,
+    name_and_version: &str,
+    query: Option<&str>,
+    count: i32,
+) {
+    let url = format!("/api/v1/crates/{}/downloads", name_and_version);
+    let downloads: Downloads = if let Some(query) = query {
+        anon.get_with_query(&url, query).good()
+    } else {
+        anon.get(&url).good()
+    };
+    let total_downloads = downloads
+        .version_downloads
+        .iter()
+        .map(|vd| vd.downloads)
+        .sum::<i32>();
+    assert_eq!(total_downloads, count);
 }
 
 #[test]
@@ -20,21 +49,6 @@ fn download() {
             .expect_build(conn);
     });
 
-    let assert_dl_count = |name_and_version: &str, query: Option<&str>, count: i32| {
-        let url = format!("/api/v1/crates/{}/downloads", name_and_version);
-        let downloads: Downloads = if let Some(query) = query {
-            anon.get_with_query(&url, query).good()
-        } else {
-            anon.get(&url).good()
-        };
-        let total_downloads = downloads
-            .version_downloads
-            .iter()
-            .map(|vd| vd.downloads)
-            .sum::<i32>();
-        assert_eq!(total_downloads, count);
-    };
-
     let download = |name_and_version: &str| {
         let url = format!("/api/v1/crates/{}/download", name_and_version);
         let response = anon.get::<()>(&url);
@@ -42,38 +56,30 @@ fn download() {
         // TODO: test the with_json code path
     };
 
-    let persist_downloads_count = || {
-        app.as_inner()
-            .downloads_counter
-            .persist_all_shards(app.as_inner())
-            .expect("failed to persist downloads count")
-            .log();
-    };
-
     download("foo_download/1.0.0");
     // No downloads are counted until the counters are persisted
-    assert_dl_count("foo_download/1.0.0", None, 0);
-    assert_dl_count("foo_download", None, 0);
-    persist_downloads_count();
+    assert_dl_count(&anon, "foo_download/1.0.0", None, 0);
+    assert_dl_count(&anon, "foo_download", None, 0);
+    persist_downloads_count(&app);
     // Now that the counters are persisted the download counts show up.
-    assert_dl_count("foo_download/1.0.0", None, 1);
-    assert_dl_count("foo_download", None, 1);
+    assert_dl_count(&anon, "foo_download/1.0.0", None, 1);
+    assert_dl_count(&anon, "foo_download", None, 1);
 
     download("FOO_DOWNLOAD/1.0.0");
-    persist_downloads_count();
-    assert_dl_count("FOO_DOWNLOAD/1.0.0", None, 2);
-    assert_dl_count("FOO_DOWNLOAD", None, 2);
+    persist_downloads_count(&app);
+    assert_dl_count(&anon, "FOO_DOWNLOAD/1.0.0", None, 2);
+    assert_dl_count(&anon, "FOO_DOWNLOAD", None, 2);
 
     let yesterday = (Utc::today() + Duration::days(-1)).format("%F");
     let query = format!("before_date={}", yesterday);
-    assert_dl_count("FOO_DOWNLOAD/1.0.0", Some(&query), 0);
+    assert_dl_count(&anon, "FOO_DOWNLOAD/1.0.0", Some(&query), 0);
     // crate/downloads always returns the last 90 days and ignores date params
-    assert_dl_count("FOO_DOWNLOAD", Some(&query), 2);
+    assert_dl_count(&anon, "FOO_DOWNLOAD", Some(&query), 2);
 
     let tomorrow = (Utc::today() + Duration::days(1)).format("%F");
     let query = format!("before_date={}", tomorrow);
-    assert_dl_count("FOO_DOWNLOAD/1.0.0", Some(&query), 2);
-    assert_dl_count("FOO_DOWNLOAD", Some(&query), 2);
+    assert_dl_count(&anon, "FOO_DOWNLOAD/1.0.0", Some(&query), 2);
+    assert_dl_count(&anon, "FOO_DOWNLOAD", Some(&query), 2);
 }
 
 #[test]


### PR DESCRIPTION
This adds a caching layer in the app backend to reduce the number of
database queries. While this query is extremely fast, a massive number
of concurrent download requests can still result in a request backlog.

In this implementation cached values are never dropped. This means
that memory usage will grow over time, however the memory usage is
expected to be well within our instance size and the application is
automatically rebooted at least once every 24 hours. Additionally, on
the rare occasion that a crate version is deleted, the cache will
continue to serve redirects and attempt to record download counts for
that version.

If a version is deleted and continues to see download requests, it is
expected that the entire shard of downloads containing that version_id
will fail to persist. Even if we expired cached entries after a certain
time period, there would still be a window where a deleted version
could cause download counts for other versions to not be persisted. It
is possible we could make the download counter logic robust against this
scenario, but given that deleting versions is rare we can mitigate this
by restarting the app after deleting crates or versions.

r? @pietroalbini 