### PR TITLE
errors: Remove `ChainError` impl for `Option`

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -130,7 +130,7 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
 
         let content_length = req
             .content_length()
-            .chain_error(|| cargo_err("missing header: Content-Length"))?;
+            .ok_or_else(|| cargo_err("missing header: Content-Length"))?;
 
         let maximums = Maximums::new(
             krate.max_upload_size,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -10,7 +10,7 @@ use crate::models::{
     Crate, CrateBadge, CrateOwner, CrateVersions, OwnerKind, TopVersions, Version,
 };
 use crate::schema::*;
-use crate::util::errors::{bad_request, ChainError};
+use crate::util::errors::bad_request;
 use crate::views::EncodableCrate;
 
 use crate::controllers::helpers::pagination::{Page, Paginated, PaginationOptions};
@@ -153,7 +153,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
             letter
                 .chars()
                 .next()
-                .chain_error(|| bad_request("letter value must contain 1 character"))?
+                .ok_or_else(|| bad_request("letter value must contain 1 character"))?
                 .to_lowercase()
                 .collect::<String>()
         );

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -39,7 +39,7 @@ pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
     let max_size = 2000;
     let length = req
         .content_length()
-        .chain_error(|| bad_request("missing header: Content-Length"))?;
+        .ok_or_else(|| bad_request("missing header: Content-Length"))?;
 
     if length > max_size {
         return Err(bad_request(&format!("max content length is: {}", max_size)));

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -165,19 +165,6 @@ impl<T, E: AppError> ChainError<T> for Result<T, E> {
     }
 }
 
-impl<T> ChainError<T> for Option<T> {
-    fn chain_error<E, C>(self, callback: C) -> AppResult<T>
-    where
-        E: AppError,
-        C: FnOnce() -> E,
-    {
-        match self {
-            Some(t) => Ok(t),
-            None => Err(Box::new(callback())),
-        }
-    }
-}
-
 impl<E: AppError> AppError for ChainedError<E> {
     fn response(&self) -> Option<AppResponse> {
         self.error.response()
@@ -264,8 +251,7 @@ pub(crate) fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
 #[test]
 fn chain_error_internal() {
     assert_eq!(
-        None::<()>
-            .chain_error(|| internal("inner"))
+        Err::<(), _>(internal("inner"))
             .chain_error(|| internal("middle"))
             .chain_error(|| internal("outer"))
             .unwrap_err()


### PR DESCRIPTION
For `Option` there is nothing to chain onto, so we might as well use the built-in `ok_or_else()` method to convert the `Option` to a `Result`.