### PR TITLE
Repository: Use `anyhow` errors as return types 

### DIFF
--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -23,7 +23,9 @@ pub fn add_crate(env: &Environment, krate: Crate) -> Result<(), PerformError> {
 
     let message: String = format!("Updating crate `{}#{}`", krate.name, krate.vers);
 
-    repo.commit_and_push(&message, &dst)
+    repo.commit_and_push(&message, &dst)?;
+
+    Ok(())
 }
 
 /// Yanks or unyanks a crate version. This requires finding the index


### PR DESCRIPTION
This makes it easier to provide additional context on some of these errors and ensure that the source error is correctly propagated.