### PR TITLE
Rename `cio-markdown` package to `cargo-registry-markdown`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,9 +245,9 @@ version = "0.2.2"
 dependencies = [
  "anyhow",
  "base64",
+ "cargo-registry-markdown",
  "cargo-registry-s3",
  "chrono",
- "cio-markdown",
  "claim",
  "clap",
  "conduit",
@@ -305,6 +305,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-registry-markdown"
+version = "0.0.0"
+dependencies = [
+ "ammonia",
+ "comrak",
+ "htmlescape",
+ "url",
+]
+
+[[package]]
 name = "cargo-registry-s3"
 version = "0.2.0"
 dependencies = [
@@ -342,16 +352,6 @@ dependencies = [
  "serde",
  "time 0.1.43",
  "winapi",
-]
-
-[[package]]
-name = "cio-markdown"
-version = "0.0.0"
-dependencies = [
- "ammonia",
- "comrak",
- "htmlescape",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,9 @@ rustdoc-args = [
 [dependencies]
 anyhow = "1.0"
 base64 = "0.13"
+cargo-registry-markdown = { path = "cargo-registry-markdown" }
 cargo-registry-s3 = { path = "cargo-registry-s3" }
 chrono = { version = "0.4.0", features = ["serde"] }
-cio-markdown = { path = "cio-markdown" }
 clap = "=3.0.0-beta.4"
 
 conduit = "0.9.0-alpha.5"

--- a/cargo-registry-markdown/Cargo.toml
+++ b/cargo-registry-markdown/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cio-markdown"
+name = "cargo-registry-markdown"
 version = "0.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"

--- a/cargo-registry-markdown/lib.rs
+++ b/cargo-registry-markdown/lib.rs
@@ -242,7 +242,7 @@ static MARKDOWN_EXTENSIONS: [&str; 7] =
 /// # Examples
 ///
 /// ```
-/// use cio_markdown::text_to_html;
+/// use cargo_registry_markdown::text_to_html;
 ///
 /// let text = "[Rust](https://rust-lang.org/) is an awesome *systems programming* language!";
 /// let rendered = text_to_html(text, "README.md", None);

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use std::{io::Read, path::Path, sync::Arc, thread};
 
+use cargo_registry_markdown::text_to_html;
 use chrono::{TimeZone, Utc};
-use cio_markdown::text_to_html;
 use clap::Clap;
 use diesel::{dsl::any, prelude::*};
 use flate2::read::GzDecoder;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,6 +1,6 @@
 //! Render README files to HTML.
 
-use cio_markdown::text_to_html;
+use cargo_registry_markdown::text_to_html;
 use swirl::PerformError;
 
 use crate::background_jobs::Environment;


### PR DESCRIPTION
This is consistent with `cargo-registry` and `cargo-registry-s3`.

We could also consider renaming `cargo-registry-s3` to `cio-s3` to make the name shorter, but as long as the main package is called `cargo-registry` I guess we should us that as the prefix for the other packages too.