### PR TITLE
EncodableCrate: Simplify `from_minimal()` method

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -46,8 +46,6 @@ pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
                 Ok(EncodableCrate::from_minimal(
                     krate,
                     &top_versions,
-                    None,
-                    false,
                     recent_downloads,
                 ))
             })

--- a/src/views.rs
+++ b/src/views.rs
@@ -313,8 +313,6 @@ impl EncodableCrate {
     pub fn from_minimal(
         krate: Crate,
         top_versions: &TopVersions,
-        badges: Option<Vec<Badge>>,
-        exact_match: bool,
         recent_downloads: Option<i64>,
     ) -> Self {
         Self::from(
@@ -323,8 +321,8 @@ impl EncodableCrate {
             None,
             None,
             None,
-            badges,
-            exact_match,
+            None,
+            false,
             recent_downloads,
         )
     }


### PR DESCRIPTION
There is only one user of this method and it is not supplying badges or using the `exact_match` field, so it should be safe to remove them