### PR TITLE
Add CloudFront invalidation for index files

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,6 +41,12 @@ export TEST_DATABASE_URL=
 # not needed if the S3 bucket is in US standard
 # export S3_INDEX_REGION=
 
+# Credentials for invalidating cached files on CloudFront. You can leave these
+# commented out if you're not using CloudFront caching for the index files.
+# export CLOUDFRONT_DISTRIBUTION=
+# export CLOUDFRONT_ACCESS_KEY=
+# export CLOUDFRONT_SECRET_KEY=
+
 # Upstream location of the registry index. Background jobs will push to
 # this URL. The default points to a local index for development.
 # Run `./script/init-local-index.sh` to initialize this repo.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-sigv4"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99b21b3aceaf224cccd693b353e1f38af4ede8c5fc618b97dd458bb63238efc"
+dependencies = [
+ "aws-smithy-http",
+ "form_urlencoded",
+ "hex",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "ring",
+ "time 0.3.14",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23861d0b53a1369eab1e8d48c8bb3492eb3def1c2f2222dfb1bad58dd03914a5"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4149b09b9d8cf37f0afc390144f5d71b8f4daadfd9540ddf43ad27b54d407470"
+dependencies = [
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time 0.3.14",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +276,7 @@ name = "cargo-registry"
 version = "0.2.2"
 dependencies = [
  "anyhow",
+ "aws-sigv4",
  "base64",
  "cargo-registry-index",
  "cargo-registry-markdown",
@@ -820,6 +880,12 @@ name = "dotenv"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "email-encoding"
@@ -2219,6 +2285,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,6 +2703,12 @@ checksum = "a346909b3fd07776f9b96b98d4a58e3666f831c9a672c279b10f795a34c36425"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standback"
@@ -3198,6 +3285,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ path = "src/tests/all.rs"
 
 [dependencies]
 anyhow = "=1.0.65"
+aws-sigv4 = "=0.48.0"
 base64 = "=0.13.0"
 cargo-registry-index = { path = "cargo-registry-index" }
 cargo-registry-markdown = { path = "cargo-registry-markdown" }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -236,6 +236,7 @@ impl TestAppBuilder {
                 index,
                 app.config.uploader().clone(),
                 app.http_client().clone(),
+                None,
             );
 
             Some(

--- a/src/worker/cloudfront.rs
+++ b/src/worker/cloudfront.rs
@@ -1,0 +1,75 @@
+use std::time::SystemTime;
+
+use aws_sigv4::{
+    http_request::{self, SignableRequest, SigningSettings},
+    SigningParams,
+};
+use reqwest::blocking::Client;
+
+#[derive(Clone)]
+pub struct CloudFront {
+    distribution_id: String,
+    access_key: String,
+    secret_key: String,
+}
+
+impl CloudFront {
+    pub fn from_environment() -> Option<Self> {
+        let distribution_id = dotenv::var("CLOUDFRONT_DISTRIBUTION").ok()?;
+        let access_key =
+            dotenv::var("CLOUDFRONT_ACCESS_KEY").expect("missing CLOUDFRONT_ACCESS_KEY");
+        let secret_key =
+            dotenv::var("CLOUDFRONT_SECRET_KEY").expect("missing CLOUDFRONT_SECRET_KEY");
+        Some(Self {
+            distribution_id,
+            access_key,
+            secret_key,
+        })
+    }
+
+    /// Invalidate a file on CloudFront
+    ///
+    /// `path` is the path to the file to invalidate, such as `config.json`, or `re/ge/regex`
+    pub fn invalidate(&self, client: &Client, path: &str) -> anyhow::Result<()> {
+        let path = path.trim_start_matches('/');
+        let url = format!(
+            "https://cloudfront.amazonaws.com/2020-05-31/distribution/{}/invalidation",
+            self.distribution_id
+        );
+        let now = chrono::offset::Utc::now().timestamp_micros();
+        let body = format!(
+            r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<InvalidationBatch xmlns="http://cloudfront.amazonaws.com/doc/2020-05-31/">
+    <CallerReference>{now}</CallerReference>
+    <Paths>
+        <Items>
+            <Path>/{path}</Path>
+        </Items>
+        <Quantity>1</Quantity>
+    </Paths>
+</InvalidationBatch>
+"#
+        );
+
+        let request = http::Request::post(&url).body(&body)?;
+        let request = SignableRequest::from(&request);
+        let params = SigningParams::builder()
+            .access_key(&self.access_key)
+            .secret_key(&self.secret_key)
+            .region("us-east-1") // cloudfront is a regionless service, use the default region for signing.
+            .service_name("cloudfront")
+            .settings(SigningSettings::default())
+            .time(SystemTime::now())
+            .build()
+            .unwrap(); // all required fields are set
+        let (mut signature_headers, _) = http_request::sign(request, &params).unwrap().into_parts();
+        client
+            .post(url)
+            .headers(signature_headers.take_headers().unwrap_or_default())
+            .body(body)
+            .send()?
+            .error_for_status()?;
+        Ok(())
+    }
+}

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -3,6 +3,7 @@
 //! the daily database maintenance, but also operations like rendering READMEs
 //! and uploading them to S3.
 
+pub mod cloudfront;
 mod daily_db_maintenance;
 pub mod dump_db;
 mod git;


### PR DESCRIPTION
Send invalidation request to CloudFront when a crate is modified.

Does nothing if `CLOUDFRONT_DISTRIBUTION` isn't set.

Fixes #4913