### PR TITLE
Remove `ChainError` trait

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -19,7 +19,7 @@ mod prelude {
 
     pub use crate::db::RequestTransaction;
     pub use crate::middleware::app::RequestApp;
-    pub use crate::util::errors::{cargo_err, AppError, AppResult, ChainError}; // TODO: Remove cargo_err from here
+    pub use crate::util::errors::{cargo_err, AppError, AppResult}; // TODO: Remove cargo_err from here
     pub use crate::util::{AppResponse, EndpointResult};
 
     use indexmap::IndexMap;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -130,7 +130,7 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
 
         let content_length = req
             .content_length()
-            .chain_error(|| cargo_err("missing header: Content-Length"))?;
+            .ok_or_else(|| cargo_err("missing header: Content-Length"))?;
 
         let maximums = Maximums::new(
             krate.max_upload_size,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -10,7 +10,7 @@ use crate::models::{
     Crate, CrateBadge, CrateOwner, CrateVersions, OwnerKind, TopVersions, Version,
 };
 use crate::schema::*;
-use crate::util::errors::{bad_request, ChainError};
+use crate::util::errors::bad_request;
 use crate::views::EncodableCrate;
 
 use crate::controllers::helpers::pagination::{Page, Paginated, PaginationOptions};
@@ -153,7 +153,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
             letter
                 .chars()
                 .next()
-                .chain_error(|| bad_request("letter value must contain 1 character"))?
+                .ok_or_else(|| bad_request("letter value must contain 1 character"))?
                 .to_lowercase()
                 .collect::<String>()
         );

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -39,7 +39,7 @@ pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
     let max_size = 2000;
     let length = req
         .content_length()
-        .chain_error(|| bad_request("missing header: Content-Length"))?;
+        .ok_or_else(|| bad_request("missing header: Content-Length"))?;
 
     if length > max_size {
         return Err(bad_request(&format!("max content length is: {}", max_size)));

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -187,7 +187,7 @@ pub fn regenerate_token_and_send(req: &mut dyn RequestExt) -> EndpointResult {
 
     let param_user_id = req.params()["user_id"]
         .parse::<i32>()
-        .chain_error(|| bad_request("invalid user_id"))?;
+        .map_err(|err| err.chain(bad_request("invalid user_id")))?;
     let authenticated_user = req.authenticate()?;
     let conn = req.db_conn()?;
     let user = authenticated_user.user();

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -2,7 +2,6 @@ use crate::controllers::frontend_prelude::*;
 
 use crate::models::{CrateOwner, OwnerKind, User};
 use crate::schema::{crate_owners, crates, users};
-use crate::util::errors::ChainError;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
@@ -25,7 +24,7 @@ pub fn stats(req: &mut dyn RequestExt) -> EndpointResult {
 
     let user_id = &req.params()["user_id"]
         .parse::<i32>()
-        .chain_error(|| bad_request("invalid user_id"))?;
+        .map_err(|err| err.chain(bad_request("invalid user_id")))?;
     let conn = req.db_conn()?;
 
     let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -90,7 +90,7 @@ pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
         .github_oauth
         .exchange_code(code)
         .request(http_client)
-        .chain_error(|| server_error("Error obtaining token"))?;
+        .map_err(|err| err.chain(server_error("Error obtaining token")))?;
     let token = token.access_token();
 
     // Fetch the user info from GitHub using the access token we just got and create a user record

--- a/src/router.rs
+++ b/src/router.rs
@@ -179,9 +179,7 @@ impl<H: Handler> Handler for R<H> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::errors::{
-        bad_request, cargo_err, forbidden, internal, not_found, AppError, ChainError,
-    };
+    use crate::util::errors::{bad_request, cargo_err, forbidden, internal, not_found, AppError};
     use crate::util::EndpointResult;
 
     use conduit::StatusCode;
@@ -227,8 +225,8 @@ mod tests {
         let response = C(|_| {
             Err("-1"
                 .parse::<u8>()
-                .chain_error(|| internal("middle error"))
-                .chain_error(|| bad_request("outer user facing error"))
+                .map_err(|err| err.chain(internal("middle error")))
+                .map_err(|err| err.chain(bad_request("outer user facing error")))
                 .unwrap_err())
         })
         .call(&mut req)

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -175,19 +175,6 @@ impl<T, E: AppError> ChainError<T> for Result<T, E> {
     }
 }
 
-impl<T> ChainError<T> for Option<T> {
-    fn chain_error<E, C>(self, callback: C) -> AppResult<T>
-    where
-        E: AppError,
-        C: FnOnce() -> E,
-    {
-        match self {
-            Some(t) => Ok(t),
-            None => Err(Box::new(callback())),
-        }
-    }
-}
-
 impl<E: AppError> AppError for ChainedError<E> {
     fn response(&self) -> Option<AppResponse> {
         self.error.response()
@@ -274,8 +261,7 @@ pub(crate) fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
 #[test]
 fn chain_error_internal() {
     assert_eq!(
-        None::<()>
-            .chain_error(|| internal("inner"))
+        Err::<(), _>(internal("inner"))
             .chain_error(|| internal("middle"))
             .chain_error(|| internal("outer"))
             .unwrap_err()


### PR DESCRIPTION
The `chain_error()` function can be replaced by `ok_or_else()` (for `Option`) or `map_err()` (for `Result`), which makes the intent a little clearer, and removes one of the layers of indirection from our error handling, without being significantly more verbose.

Please note that this only removes the `ChainError` **trait**, but the `ChainedError` **struct** still exists.