### PR TITLE
fix css icons in dashboard

### DIFF
--- a/app/styles/dashboard.module.css
+++ b/app/styles/dashboard.module.css
@@ -51,6 +51,11 @@
             font-size: 105%;
             line-height: 20px;
         }
+
+        svg {
+            display: inline-block; 
+            vertical-align: text-top;
+        }
     }
 
     @media only screen and (max-width: 750px) {
@@ -74,6 +79,11 @@
 .my-feed {
     flex-grow: 5;
     h2 { font-size: 105%; }
+
+    svg {
+        display: inline-block; 
+        vertical-align: text-top;
+    }
 
     @media only screen and (max-width: 750px) {
         order: 0;


### PR DESCRIPTION
fixed the icons in the dashboard page: the icons were a bit offset

before:
![image](https://user-images.githubusercontent.com/93072086/190237564-af5733c8-dd57-422e-96ed-0da42434566f.png)


after:
![image](https://user-images.githubusercontent.com/93072086/190237621-145aead2-a059-4b5e-ac63-963a6c1417d1.png)