### PR TITLE
Link SPDX license exceptions

### DIFF
--- a/app/utils/license.js
+++ b/app/utils/license.js
@@ -509,6 +509,54 @@ const SPDX_LICENSES = [
   'zlib-acknowledgement',
 ];
 
+// from https://github.com/spdx/license-list-data/blob/1e34565178429dc5a10bd85fd02f4e2946b856b0/json/exceptions.json
+// <exceptions.json jq '.exceptions[] | select(.isDeprecatedLicenseId | not).licenseExceptionId'
+const SPDX_EXCEPTIONS = [
+  '389-exception',
+  'Autoconf-exception-2.0',
+  'Autoconf-exception-3.0',
+  'Bison-exception-2.2',
+  'Bootloader-exception',
+  'CLISP-exception-2.0',
+  'Classpath-exception-2.0',
+  'DigiRule-FOSS-exception',
+  'FLTK-exception',
+  'Fawkes-Runtime-exception',
+  'Font-exception-2.0',
+  'GCC-exception-2.0',
+  'GCC-exception-3.1',
+  'GPL-3.0-linking-exception',
+  'GPL-3.0-linking-source-exception',
+  'GPL-CC-1.0',
+  'GStreamer-exception-2005',
+  'GStreamer-exception-2008',
+  'KiCad-libraries-exception',
+  'LGPL-3.0-linking-exception',
+  'LLVM-exception',
+  'LZMA-exception',
+  'Libtool-exception',
+  'Linux-syscall-note',
+  'OCCT-exception-1.0',
+  'OCaml-LGPL-linking-exception',
+  'OpenJDK-assembly-exception-1.0',
+  'PS-or-PDF-font-exception-20170817',
+  'Qt-GPL-exception-1.0',
+  'Qt-LGPL-exception-1.1',
+  'Qwt-exception-1.0',
+  'SHL-2.0',
+  'SHL-2.1',
+  'Swift-exception',
+  'Universal-FOSS-exception-1.0',
+  'WxWindows-exception-3.1',
+  'eCos-exception-2.0',
+  'freertos-exception-2.0',
+  'gnu-javamail-exception',
+  'i2p-gpl-java-exception',
+  'mif-exception',
+  'openvpn-openssl-exception',
+  'u-boot-exception-2.0',
+];
+
 const LICENSE_KEYWORDS = new Set(['OR', 'AND', 'WITH', '(', ')']);
 
 export function parseLicense(text) {
@@ -538,5 +586,10 @@ function licenseLink(text) {
   let spdxLicense = SPDX_LICENSES.find(it => it.toLowerCase() === lowerCaseText);
   if (spdxLicense) {
     return `https://spdx.org/licenses/${spdxLicense}.html`;
+  }
+
+  let spdxException = SPDX_EXCEPTIONS.find(it => it.toLowerCase() === lowerCaseText);
+  if (spdxException) {
+    return `https://spdx.org/licenses/${spdxException}.html`;
   }
 }

--- a/tests/utils/license-test.js
+++ b/tests/utils/license-test.js
@@ -36,7 +36,7 @@ module('parseLicense()', function () {
       [
         { isKeyword: false, link: 'https://spdx.org/licenses/GPL-2.0-or-later.html', text: 'GPL-2.0-or-later' },
         { isKeyword: true, link: undefined, text: 'WITH' },
-        { isKeyword: false, link: undefined, text: 'Bison-exception-2.2' },
+        { isKeyword: false, link: 'https://spdx.org/licenses/Bison-exception-2.2.html', text: 'Bison-exception-2.2' },
       ],
     ],
     [


### PR DESCRIPTION
For example the <kbd>LLVM-exception</kbd> in the license of https://crates.io/crates/cranelift/0.85.1.

<img src="https://user-images.githubusercontent.com/1940490/180036587-99568a2b-e59b-4913-97a8-0615419d85aa.png" width="300">
