### PR TITLE
admin/upload-index: Restore "skipping file" output

### DIFF
--- a/src/admin/upload_index.rs
+++ b/src/admin/upload_index.rs
@@ -35,10 +35,11 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
     let pb = ProgressBar::new(files.len() as u64);
     pb.set_style(ProgressStyle::with_template("{bar:60} ({pos}/{len}, ETA {eta})").unwrap());
 
-    for file in files.iter().progress_with(pb) {
+    for file in files.iter().progress_with(pb.clone()) {
         let crate_name = file.file_name().unwrap().to_str().unwrap();
         let path = repo.index_file(crate_name);
         if !path.exists() {
+            pb.suspend(|| println!("skipping file `{}`", crate_name));
             continue;
         }
 


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/issues/4836 migrated the admin tool to use `indicatif` for progress reporting, but back then there was no way to output additional messages without disturbing the progress bar. With the latest release of `indicatif` a `suspend()` method was introduced which allows us to restore the original behavior.