### PR TITLE
bin/server: Print HTTP server URL on startup

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -100,7 +100,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // When the user configures PORT=0 the operative system will allocate a random unused port.
     // This fetches that random port and uses it to display the "listening on port" message later.
-    let actual_port = server.local_addr().port();
+    let addr = server.local_addr();
 
     let server = server.with_graceful_shutdown(async move {
         // Wait for either signal
@@ -116,7 +116,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Do not change this line! Removing the line or changing its contents in any way will break
     // the test suite :)
-    println!("listening on port {}", actual_port);
+    println!("Listening at http://{}", addr);
 
     // Creating this file tells heroku to tell nginx that the application is ready
     // to receive traffic.


### PR DESCRIPTION
This makes it easier to click on the URL instead of having to copy-paste the port.

I'm aware that the code comment says "Do not change this line!", but I've adjusted the corresponding test code too... 😉 