### PR TITLE
ember-data: Replace `store.find()` calls with `store.findRecord()`

### DIFF
--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -10,7 +10,7 @@ export default class CategoryRoute extends Route {
     let categoryName = params.category_id;
 
     try {
-      return await this.store.find('category', categoryName);
+      return await this.store.findRecord('category', categoryName);
     } catch (error) {
       if (error instanceof NotFoundError) {
         let title = `${categoryName}: Category not found`;

--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -10,7 +10,7 @@ export default class CrateRoute extends Route {
     let crateName = params.crate_id;
 
     try {
-      return await this.store.find('crate', crateName);
+      return await this.store.findRecord('crate', crateName);
     } catch (error) {
       if (error.errors?.some(e => e.detail === 'Not Found')) {
         let title = `${crateName}: Crate not found`;


### PR DESCRIPTION
`store.find()` is deprecated in favor of `store.findRecord()`