### PR TITLE
Improve Avatar styling

### DIFF
--- a/app/components/owners-list.hbs
+++ b/app/components/owners-list.hbs
@@ -4,7 +4,7 @@
   data-test-owners
 >
   {{#each @owners as |owner|}}
-    <li>
+    <li local-class="{{if (eq owner.kind "team") "team"}}">
       <LinkTo
         @route={{owner.kind}}
         @model={{owner.login}}

--- a/app/components/owners-list.module.css
+++ b/app/components/owners-list.module.css
@@ -41,8 +41,12 @@
 }
 
 .avatar {
-    border-radius: 4px;
+    border-radius: 50%;
     background: white;
     box-shadow: 1px 2px 2px 0 hsla(51, 50%, 44%, .35);
     padding: 1px;
+
+    .team & {
+        border-radius: 4px;
+    }
 }

--- a/app/components/owners-list.module.css
+++ b/app/components/owners-list.module.css
@@ -42,4 +42,7 @@
 
 .avatar {
     border-radius: 4px;
+    background: white;
+    box-shadow: 1px 2px 2px 0 hsla(51, 50%, 44%, .35);
+    padding: 1px;
 }

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -153,7 +153,7 @@
     width: auto;
     margin-left: 3px;
     margin-bottom: -.4em;
-    border-radius: 3px;
+    border-radius: 50%;
 }
 
 .metadata-row {

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -154,6 +154,8 @@
     margin-left: 3px;
     margin-bottom: -.4em;
     border-radius: 50%;
+    box-shadow: 0 1px 1px 0 var(--grey600);
+    padding: 1px;
 }
 
 .metadata-row {


### PR DESCRIPTION
This PR improves the styling of the avatars in the crate owners list and the versions list. It adds a small border and drop shadow to give them a little more depth, and it also changes user avatars to circles (vs teams, which stay rectangular), similar to how GitHub does it these days.

### Before
<img width="317" alt="Bildschirmfoto 2021-11-12 um 17 40 01" src="https://user-images.githubusercontent.com/141300/141502713-4e1a2197-7c2e-4a8f-8dde-3bf99c77b423.png">
<img width="266" alt="Bildschirmfoto 2021-11-12 um 17 40 09" src="https://user-images.githubusercontent.com/141300/141502714-012e41db-f5d3-4b8e-b12e-d39dbbc7d805.png">

### After

<img width="306" alt="Bildschirmfoto 2021-11-12 um 17 39 50" src="https://user-images.githubusercontent.com/141300/141502708-06897721-3fdb-4c78-8cd2-ffd801220bb9.png">
<img width="317" alt="Bildschirmfoto 2021-11-12 um 17 39 39" src="https://user-images.githubusercontent.com/141300/141502702-e6613d3c-8148-4f6c-869d-522fc5cef5fd.png">
