### PR TITLE
controllers::krate: Protect against null bytes in query string

### DIFF
--- a/src/tests/krate/search.rs
+++ b/src/tests/krate/search.rs
@@ -113,6 +113,9 @@ fn index_queries() {
     let cl = anon.search("keyword=kw3&category=cat1");
     assert_eq!(cl.crates.len(), 0);
     assert_eq!(cl.meta.total, 0);
+
+    // ignores 0x00 characters that Postgres does not support
+    assert_eq!(anon.search("q=k\u{0}w1").meta.total, 3);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/crates.io/issues/4538.

This does add a small string replace operation to the endpoint, but compared to the database queries the overhead should be negligible.