### PR TITLE
Add `rs` alias for `rust` syntax highlighting

### DIFF
--- a/app/modifiers/highlight-syntax.js
+++ b/app/modifiers/highlight-syntax.js
@@ -40,6 +40,9 @@ hljs.registerLanguage('yaml', yaml);
 hljs.registerAliases('clike', { languageName: 'c' });
 hljs.registerAliases('markup', { languageName: 'xml' });
 
+// common aliases
+hljs.registerAliases('rs', { languageName: 'rust' });
+
 export default modifier((element, _, { selector }) => {
   let elements = selector ? element.querySelectorAll(selector) : [element];
 


### PR DESCRIPTION
As GitHub supports `rs`, many projects seem to use `rs` without realising crates.io doesn't support it, and may either never notice or notice after publishing a version.

[Rough search for examples](https://sourcegraph.com/search?q=context%3Aglobal+repo%3Acontains.file%28Cargo%5C.toml%29+file%3A%5EREADME+%60%60%60rs&patternType=literal).

A point against this PR is that it might also make sense to intentionally have as few aliases as possible to encourage consistency, so supporting `rs` might add more of a split between the two.