### PR TITLE
Extract Sentry initialization code into dedicated function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ pub mod util;
 pub mod controllers;
 pub mod models;
 mod router;
+pub mod sentry;
 pub mod views;
 
 /// Used for setting different values depending on whether the app is being run in production,

--- a/src/sentry.rs
+++ b/src/sentry.rs
@@ -1,0 +1,22 @@
+use sentry::{ClientInitGuard, ClientOptions, IntoDsn};
+use std::borrow::Cow;
+
+#[must_use]
+pub fn init() -> Option<ClientInitGuard> {
+    dotenv::var("SENTRY_DSN_API")
+        .ok()
+        .into_dsn()
+        .expect("SENTRY_DSN_API is not a valid Sentry DSN value")
+        .map(|dsn| {
+            let mut opts = ClientOptions::from(dsn);
+            opts.environment = Some(
+                dotenv::var("SENTRY_ENV_API")
+                    .map(Cow::Owned)
+                    .expect("SENTRY_ENV_API must be set when using SENTRY_DSN_API"),
+            );
+
+            opts.release = dotenv::var("HEROKU_SLUG_COMMIT").ok().map(Into::into);
+
+            sentry::init(opts)
+        })
+}

--- a/src/sentry.rs
+++ b/src/sentry.rs
@@ -1,6 +1,14 @@
 use sentry::{ClientInitGuard, ClientOptions, IntoDsn};
 use std::borrow::Cow;
 
+/// Initializes the Sentry SDK from the environment variables.
+///
+/// If `SENTRY_DSN_API` is not set then Sentry will not be initialized,
+/// otherwise it is required to be a valid DSN string. `SENTRY_ENV_API` must
+/// be set if a DSN is provided.
+///
+/// `HEROKU_SLUG_COMMIT`, if present, will be used as the `release` property
+/// on all events.
 #[must_use]
 pub fn init() -> Option<ClientInitGuard> {
     dotenv::var("SENTRY_DSN_API")


### PR DESCRIPTION
This will allow us to more easily enable Sentry error reporting for the other binaries too.