### PR TITLE
PageHeader: Remove margins on `.heading` element

### DIFF
--- a/app/components/page-header.module.css
+++ b/app/components/page-header.module.css
@@ -8,6 +8,7 @@
 .heading {
     display: flex;
     align-items: center;
+    margin: 0;
 }
 
 .icon {

--- a/app/styles/category/index.module.css
+++ b/app/styles/category/index.module.css
@@ -3,6 +3,7 @@
     align-items: center;
 
     h1 {
+        margin: 0;
         padding: 0 10px;
     }
 }


### PR DESCRIPTION
Some of them were way too large and looked a bit out-of-place.

### Before

<img width="881" alt="Bildschirmfoto 2022-08-31 um 22 01 51" src="https://user-images.githubusercontent.com/141300/187771429-23a87df0-3fd4-4f22-af98-89748d5d9690.png">

### After

<img width="881" alt="Bildschirmfoto 2022-08-31 um 22 01 37" src="https://user-images.githubusercontent.com/141300/187771424-c77e4cfa-2b29-4ce1-b64c-e52293a86c95.png">
