### PR TITLE
index: Use/Allow alphabetic ordering of features and dependencies

### DIFF
--- a/cargo-registry-index/lib.rs
+++ b/cargo-registry-index/lib.rs
@@ -139,7 +139,7 @@ pub struct Crate {
     pub v: Option<u32>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct Dependency {
     pub name: String,
     pub req: String,
@@ -152,7 +152,7 @@ pub struct Dependency {
     pub package: Option<String>,
 }
 
-#[derive(Copy, Clone, Serialize, Deserialize, Debug)]
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, PartialEq, PartialOrd, Ord, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum DependencyKind {
     Normal,

--- a/cargo-registry-index/lib.rs
+++ b/cargo-registry-index/lib.rs
@@ -5,7 +5,7 @@ extern crate serde;
 pub mod testing;
 
 use anyhow::{anyhow, Context};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -101,7 +101,7 @@ pub struct Crate {
     pub vers: String,
     pub deps: Vec<Dependency>,
     pub cksum: String,
-    pub features: HashMap<String, Vec<String>>,
+    pub features: BTreeMap<String, Vec<String>>,
     /// This field contains features with new, extended syntax. Specifically,
     /// namespaced features (`dep:`) and weak dependencies (`pkg?/feat`).
     ///
@@ -112,7 +112,7 @@ pub struct Crate {
     /// will fail to load due to not being able to parse the new syntax, even
     /// with a `Cargo.lock` file.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub features2: Option<HashMap<String, Vec<String>>>,
+    pub features2: Option<BTreeMap<String, Vec<String>>>,
     pub yanked: Option<bool>,
     #[serde(default)]
     pub links: Option<String>,

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -3,7 +3,7 @@
 use flate2::read::GzDecoder;
 use hex::ToHex;
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
@@ -216,7 +216,7 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
             .uploader()
             .upload_crate(app.http_client(), tarball, &krate, vers)?;
 
-        let (features, features2): (HashMap<_, _>, HashMap<_, _>) =
+        let (features, features2): (BTreeMap<_, _>, BTreeMap<_, _>) =
             features.into_iter().partition(|(_k, vals)| {
                 !vals
                     .iter()

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -247,7 +247,7 @@ mod tests {
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User};
     use diesel::PgConnection;
     use semver::Version;
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     #[test]
     fn test_increment_and_persist_all() {
@@ -452,7 +452,7 @@ mod tests {
             let version = NewVersion::new(
                 self.krate.id,
                 &Version::parse(&format!("{}.0.0", self.next_version)).unwrap(),
-                &HashMap::new(),
+                &BTreeMap::new(),
                 None,
                 None,
                 0,

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -127,7 +127,7 @@ impl NewVersion {
     pub fn new(
         crate_id: i32,
         num: &semver::Version,
-        features: &HashMap<String, Vec<String>>,
+        features: &BTreeMap<String, Vec<String>>,
         license: Option<String>,
         license_file: Option<&str>,
         crate_size: i32,

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -1,5 +1,5 @@
 use cargo_registry::views::krate_publish as u;
-use std::{collections::HashMap, io::Read};
+use std::{collections::BTreeMap, collections::HashMap, io::Read};
 
 use flate2::{write::GzEncoder, Compression};
 use once_cell::sync::Lazy;
@@ -36,7 +36,7 @@ pub struct PublishBuilder {
     readme: Option<String>,
     tarball: Vec<u8>,
     version: semver::Version,
-    features: HashMap<u::EncodableFeatureName, Vec<u::EncodableFeature>>,
+    features: BTreeMap<u::EncodableFeatureName, Vec<u::EncodableFeature>>,
 }
 
 impl PublishBuilder {
@@ -56,7 +56,7 @@ impl PublishBuilder {
             readme: None,
             tarball: EMPTY_TARBALL_BYTES.to_vec(),
             version: semver::Version::parse("1.0.0").unwrap(),
-            features: HashMap::new(),
+            features: BTreeMap::new(),
         }
     }
 

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -3,7 +3,7 @@ use cargo_registry::{
     schema::{dependencies, versions},
     util::errors::AppResult,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
@@ -12,7 +12,7 @@ use diesel::prelude::*;
 pub struct VersionBuilder<'a> {
     created_at: Option<NaiveDateTime>,
     dependencies: Vec<(i32, Option<&'static str>)>,
-    features: HashMap<String, Vec<String>>,
+    features: BTreeMap<String, Vec<String>>,
     license: Option<&'a str>,
     license_file: Option<&'a str>,
     num: semver::Version,
@@ -36,7 +36,7 @@ impl<'a> VersionBuilder<'a> {
         VersionBuilder {
             created_at: None,
             dependencies: Vec::new(),
-            features: HashMap::new(),
+            features: BTreeMap::new(),
             license: None,
             license_file: None,
             num,

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -11,7 +11,7 @@ use diesel::{delete, update, ExpressionMethods, QueryDsl, RunQueryDsl};
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use http::StatusCode;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::Read;
 use std::iter::FromIterator;
 use std::time::Duration;
@@ -953,9 +953,9 @@ fn features_version_2() {
     assert_eq!(crates[0].name, "foo");
     assert_eq!(crates[0].deps.len(), 1);
     assert_eq!(crates[0].v, Some(2));
-    let features = HashMap::from_iter([("old_feat".to_string(), vec![])]);
+    let features = BTreeMap::from_iter([("old_feat".to_string(), vec![])]);
     assert_eq!(crates[0].features, features);
-    let features2 = HashMap::from_iter([(
+    let features2 = BTreeMap::from_iter([(
         "new_feat".to_string(),
         vec!["dep:bar".to_string(), "bar?/feat".to_string()],
     )]);

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -2,7 +2,7 @@
 //! and manages the serialising and deserialising of this information
 //! to and from structs. The serlializing is only utilised in
 //! integration tests.
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -17,7 +17,7 @@ pub struct EncodableCrateUpload {
     pub name: EncodableCrateName,
     pub vers: EncodableCrateVersion,
     pub deps: Vec<EncodableCrateDependency>,
-    pub features: HashMap<EncodableFeatureName, Vec<EncodableFeature>>,
+    pub features: BTreeMap<EncodableFeatureName, Vec<EncodableFeature>>,
     pub description: Option<String>,
     pub homepage: Option<String>,
     pub documentation: Option<String>,
@@ -53,7 +53,7 @@ pub struct EncodableCategoryList(pub Vec<EncodableCategory>);
 pub struct EncodableCategory(pub String);
 #[derive(Serialize, Debug, Deref)]
 pub struct EncodableFeature(pub String);
-#[derive(PartialEq, Eq, Hash, Serialize, Debug, Deref)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Debug, Deref)]
 pub struct EncodableFeatureName(pub String);
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -85,7 +85,7 @@ mod test {
     use super::*;
     use crate::email::Emails;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     fn user(conn: &PgConnection) -> User {
         NewUser::new(2, "login", None, None, "access_token")
@@ -103,7 +103,7 @@ mod test {
         let version = NewVersion::new(
             krate.id,
             &semver::Version::parse("1.0.0").unwrap(),
-            &HashMap::new(),
+            &BTreeMap::new(),
             None,
             None,
             0,


### PR DESCRIPTION
This PR was extracted from https://github.com/rust-lang/crates.io/pull/5066 to make it independently reviewable and mergeable.

The main purpose of these changes is to match the order that the entries in the index are currently serialized in. This will eventually allow us to recreate the index from a single source of truth (the database) with a minimal diff.