### PR TITLE
crate.version: Fix `downloads` alias

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -11,7 +11,7 @@ export default class CrateVersionController extends Controller {
     return this.requestedVersion ? this.currentVersion : this.crate;
   }
 
-  @alias('downloadsContext.version_downloads') downloads;
+  @alias('downloadsContext.version_downloads.content') downloads;
   @alias('model.crate') crate;
   @alias('model.requestedVersion') requestedVersion;
   @alias('model.version') currentVersion;


### PR DESCRIPTION
The reference to the `HasManyArray` never changes, so the download graph is not rerendered with Ember Data v4. We pass the `content` value of the Promise into the component instead to fix this.