### PR TITLE
Explicitly specify the branch name in init-local-index.sh

### DIFF
--- a/script/init-local-index.sh
+++ b/script/init-local-index.sh
@@ -11,10 +11,10 @@ mkdir -p tmp
 rm -rf tmp/index-bare tmp/index-tmp
 
 echo "Initializing repository in tmp/index-bare..."
-git init -q --bare tmp/index-bare
+git init -q --bare --initial-branch=master tmp/index-bare
 
 echo "Creating temporary clone in tmp/index-tmp..."
-git init -q tmp/index-tmp
+git init -q --initial-branch=master tmp/index-tmp
 cd tmp/index-tmp
 cat > config.json <<-EOF
 {


### PR DESCRIPTION
Otherwise the script breaks if `init.defaultBranch` is not set to `master` (with `main` becoming a common alternative these days).

Split out from #4548.