### PR TITLE
Autofill search box when browsing categories

### DIFF
--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -5,9 +5,11 @@ import { inject as service } from '@ember/service';
 export default class CategoryRoute extends Route {
   @service router;
   @service store;
+  @service header;
 
   async model(params, transition) {
     let categoryName = params.category_id;
+    this.header.searchValue = 'category:' + params.category_id + ' '; // additional space to help user not accidentally mangle the category
 
     try {
       return await this.store.findRecord('category', categoryName);
@@ -20,5 +22,10 @@ export default class CategoryRoute extends Route {
         this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });
       }
     }
+  }
+
+  deactivate() {
+    super.deactivate(...arguments);
+    this.header.searchValue = null;
   }
 }

--- a/tests/routes/category-test.js
+++ b/tests/routes/category-test.js
@@ -27,4 +27,17 @@ module('Route | category', function (hooks) {
     assert.dom('[data-test-go-back]').doesNotExist();
     assert.dom('[data-test-try-again]').exists();
   });
+
+  test('updates the search field when the categories route is accessed', async function (assert) {
+    this.server.create('category', { category: 'foo' });
+
+    await visit('/');
+    assert.dom('[data-test-search-input]').hasValue('');
+
+    await visit('/categories/foo');
+    assert.dom('[data-test-search-input]').hasValue('category:foo ');
+
+    await visit('/');
+    assert.dom('[data-test-search-input]').hasValue('');
+  });
 });


### PR DESCRIPTION
This will fill the search box with `category:<category> ` on all
category pages helping the user discover how to filter by category.

Also means when the user appends to the search field it will be searching 
the current category that is selected, instead of previously all the crates.