### PR TITLE
renovate: Adjust `node` package grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,6 +66,21 @@
         "commitMessageTopic": "Rust",
         "labels": ["A-backend"],
     }, {
+        // Groups the `NODE_VERSION` update with the rest of the Node.js updates
+        // and assigns the `A-frontend` label to the PR.
+        "matchManagers": ["regex"],
+        "matchPackageNames": ["node"],
+        "commitMessageTopic": "Node.js",
+        "labels": ["A-frontend"],
+    }, {
+        // Use `semver` versioning scheme, instead of `node`. Ideally we would
+        // use `node`, which differentiates between LTS and non-LTS releases,
+        // but that is not compatible with the `nodejs/node` Docker image
+        // updates.
+        "matchManagers": ["npm"],
+        "matchPackageNames": ["node"],
+        "versioning": "semver",
+    }, {
         "matchPackagePatterns": [
             "^conduit$",
             "^conduit-",


### PR DESCRIPTION
#4148 introduced a new way for renovatebot to update our Node.js version, but it wasn't perfectly compatible with the others yet. This PR fixes the issue, and unifies how renovatebot updates the Node.js versions in all of the relevant files.