### PR TITLE
Update documentation on krate::downloads controller

### DIFF
--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -1,7 +1,7 @@
 //! Endpoint for exposing crate download counts
 //!
-//! The enpoints for download a crate and exposing version specific
-//! download counts are located in `krate::downloads`.
+//! The endpoint for downloading a crate and exposing version specific
+//! download counts are located in `version::downloads`.
 
 use std::cmp;
 


### PR DESCRIPTION
Fix some typo and inaccurate documentation where version specific download counts should be in `version::downloads` instead of `krate::downloads` (which is the current file)

