### PR TITLE
metrics/service: Add `background_jobs` metric

### DIFF
--- a/src/metrics/service.rs
+++ b/src/metrics/service.rs
@@ -10,7 +10,7 @@
 //! As a rule of thumb, if the metric is not straight up fetched from the database it's probably an
 //! instance-level metric, and you should add it to `src/metrics/instance.rs`.
 
-use crate::schema::{crates, versions};
+use crate::schema::{background_jobs, crates, versions};
 use crate::util::errors::AppResult;
 use diesel::{dsl::count_star, prelude::*, PgConnection};
 use prometheus::{proto::MetricFamily, IntGauge};
@@ -21,6 +21,8 @@ metrics! {
         crates_total: IntGauge,
         /// Number of versions ever published
         versions_total: IntGauge,
+        /// Number of queued up background jobs
+        background_jobs: IntGauge,
     }
 
     // All service metrics will be prefixed with this namespace.
@@ -33,6 +35,8 @@ impl ServiceMetrics {
             .set(crates::table.select(count_star()).first(conn)?);
         self.versions_total
             .set(versions::table.select(count_star()).first(conn)?);
+        self.background_jobs
+            .set(background_jobs::table.select(count_star()).first(conn)?);
 
         Ok(self.registry.gather())
     }


### PR DESCRIPTION
This can be used to monitor how long the queue of background jobs currently is.