### PR TITLE
services/playground: Extract loadCrates() method

### DIFF
--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -36,13 +36,11 @@ export default class DownloadGraph extends Component {
     super(...arguments);
 
     // load Rust Playground crates list, if necessary
-    if (!this.playground.crates) {
-      this.playground.loadCratesTask.perform().catch(error => {
-        if (!(didCancel(error) || error.isServerError || error.isNetworkError)) {
-          // report unexpected errors to Sentry
-          this.sentry.captureException(error);
-        }
-      });
-    }
+    this.playground.loadCrates().catch(error => {
+      if (!(didCancel(error) || error.isServerError || error.isNetworkError)) {
+        // report unexpected errors to Sentry
+        this.sentry.captureException(error);
+      }
+    });
   }
 }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -47,6 +47,6 @@ export default class ApplicationRoute extends Route {
 
   @task *preloadPlaygroundCratesTask() {
     yield rawTimeout(1000);
-    yield this.playground.loadCratesTask.perform();
+    yield this.playground.loadCrates();
   }
 }

--- a/app/services/playground.js
+++ b/app/services/playground.js
@@ -8,6 +8,12 @@ import ajax from '../utils/ajax';
 export default class PlaygroundService extends Service {
   @alias('loadCratesTask.lastSuccessful.value') crates;
 
+  async loadCrates() {
+    if (!this.crates) {
+      return this.loadCratesTask.perform();
+    }
+  }
+
   @dropTask *loadCratesTask() {
     let response = yield ajax('https://play.rust-lang.org/meta/crates');
     return response.crates;


### PR DESCRIPTION
This avoids duplicate requests to the playground API, caused by the `preloadPlaygroundCratesTask` in the `application` route requesting the data after it has already been loaded by the `CrateSidebar` component too.