### PR TITLE
Remove "Filter by letter" feature

### DIFF
--- a/app/controllers/crates.js
+++ b/app/controllers/crates.js
@@ -1,5 +1,4 @@
 import Controller from '@ember/controller';
-import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 
 import { reads } from 'macro-decorators';
@@ -7,12 +6,10 @@ import { reads } from 'macro-decorators';
 import { pagination } from '../utils/pagination';
 
 export default class CratesController extends Controller {
-  queryParams = ['letter', 'page', 'per_page', 'sort'];
-  @tracked letter = null;
+  queryParams = ['page', 'per_page', 'sort'];
   @tracked page = '1';
   @tracked per_page = 50;
   @tracked sort = 'alpha';
-  alphabet = [...'ABCDEFGHIJKLMNOPQRSTUVWXYZ'];
 
   @reads('model.meta.total') totalItems;
   @pagination() pagination;
@@ -29,9 +26,5 @@ export default class CratesController extends Controller {
     } else {
       return 'Alphabetical';
     }
-  }
-
-  @action handleSelection(event) {
-    this.set('letter', event.target.value);
   }
 }

--- a/app/routes/crates.js
+++ b/app/routes/crates.js
@@ -5,18 +5,11 @@ export default class CratesRoute extends Route {
   @service store;
 
   queryParams = {
-    letter: { refreshModel: true },
     page: { refreshModel: true },
     sort: { refreshModel: true },
   };
 
   model(params) {
-    // The backend throws an error if the letter param is
-    // empty or null.
-    if (!params.letter) {
-      delete params.letter;
-    }
-
     return this.store.query('crate', params);
   }
 }

--- a/app/templates/crates.hbs
+++ b/app/templates/crates.hbs
@@ -2,25 +2,6 @@
 
 <PageHeader @title="All Crates" @suffix={{if this.letter (concat "starting with '" this.letter "'")}}/>
 
-<div local-class='selection'>
-  {{#each this.alphabet as |letter|}}
-    <LinkTo @query={{hash letter=letter page=1}}>
-      {{ letter }}
-    </LinkTo>
-  {{/each}}
-
-  <label local-class="filter-dropdown-label">
-    Filter by letter:
-
-    <select local-class="filter-dropdown" {{on "change" this.handleSelection}}>
-      <option value="">No Filter</option>
-      {{#each this.alphabet as |letter|}}
-        <option value={{letter}} selected={{eq letter this.letter}}>{{ letter }}</option>
-      {{/each}}
-    </select>
-  </label>
-</div>
-
 <div local-class="results-meta">
   <ResultsCount
     @start={{this.pagination.currentPageStart}}


### PR DESCRIPTION
With over 70k crates it has become quite useless to filter the crates by their starting letter, so we might as well remove this feature to declutter the user interface a little bit.