### PR TITLE
Fix `transitionTo()` and `replaceWith()` deprecations on routes

### DIFF
--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 export default class CategoryRoute extends Route {
   @service notifications;
+  @service router;
   @service store;
 
   async model(params) {
@@ -12,7 +13,7 @@ export default class CategoryRoute extends Route {
     } catch (error) {
       if (error instanceof NotFoundError) {
         this.notifications.error(`Category '${params.category_id}' does not exist`);
-        return this.replaceWith('index');
+        return this.router.replaceWith('index');
       }
 
       throw error;

--- a/app/routes/confirm.js
+++ b/app/routes/confirm.js
@@ -5,6 +5,7 @@ import ajax from '../utils/ajax';
 
 export default class ConfirmRoute extends Route {
   @service notifications;
+  @service router;
   @service session;
   @service store;
 
@@ -29,6 +30,6 @@ export default class ConfirmRoute extends Route {
       }
     }
 
-    this.replaceWith('index');
+    this.router.replaceWith('index');
   }
 }

--- a/app/routes/crate/dependencies.js
+++ b/app/routes/crate/dependencies.js
@@ -1,6 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class VersionRoute extends Route {
+  @service router;
+
   async model() {
     let crate = this.modelFor('crate');
     let versions = await crate.get('versions');
@@ -8,6 +11,6 @@ export default class VersionRoute extends Route {
     let { defaultVersion } = crate;
     let version = versions.find(version => version.num === defaultVersion) ?? versions.lastObject;
 
-    this.replaceWith('crate.version-dependencies', crate, version.num);
+    this.router.replaceWith('crate.version-dependencies', crate, version.num);
   }
 }

--- a/app/routes/crate/docs.js
+++ b/app/routes/crate/docs.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 export default class CrateDocsRoute extends Route {
   @service notifications;
   @service redirector;
+  @service router;
 
   redirect() {
     let crate = this.modelFor('crate');
@@ -16,7 +17,7 @@ export default class CrateDocsRoute extends Route {
       // no documentation is found
       let message = 'Crate does not supply a documentation URL';
       this.notifications.error(message);
-      this.replaceWith('crate', crate);
+      this.router.replaceWith('crate', crate);
     }
   }
 }

--- a/app/routes/crate/owners.js
+++ b/app/routes/crate/owners.js
@@ -1,9 +1,12 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class OwnersRoute extends Route {
+  @service router;
+
   redirect() {
     let crate = this.modelFor('crate');
 
-    this.transitionTo('crate.settings', crate);
+    this.router.transitionTo('crate.settings', crate);
   }
 }

--- a/app/routes/crate/range.js
+++ b/app/routes/crate/range.js
@@ -23,7 +23,7 @@ export default class VersionRoute extends Route {
     let versionNum = maxSatisfying(unyankedVersionNums, npmRange) ?? maxSatisfying(allVersionNums, npmRange);
     if (!versionNum) {
       this.notifications.error(`No matching version of crate '${crate.name}' found for: ${range}`);
-      this.replaceWith('crate.index');
+      this.router.replaceWith('crate.index');
     }
 
     this.router.replaceWith('crate.version', versionNum);

--- a/app/routes/crate/repo.js
+++ b/app/routes/crate/repo.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 export default class RepoRoute extends Route {
   @service notifications;
   @service redirector;
+  @service router;
 
   redirect() {
     let crate = this.modelFor('crate');
@@ -16,7 +17,7 @@ export default class RepoRoute extends Route {
       // no repository is found
       let message = 'Crate does not supply a repository URL';
       this.notifications.error(message);
-      this.replaceWith('crate', crate);
+      this.router.replaceWith('crate', crate);
     }
   }
 }

--- a/app/routes/crate/reverse-dependencies.js
+++ b/app/routes/crate/reverse-dependencies.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class ReverseDependenciesRoute extends Route {
   @service notifications;
+  @service router;
   @service store;
 
   queryParams = {
@@ -25,7 +26,7 @@ export default class ReverseDependenciesRoute extends Route {
       }
 
       this.notifications.error(message);
-      this.replaceWith('index');
+      this.router.replaceWith('index');
     }
   }
 

--- a/app/routes/crate/version-dependencies.js
+++ b/app/routes/crate/version-dependencies.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class VersionRoute extends Route {
   @service notifications;
+  @service router;
 
   async model(params) {
     let crate = this.modelFor('crate');
@@ -12,7 +13,7 @@ export default class VersionRoute extends Route {
     let version = versions.find(version => version.num === requestedVersion);
     if (!version) {
       this.notifications.error(`Version '${requestedVersion}' of crate '${crate.name}' does not exist`);
-      this.replaceWith('crate.index');
+      this.router.replaceWith('crate.index');
     }
 
     try {
@@ -21,7 +22,7 @@ export default class VersionRoute extends Route {
       this.notifications.error(
         `Failed to load the list of dependencies for the '${crate.name}' crate. Please try again later!`,
       );
-      this.replaceWith('crate.index');
+      this.router.replaceWith('crate.index');
     }
 
     return version;

--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -4,6 +4,7 @@ import { inject as service } from '@ember/service';
 
 export default class KeywordRoute extends Route {
   @service notifications;
+  @service router;
   @service store;
 
   async model({ keyword_id }) {
@@ -12,7 +13,7 @@ export default class KeywordRoute extends Route {
     } catch (error) {
       if (error instanceof NotFoundError) {
         this.notifications.error(`Keyword '${keyword_id}' does not exist`);
-        return this.replaceWith('index');
+        return this.router.replaceWith('index');
       }
 
       throw error;

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class TeamRoute extends Route {
   @service notifications;
+  @service router;
   @service store;
 
   queryParams = {
@@ -24,7 +25,7 @@ export default class TeamRoute extends Route {
     } catch (error) {
       if (error.errors?.some(e => e.detail === 'Not Found')) {
         this.notifications.error(`Team '${params.team_id}' does not exist`);
-        return this.replaceWith('index');
+        return this.router.replaceWith('index');
       }
 
       throw error;

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -3,6 +3,7 @@ import { inject as service } from '@ember/service';
 
 export default class UserRoute extends Route {
   @service notifications;
+  @service router;
   @service store;
 
   queryParams = {
@@ -23,7 +24,7 @@ export default class UserRoute extends Route {
     } catch (error) {
       if (error.errors?.some(e => e.detail === 'Not Found')) {
         this.notifications.error(`User '${params.user_id}' does not exist`);
-        return this.replaceWith('index');
+        return this.router.replaceWith('index');
       }
 
       throw error;


### PR DESCRIPTION
These two methods on the `Route` base class are deprecated in favor of using the `router` service instead.