### PR TITLE
renovate: Group `conduit` package updates into one PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,5 +58,13 @@
         "matchPackageNames": ["rust"],
         "commitMessageTopic": "Rust",
         "labels": ["A-backend"]
+    }, {
+        "matchDatasources": ["crates"],
+        "matchPackagePatterns": [
+            "^conduit$",
+            "^conduit-",
+            "^sentry-conduit$"
+        ],
+        "groupName": "conduit packages"
     }]
 }


### PR DESCRIPTION
This should avoid multiple incompatible PRs from being opened.