### PR TITLE
KnownErrorToJson: Replace unit test with acceptance test

### DIFF
--- a/src/middleware/known_error_to_json.rs
+++ b/src/middleware/known_error_to_json.rs
@@ -24,28 +24,3 @@ impl Middleware for KnownErrorToJson {
         })
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::KnownErrorToJson;
-
-    use conduit::{Body, Handler, Method, StatusCode};
-    use conduit_middleware::MiddlewareBuilder;
-    use conduit_router::RouteBuilder;
-    use conduit_test::MockRequest;
-
-    #[test]
-    fn router_errors_become_not_found_response() {
-        let route_builder = RouteBuilder::new();
-        let mut middleware = MiddlewareBuilder::new(route_builder);
-        middleware.add(KnownErrorToJson);
-
-        let mut req = MockRequest::new(Method::GET, "/");
-        let (parts, body) = middleware.call(&mut req).unwrap().into_parts();
-        assert_eq!(parts.status, StatusCode::NOT_FOUND);
-        assert!(matches!(
-            body,
-            Body::Owned(vec) if vec == br#"{"errors":[{"detail":"Not Found"}]}"#
-        ));
-    }
-}

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -40,6 +40,7 @@ mod git;
 mod keyword;
 mod krate;
 mod metrics;
+mod not_found_error;
 mod owners;
 mod read_only_mode;
 mod record;

--- a/src/tests/not_found_error.rs
+++ b/src/tests/not_found_error.rs
@@ -1,0 +1,26 @@
+use crate::{RequestHelper, TestApp};
+use http::StatusCode;
+
+#[test]
+fn visiting_unknown_route_returns_404() {
+    let (_, anon) = TestApp::init().empty();
+
+    let response = anon.get::<()>("/does-not-exist");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        response.into_json(),
+        json!({ "errors": [{ "detail": "Not Found" }] })
+    );
+}
+
+#[test]
+fn visiting_unknown_api_route_returns_404() {
+    let (_, anon) = TestApp::init().empty();
+
+    let response = anon.get::<()>("/api/v1/does-not-exist");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        response.into_json(),
+        json!({ "errors": [{ "detail": "Not Found" }] })
+    );
+}


### PR DESCRIPTION
We don't care about the exact implementation details (middleware), but we do care that we get a 404 error with JSON payload back. This will make it easier to refactor the implementation in the future.