### PR TITLE
services/session: Clear in-memory data when logging out

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -124,13 +124,11 @@ export default class SessionService extends Service {
   logoutTask = task(async () => {
     await ajax(`/api/private/session`, { method: 'DELETE' });
 
-    this.savedTransition = null;
     this.isLoggedIn = false;
 
-    await this.loadUserTask.cancelAll({ resetState: true });
-    this.sentry.setUser(null);
-
-    this.router.transitionTo('index');
+    // We perform a proper page navigation here instead of an in-app transition to ensure
+    // that the Ember Data store and any other in-memory data is cleared on logout.
+    window.location.assign('/');
   });
 
   loadUserTask = dropTask(async () => {

--- a/tests/acceptance/logout-test.js
+++ b/tests/acceptance/logout-test.js
@@ -1,10 +1,14 @@
 import { click, currentURL, visit } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
+import window from 'ember-window-mock';
+import { setupWindowMock } from 'ember-window-mock/test-support';
+
 import { setupApplicationTest } from 'cargo/tests/helpers';
 
 module('Acceptance | Logout', function (hooks) {
   setupApplicationTest(hooks);
+  setupWindowMock(hooks);
 
   test('successful logout', async function (assert) {
     let user = this.server.create('user', { name: 'John Doe' });
@@ -17,7 +21,6 @@ module('Acceptance | Logout', function (hooks) {
     await click('[data-test-user-menu] [data-test-toggle]');
     await click('[data-test-user-menu] [data-test-logout-button]');
 
-    assert.equal(currentURL(), '/');
-    assert.dom('[data-test-user-menu] [data-test-toggle]').doesNotExist();
+    assert.equal(window.location.pathname, '/');
   });
 });


### PR DESCRIPTION
Previously, when a user logged out, the data in the Ember Data store was still kept in-memory, so when another user logged in they could potentially see information that they shouldn't have access to. This PR performs a full page reload after logout to ensure that the Ember Data store and other in-memory data is cleared to avoid issues like this.