### PR TITLE
Add tests for admin/render_readmes

### DIFF
--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -257,3 +257,83 @@ fn find_file_by_path<R: Read>(
         .unwrap_or_else(|_| panic!("[{}] Couldn't read file contents", pkg_name));
     contents
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use tar;
+
+    use super::render_pkg_readme;
+
+    fn add_file<W: Write>(pkg: &mut tar::Builder<W>, path: &str, content: &[u8]) {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_cksum();
+        pkg.append_data(&mut header, path, content).unwrap();
+    }
+
+    #[test]
+    fn test_render_pkg_readme() {
+        let mut pkg = tar::Builder::new(vec![]);
+        add_file(
+            &mut pkg,
+            "foo-0.0.1/Cargo.toml",
+            br#"
+[package]
+readme = "README.md"
+"#,
+        );
+        add_file(&mut pkg, "foo-0.0.1/README.md", b"readme");
+        let serialized_archive = pkg.into_inner().unwrap();
+        let result =
+            render_pkg_readme(tar::Archive::new(&*serialized_archive), "foo-0.0.1").unwrap();
+        assert!(result.contains("readme"))
+    }
+
+    #[test]
+    fn test_render_pkg_readme_w_link() {
+        let mut pkg = tar::Builder::new(vec![]);
+        add_file(
+            &mut pkg,
+            "foo-0.0.1/Cargo.toml",
+            br#"
+[package]
+readme = "README.md"
+repository = "https://github.com/foo/foo"
+"#,
+        );
+        add_file(
+            &mut pkg,
+            "foo-0.0.1/README.md",
+            b"readme [link](./Other.md)",
+        );
+        let serialized_archive = pkg.into_inner().unwrap();
+        let result =
+            render_pkg_readme(tar::Archive::new(&*serialized_archive), "foo-0.0.1").unwrap();
+        assert!(result.contains("\"https://github.com/foo/foo/blob/HEAD/./Other.md\""))
+    }
+
+    #[test]
+    fn test_render_pkg_readme_not_at_root() {
+        let mut pkg = tar::Builder::new(vec![]);
+        add_file(
+            &mut pkg,
+            "foo-0.0.1/Cargo.toml",
+            br#"
+[package]
+readme = "docs/README.md"
+repository = "https://github.com/foo/foo"
+"#,
+        );
+        add_file(
+            &mut pkg,
+            "foo-0.0.1/docs/README.md",
+            b"docs/readme [link](./Other.md)",
+        );
+        let serialized_archive = pkg.into_inner().unwrap();
+        let result =
+            render_pkg_readme(tar::Archive::new(&*serialized_archive), "foo-0.0.1").unwrap();
+        assert!(result.contains("docs/readme"));
+        assert!(result.contains("\"https://github.com/foo/foo/blob/HEAD/docs/./Other.md\""))
+    }
+}


### PR DESCRIPTION
Depends on #3967
(Because of https://github.com/github/feedback/discussions/4477#discussioncomment-1293255 - github ends up rendering both diffs together. Go to the commits tab and just look at the most recent commit to review).

Refactors slightly so we can add tests to the untested risky portion of this code.
I already found a couple of bugs which I will fix in follow up PRs with tests.