### PR TITLE
Ember: Use `history` location API

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'cargo',
     environment,
     rootURL: '/',
-    locationType: 'auto',
+    locationType: 'history',
     historySupportMiddleware: true,
     EmberENV: {
       FEATURES: {


### PR DESCRIPTION
`auto` is deprecated in Ember.js 4