### PR TITLE
Fix search form submit in Safari

### DIFF
--- a/app/components/header.module.css
+++ b/app/components/header.module.css
@@ -99,7 +99,10 @@
 }
 
 .submit-button {
-    display: none;
+    position: absolute;
+    visibility: hidden;
+    width: 0;
+    height: 0;
 }
 
 .sep {


### PR DESCRIPTION
Safari cannot submit a form if the submit button inside it has the `display: none` property.
This is a simple fix 🙃

Fixes #4019