### PR TITLE
renovate: Disable `dependencyDashboardApproval` option

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,6 @@
         "reviewersSampleSize": 1,
     },
     "rust": {
-        "dependencyDashboardApproval": true,
         "labels": ["A-backend"],
     },
     "regexManagers": [


### PR DESCRIPTION
There is no real downside of having these PRs open automatically and whether or not we merge them is still our decision in the end.