### PR TITLE
Add `Virtualization` category to crates.io

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -530,7 +530,8 @@ potentially adapting the display to various languages and regions.\
 [virtualization]
 name = "Virtualization"
 description = """
-For the creation and management of virtual environments.\
+For the creation and management of virtual environments and resources
+of any form including containerization systems.\
 """
 
 [visualization]

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -527,6 +527,12 @@ Crates to allow an application to format values for display to a user, \
 potentially adapting the display to various languages and regions.\
 """
 
+[virtualization]
+name = "Virtualization"
+description = """
+For the creation and management of virtual environments.\
+"""
+
 [visualization]
 name = "Visualization"
 description = """


### PR DESCRIPTION
This PR proposes the addition of a virtualization category on crates.io.
Currently, there does not seem to be a category dedicated to code concerning virtualization
technology such as containerization, VMs, resource management, etc.
Some crates that would usually fall within this category have opted for others like emulation,
which while somewhat related, can be distinct from virtualization.
Any thoughts on this?