### PR TITLE
search: Fix app crash without given `q` query parameter

### DIFF
--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -14,7 +14,7 @@ export default class SearchController extends Controller {
 
   queryParams = ['all_keywords', 'page', 'per_page', 'q', 'sort'];
   @tracked all_keywords;
-  @tracked q = null;
+  @tracked q = '';
   @tracked page = '1';
   @tracked per_page = 10;
   @tracked sort;
@@ -32,6 +32,10 @@ export default class SearchController extends Controller {
   @reads('model.meta.total') totalItems;
 
   @pagination() pagination;
+
+  get pageTitle() {
+    return 'Search Results' + (this.q ? ` for '${this.q}'` : '');
+  }
 
   get currentSortBy() {
     if (this.sort === 'downloads') {
@@ -63,13 +67,11 @@ export default class SearchController extends Controller {
   @restartableTask *dataTask() {
     let { all_keywords, page, per_page, q, sort } = this;
 
-    if (q !== null) {
-      q = q.trim();
-    }
+    let query = q.trim();
 
     let searchOptions = all_keywords
-      ? { page, per_page, sort, q, all_keywords }
-      : { page, per_page, sort, ...processSearchQuery(q) };
+      ? { page, per_page, sort, q: query, all_keywords }
+      : { page, per_page, sort, ...processSearchQuery(query) };
 
     return yield this.store.query('crate', searchOptions);
   }

--- a/app/templates/search.hbs
+++ b/app/templates/search.hbs
@@ -1,4 +1,4 @@
-{{page-title (concat "Search Results for '" this.q "'")}}
+{{page-title this.pageTitle}}
 
 <PageHeader
   @title="Search Results"

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -229,4 +229,18 @@ module('Acceptance | search', function (hooks) {
     await visit('/search?q=rust keywords:foo&page=3&per_page=15&sort=new&all_keywords=fire ball');
     assert.verifySteps(['/api/v1/crates']);
   });
+
+  test('visiting without query parameters works', async function (assert) {
+    this.server.loadFixtures();
+
+    await visit('/search');
+
+    assert.equal(currentURL(), '/search');
+    assert.equal(getPageTitle(), 'Search Results - crates.io: Rust Package Registry');
+
+    assert.dom('[data-test-header]').hasText('Search Results');
+    assert.dom('[data-test-search-nav]').hasText('Displaying 1-10 of 23 total results');
+    assert.dom('[data-test-crate-row="0"] [data-test-crate-link]').hasText('kinetic-rust');
+    assert.dom('[data-test-crate-row="0"] [data-test-version]').hasText('v0.0.16');
+  });
 });


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/4785