### PR TITLE
renovate: Adjust lockfile maintenance configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,8 +28,14 @@
         "matchLanguages": ["rust"],
         "rangeStrategy": "bump"
     }, {
+        "matchLanguages": ["js"],
+        "matchUpdateTypes": ["lockFileMaintenance"],
+        "additionalBranchPrefix": "js-",
+        "commitMessageSuffix": "(JS)"
+    }, {
         "matchLanguages": ["rust"],
         "matchUpdateTypes": ["lockFileMaintenance"],
-        "groupName": " Lock file maintenance (Rust)"
+        "additionalBranchPrefix": "rust-",
+        "commitMessageSuffix": "(Rust)"
     }]
 }


### PR DESCRIPTION
Using `groupName` for this was incorrect and did not update the PR title in the dependency dashboard. This PR uses the `commitMessageSuffix` option instead, and also `additionalBranchPrefix` to avoid conflicting branch names.