### PR TITLE
Generate index metadata files from the database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
+ "claims",
  "dotenv",
  "git2",
  "serde",

--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 path = "lib.rs"
 
 [features]
-testing = ["serde_json"]
+testing = []
 
 [dependencies]
 anyhow = "=1.0.70"
@@ -18,7 +18,10 @@ base64 = "=0.13.1"
 dotenv = "=0.15.0"
 git2 = "=0.17.1"
 serde = { version = "=1.0.160", features = ["derive"] }
+serde_json = "=1.0.96"
 tempfile = "=3.5.0"
 tracing = "=0.1.37"
 url = "=2.3.1"
-serde_json = { version = "=1.0.96", optional = true }
+
+[dev-dependencies]
+claims = "=0.7.1"

--- a/cargo-registry-index/lib.rs
+++ b/cargo-registry-index/lib.rs
@@ -156,6 +156,13 @@ impl Crate {
     }
 }
 
+pub fn write_crates<W: Write>(crates: &[Crate], mut writer: W) -> anyhow::Result<()> {
+    for krate in crates {
+        krate.write_to(&mut writer)?;
+    }
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Dependency {
     pub name: String,
@@ -625,6 +632,34 @@ mod tests {
         let mut buffer = Vec::new();
         assert_ok!(krate.write_to(&mut buffer));
         assert_ok_eq!(String::from_utf8(buffer), "\
+            {\"name\":\"foo\",\"vers\":\"1.2.3\",\"deps\":[],\"cksum\":\"0123456789asbcdef\",\"features\":{},\"yanked\":null}\n\
+        ");
+    }
+
+    #[test]
+    fn test_write_crates() {
+        let versions = vec!["0.1.0", "1.0.0-beta.1", "1.0.0", "1.2.3"];
+        let crates = versions
+            .into_iter()
+            .map(|vers| Crate {
+                name: "foo".to_string(),
+                vers: vers.to_string(),
+                deps: vec![],
+                cksum: "0123456789asbcdef".to_string(),
+                features: Default::default(),
+                features2: None,
+                yanked: None,
+                links: None,
+                v: None,
+            })
+            .collect::<Vec<_>>();
+
+        let mut buffer = Vec::new();
+        assert_ok!(write_crates(&crates, &mut buffer));
+        assert_ok_eq!(String::from_utf8(buffer), "\
+            {\"name\":\"foo\",\"vers\":\"0.1.0\",\"deps\":[],\"cksum\":\"0123456789asbcdef\",\"features\":{},\"yanked\":null}\n\
+            {\"name\":\"foo\",\"vers\":\"1.0.0-beta.1\",\"deps\":[],\"cksum\":\"0123456789asbcdef\",\"features\":{},\"yanked\":null}\n\
+            {\"name\":\"foo\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"0123456789asbcdef\",\"features\":{},\"yanked\":null}\n\
             {\"name\":\"foo\",\"vers\":\"1.2.3\",\"deps\":[],\"cksum\":\"0123456789asbcdef\",\"features\":{},\"yanked\":null}\n\
         ");
     }

--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -1,3 +1,4 @@
+use crate::background_jobs::Job;
 use crate::{admin::dialoguer, config, db, models::Crate, schema::crates};
 
 use diesel::prelude::*;
@@ -54,5 +55,12 @@ fn delete(opts: Opts, conn: &mut PgConnection) {
         panic!("aborting transaction");
     }
 
-    uploader.delete_index(&client, &krate.name).unwrap();
+    if dotenv::var("FEATURE_INDEX_SYNC").is_ok() {
+        Job::sync_to_git_index(&krate.name).enqueue(conn).unwrap();
+        Job::sync_to_sparse_index(&krate.name)
+            .enqueue(conn)
+            .unwrap();
+    } else {
+        uploader.delete_index(&client, &krate.name).unwrap();
+    }
 }

--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -56,10 +56,7 @@ fn delete(opts: Opts, conn: &mut PgConnection) {
     }
 
     if dotenv::var("FEATURE_INDEX_SYNC").is_ok() {
-        Job::sync_to_git_index(&krate.name).enqueue(conn).unwrap();
-        Job::sync_to_sparse_index(&krate.name)
-            .enqueue(conn)
-            .unwrap();
+        Job::enqueue_sync_to_index(&krate.name, conn).unwrap();
     } else {
         uploader.delete_index(&client, &krate.name).unwrap();
     }

--- a/src/admin/delete_version.rs
+++ b/src/admin/delete_version.rs
@@ -1,3 +1,4 @@
+use crate::background_jobs::Job;
 use crate::{
     admin::dialoguer,
     db,
@@ -56,5 +57,12 @@ fn delete(opts: Opts, conn: &mut PgConnection) {
 
     if !opts.yes && !dialoguer::confirm("commit?") {
         panic!("aborting transaction");
+    }
+
+    if dotenv::var("FEATURE_INDEX_SYNC").is_ok() {
+        Job::sync_to_git_index(&krate.name).enqueue(conn).unwrap();
+        Job::sync_to_sparse_index(&krate.name)
+            .enqueue(conn)
+            .unwrap();
     }
 }

--- a/src/admin/delete_version.rs
+++ b/src/admin/delete_version.rs
@@ -60,9 +60,6 @@ fn delete(opts: Opts, conn: &mut PgConnection) {
     }
 
     if dotenv::var("FEATURE_INDEX_SYNC").is_ok() {
-        Job::sync_to_git_index(&krate.name).enqueue(conn).unwrap();
-        Job::sync_to_sparse_index(&krate.name)
-            .enqueue(conn)
-            .unwrap();
+        Job::enqueue_sync_to_index(&krate.name, conn).unwrap();
     }
 }

--- a/src/admin/yank_version.rs
+++ b/src/admin/yank_version.rs
@@ -66,10 +66,7 @@ fn yank(opts: Opts, conn: &mut PgConnection) {
         .unwrap();
 
     if dotenv::var("FEATURE_INDEX_SYNC").is_ok() {
-        Job::sync_to_git_index(&krate.name).enqueue(conn).unwrap();
-        Job::sync_to_sparse_index(&krate.name)
-            .enqueue(conn)
-            .unwrap();
+        Job::enqueue_sync_to_index(&krate.name, conn).unwrap();
     } else {
         crate::worker::sync_yanked(krate.name, v.num)
             .enqueue(conn)

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -18,6 +18,8 @@ pub enum Job {
     IndexAddCrate(IndexAddCrateJob),
     IndexSquash,
     IndexSyncToHttp(IndexSyncToHttpJob),
+    SyncToGitIndex(SyncToIndexJob),
+    SyncToSparseIndex(SyncToIndexJob),
     IndexUpdateYanked(IndexUpdateYankedJob),
     NormalizeIndex(NormalizeIndexJob),
     RenderAndUploadReadme(RenderAndUploadReadmeJob),
@@ -47,7 +49,21 @@ impl Job {
     const INDEX_UPDATE_YANKED: &str = "sync_yanked";
     const NORMALIZE_INDEX: &str = "normalize_index";
     const RENDER_AND_UPLOAD_README: &str = "render_and_upload_readme";
+    const SYNC_TO_GIT_INDEX: &str = "sync_to_git_index";
+    const SYNC_TO_SPARSE_INDEX: &str = "sync_to_sparse_index";
     const UPDATE_DOWNLOADS: &str = "update_downloads";
+
+    pub fn sync_to_git_index<T: ToString>(krate: T) -> Job {
+        Job::SyncToGitIndex(SyncToIndexJob {
+            krate: krate.to_string(),
+        })
+    }
+
+    pub fn sync_to_sparse_index<T: ToString>(krate: T) -> Job {
+        Job::SyncToSparseIndex(SyncToIndexJob {
+            krate: krate.to_string(),
+        })
+    }
 
     fn as_type_str(&self) -> &'static str {
         match self {
@@ -59,6 +75,8 @@ impl Job {
             Job::IndexUpdateYanked(_) => Self::INDEX_UPDATE_YANKED,
             Job::NormalizeIndex(_) => Self::NORMALIZE_INDEX,
             Job::RenderAndUploadReadme(_) => Self::RENDER_AND_UPLOAD_README,
+            Job::SyncToGitIndex(_) => Self::SYNC_TO_GIT_INDEX,
+            Job::SyncToSparseIndex(_) => Self::SYNC_TO_SPARSE_INDEX,
             Job::UpdateDownloads => Self::UPDATE_DOWNLOADS,
         }
     }
@@ -73,6 +91,8 @@ impl Job {
             Job::IndexUpdateYanked(inner) => serde_json::to_value(inner),
             Job::NormalizeIndex(inner) => serde_json::to_value(inner),
             Job::RenderAndUploadReadme(inner) => serde_json::to_value(inner),
+            Job::SyncToGitIndex(inner) => serde_json::to_value(inner),
+            Job::SyncToSparseIndex(inner) => serde_json::to_value(inner),
             Job::UpdateDownloads => Ok(serde_json::Value::Null),
         }
     }
@@ -101,6 +121,8 @@ impl Job {
             Self::INDEX_UPDATE_YANKED => Job::IndexUpdateYanked(from_value(value)?),
             Self::NORMALIZE_INDEX => Job::NormalizeIndex(from_value(value)?),
             Self::RENDER_AND_UPLOAD_README => Job::RenderAndUploadReadme(from_value(value)?),
+            Self::SYNC_TO_GIT_INDEX => Job::SyncToGitIndex(from_value(value)?),
+            Self::SYNC_TO_SPARSE_INDEX => Job::SyncToSparseIndex(from_value(value)?),
             Self::UPDATE_DOWNLOADS => Job::UpdateDownloads,
             job_type => Err(PerformError::from(format!("Unknown job type {job_type}")))?,
         })
@@ -136,6 +158,8 @@ impl Job {
                 args.base_url.as_deref(),
                 args.pkg_path_in_vcs.as_deref(),
             ),
+            Job::SyncToGitIndex(args) => worker::sync_to_git_index(env, conn, &args.krate),
+            Job::SyncToSparseIndex(args) => worker::sync_to_sparse_index(env, conn, &args.krate),
             Job::UpdateDownloads => worker::perform_update_downloads(&mut *fresh_connection(pool)?),
         }
     }
@@ -170,6 +194,11 @@ pub struct IndexAddCrateJob {
 #[derive(Serialize, Deserialize)]
 pub struct IndexSyncToHttpJob {
     pub(super) crate_name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SyncToIndexJob {
+    pub(super) krate: String,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ pub struct Server {
     pub version_id_cache_ttl: Duration,
     pub cdn_user_agent: String,
     pub balance_capacity: BalanceCapacityConfig,
+    pub feature_index_sync: bool,
 }
 
 impl Default for Server {
@@ -151,6 +152,7 @@ impl Default for Server {
             cdn_user_agent: dotenv::var("WEB_CDN_USER_AGENT")
                 .unwrap_or_else(|_| "Amazon CloudFront".into()),
             balance_capacity: BalanceCapacityConfig::from_environment(),
+            feature_index_sync: dotenv::var("FEATURE_INDEX_SYNC").is_ok(),
         }
     }
 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -274,8 +274,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             };
 
             if app.config.feature_index_sync {
-                Job::sync_to_git_index(&git_crate.name).enqueue(conn)?;
-                Job::sync_to_sparse_index(&git_crate.name).enqueue(conn)?;
+                Job::enqueue_sync_to_index(&krate.name, conn)?;
             } else {
                 worker::add_crate(git_crate).enqueue(conn)?;
             }

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -86,8 +86,7 @@ fn modify_yank(
     insert_version_owner_action(conn, version.id, user.id, api_token_id, action)?;
 
     if state.config.feature_index_sync {
-        Job::sync_to_git_index(&krate.name).enqueue(conn)?;
-        Job::sync_to_sparse_index(&krate.name).enqueue(conn)?;
+        Job::enqueue_sync_to_index(&krate.name, conn)?;
     } else {
         worker::sync_yanked(krate.name, version.num).enqueue(conn)?;
     }

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -44,6 +44,16 @@ pub enum DependencyKind {
     // if you add a kind here, be sure to update `from_row` below.
 }
 
+impl From<IndexDependencyKind> for DependencyKind {
+    fn from(dk: IndexDependencyKind) -> Self {
+        match dk {
+            IndexDependencyKind::Normal => DependencyKind::Normal,
+            IndexDependencyKind::Build => DependencyKind::Build,
+            IndexDependencyKind::Dev => DependencyKind::Dev,
+        }
+    }
+}
+
 impl From<DependencyKind> for IndexDependencyKind {
     fn from(dk: DependencyKind) -> Self {
         match dk {

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use chrono::NaiveDateTime;
 use diesel::associations::Identifiable;
 use diesel::pg::Pg;
@@ -431,6 +433,76 @@ impl Crate {
                 .load(conn)?;
 
         Ok(rows.records_and_total())
+    }
+
+    /// Serialize the crate as an index metadata file
+    pub fn index_metadata(&self, conn: &mut PgConnection) -> QueryResult<String> {
+        let mut versions: Vec<Version> = self.all_versions().load(conn)?;
+        versions.sort_by_cached_key(|k| {
+            semver::Version::parse(&k.num)
+                .expect("version was valid semver when inserted into the database")
+        });
+
+        let mut body = Vec::new();
+        for version in versions {
+            let mut deps: Vec<cargo_registry_index::Dependency> = version
+                .dependencies(conn)?
+                .into_iter()
+                .map(|(dep, name)| {
+                    // If this dependency has an explicit name in `Cargo.toml` that
+                    // means that the `name` we have listed is actually the package name
+                    // that we're depending on. The `name` listed in the index is the
+                    // Cargo.toml-written-name which is what cargo uses for
+                    // `--extern foo=...`
+                    let (name, package) = match dep.explicit_name {
+                        Some(explicit_name) => (explicit_name, Some(name)),
+                        None => (name, None),
+                    };
+                    cargo_registry_index::Dependency {
+                        name,
+                        req: dep.req,
+                        features: dep.features,
+                        optional: dep.optional,
+                        default_features: dep.default_features,
+                        kind: Some(dep.kind.into()),
+                        package,
+                        target: dep.target,
+                    }
+                })
+                .collect();
+            deps.sort();
+
+            let features: BTreeMap<String, Vec<String>> =
+                serde_json::from_value(version.features).unwrap_or_default();
+            let (features, features2): (BTreeMap<_, _>, BTreeMap<_, _>) =
+                features.into_iter().partition(|(_k, vals)| {
+                    !vals
+                        .iter()
+                        .any(|v| v.starts_with("dep:") || v.contains("?/"))
+                });
+
+            let (features2, v) = if features2.is_empty() {
+                (None, None)
+            } else {
+                (Some(features2), Some(2))
+            };
+
+            let krate = cargo_registry_index::Crate {
+                name: self.name.clone(),
+                vers: version.num.to_string(),
+                cksum: version.checksum,
+                yanked: Some(version.yanked),
+                deps,
+                features,
+                links: version.links,
+                features2,
+                v,
+            };
+            serde_json::to_writer(&mut body, &krate).unwrap();
+            body.push(b'\n');
+        }
+        let body = String::from_utf8(body).unwrap();
+        Ok(body)
     }
 }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -34,6 +34,7 @@ mod dump_db;
 mod github_secret_scanning;
 mod krate;
 mod middleware;
+mod models;
 mod not_found_error;
 mod owners;
 mod pagination;

--- a/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted.json
+++ b/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted.json
@@ -44,14 +44,14 @@
         ],
         [
           "content-length",
-          "154"
+          "309"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "{\"name\":\"foo_whitelist\",\"vers\":\"1.1.0\",\"deps\":[],\"cksum\":\"4e33dc59bbbc96645fc01945fb502507d1b7bd3a2d06227bf7b0fe8842f284c2\",\"features\":{},\"yanked\":false}\n"
+      "body": "{\"name\":\"foo_whitelist\",\"vers\":\"0.99.0\",\"deps\":[],\"cksum\":\"                                                                \",\"features\":{},\"yanked\":false}\n{\"name\":\"foo_whitelist\",\"vers\":\"1.1.0\",\"deps\":[],\"cksum\":\"4e33dc59bbbc96645fc01945fb502507d1b7bd3a2d06227bf7b0fe8842f284c2\",\"features\":{},\"yanked\":false}\n"
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_publish_new_krate_twice.json
+++ b/src/tests/http-data/krate_publish_new_krate_twice.json
@@ -44,14 +44,14 @@
         ],
         [
           "content-length",
-          "150"
+          "301"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "{\"name\":\"foo_twice\",\"vers\":\"2.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+      "body": "{\"name\":\"foo_twice\",\"vers\":\"0.99.0\",\"deps\":[],\"cksum\":\"                                                                \",\"features\":{},\"yanked\":false}\n{\"name\":\"foo_twice\",\"vers\":\"2.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/krate_publish_publish_after_removing_documentation.json
+++ b/src/tests/http-data/krate_publish_publish_after_removing_documentation.json
@@ -44,14 +44,14 @@
         ],
         [
           "content-length",
-          "150"
+          "300"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "{\"name\":\"docscrate\",\"vers\":\"0.2.1\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+      "body": "{\"name\":\"docscrate\",\"vers\":\"0.2.0\",\"deps\":[],\"cksum\":\"                                                                \",\"features\":{},\"yanked\":false}\n{\"name\":\"docscrate\",\"vers\":\"0.2.1\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
     },
     "response": {
       "status": 200,
@@ -104,14 +104,14 @@
         ],
         [
           "content-length",
-          "300"
+          "450"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "{\"name\":\"docscrate\",\"vers\":\"0.2.1\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n{\"name\":\"docscrate\",\"vers\":\"0.2.2\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+      "body": "{\"name\":\"docscrate\",\"vers\":\"0.2.0\",\"deps\":[],\"cksum\":\"                                                                \",\"features\":{},\"yanked\":false}\n{\"name\":\"docscrate\",\"vers\":\"0.2.1\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n{\"name\":\"docscrate\",\"vers\":\"0.2.2\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
     },
     "response": {
       "status": 200,

--- a/src/tests/http-data/team_publish_owned.json
+++ b/src/tests/http-data/team_publish_owned.json
@@ -44,14 +44,14 @@
         ],
         [
           "content-length",
-          "155"
+          "311"
         ],
         [
           "content-type",
           "text/plain"
         ]
       ],
-      "body": "{\"name\":\"foo_team_owned\",\"vers\":\"2.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+      "body": "{\"name\":\"foo_team_owned\",\"vers\":\"0.99.0\",\"deps\":[],\"cksum\":\"                                                                \",\"features\":{},\"yanked\":false}\n{\"name\":\"foo_team_owned\",\"vers\":\"2.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
     },
     "response": {
       "status": 200,

--- a/src/tests/models/krate.rs
+++ b/src/tests/models/krate.rs
@@ -1,0 +1,47 @@
+use crate::builders::{CrateBuilder, VersionBuilder};
+use crate::util::insta::assert_yaml_snapshot;
+use crate::TestApp;
+use chrono::{Days, Utc};
+
+#[test]
+fn index_metadata() {
+    let (app, _, user) = TestApp::init().with_user();
+    let user = user.as_model();
+
+    app.db(|conn| {
+        let created_at_1 = Utc::now()
+            .checked_sub_days(Days::new(14))
+            .unwrap()
+            .naive_utc();
+
+        let created_at_2 = Utc::now()
+            .checked_sub_days(Days::new(7))
+            .unwrap()
+            .naive_utc();
+
+        let fooo = CrateBuilder::new("foo", user.id)
+            .version(VersionBuilder::new("0.1.0"))
+            .expect_build(conn);
+
+        let metadata = fooo.index_metadata(conn).unwrap();
+        assert_yaml_snapshot!(metadata);
+
+        let bar = CrateBuilder::new("bar", user.id)
+            .version(
+                VersionBuilder::new("1.0.0-beta.1")
+                    .created_at(created_at_1)
+                    .yanked(true),
+            )
+            .version(VersionBuilder::new("1.0.0").created_at(created_at_1))
+            .version(
+                VersionBuilder::new("2.0.0")
+                    .created_at(created_at_2)
+                    .dependency(&fooo, None),
+            )
+            .version(VersionBuilder::new("1.0.1").checksum("0123456789abcdef"))
+            .expect_build(conn);
+
+        let metadata = bar.index_metadata(conn).unwrap();
+        assert_yaml_snapshot!(metadata);
+    });
+}

--- a/src/tests/models/mod.rs
+++ b/src/tests/models/mod.rs
@@ -1,0 +1,1 @@
+mod krate;

--- a/src/tests/models/snapshots/all__models__krate__index_metadata-2.snap
+++ b/src/tests/models/snapshots/all__models__krate__index_metadata-2.snap
@@ -1,0 +1,36 @@
+---
+source: src/tests/models/krate.rs
+expression: metadata
+---
+- name: bar
+  vers: 1.0.0-beta.1
+  deps: []
+  cksum: "                                                                "
+  features: {}
+  yanked: true
+- name: bar
+  vers: 1.0.0
+  deps: []
+  cksum: "                                                                "
+  features: {}
+  yanked: false
+- name: bar
+  vers: 2.0.0
+  deps:
+    - name: foo
+      req: ">= 0"
+      features: []
+      optional: false
+      default_features: false
+      target: ~
+      kind: normal
+  cksum: "                                                                "
+  features: {}
+  yanked: false
+- name: bar
+  vers: 1.0.1
+  deps: []
+  cksum: "0123456789abcdef                                                "
+  features: {}
+  yanked: false
+

--- a/src/tests/models/snapshots/all__models__krate__index_metadata.snap
+++ b/src/tests/models/snapshots/all__models__krate__index_metadata.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/models/krate.rs
+expression: metadata
+---
+- name: foo
+  vers: 0.1.0
+  deps: []
+  cksum: "                                                                "
+  features: {}
+  yanked: false
+

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -359,6 +359,7 @@ fn simple_config() -> config::Server {
         version_id_cache_ttl: Duration::from_secs(5 * 60),
         cdn_user_agent: "Amazon CloudFront".to_string(),
         balance_capacity: BalanceCapacityConfig::for_testing(),
+        feature_index_sync: true,
     }
 }
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -20,7 +20,7 @@ pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
 pub(crate) use dump_db::perform_dump_db;
 pub(crate) use git::{
     perform_index_add_crate, perform_index_squash, perform_index_sync_to_http,
-    perform_index_update_yanked, perform_normalize_index,
+    perform_index_update_yanked, perform_normalize_index, sync_to_git_index, sync_to_sparse_index,
 };
 pub(crate) use readmes::perform_render_and_upload_readme;
 pub(crate) use update_downloads::perform_update_downloads;


### PR DESCRIPTION
When a crate is modified, rather than editing the existing index file in git, this change re-generates the entire file from the database. This makes the jobs idempotent and prevents the index from getting out of sync with the database.

The `delete_version` and `delete_crate` admin tasks now also modify the index.

Test file changes are caused because the tests were inserting versions into the DB without adding them to the index.