### PR TITLE
search: Show "Exact Match" as regular search result

### DIFF
--- a/app/components/crate-list.hbs
+++ b/app/components/crate-list.hbs
@@ -1,15 +1,6 @@
 <div ...attributes>
   {{!-- The extra div wrapper is needed for specificity issues with `margin` --}}
   <ol local-class="list">
-    {{#if @exactMatch}}
-      <li local-class="row exact-match">
-        <LinkTo @route="crate" @model={{@exactMatch}}>
-          <h1>Exact Match</h1>
-        </LinkTo>
-        <CrateRow @crate={{@exactMatch}} data-test-crate-row="exact-match" />
-      </li>
-    {{/if}}
-
     {{#each @crates as |crate index|}}
       <li local-class="row">
         <CrateRow @crate={{crate}} data-test-crate-row={{index}} />

--- a/app/components/crate-list.module.css
+++ b/app/components/crate-list.module.css
@@ -9,12 +9,3 @@
         margin-bottom: 15px;
     }
 }
-
-.exact-match:not(:last-child) {
-    margin-bottom: 60px;
-
-    h1 {
-        margin-top: 0;
-        color: green
-    }
-}

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -63,12 +63,4 @@ export default class SearchController extends Controller {
 
     return yield this.store.query('crate', { all_keywords, page, per_page, q, sort });
   }
-
-  get exactMatch() {
-    return this.model.find(it => it.exact_match);
-  }
-
-  get otherCrates() {
-    return this.model.filter(it => !it.exact_match);
-  }
 }

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -16,7 +16,6 @@ export default class Crate extends Model {
   @attr homepage;
   @attr documentation;
   @attr repository;
-  @attr exact_match;
 
   @hasMany('versions', { async: true }) versions;
 

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  <CrateList @exactMatch={{this.exactMatch}} @crates={{this.otherCrates}} local-class="list" />
+  <CrateList @crates={{this.model}} local-class="list" />
 
   <Pagination @pagination={{this.pagination}} />
 {{else}}


### PR DESCRIPTION
Users know what they searched for and the exact result, if there is one, will always be the first result anyways, so this special highlighting does not have a particularly big benefit.

This also resolves https://github.com/rust-lang/crates.io/issues/3910 at the same time.