### PR TITLE
Don't save `cargo login $token` command to shell history

### DIFF
--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -97,7 +97,7 @@
           its value again. For use on the command line you can save it to <code>~/.cargo/credentials</code>
           with:
 
-          <pre class="terminal">cargo login {{token.token}}</pre>
+          <pre class="terminal"> cargo login {{token.token}}</pre>
         </div>
       </div>
     {{/if}}


### PR DESCRIPTION
Most unix shells do not save commands starting with a space to history.

Prefixing the suggested `cargo login $token` command with a space makes stealing crates.io credentials a little bit harder.