### PR TITLE
models/version: Add missing `fetch` import

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -1,6 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 import { keepLatestTask, task } from 'ember-concurrency';
+import fetch from 'fetch';
 import { alias } from 'macro-decorators';
 import semverParse from 'semver/functions/parse';
 import { cached } from 'tracked-toolbox';


### PR DESCRIPTION
This is needed for fastboot to work correctly, but also to correctly use the `fetch()` polyfill, if necessary.