### PR TITLE
Allow organization owners to add teams from their org to crates

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -26,6 +26,12 @@ pub trait GitHubClient: Send + Sync {
         username: &str,
         auth: &AccessToken,
     ) -> AppResult<GitHubTeamMembership>;
+    fn org_membership(
+        &self,
+        org_id: i32,
+        username: &str,
+        auth: &AccessToken,
+    ) -> AppResult<GitHubOrgMembership>;
 }
 
 #[derive(Debug)]
@@ -38,6 +44,7 @@ impl RealGitHubClient {
     pub fn new(client: Option<Client>, base_url: String) -> Self {
         Self { base_url, client }
     }
+
     /// Does all the nonsense for sending a GET to Github.
     pub fn request<T>(&self, url: &str, auth: &AccessToken) -> AppResult<T>
     where
@@ -104,6 +111,18 @@ impl GitHubClient for RealGitHubClient {
         let url = format!("/organizations/{org_id}/team/{team_id}/memberships/{username}");
         self.request(&url, auth)
     }
+
+    fn org_membership(
+        &self,
+        org_id: i32,
+        username: &str,
+        auth: &AccessToken,
+    ) -> AppResult<GitHubOrgMembership> {
+        self.request(
+            &format!("/organizations/{org_id}/memberships/{username}"),
+            auth,
+        )
+    }
 }
 
 fn handle_error_response(error: &reqwest::Error) -> Box<dyn AppError> {
@@ -151,6 +170,12 @@ pub struct GitHubTeam {
 #[derive(Debug, Deserialize)]
 pub struct GitHubTeamMembership {
     pub state: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubOrgMembership {
+    pub state: String,
+    pub role: String,
 }
 
 pub fn team_url(login: &str) -> String {


### PR DESCRIPTION
Right now, to be able to add a GitHub team to the list of owners of a crate, you have to both be an existing owner of the crate and to be a member of the team you want to add. The second protection is important to prevent people from inviting random teams to their crates, as we don't have an invite system for teams.

Still, that restriction gets annoying when the user adding a team to a crate is an owner of the GitHub organization the team is defined in. The user still *can* add the team, but they first need to add themselves to the team in question (and they can do so, since they're owners of the organization), which is an unnecessary annoyance.

This PR was prompted by having to add a team in the `rust-lang` organization to a crate, when the existing owner is @rust-lang-owner. In the future infra will likely want to automate adding and removing teams from crates (based on the team repo), and this limitation would prevent implementing that.

Note that this PR does **not** allow organization owners to publish crates owned by one of their org's teams, as that change might require more scrutiny.

---

In addition to implementing the change, I refactored how GitHub teams test work by removing the need to use the recording proxy to assert the right requests were made. Instead, I put the GitHub client behind a trait and mocked that with sample data for tests. This should also allow us to remove https://github.com/crates-test-org, @crates-tester-1 and @crates-tester-2 from the real GitHub.