### PR TITLE
embroider: Remove obsolete `ember-get-config` workaround

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -55,9 +55,6 @@ module.exports = function (defaults) {
     return require('@embroider/compat').compatBuild(app, Webpack, {
       staticAddonTestSupportTrees: true,
       staticModifiers: true,
-
-      // see https://github.com/embroider-build/embroider/issues/823
-      compatAdapters: new Map([['ember-get-config', null]]),
     });
   }
 


### PR DESCRIPTION
https://github.com/embroider-build/embroider/issues/823 has been resolved by now.