### PR TITLE
Fix rustdoc link rendering in READMEs

### DIFF
--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -79,6 +79,12 @@ a, .link {
     }
 }
 
+/* Using `:not(...)` here for specificity reasons */
+a:not([href]) {
+    color: initial;
+    cursor: initial;
+}
+
 pre:global(.terminal) {
     background: var(--main-color);
     color: white;

--- a/cargo-registry-markdown/lib.rs
+++ b/cargo-registry-markdown/lib.rs
@@ -465,6 +465,21 @@ mod tests {
     }
 
     #[test]
+    fn rustdoc_links() {
+        let repository = "https://github.com/foo/bar/";
+
+        assert_eq!(
+            markdown_to_html("[stylish](::stylish)", Some(repository), ""),
+            "<p><a href=\"https://github.com/foo/bar/blob/HEAD/::stylish\" rel=\"nofollow noopener noreferrer\">stylish</a></p>\n"
+        );
+
+        assert_eq!(
+            markdown_to_html("[Display](stylish::Display)", Some(repository), ""),
+            "<p><a rel=\"nofollow noopener noreferrer\">Display</a></p>\n"
+        );
+    }
+
+    #[test]
     fn text_to_html_renders_markdown() {
         for f in &[
             "README",

--- a/cargo-registry-markdown/lib.rs
+++ b/cargo-registry-markdown/lib.rs
@@ -188,6 +188,12 @@ impl UrlRelativeEvaluate for SanitizeUrl {
             // Always allow fragment URLs.
             return Some(Cow::Borrowed(url));
         }
+
+        if url.starts_with("::") {
+            // Always reject relative rustdoc URLs.
+            return None;
+        }
+
         self.base_url.as_ref().map(|base_url| {
             let mut new_url = base_url.clone();
             // Assumes GitHub’s URL scheme. GitHub renders text and markdown
@@ -470,7 +476,7 @@ mod tests {
 
         assert_eq!(
             markdown_to_html("[stylish](::stylish)", Some(repository), ""),
-            "<p><a href=\"https://github.com/foo/bar/blob/HEAD/::stylish\" rel=\"nofollow noopener noreferrer\">stylish</a></p>\n"
+            "<p><a rel=\"nofollow noopener noreferrer\">stylish</a></p>\n"
         );
 
         assert_eq!(


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/5017

Unfortunately `ammonia` does not easily allow us to remove the empty links completely, but we can remove the clickable link styling from `<a>` elements without an `href` attribute. This, plus ignoring relative links starting with `::` allows us to fix the issue linked above.

For any crates.io users reading this: Note that we will need to rerender all README files for this to work on older releases. Once deployed, it should work fine for new releases though.