### PR TITLE
crate.range: Show error page if data fails to load

### DIFF
--- a/app/routes/crate/range.js
+++ b/app/routes/crate/range.js
@@ -14,18 +14,23 @@ export default class VersionRoute extends Route {
   async model({ range }, transition) {
     let crate = this.modelFor('crate');
 
-    let versions = await crate.get('versions');
-    let allVersionNums = versions.map(it => it.num);
-    let unyankedVersionNums = versions.filter(it => !it.yanked).map(it => it.num);
+    try {
+      let versions = await crate.hasMany('versions').load();
+      let allVersionNums = versions.map(it => it.num);
+      let unyankedVersionNums = versions.filter(it => !it.yanked).map(it => it.num);
 
-    let npmRange = cargoRangeToNpm(range);
-    // find a version that matches the specified range
-    let versionNum = maxSatisfying(unyankedVersionNums, npmRange) ?? maxSatisfying(allVersionNums, npmRange);
-    if (versionNum) {
-      this.router.replaceWith('crate.version', versionNum);
-    } else {
-      let title = `${crate.name}: No matching version found for ${range}`;
-      this.router.replaceWith('catch-all', { transition, title });
+      let npmRange = cargoRangeToNpm(range);
+      // find a version that matches the specified range
+      let versionNum = maxSatisfying(unyankedVersionNums, npmRange) ?? maxSatisfying(allVersionNums, npmRange);
+      if (versionNum) {
+        this.router.replaceWith('crate.version', versionNum);
+      } else {
+        let title = `${crate.name}: No matching version found for ${range}`;
+        this.router.replaceWith('catch-all', { transition, title });
+      }
+    } catch (error) {
+      let title = `${crate.name}: Failed to load version data`;
+      this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });
     }
   }
 }

--- a/app/routes/crate/range.js
+++ b/app/routes/crate/range.js
@@ -11,7 +11,7 @@ export default class VersionRoute extends Route {
   @service notifications;
   @service router;
 
-  async model({ range }) {
+  async model({ range }, transition) {
     let crate = this.modelFor('crate');
 
     let versions = await crate.get('versions');
@@ -21,11 +21,11 @@ export default class VersionRoute extends Route {
     let npmRange = cargoRangeToNpm(range);
     // find a version that matches the specified range
     let versionNum = maxSatisfying(unyankedVersionNums, npmRange) ?? maxSatisfying(allVersionNums, npmRange);
-    if (!versionNum) {
-      this.notifications.error(`No matching version of crate '${crate.name}' found for: ${range}`);
-      this.router.replaceWith('crate.index');
+    if (versionNum) {
+      this.router.replaceWith('crate.version', versionNum);
+    } else {
+      let title = `${crate.name}: No matching version found for ${range}`;
+      this.router.replaceWith('catch-all', { transition, title });
     }
-
-    this.router.replaceWith('crate.version', versionNum);
   }
 }

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -78,6 +78,15 @@ module('Route | crate.range', function (hooks) {
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 
+  test('shows an error page if crate not found', async function (assert) {
+    await visit('/crates/foo/range/^3');
+    assert.equal(currentURL(), '/crates/foo/range/%5E3');
+    assert.dom('[data-test-404-page]').exists();
+    assert.dom('[data-test-title]').hasText('Crate not found');
+    assert.dom('[data-test-go-back]').exists();
+    assert.dom('[data-test-try-again]').doesNotExist();
+  });
+
   test('shows an error page if no match found', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0' });

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -87,6 +87,17 @@ module('Route | crate.range', function (hooks) {
     assert.dom('[data-test-try-again]').doesNotExist();
   });
 
+  test('shows an error page if crate fails to load', async function (assert) {
+    this.server.get('/api/v1/crates/:crate_name', {}, 500);
+
+    await visit('/crates/foo/range/^3');
+    assert.equal(currentURL(), '/crates/foo/range/%5E3');
+    assert.dom('[data-test-404-page]').exists();
+    assert.dom('[data-test-title]').hasText('Crate failed to load');
+    assert.dom('[data-test-go-back]').doesNotExist();
+    assert.dom('[data-test-try-again]').exists();
+  });
+
   test('shows an error page if no match found', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0' });

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -1,7 +1,9 @@
-import { currentURL, visit } from '@ember/test-helpers';
+import { currentURL } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import { setupApplicationTest } from 'cargo/tests/helpers';
+
+import { visit } from '../../helpers/visit-ignoring-abort';
 
 module('Route | crate.range', function (hooks) {
   setupApplicationTest(hooks);
@@ -76,7 +78,7 @@ module('Route | crate.range', function (hooks) {
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 
-  test('redirects to main crate page if no match found', async function (assert) {
+  test('shows an error page if no match found', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0' });
     this.server.create('version', { crate, num: '1.1.0' });
@@ -84,9 +86,10 @@ module('Route | crate.range', function (hooks) {
     this.server.create('version', { crate, num: '2.0.0' });
 
     await visit('/crates/foo/range/^3');
-    assert.equal(currentURL(), `/crates/foo`);
-    assert.dom('[data-test-crate-name]').hasText('foo');
-    assert.dom('[data-test-crate-version]').hasText('2.0.0');
-    assert.dom('[data-test-notification-message="error"]').hasText("No matching version of crate 'foo' found for: ^3");
+    assert.equal(currentURL(), '/crates/foo/range/%5E3');
+    assert.dom('[data-test-404-page]').exists();
+    assert.dom('[data-test-title]').hasText('foo: No matching version found for ^3');
+    assert.dom('[data-test-go-back]').exists();
+    assert.dom('[data-test-try-again]').doesNotExist();
   });
 });


### PR DESCRIPTION
Similar to the crate and version pages. This ensures that the URL stays the same so it can be fixed if there was a typo.

<img width="753" alt="Bildschirmfoto 2022-01-22 um 21 21 09" src="https://user-images.githubusercontent.com/141300/150654244-0825e7b5-f844-451b-bbf1-2b53d3708d22.png">
