### PR TITLE
Drop index/ prefix when uploading crate metadata.

### DIFF
--- a/src/tests/http-data/krate_publish_features_version_2
+++ b/src/tests/http-data/krate_publish_features_version_2
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/foo",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_good_badges
+++ b/src/tests/http-data/krate_publish_good_badges
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/ob/foobadger",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/ob/foobadger",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_good_categories
+++ b/src/tests/http-data/krate_publish_good_categories
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_good_cat",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_good_cat",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_ignored_badges
+++ b/src/tests/http-data/krate_publish_ignored_badges
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_ignored_badge",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_ignored_badge",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_ignored_categories
+++ b/src/tests/http-data/krate_publish_ignored_categories
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_ignored_cat",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_ignored_cat",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency
+++ b/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency
@@ -35,7 +35,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/foo",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate
+++ b/src/tests/http-data/krate_publish_new_krate
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_new",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_new",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_git_upload
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/fgt",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fgt",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_appends
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_appends
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/fpp",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fpp",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/fpp",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fpp",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_conflicts",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_conflicts",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_records_verified_email
+++ b/src/tests/http-data/krate_publish_new_krate_records_verified_email
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_verified_email",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_verified_email",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted
+++ b/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_whitelist",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_whitelist",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_twice
+++ b/src/tests/http-data/krate_publish_new_krate_twice
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_twice",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_twice",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_weird_version
+++ b/src/tests/http-data/krate_publish_new_krate_weird_version
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_weird",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_weird",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_with_dependency
+++ b/src/tests/http-data/krate_publish_new_krate_with_dependency
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/ne/w_/new_dep",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ne/w_/new_dep",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_with_readme
+++ b/src/tests/http-data/krate_publish_new_krate_with_readme
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_readme",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_readme",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_krate_with_token
+++ b/src/tests/http-data/krate_publish_new_krate_with_token
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_new",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_new",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_with_renamed_dependency
+++ b/src/tests/http-data/krate_publish_new_with_renamed_dependency
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/ne/w-/new-krate",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ne/w-/new-krate",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency
+++ b/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/ne/w-/new-krate",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ne/w-/new-krate",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_publish_after_removing_documentation
+++ b/src/tests/http-data/krate_publish_publish_after_removing_documentation
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/do/cs/docscrate",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/do/cs/docscrate",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/do/cs/docscrate",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/do/cs/docscrate",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_publish_new_crate_rate_limited
+++ b/src/tests/http-data/krate_publish_publish_new_crate_rate_limited
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/ra/te/rate_limited1",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/ra/te/rate_limited2",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited2",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
+++ b/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/ra/te/rate_limited1",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/ra/te/rate_limited1",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_publish_records_an_audit_action
+++ b/src/tests/http-data/krate_publish_publish_records_an_audit_action
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/fyk",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
+++ b/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_versions_updated_at",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_versions_updated_at",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_versions_updated_at",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_versions_updated_at",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_yanking_publish_after_yank_max_version
+++ b/src/tests/http-data/krate_yanking_publish_after_yank_max_version
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fy/k_/fyk_max",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fy/k_/fyk_max",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/fyk",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_yanking_yank_max_version
+++ b/src/tests/http-data/krate_yanking_yank_max_version
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fy/k_/fyk_max",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fy/k_/fyk_max",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_yanking_yank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_yank_records_an_audit_action
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/fyk",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/krate_yanking_yank_works_as_intended
+++ b/src/tests/http-data/krate_yanking_yank_works_as_intended
@@ -68,7 +68,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/3/f/fyk",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/owners_new_crate_owner
+++ b/src/tests/http-data/owners_new_crate_owner
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_owner",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_owner",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_owner",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_owner",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/team_publish_owned
+++ b/src/tests/http-data/team_publish_owned
@@ -580,7 +580,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_team_owned",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_team_owned",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/http-data/version_version_size
+++ b/src/tests/http-data/version_version_size
@@ -135,7 +135,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_version_size",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_version_size",
       "method": "PUT",
       "headers": [
         [
@@ -202,7 +202,7 @@
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/index/fo/o_/foo_version_size",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_version_size",
       "method": "PUT",
       "headers": [
         [


### PR DESCRIPTION
The metadata is already uploaded into a dedicated bucket, so the additional index/ prefix is unnecessary.