### PR TITLE
renovate: Remove `matchDatasource` from `conduit` grouping rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,7 +59,6 @@
         "commitMessageTopic": "Rust",
         "labels": ["A-backend"]
     }, {
-        "matchDatasources": ["crates"],
         "matchPackagePatterns": [
             "^conduit$",
             "^conduit-",


### PR DESCRIPTION
This appears to not work as intended and is not really necessary anyway.