### PR TITLE
database: Simplify `trigger_versions_set_updated_at` trigger on the `versions` table

### DIFF
--- a/migrations/2021-10-08-113656_simplify_versions_trigger/down.sql
+++ b/migrations/2021-10-08-113656_simplify_versions_trigger/down.sql
@@ -1,0 +1,9 @@
+-- remove the new trigger
+DROP TRIGGER trigger_versions_set_updated_at ON versions;
+
+-- add the old trigger again
+CREATE TRIGGER trigger_versions_set_updated_at
+    BEFORE UPDATE
+    ON versions
+    FOR EACH ROW
+EXECUTE PROCEDURE set_updated_at_ignore_downloads();

--- a/migrations/2021-10-08-113656_simplify_versions_trigger/up.sql
+++ b/migrations/2021-10-08-113656_simplify_versions_trigger/up.sql
@@ -1,0 +1,9 @@
+-- remove the old trigger
+DROP TRIGGER trigger_versions_set_updated_at ON versions;
+
+-- add the new trigger only for the `yanked` column
+CREATE TRIGGER trigger_versions_set_updated_at
+    BEFORE UPDATE OF yanked
+    ON versions
+    FOR EACH ROW
+EXECUTE PROCEDURE set_updated_at();


### PR DESCRIPTION
The only mutable columns in this table are `yanked` and `downloads`, but the trigger should specifically not be used when the `downloads` column changes. That means we're only left with the `yanked` column and can be more specific in the trigger condition.

This unblocks #3992, but also generally simplifies the table trigger.