### PR TITLE
admin::render_readmes: Use `Result` return types

### DIFF
--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -242,18 +242,13 @@ fn find_file_by_path<R: Read>(
     path: &Path,
     pkg_name: &str,
 ) -> Option<String> {
-    let mut file = entries
-        .find(|entry| match *entry {
-            Err(_) => false,
-            Ok(ref file) => {
-                let filepath = match file.path() {
-                    Ok(p) => p,
-                    Err(_) => return false,
-                };
-                filepath == path
-            }
-        })?
-        .unwrap_or_else(|_| panic!("[{}] file is not present: {}", pkg_name, path.display()));
+    let mut file = entries.filter_map(|entry| entry.ok()).find(|file| {
+        let filepath = match file.path() {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        filepath == path
+    })?;
 
     let mut contents = String::new();
     file.read_to_string(&mut contents)

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -242,13 +242,12 @@ fn find_file_by_path<R: Read>(
     path: &Path,
     pkg_name: &str,
 ) -> Option<String> {
-    let mut file = entries.filter_map(|entry| entry.ok()).find(|file| {
-        let filepath = match file.path() {
-            Ok(p) => p,
-            Err(_) => return false,
-        };
-        filepath == path
-    })?;
+    let mut file = entries
+        .filter_map(|entry| entry.ok())
+        .find(|file| match file.path() {
+            Ok(p) => p == path,
+            Err(_) => false,
+        })?;
 
     let mut contents = String::new();
     file.read_to_string(&mut contents)

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -33,7 +33,7 @@ fn main() -> anyhow::Result<()> {
         SubCommand::DeleteCrate(opts) => delete_crate::run(opts),
         SubCommand::DeleteVersion(opts) => delete_version::run(opts),
         SubCommand::Populate(opts) => populate::run(opts),
-        SubCommand::RenderReadmes(opts) => render_readmes::run(opts),
+        SubCommand::RenderReadmes(opts) => render_readmes::run(opts)?,
         SubCommand::TestPagerduty(opts) => test_pagerduty::run(opts)?,
         SubCommand::TransferCrates(opts) => transfer_crates::run(opts),
         SubCommand::VerifyToken(opts) => verify_token::run(opts).unwrap(),


### PR DESCRIPTION
... instead of dropping the errors via `Option` and using `panic!()` everywhere.

/cc @nipunn1313 