### PR TITLE
Replace `license-exprs` crate with `spdx`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,6 @@ dependencies = [
  "indexmap",
  "lazy_static",
  "lettre",
- "license-exprs",
  "minijinja",
  "moka",
  "oauth2",
@@ -286,6 +285,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.0",
+ "spdx",
  "swirl",
  "tar",
  "tempfile",
@@ -1463,12 +1463,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "license-exprs"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a577c3a5f3982766dd577c4440b86c53c6ffd42007e4c1d83d2da3ce9f99cc3d"
 
 [[package]]
 name = "lock_api"
@@ -2749,6 +2743,15 @@ checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spdx"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31283ed7fe3bca10f3e5ec2fe2787f16764a4275949606fd48d4fc919a760e3"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ hyper = { version = "=0.14.16", features = ["client", "http1"] }
 indexmap = { version = "=1.7.0", features = ["serde-1"] }
 tikv-jemallocator = { version = "=0.4.1", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "=0.10.0-rc.4", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
-license-exprs = "=1.6.0"
 minijinja = "=0.8.2"
 moka = "=0.6.2"
 oauth2 = { version = "=4.1.0", default-features = false, features = ["reqwest"] }
@@ -78,6 +77,7 @@ sentry-conduit = { version = "=0.4.0", default-features = false }
 serde = { version = "=1.0.131", features = ["derive"] }
 serde_json = "=1.0.73"
 sha2 = "=0.10.0"
+spdx = "=0.8.0"
 swirl = { git = "https://github.com/sgrif/swirl.git", rev = "e87cf37" }
 tar = "=0.4.38"
 tempfile = "=3.2.0"

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -189,11 +189,16 @@ impl NewVersion {
 }
 
 fn validate_license_expr(s: &str) -> AppResult<()> {
-    for part in s.split('/') {
-        license_exprs::validate_license_expr(part).map_err(|e| {
-            cargo_err(&format_args!("{}; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers", e))
-        })?;
-    }
+    pub const PARSE_MODE: spdx::ParseMode = spdx::ParseMode {
+        allow_lower_case_operators: false,
+        allow_slash_as_or_operator: true,
+        allow_imprecise_license_names: false,
+        allow_postfix_plus_on_gpl: true,
+    };
+
+    spdx::Expression::parse_mode(s, PARSE_MODE).map_err(|_| {
+        cargo_err("unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers")
+    })?;
 
     Ok(())
 }
@@ -277,13 +282,11 @@ mod tests {
         assert_ok!(validate_license_expr("MIT OR Apache-2.0"));
         assert_ok!(validate_license_expr("MIT/Apache-2.0"));
         assert_ok!(validate_license_expr("MIT AND Apache-2.0"));
+        assert_ok!(validate_license_expr("MIT OR (Apache-2.0 AND MIT)"));
+        assert_ok!(validate_license_expr("GPL-3.0+"));
 
         let error = assert_err!(validate_license_expr("apache 2.0"));
         let error = format!("{}", error);
-        assert!(error.starts_with("unknown license or other term: apache; see http"));
-
-        let error = assert_err!(validate_license_expr("MIT OR (Apache-2.0 AND MIT)"));
-        let error = format!("{}", error);
-        assert!(error.starts_with("unknown license or other term: (Apache-2.0; see http"));
+        assert!(error.starts_with("unknown or invalid license expression; see http"));
     }
 }


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/2595

tl;dr you can now use parenthesis (e.g. `X AND (Y OR Z)`) in license expressions. the custom `/` operator is still supported for now, though not directly compatible with the use of parenthesis.