### PR TITLE
ember-data: Silence `model-save-promise` deprecation

### DIFF
--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -1,0 +1,10 @@
+/* eslint-env browser */
+
+self.deprecationWorkflow = self.deprecationWorkflow || {};
+self.deprecationWorkflow.config = {
+  workflow: [
+    // disabled because it's a false positive caused by ember-concurrency
+    // checking if `__ec_cancel__` is available.
+    { handler: 'silence', matchId: 'ember-data:model-save-promise' },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "ember-cli-code-coverage": "1.0.3",
     "ember-cli-dependency-checker": "3.3.1",
     "ember-cli-dependency-lint": "2.0.1",
+    "ember-cli-deprecation-workflow": "2.1.0",
     "ember-cli-fastboot": "3.3.2",
     "ember-cli-head": "2.0.0",
     "ember-cli-htmlbars": "6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ specifiers:
   ember-cli-code-coverage: 1.0.3
   ember-cli-dependency-checker: 3.3.1
   ember-cli-dependency-lint: 2.0.1
+  ember-cli-deprecation-workflow: 2.1.0
   ember-cli-fastboot: 3.3.2
   ember-cli-head: 2.0.0
   ember-cli-htmlbars: 6.1.0
@@ -142,6 +143,7 @@ devDependencies:
   ember-cli-code-coverage: 1.0.3
   ember-cli-dependency-checker: 3.3.1_ember-cli@4.6.0
   ember-cli-dependency-lint: 2.0.1
+  ember-cli-deprecation-workflow: 2.1.0
   ember-cli-fastboot: 3.3.2
   ember-cli-head: 2.0.0
   ember-cli-htmlbars: 6.1.0
@@ -7952,6 +7954,18 @@ packages:
       broccoli-plugin: 1.3.1
       chalk: 2.4.2
       semver: 5.7.1
+    dev: true
+
+  /ember-cli-deprecation-workflow/2.1.0:
+    resolution: {integrity: sha512-Ay9P9iKMJdY4Gq5XPowh3HqqeAzLfwBRj1oB1ZKkDW1fryZQWBN4pZuRnjnB+3VWZjBnZif5e7Pacc7YNW9hWg==}
+    engines: {node: 12.* || >= 14}
+    dependencies:
+      broccoli-funnel: 3.0.8
+      broccoli-merge-trees: 4.2.0
+      broccoli-plugin: 4.0.7
+      ember-cli-htmlbars: 5.7.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /ember-cli-fastboot/3.3.2:


### PR DESCRIPTION
As the code comment says, this deprecation warning is causing false positives due to our usage of ember-concurrency.