### PR TITLE
use new cargo fmt check option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v1.3.0
 
-      - run: cargo fmt -- --check
+      - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features --all
 
   backend:


### PR DESCRIPTION
As of v1.58, cargo fmt now supports the --check flag directly. Trying to get this utilized in relevant places across the r-l repos both because it's more succinct and so more people will see/become aware they no longer have to invoke the check the old way