### PR TITLE
catch-all: Fix broken "Go back" and "Reload" links

### DIFF
--- a/app/controllers/catch-all.js
+++ b/app/controllers/catch-all.js
@@ -2,8 +2,11 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 
 export default class CatchAllController extends Controller {
-  @action reload(event) {
-    event.preventDefault();
+  @action reload() {
     this.model.transition.retry();
+  }
+
+  @action back() {
+    history.back();
   }
 }

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -60,6 +60,7 @@ h1 {
 a, .link {
     color: var(--link-color);
     text-decoration: none;
+    cursor: pointer;
 
     &:hover {
         color: var(--link-hover-color);

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -57,7 +57,7 @@ h1 {
     }
 }
 
-a {
+a, .link {
     color: var(--link-color);
     text-decoration: none;
 

--- a/app/styles/catch-all.module.css
+++ b/app/styles/catch-all.module.css
@@ -15,5 +15,7 @@
 }
 
 .link {
+    composes: button-reset from '../styles/shared/buttons.module.css';
+    composes: link from '../styles/application.module.css';
     font-weight: 500;
 }

--- a/app/templates/catch-all.hbs
+++ b/app/templates/catch-all.hbs
@@ -5,9 +5,9 @@
     <h1 local-class="title" data-test-title>{{or @model.title "Page not found"}}</h1>
 
     {{#if @model.tryAgain}}
-      <a href="javascript:location.reload()" local-class="link" data-test-try-again {{on "click" this.reload}}>Try Again</a>
+      <button type="button" local-class="link" data-test-try-again {{on "click" this.reload}}>Try Again</button>
     {{else}}
-      <a href="javascript:history.back()" local-class="link" data-test-go-back>Go Back</a>
+      <button type="button" local-class="link" data-test-go-back {{on "click" this.back}}>Go Back</button>
     {{/if}}
   </div>
 </div>


### PR DESCRIPTION
> Refused to run the JavaScript URL because it violates the following Content Security Policy directive: "script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='". Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable inline execution. Note that hashes do not apply to event handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword is present.

This PR fixes the above error, that is triggered from hitting the "Go back" link on e.g. https://crates.io/crates/jdfgkjsdfjksnd