### PR TITLE
Adjust `/me` redirection to `/settings/tokens`

### DIFF
--- a/app/routes/me/index.js
+++ b/app/routes/me/index.js
@@ -5,6 +5,8 @@ export default class MeIndexRoute extends Route {
   @service router;
 
   redirect() {
-    this.router.replaceWith('settings');
+    // `cargo login` is showing links to https://crates.io/me to access the API tokens,
+    // so we need to keep this route and redirect the user to the API tokens settings page.
+    this.router.replaceWith('settings.tokens');
   }
 }


### PR DESCRIPTION
As discussed on Discord, the `cargo login` command is showing links to https://crates.io/me to access the API tokens. Since that is probably more important than any other bookmarks and has backwards compatibility concerns this PR is changing the `/me` redirection to `/settings/tokens` (instead of `/settings` aka. `/settings/profile`).