### PR TITLE
EncodableVersion: Expose new `checksum` field on the API

### DIFF
--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -60,6 +60,12 @@ impl<'a> VersionBuilder<'a> {
         self
     }
 
+    /// Sets the version's `checksum` value.
+    pub fn checksum(mut self, checksum: &str) -> Self {
+        self.checksum = checksum.to_string();
+        self
+    }
+
     /// Adds a dependency to this version.
     pub fn dependency(mut self, dependency: &Crate, target: Option<&'static str>) -> Self {
         self.dependencies.push((dependency.id, target));

--- a/src/tests/snapshots/all__version__index-2.snap
+++ b/src/tests/snapshots/all__version__index-2.snap
@@ -5,6 +5,7 @@ expression: json
 ---
 versions:
   - audit_actions: []
+    checksum: "                                                                "
     crate: foo_vers_index
     crate_size: 0
     created_at: "[datetime]"
@@ -28,6 +29,7 @@ versions:
     updated_at: "[datetime]"
     yanked: false
   - audit_actions: []
+    checksum: "                                                                "
     crate: foo_vers_index
     crate_size: 0
     created_at: "[datetime]"

--- a/src/tests/snapshots/all__version__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/snapshots/all__version__show_by_crate_name_and_semver_no_published_by.snap
@@ -1,10 +1,11 @@
 ---
 source: src/tests/version.rs
-assertion_line: 120
+assertion_line: 108
 expression: json
 ---
 version:
   audit_actions: []
+  checksum: "                                                                "
   crate: foo_vers_show_no_pb
   crate_size: 0
   created_at: "[datetime]"

--- a/src/tests/snapshots/all__version__show_by_crate_name_and_version.snap
+++ b/src/tests/snapshots/all__version__show_by_crate_name_and_version.snap
@@ -1,10 +1,11 @@
 ---
 source: src/tests/version.rs
-assertion_line: 82
+assertion_line: 78
 expression: json
 ---
 version:
   audit_actions: []
+  checksum: c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4
   crate: foo_vers_show
   crate_size: 1234
   created_at: "[datetime]"

--- a/src/tests/snapshots/all__version__show_by_id.snap
+++ b/src/tests/snapshots/all__version__show_by_id.snap
@@ -1,10 +1,11 @@
 ---
 source: src/tests/version.rs
-assertion_line: 63
+assertion_line: 55
 expression: json
 ---
 version:
   audit_actions: []
+  checksum: "                                                                "
   crate: foo_vers_show_id
   crate_size: 1234
   created_at: "[datetime]"

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -69,6 +69,7 @@ fn show_by_crate_name_and_version() {
         let krate = CrateBuilder::new("foo_vers_show", user.id).expect_build(conn);
         VersionBuilder::new("2.0.0")
             .size(1234)
+            .checksum("c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4")
             .expect_build(krate.id, user.id, conn)
     });
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -597,6 +597,7 @@ pub struct EncodableVersion {
     pub crate_size: Option<i32>,
     pub published_by: Option<EncodablePublicUser>,
     pub audit_actions: Vec<EncodableAuditAction>,
+    pub checksum: String,
 }
 
 impl EncodableVersion {
@@ -616,6 +617,7 @@ impl EncodableVersion {
             yanked,
             license,
             crate_size,
+            checksum,
             ..
         } = version;
 
@@ -639,6 +641,7 @@ impl EncodableVersion {
             license,
             links,
             crate_size,
+            checksum,
             published_by: published_by.map(User::into),
             audit_actions: audit_actions
                 .into_iter()
@@ -749,6 +752,7 @@ mod tests {
                 authors: "".to_string(),
             },
             crate_size: Some(1234),
+            checksum: String::new(),
             published_by: None,
             audit_actions: vec![EncodableAuditAction {
                 action: "publish".to_string(),


### PR DESCRIPTION
This got introduced by https://github.com/rust-lang/crates.io/pull/5077 and backfilled using https://github.com/rust-lang/crates.io/pull/5112.