### PR TITLE
TestApp: Simplify `crates_from_index_head()` method

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -244,7 +244,8 @@ impl Repository {
     pub fn commit_and_push(&self, message: &str, modified_file: &Path) -> Result<(), PerformError> {
         println!("Committing and pushing \"{}\"", message);
 
-        self.perform_commit_and_push(message, modified_file)
+        let relative_path = modified_file.strip_prefix(self.checkout_path.path())?;
+        self.perform_commit_and_push(message, relative_path)
             .map(|_| println!("Commit and push finished for \"{}\"", message))
             .map_err(|err| {
                 eprintln!("Commit and push for \"{}\" errored: {}", message, err);

--- a/src/git.rs
+++ b/src/git.rs
@@ -177,10 +177,10 @@ impl Repository {
     pub fn index_file(&self, name: &str) -> PathBuf {
         self.checkout_path
             .path()
-            .join(self.relative_index_file(name))
+            .join(Self::relative_index_file(name))
     }
 
-    pub fn relative_index_file(&self, name: &str) -> PathBuf {
+    pub fn relative_index_file(name: &str) -> PathBuf {
         let name = name.to_lowercase();
         match name.len() {
             1 => Path::new("1").join(&name),

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -161,7 +161,7 @@ fn new_with_renamed_dependency() {
     token.enqueue_publish(crate_to_publish).good();
     app.run_pending_background_jobs();
 
-    let crates = app.crates_from_index_head("ne/w-/new-krate");
+    let crates = app.crates_from_index_head("new-krate");
     assert_eq!(crates.len(), 1);
     assert_eq!(crates[0].name, "new-krate");
     assert_eq!(crates[0].vers, "1.0.0");
@@ -187,7 +187,7 @@ fn new_with_underscore_renamed_dependency() {
     token.enqueue_publish(crate_to_publish).good();
     app.run_pending_background_jobs();
 
-    let crates = app.crates_from_index_head("ne/w-/new-krate");
+    let crates = app.crates_from_index_head("new-krate");
     assert_eq!(crates.len(), 1);
     assert_eq!(crates[0].name, "new-krate");
     assert_eq!(crates[0].vers, "1.0.0");
@@ -528,7 +528,7 @@ fn new_krate_git_upload() {
     token.enqueue_publish(crate_to_publish).good();
     app.run_pending_background_jobs();
 
-    let crates = app.crates_from_index_head("3/f/fgt");
+    let crates = app.crates_from_index_head("fgt");
     assert_eq!(crates.len(), 1);
     assert_eq!(crates[0].name, "fgt");
     assert_eq!(crates[0].vers, "1.0.0");
@@ -549,7 +549,7 @@ fn new_krate_git_upload_appends() {
     token.enqueue_publish(crate_to_publish).good();
     app.run_pending_background_jobs();
 
-    let crates = app.crates_from_index_head("3/f/fpp");
+    let crates = app.crates_from_index_head("fpp");
     assert!(crates.len() == 2);
     assert_eq!(crates[0].name, "FPP");
     assert_eq!(crates[0].vers, "0.0.1");

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -49,7 +49,7 @@ fn yank_works_as_intended() {
     token.enqueue_publish(crate_to_publish).good();
     app.run_pending_background_jobs();
 
-    let crates = app.crates_from_index_head("3/f/fyk");
+    let crates = app.crates_from_index_head("fyk");
     assert_eq!(crates.len(), 1);
     assert_some_eq!(crates[0].yanked, false);
 
@@ -60,7 +60,7 @@ fn yank_works_as_intended() {
     // yank it
     token.yank("fyk", "1.0.0").good();
 
-    let crates = app.crates_from_index_head("3/f/fyk");
+    let crates = app.crates_from_index_head("fyk");
     assert_eq!(crates.len(), 1);
     assert_some_eq!(crates[0].yanked, true);
 
@@ -70,7 +70,7 @@ fn yank_works_as_intended() {
     // un-yank it
     token.unyank("fyk", "1.0.0").good();
 
-    let crates = app.crates_from_index_head("3/f/fyk");
+    let crates = app.crates_from_index_head("fyk");
     assert_eq!(crates.len(), 1);
     assert_some_eq!(crates[0].yanked, false);
 
@@ -80,7 +80,7 @@ fn yank_works_as_intended() {
     // yank it
     cookie.yank("fyk", "1.0.0").good();
 
-    let crates = app.crates_from_index_head("3/f/fyk");
+    let crates = app.crates_from_index_head("fyk");
     assert_eq!(crates.len(), 1);
     assert_some_eq!(crates[0].yanked, true);
 
@@ -90,7 +90,7 @@ fn yank_works_as_intended() {
     // un-yank it
     cookie.unyank("fyk", "1.0.0").good();
 
-    let crates = app.crates_from_index_head("3/f/fyk");
+    let crates = app.crates_from_index_head("fyk");
     assert_eq!(crates.len(), 1);
     assert_some_eq!(crates[0].yanked, false);
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -10,7 +10,7 @@ use cargo_registry::{
 };
 use std::{rc::Rc, sync::Arc, time::Duration};
 
-use cargo_registry::git::Repository as WorkerRepository;
+use cargo_registry::git::{Repository as WorkerRepository, Repository};
 use diesel::PgConnection;
 use git2::Repository as UpstreamRepository;
 use reqwest::{blocking::Client, Proxy};
@@ -134,12 +134,12 @@ impl TestApp {
     }
 
     /// Obtain a list of crates from the index HEAD
-    pub fn crates_from_index_head(&self, path: &str) -> Vec<cargo_registry::git::Crate> {
-        let path = std::path::Path::new(path);
+    pub fn crates_from_index_head(&self, crate_name: &str) -> Vec<cargo_registry::git::Crate> {
+        let path = Repository::relative_index_file(crate_name);
         let index = self.upstream_repository();
         let tree = index.head().unwrap().peel_to_tree().unwrap();
         let blob = tree
-            .get_path(path)
+            .get_path(&path)
             .unwrap()
             .to_object(index)
             .unwrap()

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -1,5 +1,5 @@
 use crate::background_jobs::Environment;
-use crate::git::{Crate, Credentials};
+use crate::git::{Crate, Credentials, Repository};
 use crate::models::Version;
 use chrono::Utc;
 use std::fs::{self, OpenOptions};
@@ -21,7 +21,7 @@ pub fn add_crate(env: &Environment, krate: Crate) -> Result<(), PerformError> {
 
     let message: String = format!("Updating crate `{}#{}`", krate.name, krate.vers);
 
-    repo.commit_and_push(&message, &repo.relative_index_file(&krate.name))
+    repo.commit_and_push(&message, &Repository::relative_index_file(&krate.name))
 }
 
 /// Yanks or unyanks a crate version. This requires finding the index
@@ -61,7 +61,7 @@ pub fn yank(
         version.num
     );
 
-    repo.commit_and_push(&message, &repo.relative_index_file(&krate))?;
+    repo.commit_and_push(&message, &Repository::relative_index_file(&krate))?;
 
     Ok(())
 }

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -1,5 +1,5 @@
 use crate::background_jobs::Environment;
-use crate::git::{Crate, Credentials, Repository};
+use crate::git::{Crate, Credentials};
 use crate::models::Version;
 use chrono::Utc;
 use std::fs::{self, OpenOptions};
@@ -21,7 +21,7 @@ pub fn add_crate(env: &Environment, krate: Crate) -> Result<(), PerformError> {
 
     let message: String = format!("Updating crate `{}#{}`", krate.name, krate.vers);
 
-    repo.commit_and_push(&message, &Repository::relative_index_file(&krate.name))
+    repo.commit_and_push(&message, &dst)
 }
 
 /// Yanks or unyanks a crate version. This requires finding the index
@@ -61,7 +61,7 @@ pub fn yank(
         version.num
     );
 
-    repo.commit_and_push(&message, &Repository::relative_index_file(&krate))?;
+    repo.commit_and_push(&message, &dst)?;
 
     Ok(())
 }


### PR DESCRIPTION
We can calculate the `path` automatically from the `crate_name`. There is no need for us to manually specify it in the tests.