### PR TITLE
Fix `keyword` route links

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -23,7 +23,7 @@
     <ul local-class="keywords">
       {{#each @crate.keywords as |keyword|}}
         <li>
-          <LinkTo @route="keyword" @model={{keyword}}>
+          <LinkTo @route="keyword" @model={{keyword.id}} data-test-keyword={{keyword.id}}>
             <span local-class="hash">#</span>{{keyword.id}}
           </LinkTo>
         </li>

--- a/app/templates/keywords.hbs
+++ b/app/templates/keywords.hbs
@@ -21,9 +21,9 @@
 
 <div local-class="list">
   {{#each this.model as |keyword|}}
-    <div local-class="row">
-      <LinkTo @route="keyword" @model={{keyword}}>{{keyword.id}}</LinkTo>
-      <span local-class="crate-count">
+    <div local-class="row" data-test-keyword={{keyword.id}}>
+      <LinkTo @route="keyword" @model={{keyword.id}}>{{keyword.id}}</LinkTo>
+      <span local-class="crate-count" data-test-count>
         {{format-num keyword.crates_cnt}} {{if (eq keyword.crates_cnt 1) "crate" "crates"}}
       </span>
     </div>

--- a/tests/bugs/4506-test.js
+++ b/tests/bugs/4506-test.js
@@ -1,0 +1,45 @@
+import { click } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'cargo/tests/helpers';
+
+import { visit } from '../helpers/visit-ignoring-abort';
+
+module('Bug #4506', function (hooks) {
+  setupApplicationTest(hooks);
+
+  function prepare(context) {
+    let { server } = context;
+
+    server.create('keyword', { keyword: 'no-std' });
+
+    let foo = server.create('crate', { name: 'foo', keywordIds: ['no-std'] });
+    server.create('version', { crate: foo });
+
+    let bar = server.create('crate', { name: 'bar', keywordIds: ['no-std'] });
+    server.create('version', { crate: bar });
+  }
+
+  test('is fixed', async function (assert) {
+    prepare(this);
+
+    await visit('/crates/foo');
+    assert.dom('[data-test-keyword]').exists({ count: 1 });
+
+    await click('[data-test-keyword="no-std"]');
+    assert.dom('[data-test-total-rows]').hasText('2');
+    assert.dom('[data-test-crate-row]').exists({ count: 2 });
+  });
+
+  test('is fixed for /keywords too', async function (assert) {
+    prepare(this);
+
+    await visit('/keywords');
+    assert.dom('[data-test-keyword]').exists({ count: 1 });
+    assert.dom('[data-test-keyword="no-std"] [data-test-count]').hasText('2 crates');
+
+    await click('[data-test-keyword="no-std"] a');
+    assert.dom('[data-test-total-rows]').hasText('2');
+    assert.dom('[data-test-crate-row]').exists({ count: 2 });
+  });
+});


### PR DESCRIPTION
This apparently broke in 8f62c4c 😱

Fixes https://github.com/rust-lang/crates.io/issues/4506