### PR TITLE
claim: Use git dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,8 +394,7 @@ dependencies = [
 [[package]]
 name = "claim"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81099d6bb72e1df6d50bb2347224b666a670912bb7f06dbe867a4a070ab3ce8"
+source = "git+https://github.com/Turbo87/rust-claim.git?rev=23892a3#23892a345d38e1434303143a73033925284ad04d"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ url = "=2.2.2"
 
 [dev-dependencies]
 cargo-registry-index = { path = "cargo-registry-index", features = ["testing"] }
-claim = "=0.5.0"
+claim = { git = "https://github.com/Turbo87/rust-claim.git", rev = "23892a3" }
 conduit-test = "=0.10.0"
 hyper-tls = "=0.5.0"
 lazy_static = "=1.4.0"


### PR DESCRIPTION
This should resolve a version conflict with our `dashmap` dependency and the transitive `autocfg` dependency.

see https://github.com/svartalf/rust-claim/pull/10 and https://github.com/rust-lang/crates.io/pull/4763