### PR TITLE
errors: Derive `Error` (and `Display`) for `AppErrToStdErr`

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -253,16 +253,9 @@ pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
     })
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
 struct AppErrToStdErr(pub Box<dyn AppError>);
-
-impl Error for AppErrToStdErr {}
-
-impl fmt::Display for AppErrToStdErr {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 pub(crate) fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
     Box::new(AppErrToStdErr(e))


### PR DESCRIPTION
Instead of implementing `Error` and `Display` ourselves we can rely on https://github.com/dtolnay/thiserror to derive them for us.