### PR TITLE
CrateHeader: Add `v` prefix to version number

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -3,7 +3,7 @@
     <div local-class="heading">
       <h1 data-test-crate-name>{{@crate.name}}</h1>
       {{#if @version}}
-        <h2 data-test-crate-version>{{@version.num}}</h2>
+        <h2 data-test-crate-version>v{{@version.num}}</h2>
       {{/if}}
     </div>
 

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -24,7 +24,7 @@ module('Acceptance | crate page', function (hooks) {
     assert.equal(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
-    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
+    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('v0.6.1');
   });
 
   test('visiting /crates/nanomsg', async function (assert) {
@@ -39,7 +39,7 @@ module('Acceptance | crate page', function (hooks) {
     assert.equal(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
-    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
+    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('v0.6.1');
     assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview');
 
     await percySnapshot(assert);
@@ -58,7 +58,7 @@ module('Acceptance | crate page', function (hooks) {
     assert.equal(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
-    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.1');
+    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('v0.6.1');
     assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview');
   });
 
@@ -74,7 +74,7 @@ module('Acceptance | crate page', function (hooks) {
     assert.equal(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
-    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('0.6.0');
+    assert.dom('[data-test-heading] [data-test-crate-version]').hasText('v0.6.0');
     assert.dom('[data-test-crate-stats-label]').hasText('Stats Overview for 0.6.0 (see all)');
 
     await percySnapshot(assert);

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -18,7 +18,7 @@ module('Route | crate.range', function (hooks) {
     await visit('/crates/foo/range/^1.1.0');
     assert.equal(currentURL(), `/crates/foo/1.2.3`);
     assert.dom('[data-test-crate-name]').hasText('foo');
-    assert.dom('[data-test-crate-version]').hasText('1.2.3');
+    assert.dom('[data-test-crate-version]').hasText('v1.2.3');
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 
@@ -32,7 +32,7 @@ module('Route | crate.range', function (hooks) {
     await visit('/crates/foo/range/~1.1.0');
     assert.equal(currentURL(), `/crates/foo/1.1.1`);
     assert.dom('[data-test-crate-name]').hasText('foo');
-    assert.dom('[data-test-crate-version]').hasText('1.1.1');
+    assert.dom('[data-test-crate-version]').hasText('v1.1.1');
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 
@@ -46,7 +46,7 @@ module('Route | crate.range', function (hooks) {
     await visit('/crates/foo/range/>=1.3.0, <1.4.0');
     assert.equal(currentURL(), `/crates/foo/1.3.4`);
     assert.dom('[data-test-crate-name]').hasText('foo');
-    assert.dom('[data-test-crate-version]').hasText('1.3.4');
+    assert.dom('[data-test-crate-version]').hasText('v1.3.4');
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 
@@ -60,7 +60,7 @@ module('Route | crate.range', function (hooks) {
     await visit('/crates/foo/range/^1.0.0');
     assert.equal(currentURL(), `/crates/foo/1.1.1`);
     assert.dom('[data-test-crate-name]').hasText('foo');
-    assert.dom('[data-test-crate-version]').hasText('1.1.1');
+    assert.dom('[data-test-crate-version]').hasText('v1.1.1');
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 
@@ -74,7 +74,7 @@ module('Route | crate.range', function (hooks) {
     await visit('/crates/foo/range/^1.0.0');
     assert.equal(currentURL(), `/crates/foo/1.1.1`);
     assert.dom('[data-test-crate-name]').hasText('foo');
-    assert.dom('[data-test-crate-version]').hasText('1.1.1');
+    assert.dom('[data-test-crate-version]').hasText('v1.1.1');
     assert.dom('[data-test-notification-message]').doesNotExist();
   });
 

--- a/tests/routes/crate/version/model-test.js
+++ b/tests/routes/crate/version/model-test.js
@@ -18,7 +18,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       await visit('/crates/foo/1.2.3');
       assert.equal(currentURL(), `/crates/foo/1.2.3`);
       assert.dom('[data-test-crate-name]').hasText('foo');
-      assert.dom('[data-test-crate-version]').hasText('1.2.3');
+      assert.dom('[data-test-crate-version]').hasText('v1.2.3');
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -48,7 +48,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       await visit('/crates/foo');
       assert.equal(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
-      assert.dom('[data-test-crate-version]').hasText('2.0.0');
+      assert.dom('[data-test-crate-version]').hasText('v2.0.0');
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -61,7 +61,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       await visit('/crates/foo');
       assert.equal(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
-      assert.dom('[data-test-crate-version]').hasText('1.0.0');
+      assert.dom('[data-test-crate-version]').hasText('v1.0.0');
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -76,7 +76,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       await visit('/crates/foo');
       assert.equal(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
-      assert.dom('[data-test-crate-version]').hasText('2.0.0-beta.2');
+      assert.dom('[data-test-crate-version]').hasText('v2.0.0-beta.2');
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -89,7 +89,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       await visit('/crates/foo');
       assert.equal(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
-      assert.dom('[data-test-crate-version]').hasText('2.0.0-beta.1');
+      assert.dom('[data-test-crate-version]').hasText('v2.0.0-beta.1');
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
   });


### PR DESCRIPTION
The tiniest possible change, but this matches how we display them in the search results and makes the page a little more consistent.

<img width="525" alt="Bildschirmfoto 2022-09-01 um 20 08 35" src="https://user-images.githubusercontent.com/141300/187983483-dba96ebf-8e77-41cf-8c13-021c15b83430.png">
