### PR TITLE
tests/record: Fix server bind IP address

### DIFF
--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -121,7 +121,7 @@ pub fn proxy() -> (String, Bomb) {
                 None
             };
 
-            let addr = ([127, 0, 0, 0], 0).into();
+            let addr = ([127, 0, 0, 1], 0).into();
             let server = Server::bind(&addr).serve(Proxy {
                 sink: sink2,
                 record: Arc::clone(&record),


### PR DESCRIPTION
While 127.0.0.0 appears to work good enough on Unix machines, it did cause macOS to fail all tests. Since the original was 127.0.0.1 this commit is fixing it back to the way it was before :D

/cc @jtgeibel 