### PR TITLE
CI: Adjust Rust channels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,9 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-20.04
+
+    continue-on-error: ${{ matrix.rust != 'stable' }}
     strategy:
-      # TODO: [ci] should be true if GitHub Actions supports ""allow failures" on matrix
-      fail-fast: false
       matrix:
         rust:
           - stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install ${{ env.RUST_VERSION }} Rust
+        if: matrix.rust == 'stable'
+        run: |
+          rustup update ${{ env.RUST_VERSION }}
+          rustup default ${{ env.RUST_VERSION }}
+
       - name: Install ${{ matrix.rust }} Rust
+        if: matrix.rust != 'stable'
         run: |
           rustup update ${{ matrix.rust }}
           rustup default ${{ matrix.rust }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 
   pull_request:
 
+env:
+  RUST_VERSION: 1.56.0
+
 jobs:
   frontend:
     name: Frontend
@@ -74,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: rustup default 1.56.0
+      - run: rustup default ${{ env.RUST_VERSION }}
       - run: rustup component add rustfmt
       - run: rustup component add clippy
 


### PR DESCRIPTION
This adds `continue-on-error: true` for the `beta` channel, and pins the `stable` channel to the version that we use in production.