### PR TITLE
render: fix center image test

### DIFF
--- a/src/render.rs
+++ b/src/render.rs
@@ -534,11 +534,11 @@ mod tests {
     #[test]
     fn image_alignment() {
         let text =
-            "<img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"\" align=\"center\">\n";
+            "<p align=\"center\"><img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"\"></p>\n";
         let result = markdown_to_html(text, None);
         assert_eq!(
             result,
-            "<img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"\" align=\"center\">\n"
+            "<p align=\"center\"><img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"\"></p>\n"
         );
     }
 }


### PR DESCRIPTION
The image test is actually not representative and will not center the image. This fix helps users discover how to center images and proves that they will be centered on crates.io.

Note: I am the original author of this testcase from PR #3862 