### PR TITLE
Add `BLOCKED_ROUTES` environment variable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ mod database_pools;
 
 pub use self::base::Base;
 pub use self::database_pools::DatabasePools;
+use std::collections::HashSet;
 
 pub struct Server {
     pub base: Base,
@@ -28,6 +29,7 @@ pub struct Server {
     pub use_test_database_pool: bool,
     pub instance_metrics_log_every_seconds: Option<u64>,
     pub force_unconditional_redirects: bool,
+    pub blocked_routes: HashSet<String>,
 }
 
 impl Default for Server {
@@ -58,6 +60,8 @@ impl Default for Server {
     ///   If the environment variable is not present instance metrics are not logged.
     /// - `FORCE_UNCONDITIONAL_REDIRECTS`: Whether to force unconditional redirects in the download
     ///   endpoint even with a healthy database pool.
+    /// - `BLOCKED_ROUTES`: A comma separated list of HTTP routes that are manually blocked by an
+    ///   operator.
     ///
     /// # Panics
     ///
@@ -100,6 +104,9 @@ impl Default for Server {
             use_test_database_pool: false,
             instance_metrics_log_every_seconds: env_optional("INSTANCE_METRICS_LOG_EVERY_SECONDS"),
             force_unconditional_redirects: dotenv::var("FORCE_UNCONDITIONAL_REDIRECTS").is_ok(),
+            blocked_routes: env_optional("BLOCKED_ROUTES")
+                .map(|routes: String| routes.split(',').map(|s| s.into()).collect())
+                .unwrap_or_else(HashSet::new),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,8 +60,8 @@ impl Default for Server {
     ///   If the environment variable is not present instance metrics are not logged.
     /// - `FORCE_UNCONDITIONAL_REDIRECTS`: Whether to force unconditional redirects in the download
     ///   endpoint even with a healthy database pool.
-    /// - `BLOCKED_ROUTES`: A comma separated list of HTTP routes that are manually blocked by an
-    ///   operator.
+    /// - `BLOCKED_ROUTES`: A comma separated list of HTTP route patterns that are manually blocked
+    ///   by an operator (e.g. `/crates/:crate_id/:version/download`).
     ///
     /// # Panics
     ///

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,9 +1,10 @@
 use std::sync::Arc;
 
-use conduit::{Handler, HandlerResult, RequestExt};
-use conduit_router::{RequestParams, RouteBuilder};
+use conduit::{box_error, header, Body, Handler, HandlerResult, RequestExt, Response, StatusCode};
+use conduit_router::{RequestParams, RouteBuilder, RoutePattern};
 
 use crate::controllers::*;
+use crate::middleware::app::RequestApp;
 use crate::util::errors::{std_error, AppError};
 use crate::util::EndpointResult;
 use crate::{App, Env};
@@ -150,6 +151,21 @@ struct C(pub fn(&mut dyn RequestExt) -> EndpointResult);
 
 impl Handler for C {
     fn call(&self, req: &mut dyn RequestExt) -> HandlerResult {
+        // Allow blocking individual routes by their pattern through the `BLOCKED_ROUTES`
+        // environment variable. This is not in a middleware because we need access to
+        // `RoutePattern` before executing the response handler.
+        if let Some(pattern) = req.extensions().find::<RoutePattern>() {
+            if req.app().config.blocked_routes.contains(pattern.pattern()) {
+                let body = "This route is temporarily blocked. See https://status.crates.io";
+
+                return Response::builder()
+                    .status(StatusCode::SERVICE_UNAVAILABLE)
+                    .header(header::CONTENT_LENGTH, body.len())
+                    .body(Body::from_vec(body.as_bytes().to_vec()))
+                    .map_err(box_error);
+            }
+        }
+
         let C(f) = *self;
         match f(req) {
             Ok(resp) => Ok(resp),

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use conduit::{box_error, header, Body, Handler, HandlerResult, RequestExt, Response, StatusCode};
+use conduit::{Handler, HandlerResult, RequestExt};
 use conduit_router::{RequestParams, RouteBuilder, RoutePattern};
 
 use crate::controllers::*;
 use crate::middleware::app::RequestApp;
-use crate::util::errors::{std_error, AppError};
+use crate::util::errors::{std_error, AppError, RouteBlocked};
 use crate::util::EndpointResult;
 use crate::{App, Env};
 
@@ -156,13 +156,7 @@ impl Handler for C {
         // `RoutePattern` before executing the response handler.
         if let Some(pattern) = req.extensions().find::<RoutePattern>() {
             if req.app().config.blocked_routes.contains(pattern.pattern()) {
-                let body = "This route is temporarily blocked. See https://status.crates.io";
-
-                return Response::builder()
-                    .status(StatusCode::SERVICE_UNAVAILABLE)
-                    .header(header::CONTENT_LENGTH, body.len())
-                    .body(Body::from_vec(body.as_bytes().to_vec()))
-                    .map_err(box_error);
+                return Ok(RouteBlocked.response().unwrap());
             }
         }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -32,6 +32,7 @@ use diesel::prelude::*;
 mod account_lock;
 mod authentication;
 mod badge;
+mod blocked_routes;
 mod builders;
 mod categories;
 mod category;

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -1,0 +1,42 @@
+use crate::builders::{CrateBuilder, VersionBuilder};
+use crate::util::{RequestHelper, TestApp};
+use conduit::StatusCode;
+
+#[test]
+fn test_non_blocked_download_route() {
+    let (app, anon, user) = TestApp::init()
+        .with_config(|config| {
+            config.blocked_routes.clear();
+        })
+        .with_user();
+
+    app.db(|conn| {
+        CrateBuilder::new("foo", user.as_model().id)
+            .version(VersionBuilder::new("1.0.0"))
+            .expect_build(conn);
+    });
+
+    let status = anon.get::<()>("/api/v1/crates/foo/1.0.0/download").status();
+    assert_eq!(StatusCode::FOUND, status);
+}
+
+#[test]
+fn test_blocked_download_route() {
+    let (app, anon, user) = TestApp::init()
+        .with_config(|config| {
+            config.blocked_routes.clear();
+            config
+                .blocked_routes
+                .insert("/crates/:crate_id/:version/download".into());
+        })
+        .with_user();
+
+    app.db(|conn| {
+        CrateBuilder::new("foo", user.as_model().id)
+            .version(VersionBuilder::new("1.0.0"))
+            .expect_build(conn);
+    });
+
+    let status = anon.get::<()>("/api/v1/crates/foo/1.0.0/download").status();
+    assert_eq!(StatusCode::SERVICE_UNAVAILABLE, status);
+}

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -14,6 +14,7 @@ use cargo_registry::git::Repository as WorkerRepository;
 use diesel::PgConnection;
 use git2::Repository as UpstreamRepository;
 use reqwest::{blocking::Client, Proxy};
+use std::collections::HashSet;
 use swirl::Runner;
 use url::Url;
 
@@ -335,6 +336,7 @@ fn simple_config() -> config::Server {
         use_test_database_pool: true,
         instance_metrics_log_every_seconds: None,
         force_unconditional_redirects: false,
+        blocked_routes: HashSet::new(),
     }
 }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -27,7 +27,7 @@ mod json;
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{
     InsecurelyGeneratedTokenRevoked, MetricsDisabled, NotFound, OwnershipInvitationExpired,
-    ReadOnlyMode, TooManyRequests,
+    ReadOnlyMode, RouteBlocked, TooManyRequests,
 };
 
 /// Returns an error with status 200 and the provided description as JSON

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -257,3 +257,21 @@ impl fmt::Display for MetricsDisabled {
         f.write_str("Metrics are disabled on this crates.io instance")
     }
 }
+
+#[derive(Debug)]
+pub(crate) struct RouteBlocked;
+
+impl AppError for RouteBlocked {
+    fn response(&self) -> Option<AppResponse> {
+        Some(json_error(
+            &self.to_string(),
+            StatusCode::SERVICE_UNAVAILABLE,
+        ))
+    }
+}
+
+impl fmt::Display for RouteBlocked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("This route is temporarily blocked. See https://status.crates.io.")
+    }
+}


### PR DESCRIPTION
This PR adds the `BLOCKED_ROUTES` environment variable, which allows to block individual routes through the environment. This is going to be useful during incident response if we need to block an individual route (for example if the route is degrading the performance of the database), as it would remove the need to deploy an hotfix to disable that route.

r? @jtgeibel 