### PR TITLE
Replace is_alphanumeric + is_ascii with is_ascii_alphanumeric

### DIFF
--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -54,11 +54,10 @@ impl Keyword {
             return false;
         }
         // unwrap is okay because name is non-empty
-        name.chars().next().unwrap().is_alphanumeric()
+        name.chars().next().unwrap().is_ascii_alphanumeric()
             && name
                 .chars()
-                .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-            && name.chars().all(|c| c.is_ascii())
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
     }
 
     pub fn update_crate(conn: &PgConnection, krate: &Crate, keywords: &[&str]) -> QueryResult<()> {


### PR DESCRIPTION
The use of `is_alphanumeric` for keyword validation is from 2014 (ee1c49be24d47c3d6a6a4d11acc7069976872892, aebaec8f3fe8514b350d48bef6461ed41380ffb2) which is way before `is_ascii_alphanumeric` became available (2018, Rust 1.24).