### PR TITLE
Replace "Toggle Design" button with new `/settings/appearance` route

### DIFF
--- a/app/components/footer.module.css
+++ b/app/components/footer.module.css
@@ -1,10 +1,14 @@
-:root {
+:root, [data-theme="classic"] {
     --footer-bg-color: var(--green800);
     --footer-header-color: var(--yellow500);
     --footer-header-shadow-color: var(--green900);
     --footer-link-color: #fff;
     --footer-link-hover-color: var(--yellow500);
     --footer-link-hover-shadow-color: var(--green900);
+}
+
+[data-theme="new-design"] {
+    --footer-bg-color: var(--grey900);
 }
 
 .footer {

--- a/app/components/radio-button.hbs
+++ b/app/components/radio-button.hbs
@@ -1,0 +1,6 @@
+<input
+  type="radio"
+  checked={{eq @groupValue @value}}
+  ...attributes
+  {{on "change" (fn @onChange @value)}}
+/>

--- a/app/components/settings-page.hbs
+++ b/app/components/settings-page.hbs
@@ -1,6 +1,9 @@
 <div local-class="page" ...attributes>
   <SideMenu as |menu|>
     <menu.Item @link={{link "settings.profile"}}>Profile</menu.Item>
+    {{#if this.design.showToggleButton}}
+      <menu.Item @link={{link "settings.appearance"}}>Appearance</menu.Item>
+    {{/if}}
     <menu.Item @link={{link "settings.email-notifications"}}>Email Notifications</menu.Item>
     <menu.Item @link={{link "settings.tokens"}}>API Tokens</menu.Item>
   </SideMenu>

--- a/app/components/settings-page.js
+++ b/app/components/settings-page.js
@@ -1,0 +1,6 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class SettingsPage extends Component {
+  @service design;
+}

--- a/app/components/theme-preview.hbs
+++ b/app/components/theme-preview.hbs
@@ -1,0 +1,20 @@
+<div local-class="preview" data-theme={{@theme}} ...attributes>
+  <div local-class="header">
+    <div local-class="logo"></div>
+    <div local-class="title"></div>
+  </div>
+
+  <div local-class="main">
+    <div local-class="text"></div>
+    <div local-class="text"></div>
+    <div local-class="box">
+      <div local-class="text"></div>
+      <div local-class="text"></div>
+    </div>
+  </div>
+
+  <div local-class="footer">
+    <div local-class="title"></div>
+    <div local-class="link"></div>
+  </div>
+</div>

--- a/app/components/theme-preview.module.css
+++ b/app/components/theme-preview.module.css
@@ -1,0 +1,93 @@
+.preview {
+    display: grid;
+    grid-template-rows: 1fr 4fr 2fr;
+    background-color: var(--main-bg);
+    border: 1px solid var(--main-bg-dark);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    background-color: var(--header-bg-color);
+
+    .logo {
+        margin-left: 5%;
+        height: 35%;
+        aspect-ratio: 1;
+        border-radius: 99999px;
+        background-color: var(--yellow500);
+    }
+
+    .title {
+        margin-left: 5%;
+        height: 35%;
+        width: 40%;
+        border-radius: 99999px;
+        background-color: white;
+    }
+}
+
+.main {
+    background-color: var(--main-bg);
+
+    .text {
+        margin-top: 4%;
+        margin-left: 5%;
+        height: calc(35% / 4);
+        width: 70%;
+        border-radius: 99999px;
+        background-color: var(--main-color);
+
+        & + .text {
+            width: 50%;
+        }
+    }
+
+    .box {
+        display: inline-block;
+        margin-top: 5%;
+        margin-left: 5%;
+        height: 40%;
+        width: 50%;
+        border-radius: 2px;
+        background-color: white;
+
+        .text {
+            margin-top: 7%;
+            margin-left: 5%;
+            height: calc(35% / (4 * 0.4));
+            width: 50%;
+            border-radius: 99999px;
+            background-color: var(--main-color);
+
+            & + .text {
+                width: 70%;
+                background-color: var(--main-color-light);
+            }
+        }
+    }
+}
+
+.footer {
+    background-color: var(--footer-bg-color);
+
+    .title {
+        margin-top: 4%;
+        margin-left: 5%;
+        height: calc(35% / 3);
+        width: 15%;
+        border-radius: 99999px;
+        background-color: var(--footer-header-color);
+    }
+
+    .link {
+        margin-top: 4%;
+        margin-left: 5%;
+        height: calc(35% / 3);
+        width: 25%;
+        border-radius: 99999px;
+        background-color: var(--footer-link-color);
+    }
+}

--- a/app/controllers/settings/appearance.js
+++ b/app/controllers/settings/appearance.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+import { inject as service } from '@ember/service';
+
+export default class AppearanceSettingsController extends Controller {
+  @service design;
+}

--- a/app/controllers/settings/appearance.js
+++ b/app/controllers/settings/appearance.js
@@ -2,14 +2,14 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
+import { alias } from 'macro-decorators';
+
 export default class AppearanceSettingsController extends Controller {
   @service design;
 
-  get theme() {
-    return this.design.useNewDesign ? 'new-design' : 'classic';
-  }
+  @alias('design.theme') theme;
 
   @action setTheme(theme) {
-    this.design.setNewDesign(theme === 'new-design');
+    this.theme = theme;
   }
 }

--- a/app/controllers/settings/appearance.js
+++ b/app/controllers/settings/appearance.js
@@ -1,6 +1,15 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class AppearanceSettingsController extends Controller {
   @service design;
+
+  get theme() {
+    return this.design.useNewDesign ? 'new-design' : 'classic';
+  }
+
+  @action setTheme(theme) {
+    this.design.setNewDesign(theme === 'new-design');
+  }
 }

--- a/app/router.js
+++ b/app/router.js
@@ -32,6 +32,7 @@ Router.map(function () {
     this.route('pending-invites');
   });
   this.route('settings', function () {
+    this.route('appearance');
     this.route('email-notifications');
     this.route('profile');
     this.route('tokens');

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -20,7 +20,11 @@ export default class DesignService extends Service {
 
   @action
   toggle() {
-    this.useNewDesign = !this.useNewDesign;
+    this.setNewDesign(!this.useNewDesign);
+  }
+
+  setNewDesign(value) {
+    this.useNewDesign = value;
     localStorage.setItem('use-new-design', String(this.useNewDesign));
   }
 }

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -10,6 +10,14 @@ export default class DesignService extends Service {
   @tracked useNewDesign = !this.fastboot.isFastBoot && localStorage.getItem('use-new-design') === 'true';
   @tracked showToggleButton = config.environment === 'development' || config.environment === 'test';
 
+  get theme() {
+    return this.useNewDesign ? 'new-design' : 'classic';
+  }
+
+  set theme(theme) {
+    this.setNewDesign(theme === 'new-design');
+  }
+
   setNewDesign(value) {
     this.useNewDesign = value;
     localStorage.setItem('use-new-design', String(this.useNewDesign));

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -1,8 +1,5 @@
-import { action } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-
-import window from 'ember-window-mock';
 
 import config from '../config/environment';
 import * as localStorage from '../utils/local-storage';
@@ -12,16 +9,6 @@ export default class DesignService extends Service {
 
   @tracked useNewDesign = !this.fastboot.isFastBoot && localStorage.getItem('use-new-design') === 'true';
   @tracked showToggleButton = config.environment === 'development' || config.environment === 'test';
-
-  constructor() {
-    super(...arguments);
-    window.toggleDesign = () => this.toggle();
-  }
-
-  @action
-  toggle() {
-    this.setNewDesign(!this.useNewDesign);
-  }
 
   setNewDesign(value) {
     this.useNewDesign = value;

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -11,7 +11,7 @@ export default class DesignService extends Service {
   @service fastboot;
 
   @tracked useNewDesign = !this.fastboot.isFastBoot && localStorage.getItem('use-new-design') === 'true';
-  @tracked showToggleButton = config.environment === 'development';
+  @tracked showToggleButton = config.environment === 'development' || config.environment === 'test';
 
   constructor() {
     super(...arguments);

--- a/app/services/design.js
+++ b/app/services/design.js
@@ -4,22 +4,20 @@ import { tracked } from '@glimmer/tracking';
 import config from '../config/environment';
 import * as localStorage from '../utils/local-storage';
 
+const KNOWN_THEMES = new Set(['classic', 'new-design']);
+
 export default class DesignService extends Service {
   @service fastboot;
 
-  @tracked useNewDesign = !this.fastboot.isFastBoot && localStorage.getItem('use-new-design') === 'true';
+  @tracked _theme = localStorage.getItem('theme');
   @tracked showToggleButton = config.environment === 'development' || config.environment === 'test';
 
   get theme() {
-    return this.useNewDesign ? 'new-design' : 'classic';
+    return KNOWN_THEMES.has(this._theme) ? this._theme : 'classic';
   }
 
   set theme(theme) {
-    this.setNewDesign(theme === 'new-design');
-  }
-
-  setNewDesign(value) {
-    this.useNewDesign = value;
-    localStorage.setItem('use-new-design', String(this.useNewDesign));
+    this._theme = theme;
+    localStorage.setItem('theme', theme);
   }
 }

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -1,4 +1,4 @@
-:root {
+:root, [data-theme="classic"] {
     --violet800: hsl(252, 44%, 24%);
     --grey900: hsl(200, 15%, 19%);
     --grey700: hsl(200, 11%, 43%);
@@ -29,10 +29,9 @@
     --placeholder-bg2: hsl(213, 16%, 75%);
 }
 
-:root[data-theme="new-design"] {
+[data-theme="new-design"] {
     --header-bg-color: var(--violet800);
     --main-bg: white;
-    --footer-bg-color: var(--grey900);
 }
 
 * {

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -122,23 +122,3 @@ noscript {
     margin: 15px 0;
     padding: 0 15px;
 }
-
-.toggle-design-button {
-    position: fixed;
-    bottom: 30px;
-    left: 30px;
-    z-index: 100;
-    padding: 10px;
-    border: none;
-    border-radius: 5px;
-    background: white;
-    box-shadow: 0 0 3px rgba(0, 0, 0, 0.2);
-    color: black;
-    font-family: sans-serif;
-    cursor: pointer;
-
-    &:hover {
-        background: #f7f7f7;
-        box-shadow: 0 0 6px rgba(0, 0, 0, 0.2);
-    }
-}

--- a/app/styles/settings/appearance.module.css
+++ b/app/styles/settings/appearance.module.css
@@ -6,8 +6,14 @@
 
 .theme-label {
     display: inline-block;
-    padding: 10px;
+    padding: 16px;
     background: white;
     border-radius: 6px;
     box-shadow: 0 2px 3px hsla(51, 50%, 44%, .35);
+}
+
+.theme-preview {
+    width: 200px;
+    height: 160px;
+    margin-bottom: 16px;
 }

--- a/app/styles/settings/appearance.module.css
+++ b/app/styles/settings/appearance.module.css
@@ -1,3 +1,13 @@
-.toggle-button {
-    composes: yellow-button from '../shared/buttons.module.css';
+.themes-form {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.theme-label {
+    display: inline-block;
+    padding: 10px;
+    background: white;
+    border-radius: 6px;
+    box-shadow: 0 2px 3px hsla(51, 50%, 44%, .35);
 }

--- a/app/styles/settings/appearance.module.css
+++ b/app/styles/settings/appearance.module.css
@@ -1,0 +1,3 @@
+.toggle-button {
+    composes: yellow-button from '../shared/buttons.module.css';
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -15,9 +15,3 @@
 </main>
 
 <Footer/>
-
-{{#if this.design.showToggleButton}}
-  <button type="button" local-class="toggle-design-button" {{on "click" this.design.toggle}}>
-    Toggle Design
-  </button>
-{{/if}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,7 +1,7 @@
 <HeadLayout />
 
 {{page-title "crates.io: Rust Package Registry" separator=' - ' prepend=true}}
-{{set-theme (if this.design.useNewDesign "new-design")}}
+{{set-theme this.design.theme}}
 
 <ProgressBar/>
 <NotificationContainer @position="top-right"/>

--- a/app/templates/settings/appearance.hbs
+++ b/app/templates/settings/appearance.hbs
@@ -1,0 +1,11 @@
+{{page-title 'Settings'}}
+
+<PageHeader @title="Account Settings" @icon="gear"/>
+
+<SettingsPage>
+  <h2>Appearance</h2>
+
+  <button type="button" local-class="toggle-button" {{on "click" this.design.toggle}}>
+    Toggle Design
+  </button>
+</SettingsPage>

--- a/app/templates/settings/appearance.hbs
+++ b/app/templates/settings/appearance.hbs
@@ -5,7 +5,25 @@
 <SettingsPage>
   <h2>Appearance</h2>
 
-  <button type="button" local-class="toggle-button" {{on "click" this.design.toggle}}>
-    Toggle Design
-  </button>
+  <form local-class="themes-form">
+    <label local-class="theme-label">
+      <RadioButton
+        @groupValue={{this.theme}}
+        @value="classic"
+        @onChange={{this.setTheme}}
+      />
+
+      Classic
+    </label>
+
+    <label local-class="theme-label">
+      <RadioButton
+        @groupValue={{this.theme}}
+        @value="new-design"
+        @onChange={{this.setTheme}}
+      />
+
+      Purple
+    </label>
+  </form>
 </SettingsPage>

--- a/app/templates/settings/appearance.hbs
+++ b/app/templates/settings/appearance.hbs
@@ -7,6 +7,8 @@
 
   <form local-class="themes-form">
     <label local-class="theme-label">
+      <ThemePreview @theme="classic" local-class="theme-preview" />
+
       <RadioButton
         @groupValue={{this.theme}}
         @value="classic"
@@ -17,6 +19,8 @@
     </label>
 
     <label local-class="theme-label">
+      <ThemePreview @theme="new-design" local-class="theme-preview" />
+
       <RadioButton
         @groupValue={{this.theme}}
         @value="new-design"


### PR DESCRIPTION
Just like the "Toggle Design" button before, this route is only visible in development mode, or to be more precise: the link to this route is only visible in development mode, so that we can test this out in production too.

This should be seen as a first step towards implementing a "dark color scheme" mode (see https://github.com/rust-lang/crates.io/pull/3585), roughly inspired by how GitHub has implemented it in their user settings.

<img width="1000" alt="Bildschirmfoto 2021-12-26 um 19 34 12" src="https://user-images.githubusercontent.com/141300/147417178-16083d7d-6f57-47e0-b980-820ee5af1acf.png">
