### PR TITLE
Allow '+' in keywords

### DIFF
--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -56,7 +56,7 @@ impl Keyword {
             Some(c) => c,
         };
         first.is_ascii_alphanumeric()
-            && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+            && chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+')
     }
 
     pub fn update_crate(conn: &PgConnection, krate: &Crate, keywords: &[&str]) -> QueryResult<()> {

--- a/src/tests/http-data/krate_publish_good_keywords
+++ b/src/tests/http-data/krate_publish_good_keywords
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_good_key/foo_good_key-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_good_key",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "166"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZm9vX2dvb2Rfa2V5IiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -711,6 +711,18 @@ fn publish_after_removing_documentation() {
 }
 
 #[test]
+fn good_keywords() {
+    let (_, _, _, token) = TestApp::full().with_token();
+    let crate_to_publish = PublishBuilder::new("foo_good_key")
+        .keyword("c++")
+        .keyword("crates-io_index")
+        .keyword("1password");
+    let json = token.publish_crate(crate_to_publish).good();
+    assert_eq!(json.krate.name, "foo_good_key");
+    assert_eq!(json.krate.max_version, "1.0.0");
+}
+
+#[test]
 fn bad_keywords() {
     let (_, _, _, token) = TestApp::full().with_token();
     let crate_to_publish =


### PR DESCRIPTION
Prior art: '+' in feature names &mdash; https://github.com/rust-lang/crates.io/pull/2510. See that PR for the rationales in favor of that.

Specifically I would be interested in using "c++" as a tag on some of my FFI crates. Alphanumericizing it to "cpp" or "cxx" is not so good because those are each the name of a specific crate for a specific approach to C++ interop, and a crate that's generally suitable for C++ interop wouldn't want its keywords to imply it only works in concert with one of those two other crates.

Cargo has supported '+' in keywords since Rust 1.1.