### PR TITLE
Ensure the HEAD for test indexes is "master"

### DIFF
--- a/src/tests/git.rs
+++ b/src/tests/git.rs
@@ -24,7 +24,13 @@ pub fn init() {
         fs::create_dir_all(root().parent().unwrap()).unwrap();
     });
 
-    let bare = git2::Repository::init_bare(&bare()).unwrap();
+    let bare = git2::Repository::init_opts(
+        &bare(),
+        git2::RepositoryInitOptions::new()
+            .bare(true)
+            .initial_head("master"),
+    )
+    .unwrap();
     let mut config = bare.config().unwrap();
     config.set_str("user.name", "name").unwrap();
     config.set_str("user.email", "email").unwrap();


### PR DESCRIPTION
Different versions of git2 in different systems use a different name for
the HEAD branch they create, switching between "master" and "main". This
causes test failures when they pick "main", as the rest of crates.io
assumes the branch is named "master".

This commit changes the HEAD name during tests to always be "master",
allowing the test suite to work everywhere without breakages.

Refactoring the application not to care about the branch name will be
done in a future commit, this just focuses on unbreaking the test suite.