### PR TITLE
Add support for new feature syntax (RFC 3143)

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -98,9 +98,13 @@ pub struct Crate {
     pub deps: Vec<Dependency>,
     pub cksum: String,
     pub features: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub features2: Option<HashMap<String, Vec<String>>>,
     pub yanked: Option<bool>,
     #[serde(default)]
     pub links: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub v: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/git.rs
+++ b/src/git.rs
@@ -98,11 +98,39 @@ pub struct Crate {
     pub deps: Vec<Dependency>,
     pub cksum: String,
     pub features: HashMap<String, Vec<String>>,
+    /// This field contains features with new, extended syntax. Specifically,
+    /// namespaced features (`dep:`) and weak dependencies (`pkg?/feat`).
+    ///
+    /// It is only populated if a feature uses the new syntax. Cargo merges it
+    /// on top of the `features` field when reading the entries.
+    ///
+    /// This is separated from `features` because versions older than 1.19
+    /// will fail to load due to not being able to parse the new syntax, even
+    /// with a `Cargo.lock` file.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub features2: Option<HashMap<String, Vec<String>>>,
     pub yanked: Option<bool>,
     #[serde(default)]
     pub links: Option<String>,
+    /// The schema version for this entry.
+    ///
+    /// If this is None, it defaults to version 1. Entries with unknown
+    /// versions are ignored by cargo starting with 1.51.
+    ///
+    /// Version `2` format adds the `features2` field.
+    ///
+    /// This provides a method to safely introduce changes to index entries
+    /// and allow older versions of cargo to ignore newer entries it doesn't
+    /// understand. This is honored as of 1.51, so unfortunately older
+    /// versions will ignore it, and potentially misinterpret version 2 and
+    /// newer entries.
+    ///
+    /// The intent is that versions older than 1.51 will work with a
+    /// pre-existing `Cargo.lock`, but they may not correctly process `cargo
+    /// update` or build a lock from scratch. In that case, cargo may
+    /// incorrectly select a new package that uses a new index format. A
+    /// workaround is to downgrade any packages that are incompatible with the
+    /// `--precise` flag of `cargo update`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub v: Option<u32>,
 }

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -297,10 +297,8 @@ impl Crate {
 
     /// Validates a whole feature string, `features = ["THIS", "ALL/THIS"]`.
     pub fn valid_feature(name: &str) -> bool {
-        match name.find('/') {
-            Some(pos) => {
-                let (dep, dep_feat) = name.split_at(pos);
-                let dep_feat = &dep_feat[1..];
+        match name.split_once('/') {
+            Some((dep, dep_feat)) => {
                 let dep = dep.strip_suffix('?').unwrap_or(dep);
                 Crate::valid_feature_prefix(dep) && Crate::valid_feature_name(dep_feat)
             }

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -297,12 +297,15 @@ impl Crate {
 
     /// Validates a whole feature string, `features = ["THIS", "ALL/THIS"]`.
     pub fn valid_feature(name: &str) -> bool {
-        let mut parts = name.split('/');
-        let name_part = parts.next_back(); // required
-        let prefix_part = parts.next_back(); // optional
-        parts.next().is_none()
-            && name_part.map_or(false, Crate::valid_feature_name)
-            && prefix_part.map_or(true, Crate::valid_feature_prefix)
+        match name.find('/') {
+            Some(pos) => {
+                let (dep, dep_feat) = name.split_at(pos);
+                let dep_feat = &dep_feat[1..];
+                let dep = dep.strip_suffix('?').unwrap_or(dep);
+                Crate::valid_feature_prefix(dep) && Crate::valid_feature_name(dep_feat)
+            }
+            None => Crate::valid_feature_name(name.strip_prefix("dep:").unwrap_or(name)),
+        }
     }
 
     /// Return both the newest (most recently updated) and
@@ -498,6 +501,11 @@ mod tests {
         assert!(Crate::valid_feature("c++20"));
         assert!(Crate::valid_feature("krate/c++20"));
         assert!(!Crate::valid_feature("c++20/wow"));
+        assert!(Crate::valid_feature("foo?/bar"));
+        assert!(Crate::valid_feature("dep:foo"));
+        assert!(!Crate::valid_feature("dep:foo?/bar"));
+        assert!(!Crate::valid_feature("foo/?bar"));
+        assert!(!Crate::valid_feature("foo?bar"));
     }
 }
 

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -36,6 +36,7 @@ pub struct PublishBuilder {
     readme: Option<String>,
     tarball: Vec<u8>,
     version: semver::Version,
+    features: HashMap<u::EncodableFeatureName, Vec<u::EncodableFeature>>,
 }
 
 impl PublishBuilder {
@@ -55,6 +56,7 @@ impl PublishBuilder {
             readme: None,
             tarball: EMPTY_TARBALL_BYTES.to_vec(),
             version: semver::Version::parse("1.0.0").unwrap(),
+            features: HashMap::new(),
         }
     }
 
@@ -166,11 +168,22 @@ impl PublishBuilder {
         self
     }
 
+    // Adds a feature.
+    pub fn feature(mut self, name: &str, values: &[&str]) -> Self {
+        let values = values
+            .iter()
+            .map(|s| u::EncodableFeature(s.to_string()))
+            .collect();
+        self.features
+            .insert(u::EncodableFeatureName(name.to_string()), values);
+        self
+    }
+
     pub fn build(self) -> (String, Vec<u8>) {
         let new_crate = u::EncodableCrateUpload {
             name: u::EncodableCrateName(self.krate_name.clone()),
             vers: u::EncodableCrateVersion(self.version),
-            features: HashMap::new(),
+            features: self.features,
             deps: self.deps,
             description: self.desc,
             homepage: None,

--- a/src/tests/http-data/krate_publish_features_version_2
+++ b/src/tests/http-data/krate_publish_features_version_2
@@ -1,0 +1,69 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "host",
+          "alexcrichton-test.s3.amazonaws.com"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-type",
+          "application/x-tar"
+        ],
+        [
+          "authorization",
+          "AWS AKIAICL5IWUZYWWKA7JA:uDc39eNdF6CcwB+q+JwKsoDLQc4="
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 07:53:06 -0700"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "x-amz-request-id",
+          "26589A5E52F8395C"
+        ],
+        [
+          "ETag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 14:53:07 GMT"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "x-amz-id-2",
+          "JdIvnNTw53aqXjBIqBLNuN4kxf/w1XWX+xuIiGBDYy7yzOSDuAMtBSrTW4ZWetcCIdqCUHuQ51A="
+        ],
+        [
+          "Server",
+          "AmazonS3"
+        ]
+      ],
+      "body": ""
+    }
+  }
+]


### PR DESCRIPTION
This adds support for the new feature syntax described in [RFC 3143](https://rust-lang.github.io/rfcs/3143-cargo-weak-namespaced-features.html).  There are two new feature values that are allowed in the `[features]` table: weak dependencies (`foo?/feat-name`) and namespaced dependencies (`dep:bar`).  When these style of features are detected, they are placed in the index in a separate field called `features2` to prevent older versions of cargo from breaking on them. Additionally, it sets a new version field called `v` to indicate that this new field is present, which prevents versions starting at 1.51 from selecting those versions.
