### PR TITLE
Change crate file `Content-Type` to `application/gzip`

### DIFF
--- a/src/tests/http-data/krate_publish_features_version_2
+++ b/src/tests/http-data/krate_publish_features_version_2
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "authorization",

--- a/src/tests/http-data/krate_publish_good_badges
+++ b/src/tests/http-data/krate_publish_good_badges
@@ -26,7 +26,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_good_categories
+++ b/src/tests/http-data/krate_publish_good_categories
@@ -14,7 +14,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "content-length",

--- a/src/tests/http-data/krate_publish_ignored_badges
+++ b/src/tests/http-data/krate_publish_ignored_badges
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_publish_ignored_categories
+++ b/src/tests/http-data/krate_publish_ignored_categories
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept",

--- a/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency
+++ b/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_publish_new_krate
+++ b/src/tests/http-data/krate_publish_new_krate
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "authorization",

--- a/src/tests/http-data/krate_publish_new_krate_git_upload
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "content-length",

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_appends
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_appends
@@ -6,7 +6,7 @@
       "headers": [
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",
@@ -73,7 +73,7 @@
       "headers": [
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts
@@ -14,7 +14,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "content-length",

--- a/src/tests/http-data/krate_publish_new_krate_records_verified_email
+++ b/src/tests/http-data/krate_publish_new_krate_records_verified_email
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "authorization",

--- a/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted
+++ b/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted
@@ -26,7 +26,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "date",

--- a/src/tests/http-data/krate_publish_new_krate_twice
+++ b/src/tests/http-data/krate_publish_new_krate_twice
@@ -10,7 +10,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_new_krate_weird_version
+++ b/src/tests/http-data/krate_publish_new_krate_weird_version
@@ -26,7 +26,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept",

--- a/src/tests/http-data/krate_publish_new_krate_with_broken_dependency_requirement
+++ b/src/tests/http-data/krate_publish_new_krate_with_broken_dependency_requirement
@@ -18,7 +18,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_new_krate_with_dependency
+++ b/src/tests/http-data/krate_publish_new_krate_with_dependency
@@ -18,7 +18,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_new_krate_with_readme
+++ b/src/tests/http-data/krate_publish_new_krate_with_readme
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept",

--- a/src/tests/http-data/krate_publish_new_krate_with_token
+++ b/src/tests/http-data/krate_publish_new_krate_with_token
@@ -22,7 +22,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_new_with_renamed_dependency
+++ b/src/tests/http-data/krate_publish_new_with_renamed_dependency
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency
+++ b/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_publish_publish_after_removing_documentation
+++ b/src/tests/http-data/krate_publish_publish_after_removing_documentation
@@ -18,7 +18,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "host",
@@ -77,7 +77,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "host",

--- a/src/tests/http-data/krate_publish_publish_new_crate_rate_limited
+++ b/src/tests/http-data/krate_publish_publish_new_crate_rate_limited
@@ -10,7 +10,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",
@@ -77,7 +77,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
+++ b/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
@@ -10,7 +10,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",
@@ -77,7 +77,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_publish_publish_records_an_audit_action
+++ b/src/tests/http-data/krate_publish_publish_records_an_audit_action
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
+++ b/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -97,7 +97,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_yanking_publish_after_yank_max_version
+++ b/src/tests/http-data/krate_yanking_publish_after_yank_max_version
@@ -10,7 +10,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "content-length",
@@ -89,7 +89,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "host",

--- a/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_yanking_yank_max_version
+++ b/src/tests/http-data/krate_yanking_yank_max_version
@@ -6,7 +6,7 @@
       "headers": [
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept",
@@ -73,7 +73,7 @@
       "headers": [
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/krate_yanking_yank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_yank_records_an_audit_action
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/krate_yanking_yank_works_as_intended
+++ b/src/tests/http-data/krate_yanking_yank_works_as_intended
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="

--- a/src/tests/http-data/owners_new_crate_owner
+++ b/src/tests/http-data/owners_new_crate_owner
@@ -18,7 +18,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "date",
@@ -77,7 +77,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "accept-encoding",

--- a/src/tests/http-data/team_publish_owned
+++ b/src/tests/http-data/team_publish_owned
@@ -534,7 +534,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "content-length",

--- a/src/tests/http-data/team_remove_team_as_team_owner
+++ b/src/tests/http-data/team_remove_team_as_team_owner
@@ -649,7 +649,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "date",

--- a/src/tests/http-data/version_version_size
+++ b/src/tests/http-data/version_version_size
@@ -30,7 +30,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -93,7 +93,7 @@
         ],
         [
           "content-type",
-          "application/x-tar"
+          "application/gzip"
         ],
         [
           "host",

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -143,7 +143,7 @@ impl Uploader {
             &path,
             content,
             content_length,
-            "application/x-tar",
+            "application/gzip",
             extra_headers,
         )
         .map_err(|e| internal(&format_args!("failed to upload crate: {}", e)))?;


### PR DESCRIPTION
Using `application/x-tar` is incorrect, because these files are not plain tarballs, but gzipped tarballs instead.

Resolves the first part of https://github.com/rust-lang/crates.io/issues/3930.

Existing crate files would still need to be changed using something like https://stackoverflow.com/a/46932483/1478093