### PR TITLE
Use slightly darker background color for header and footer

### DIFF
--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -21,7 +21,7 @@
     --yellow500: hsl(44, 100%, 60%);
     --yellow700: hsl(44, 67%, 50%);
 
-    --header-bg-color: hsl(115, 31%, 27%);
+    --header-bg-color: hsl(115, 31%, 23%);
 
     --font-sans: "Fira Sans", sans-serif;
     --font-monospace: "Fira Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",


### PR DESCRIPTION
### Before

<img width="1742" alt="Bildschirmfoto 2022-09-22 um 14 40 42" src="https://user-images.githubusercontent.com/141300/191749623-a46c93cd-ce37-438d-a518-93f1b650f100.png">

### After

<img width="1743" alt="Bildschirmfoto 2022-09-22 um 14 40 27" src="https://user-images.githubusercontent.com/141300/191749628-79ff07fb-5c98-49c5-9321-07f6656b350d.png">


This increases the contrast of our header and footer text a bit :)