### PR TITLE
worker::git: Adjust `update_crate_index()` to handle deleted files

### DIFF
--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -263,4 +263,17 @@ impl Uploader {
         self.delete(http_client, &path, UploadBucket::Index)?;
         Ok(())
     }
+
+    pub(crate) fn sync_index(
+        &self,
+        http_client: &Client,
+        crate_name: &str,
+        index: Option<String>,
+    ) -> Result<()> {
+        if let Some(index) = index {
+            self.upload_index(http_client, crate_name, index)
+        } else {
+            self.delete_index(http_client, crate_name)
+        }
+    }
 }


### PR DESCRIPTION
This PR ensures that the `update_crate_index()` background task will be able to handle the case where a crate has been deleted from the git index. If a `NotFound` error kind is detected we will issue a `DELETE` command to the S3 index instead of uploading the file contents.
