### PR TITLE
Use embroider build system by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,21 +46,6 @@ jobs:
         if: github.repository != 'rust-lang/crates.io'
         run: yarn test-coverage
 
-  embroider:
-    name: Frontend (embroider)
-    runs-on: ubuntu-20.04
-    env:
-      USE_EMBROIDER: 'true'
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: volta-cli/action@v1
-
-      - run: yarn install
-
-      - run: yarn test
-        continue-on-error: true
-
   backend-lint:
     name: Backend (linting)
     runs-on: ubuntu-20.04

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -3,8 +3,6 @@
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 const postcssCustomMedia = require('postcss-custom-media');
 
-const { USE_EMBROIDER } = process.env;
-
 module.exports = function (defaults) {
   let env = EmberApp.env();
   let isProd = env === 'production';
@@ -50,13 +48,9 @@ module.exports = function (defaults) {
   app.import('node_modules/normalize.css/normalize.css', { prepend: true });
   app.import('vendor/qunit.css', { type: 'test' });
 
-  if (USE_EMBROIDER) {
-    const { Webpack } = require('@embroider/webpack');
-    return require('@embroider/compat').compatBuild(app, Webpack, {
-      staticAddonTestSupportTrees: true,
-      staticModifiers: true,
-    });
-  }
-
-  return app.toTree();
+  const { Webpack } = require('@embroider/webpack');
+  return require('@embroider/compat').compatBuild(app, Webpack, {
+    staticAddonTestSupportTrees: true,
+    staticModifiers: true,
+  });
 };


### PR DESCRIPTION
embroider is at v1.0.0 now and has been building a correctly working app for a while now, so it should be viable for us to upgrade now.

see https://github.com/embroider-build/embroider/