### PR TITLE
Disable in-browser translation

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="notranslate" translate="no">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -20,6 +20,8 @@
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/cargo.png" type="image/png">
     <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Cargo">
+
+    <meta name="google" content="notranslate" />
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
In-browser translation tool are mutating the DOM in ways that are unfortunately incompatible with the way most SPAs are handling DOM updates. This leads to cryptic Sentry issues like "Failed to run removeChild() bla bla". This commit attempts to disable the in-browser translation to fix these issues.

Related:
- https://stackoverflow.com/a/54200382/1478093
- https://github.com/facebook/react/issues/11538#issuecomment-350110297
- https://stackoverflow.com/questions/12238396/how-to-disable-google-translate-from-html-in-chrome