### PR TITLE
ESLint: Add missing `@babel/plugin-proposal-decorators` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@babel/eslint-parser": "7.18.9",
+    "@babel/plugin-proposal-decorators": "7.18.10",
     "@ember/optional-features": "2.0.0",
     "@ember/render-modifiers": "2.0.4",
     "@ember/test-helpers": "2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
 
 specifiers:
   '@babel/eslint-parser': 7.18.9
+  '@babel/plugin-proposal-decorators': 7.18.10
   '@ember/optional-features': 2.0.0
   '@ember/render-modifiers': 2.0.4
   '@ember/test-helpers': 2.8.1
@@ -116,6 +117,7 @@ dependencies:
 
 devDependencies:
   '@babel/eslint-parser': 7.18.9_eslint@8.22.0
+  '@babel/plugin-proposal-decorators': 7.18.10
   '@ember/optional-features': 2.0.0
   '@ember/render-modifiers': 2.0.4_ember-source@4.2.0
   '@ember/test-helpers': 2.8.1_ember-source@4.2.0
@@ -783,6 +785,24 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/plugin-proposal-decorators/7.18.10:
+    resolution: {integrity: sha512-wdGTwWF5QtpTY/gbBtQLAiCnoxfD4qMbN87NYZle1dOZ9Os8Y6zXcKrIaOU8W+TIvFUWVGG9tUgNww3CjXRVVw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/helper-create-class-features-plugin': 7.18.9
+      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/helper-replace-supers': 7.18.9
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/plugin-syntax-decorators': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/plugin-proposal-decorators/7.18.10_57xwnn2kfhwzdzxftom2n7mm3i:
     resolution: {integrity: sha512-wdGTwWF5QtpTY/gbBtQLAiCnoxfD4qMbN87NYZle1dOZ9Os8Y6zXcKrIaOU8W+TIvFUWVGG9tUgNww3CjXRVVw==}
     engines: {node: '>=6.9.0'}
@@ -1080,6 +1100,18 @@ packages:
     dependencies:
       '@babel/core': 7.18.10
       '@babel/helper-plugin-utils': 7.18.9
+
+  /@babel/plugin-syntax-decorators/7.18.6:
+    resolution: {integrity: sha512-fqyLgjcxf/1yhyZ6A+yo1u9gJ7eleFQod2lkaUsF9DQ7sbbY3Ligym3L0+I2c0WmqNKDpoD9UTb1AKP3qRMOAQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/helper-plugin-utils': 7.18.9
+    dev: true
 
   /@babel/plugin-syntax-decorators/7.18.6_@babel+core@7.18.10:
     resolution: {integrity: sha512-fqyLgjcxf/1yhyZ6A+yo1u9gJ7eleFQod2lkaUsF9DQ7sbbY3Ligym3L0+I2c0WmqNKDpoD9UTb1AKP3qRMOAQ==}


### PR DESCRIPTION
This is referenced by the ESLint config and can sometimes cause issues if not explicitly specified. This is probably a side effect of us switching to pnpm, which is a bit more strict in terms of peer dependencies.