### PR TITLE
Update discord pointer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ of the following ways:
 
 - [File a new issue](https://github.com/rust-lang/crates.io/issues/new)
 - Email [help@crates.io](mailto:help@crates.io)
-- Chat on ops > #crates-io-team channel on https://discord.gg/rust-lang
+- Chat on web presence > #crates-io-team channel on https://discord.gg/rust-lang
 
 A volunteer will get back to you as soon as possible.
 


### PR DESCRIPTION
#crates-io-team is now in "web presence" instead of "ops" this updates the README to reflect the change