### PR TITLE
git-import admin tool can resume partial imports

### DIFF
--- a/src/admin/git_import.rs
+++ b/src/admin/git_import.rs
@@ -48,29 +48,33 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
         let crate_name = file.file_name().unwrap().to_str().unwrap();
         let path = repo.index_file(crate_name);
         if !path.exists() {
+            println!("skipping {}", path.display());
             continue;
         }
         let file = File::open(path)?;
         let reader = BufReader::new(file);
-        for line in reader.lines() {
-            let krate: cargo_registry_index::Crate = serde_json::from_str(&line?)?;
-            conn.transaction(|| {
+        conn.transaction(|| -> anyhow::Result<()> {
+            for line in reader.lines() {
+                let krate: cargo_registry_index::Crate = serde_json::from_str(&line?)?;
                 import_data(&conn, &krate)
-                    .with_context(|| format!("failed to update crate: {krate:?}"))
-            })?;
-        }
+                    .with_context(|| format!("failed to update crate: {krate:?}"))?
+            }
+            Ok(())
+        })?;
     }
+    println!("completed");
 
     Ok(())
 }
 
-fn import_data(conn: &PgConnection, krate: &cargo_registry_index::Crate) -> QueryResult<()> {
+fn import_data(conn: &PgConnection, krate: &cargo_registry_index::Crate) -> anyhow::Result<()> {
     let version_id: i32 = versions::table
         .inner_join(crates::table)
         .filter(crates::name.eq(&krate.name))
         .filter(versions::num.eq(&krate.vers))
         .select(versions::id)
-        .first(conn)?;
+        .first(conn)
+        .context("could not find crate")?;
 
     // Update the `checksum` and `links` fields.
     diesel::update(versions::table)
@@ -79,31 +83,44 @@ fn import_data(conn: &PgConnection, krate: &cargo_registry_index::Crate) -> Quer
             versions::links.eq(&krate.links),
         ))
         .filter(versions::id.eq(version_id))
+        .filter(versions::checksum.is_null())
+        .filter(versions::links.is_null())
         .execute(conn)?;
-    // Update the `explicit_name` field for each dependency.
-    for dep in &krate.deps {
-        if let Some(package) = &dep.package {
-            // This is a little tricky because there can be two identical deps in the
-            // database. The only difference in git is the field we're trying to
-            // fill (explicit_name). Using `first` here & filtering out existing `explicit_name`
-            // entries ensure that we assign one explicit_name to each dep.
-            let id: i32 = dependencies::table
-                .inner_join(crates::table)
-                .filter(dependencies::explicit_name.is_null())
-                .filter(dependencies::version_id.eq(version_id))
-                .filter(dependencies::req.eq(&dep.req))
-                .filter(dependencies::features.eq(&dep.features))
-                .filter(dependencies::optional.eq(&dep.optional))
-                .filter(dependencies::default_features.eq(&dep.default_features))
-                .filter(dependencies::target.is_not_distinct_from(&dep.target))
-                .filter(dependencies::kind.eq(dep.kind.map(|k| k as i32).unwrap_or_default()))
-                .filter(crates::name.eq(package))
-                .select(dependencies::id)
-                .first(conn)?;
-            diesel::update(dependencies::table)
-                .set(dependencies::explicit_name.eq(&dep.name))
-                .filter(dependencies::id.eq(id))
-                .execute(conn)?;
+
+    // Check if any of this crate's dependencies have a missing explicit_name.
+    if krate.deps.iter().any(|d| d.package.is_some())
+        && dependencies::table
+            .filter(dependencies::version_id.eq(version_id))
+            .filter(dependencies::explicit_name.is_not_null())
+            .count()
+            .get_result::<i64>(conn)?
+            == 0
+    {
+        for dep in &krate.deps {
+            if let Some(package) = &dep.package {
+                // This is a little tricky because there can be two identical deps in the
+                // database. The only difference in git is the field we're trying to
+                // fill (explicit_name). Using `first` here & filtering out existing `explicit_name`
+                // entries ensure that we assign one explicit_name to each dep.
+                let id: i32 = dependencies::table
+                    .inner_join(crates::table)
+                    .filter(dependencies::explicit_name.is_null())
+                    .filter(dependencies::version_id.eq(version_id))
+                    .filter(dependencies::req.eq(&dep.req))
+                    .filter(dependencies::features.eq(&dep.features))
+                    .filter(dependencies::optional.eq(&dep.optional))
+                    .filter(dependencies::default_features.eq(&dep.default_features))
+                    .filter(dependencies::target.is_not_distinct_from(&dep.target))
+                    .filter(dependencies::kind.eq(dep.kind.map(|k| k as i32).unwrap_or_default()))
+                    .filter(crates::name.eq(package))
+                    .select(dependencies::id)
+                    .first(conn)
+                    .context("could not find dep")?;
+                diesel::update(dependencies::table)
+                    .set(dependencies::explicit_name.eq(&dep.name))
+                    .filter(dependencies::id.eq(id))
+                    .execute(conn)?;
+            }
         }
     }
     Ok(())

--- a/src/admin/git_import.rs
+++ b/src/admin/git_import.rs
@@ -53,7 +53,7 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
         }
         let file = File::open(path)?;
         let reader = BufReader::new(file);
-        conn.transaction(|| -> anyhow::Result<()> {
+        let result = conn.transaction(|| -> anyhow::Result<()> {
             for line in reader.lines() {
                 let krate: cargo_registry_index::Crate = serde_json::from_str(&line?)?;
                 import_data(&conn, &krate).with_context(|| {
@@ -61,7 +61,10 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
                 })?
             }
             Ok(())
-        })?;
+        });
+        if let Err(err) = result {
+            println!("{}", err);
+        }
     }
     println!("completed");
 

--- a/src/admin/git_import.rs
+++ b/src/admin/git_import.rs
@@ -43,12 +43,12 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
     let pb = ProgressBar::new(files.len() as u64);
     pb.set_style(ProgressStyle::with_template("{bar:60} ({pos}/{len}, ETA {eta})").unwrap());
 
-    for file in files.iter().progress_with(pb) {
+    for file in files.iter().progress_with(pb.clone()) {
         thread::sleep(Duration::from_millis(opts.delay));
         let crate_name = file.file_name().unwrap().to_str().unwrap();
         let path = repo.index_file(crate_name);
         if !path.exists() {
-            println!("skipping {}", path.display());
+            pb.suspend(|| println!("skipping {}", path.display()));
             continue;
         }
         let file = File::open(path)?;


### PR DESCRIPTION
The `git-import` admin tool assumed that no `explicit_name`s had been imported, which caused it to fail after a partial run.

This change updates the tool to filter out versions that already have `explicit_name`s in their dependencies, allowing it to be run multiple times.

The transaction scope is changed to run over a crate rather than a version, which seems to provide slightly better performance.

r? @Turbo87 