### PR TITLE
accept-invite: Use `<LinkTo>` instead of raw `<a>`

### DIFF
--- a/app/templates/accept-invite.hbs
+++ b/app/templates/accept-invite.hbs
@@ -1,13 +1,13 @@
 {{#if @model.ok}}
   <h1>You've been added as a crate owner!</h1>
-  <p data-test-success-message>Visit your <a href="/dashboard">dashboard</a> to view all of your crates, or <a href="/me">account settings</a> to manage email notification preferences for all of your crates.</p>
+  <p data-test-success-message>Visit your <LinkTo @route="dashboard">dashboard</LinkTo> to view all of your crates, or <LinkTo @route="me">account settings</LinkTo> to manage email notification preferences for all of your crates.</p>
 {{else}}
   <h1>Error in accepting crate ownership.</h1>
   <p data-test-error-message>
     {{#if @model.errorText}}
       {{@model.errorText}}
     {{else}}
-      You may want to visit <a href="/me/pending-invites">crates.io/me/pending-invites</a> to try again.
+      You may want to visit <LinkTo @route="me.pending-invites">crates.io/me/pending-invites</LinkTo> to try again.
     {{/if}}
   </p>
 {{/if}}


### PR DESCRIPTION
This uses an in-app transition instead of completely reloading the app