### PR TITLE
Don't auto-generate empty http-data files

### DIFF
--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -55,10 +55,10 @@ impl Drop for Bomb {
                 }
             }
             Ok(_) if thread::panicking() => {}
-            Ok(None) => {}
-            Ok(Some((data, file))) => {
+            Ok(Some((data, file))) if data != b"[]\n" => {
                 assert_ok!(assert_ok!(File::create(&file)).write_all(&data));
             }
+            Ok(_) => {}
         }
     }
 }


### PR DESCRIPTION
If the data file would consist of an empty array, then don't write it as this is the default if a file does not exist.

Extracted from https://github.com/rust-lang/crates.io/pull/5022