### PR TITLE
Cargo: Use v2 resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 description = "Backend of crates.io"
 edition = "2018"
+resolver = "2"
 default-run = "server"
 
 [workspace]

--- a/src/s3/Cargo.toml
+++ b/src/s3/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 description = "Interaction between crates.io and S3 for storing crate files"
 edition = "2018"
+resolver = "2"
 
 [lib]
 


### PR DESCRIPTION
see https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2

It doesn't make a difference for us right now, but I guess we should move to the new resolver instead of staying behind on the old one for no reason :)