### PR TITLE
sentry: Enable `tracing` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ dependencies = [
  "sentry-contexts",
  "sentry-core",
  "sentry-panic",
+ "sentry-tracing",
  "tokio",
 ]
 
@@ -2296,6 +2297,17 @@ checksum = "692bf989f0c99f025e33d7f58e62822c3771f56d189698c66dcc863122255d95"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d291df287241b0ef97f5bf9e9a595691ef8dfb49bc6acfd55b9dc2ade681f1c9"
+dependencies = [
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ rand = "0.8"
 reqwest = { version = "0.11", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "0.2.0"
 semver = { version = "1.0.3", features = ["serde"] }
-sentry = "0.23.0"
+sentry = { version = "0.23.0", features = ["tracing"] }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 sha2 = "0.9"

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -25,8 +25,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .parse::<filter::Targets>()
         .expect("Invalid RUST_LOG value");
 
+    let sentry_filter = filter::Targets::new().with_default(Level::INFO);
+
     tracing_subscriber::registry()
         .with(tracing_subscriber::fmt::layer().with_filter(log_filter))
+        .with(sentry::integrations::tracing::layer().with_filter(sentry_filter))
         .init();
 
     let config = cargo_registry::config::Server::default();

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{metrics::LogEncoder, util::errors::AppResult, App, Env};
-use std::{fs::File, process::Command, sync::Arc, time::Duration};
+use std::{env, fs::File, process::Command, sync::Arc, time::Duration};
 
 use conduit_hyper::Service;
 use futures_util::future::FutureExt;
@@ -10,6 +10,8 @@ use reqwest::blocking::Client;
 use std::io::Write;
 use tokio::io::AsyncWriteExt;
 use tokio::signal::unix::{signal, SignalKind};
+use tracing::Level;
+use tracing_subscriber::{filter, prelude::*};
 
 const CORE_THREADS: usize = 4;
 
@@ -17,7 +19,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _sentry = cargo_registry::sentry::init();
 
     // Initialize logging
-    tracing_subscriber::fmt::init();
+
+    let log_filter = env::var("RUST_LOG")
+        .unwrap_or_default()
+        .parse::<filter::Targets>()
+        .expect("Invalid RUST_LOG value");
+
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer().with_filter(log_filter))
+        .init();
 
     let config = cargo_registry::config::Server::default();
     let env = config.env();


### PR DESCRIPTION
https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.2.21 enables us to use per-layer event filters, which previously blocked us from using the `tracing` feature of `sentry`. This PR enables the feature using the default configuration, which reports all `error!()` usages as errors and `warn!()` and `info!()` as breadcrumbs for associated errors.