### PR TITLE
worker::git: Read `yanked` status from database 

### DIFF
--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -61,7 +61,7 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
 
     insert_version_owner_action(&conn, version.id, user.id, api_token_id, action)?;
 
-    worker::yank(krate.name, version.num, yanked).enqueue(&conn)?;
+    worker::sync_yanked(krate.name, version.num).enqueue(&conn)?;
 
     ok_true()
 }

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -61,7 +61,7 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
 
     insert_version_owner_action(&conn, version.id, user.id, api_token_id, action)?;
 
-    worker::yank(krate.name, version, yanked).enqueue(&conn)?;
+    worker::yank(krate.name, version.num, yanked).enqueue(&conn)?;
 
     ok_true()
 }

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -66,16 +66,21 @@ pub fn sync_yanked(
         })
         .collect::<Result<Vec<_>, PerformError>>();
     let new = new?.join("\n") + "\n";
-    fs::write(&dst, new.as_bytes())?;
 
-    let message: String = format!(
-        "{} crate `{}#{}`",
-        if yanked { "Yanking" } else { "Unyanking" },
-        krate,
-        version_num
-    );
+    if new != prev {
+        fs::write(&dst, new.as_bytes())?;
 
-    repo.commit_and_push(&message, &dst)?;
+        let message: String = format!(
+            "{} crate `{}#{}`",
+            if yanked { "Yanking" } else { "Unyanking" },
+            krate,
+            version_num
+        );
+
+        repo.commit_and_push(&message, &dst)?;
+    } else {
+        debug!("Skipping `yanked` update because index is up-to-date");
+    }
 
     Ok(())
 }

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -70,12 +70,8 @@ pub fn sync_yanked(
     if new != prev {
         fs::write(&dst, new.as_bytes())?;
 
-        let message: String = format!(
-            "{} crate `{}#{}`",
-            if yanked { "Yanking" } else { "Unyanking" },
-            krate,
-            version_num
-        );
+        let action = if yanked { "Yanking" } else { "Unyanking" };
+        let message = format!("{} crate `{}#{}`", action, krate, version_num);
 
         repo.commit_and_push(&message, &dst)?;
     } else {

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -1,6 +1,5 @@
 use crate::background_jobs::Environment;
 use crate::git::{Crate, Credentials};
-use crate::models::Version;
 use chrono::Utc;
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
@@ -32,7 +31,7 @@ pub fn add_crate(env: &Environment, krate: Crate) -> Result<(), PerformError> {
 pub fn yank(
     env: &Environment,
     krate: String,
-    version: Version,
+    version_num: String,
     yanked: bool,
 ) -> Result<(), PerformError> {
     let repo = env.lock_index()?;
@@ -44,7 +43,7 @@ pub fn yank(
         .map(|line| {
             let mut git_crate = serde_json::from_str::<Crate>(line)
                 .map_err(|_| format!("couldn't decode: `{}`", line))?;
-            if git_crate.name != krate || git_crate.vers != version.num {
+            if git_crate.name != krate || git_crate.vers != version_num {
                 return Ok(line.to_string());
             }
             git_crate.yanked = Some(yanked);
@@ -58,7 +57,7 @@ pub fn yank(
         "{} crate `{}#{}`",
         if yanked { "Yanking" } else { "Unyanking" },
         krate,
-        version.num
+        version_num
     );
 
     repo.commit_and_push(&message, &dst)?;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -11,6 +11,6 @@ mod update_downloads;
 
 pub use daily_db_maintenance::daily_db_maintenance;
 pub use dump_db::dump_db;
-pub use git::{add_crate, squash_index, yank};
+pub use git::{add_crate, squash_index, sync_yanked};
 pub use readmes::render_and_upload_readme;
 pub use update_downloads::update_downloads;


### PR DESCRIPTION
This PR implements one part of https://github.com/rust-lang/crates.io/issues/4172. By no longer passing `yanked` into the `yank` (now `sync_yanked`) background worker task, and instead reading `yanked` from the database, we can avoid issues from tasks running out of order.