### PR TITLE
Extract `sql` module with all custom `sql_function!()` calls

### DIFF
--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -108,7 +108,7 @@ fn check_stalled_update_downloads(conn: &PgConnection) -> Result<()> {
 
 /// Check for known spam patterns
 fn check_spam_attack(conn: &PgConnection) -> Result<()> {
-    use cargo_registry::models::krate::canon_crate_name;
+    use cargo_registry::sql::canon_crate_name;
     use diesel::dsl::*;
 
     const EVENT_KEY: &str = "spam_attack";

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -9,9 +9,8 @@ use crate::controllers::frontend_prelude::*;
 
 use crate::models::{Crate, CrateVersions, Version, VersionDownload};
 use crate::schema::version_downloads;
+use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
-
-use crate::models::krate::to_char;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -2,16 +2,17 @@ use crate::controllers::frontend_prelude::*;
 
 use crate::models::{CrateOwner, OwnerKind, User};
 use crate::schema::{crate_owners, crates, users};
+use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     use self::users::dsl::{gh_login, id, users};
 
-    let name = crate::lower(&req.params()["user_id"]);
+    let name = lower(&req.params()["user_id"]);
     let conn = req.db_conn()?;
     let user: User = users
-        .filter(crate::lower(gh_login).eq(name))
+        .filter(lower(gh_login).eq(name))
         .order(id.desc())
         .first(&*conn)?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ pub mod middleware;
 mod publish_rate_limit;
 pub mod render;
 pub mod schema;
+pub mod sql;
 pub mod tasks;
 mod test_util;
 pub mod uploaders;
@@ -126,5 +127,3 @@ pub fn env_optional<T: FromStr>(s: &str) -> Option<T> {
             .unwrap_or_else(|_| panic!("`{}` was defined but could not be parsed", s))
     })
 }
-
-sql_function!(fn lower(x: ::diesel::sql_types::Text) -> ::diesel::sql_types::Text);

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -15,7 +15,7 @@ pub struct Category {
     pub created_at: NaiveDateTime,
 }
 
-type WithSlug<'a> = diesel::dsl::Eq<categories::slug, crate::lower::HelperType<&'a str>>;
+type WithSlug<'a> = diesel::dsl::Eq<categories::slug, crate::sql::lower::HelperType<&'a str>>;
 type BySlug<'a> = diesel::dsl::Filter<categories::table, WithSlug<'a>>;
 type WithSlugsCaseSensitive<'a> = diesel::dsl::Eq<
     categories::slug,
@@ -40,7 +40,7 @@ pub struct CrateCategory {
 
 impl Category {
     pub fn with_slug(slug: &str) -> WithSlug<'_> {
-        categories::slug.eq(crate::lower(slug))
+        categories::slug.eq(crate::sql::lower(slug))
     }
 
     pub fn by_slug(slug: &str) -> BySlug<'_> {

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -3,6 +3,7 @@ use diesel::prelude::*;
 
 use crate::models::Crate;
 use crate::schema::*;
+use crate::sql::lower;
 
 #[derive(Clone, Identifiable, Queryable, Debug)]
 pub struct Keyword {
@@ -25,7 +26,7 @@ pub struct CrateKeyword {
 impl Keyword {
     pub fn find_by_keyword(conn: &PgConnection, name: &str) -> QueryResult<Keyword> {
         keywords::table
-            .filter(keywords::keyword.eq(crate::lower(name)))
+            .filter(keywords::keyword.eq(lower(name)))
             .first(&*conn)
     }
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDateTime;
 use diesel::associations::Identifiable;
 use diesel::pg::Pg;
 use diesel::prelude::*;
-use diesel::sql_types::Bool;
+use diesel::sql_types::{Bool, Text};
 use url::Url;
 
 use crate::app::App;
@@ -17,6 +17,7 @@ use crate::util::errors::{cargo_err, AppResult};
 use crate::models::helpers::with_count::*;
 use crate::publish_rate_limit::PublishRateLimit;
 use crate::schema::*;
+use crate::sql::canon_crate_name;
 
 #[derive(Debug, Queryable, Identifiable, Associations, Clone, Copy)]
 #[belongs_to(Crate)]
@@ -72,7 +73,7 @@ pub const ALL_COLUMNS: AllColumns = (
 
 pub const MAX_NAME_LENGTH: usize = 64;
 
-type CanonCrateName<T> = self::canon_crate_name::HelperType<T>;
+type CanonCrateName<T> = canon_crate_name::HelperType<T>;
 type All = diesel::dsl::Select<crates::table, AllColumns>;
 type WithName<'a> = diesel::dsl::Eq<CanonCrateName<crates::name>, CanonCrateName<&'a str>>;
 type ByName<'a> = diesel::dsl::Filter<All, WithName<'a>>;
@@ -439,10 +440,6 @@ impl Crate {
         Ok(rows.records_and_total())
     }
 }
-
-use diesel::sql_types::{Date, Text};
-sql_function!(fn canon_crate_name(x: Text) -> Text);
-sql_function!(fn to_char(a: Date, b: Text) -> Text);
 
 #[cfg(test)]
 mod tests {

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -6,6 +6,7 @@ use crate::util::errors::{cargo_err, AppResult};
 
 use crate::models::{Crate, Team, User};
 use crate::schema::{crate_owners, users};
+use crate::sql::lower;
 
 #[derive(Insertable, Associations, Identifiable, Debug, Clone, Copy)]
 #[belongs_to(Crate)]
@@ -69,7 +70,7 @@ impl Owner {
             )?))
         } else {
             users::table
-                .filter(crate::lower(users::gh_login).eq(name.to_lowercase()))
+                .filter(lower(users::gh_login).eq(name.to_lowercase()))
                 .filter(users::gh_id.ne(-1))
                 .order(users::gh_id.desc())
                 .first(conn)

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,0 +1,14 @@
+use diesel::sql_types::{Array, Date, Double, Interval, Text, Timestamp};
+
+sql_function!(#[aggregate] fn array_agg<T>(x: T) -> Array<T>);
+sql_function!(fn canon_crate_name(x: Text) -> Text);
+sql_function!(fn to_char(a: Date, b: Text) -> Text);
+sql_function!(fn lower(x: Text) -> Text);
+sql_function!(fn date_part(x: Text, y: Timestamp) -> Double);
+sql_function! {
+    #[sql_name = "date_part"]
+    fn interval_part(x: Text, y: Interval) -> Double;
+}
+sql_function!(fn floor(x: Double) -> Integer);
+sql_function!(fn greatest<T>(x: T, y: T) -> T);
+sql_function!(fn least<T>(x: T, y: T) -> T);


### PR DESCRIPTION
This seems a bit more organized compared to having them scattered all over the place.