### PR TITLE
catch-all: Fix `reload()` action

### DIFF
--- a/app/controllers/catch-all.js
+++ b/app/controllers/catch-all.js
@@ -3,10 +3,11 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 
 export default class CatchAllController extends Controller {
+  @service router;
   @service session;
 
   @action reload() {
-    this.model.transition.retry();
+    this.router.replaceWith(this.router.currentURL);
   }
 
   @action back() {


### PR DESCRIPTION
This fixes https://sentry.io/organizations/rust-lang/issues/2966611026. Technically `transition.retry()` should also work, but for some reason it sometimes fails, likely due to a routing bug in Ember.js. Using `replaceWith()` with the current route results in the same behavior, but avoiding this issue. Unfortunately I did not find a way to reproduce this as part of the test suite :-/

Resolves https://github.com/rust-lang/crates.io/issues/4786