### PR TITLE
admin::on_call: Work around potential Rust v1.57.0-beta.1 bug

### DIFF
--- a/src/admin/on_call.rs
+++ b/src/admin/on_call.rs
@@ -62,6 +62,7 @@ struct FullEvent {
 }
 
 #[derive(serde::Deserialize, Debug)]
+#[allow(dead_code)] // workaround for a potential bug in Rust v1.57.0-beta.1
 struct InvalidEvent {
     message: String,
     errors: Vec<String>,


### PR DESCRIPTION
The fields in the `InvalidEvent` struct are used by the `Debug` implementation, which is used by the `anyhow!()` macro call in the `Event::send()` implementation.

The Rust v1.57.0-beta.1 compiler does not appear to agree on that though and marks these fields as unused. This PR adds `#[allow(dead_code)]` to work around the issue for now and fix our CI builds to unblock other updates.