### PR TITLE
Adding categories related to Aerospace

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -32,6 +32,47 @@ description = """
 Tools for making your creations usable by as many people as possible. \
 """
 
+[aerospace]
+name = "Aerospace"
+description = """
+Crates for aeronautics (within the atmosphere) and astronautics \
+(in outer space) implications.\
+"""
+
+[aerospace.categories.drones]
+name = "Drones"
+description = """
+Crates related to Multicopters, Fixed wing, VTOL (Vertical Takeoff and Landing) \
+and Airships/Balloons.\
+"""
+
+[aerospace.categories.protocols]
+name = "Aerospace protocols"
+description = """
+Crates of protocol implementations for aerospace implications.\
+"""
+
+[aerospace.categories.simulation]
+name = "Aerospace simulations"
+description = """
+Crates related to any kind of simulations used in aerospace - fluids, \
+aerodynamics, etc.\
+"""
+
+[aerospace.categories.space-protocols]
+name = "Space protocols"
+description = """
+Protocol implementations for implicatoins in space like CCSDS.\
+"""
+
+[aerospace.categories.unmanned-aerial-vehicles]
+name = "Unmanned aerial vehicles"
+description = """
+Crates related to Unmanned aerial vehicles like Multicopters, Fixed wing, \
+VTOL (Vertical Takeoff and Landing), Airships/Balloons, Rovers, Boats, \
+Submersibles.\
+"""
+
 [algorithms]
 name = "Algorithms"
 description = """


### PR DESCRIPTION
Resolves #4105

I've also added the category `Software-defined radio`.
Here are 2 crates that are in this category:

- https://github.com/rsadsb/adsb_deku
- https://github.com/FutureSDR/FutureSDR

I can remove the `SDR` from this PR if it's necessary to discuss it first at a meeting @Turbo87.

CC @wcampbell0x2a @bastibl @MoralCode