### PR TITLE
controllers::crate_owner_invitation: Simplify `users` assignment

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -229,10 +229,7 @@ fn prepare_list(
 
     Ok(PrivateListResponse {
         invitations,
-        users: users
-            .into_iter()
-            .map(|(_, user)| EncodablePublicUser::from(user))
-            .collect(),
+        users: users.into_iter().map(|(_, user)| user.into()).collect(),
         meta: ResponseMeta { next_page },
     })
 }


### PR DESCRIPTION
The compiler already knows that we want a `Vec<EncodablePublicUser>` so we can use `.into()` instead :)