### PR TITLE
Match monospace font with main font

### DIFF
--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -11,7 +11,8 @@
     --footer-bg-color: var(--green800);
 
     --font-sans: "Fira Sans", sans-serif;
-    --font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --font-monospace: "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+        "Courier New", monospace;
 
     --main-color: #383838;
     --main-color-light: #858585;


### PR DESCRIPTION
Since Fira Sans is used across crates.io, it makes sense to use Fira Mono for monospaced text to increase consistency. After Fira Mono there is now `ui-monospace` in the font stack, which renders as SF Mono on Safari without having to manually install SF Mono. `ui-monospace` [is part of](https://www.w3.org/TR/css-fonts-4/#ui-monospace-def) the CSS Fonts Module Level 4 draft.