### PR TITLE
Remove unused `docs.rs` metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,6 @@ doctest = true
 name = "all"
 path = "src/tests/all.rs"
 
-[package.metadata.docs.rs]
-rustdoc-args = [
-    "--no-defaults",
-    "--passes", "collapse-docs",
-    "--passes", "unindent-comments"
-]
-
 [dependencies]
 anyhow = "=1.0.57"
 base64 = "=0.13.0"


### PR DESCRIPTION
We're not publishing this package, so there is no need for us to have docs.rs metadata specified