### PR TITLE
renovate: Group `diesel` packages in one pull request

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,5 +76,12 @@
             "^sentry-conduit$",
         ],
         "groupName": "conduit packages",
+    }, {
+        "matchLanguages": ["rust"],
+        "matchPackagePatterns": [
+            "^diesel$",
+            "^diesel_",
+        ],
+        "groupName": "diesel packages",
     }],
 }


### PR DESCRIPTION
Similar to how we already do it for `conduit` updates