### PR TITLE
renovate: Add `A-backend` to Rust PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,8 @@
         "reviewersSampleSize": 1
     },
     "rust": {
-        "dependencyDashboardApproval": true
+        "dependencyDashboardApproval": true,
+        "labels": ["A-backend"]
     },
     "postUpdateOptions": ["yarnDedupeFewer"],
     "packageRules": [{


### PR DESCRIPTION
... similar to what we do for JS PRs already.