### PR TITLE
Prevent login flow from being disrupted by unrelated events

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -72,7 +72,7 @@ export default class SessionService extends Service {
     let { url } = await ajax(`/api/private/session/begin`);
     win.location = url;
 
-    let event = await race([waitForEvent(window, 'message'), this.windowCloseWatcherTask.perform(win)]);
+    let event = await race([this.windowEventWatcherTask.perform(), this.windowCloseWatcherTask.perform(win)]);
     if (event.closed) {
       this.notifications.warning('Login was canceled because the popup window was closed.');
       return;
@@ -109,6 +109,10 @@ export default class SessionService extends Service {
     if (transition) {
       transition.retry();
     }
+  });
+
+  windowEventWatcherTask = task(async () => {
+    return await waitForEvent(window, 'message');
   });
 
   windowCloseWatcherTask = task(async window => {

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -79,14 +79,8 @@ export default class SessionService extends Service {
     }
 
     win.close();
-    if (event.origin !== window.location.origin || !event.data) {
-      return;
-    }
 
-    let { code, state } = event.data;
-    if (!code || !state) {
-      return;
-    }
+    let { code, state } = event;
 
     let response = await fetch(`/api/private/session/authorize?code=${code}&state=${state}`);
     if (!response.ok) {
@@ -112,7 +106,20 @@ export default class SessionService extends Service {
   });
 
   windowEventWatcherTask = task(async () => {
-    return await waitForEvent(window, 'message');
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      let event = await waitForEvent(window, 'message');
+      if (event.origin !== window.location.origin || !event.data) {
+        continue;
+      }
+
+      let { code, state } = event.data;
+      if (!code || !state) {
+        continue;
+      }
+
+      return { code, state };
+    }
   });
 
   windowCloseWatcherTask = task(async window => {


### PR DESCRIPTION
This, in theory, fixes an issue where when I attempt to log in to http://crates.io via GitHub, the OAUTH popup closes before I can interact with it. In my case, an unrelated browser extension appears to emit an event on the popups window. 

As it turns out, `window.addEventListner('event', () => { })` can be unexpedetly chatty, especially when users have browser extensions installed.

On a positive note, OAUTH has a mechanism by which we can ensure the `event` is from the intended login flow session, which is the `state` value we already pass to it. This PR merely utilizes it for this purpose.


---

Please note, for some reason, I am not able to get this project running locally so testing this exact code hasn't been possible. I am reasonably sure this, or something very close to this will work, but most likely will need to be taken over the finish line by someone else.

To verify the hypothesis, and to log in, I used the chrome inspect & some clever conditional breakpoints to inject code to adjust the behavior to mimic the above.

Also, it is worth noting that as I read this task, I suspect the existing functionality has some opportunities to be tightened up, but that is likely a larger effort outside of a bugifx.