### PR TITLE
Always run background jobs after a test publish

### DIFF
--- a/src/tests/http-data/krate_publish_new_krate_git_upload_appends
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_appends
@@ -31,6 +31,36 @@
   },
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fpp",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "157"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiRlBQIiwidmVycyI6IjAuMC4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/FPP/FPP-1.0.0.crate",
       "method": "PUT",
       "headers": [
@@ -52,36 +82,6 @@
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-    },
-    "response": {
-      "status": 200,
-      "headers": [],
-      "body": ""
-    }
-  },
-  {
-    "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fpp",
-      "method": "PUT",
-      "headers": [
-        [
-          "accept",
-          "*/*"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-length",
-          "314"
-        ],
-        [
-          "content-type",
-          "text/plain"
-        ]
-      ],
-      "body": "eyJuYW1lIjoiRlBQIiwidmVycyI6IjAuMC4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6IkZQUCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_publish_publish_after_removing_documentation
+++ b/src/tests/http-data/krate_publish_publish_after_removing_documentation
@@ -31,6 +31,36 @@
   },
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/do/cs/docscrate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "163"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZG9jc2NyYXRlIiwidmVycyI6IjAuMi4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/docscrate/docscrate-0.2.2.crate",
       "method": "PUT",
       "headers": [
@@ -52,36 +82,6 @@
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-    },
-    "response": {
-      "status": 200,
-      "headers": [],
-      "body": ""
-    }
-  },
-  {
-    "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/do/cs/docscrate",
-      "method": "PUT",
-      "headers": [
-        [
-          "accept",
-          "*/*"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-length",
-          "326"
-        ],
-        [
-          "content-type",
-          "text/plain"
-        ]
-      ],
-      "body": "eyJuYW1lIjoiZG9jc2NyYXRlIiwidmVycyI6IjAuMi4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImRvY3NjcmF0ZSIsInZlcnMiOiIwLjIuMiIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
+++ b/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates
@@ -31,6 +31,36 @@
   },
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "167"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoicmF0ZV9saW1pdGVkMSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/rate_limited1/rate_limited1-1.0.1.crate",
       "method": "PUT",
       "headers": [
@@ -52,36 +82,6 @@
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-    },
-    "response": {
-      "status": 200,
-      "headers": [],
-      "body": ""
-    }
-  },
-  {
-    "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
-      "method": "PUT",
-      "headers": [
-        [
-          "accept",
-          "*/*"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-length",
-          "334"
-        ],
-        [
-          "content-type",
-          "text/plain"
-        ]
-      ],
-      "body": "eyJuYW1lIjoicmF0ZV9saW1pdGVkMSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJyYXRlX2xpbWl0ZWQxIiwidmVycyI6IjEuMC4xIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
+++ b/src/tests/http-data/krate_publish_uploading_new_version_touches_crate
@@ -31,6 +31,36 @@
   },
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_versions_updated_at",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "177"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25zX3VwZGF0ZWRfYXQiLCJ2ZXJzIjoiMS4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_versions_updated_at/foo_versions_updated_at-2.0.0.crate",
       "method": "PUT",
       "headers": [
@@ -52,36 +82,6 @@
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-    },
-    "response": {
-      "status": 200,
-      "headers": [],
-      "body": ""
-    }
-  },
-  {
-    "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_versions_updated_at",
-      "method": "PUT",
-      "headers": [
-        [
-          "accept",
-          "*/*"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-length",
-          "354"
-        ],
-        [
-          "content-type",
-          "text/plain"
-        ]
-      ],
-      "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25zX3VwZGF0ZWRfYXQiLCJ2ZXJzIjoiMS4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0KeyJuYW1lIjoiZm9vX3ZlcnNpb25zX3VwZGF0ZWRfYXQiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_yanking_publish_after_yank_max_version
+++ b/src/tests/http-data/krate_yanking_publish_after_yank_max_version
@@ -44,14 +44,14 @@
         ],
         [
           "content-length",
-          "160"
+          "161"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6dHJ1ZSwibGlua3MiOm51bGx9Cg=="
+      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
       "status": 200,
@@ -104,14 +104,14 @@
         ],
         [
           "content-length",
-          "322"
+          "321"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJmeWtfbWF4IiwidmVycyI6IjIuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6dHJ1ZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZ5a19tYXgiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_unyank_records_an_audit_action
@@ -44,14 +44,14 @@
         ],
         [
           "content-length",
-          "156"
+          "157"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjp0cnVlLCJsaW5rcyI6bnVsbH0K"
+      "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_yanking_yank_max_version
+++ b/src/tests/http-data/krate_yanking_yank_max_version
@@ -31,6 +31,36 @@
   },
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "161"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-2.0.0.crate",
       "method": "PUT",
       "headers": [
@@ -74,44 +104,14 @@
         ],
         [
           "content-length",
-          "321"
+          "322"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6dHJ1ZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZ5a19tYXgiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
-    },
-    "response": {
-      "status": 200,
-      "headers": [],
-      "body": ""
-    }
-  },
-  {
-    "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
-      "method": "PUT",
-      "headers": [
-        [
-          "accept",
-          "*/*"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-length",
-          "321"
-        ],
-        [
-          "content-type",
-          "text/plain"
-        ]
-      ],
-      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6dHJ1ZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZ5a19tYXgiLCJ2ZXJzIjoiMi4wLjAiLCJkZXBzIjpbXSwiY2tzdW0iOiJhY2I1NjA0YjEyNmFjODk0YzFlYjExYzQ1NzViZjIwNzJmZWE2MTIzMmE4ODhlNDUzNzcwYzc5ZDdlZDU2NDE5IiwiZmVhdHVyZXMiOnt9LCJ5YW5rZWQiOmZhbHNlLCJsaW5rcyI6bnVsbH0K"
+      "body": "eyJuYW1lIjoiZnlrX21heCIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJmeWtfbWF4IiwidmVycyI6IjIuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_yanking_yank_records_an_audit_action
+++ b/src/tests/http-data/krate_yanking_yank_records_an_audit_action
@@ -44,14 +44,14 @@
         ],
         [
           "content-length",
-          "156"
+          "157"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjp0cnVlLCJsaW5rcyI6bnVsbH0K"
+      "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/owners_new_crate_owner
+++ b/src/tests/http-data/owners_new_crate_owner
@@ -31,6 +31,36 @@
   },
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_owner",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "163"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZm9vX293bmVyIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_owner/foo_owner-2.0.0.crate",
       "method": "PUT",
       "headers": [
@@ -52,36 +82,6 @@
         ]
       ],
       "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-    },
-    "response": {
-      "status": 200,
-      "headers": [],
-      "body": ""
-    }
-  },
-  {
-    "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_owner",
-      "method": "PUT",
-      "headers": [
-        [
-          "accept",
-          "*/*"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-length",
-          "326"
-        ],
-        [
-          "content-type",
-          "text/plain"
-        ]
-      ],
-      "body": "eyJuYW1lIjoiZm9vX293bmVyIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9CnsibmFtZSI6ImZvb19vd25lciIsInZlcnMiOiIyLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/version_version_size
+++ b/src/tests/http-data/version_version_size
@@ -31,6 +31,36 @@
   },
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_version_size",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "170"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25fc2l6ZSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQo="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_version_size/foo_version_size-2.0.0.crate",
       "method": "PUT",
       "headers": [
@@ -52,36 +82,6 @@
         ]
       ],
       "body": "H4sIAAAAAAAA/+3GMQ6AIAwAwD6FD4itDj6HYIKmi02oOvh6nQwfgIXedJtIuFNWliMoP2mYPHocV96hOvxRcfxOONMCTVx6xuwcdCqCMcaYHr0JrJTmAAgAAA=="
-    },
-    "response": {
-      "status": 200,
-      "headers": [],
-      "body": ""
-    }
-  },
-  {
-    "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_version_size",
-      "method": "PUT",
-      "headers": [
-        [
-          "accept",
-          "*/*"
-        ],
-        [
-          "accept-encoding",
-          "gzip"
-        ],
-        [
-          "content-length",
-          "340"
-        ],
-        [
-          "content-type",
-          "text/plain"
-        ]
-      ],
-      "body": "eyJuYW1lIjoiZm9vX3ZlcnNpb25fc2l6ZSIsInZlcnMiOiIxLjAuMCIsImRlcHMiOltdLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2UsImxpbmtzIjpudWxsfQp7Im5hbWUiOiJmb29fdmVyc2lvbl9zaXplIiwidmVycyI6IjIuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiNzUyMmRkNjFiZGRmZDM1MDFiYTQ4YWY4YmFiY2ZmZDJjODkwOTE5ZGE5MGM4NWI2ZWFhZjdmZDk0NzlmOTAxYSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
     },
     "response": {
       "status": 200,

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -46,8 +46,7 @@ fn yank_works_as_intended() {
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk");
-    token.enqueue_publish(crate_to_publish).good();
-    app.run_pending_background_jobs();
+    token.publish_crate(crate_to_publish).good();
 
     let crates = app.crates_from_index_head("fyk");
     assert_eq!(crates.len(), 1);
@@ -124,7 +123,7 @@ fn yank_max_version() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk_max");
-    token.enqueue_publish(crate_to_publish).good();
+    token.publish_crate(crate_to_publish).good();
 
     // double check the max version
     let json = anon.show_crate("fyk_max");
@@ -132,7 +131,7 @@ fn yank_max_version() {
 
     // add version 2.0.0
     let crate_to_publish = PublishBuilder::new("fyk_max").version("2.0.0");
-    let json = token.enqueue_publish(crate_to_publish).good();
+    let json = token.publish_crate(crate_to_publish).good();
     assert_eq!(json.krate.max_version, "2.0.0");
 
     // yank version 1.0.0
@@ -178,7 +177,7 @@ fn publish_after_yank_max_version() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk_max");
-    token.enqueue_publish(crate_to_publish).good();
+    token.publish_crate(crate_to_publish).good();
 
     // double check the max version
     let json = anon.show_crate("fyk_max");
@@ -192,7 +191,7 @@ fn publish_after_yank_max_version() {
 
     // add version 2.0.0
     let crate_to_publish = PublishBuilder::new("fyk_max").version("2.0.0");
-    let json = token.enqueue_publish(crate_to_publish).good();
+    let json = token.publish_crate(crate_to_publish).good();
     assert_eq!(json.krate.max_version, "2.0.0");
 
     // unyank version 1.0.0
@@ -208,7 +207,7 @@ fn yank_records_an_audit_action() {
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk");
-    token.enqueue_publish(crate_to_publish).good();
+    token.publish_crate(crate_to_publish).good();
 
     // Yank it
     token.yank("fyk", "1.0.0").good();
@@ -229,7 +228,7 @@ fn unyank_records_an_audit_action() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk");
-    token.enqueue_publish(crate_to_publish).good();
+    token.publish_crate(crate_to_publish).good();
 
     // Yank version 1.0.0
     token.yank("fyk", "1.0.0").good();

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -136,7 +136,7 @@ fn new_crate_owner() {
 
     // Create a crate under one user
     let crate_to_publish = PublishBuilder::new("foo_owner").version("1.0.0");
-    token.enqueue_publish(crate_to_publish).good();
+    token.publish_crate(crate_to_publish).good();
 
     // Add the second user as an owner (with a different case to make sure that works)
     let user2 = app.db_new_user("Bar");
@@ -154,7 +154,7 @@ fn new_crate_owner() {
     let crate_to_publish = PublishBuilder::new("foo_owner").version("2.0.0");
     user2
         .db_new_token("bar_token")
-        .enqueue_publish(crate_to_publish)
+        .publish_crate(crate_to_publish)
         .good();
 }
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -195,7 +195,7 @@ fn add_team_as_non_member() {
 
 #[test]
 fn remove_team_as_named_owner() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::full().empty();
     let username = "user-all-teams";
     let user_on_both_teams = app.db_new_user(username);
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -223,7 +223,7 @@ fn remove_team_as_named_owner() {
 
     let user_on_one_team = app.db_new_user("user-one-team");
     let crate_to_publish = PublishBuilder::new("foo_remove_team").version("2.0.0");
-    let response = user_on_one_team.enqueue_publish(crate_to_publish);
+    let response = user_on_one_team.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -271,7 +271,7 @@ fn remove_team_as_team_owner() {
 // Test trying to publish a crate we don't own
 #[test]
 fn publish_not_owned() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::full().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
@@ -286,7 +286,7 @@ fn publish_not_owned() {
     let user_on_one_team = app.db_new_user("user-one-team");
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned").version("2.0.0");
-    let response = user_on_one_team.enqueue_publish(crate_to_publish);
+    let response = user_on_one_team.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -296,7 +296,7 @@ fn publish_not_owned() {
 
 #[test]
 fn publish_org_owner_owned() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::full().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
@@ -311,7 +311,7 @@ fn publish_org_owner_owned() {
     let user_org_owner = app.db_new_user("user-org-owner");
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned").version("2.0.0");
-    let response = user_org_owner.enqueue_publish(crate_to_publish);
+    let response = user_org_owner.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -337,7 +337,7 @@ fn publish_owned() {
     let user_on_one_team = app.db_new_user("user-one-team");
 
     let crate_to_publish = PublishBuilder::new("foo_team_owned").version("2.0.0");
-    user_on_one_team.enqueue_publish(crate_to_publish).good();
+    user_on_one_team.publish_crate(crate_to_publish).good();
 }
 
 // Test trying to change owners (when only on an owning team)

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -138,6 +138,7 @@ impl TestApp {
             .unwrap()
     }
 
+    #[track_caller]
     pub fn run_pending_background_jobs(&self) {
         let runner = &self.0.runner;
         let runner = runner.as_ref().expect("Index has not been initialized");

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -137,14 +137,14 @@ fn version_size() {
     let (_, _, user) = TestApp::full().with_user();
 
     let crate_to_publish = PublishBuilder::new("foo_version_size").version("1.0.0");
-    user.enqueue_publish(crate_to_publish).good();
+    user.publish_crate(crate_to_publish).good();
 
     // Add a file to version 2 so that it's a different size than version 1
     let files = [("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_])];
     let crate_to_publish = PublishBuilder::new("foo_version_size")
         .version("2.0.0")
         .files(&files);
-    user.enqueue_publish(crate_to_publish).good();
+    user.publish_crate(crate_to_publish).good();
 
     let crate_json = user.show_crate("foo_version_size");
 


### PR DESCRIPTION
The original intent was that tests would be able to enqueue mutliple
actions and process them more asynchronously to act as more of a stress
test of the background worker logic. However, we have no tests explicity
testing such behavior and we can always add back such methods if we
decide to implement such tests.

This change reorders some requests in the http-data files. For the most
part requests are unchanged, however now if 2 versions of a crate are
published in rapid succession the HTTP index is guarenteed to see both
versions of that file.

Previously, if versions A and B were published they would both go in
the background queue. When the queue was processed, the versions would
be published to the git index and each of those jobs would enqueue an
HTTP sync. However, those syncs would occur after the two publishes and
so both syncs would see the full index file with both versions. This is
not an issue in production, as there is no requirement to push such
intermediate states to the HTTP index as long as it is eventually
consistent. In testing however, it is a bit more convenient to see the 
more typical sequence of events.

Some tests now require the full test harness, even if a crate publish
is expected to fail.

Extracted from https://github.com/rust-lang/crates.io/pull/5022