### PR TITLE
bump node docker image to 16.15.0

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,7 +95,7 @@ as well.
 
 In order to run the frontend on Windows and macOS, you will need to have installed:
 
-- [node](https://nodejs.org/en/) >= 12.9.1 (see `package.json` and `.github/workflows/ci.yml` for what we currently use)
+- [node](https://nodejs.org/en/) >= 16.15.0 (see `package.json` and `.github/workflows/ci.yml` for what we currently use)
 - [yarn](https://classic.yarnpkg.com/en/docs/install) v1.x
 
 Follow the links for each of these tools for their recommended installation

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-alpine
+FROM node:16.15.0-alpine
 
 WORKDIR /app
 COPY package.json yarn.lock /app/


### PR DESCRIPTION
The current `frontend.Dockerfile` has 16.14.2, but 16.15.0 is required (see PR #4751). You'll run into an error when trying to run a `docker-compose build`. This PR bumps the version. 😄 

```
------
 > [cratesio_frontend 4/5] RUN yarn install:
#20 1.106 yarn install v1.22.18
#20 1.663 [1/5] Validating package.json...
#20 1.684 error cargo@0.0.0: The engine "node" is incompatible with this module. Expected version "16.15.0". Got "16.14.2"
#20 1.717 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
#20 1.717 error Found incompatible module.
------
failed to solve: executor failed running [/bin/sh -c yarn install]: exit code: 1
```