### PR TITLE
Address some clippy warnings

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -94,7 +94,7 @@ fn prepare_list(
             ListFilter::CrateName(crate_name) => {
                 // Only allow crate owners to query pending invitations for their crate.
                 let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
-                let owners = krate.owners(&*conn)?;
+                let owners = krate.owners(&conn)?;
                 if user.rights(req.app(), &owners)? != Rights::Full {
                     return Err(forbidden());
                 }

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -22,7 +22,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 
     let query = query.pages_pagination(PaginationOptions::builder().gather(req)?);
     let conn = req.db_read()?;
-    let data: Paginated<Keyword> = query.load(&*conn)?;
+    let data: Paginated<Keyword> = query.load(&conn)?;
     let total = data.total();
     let kws = data
         .into_iter()

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -359,7 +359,7 @@ pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["crate_id"];
     let conn = req.db_read()?;
     let krate: Crate = Crate::by_name(name).first(&*conn)?;
-    let (rev_deps, total) = krate.reverse_dependencies(&*conn, pagination_options)?;
+    let (rev_deps, total) = krate.reverse_dependencies(&conn, pagination_options)?;
     let rev_deps: Vec<_> = rev_deps
         .into_iter()
         .map(|dep| EncodableDependency::from_reverse_dep(dep, &krate.name))

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -295,7 +295,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         (total, next_page, None, results, conn)
     } else {
         let query = query.pages_pagination(pagination);
-        let data: Paginated<(Crate, bool, Option<i64>)> = query.load(&*conn)?;
+        let data: Paginated<(Crate, bool, Option<i64>)> = query.load(&conn)?;
         (
             data.total(),
             data.next_page_params().map(|p| req.query_with_params(p)),

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -78,7 +78,7 @@ pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
         )));
     }
 
-    let api_token = ApiToken::insert(&*conn, user.id, name)?;
+    let api_token = ApiToken::insert(&conn, user.id, name)?;
     let api_token = EncodableApiTokenWithToken::from(api_token);
 
     Ok(req.json(&json!({ "api_token": api_token })))

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -70,7 +70,7 @@ pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
         ))
         .pages_pagination(PaginationOptions::builder().gather(req)?);
     let conn = req.db_read_prefer_primary()?;
-    let data: Paginated<(Version, String, Option<User>)> = query.load(&*conn)?;
+    let data: Paginated<(Version, String, Option<User>)> = query.load(&conn)?;
     let more = data.next_page_params().is_some();
     let versions = data.iter().map(|(v, _, _)| v).cloned().collect::<Vec<_>>();
     let data = data

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -766,7 +766,7 @@ fn extract_token_from_invite_email(emails: &Emails) -> String {
     let after_token = " ";
     let body = message.body.as_str();
     let before_pos = body.find(before_token).unwrap() + before_token.len();
-    let after_pos = before_pos + (&body[before_pos..]).find(after_token).unwrap();
+    let after_pos = before_pos + body[before_pos..].find(after_token).unwrap();
     body[before_pos..after_pos].to_string()
 }
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -105,7 +105,7 @@ where
         Ok(body.len())
     );
 
-    match serde_json::from_slice(&*body) {
+    match serde_json::from_slice(&body) {
         Ok(t) => t,
         Err(e) => panic!("failed to decode: {:?}", e),
     }


### PR DESCRIPTION
The 2nd commit address a warning from the `beta` channel, and the 1st commit is from `nightly`. Both cleanups are reasonable.