### PR TITLE
sentry: Use `allowUrls` option to filter out errors in injected scripts

### DIFF
--- a/app/sentry.js
+++ b/app/sentry.js
@@ -18,6 +18,8 @@ export function init() {
     ...config.sentry,
     integrations,
 
+    allowUrls: ['crates.io', 'crates-io.herokuapp.com', 'staging.crates-io', 'staging-crates-io.herokuapp.com'],
+
     beforeSend(event, hint) {
       let error = hint?.originalException;
 


### PR DESCRIPTION
This is based on https://dzone.com/articles/6-tips-for-reducing-javascript-error-noise and filters out errors from e.g. broken browser extensions. It ensures that we only report errors that originate in the scripts served by our own servers.