### PR TITLE
markdown: Remove `README` references

### DIFF
--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -7,7 +7,7 @@ use crate::{
 use std::{io::Read, path::Path, sync::Arc, thread};
 
 use chrono::{TimeZone, Utc};
-use cio_markdown::readme_to_html;
+use cio_markdown::text_to_html;
 use clap::Clap;
 use diesel::{dsl::any, prelude::*};
 use flate2::read::GzDecoder;
@@ -212,7 +212,7 @@ fn get_readme(
             krate_name, version.num, manifest.package.readme?
         );
         let contents = find_file_by_path(&mut entries, Path::new(&path), version, krate_name);
-        readme_to_html(
+        text_to_html(
             &contents,
             manifest
                 .package

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
 //! Render README files to HTML.
 
-use cio_markdown::readme_to_html;
+use cio_markdown::text_to_html;
 use swirl::PerformError;
 
 use crate::background_jobs::Environment;
@@ -18,7 +18,7 @@ pub fn render_and_upload_readme(
     use crate::schema::*;
     use diesel::prelude::*;
 
-    let rendered = readme_to_html(&text, &readme_path, base_url.as_deref());
+    let rendered = text_to_html(&text, &readme_path, base_url.as_deref());
 
     conn.transaction(|| {
         Version::record_readme_rendering(version_id, conn)?;


### PR DESCRIPTION
This module can be used for any kind of markdown file, not just `README.md` files :)