### PR TITLE
tests: Use `insta` to assert on full version API responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,7 @@ dependencies = [
  "hyper-tls",
  "indexmap",
  "indicatif",
+ "insta",
  "ipnetwork",
  "lettre",
  "minijinja",
@@ -1284,6 +1285,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dc501f12ec0c339b385787fa89ffda3d5d2caa62e558da731134c24d6e0c4"
+dependencies = [
+ "console",
+ "linked-hash-map",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1443,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -2507,6 +2530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,6 +3421,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4583db5cbd4c4c0303df2d15af80f0539db703fa1c68802d4cbbd2dd0f88f6"
 dependencies = [
  "dirs",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ cargo-registry-index = { path = "cargo-registry-index", features = ["testing"] }
 claim = { git = "https://github.com/Turbo87/rust-claim.git", rev = "23892a3" }
 conduit-test = "=0.10.0"
 hyper-tls = "=0.5.0"
+insta = { version = "=1.19.0", features = ["redactions", "yaml"] }
 once_cell = "=1.13.1"
 tokio = "=1.20.1"
 tower-service = "=0.3.2"

--- a/src/tests/snapshots/all__version__authors.snap
+++ b/src/tests/snapshots/all__version__authors.snap
@@ -1,0 +1,9 @@
+---
+source: src/tests/version.rs
+assertion_line: 139
+expression: json
+---
+meta:
+  names: []
+users: []
+

--- a/src/tests/snapshots/all__version__index-2.snap
+++ b/src/tests/snapshots/all__version__index-2.snap
@@ -1,0 +1,53 @@
+---
+source: src/tests/version.rs
+assertion_line: 32
+expression: json
+---
+versions:
+  - audit_actions: []
+    crate: foo_vers_index
+    crate_size: 0
+    created_at: "[datetime]"
+    dl_path: /api/v1/crates/foo_vers_index/2.0.1/download
+    downloads: 0
+    features: {}
+    id: "[id]"
+    license: MIT/Apache-2.0
+    links:
+      authors: /api/v1/crates/foo_vers_index/2.0.1/authors
+      dependencies: /api/v1/crates/foo_vers_index/2.0.1/dependencies
+      version_downloads: /api/v1/crates/foo_vers_index/2.0.1/downloads
+    num: 2.0.1
+    published_by:
+      avatar: ~
+      id: "[id]"
+      login: foo
+      name: ~
+      url: "https://github.com/foo"
+    readme_path: /api/v1/crates/foo_vers_index/2.0.1/readme
+    updated_at: "[datetime]"
+    yanked: false
+  - audit_actions: []
+    crate: foo_vers_index
+    crate_size: 0
+    created_at: "[datetime]"
+    dl_path: /api/v1/crates/foo_vers_index/2.0.0/download
+    downloads: 0
+    features: {}
+    id: "[id]"
+    license: MIT
+    links:
+      authors: /api/v1/crates/foo_vers_index/2.0.0/authors
+      dependencies: /api/v1/crates/foo_vers_index/2.0.0/dependencies
+      version_downloads: /api/v1/crates/foo_vers_index/2.0.0/downloads
+    num: 2.0.0
+    published_by:
+      avatar: ~
+      id: "[id]"
+      login: foo
+      name: ~
+      url: "https://github.com/foo"
+    readme_path: /api/v1/crates/foo_vers_index/2.0.0/readme
+    updated_at: "[datetime]"
+    yanked: false
+

--- a/src/tests/snapshots/all__version__index-2.snap
+++ b/src/tests/snapshots/all__version__index-2.snap
@@ -8,29 +8,6 @@ versions:
     crate: foo_vers_index
     crate_size: 0
     created_at: "[datetime]"
-    dl_path: /api/v1/crates/foo_vers_index/2.0.1/download
-    downloads: 0
-    features: {}
-    id: "[id]"
-    license: MIT/Apache-2.0
-    links:
-      authors: /api/v1/crates/foo_vers_index/2.0.1/authors
-      dependencies: /api/v1/crates/foo_vers_index/2.0.1/dependencies
-      version_downloads: /api/v1/crates/foo_vers_index/2.0.1/downloads
-    num: 2.0.1
-    published_by:
-      avatar: ~
-      id: "[id]"
-      login: foo
-      name: ~
-      url: "https://github.com/foo"
-    readme_path: /api/v1/crates/foo_vers_index/2.0.1/readme
-    updated_at: "[datetime]"
-    yanked: false
-  - audit_actions: []
-    crate: foo_vers_index
-    crate_size: 0
-    created_at: "[datetime]"
     dl_path: /api/v1/crates/foo_vers_index/2.0.0/download
     downloads: 0
     features: {}
@@ -48,6 +25,29 @@ versions:
       name: ~
       url: "https://github.com/foo"
     readme_path: /api/v1/crates/foo_vers_index/2.0.0/readme
+    updated_at: "[datetime]"
+    yanked: false
+  - audit_actions: []
+    crate: foo_vers_index
+    crate_size: 0
+    created_at: "[datetime]"
+    dl_path: /api/v1/crates/foo_vers_index/2.0.1/download
+    downloads: 0
+    features: {}
+    id: "[id]"
+    license: MIT/Apache-2.0
+    links:
+      authors: /api/v1/crates/foo_vers_index/2.0.1/authors
+      dependencies: /api/v1/crates/foo_vers_index/2.0.1/dependencies
+      version_downloads: /api/v1/crates/foo_vers_index/2.0.1/downloads
+    num: 2.0.1
+    published_by:
+      avatar: ~
+      id: "[id]"
+      login: foo
+      name: ~
+      url: "https://github.com/foo"
+    readme_path: /api/v1/crates/foo_vers_index/2.0.1/readme
     updated_at: "[datetime]"
     yanked: false
 

--- a/src/tests/snapshots/all__version__index.snap
+++ b/src/tests/snapshots/all__version__index.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/version.rs
+assertion_line: 23
+expression: json
+---
+versions: []
+

--- a/src/tests/snapshots/all__version__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/snapshots/all__version__show_by_crate_name_and_semver_no_published_by.snap
@@ -1,0 +1,25 @@
+---
+source: src/tests/version.rs
+assertion_line: 120
+expression: json
+---
+version:
+  audit_actions: []
+  crate: foo_vers_show_no_pb
+  crate_size: 0
+  created_at: "[datetime]"
+  dl_path: /api/v1/crates/foo_vers_show_no_pb/1.0.0/download
+  downloads: 0
+  features: {}
+  id: "[id]"
+  license: ~
+  links:
+    authors: /api/v1/crates/foo_vers_show_no_pb/1.0.0/authors
+    dependencies: /api/v1/crates/foo_vers_show_no_pb/1.0.0/dependencies
+    version_downloads: /api/v1/crates/foo_vers_show_no_pb/1.0.0/downloads
+  num: 1.0.0
+  published_by: ~
+  readme_path: /api/v1/crates/foo_vers_show_no_pb/1.0.0/readme
+  updated_at: "[datetime]"
+  yanked: false
+

--- a/src/tests/snapshots/all__version__show_by_crate_name_and_version.snap
+++ b/src/tests/snapshots/all__version__show_by_crate_name_and_version.snap
@@ -1,0 +1,30 @@
+---
+source: src/tests/version.rs
+assertion_line: 82
+expression: json
+---
+version:
+  audit_actions: []
+  crate: foo_vers_show
+  crate_size: 1234
+  created_at: "[datetime]"
+  dl_path: /api/v1/crates/foo_vers_show/2.0.0/download
+  downloads: 0
+  features: {}
+  id: "[id]"
+  license: ~
+  links:
+    authors: /api/v1/crates/foo_vers_show/2.0.0/authors
+    dependencies: /api/v1/crates/foo_vers_show/2.0.0/dependencies
+    version_downloads: /api/v1/crates/foo_vers_show/2.0.0/downloads
+  num: 2.0.0
+  published_by:
+    avatar: ~
+    id: "[id]"
+    login: foo
+    name: ~
+    url: "https://github.com/foo"
+  readme_path: /api/v1/crates/foo_vers_show/2.0.0/readme
+  updated_at: "[datetime]"
+  yanked: false
+

--- a/src/tests/snapshots/all__version__show_by_id.snap
+++ b/src/tests/snapshots/all__version__show_by_id.snap
@@ -1,0 +1,30 @@
+---
+source: src/tests/version.rs
+assertion_line: 63
+expression: json
+---
+version:
+  audit_actions: []
+  crate: foo_vers_show_id
+  crate_size: 1234
+  created_at: "[datetime]"
+  dl_path: /api/v1/crates/foo_vers_show_id/2.0.0/download
+  downloads: 0
+  features: {}
+  id: "[id]"
+  license: ~
+  links:
+    authors: /api/v1/crates/foo_vers_show_id/2.0.0/authors
+    dependencies: /api/v1/crates/foo_vers_show_id/2.0.0/dependencies
+    version_downloads: /api/v1/crates/foo_vers_show_id/2.0.0/downloads
+  num: 2.0.0
+  published_by:
+    avatar: ~
+    id: "[id]"
+    login: foo
+    name: ~
+    url: "https://github.com/foo"
+  readme_path: /api/v1/crates/foo_vers_show_id/2.0.0/readme
+  updated_at: "[datetime]"
+  yanked: false
+

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -36,6 +36,7 @@ use std::collections::HashMap;
 mod chaosproxy;
 mod fresh_schema;
 mod github;
+pub mod insta;
 mod response;
 mod test_app;
 

--- a/src/tests/util/insta.rs
+++ b/src/tests/util/insta.rs
@@ -6,3 +6,10 @@ pub fn id_redaction(expected_id: i32) -> insta::internals::Redaction {
         "[id]"
     })
 }
+
+pub fn any_id_redaction() -> insta::internals::Redaction {
+    insta::dynamic_redaction(move |value, _path| {
+        assert_some!(value.as_i64());
+        "[id]"
+    })
+}

--- a/src/tests/util/insta.rs
+++ b/src/tests/util/insta.rs
@@ -1,0 +1,6 @@
+pub fn id_redaction(expected_id: i32) -> insta::internals::Redaction {
+    insta::dynamic_redaction(move |value, _path| {
+        assert_eq!(value.as_i64().unwrap(), expected_id as i64);
+        "[id]"
+    })
+}

--- a/src/tests/util/insta.rs
+++ b/src/tests/util/insta.rs
@@ -1,3 +1,5 @@
+pub use ::insta::*;
+
 pub fn id_redaction(expected_id: i32) -> insta::internals::Redaction {
     insta::dynamic_redaction(move |value, _path| {
         assert_eq!(value.as_i64().unwrap(), expected_id as i64);

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -30,8 +30,8 @@ fn index() {
     let query = format!("ids[]={v1}&ids[]={v2}");
     let json: Value = anon.get_with_query(url, &query).good();
     assert_yaml_snapshot!(json, {
-        ".versions[0].id" => insta::id_redaction(v2),
-        ".versions[1].id" => insta::id_redaction(v1),
+        ".versions" => insta::sorted_redaction(),
+        ".versions[].id" => insta::any_id_redaction(),
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
         ".versions[].published_by.id" => insta::id_redaction(user.id),

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -42,7 +42,6 @@ fn index() {
 fn show_by_id() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
-    let user_id = user.id;
 
     let v = app.db(|conn| {
         let krate = CrateBuilder::new("foo_vers_show_id", user.id).expect_build(conn);
@@ -50,15 +49,14 @@ fn show_by_id() {
             .size(1234)
             .expect_build(krate.id, user.id, conn)
     });
-    let version_id = v.id;
 
     let url = format!("/api/v1/versions/{}", v.id);
     let json: Value = anon.get(&url).good();
     assert_yaml_snapshot!(json, {
-        ".version.id" => insta::id_redaction(version_id),
+        ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
-        ".version.published_by.id" => insta::id_redaction(user_id),
+        ".version.published_by.id" => insta::id_redaction(user.id),
     });
 }
 
@@ -66,7 +64,6 @@ fn show_by_id() {
 fn show_by_crate_name_and_version() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
-    let user_id = user.id;
 
     let v = app.db(|conn| {
         let krate = CrateBuilder::new("foo_vers_show", user.id).expect_build(conn);
@@ -74,15 +71,14 @@ fn show_by_crate_name_and_version() {
             .size(1234)
             .expect_build(krate.id, user.id, conn)
     });
-    let version_id = v.id;
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
     let json: Value = anon.get(url).good();
     assert_yaml_snapshot!(json, {
-        ".version.id" => insta::id_redaction(version_id),
+        ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
-        ".version.published_by.id" => insta::id_redaction(user_id),
+        ".version.published_by.id" => insta::id_redaction(user.id),
     });
 }
 
@@ -106,12 +102,11 @@ fn show_by_crate_name_and_semver_no_published_by() {
 
         version
     });
-    let version_id = v.id;
 
     let url = "/api/v1/crates/foo_vers_show_no_pb/1.0.0";
     let json: Value = anon.get(url).good();
     assert_yaml_snapshot!(json, {
-        ".version.id" => insta::id_redaction(version_id),
+        ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
     });

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -1,11 +1,11 @@
 use crate::{
     builders::{CrateBuilder, PublishBuilder, VersionBuilder},
-    util, RequestHelper, TestApp,
+    RequestHelper, TestApp,
 };
 use cargo_registry::{models::Version, schema::versions};
 
+use crate::util::insta::{self, assert_yaml_snapshot};
 use diesel::prelude::*;
-use insta::assert_yaml_snapshot;
 use serde_json::Value;
 
 #[test]
@@ -30,11 +30,11 @@ fn index() {
     let query = format!("ids[]={v1}&ids[]={v2}");
     let json: Value = anon.get_with_query(url, &query).good();
     assert_yaml_snapshot!(json, {
-        ".versions[0].id" => util::insta::id_redaction(v2),
-        ".versions[1].id" => util::insta::id_redaction(v1),
+        ".versions[0].id" => insta::id_redaction(v2),
+        ".versions[1].id" => insta::id_redaction(v1),
         ".versions[].created_at" => "[datetime]",
         ".versions[].updated_at" => "[datetime]",
-        ".versions[].published_by.id" => util::insta::id_redaction(user.id),
+        ".versions[].published_by.id" => insta::id_redaction(user.id),
     });
 }
 
@@ -55,10 +55,10 @@ fn show_by_id() {
     let url = format!("/api/v1/versions/{}", v.id);
     let json: Value = anon.get(&url).good();
     assert_yaml_snapshot!(json, {
-        ".version.id" => util::insta::id_redaction(version_id),
+        ".version.id" => insta::id_redaction(version_id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
-        ".version.published_by.id" => util::insta::id_redaction(user_id),
+        ".version.published_by.id" => insta::id_redaction(user_id),
     });
 }
 
@@ -79,10 +79,10 @@ fn show_by_crate_name_and_version() {
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
     let json: Value = anon.get(url).good();
     assert_yaml_snapshot!(json, {
-        ".version.id" => util::insta::id_redaction(version_id),
+        ".version.id" => insta::id_redaction(version_id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
-        ".version.published_by.id" => util::insta::id_redaction(user_id),
+        ".version.published_by.id" => insta::id_redaction(user_id),
     });
 }
 
@@ -111,7 +111,7 @@ fn show_by_crate_name_and_semver_no_published_by() {
     let url = "/api/v1/crates/foo_vers_show_no_pb/1.0.0";
     let json: Value = anon.get(url).good();
     assert_yaml_snapshot!(json, {
-        ".version.id" => util::insta::id_redaction(version_id),
+        ".version.id" => insta::id_redaction(version_id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
     });

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -136,7 +136,7 @@ fn authors() {
 
     let json: Value = anon.get("/api/v1/crates/foo_authors/1.0.0/authors").good();
     let json = json.as_object().unwrap();
-    assert!(json.contains_key("users"));
+    assert_yaml_snapshot!(json);
 }
 
 #[test]

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -1,6 +1,6 @@
 use crate::{
     builders::{CrateBuilder, PublishBuilder, VersionBuilder},
-    RequestHelper, TestApp, VersionResponse,
+    util, RequestHelper, TestApp, VersionResponse,
 };
 use cargo_registry::{models::Version, schema::versions, views::EncodableVersion};
 
@@ -79,16 +79,10 @@ fn show_by_crate_name_and_version() {
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
     let json: Value = anon.get(url).good();
     assert_yaml_snapshot!(json, {
-        ".version.id" => insta::dynamic_redaction(move |value, _path| {
-            assert_eq!(value.as_i64().unwrap(), version_id as i64);
-            "[id]"
-        }),
+        ".version.id" => util::insta::id_redaction(version_id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
-        ".version.published_by.id" => insta::dynamic_redaction(move |value, _path| {
-            assert_eq!(value.as_i64().unwrap(), user_id as i64);
-            "[id]"
-        }),
+        ".version.published_by.id" => util::insta::id_redaction(user_id),
     });
 }
 


### PR DESCRIPTION
see https://insta.rs

This allows us to more easily assert on the exact structure of our API responses and give us a straight-forward way to keep the assertions up-to-date. 

Currently, if we add a new field to our API responses, the tests will still pass, because the tests are using the same structs as the production code. Even worse, if we remove a field the same is true, even though this should be considered a breaking change. With snapshot tests it will be easy to detect these sort of things because the test files will need to be updated.