### PR TITLE
LogRequest: Use `at=error` for all 5xx status code responses

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -198,9 +198,13 @@ impl Display for RequestLine<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut line = LogLine::new(f);
 
-        let (at, status) = match self.res {
-            Ok(resp) => ("info", resp.status()),
-            Err(_) => ("error", StatusCode::INTERNAL_SERVER_ERROR),
+        let status = self.res.as_ref().map(|res| res.status());
+        let status = status.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+        let at = if status.is_server_error() {
+            "error"
+        } else {
+            "info"
         };
 
         line.add_field("at", at)?;


### PR DESCRIPTION
We are currently only using `at=error` for cases where the route handler did not explicitly return a 5xx status code, but we should probably use it for all cases where 5xx is returned. This PR changes the code to achieve that.