### PR TITLE
renovate: Update `RustConfig` and `RUST_VERSION` in CI config automatically

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,22 @@
         "dependencyDashboardApproval": true,
         "labels": ["A-backend"]
     },
+    "regexManagers": [
+        {
+            "fileMatch": ["^.github/workflows/[^\\.]+\\.ya?ml$"],
+            "matchStrings": ["RUST_VERSION:\\s*(?<currentValue>.*?)\n"],
+            "depNameTemplate": "rust",
+            "datasourceTemplate": "github-releases",
+            "lookupNameTemplate": "rust-lang/rust"
+        },
+        {
+            "fileMatch": ["^RustConfig$"],
+            "matchStrings": ["VERSION=(?<currentValue>.*?)\n"],
+            "depNameTemplate": "rust",
+            "datasourceTemplate": "github-releases",
+            "lookupNameTemplate": "rust-lang/rust"
+        }
+    ],
     "postUpdateOptions": ["yarnDedupeFewer"],
     "packageRules": [{
         "matchPackageNames": ["ember-cli", "ember-data", "ember-source"],
@@ -37,5 +53,10 @@
         "matchUpdateTypes": ["lockFileMaintenance"],
         "additionalBranchPrefix": "rust-",
         "commitMessageSuffix": "(Rust)"
+    }, {
+        "matchManagers": ["regex"],
+        "matchPackageNames": ["rust"],
+        "commitMessageTopic": "Rust",
+        "labels": ["A-backend"]
     }]
 }


### PR DESCRIPTION
With this PR we will have renovatebot open a PR whenever a new Rust version is released. It will update the version in `RustConfig` (used by the Heroku buildpack) and the `RUST_VERSION` environment variable in the CI config, once #4101 is merged.

Example:
- https://github.com/Turbo87/crates.io/pull/29

Related:
- https://fasterthanli.me/articles/my-ideal-rust-workflow ("Automating dependency updates" section)
