### PR TITLE
Adjust application test background color

### DIFF
--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -10,4 +10,18 @@ export function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
   setupMirage(hooks);
   setupSentryMock(hooks);
+  setupAppTestBodyClass(hooks);
+}
+
+function setupAppTestBodyClass(hooks) {
+  const ID = 'app-test';
+
+  hooks.beforeEach(function () {
+    this.bodyClass = this.owner.lookup('service:body-class');
+    this.bodyClass.register(ID, ['app-test']);
+  });
+
+  hooks.afterEach(function () {
+    this.bodyClass.deregister(ID);
+  });
 }

--- a/vendor/qunit.css
+++ b/vendor/qunit.css
@@ -1,3 +1,3 @@
-#ember-testing-container {
+body.app-test .ember-application {
   background-color: var(--header-bg-color);
 }


### PR DESCRIPTION
This ensures that the checker board pattern is used in rendering tests, but application tests use the correct background from the `body` element.