### PR TITLE
renovatebot: Remove `assignees` from pull requests

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,6 @@
         "enabled": false
     },
     "js": {
-        "assignees": ["locks", "pichfl", "Turbo87"],
-        "assigneesSampleSize": 1,
         "labels": ["A-frontend"],
         "reviewers": ["locks", "pichfl", "Turbo87"],
         "reviewersSampleSize": 1


### PR DESCRIPTION
`reviewers` is enough, we don't need `assignees` too