### PR TITLE
database/versions: Add generated `version_no_prerelease` column

### DIFF
--- a/migrations/2021-10-07-220812_add_version_no_prerelease/down.sql
+++ b/migrations/2021-10-07-220812_add_version_no_prerelease/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE versions
+    DROP COLUMN version_no_prerelease;

--- a/migrations/2021-10-07-220812_add_version_no_prerelease/up.sql
+++ b/migrations/2021-10-07-220812_add_version_no_prerelease/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE versions
+    ADD COLUMN version_no_prerelease semver_triple
+        GENERATED ALWAYS AS ( to_semver_no_prerelease(num) ) STORED;

--- a/src/models/krate_reverse_dependencies.sql
+++ b/src/models/krate_reverse_dependencies.sql
@@ -12,7 +12,7 @@ SELECT *, COUNT(*) OVER () as total FROM (
         SELECT versions.*,
         row_number() OVER (
             PARTITION BY crate_id
-            ORDER BY to_semver_no_prerelease(num) DESC NULLS LAST
+            ORDER BY version_no_prerelease DESC NULLS LAST
         ) rn
         FROM versions
         WHERE NOT yanked

--- a/src/tasks/dump_db/dump-db.toml
+++ b/src/tasks/dump_db/dump-db.toml
@@ -212,6 +212,7 @@ yanked = "public"
 license = "public"
 crate_size = "public"
 published_by = "public"
+version_no_prerelease = "private"
 
 [versions_published_by.columns]
 version_id = "private"


### PR DESCRIPTION
This is an attempt to speed up the reverse dependencies query, as hinted at in https://github.com/rust-lang/crates.io/pull/3886#issuecomment-913432943.

Instead of running `to_semver_no_prerelease(num)` in every query, we use a [generated column](https://www.postgresql.org/docs/current/ddl-generated-columns.html) to speed up the query.

In my local tests with the imported database dump the query times were previously around 1700ms for the `rand` crate, and after this change they consistently dropped down to around 900ms.