### PR TITLE
Split DB_POOL_SIZE & DB_MIN_IDLE environment variables

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,10 +33,15 @@
           "required": false,
           "description": "The maximum number of replica database connections managed by the pool. Set so that this value times the number of dynos is less than your connection limit."
       },
-      "DB_MIN_IDLE": {
+      "DB_PRIMARY_MIN_IDLE": {
           "value": "5",
           "required": false,
-          "description": "The pool will try to maintain at least this many idle connections at all times, while respecting the maximum size of the pool."
+          "description": "The pool will try to maintain at least this many idle connections on the primary database at all times, while respecting the maximum size of the pool."
+      },
+      "DB_REPLICA_MIN_IDLE": {
+          "value": "1",
+          "required": false,
+          "description": "The pool will try to maintain at least this many idle connections on the replica database at all times, while respecting the maximum size of the pool."
       },
       "DB_HELPER_THREADS": {
           "value": "3",

--- a/app.json
+++ b/app.json
@@ -23,10 +23,15 @@
           "value": "",
           "required": false
       },
-      "DB_POOL_SIZE": {
+      "DB_PRIMARY_POOL_SIZE": {
           "value": "10",
           "required": false,
-          "description": "The maximum number of database connections managed by the pool. Set so that this value times the number of dynos is less than your connection limit."
+          "description": "The maximum number of primary database connections managed by the pool. Set so that this value times the number of dynos is less than your connection limit."
+      },
+      "DB_REPLICA_POOL_SIZE": {
+          "value": "3",
+          "required": false,
+          "description": "The maximum number of replica database connections managed by the pool. Set so that this value times the number of dynos is less than your connection limit."
       },
       "DB_MIN_IDLE": {
           "value": "5",

--- a/src/app.rs
+++ b/src/app.rs
@@ -101,7 +101,7 @@ impl App {
             };
 
             let primary_db_config = r2d2::Pool::builder()
-                .max_size(config.db.primary_max_pool_size())
+                .max_size(config.db.primary.pool_size)
                 .min_idle(config.db.primary.min_idle)
                 .connection_timeout(Duration::from_secs(db_connection_timeout))
                 .connection_customizer(Box::new(primary_db_connection_config))

--- a/src/app.rs
+++ b/src/app.rs
@@ -76,12 +76,6 @@ impl App {
             ),
         );
 
-        let db_min_idle = match (dotenv::var("DB_MIN_IDLE"), config.env()) {
-            (Ok(num), _) => Some(num.parse().expect("couldn't parse DB_MIN_IDLE")),
-            (_, Env::Production) => Some(5),
-            _ => None,
-        };
-
         let db_helper_threads = match (dotenv::var("DB_HELPER_THREADS"), config.env()) {
             (Ok(num), _) => num.parse().expect("couldn't parse DB_HELPER_THREADS"),
             (_, Env::Production) => 3,
@@ -108,7 +102,7 @@ impl App {
 
             let primary_db_config = r2d2::Pool::builder()
                 .max_size(config.db.primary_max_pool_size())
-                .min_idle(db_min_idle)
+                .min_idle(config.db.primary.min_idle)
                 .connection_timeout(Duration::from_secs(db_connection_timeout))
                 .connection_customizer(Box::new(primary_db_connection_config))
                 .thread_pool(thread_pool.clone());
@@ -134,7 +128,7 @@ impl App {
 
                 let replica_db_config = r2d2::Pool::builder()
                     .max_size(pool_config.pool_size)
-                    .min_idle(db_min_idle)
+                    .min_idle(pool_config.min_idle)
                     .connection_timeout(Duration::from_secs(db_connection_timeout))
                     .connection_customizer(Box::new(replica_db_connection_config))
                     .thread_pool(thread_pool);

--- a/src/app.rs
+++ b/src/app.rs
@@ -76,12 +76,6 @@ impl App {
             ),
         );
 
-        let db_pool_size = match (dotenv::var("DB_POOL_SIZE"), config.env()) {
-            (Ok(num), _) => num.parse().expect("couldn't parse DB_POOL_SIZE"),
-            (_, Env::Production) => 10,
-            _ => 3,
-        };
-
         let db_min_idle = match (dotenv::var("DB_MIN_IDLE"), config.env()) {
             (Ok(num), _) => Some(num.parse().expect("couldn't parse DB_MIN_IDLE")),
             (_, Env::Production) => Some(5),
@@ -113,7 +107,7 @@ impl App {
             };
 
             let primary_db_config = r2d2::Pool::builder()
-                .max_size(db_pool_size)
+                .max_size(config.db.primary_max_pool_size())
                 .min_idle(db_min_idle)
                 .connection_timeout(Duration::from_secs(db_connection_timeout))
                 .connection_customizer(Box::new(primary_db_connection_config))
@@ -139,7 +133,7 @@ impl App {
                 };
 
                 let replica_db_config = r2d2::Pool::builder()
-                    .max_size(db_pool_size)
+                    .max_size(config.db.replica_max_pool_size())
                     .min_idle(db_min_idle)
                     .connection_timeout(Duration::from_secs(db_connection_timeout))
                     .connection_customizer(Box::new(replica_db_connection_config))

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -4,6 +4,8 @@
 //! - `READ_ONLY_REPLICA_URL`: The URL of an optional postgres read-only replica database.
 //! - `DB_PRIMARY_POOL_SIZE`: The number of connections of the primary database.
 //! - `DB_REPLICA_POOL_SIZE`: The number of connections of the read-only / replica database.
+//! - `DB_PRIMARY_MIN_IDLE`: The primary pool will maintain at least this number of connections.
+//! - `DB_REPLICA_MIN_IDLE`: The replica pool will maintain at least this number of connections.
 //! - `DB_OFFLINE`: If set to `leader` then use the read-only follower as if it was the leader.
 //!   If set to `follower` then act as if `READ_ONLY_REPLICA_URL` was unset.
 //! - `READ_ONLY_MODE`: If defined (even as empty) then force all connections to be read-only.

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -32,17 +32,6 @@ impl DatabasePools {
     pub fn are_all_read_only(&self) -> bool {
         self.primary.read_only_mode
     }
-
-    pub fn primary_max_pool_size(&self) -> u32 {
-        self.primary.pool_size
-    }
-
-    pub fn replica_max_pool_size(&self) -> u32 {
-        self.replica
-            .as_ref()
-            .map(|config| config.pool_size)
-            .unwrap_or(Self::DEFAULT_POOL_SIZE)
-    }
 }
 
 impl DatabasePools {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -83,7 +83,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     // In production we currently have 2 equally sized pools (primary and a read-only replica).
     // Because such a large portion of production traffic is for download requests (which update
     // download counts), we consider only the primary pool here.
-    if let Ok(capacity) = env::var("DB_POOL_SIZE") {
+    if let Ok(capacity) = env::var("DB_PRIMARY_POOL_SIZE") {
         if let Ok(capacity) = capacity.parse() {
             if capacity >= 10 {
                 println!(
@@ -92,7 +92,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
                 );
                 m.around(balance_capacity::BalanceCapacity::new(capacity))
             } else {
-                println!("BalanceCapacity middleware not enabled. DB_POOL_SIZE is too low.");
+                println!("BalanceCapacity middleware not enabled. DB_PRIMARY_POOL_SIZE is too low.");
             }
         }
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -92,7 +92,9 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
                 );
                 m.around(balance_capacity::BalanceCapacity::new(capacity))
             } else {
-                println!("BalanceCapacity middleware not enabled. DB_PRIMARY_POOL_SIZE is too low.");
+                println!(
+                    "BalanceCapacity middleware not enabled. DB_PRIMARY_POOL_SIZE is too low."
+                );
             }
         }
     }

--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -88,7 +88,8 @@ impl ServerBin {
         // Bind a random port every time the server is started.
         env.insert("PORT".into(), "0".into());
         // Avoid creating too many database connections.
-        env.insert("DB_POOL_SIZE".into(), "2".into());
+        env.insert("DB_PRIMARY_POOL_SIZE".into(), "2".into());
+        env.insert("DB_REPLICA_POOL_SIZE".into(), "1".into());
         env.remove("DB_MIN_SIZE");
         // Other configuration variables needed for the application to boot.
         env.insert("WEB_ALLOWED_ORIGINS".into(), "http://localhost:8888".into());


### PR DESCRIPTION
This PR splits the existing environment variables `DB_POOL_SIZE` & `DB_MIN_IDLE` into separate variables to provide different connection settings to the primary & replica databases. The main reason for this change is to be able to configure different values for both database pools.

The new env variables are:

* `DB_PRIMARY_POOL_SIZE` & `DB_REPLICA_POOL_SIZE` to configure the number of connections in the primary & replica pool
* `DB_PRIMARY_MIN_IDLE` & `DB_REPLICA_MIN_IDLE` to set the number of idle connections each pool at least maintains
* update descriptions of env vars.

**Note** the descriptions of the `*_POOL_SIZE` variables in `app.json` are most likely off & need correct wording.