### PR TITLE
Stop saving badges in the database

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -11,8 +11,8 @@ use swirl::Job;
 
 use crate::controllers::cargo_prelude::*;
 use crate::models::{
-    insert_version_owner_action, Badge, Category, Crate, DependencyKind, Keyword, NewCrate,
-    NewVersion, Rights, VersionAction,
+    insert_version_owner_action, Category, Crate, DependencyKind, Keyword, NewCrate, NewVersion,
+    Rights, VersionAction,
 };
 use crate::worker;
 
@@ -186,9 +186,6 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
         // in order to be able to warn about them
         let ignored_invalid_categories = Category::update_crate(&conn, &krate, &categories)?;
 
-        // Update all badges for this crate, collecting any invalid badges in
-        // order to be able to warn about them
-        let ignored_invalid_badges = Badge::update_crate(&conn, &krate, new_crate.badges.as_ref())?;
         let top_versions = krate.top_versions(&conn)?;
 
         // Read tarball from request
@@ -248,7 +245,7 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
         // warnings at this time, but if we need to, the field is available.
         let warnings = PublishWarnings {
             invalid_categories: ignored_invalid_categories,
-            invalid_badges: ignored_invalid_badges,
+            invalid_badges: vec![],
             other: vec![],
         };
 

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -813,15 +813,7 @@ fn ignored_badges() {
     let json = token.publish_crate(crate_to_publish).good();
     assert_eq!(json.krate.name, "foo_ignored_badge");
     assert_eq!(json.krate.max_version, "1.0.0");
-    assert_eq!(json.warnings.invalid_badges.len(), 2);
-    assert!(json
-        .warnings
-        .invalid_badges
-        .contains(&"travis-ci".to_string(),));
-    assert!(json
-        .warnings
-        .invalid_badges
-        .contains(&"not-a-badge".to_string(),));
+    assert_eq!(json.warnings.invalid_badges.len(), 0);
 
     let json = anon.show_crate("foo_ignored_badge");
     let badges = json.krate.badges.unwrap();


### PR DESCRIPTION
This PR follows #5071 and removes the code line that saves badges during publish to the database. The existing database records are still preserved for now, but no longer updated when a new version is published, and they are no longer available on the API (see #5071).