### PR TITLE
models::Krate: Change `top_versions()` to query `created_at` instead of `updated_at`

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -311,7 +311,7 @@ impl Crate {
         use crate::schema::versions::dsl::*;
 
         Ok(TopVersions::from_date_version_pairs(
-            self.versions().select((updated_at, num)).load(conn)?,
+            self.versions().select((created_at, num)).load(conn)?,
         ))
     }
 


### PR DESCRIPTION
If a version is yanked and unyanked it shouldn't show up as the "newest" version, if there are legitimately newer versions available.