### PR TITLE
Improve database fallbacks

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -15,7 +15,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     let offset = options.offset().unwrap_or_default();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let categories =
         Category::toplevel(&conn, sort, i64::from(options.per_page), i64::from(offset))?;
     let categories = categories
@@ -35,7 +35,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /categories/:category_id` route.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let slug = &req.params()["category_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let cat: Category = Category::by_slug(slug).first(&*conn)?;
     let subcats = cat
         .subcategories(&conn)?
@@ -65,7 +65,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
 
 /// Handles the `GET /category_slugs` route.
 pub fn slugs(req: &mut dyn RequestExt) -> EndpointResult {
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let slugs: Vec<Slug> = categories::table
         .select((categories::slug, categories::slug, categories::description))
         .order(categories::slug)

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -256,7 +256,7 @@ pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
 
     let crate_invite = crate_invite.crate_owner_invite;
     let user_id = req.authenticate()?.user_id();
-    let conn = &*req.db_conn()?;
+    let conn = &*req.db_write()?;
     let config = &req.app().config;
 
     let invitation = CrateOwnerInvitation::find_by_id(user_id, crate_invite.crate_id, conn)?;
@@ -272,7 +272,7 @@ pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
 pub fn handle_invite_with_token(req: &mut dyn RequestExt) -> EndpointResult {
     let config = &req.app().config;
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
     let req_token = &req.params()["token"];
 
     let invitation = CrateOwnerInvitation::find_by_token(req_token, &conn)?;

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -82,7 +82,7 @@ fn prepare_list(
         .gather(req)?;
 
     let user = auth.user();
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let config = &req.app().config;
 
     let mut crate_names = HashMap::new();

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -21,7 +21,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     }
 
     let query = query.pages_pagination(PaginationOptions::builder().gather(req)?);
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let data: Paginated<Keyword> = query.load(&*conn)?;
     let total = data.total();
     let kws = data
@@ -38,7 +38,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /keywords/:keyword_id` route.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["keyword_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
 
     let kw = Keyword::find_by_keyword(&conn, name)?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -18,7 +18,7 @@ pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::sql_types::BigInt;
 
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
 
     let mut versions: Vec<Version> = krate.all_versions().load(&*conn)?;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -47,7 +47,7 @@ pub fn following(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::exists;
 
     let user_id = req.authenticate()?.forbid_api_token_auth()?.user_id();
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let follow = follow_target(req, &conn, user_id)?;
     let following =
         diesel::select(exists(follows::table.find(follow.id()))).get_result::<bool>(&*conn)?;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -22,7 +22,7 @@ fn follow_target(
 /// Handles the `PUT /crates/:crate_id/follow` route.
 pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = req.authenticate()?.user_id();
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
     diesel::insert_into(follows::table)
         .values(&follow)
@@ -35,7 +35,7 @@ pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `DELETE /crates/:crate_id/follow` route.
 pub fn unfollow(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = req.authenticate()?.user_id();
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
     diesel::delete(&follow).execute(&*conn)?;
 

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -24,7 +24,7 @@ use crate::models::krate::ALL_COLUMNS;
 pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
     use crate::schema::crates::dsl::*;
 
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let num_crates: i64 = crates.count().get_result(&*conn)?;
     let num_downloads: i64 = metadata::table
         .select(metadata::total_downloads)
@@ -111,7 +111,7 @@ pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id` route.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["crate_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(name).first(&*conn)?;
 
     let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
@@ -199,7 +199,7 @@ pub fn readme(req: &mut dyn RequestExt) -> EndpointResult {
 // this information already, but ember is definitely requesting it
 pub fn versions(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
         .all_versions()
@@ -230,7 +230,7 @@ pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
 
     let pagination_options = PaginationOptions::builder().gather(req)?;
     let name = &req.params()["crate_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(name).first(&*conn)?;
     let (rev_deps, total) = krate.reverse_dependencies(&*conn, pagination_options)?;
     let rev_deps: Vec<_> = rev_deps

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -7,7 +7,7 @@ use crate::views::EncodableOwner;
 /// Handles the `GET /crates/:crate_id/owners` route.
 pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = krate
         .owners(&conn)?
@@ -21,7 +21,7 @@ pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id/owner_team` route.
 pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = Team::owning(&krate, &conn)?
         .into_iter()
@@ -34,7 +34,7 @@ pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id/owner_user` route.
 pub fn owner_user(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = User::owning(&krate, &conn)?
         .into_iter()

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -84,7 +84,7 @@ fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
     let app = req.app();
     let crate_name = &req.params()["crate_id"];
 
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
     let user = authenticated_user.user();
 
     conn.transaction(|| {

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -243,7 +243,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         .limit_page_numbers(req.app().clone())
         .enable_seek(supports_seek)
         .gather(req)?;
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
 
     let (explicit_page, seek) = match pagination.page.clone() {
         Page::Numeric(_) => (true, None),

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -24,7 +24,7 @@ pub fn prometheus(req: &mut dyn RequestExt) -> EndpointResult {
     }
 
     let metrics = match req.params()["kind"].as_str() {
-        "service" => app.service_metrics.gather(&*req.db_read_only()?)?,
+        "service" => app.service_metrics.gather(&*req.db_read()?)?,
         "instance" => app.instance_metrics.gather(app)?,
         _ => return Err(not_found()),
     };

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -9,7 +9,7 @@ pub fn show_team(req: &mut dyn RequestExt) -> EndpointResult {
     use self::teams::dsl::{login, teams};
 
     let name = &req.params()["team_id"];
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let team: Team = teams.filter(login.eq(name)).first(&*conn)?;
 
     Ok(req.json(&json!({ "team": EncodableTeam::from(team) })))

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -11,7 +11,7 @@ use serde_json as json;
 /// Handles the `GET /me/tokens` route.
 pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
     let authenticated_user = req.authenticate()?.forbid_api_token_auth()?;
-    let conn = req.db_write()?;
+    let conn = req.db_read_prefer_primary()?;
     let user = authenticated_user.user();
 
     let tokens: Vec<ApiToken> = ApiToken::belonging_to(&user)

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -69,7 +69,7 @@ pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
             users::all_columns.nullable(),
         ))
         .pages_pagination(PaginationOptions::builder().gather(req)?);
-    let conn = req.db_write()?;
+    let conn = req.db_read_prefer_primary()?;
     let data: Paginated<(Version, String, Option<User>)> = query.load(&*conn)?;
     let more = data.next_page_params().is_some();
     let versions = data.iter().map(|(v, _, _)| v).cloned().collect::<Vec<_>>();

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -14,7 +14,7 @@ use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCra
 /// Handles the `GET /me` route.
 pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = req.authenticate()?.forbid_api_token_auth()?.user_id();
-    let conn = req.db_write()?;
+    let conn = req.db_read_prefer_primary()?;
 
     let (user, verified, email, verification_sent): (User, Option<bool>, Option<String>, bool) =
         users::table

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -10,7 +10,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     use self::users::dsl::{gh_login, id, users};
 
     let name = lower(&req.params()["user_id"]);
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
     let user: User = users
         .filter(lower(gh_login).eq(name))
         .order(id.desc())
@@ -26,7 +26,7 @@ pub fn stats(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = &req.params()["user_id"]
         .parse::<i32>()
         .map_err(|err| err.chain(bad_request("invalid user_id")))?;
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
 
     let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)
         .inner_join(crates::table)

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -10,7 +10,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     use self::users::dsl::{gh_login, id, users};
 
     let name = lower(&req.params()["user_id"]);
-    let conn = req.db_write()?;
+    let conn = req.db_read_prefer_primary()?;
     let user: User = users
         .filter(lower(gh_login).eq(name))
         .order(id.desc())

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -26,7 +26,7 @@ pub fn stats(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = &req.params()["user_id"]
         .parse::<i32>()
         .map_err(|err| err.chain(bad_request("invalid user_id")))?;
-    let conn = req.db_write()?;
+    let conn = req.db_read_prefer_primary()?;
 
     let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)
         .inner_join(crates::table)

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -95,7 +95,12 @@ pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
 
     // Fetch the user info from GitHub using the access token we just got and create a user record
     let ghuser = req.app().github.current_user(token)?;
-    let user = save_user_to_database(&ghuser, token.secret(), &req.app().emails, &*req.db_conn()?)?;
+    let user = save_user_to_database(
+        &ghuser,
+        token.secret(),
+        &req.app().emails,
+        &*req.db_write()?,
+    )?;
 
     // Log in by setting a cookie and the middleware authentication
     req.session_mut()

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -67,7 +67,7 @@ fn verify_origin(req: &dyn RequestExt) -> AppResult<()> {
 }
 
 fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
 
     let session = req.session();
     let user_id_from_session = session.get("user_id").and_then(|s| s.parse::<i32>().ok());

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -14,7 +14,7 @@ use crate::views::EncodableVersion;
 /// Handles the `GET /versions` route.
 pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::any;
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
 
     // Extract all ids requested.
     let query = url::form_urlencoded::parse(req.query_string().unwrap_or("").as_bytes());
@@ -54,7 +54,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn show_by_id(req: &mut dyn RequestExt) -> EndpointResult {
     let id = &req.params()["version_id"];
     let id = id.parse().unwrap_or(0);
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table
         .find(id)
         .inner_join(crates::table)

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -122,7 +122,7 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
 
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
 
     let cutoff_end_date = req

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -37,7 +37,7 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
         let conn = if app.config.force_unconditional_redirects {
             None
         } else {
-            match req.db_write() {
+            match req.db_read_prefer_primary() {
                 Ok(conn) => Some(conn),
                 Err(PoolError::UnhealthyPool) => None,
                 Err(err) => return Err(err.into()),

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -37,7 +37,7 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
         let conn = if app.config.force_unconditional_redirects {
             None
         } else {
-            match req.db_conn() {
+            match req.db_write() {
                 Ok(conn) => Some(conn),
                 Err(PoolError::UnhealthyPool) => None,
                 Err(err) => return Err(err.into()),

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -20,7 +20,7 @@ use super::{extract_crate_name_and_semver, version_and_crate};
 /// be 0)
 pub fn dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
     let deps = version.dependencies(&conn)?;
     let deps = deps
@@ -48,7 +48,7 @@ pub fn authors(req: &mut dyn RequestExt) -> EndpointResult {
 /// API route to have.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
-    let conn = req.db_read_only()?;
+    let conn = req.db_read()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;
     let published_by = version.published_by(&conn);
     let actions = VersionOwnerAction::by_version(&conn, &version)?;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -34,7 +34,7 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
     let authenticated_user = req.authenticate()?;
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
 
-    let conn = req.db_conn()?;
+    let conn = req.db_write()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;
     let api_token_id = authenticated_user.api_token_id();
     let user = authenticated_user.user();

--- a/src/db.rs
+++ b/src/db.rs
@@ -146,7 +146,7 @@ pub fn connection_url(url: &str) -> String {
 
 pub trait RequestTransaction {
     /// Obtain a read/write database connection from the primary pool
-    fn db_conn(&self) -> Result<DieselPooledConn<'_>, PoolError>;
+    fn db_write(&self) -> Result<DieselPooledConn<'_>, PoolError>;
 
     /// Obtain a readonly database connection from the replica pool
     ///
@@ -155,7 +155,7 @@ pub trait RequestTransaction {
 }
 
 impl<T: RequestExt + ?Sized> RequestTransaction for T {
-    fn db_conn(&self) -> Result<DieselPooledConn<'_>, PoolError> {
+    fn db_write(&self) -> Result<DieselPooledConn<'_>, PoolError> {
         self.app().primary_database.get()
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -171,7 +171,16 @@ impl<T: RequestExt + ?Sized> RequestTransaction for T {
             Some(Ok(connection)) => Ok(connection),
 
             // Replica is not available, but primary might be available
-            Some(Err(PoolError::UnhealthyPool)) => self.app().primary_database.get(),
+            Some(Err(PoolError::UnhealthyPool)) => {
+                let _ = self
+                    .app()
+                    .instance_metrics
+                    .database_fallback_used
+                    .get_metric_with_label_values(&["follower"])
+                    .map(|metric| metric.inc());
+
+                self.app().primary_database.get()
+            }
 
             // Replica failed
             Some(Err(error)) => Err(error),
@@ -190,7 +199,16 @@ impl<T: RequestExt + ?Sized> RequestTransaction for T {
             (Ok(connection), _) => Ok(connection),
 
             // Primary is not available, but replica might be available
-            (Err(PoolError::UnhealthyPool), Some(read_only_pool)) => read_only_pool.get(),
+            (Err(PoolError::UnhealthyPool), Some(read_only_pool)) => {
+                let _ = self
+                    .app()
+                    .instance_metrics
+                    .database_fallback_used
+                    .get_metric_with_label_values(&["primary"])
+                    .map(|metric| metric.inc());
+
+                read_only_pool.get()
+            }
 
             // Primary failed and replica is disabled
             (Err(error), None) => Err(error),

--- a/src/db.rs
+++ b/src/db.rs
@@ -151,7 +151,7 @@ pub trait RequestTransaction {
     /// Obtain a readonly database connection from the replica pool
     ///
     /// If the replica pool is disabled or unavailable, the primary pool is used instead.
-    fn db_read_only(&self) -> Result<DieselPooledConn<'_>, PoolError>;
+    fn db_read(&self) -> Result<DieselPooledConn<'_>, PoolError>;
 }
 
 impl<T: RequestExt + ?Sized> RequestTransaction for T {
@@ -159,7 +159,7 @@ impl<T: RequestExt + ?Sized> RequestTransaction for T {
         self.app().primary_database.get()
     }
 
-    fn db_read_only(&self) -> Result<DieselPooledConn<'_>, PoolError> {
+    fn db_read(&self) -> Result<DieselPooledConn<'_>, PoolError> {
         let read_only_pool = self.app().read_only_replica_database.as_ref();
         match read_only_pool.map(|pool| pool.get()) {
             // Replica is available

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -31,6 +31,8 @@ metrics! {
         database_used_conns: IntGaugeVec["pool"],
         /// Amount of time required to obtain a database connection
         pub database_time_to_obtain_connection: HistogramVec["pool"],
+        /// Number of times the database pool was unavailable and the fallback was used
+        pub database_fallback_used: IntGaugeVec["pool"],
 
         /// Number of requests processed by this instance
         pub requests_total: IntCounter,


### PR DESCRIPTION
As suggested on Discord (see https://discord.com/channels/442252698964721669/835156566746595386/923210089085665381), this PR:

- implements a primary database fallback if the replica is unavailable
- renames the existing connection pool methods to `db_read()` and `db_write()`
- implements an additional `db_read_prefer_primary()` method
- uses that new method for endpoints that prefer the primary database, but don't need to write anything to the database

This should improve our resilience a little bit in case of database issues.