### PR TITLE
Add FAQ on how to leave crate open for adoption

### DIFF
--- a/app/templates/policies.hbs
+++ b/app/templates/policies.hbs
@@ -45,14 +45,14 @@
 <h3 id='delete-crate'><a href='#delete-crate'>How can I delete a crate I own from the registry?</a></h3>
 
 <p>
-  You can't delete crates from the registry but you could leave it open for
-  ownership transfering.
+  You can't delete crates from the registry, but you can leave it open for
+  transferring ownership to others.
 </p>
 
 <p>
-  To do this, you must yank all of the versions in the crate
-  and publish a version with a message communicating to crates.io support team
-  that you are consent to transfer the crate to the first person who asks for it:
+  To do this, you must publish a version with a message in the README
+  communicating to crates.io support team that you consent to transfer the
+  crate to the first person who asks for it:
 </p>
 
 <blockquote>

--- a/app/templates/policies.hbs
+++ b/app/templates/policies.hbs
@@ -42,6 +42,24 @@
   Code of Conduct.
 </p>
 
+<h3 id='delete-crate'><a href='#delete-crate'>How can I delete a crate I own from the registry?</a></h3>
+
+<p>
+  You can't delete crates from the registry but you could leave it open for
+  ownership transfering.
+</p>
+
+<p>
+  To do this, you must yank all of the versions in the crate
+  and publish a version with a message communicating to crates.io support team
+  that you are consent to transfer the crate to the first person who asks for it:
+</p>
+
+<blockquote>
+  I consent to the transfer of this crate to the first person who asks
+  help@crates.io for it.
+</blockquote>
+
 <h3 id='squatting'><a href='#squatting'>Squatting</a></h3>
 
 <p>


### PR DESCRIPTION
Provides a section in the policies page to communicate to users how they could leave a crate
open for transferring. The idea was first shared by @carols10cents.