### PR TITLE
Sentry: Set transaction name instead of custom `routeName` tag

### DIFF
--- a/tests/helpers/sentry.js
+++ b/tests/helpers/sentry.js
@@ -21,10 +21,15 @@ class MockSentryService extends Service {
 }
 
 class MockScope {
+  transaction = null;
   tags = {};
 
   setTag(key, value) {
     this.tags[key] = value;
+  }
+
+  setTransactionName(transaction) {
+    this.transaction = transaction;
   }
 }
 


### PR DESCRIPTION
This allows Sentry to properly group issues by the route that they're happening on.