### PR TITLE
UserAvatar: Replace `width` and `height` properties with `size`

### DIFF
--- a/app/components/user-avatar.hbs
+++ b/app/components/user-avatar.hbs
@@ -1,7 +1,7 @@
 <img
   src={{this.src}}
-  width={{this.width}}
-  height={{this.height}}
+  width={{this.size}}
+  height={{this.size}}
   alt={{this.alt}}
   title={{this.title}}
   ...attributes

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -1,8 +1,7 @@
-import { readOnly } from '@ember/object/computed';
 import Component from '@glimmer/component';
 
 export default class UserAvatar extends Component {
-  get width() {
+  get size() {
     if (this.args.size === 'medium') {
       return 85;
     } else if (this.args.size === 'medium-small') {
@@ -11,8 +10,6 @@ export default class UserAvatar extends Component {
       return 22; // small
     }
   }
-
-  @readOnly('width') height;
 
   get alt() {
     return this.args.user.name !== null
@@ -34,6 +31,6 @@ export default class UserAvatar extends Component {
   }
 
   get src() {
-    return `${this.args.user.avatar}&s=${this.width * 2}`;
+    return `${this.args.user.avatar}&s=${this.size * 2}`;
   }
 }


### PR DESCRIPTION
There is no point in having both if one is just an alias of the other one.