### PR TITLE
Disable `crypto` import warning in `axe-core`

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -52,5 +52,13 @@ module.exports = function (defaults) {
   return require('@embroider/compat').compatBuild(app, Webpack, {
     staticAddonTestSupportTrees: true,
     staticModifiers: true,
+    packagerOptions: {
+      webpackConfig: {
+        resolve: {
+          // disables `crypto` import warning in `axe-core`
+          fallback: { crypto: false },
+        },
+      },
+    },
   });
 };


### PR DESCRIPTION
This popped up during the migration to embroider.