### PR TITLE
Split `LogRequests` middleware into multiple middlewares

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -10,6 +10,7 @@ use self::ember_html::EmberHtml;
 use self::head::Head;
 use self::known_error_to_json::KnownErrorToJson;
 use self::log_connection_pool_status::LogConnectionPoolStatus;
+use self::request_timing::RequestTiming;
 use self::static_or_continue::StaticOrContinue;
 use self::update_metrics::UpdateMetrics;
 
@@ -23,6 +24,7 @@ mod known_error_to_json;
 mod log_connection_pool_status;
 pub mod log_request;
 mod normalize_path;
+mod request_timing;
 mod require_user_agent;
 mod static_or_continue;
 mod update_metrics;
@@ -47,6 +49,8 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
         m.add(log_request::LogRequests::default());
         m.around(SentryMiddleware::default());
     }
+
+    m.add(RequestTiming::default());
 
     if env == Env::Development {
         // Optionally print debug information for each request

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -11,6 +11,7 @@ use self::head::Head;
 use self::known_error_to_json::KnownErrorToJson;
 use self::log_connection_pool_status::LogConnectionPoolStatus;
 use self::request_timing::RequestTiming;
+use self::sentry::SentryMiddleware as CustomSentryMiddleware;
 use self::static_or_continue::StaticOrContinue;
 use self::update_metrics::UpdateMetrics;
 
@@ -26,6 +27,7 @@ pub mod log_request;
 mod normalize_path;
 mod request_timing;
 mod require_user_agent;
+mod sentry;
 mod static_or_continue;
 mod update_metrics;
 
@@ -47,6 +49,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
 
     if env != Env::Test {
         m.add(log_request::LogRequests::default());
+        m.add(CustomSentryMiddleware::default());
         m.around(SentryMiddleware::default());
     }
 

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -7,6 +7,7 @@ use crate::util::request_header;
 use conduit::{header, RequestExt, StatusCode};
 use conduit_cookie::RequestSession;
 
+use crate::middleware::normalize_path::OriginalPath;
 use crate::middleware::request_timing::ResponseTime;
 use std::fmt::{self, Display, Formatter};
 
@@ -15,15 +16,7 @@ const SLOW_REQUEST_THRESHOLD_MS: u64 = 1000;
 #[derive(Default)]
 pub(super) struct LogRequests();
 
-struct OriginalPath(String);
-
 impl Middleware for LogRequests {
-    fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
-        let path = OriginalPath(req.path().to_string());
-        req.mut_extensions().insert(path);
-        Ok(())
-    }
-
     fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
         let response_time = req.extensions().find::<ResponseTime>().unwrap();
 

--- a/src/middleware/request_timing.rs
+++ b/src/middleware/request_timing.rs
@@ -1,0 +1,66 @@
+use super::prelude::*;
+use crate::util::request_header;
+
+use conduit::RequestExt;
+
+use std::fmt::{self, Display, Formatter};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[derive(Default)]
+pub struct RequestTiming();
+
+pub struct ResponseTime(u64);
+
+impl ResponseTime {
+    pub fn as_millis(&self) -> u64 {
+        self.0
+    }
+}
+
+impl Display for ResponseTime {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)?;
+        f.write_str("ms")?;
+        Ok(())
+    }
+}
+
+impl Middleware for RequestTiming {
+    fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
+        let response_time =
+            if let Ok(start_ms) = request_header(req, "x-request-start").parse::<u128>() {
+                let current_ms = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .expect("Time went way backwards")
+                    .as_millis();
+
+                if current_ms > start_ms {
+                    // The result cannot be negative
+                    current_ms - start_ms
+                } else {
+                    // Because our nginx proxy and app run on the same dyno in production, we
+                    // shouldn't have to worry about clock drift. But if something goes wrong,
+                    // calculate the response time based on when the request reached this app.
+                    fallback_response_time(req)
+                }
+            } else {
+                // X-Request-Start header couldn't be parsed.
+                // We are probably running locally and not behind nginx.
+                fallback_response_time(req)
+            };
+
+        // This will only trucate for requests lasting > 500 million years
+        let response_time = response_time as u64;
+
+        req.mut_extensions().insert(ResponseTime(response_time));
+
+        res
+    }
+}
+
+/// Calculate the response time based on when the request reached the in-app web server.
+///
+/// This serves as a fallback in case the `X-Request-Start` header is missing or invalid.
+fn fallback_response_time(req: &mut dyn RequestExt) -> u128 {
+    req.elapsed().as_millis()
+}

--- a/src/middleware/sentry.rs
+++ b/src/middleware/sentry.rs
@@ -1,0 +1,55 @@
+use super::prelude::*;
+use crate::middleware::log_request::CustomMetadata;
+use crate::middleware::request_timing::ResponseTime;
+use conduit::{RequestExt, StatusCode};
+use conduit_cookie::RequestSession;
+
+#[derive(Default)]
+pub struct SentryMiddleware();
+
+impl Middleware for SentryMiddleware {
+    fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
+        sentry::configure_scope(|scope| {
+            {
+                let id = req.session().get("user_id").map(|str| str.to_string());
+
+                let user = sentry::User {
+                    id,
+                    ..Default::default()
+                };
+
+                scope.set_user(Some(user));
+            }
+
+            if let Some(request_id) = req
+                .headers()
+                .get("x-request-id")
+                .and_then(|value| value.to_str().ok())
+            {
+                scope.set_tag("request.id", request_id);
+            }
+
+            {
+                let status = res
+                    .as_ref()
+                    .map(|resp| resp.status())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+                scope.set_tag("response.status", status.as_str());
+            }
+
+            let response_time = req.extensions().find::<ResponseTime>();
+            if let Some(response_time) = response_time {
+                scope.set_extra("Response time [ms]", response_time.as_millis().into());
+            }
+
+            if let Some(metadata) = req.extensions().find::<CustomMetadata>() {
+                for (key, value) in &metadata.entries {
+                    scope.set_extra(key, value.to_string().into());
+                }
+            }
+        });
+
+        res
+    }
+}


### PR DESCRIPTION
The `LogRequests` middleware is currently performing multiple tasks:

- Save `req.path()` before the `NormalizePath` middleware potentially mutates the request path
- Calculate response timing based on the `x-request-start` HTTP header from Heroku (or the `StartInstant` extension as a fallback)
- Log requests to stdout
- Report errors to Sentry

The Sentry error reporting was originally built into the `LogRequests` middleware because it also needed access to the original path and the response timing.

This PR proposes to split the `LogRequests` middleware, so that each middlewares is performing only one of the functions respectively:

- The "original path" code is moved into the `NormalizePath` middleware that is responsible for mutating the path in the first place
- The request timing code is moved into a new `RequestTiming` middleware, which saves the response time in the request extension map
- The Sentry error reporting code is moved into a new `SentryMiddleware`