### PR TITLE
router: Set Sentry `transaction` field before calling the request handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,6 @@ checksum = "b5986c05b82a52b92c26ddd2da6ac06aad59f43ba6db81786307e0bbe63e74b2"
 dependencies = [
  "conduit",
  "conduit-middleware",
- "conduit-router",
  "sentry-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ reqwest = { version = "0.11", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "0.2.0"
 semver = { version = "1.0.3", features = ["serde"] }
 sentry = { version = "0.23.0", features = ["tracing"] }
-sentry-conduit = "0.2.0"
+sentry-conduit = { version = "0.2.0", default-features = false }
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
 sha2 = "0.9"


### PR DESCRIPTION
This disables the `router` feature of `sentry-conduit` and instead calls `set_transaction()` of Sentry manually before calling the route handler itself. This has the advantage of also adding the `transaction` field to Sentry issues that are not reported by the `sentry-conduit` middleware itself.