### PR TITLE
Sort headers of http-data files

### DIFF
--- a/src/tests/http-data/krate_publish_features_version_2
+++ b/src/tests/http-data/krate_publish_features_version_2
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W3sibmFtZSI6ImJhciIsInJlcSI6Ij4gMCIsImZlYXR1cmVzIjpbXSwib3B0aW9uYWwiOmZhbHNlLCJkZWZhdWx0X2ZlYXR1cmVzIjp0cnVlLCJ0YXJnZXQiOm51bGwsImtpbmQiOiJub3JtYWwifV0sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7Im9sZF9mZWF0IjpbXX0sImZlYXR1cmVzMiI6eyJuZXdfZmVhdCI6WyJkZXA6YmFyIiwiYmFyPy9mZWF0Il19LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbCwidiI6Mn0K"
     },
     "response": {

--- a/src/tests/http-data/krate_publish_good_badges
+++ b/src/tests/http-data/krate_publish_good_badges
@@ -9,16 +9,16 @@
           "*/*"
         ],
         [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
           "content-length",
           "35"
         ],
         [
           "content-type",
           "application/gzip"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vYmFkZ2VyIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_good_categories
+++ b/src/tests/http-data/krate_publish_good_categories
@@ -5,20 +5,20 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
+          "accept",
+          "*/*"
         ],
         [
-          "content-type",
-          "application/gzip"
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
           "35"
         ],
         [
-          "accept",
-          "*/*"
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX2dvb2RfY2F0IiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_ignored_badges
+++ b/src/tests/http-data/krate_publish_ignored_badges
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX2lnbm9yZWRfYmFkZ2UiLCJ2ZXJzIjoiMS4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {

--- a/src/tests/http-data/krate_publish_ignored_categories
+++ b/src/tests/http-data/krate_publish_ignored_categories
@@ -5,20 +5,20 @@
       "method": "PUT",
       "headers": [
         [
-          "content-length",
-          "35"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "content-type",
-          "application/gzip"
+          "content-length",
+          "35"
         ],
         [
-          "accept",
-          "*/*"
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX2lnbm9yZWRfY2F0IiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency
+++ b/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W3sibmFtZSI6ImZvby1kZXAiLCJyZXEiOiI+IDAiLCJmZWF0dXJlcyI6W10sIm9wdGlvbmFsIjpmYWxzZSwiZGVmYXVsdF9mZWF0dXJlcyI6dHJ1ZSwidGFyZ2V0IjpudWxsLCJraW5kIjoibm9ybWFsIn1dLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate
+++ b/src/tests/http-data/krate_publish_new_krate
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX25ldyIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_git_upload
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload
@@ -5,20 +5,20 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
+          "accept",
+          "*/*"
         ],
         [
-          "content-type",
-          "application/gzip"
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
           "35"
         ],
         [
-          "accept",
-          "*/*"
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZmd0IiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_appends
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_appends
@@ -5,20 +5,20 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ],
-        [
           "content-length",
           "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,20 +35,20 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ],
-        [
           "content-length",
           "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -65,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -79,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiRlBQIiwidmVycyI6IjAuMC4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6IkZQUCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
@@ -94,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -108,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiRlBQIiwidmVycyI6IjAuMC4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6IkZQUCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts
@@ -5,21 +5,22 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
+          "accept",
+          "*/*"
         ],
         [
-          "content-type",
-          "application/gzip"
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
           "35"
         ],
         [
-          "accept",
-          "*/*"
-        ]      ],
+          "content-type",
+          "application/gzip"
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -34,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -48,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX2NvbmZsaWN0cyIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_records_verified_email
+++ b/src/tests/http-data/krate_publish_new_krate_records_verified_email
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3ZlcmlmaWVkX2VtYWlsIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted
+++ b/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted
@@ -5,12 +5,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3doaXRlbGlzdCIsInZlcnMiOiIxLjEuMCIsImRlcHMiOltdLCJja3N1bSI6IjRlMzNkYzU5YmJiYzk2NjQ1ZmMwMTk0NWZiNTAyNTA3ZDFiN2JkM2EyZDA2MjI3YmY3YjBmZTg4NDJmMjg0YzIiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_twice
+++ b/src/tests/http-data/krate_publish_new_krate_twice
@@ -5,21 +5,22 @@
       "method": "PUT",
       "headers": [
         [
-          "content-length",
-          "35"
-        ],
-        [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ]      ],
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -34,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -48,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3R3aWNlIiwidmVycyI6IjIuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_weird_version
+++ b/src/tests/http-data/krate_publish_new_krate_weird_version
@@ -5,6 +5,10 @@
       "method": "PUT",
       "headers": [
         [
+          "accept",
+          "*/*"
+        ],
+        [
           "accept-encoding",
           "gzip"
         ],
@@ -15,10 +19,6 @@
         [
           "content-type",
           "application/gzip"
-        ],
-        [
-          "accept",
-          "*/*"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3dlaXJkIiwidmVycyI6IjAuMC4wLXByZSIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_with_dependency
+++ b/src/tests/http-data/krate_publish_new_krate_with_dependency
@@ -5,8 +5,8 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
@@ -17,8 +17,8 @@
           "35"
         ],
         [
-          "accept",
-          "*/*"
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoibmV3X2RlcCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOlt7Im5hbWUiOiJmb28tZGVwIiwicmVxIjoiMS4wLjAiLCJmZWF0dXJlcyI6W10sIm9wdGlvbmFsIjpmYWxzZSwiZGVmYXVsdF9mZWF0dXJlcyI6dHJ1ZSwidGFyZ2V0IjpudWxsLCJraW5kIjoibm9ybWFsIn1dLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_with_readme
+++ b/src/tests/http-data/krate_publish_new_krate_with_readme
@@ -5,20 +5,20 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-type",
-          "application/gzip"
-        ],
-        [
           "accept",
           "*/*"
         ],
         [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
           "content-length",
           "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,20 +35,20 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
         ],
         [
-          "content-type",
-          "text/html"
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
           "0"
+        ],
+        [
+          "content-type",
+          "text/html"
         ]
       ],
       "body": ""
@@ -65,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -79,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3JlYWRtZSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_krate_with_token
+++ b/src/tests/http-data/krate_publish_new_krate_with_token
@@ -5,21 +5,22 @@
       "method": "PUT",
       "headers": [
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept",
           "*/*"
         ],
         [
-          "content-type",
-          "application/gzip"
-        ],
-        [
           "accept-encoding",
           "gzip"
-        ]      ],
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -34,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -48,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX25ldyIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_with_renamed_dependency
+++ b/src/tests/http-data/krate_publish_new_with_renamed_dependency
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoibmV3LWtyYXRlIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W3sibmFtZSI6Im15LW5hbWUiLCJyZXEiOiI+IDAiLCJmZWF0dXJlcyI6W10sIm9wdGlvbmFsIjpmYWxzZSwiZGVmYXVsdF9mZWF0dXJlcyI6dHJ1ZSwidGFyZ2V0IjpudWxsLCJraW5kIjoibm9ybWFsIiwicGFja2FnZSI6InBhY2thZ2UtbmFtZSJ9XSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {

--- a/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency
+++ b/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoibmV3LWtyYXRlIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W3sibmFtZSI6Il9teS1uYW1lIiwicmVxIjoiPiAwIiwiZmVhdHVyZXMiOltdLCJvcHRpb25hbCI6ZmFsc2UsImRlZmF1bHRfZmVhdHVyZXMiOnRydWUsInRhcmdldCI6bnVsbCwia2luZCI6Im5vcm1hbCIsInBhY2thZ2UiOiJwYWNrYWdlLW5hbWUifV0sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_publish_after_removing_documentation
+++ b/src/tests/http-data/krate_publish_publish_after_removing_documentation
@@ -13,12 +13,12 @@
           "gzip"
         ],
         [
-          "content-type",
-          "application/gzip"
-        ],
-        [
           "content-length",
           "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,20 +35,20 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
-        ],
-        [
-          "content-length",
-          "35"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -65,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -79,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZG9jc2NyYXRlIiwidmVycyI6IjAuMi4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImRvY3NjcmF0ZSIsInZlcnMiOiIwLjIuMiIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
@@ -94,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -108,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZG9jc2NyYXRlIiwidmVycyI6IjAuMi4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImRvY3NjcmF0ZSIsInZlcnMiOiIwLjIuMiIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_publish_new_crate_rate_limited
+++ b/src/tests/http-data/krate_publish_publish_new_crate_rate_limited
@@ -5,21 +5,22 @@
       "method": "PUT",
       "headers": [
         [
-          "content-length",
-          "35"
-        ],
-        [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ]      ],
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -34,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -48,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoicmF0ZV9saW1pdGVkMSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
@@ -63,21 +65,22 @@
       "method": "PUT",
       "headers": [
         [
-          "content-length",
-          "35"
-        ],
-        [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ]      ],
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -92,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -106,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoicmF0ZV9saW1pdGVkMiIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
+++ b/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
@@ -5,21 +5,22 @@
       "method": "PUT",
       "headers": [
         [
-          "content-length",
-          "35"
-        ],
-        [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ]      ],
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -34,21 +35,22 @@
       "method": "PUT",
       "headers": [
         [
-          "content-length",
-          "35"
-        ],
-        [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ]      ],
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -63,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -77,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoicmF0ZV9saW1pdGVkMSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJyYXRlX2xpbWl0ZWQxIiwidmVycyI6IjEuMC4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
@@ -92,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -106,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoicmF0ZV9saW1pdGVkMSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJyYXRlX2xpbWl0ZWQxIiwidmVycyI6IjEuMC4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_publish_records_an_audit_action
+++ b/src/tests/http-data/krate_publish_publish_records_an_audit_action
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
+++ b/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
@@ -65,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -79,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25zX3VwZGF0ZWRfYXQiLCJ2ZXJzIjoiMS4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0KeyJuYW1lIjoiZm9vX3ZlcnNpb25zX3VwZGF0ZWRfYXQiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {
@@ -94,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -108,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25zX3VwZGF0ZWRfYXQiLCJ2ZXJzIjoiMS4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0KeyJuYW1lIjoiZm9vX3ZlcnNpb25zX3VwZGF0ZWRfYXQiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {

--- a/src/tests/http-data/krate_yanking_publish_after_yank_max_version
+++ b/src/tests/http-data/krate_yanking_publish_after_yank_max_version
@@ -5,20 +5,20 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
-        ],
-        [
-          "content-length",
-          "35"
-        ],
-        [
           "accept",
           "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6dHJ1ZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
@@ -64,6 +65,10 @@
       "method": "PUT",
       "headers": [
         [
+          "accept",
+          "*/*"
+        ],
+        [
           "accept-encoding",
           "gzip"
         ],
@@ -74,10 +79,6 @@
         [
           "content-type",
           "application/gzip"
-        ],
-        [
-          "accept",
-          "*/*"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -94,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -108,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJmeWtfbWF4IiwidmVycyI6IjIuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjp0cnVlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {

--- a/src/tests/http-data/krate_yanking_yank_max_version
+++ b/src/tests/http-data/krate_yanking_yank_max_version
@@ -5,20 +5,20 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
           "35"
         ],
         [
-          "accept-encoding",
-          "gzip"
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,20 +35,20 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
           "gzip"
         ],
         [
-          "accept",
-          "*/*"
-        ],
-        [
           "content-length",
           "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -65,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -79,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6dHJ1ZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZ5a19tYXgiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {
@@ -94,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -108,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6dHJ1ZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZ5a19tYXgiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {

--- a/src/tests/http-data/krate_yanking_yank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_yank_records_an_audit_action
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjp0cnVlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {

--- a/src/tests/http-data/krate_yanking_yank_works_as_intended
+++ b/src/tests/http-data/krate_yanking_yank_works_as_intended
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {

--- a/src/tests/http-data/owners_new_crate_owner
+++ b/src/tests/http-data/owners_new_crate_owner
@@ -5,6 +5,10 @@
       "method": "PUT",
       "headers": [
         [
+          "accept",
+          "*/*"
+        ],
+        [
           "accept-encoding",
           "gzip"
         ],
@@ -15,11 +19,8 @@
         [
           "content-type",
           "application/gzip"
-        ],
-        [
-          "accept",
-          "*/*"
-        ]      ],
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
     "response": {
@@ -34,8 +35,8 @@
       "method": "PUT",
       "headers": [
         [
-          "content-type",
-          "application/gzip"
+          "accept",
+          "*/*"
         ],
         [
           "accept-encoding",
@@ -46,8 +47,8 @@
           "35"
         ],
         [
-          "accept",
-          "*/*"
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -64,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -78,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX293bmVyIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZvb19vd25lciIsInZlcnMiOiIyLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
@@ -93,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -107,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX293bmVyIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZvb19vd25lciIsInZlcnMiOiIyLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {

--- a/src/tests/http-data/team_publish_owned
+++ b/src/tests/http-data/team_publish_owned
@@ -9,16 +9,16 @@
           "*/*"
         ],
         [
-          "content-type",
-          "application/gzip"
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
           "35"
         ],
         [
-          "accept-encoding",
-          "gzip"
+          "content-type",
+          "application/gzip"
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3RlYW1fb3duZWQiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {

--- a/src/tests/http-data/version_version_size
+++ b/src/tests/http-data/version_version_size
@@ -9,12 +9,12 @@
           "*/*"
         ],
         [
-          "content-length",
-          "35"
-        ],
-        [
           "accept-encoding",
           "gzip"
+        ],
+        [
+          "content-length",
+          "35"
         ],
         [
           "content-type",
@@ -35,12 +35,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -49,7 +49,8 @@
         [
           "content-type",
           "application/gzip"
-        ]      ],
+        ]
+      ],
       "body": "H4sIAAAAAAAA/+3GMQ6AIAwAwD6FD4itDj6HYIKmi02oOvh6nQwfgIXedJtIuFNWliMoP2mYPHocV96hOvxRcfxOONMCTVx6xuwcdCqCMcaYHr0JrJTmAAgAAA=="
     },
     "response": {
@@ -64,12 +65,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -78,7 +79,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25fc2l6ZSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJmb29fdmVyc2lvbl9zaXplIiwidmVycyI6IjIuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiNzUyMmRkNjFiZGRmZDM1MDFiYTQ4YWY4YmFiY2ZmZDJjODkwOTE5ZGE5MGM4NWI2ZWFhZjdmZDk0NzlmOTAxYSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
@@ -93,12 +95,12 @@
       "method": "PUT",
       "headers": [
         [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
           "accept",
           "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
         ],
         [
           "content-length",
@@ -107,7 +109,8 @@
         [
           "content-type",
           "text/plain"
-        ]      ],
+        ]
+      ],
       "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25fc2l6ZSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJmb29fdmVyc2lvbl9zaXplIiwidmVycyI6IjIuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiNzUyMmRkNjFiZGRmZDM1MDFiYTQ4YWY4YmFiY2ZmZDJjODkwOTE5ZGE5MGM4NWI2ZWFhZjdmZDk0NzlmOTAxYSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {


### PR DESCRIPTION
The files were regenerated with `RECORD=force cargo test` (see https://github.com/rust-lang/crates.io/pull/5040) and manually reviewed.

Extracted from https://github.com/rust-lang/crates.io/pull/5022