### PR TITLE
mirage: Replace `withMeta()` utility function with object spread operator

### DIFF
--- a/mirage/route-handlers/-utils.js
+++ b/mirage/route-handlers/-utils.js
@@ -22,11 +22,6 @@ export function pageParams(request) {
   return { page, perPage, start, end };
 }
 
-export function withMeta(response, meta) {
-  response.meta = meta;
-  return response;
-}
-
 export function compareStrings(a, b) {
   return a < b ? -1 : a > b ? 1 : 0;
 }

--- a/mirage/route-handlers/categories.js
+++ b/mirage/route-handlers/categories.js
@@ -1,4 +1,4 @@
-import { compareStrings, notFound, pageParams, withMeta } from './-utils';
+import { compareStrings, notFound, pageParams } from './-utils';
 
 export function register(server) {
   server.get('/api/v1/categories', function (schema, request) {
@@ -8,7 +8,7 @@ export function register(server) {
     let categories = allCategories.slice(start, end);
     let total = allCategories.length;
 
-    return withMeta(this.serialize(categories), { total });
+    return { ...this.serialize(categories), meta: { total } };
   });
 
   server.get('/api/v1/categories/:category_id', function (schema, request) {

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -1,7 +1,7 @@
 import { Response } from 'ember-cli-mirage';
 
 import { getSession } from '../utils/session';
-import { compareIsoDates, compareStrings, notFound, pageParams, withMeta } from './-utils';
+import { compareIsoDates, compareStrings, notFound, pageParams } from './-utils';
 
 export function list(schema, request) {
   const { start, end } = pageParams(request);
@@ -46,7 +46,7 @@ export function list(schema, request) {
     crates = crates.sort((a, b) => compareStrings(a.id.toLowerCase(), b.id.toLowerCase()));
   }
 
-  return withMeta(this.serialize(crates.slice(start, end)), { total: crates.length });
+  return { ...this.serialize(crates.slice(start, end)), meta: { total: crates.length } };
 }
 
 export function register(server) {
@@ -221,7 +221,7 @@ export function register(server) {
 
     let versionDownloads = schema.versionDownloads.all().filter(it => it.version.crateId === crate.id);
 
-    return withMeta(this.serialize(versionDownloads), { extra_downloads: crate._extra_downloads });
+    return { ...this.serialize(versionDownloads), meta: { extra_downloads: crate._extra_downloads } };
   });
 
   server.put('/api/v1/crates/:name/owners', (schema, request) => {

--- a/mirage/route-handlers/keywords.js
+++ b/mirage/route-handlers/keywords.js
@@ -1,4 +1,4 @@
-import { notFound, pageParams, withMeta } from './-utils';
+import { notFound, pageParams } from './-utils';
 
 export function register(server) {
   server.get('/api/v1/keywords', function (schema, request) {
@@ -8,7 +8,7 @@ export function register(server) {
     let keywords = allKeywords.slice(start, end);
     let total = allKeywords.length;
 
-    return withMeta(this.serialize(keywords), { total });
+    return { ...this.serialize(keywords), meta: { total } };
   });
 
   server.get('/api/v1/keywords/:keyword_id', (schema, request) => {

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -1,7 +1,6 @@
 import { Response } from 'ember-cli-mirage';
 
 import { getSession } from '../utils/session';
-import { withMeta } from './-utils';
 
 export function register(server) {
   server.get('/api/v1/me', function (schema) {
@@ -83,7 +82,7 @@ export function register(server) {
     let totalPages = Math.ceil(totalCount / perPage);
     let more = page < totalPages;
 
-    return withMeta(this.serialize(versions), { more });
+    return { ...this.serialize(versions), meta: { more } };
   });
 
   server.put('/api/v1/confirm/:token', (schema, request) => {


### PR DESCRIPTION
This seems a bit more straight forward compared to the `withMeta()` function hiding what's being returned.