### PR TITLE
VersionList::Row: Adjust for missing `license` information

### DIFF
--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -58,37 +58,41 @@
       </time>
     </div>
 
-    <div local-class="metadata-row">
-      {{#if @version.crate_size}}
-        <span local-class="bytes">
-          {{svg-jar "weight"}}
-          {{pretty-bytes @version.crate_size}}
-        </span>
-      {{/if}}
+    {{#if (or @version.crate_size @version.license @version.featureList)}}
+      <div local-class="metadata-row">
+        {{#if @version.crate_size}}
+          <span local-class="bytes">
+            {{svg-jar "weight"}}
+            {{pretty-bytes @version.crate_size}}
+          </span>
+        {{/if}}
 
-      <span local-class="license">
-        {{svg-jar "license"}}
-        <LicenseExpression @license={{@version.license}} />
-      </span>
+        {{#if @version.license}}
+          <span local-class="license">
+            {{svg-jar "license"}}
+            <LicenseExpression @license={{@version.license}} />
+          </span>
+        {{/if}}
 
-      {{#if @version.featureList}}
-        <span local-class="num-features" data-test-feature-list>
-          {{svg-jar "checkbox"}}
-          {{@version.featureList.length}} {{if (eq @version.featureList.length 1) "Feature" "Features"}}
+        {{#if @version.featureList}}
+          <span local-class="num-features" data-test-feature-list>
+            {{svg-jar "checkbox"}}
+            {{@version.featureList.length}} {{if (eq @version.featureList.length 1) "Feature" "Features"}}
 
-          <EmberTooltip>
-            <ul local-class="feature-list">
-              {{#each @version.featureList as |feature|}}
-                <li>
-                  {{svg-jar (if feature.isDefault "checkbox" "checkbox-empty")}}
-                  {{feature.name}}
-                </li>
-              {{/each}}
-            </ul>
-          </EmberTooltip>
-        </span>
-      {{/if}}
-    </div>
+            <EmberTooltip>
+              <ul local-class="feature-list">
+                {{#each @version.featureList as |feature|}}
+                  <li>
+                    {{svg-jar (if feature.isDefault "checkbox" "checkbox-empty")}}
+                    {{feature.name}}
+                  </li>
+                {{/each}}
+              </ul>
+            </EmberTooltip>
+          </span>
+        {{/if}}
+      </div>
+    {{/if}}
   </div>
 
   {{#if this.isOwner}}


### PR DESCRIPTION
Some of the earliest versions were published without any license information at all

#### Before 
<img width="479" alt="Bildschirmfoto 2021-10-17 um 10 16 22" src="https://user-images.githubusercontent.com/141300/137618185-794405fd-1a40-4709-b3f7-314929bf2ae7.png">

#### After 
<img width="576" alt="Bildschirmfoto 2021-10-17 um 10 16 12" src="https://user-images.githubusercontent.com/141300/137618186-694404c2-a9ef-42b4-91d1-ecc39d722b62.png">
