### PR TITLE
Align text in page headers properly

### DIFF
--- a/app/components/crate-header.module.css
+++ b/app/components/crate-header.module.css
@@ -10,7 +10,7 @@
 
 .heading {
     display: flex;
-    align-items: center;
+    align-items: baseline;
 
     h1, h2 {
         margin: 0;

--- a/app/components/page-header.module.css
+++ b/app/components/page-header.module.css
@@ -7,7 +7,7 @@
 
 .heading {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     margin: 0;
 }
 


### PR DESCRIPTION
### Before

<img width="621" alt="Bildschirmfoto 2022-09-01 um 18 09 49" src="https://user-images.githubusercontent.com/141300/187961845-a79ddd96-a1f5-4793-b807-6b5e70f791ed.png">
<img width="492" alt="Bildschirmfoto 2022-09-01 um 18 09 43" src="https://user-images.githubusercontent.com/141300/187961844-0415a3fc-1825-4e49-85ac-60f9d0674086.png">


### After

<img width="521" alt="Bildschirmfoto 2022-09-01 um 18 09 56" src="https://user-images.githubusercontent.com/141300/187961850-59300806-24d1-4d21-b0ec-ba37e5c0e59d.png">
<img width="503" alt="Bildschirmfoto 2022-09-01 um 18 09 29" src="https://user-images.githubusercontent.com/141300/187961836-d7a2658d-a5b3-4917-a1f3-a75abd5b7197.png">
