### PR TITLE
DownloadGraph: Fix `extra` property access

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -77,7 +77,7 @@ export function toChartData(data) {
     return { datasets: [] };
   }
 
-  let extra = data.content?.meta?.extra_downloads ?? [];
+  let extra = data.meta?.extra_downloads ?? [];
 
   let dates = {};
   let versions = new Map();

--- a/tests/components/download-graph-test.js
+++ b/tests/components/download-graph-test.js
@@ -516,15 +516,13 @@ function exampleData() {
     { version: FIVE_5, date: '2020-12-27', downloads: 15_713 },
   ];
 
-  downloads.content = {
-    meta: {
-      extra_downloads: [
-        { date: '2020-12-30', downloads: 36_745 },
-        { date: '2020-12-29', downloads: 33_242 },
-        { date: '2020-12-28', downloads: 19_981 },
-        { date: '2020-12-27', downloads: 19_064 },
-      ],
-    },
+  downloads.meta = {
+    extra_downloads: [
+      { date: '2020-12-30', downloads: 36_745 },
+      { date: '2020-12-29', downloads: 33_242 },
+      { date: '2020-12-28', downloads: 19_981 },
+      { date: '2020-12-27', downloads: 19_064 },
+    ],
   };
 
   return downloads;


### PR DESCRIPTION
The attempted fix (e2398df) for the breakage caused by the Ember Data v4 update (072394d) caused this property path to no longer be valid. This commit should fix the issue.

Resolves https://github.com/rust-lang/crates.io/issues/4373