### PR TITLE
router: Remove `/api/v1/` subrouter

### DIFF
--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -27,7 +27,7 @@ fn test_blocked_download_route() {
             config.blocked_routes.clear();
             config
                 .blocked_routes
-                .insert("/crates/:crate_id/:version/download".into());
+                .insert("/api/v1/crates/:crate_id/:version/download".into());
         })
         .with_user();
 


### PR DESCRIPTION
Instead of having a subrouter, we can just add the routes directly to the primary router and simplify the code a little bit.