### PR TITLE
Refactor `upload` to avoid passing content_length

### DIFF
--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -197,7 +197,6 @@ impl DumpTarball {
             &client,
             target_name,
             tarfile,
-            content_length,
             "application/gzip",
             header::HeaderMap::new(),
         )?;


### PR DESCRIPTION
Use `seek()` on the `content` passed to `upload` rather than separately passing in a `content_length`.

r? @Turbo87 