### PR TITLE
Toggle stacked download graph

### DIFF
--- a/app/components/download-graph.hbs
+++ b/app/components/download-graph.hbs
@@ -1,7 +1,36 @@
 <div local-class="toggle-stacked">
-  <a {{on "click" this.toggleChart}}>
-    Toggle Stacked Chart
-  </a>
+  <span local-class="toggle-stacked-label">Display as </span>
+  <Dropdown as |dd|>
+    <dd.Trigger local-class="trigger">
+      <span local-class="trigger-label">
+        {{#if this.stacked}}
+          Stacked
+        {{else}}
+          Unstacked
+        {{/if}}
+      </span>
+    </dd.Trigger>
+    <dd.Menu as |menu|>
+      <menu.Item>
+        <button
+          type="button"
+          local-class="dropdown-button"
+          {{on "click" this.setStacked}}
+        >
+          Stacked
+        </button>
+      </menu.Item>
+      <menu.Item>
+        <button
+          type="button"
+          local-class="dropdown-button"
+          {{on "click" this.setUnstacked}}
+        >
+          Unstacked
+        </button>
+      </menu.Item>
+    </dd.Menu>
+  </Dropdown>
 </div>
 <div
   local-class="wrapper"

--- a/app/components/download-graph.hbs
+++ b/app/components/download-graph.hbs
@@ -1,37 +1,3 @@
-<div local-class="toggle-stacked">
-  <span local-class="toggle-stacked-label">Display as </span>
-  <Dropdown as |dd|>
-    <dd.Trigger local-class="trigger">
-      <span local-class="trigger-label">
-        {{#if this.stacked}}
-          Stacked
-        {{else}}
-          Unstacked
-        {{/if}}
-      </span>
-    </dd.Trigger>
-    <dd.Menu as |menu|>
-      <menu.Item>
-        <button
-          type="button"
-          local-class="dropdown-button"
-          {{on "click" this.setStacked}}
-        >
-          Stacked
-        </button>
-      </menu.Item>
-      <menu.Item>
-        <button
-          type="button"
-          local-class="dropdown-button"
-          {{on "click" this.setUnstacked}}
-        >
-          Unstacked
-        </button>
-      </menu.Item>
-    </dd.Menu>
-  </Dropdown>
-</div>
 <div
   local-class="wrapper"
   data-test-download-graph
@@ -44,6 +10,7 @@
     <canvas
       {{did-insert this.createChart}}
       {{did-update this.updateChart @data}}
+      {{did-update this.updateStacked @stacked}}
       {{will-destroy this.destroyChart}}
     />
   {{else}}

--- a/app/components/download-graph.hbs
+++ b/app/components/download-graph.hbs
@@ -1,3 +1,8 @@
+<div local-class="toggle-stacked">
+  <a {{on "click" this.toggleChart}}>
+    Toggle Stacked Chart
+  </a>
+</div>
 <div
   local-class="wrapper"
   data-test-download-graph

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -48,6 +48,8 @@ export default class DownloadGraph extends Component {
         },
       },
     });
+
+    this.stacked = true;
   }
 
   @action updateChart() {
@@ -55,6 +57,21 @@ export default class DownloadGraph extends Component {
 
     if (chart) {
       chart.data = this.data;
+      chart.update();
+    }
+  }
+
+  @action toggleChart() {
+    let { chart, data, stacked } = this;
+
+    if (chart) {
+      this.stacked = stacked = !stacked;
+      data.dataset = data.datasets.map(d => {
+        d.fill = stacked ? 'origin' : false;
+        chart.options.scales.y.stacked = stacked;
+        return d;
+      });
+      chart.data = data;
       chart.update();
     }
   }

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -2,7 +2,6 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 
 import subDays from 'date-fns/subDays';
 import window from 'ember-window-mock';
@@ -16,8 +15,6 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
 
 export default class DownloadGraph extends Component {
   @service chartjs;
-
-  @tracked stacked;
 
   @action loadChartJs() {
     waitForPromise(this.chartjs.loadTask.perform()).catch(() => {
@@ -51,8 +48,6 @@ export default class DownloadGraph extends Component {
         },
       },
     });
-
-    this.stacked = true;
   }
 
   @action updateChart() {
@@ -64,27 +59,17 @@ export default class DownloadGraph extends Component {
     }
   }
 
-  @action setStacked() {
-    this.updateStacked(true);
-  }
-
-  @action setUnstacked() {
-    this.updateStacked(false);
-  }
-
-  @action updateStacked(stacked) {
+  @action updateStacked() {
     let { chart, data } = this;
 
     if (chart) {
-      this.stacked = stacked;
       data.dataset = data.datasets.map(d => {
-        d.fill = stacked ? 'origin' : false;
-        chart.options.scales.y.stacked = stacked;
+        d.fill = this.args.stacked ? 'origin' : false;
+        chart.options.scales.y.stacked = this.args.stacked;
         return d;
       });
       chart.data = data;
       chart.update();
-      console.log(this.stacked);
     }
   }
 

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -2,6 +2,7 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
 
 import subDays from 'date-fns/subDays';
 import window from 'ember-window-mock';
@@ -15,6 +16,8 @@ const ONE_DAY = 24 * 60 * 60 * 1000;
 
 export default class DownloadGraph extends Component {
   @service chartjs;
+
+  @tracked stacked;
 
   @action loadChartJs() {
     waitForPromise(this.chartjs.loadTask.perform()).catch(() => {
@@ -61,11 +64,19 @@ export default class DownloadGraph extends Component {
     }
   }
 
-  @action toggleChart() {
-    let { chart, data, stacked } = this;
+  @action setStacked() {
+    this.updateStacked(true);
+  }
+
+  @action setUnstacked() {
+    this.updateStacked(false);
+  }
+
+  @action updateStacked(stacked) {
+    let { chart, data } = this;
 
     if (chart) {
-      this.stacked = stacked = !stacked;
+      this.stacked = stacked;
       data.dataset = data.datasets.map(d => {
         d.fill = stacked ? 'origin' : false;
         chart.options.scales.y.stacked = stacked;
@@ -73,6 +84,7 @@ export default class DownloadGraph extends Component {
       });
       chart.data = data;
       chart.update();
+      console.log(this.stacked);
     }
   }
 

--- a/app/components/download-graph.module.css
+++ b/app/components/download-graph.module.css
@@ -13,31 +13,3 @@
 .error {
     text-align: center;
 }
-
-.toggle-stacked {
-    float: right;
-    margin-top: calc(1.33em - 10px);
-    margin-bottom: calc(1.33em - 10px);
-}
-
-.trigger {
-    background-color: var(--main-bg-dark);
-    font-size: 85%;
-    padding: 10px;
-    border: none;
-    border-radius: 5px;
-
-    .trigger-label {
-        min-width: 65px;
-    }
-}
-
-.dropdown-button {
-    background: none;
-    border: 0;
-    padding: 10px 0;
-
-    img {
-        vertical-align: top;
-    }
-}

--- a/app/components/download-graph.module.css
+++ b/app/components/download-graph.module.css
@@ -13,3 +13,9 @@
 .error {
     text-align: center;
 }
+
+.toggle-stacked {
+    float: right;
+    margin-top: 1.33em;
+    margin-bottom: 1.33em;
+}

--- a/app/components/download-graph.module.css
+++ b/app/components/download-graph.module.css
@@ -16,6 +16,28 @@
 
 .toggle-stacked {
     float: right;
-    margin-top: 1.33em;
-    margin-bottom: 1.33em;
+    margin-top: calc(1.33em - 10px);
+    margin-bottom: calc(1.33em - 10px);
+}
+
+.trigger {
+    background-color: var(--main-bg-dark);
+    font-size: 85%;
+    padding: 10px;
+    border: none;
+    border-radius: 5px;
+
+    .trigger-label {
+        min-width: 65px;
+    }
+}
+
+.dropdown-button {
+    background: none;
+    border: 0;
+    padding: 10px 0;
+
+    img {
+        vertical-align: top;
+    }
 }

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
 
 import { task } from 'ember-concurrency';
 import { alias } from 'macro-decorators';

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,5 +1,7 @@
 import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
 
 import { task } from 'ember-concurrency';
 import { alias } from 'macro-decorators';
@@ -9,6 +11,16 @@ export default class CrateVersionController extends Controller {
 
   get downloadsContext() {
     return this.requestedVersion ? this.currentVersion : this.crate;
+  }
+
+  @tracked stackedGraph = true;
+
+  @action setStackedGraph() {
+    this.stackedGraph = true;
+  }
+
+  @action setUnstackedGraph() {
+    this.stackedGraph = false;
   }
 
   @alias('downloadsContext.version_downloads.content') downloads;

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -136,3 +136,26 @@
 .graph-data {
     clear: both;
 }
+
+.toggle-stacked {
+    float: right;
+    margin-top: calc(1.33em - 10px);
+    margin-bottom: calc(1.33em - 10px);
+
+    .trigger {
+        background-color: var(--main-bg-dark);
+        font-size: 85%;
+        padding: 10px;
+        border: none;
+        border-radius: 5px;
+    
+        .trigger-label {
+            min-width: 65px;
+        }
+    }
+    
+    .dropdown-button {
+        background: none;
+        border: 0;
+    }
+}

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -125,9 +125,14 @@
 
     h4 {
         color: var(--main-color-light);
+        float: left;
     }
 
     @media only percy {
         display: none;
     }
+}
+
+.graph-data {
+    clear: both;
 }

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -79,7 +79,41 @@
     </div>
     <div local-class='graph'>
       <h4>Downloads over the last 90 days</h4>
-      <DownloadGraph @data={{this.downloads}} local-class="graph-data" />
+      <div local-class="toggle-stacked">
+        <span local-class="toggle-stacked-label">Display as </span>
+        <Dropdown as |dd|>
+          <dd.Trigger local-class="trigger">
+            <span local-class="trigger-label">
+              {{#if this.stackedGraph}}
+                Stacked
+              {{else}}
+                Unstacked
+              {{/if}}
+            </span>
+          </dd.Trigger>
+          <dd.Menu as |menu|>
+            <menu.Item>
+              <button
+                type="button"
+                local-class="dropdown-button"
+                {{on "click" this.setStackedGraph}}
+              >
+                Stacked
+              </button>
+            </menu.Item>
+            <menu.Item>
+              <button
+                type="button"
+                local-class="dropdown-button"
+                {{on "click" this.setUnstackedGraph}}
+              >
+                Unstacked
+              </button>
+            </menu.Item>
+          </dd.Menu>
+        </Dropdown>
+      </div>
+      <DownloadGraph @data={{this.downloads}} @stacked={{this.stackedGraph}} local-class="graph-data" />
     </div>
   </div>
 {{/if}}


### PR DESCRIPTION
Related Issues:
- https://github.com/rust-lang/crates.io/issues/3876

This PR add a button to the graph of download counts which toggle between stacked / unstacked graph.

Screenshots:

- Stacked graph: <img width="1552" alt="image" src="https://user-images.githubusercontent.com/30400950/181035074-bc26aa75-bf25-418e-a9d5-ae6109afaf38.png">
- Unstacked graph: <img width="1552" alt="image" src="https://user-images.githubusercontent.com/30400950/181035124-b59023a9-848d-4656-b733-df324782dc41.png">
