### PR TITLE
renovate: Disable dependency version pinning for Rust dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,7 +16,8 @@
         "reviewersSampleSize": 1
     },
     "rust": {
-        "dependencyDashboardApproval": true
+        "dependencyDashboardApproval": true,
+        "rangeStrategy": "bump"
     },
     "postUpdateOptions": ["yarnDedupeFewer"],
     "packageRules": [{


### PR DESCRIPTION
This matches what we're currently doing manually. Using version pinning is a bigger discussion that should not block our usage of renovatebot.