### PR TITLE
Repository: Extract `run_command()` function

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -66,7 +66,7 @@ impl Credentials {
     /// - If non-SSH credentials are use, `Err` is returned.
     /// - If creation of the temporary file fails, `Err` is returned.
     ///
-    pub fn write_temporary_ssh_key(&self) -> anyhow::Result<tempfile::TempPath> {
+    fn write_temporary_ssh_key(&self) -> anyhow::Result<tempfile::TempPath> {
         let key = match self {
             Credentials::Ssh { key } => key,
             _ => return Err(anyhow!("SSH key not available")),
@@ -179,10 +179,9 @@ impl RepositoryConfig {
 }
 
 pub struct Repository {
-    /// bla
-    pub checkout_path: TempDir,
+    checkout_path: TempDir,
     repository: git2::Repository,
-    pub credentials: Credentials,
+    credentials: Credentials,
 }
 
 impl Repository {

--- a/src/git.rs
+++ b/src/git.rs
@@ -50,6 +50,20 @@ impl Credentials {
         }
     }
 
+    /// Write the SSH key to a temporary file and return the path. The file is
+    /// deleted once the returned path is dropped.
+    ///
+    /// This function can be used when running `git push` instead of using the
+    /// `git2` crate for pushing commits to remote git servers.
+    ///
+    /// Note: On Linux this function creates the temporary file in `/dev/shm` to
+    /// avoid writing it to disk.
+    ///
+    /// # Errors
+    ///
+    /// - If non-SSH credentials are use, `Err` is returned.
+    /// - If creation of the temporary file fails, `Err` is returned.
+    ///
     pub fn write_temporary_ssh_key(&self) -> Result<tempfile::TempPath, PerformError> {
         let key = match self {
             Credentials::Ssh { key } => key,


### PR DESCRIPTION
This new function makes it easier to run arbitrary `git` commands in the working folder of the local index clone. It was extracted from the `squash_index()` background worker tasks, which uses it to run `git push --force-with-lease`, which is not yet supported by the `git2` crate.

The main goal of this PR is to reduce the visibility of the `checkout_path` and `credentials` fields on the `Repository`, which outside code should ideally not have any access to.

Note that this includes the commits from and is based on #4363.