### PR TITLE
Pin Node.js version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,13 @@
     "regexManagers": [
         {
             "fileMatch": ["^.github/workflows/[^\\.]+\\.ya?ml$"],
+            "matchStrings": ["NODE_VERSION:\\s*(?<currentValue>.*?)\n"],
+            "depNameTemplate": "node",
+            "datasourceTemplate": "github-releases",
+            "lookupNameTemplate": "nodejs/node"
+        },
+        {
+            "fileMatch": ["^.github/workflows/[^\\.]+\\.ya?ml$"],
             "matchStrings": ["RUST_VERSION:\\s*(?<currentValue>.*?)\n"],
             "depNameTemplate": "rust",
             "datasourceTemplate": "github-releases",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
 
 env:
+  NODE_VERSION: 14.18.1
   RUST_VERSION: 1.56.1
 
 jobs:
@@ -29,7 +30,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install node modules
         run: yarn install
@@ -59,7 +60,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.x'
+          node-version: ${{ env.NODE_VERSION }}
 
       - run: yarn install
 

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.12-alpine
+FROM node:14.18.1-alpine
 
 WORKDIR /app
 COPY package.json yarn.lock /app/

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "ember-modifier": "3.0.0"
   },
   "engines": {
-    "node": "^14.9.0",
+    "node": "14.18.1",
     "npm": "^8.0.0"
   },
   "ember": {


### PR DESCRIPTION
We currently use one Node.js version in production, another on CI and yet another one for our Docker setup. This PR pins them all to the same release (latest v14.x) and configures renovatebot to automatically keep the versions updated.