### PR TITLE
Add a -y option for scripting of delete crate/delete version admin utils

### DIFF
--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -174,7 +174,9 @@ impl Uploader {
             }
             Uploader::Local => {
                 let filename = Self::local_uploads_path(path, upload_bucket);
-                std::fs::remove_file(&filename)?;
+                // Ignore errors if the local index file doesn't exist; this can happen if you
+                // aren't running the background job worker locally
+                let _ = std::fs::remove_file(&filename);
             }
         }
         Ok(())


### PR DESCRIPTION
If `-y` is specified, don't ask for interactive confirmation.

There are a bunch of crates that were published in violation of our policies, and I want to run the admin delete-crate utility as part of a script and not have to manually hit `y` all the time :)