### PR TITLE
Remove obsolete `ember-keyboard` options

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -34,12 +34,6 @@ module.exports = function (environment) {
       autoClear: true,
       clearDuration: 10_000,
     },
-    emberKeyboard: {
-      disableInputsInitializer: true,
-
-      // see https://github.com/adopted-ember-addons/ember-keyboard/pull/499
-      propagation: true,
-    },
   };
 
   if (environment === 'development') {


### PR DESCRIPTION
These options have been removed in v7.x