### PR TITLE
ember-cli-babel: Ensure parallel builds

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,6 +20,11 @@ module.exports = function (defaults) {
     babel: {
       plugins: [require.resolve('ember-auto-import/babel-plugin')],
     },
+
+    'ember-cli-babel': {
+      throwUnlessParallelizable: true,
+    },
+
     'ember-fetch': {
       preferNative: true,
     },


### PR DESCRIPTION
If the build is "parallelizable" it improves the build time performance :)