### PR TITLE
admin/upload_index: Use `indicatif` for progress reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "indexmap",
+ "indicatif",
  "ipnetwork",
  "lazy_static",
  "lettre",
@@ -1310,6 +1311,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1725,12 @@ checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "oauth2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ hex = "=0.4.3"
 http = "=0.2.7"
 hyper = { version = "=0.14.19", features = ["client", "http1"] }
 indexmap = { version = "=1.8.2", features = ["serde-1"] }
+indicatif = "=0.16.2"
 ipnetwork = "=0.19.0"
 tikv-jemallocator = { version = "=0.5.0", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "=0.10.0-rc.6", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }

--- a/src/admin/upload_index.rs
+++ b/src/admin/upload_index.rs
@@ -1,7 +1,6 @@
-use std::time::{Duration, Instant};
-
 use crate::admin::dialoguer;
 use cargo_registry_index::{Repository, RepositoryConfig};
+use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
 use reqwest::blocking::Client;
 
 use crate::config;
@@ -33,23 +32,18 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let mut progress_update_time = Instant::now();
-    for (i, file) in files.iter().enumerate() {
+    let pb = ProgressBar::new(files.len() as u64);
+    pb.set_style(ProgressStyle::default_bar().template("{bar:60} ({pos}/{len}, ETA {eta})"));
+
+    for file in files.iter().progress_with(pb) {
         let crate_name = file.file_name().unwrap().to_str().unwrap();
         let path = repo.index_file(crate_name);
         if !path.exists() {
-            println!("skipping file `{}`", crate_name);
             continue;
         }
+
         let contents = std::fs::read_to_string(&path)?;
         uploader.upload_index(&client, crate_name, contents)?;
-
-        // Print a progress update every 10 seconds.
-        let now = Instant::now();
-        if now - progress_update_time > Duration::from_secs(10) {
-            progress_update_time = now;
-            println!("uploading {}/{}", i, files.len());
-        }
     }
 
     println!(


### PR DESCRIPTION
This PR uses https://github.com/console-rs/indicatif to display a progress bar while backfilling the HTTP-based index, with the main advantage of having a somewhat reasonable ETA display :)

/cc @arlosi 