### PR TITLE
Update `comrak` to v0.12.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "comrak"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b423acba50d5016684beaf643f9991e622633a4c858be6885653071c2da2b0c6"
+checksum = "ff3c476e1a33eb4df1212a02db79d0f788bbd760901f34f5897644623e0e4e74"
 dependencies = [
  "entities",
  "lazy_static",

--- a/src/markdown/Cargo.toml
+++ b/src/markdown/Cargo.toml
@@ -13,6 +13,6 @@ path = "lib.rs"
 
 [dependencies]
 ammonia = "3.1.2"
-comrak = { version = "0.10.1", default-features = false }
+comrak = { version = "0.12.1", default-features = false }
 htmlescape = "0.3.1"
 url = "2.2.2"


### PR DESCRIPTION
see https://github.com/kivikakk/comrak/releases

This does not appear to contain any significant changes for us, but it prevents `cargo outdated` from complaining 😆 