### PR TITLE
Bump CI to PostgreSQL 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_PASSWORD: postgres
         # Set health checks to wait until postgres has started


### PR DESCRIPTION
This PR bumps CI's PostgreSQL to version 13, to match what we will upgrade to tomorrow.