### PR TITLE
Sentry: Improve metadata collection

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -86,6 +86,8 @@ pub fn add_custom_metadata<V: Display>(req: &mut dyn RequestExt, key: &'static s
         metadata.entries.push((key, value.to_string()));
         req.mut_extensions().insert(metadata);
     }
+
+    sentry::configure_scope(|scope| scope.set_extra(key, value.to_string().into()));
 }
 
 fn report_to_sentry(req: &dyn RequestExt, res: &AfterResult, response_time: u64) {
@@ -119,12 +121,6 @@ fn report_to_sentry(req: &dyn RequestExt, res: &AfterResult, response_time: u64)
         }
 
         scope.set_extra("Response time [ms]", response_time.into());
-
-        if let Some(metadata) = req.extensions().find::<CustomMetadata>() {
-            for (key, value) in &metadata.entries {
-                scope.set_extra(key, value.to_string().into());
-            }
-        }
     });
 }
 


### PR DESCRIPTION
The `request.id` tag and the "custom metadata" are currently only assigned to the Sentry scope in the `after()` method of the `LogRequest` middleware. This means that for any manual `sentry::capture_exception()` call these fields will not be set correctly.

This PR moves the `configure_scope()` calls into the `before()` method and `add_custom_metadata()` function instead. This allows us to send the fields to Sentry for error reports as soon as they are available.