### PR TITLE
DO NOT MERGE YET encode `+` as `%2B` in S3 paths

### DIFF
--- a/src/tests/http-data/krate_publish_new_krate_version_with_plus
+++ b/src/tests/http-data/krate_publish_new_krate_version_with_plus
@@ -1,0 +1,136 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_plus/foo_plus-1.0.0+build-metadata.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "host",
+          "alexcrichton-test.s3.amazonaws.com"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "authorization",
+          "AWS AKIAICL5IWUZYWWKA7JA:eW1SP7V3WdqHXWZLcbN1BI2Zo0g="
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 07:53:06 -0700"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ],
+        [
+          "accept",
+          "*/*"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "ETag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "Server",
+          "AmazonS3"
+        ],
+        [
+          "x-amz-request-id",
+          "11703800587FA328"
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 14:53:07 GMT"
+        ],
+        [
+          "x-amz-id-2",
+          "fIN5XfJH1PExUU+fEoYZiLAlq/GVmVohMf24Gi5CEHocX1oLc56Mhq9ILtXEsC5xgXEtboWFrEI="
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_plus",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "content-length",
+          "177"
+        ],
+        [
+          "date",
+          "Fri, 15 Sep 2017 07:53:06 -0700"
+        ],
+        [
+          "authorization",
+          "AWS AKIAICL5IWUZYWWKA7JA:uDc39eNdF6CcwB+q+JwKsoDLQc4="
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ],
+        [
+          "host",
+          "alexcrichton-test.s3.amazonaws.com"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZm9vX3BsdXMiLCJ2ZXJzIjoiMS4wLjArYnVpbGQtbWV0YWRhdGEiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "x-amz-request-id",
+          "26589A5E52F8395C"
+        ],
+        [
+          "x-amz-id-2",
+          "JdIvnNTw53aqXjBIqBLNuN4kxf/w1XWX+xuIiGBDYy7yzOSDuAMtBSrTW4ZWetcCIdqCUHuQ51A="
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "Server",
+          "AmazonS3"
+        ],
+        [
+          "date",
+          "Fri,15 Sep 2017 14:53:07 GMT"
+        ],
+        [
+          "ETag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ]
+      ],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/http-data/krate_publish_new_krate_version_with_plus
+++ b/src/tests/http-data/krate_publish_new_krate_version_with_plus
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_plus/foo_plus-1.0.0+build-metadata.crate",
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_plus/foo_plus-1.0.0%2Bbuild-metadata.crate",
       "method": "PUT",
       "headers": [
         [

--- a/src/tests/krate/downloads.rs
+++ b/src/tests/krate/downloads.rs
@@ -96,6 +96,21 @@ fn download_nonexistent_version_of_existing_crate_404s() {
 }
 
 #[test]
+fn download_version_with_plus() {
+    let (app, anon, user) = TestApp::init().with_user();
+    let user = user.as_model();
+
+    app.db(|conn| {
+        CrateBuilder::new("foo_plus", user.id)
+            .version(VersionBuilder::new("1.0.0+hello"))
+            .expect_build(conn);
+    });
+
+    anon.get::<()>("/api/v1/crates/foo_plus/1.0.0+hello/download")
+        .assert_redirect_ends_with("/crates/foo_plus/foo_plus-1.0.0+hello.crate");
+}
+
+#[test]
 fn download_noncanonical_crate_name() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();

--- a/src/tests/krate/downloads.rs
+++ b/src/tests/krate/downloads.rs
@@ -107,7 +107,7 @@ fn download_version_with_plus() {
     });
 
     anon.get::<()>("/api/v1/crates/foo_plus/1.0.0+hello/download")
-        .assert_redirect_ends_with("/crates/foo_plus/foo_plus-1.0.0+hello.crate");
+        .assert_redirect_ends_with("/crates/foo_plus/foo_plus-1.0.0%2Bhello.crate");
 }
 
 #[test]

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -146,6 +146,17 @@ fn new_krate_weird_version() {
 }
 
 #[test]
+fn new_krate_version_with_plus() {
+    let (_, _, _, token) = TestApp::full().with_token();
+
+    let crate_to_publish = PublishBuilder::new("foo_plus").version("1.0.0+build-metadata");
+    let json: GoodCrate = token.enqueue_publish(crate_to_publish).good();
+
+    assert_eq!(json.krate.name, "foo_plus");
+    assert_eq!(json.krate.max_version, "1.0.0+build-metadata");
+}
+
+#[test]
 fn new_with_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
 

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -150,7 +150,7 @@ fn new_krate_version_with_plus() {
     let (_, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_plus").version("1.0.0+build-metadata");
-    let json: GoodCrate = token.enqueue_publish(crate_to_publish).good();
+    let json: GoodCrate = token.publish_crate(crate_to_publish).good();
 
     assert_eq!(json.krate.name, "foo_plus");
     assert_eq!(json.krate.max_version, "1.0.0+build-metadata");

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -48,14 +48,19 @@ impl<T> Response<T> {
 
     #[track_caller]
     pub fn assert_redirect_ends_with(&self, target: &str) -> &Self {
-        assert!(self
+        let redirect_url = self
             .response
             .headers()
             .get(header::LOCATION)
             .unwrap()
             .to_str()
-            .unwrap()
-            .ends_with(target));
+            .unwrap();
+        assert!(
+            redirect_url.ends_with(target),
+            "assertion failed: `redirect_url.ends_with(target)`
+ redirect_url: `\"{redirect_url}\"`
+       target: `\"{target}\"`"
+        );
         self
     }
 }

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -79,6 +79,7 @@ impl Uploader {
 
     /// Returns the internal path of an uploaded crate's version archive.
     fn crate_path(name: &str, version: &str) -> String {
+        let version = version.replace('+', "%2B");
         format!("crates/{name}/{name}-{version}.crate")
     }
 


### PR DESCRIPTION
🚨 🚨 🚨 🚨  We need to do migration of some files on S3 before this can be merged!!! 🚨 🚨 🚨 🚨 

Fixes https://github.com/rust-lang/crates.io/issues/4891, I think.

To test this:

- First, on the master branch with S3 configured, publish a crate with some build metadata (that is, containing a `+`)
- Observe the behavior reported in #4891, that the S3 URL is treating the `+` more like a space: requests to the S3 URL containing `%2B` (encoded `+`) will return 403 when it should return 200.
- Manually do the mass migration I think we need to script to change all `+` into `%2B`, by downloading and re-uploading the S3 file using `%2B` instead of `+` (or using the `aws` CLI). Don't use the S3 "copy" web interface, that seems to double encode.
- Observe requests to the S3 URL containing `%2B` now return 200.
- Switch to this PR's branch.
- Create a new local project that depends on the migrated crate containing build metadata on the registry now running this branch, to simulate us having deployed it. Verify Cargo can find and download that crate version.
- Remove the old S3 file containing `+` and confirm Cargo can still find and download that crate version (clear Cargo's download cache first to be sure), to simulate cleaning up after this branch is deployed
- Publish a new version containing build metadata and observe that when this branch does the uploading, the `+` gets encoded as `%2B` in the S3 path
- Verify Cargo can find and download that crate version too.
