### PR TITLE
Cargo: Enable doctests again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ opt-level = 2
 
 [lib]
 name = "cargo_registry"
-doctest = false
+doctest = true
 
 [[test]]
 name = "all"

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -55,9 +55,12 @@ pub fn remove_owners(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Parse the JSON request body of requests to modify the owners of a crate.
-/// The format is
 ///
-///     {"owners": ["username", "github:org:team", ...]}
+/// The format is:
+///
+/// ```json
+/// {"owners": ["username", "github:org:team", ...]}
+/// ```
 fn parse_owners_request(req: &mut dyn RequestExt) -> AppResult<Vec<String>> {
     let mut body = String::new();
     req.body().read_to_string(&mut body)?;


### PR DESCRIPTION
They were disabled in 2014 for some unknown reason, but these days there is really no reason to have them disabled.