### PR TITLE
sentry: Enable performance tracing via `SENTRY_TRACES_SAMPLE_RATE` env var

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -46,7 +46,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     let blocked_traffic = app.config.blocked_traffic.clone();
 
     if env != Env::Test {
-        m.add(SentryMiddleware::default());
+        m.add(SentryMiddleware::with_transactions());
         m.add(log_request::LogRequests::default());
     }
 

--- a/src/sentry/middleware.rs
+++ b/src/sentry/middleware.rs
@@ -11,6 +11,13 @@ pub struct CustomSentryMiddleware {
     inner: SentryMiddleware,
 }
 
+impl CustomSentryMiddleware {
+    pub fn with_transactions() -> Self {
+        let inner = SentryMiddleware::with_transactions();
+        Self { inner }
+    }
+}
+
 impl Middleware for CustomSentryMiddleware {
     fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
         self.inner.before(req)?;

--- a/src/sentry/mod.rs
+++ b/src/sentry/mod.rs
@@ -1,5 +1,6 @@
 mod middleware;
 
+use crate::env_optional;
 pub use middleware::CustomSentryMiddleware as SentryMiddleware;
 use sentry::{ClientInitGuard, ClientOptions, IntoDsn};
 
@@ -25,12 +26,15 @@ pub fn init() -> ClientInitGuard {
 
     let release = dotenv::var("HEROKU_SLUG_COMMIT").ok().map(Into::into);
 
+    let traces_sample_rate = env_optional("SENTRY_TRACES_SAMPLE_RATE").unwrap_or(0.0);
+
     let opts = ClientOptions {
         auto_session_tracking: true,
         dsn,
         environment,
         release,
         session_mode: sentry::SessionMode::Request,
+        traces_sample_rate,
         ..Default::default()
     };
 


### PR DESCRIPTION
see https://docs.sentry.io/product/performance/ and https://github.com/Turbo87/sentry-conduit/pull/76