### PR TITLE
Revert "sentry: Enable `tracing` feature"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,7 +2246,6 @@ dependencies = [
  "sentry-contexts",
  "sentry-core",
  "sentry-panic",
- "sentry-tracing",
  "tokio",
 ]
 
@@ -2299,17 +2298,6 @@ checksum = "692bf989f0c99f025e33d7f58e62822c3771f56d189698c66dcc863122255d95"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
-]
-
-[[package]]
-name = "sentry-tracing"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d291df287241b0ef97f5bf9e9a595691ef8dfb49bc6acfd55b9dc2ade681f1c9"
-dependencies = [
- "sentry-core",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rand = "0.8"
 reqwest = { version = "0.11", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "0.2.0"
 semver = { version = "1.0.3", features = ["serde"] }
-sentry = { version = "0.23.0", features = ["tracing"] }
+sentry = "0.23.0"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 sha2 = "0.9"

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -11,7 +11,6 @@ use sentry::{ClientOptions, IntoDsn};
 use std::io::Write;
 use tokio::io::AsyncWriteExt;
 use tokio::signal::unix::{signal, SignalKind};
-use tracing_subscriber::prelude::*;
 
 const CORE_THREADS: usize = 4;
 
@@ -34,10 +33,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
 
     // Initialize logging
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
-        .with(sentry::integrations::tracing::layer())
-        .init();
+    tracing_subscriber::fmt::init();
 
     let config = cargo_registry::config::Server::default();
     let env = config.env();


### PR DESCRIPTION
This reverts commit 43ac758c4575f49ae853712f6d75a03bdea898c1.

Using `tracing_subscriber::fmt::layer()` disabled the `RUST_LOG` based env filter. But if we add the filter to the registry it basically disables the breadcrumb tracing for Sentry. https://docs.rs/tracing-subscriber/0.2.20/tracing_subscriber/layer/trait.Layer.html#filtering-with-layers has more information on this. Until we find a way to filter what the `fmt` subscriber prints without disabling the breadcrumbs for Sentry we should probably not use their `tracing` integration.