### PR TITLE
Update `handlebars` crate to v4.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "3.5.5"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4498fc115fa7d34de968184e473529abb40eeb6be8bc5f7faba3d08c316cb3e3"
+checksum = "66b09e2322d20d14bc2572401ce7c1d60b4748580a76c230ed9c1f8938f0c833"
 dependencies = [
  "log",
  "pest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ flate2 = "1.0"
 futures-channel = { version = "0.3.1", default-features = false }
 futures-util = "0.3"
 git2 = "0.13.0"
-handlebars = "3.0.1"
+handlebars = "4.1.3"
 hex = "0.4"
 htmlescape = "0.3.1"
 http = "0.2"

--- a/src/tasks/dump_db/dump-export.sql.hbs
+++ b/src/tasks/dump_db/dump-export.sql.hbs
@@ -1,9 +1,9 @@
 BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
-{{~#each tables}}
-{{~#if this.filter}}
+{{#each tables}}
+{{#if this.filter}}
     \copy (SELECT {{this.columns}} FROM "{{this.name}}" WHERE {{this.filter}}) TO 'data/{{this.name}}.csv' WITH CSV HEADER
-{{~else}}
+{{else}}
     \copy "{{this.name}}" ({{this.columns}}) TO 'data/{{this.name}}.csv' WITH CSV HEADER
-{{~/if}}
-{{~/each}}
+{{/if}}
+{{/each}}
 COMMIT;

--- a/src/tasks/dump_db/dump-import.sql.hbs
+++ b/src/tasks/dump_db/dump-import.sql.hbs
@@ -1,38 +1,38 @@
 BEGIN;
     -- Disable triggers on each table.
-{{~#each tables}}
+{{#each tables}}
     ALTER TABLE "{{this.name}}" DISABLE TRIGGER ALL;
-{{~/each}}
+{{/each}}
 
     -- Set defaults for non-nullable columns not included in the dump.
-{{~#each tables as |table|}}
-{{~#each column_defaults}}
+{{#each tables as |table|}}
+{{#each column_defaults}}
     ALTER TABLE "{{table.name}}" ALTER COLUMN "{{@key}}" SET DEFAULT {{this}};
-{{~/each}}
-{{~/each}}
+{{/each}}
+{{/each}}
 
     -- Truncate all tables.
-{{~#each tables}}
+{{#each tables}}
     TRUNCATE "{{this.name}}" RESTART IDENTITY CASCADE;
-{{~/each}}
+{{/each}}
 
     -- Enable this trigger so that `crates.textsearchable_index_col` can be excluded from the export
     ALTER TABLE "crates" ENABLE TRIGGER "trigger_crates_tsvector_update";
 
     -- Import the CSV data.
-{{~#each tables}}
+{{#each tables}}
     \copy "{{this.name}}" ({{this.columns}}) FROM 'data/{{this.name}}.csv' WITH CSV HEADER
-{{~/each}}
+{{/each}}
 
     -- Drop the defaults again.
-{{~#each tables as |table|}}
-{{~#each column_defaults}}
+{{#each tables as |table|}}
+{{#each column_defaults}}
     ALTER TABLE "{{table.name}}" ALTER COLUMN "{{@key}}" DROP DEFAULT;
-{{~/each}}
-{{~/each}}
+{{/each}}
+{{/each}}
 
     -- Reenable triggers on each table.
-{{~#each tables}}
+{{#each tables}}
     ALTER TABLE "{{this.name}}" ENABLE TRIGGER ALL;
-{{~/each}}
+{{/each}}
 COMMIT;


### PR DESCRIPTION
see https://github.com/sunng87/handlebars-rust/blob/master/CHANGELOG.md

~It looks like none of the breaking changes in the v4 release are relevant to us.~

Update: I was wrong, https://github.com/sunng87/handlebars-rust/pull/404 does affect us. I've added another commit which removes the now problematic handlebars whitespace control characters.