### PR TITLE
worker::git: Move database update out of `yank()` job

### DIFF
--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -42,6 +42,12 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
     if user.rights(req.app(), &owners)? < Rights::Publish {
         return Err(cargo_err("must already be an owner to yank or unyank"));
     }
+
+    if version.yanked == yanked {
+        // The crate is alread in the state requested, nothing to do
+        return ok_true();
+    }
+
     let action = if yanked {
         VersionAction::Yank
     } else {

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -6,6 +6,7 @@ use super::{extract_crate_name_and_semver, version_and_crate};
 use crate::controllers::cargo_prelude::*;
 use crate::models::Rights;
 use crate::models::{insert_version_owner_action, VersionAction};
+use crate::schema::versions;
 use crate::worker;
 
 /// Handles the `DELETE /crates/:crate_id/:version/yank` route.
@@ -47,6 +48,10 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
         // The crate is alread in the state requested, nothing to do
         return ok_true();
     }
+
+    diesel::update(&version)
+        .set(versions::yanked.eq(yanked))
+        .execute(&*conn)?;
 
     let action = if yanked {
         VersionAction::Yank

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -45,7 +45,7 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
     }
 
     if version.yanked == yanked {
-        // The crate is alread in the state requested, nothing to do
+        // The crate is already in the state requested, nothing to do
         return ok_true();
     }
 


### PR DESCRIPTION
When publishing, we also save the new version (and crate) directly in the database, so we should be able to do the same when yanking/unyanking, and avoid potentially returning incorrect data right after the request and before the background job has finished.