### PR TITLE
tests: Extract `UpstreamIndex` struct

### DIFF
--- a/src/tests/git.rs
+++ b/src/tests/git.rs
@@ -1,8 +1,28 @@
+use git2::Repository;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
 use std::sync::Once;
 use std::thread;
+use url::Url;
+
+pub struct UpstreamIndex {
+    pub repository: Repository,
+}
+
+impl UpstreamIndex {
+    pub fn new() -> anyhow::Result<Self> {
+        init();
+
+        let thread_local_path = bare();
+        let repository = Repository::open_bare(thread_local_path)?;
+        Ok(Self { repository })
+    }
+
+    pub fn url() -> Url {
+        Url::from_file_path(&bare()).unwrap()
+    }
+}
 
 fn root() -> PathBuf {
     env::current_dir()
@@ -12,11 +32,11 @@ fn root() -> PathBuf {
         .join(thread::current().name().unwrap())
 }
 
-pub fn bare() -> PathBuf {
+fn bare() -> PathBuf {
     root().join("bare")
 }
 
-pub fn init() {
+fn init() {
     static INIT: Once = Once::new();
     let _ = fs::remove_dir_all(&bare());
 

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -563,14 +563,7 @@ fn new_krate_git_upload_appends() {
 fn new_krate_git_upload_with_conflicts() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let index = app.upstream_repository();
-    let target = index.head().unwrap().target().unwrap();
-    let sig = index.signature().unwrap();
-    let parent = index.find_commit(target).unwrap();
-    let tree = index.find_tree(parent.tree_id()).unwrap();
-    index
-        .commit(Some("HEAD"), &sig, &sig, "empty commit", &tree, &[&parent])
-        .unwrap();
+    app.upstream_index().create_empty_commit().unwrap();
 
     let crate_to_publish = PublishBuilder::new("foo_conflicts");
     token.enqueue_publish(crate_to_publish).good();

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -132,11 +132,6 @@ impl TestApp {
         assert_some!(self.0.index.as_ref())
     }
 
-    /// Obtain a reference to the upstream repository ("the index")
-    pub fn upstream_repository(&self) -> &git2::Repository {
-        &self.upstream_index().repository
-    }
-
     /// Obtain a list of crates from the index HEAD
     pub fn crates_from_index_head(&self, crate_name: &str) -> Vec<cargo_registry::git::Crate> {
         self.upstream_index().crates_from_index_head(crate_name)

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -11,7 +11,7 @@ use cargo_registry::{
 };
 use std::{rc::Rc, sync::Arc, time::Duration};
 
-use cargo_registry::git::{Repository as WorkerRepository, Repository};
+use cargo_registry::git::Repository as WorkerRepository;
 use diesel::PgConnection;
 use reqwest::{blocking::Client, Proxy};
 use std::collections::HashSet;
@@ -139,24 +139,7 @@ impl TestApp {
 
     /// Obtain a list of crates from the index HEAD
     pub fn crates_from_index_head(&self, crate_name: &str) -> Vec<cargo_registry::git::Crate> {
-        let path = Repository::relative_index_file(crate_name);
-        let index = self.upstream_repository();
-        let tree = index.head().unwrap().peel_to_tree().unwrap();
-        let blob = tree
-            .get_path(&path)
-            .unwrap()
-            .to_object(index)
-            .unwrap()
-            .peel_to_blob()
-            .unwrap();
-        let content = blob.content();
-
-        // The index format consists of one JSON object per line
-        // It is not a JSON array
-        let lines = std::str::from_utf8(content).unwrap().lines();
-        lines
-            .map(|line| serde_json::from_str(line).unwrap())
-            .collect()
+        self.upstream_index().crates_from_index_head(crate_name)
     }
 
     pub fn run_pending_background_jobs(&self) {

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -128,9 +128,13 @@ impl TestApp {
     }
 
     /// Obtain a reference to the upstream repository ("the index")
+    pub fn upstream_index(&self) -> &UpstreamIndex {
+        assert_some!(self.0.index.as_ref())
+    }
+
+    /// Obtain a reference to the upstream repository ("the index")
     pub fn upstream_repository(&self) -> &git2::Repository {
-        let index = self.0.index.as_ref().unwrap();
-        &index.repository
+        &self.upstream_index().repository
     }
 
     /// Obtain a list of crates from the index HEAD

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -134,7 +134,9 @@ impl TestApp {
 
     /// Obtain a list of crates from the index HEAD
     pub fn crates_from_index_head(&self, crate_name: &str) -> Vec<cargo_registry::git::Crate> {
-        self.upstream_index().crates_from_index_head(crate_name)
+        self.upstream_index()
+            .crates_from_index_head(crate_name)
+            .unwrap()
     }
 
     pub fn run_pending_background_jobs(&self) {


### PR DESCRIPTION
This should encapsulate our mocked upstream index git operations a little bit better in the testing code.