### PR TITLE
Crate with all versions yanked display reduced info

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -253,7 +253,14 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
         };
 
         Ok(req.json(&GoodCrate {
-            krate: EncodableCrate::from_minimal(krate, Some(&top_versions), None, false, None),
+            krate: EncodableCrate::from_minimal(
+                krate,
+                Some(&top_versions),
+                None,
+                false,
+                None,
+                false,
+            ),
             warnings,
         }))
     })

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -199,6 +199,16 @@ impl<'a> NewCrate<'a> {
 }
 
 impl Crate {
+    pub fn from_yanked(krate: Crate) -> Crate {
+        Crate {
+            description: None,
+            homepage: None,
+            documentation: None,
+            repository: None,
+            ..krate
+        }
+    }
+
     /// SQL filter based on whether the crate's name loosely matches the given
     /// string.
     ///

--- a/src/views.rs
+++ b/src/views.rs
@@ -245,6 +245,7 @@ impl EncodableCrate {
         badges: Option<Vec<Badge>>,
         exact_match: bool,
         recent_downloads: Option<i64>,
+        all_versions_yanked: bool,
     ) -> Self {
         let Crate {
             name,
@@ -256,15 +257,29 @@ impl EncodableCrate {
             documentation,
             repository,
             ..
-        } = krate;
+        } = if all_versions_yanked {
+            Crate::from_yanked(krate)
+        } else {
+            krate
+        };
         let versions_link = match versions {
             Some(..) => None,
             None => Some(format!("/api/v1/crates/{name}/versions")),
         };
         let keyword_ids = keywords.map(|kws| kws.iter().map(|kw| kw.keyword.clone()).collect());
         let category_ids = categories.map(|cats| cats.iter().map(|cat| cat.slug.clone()).collect());
-        let badges = badges.map(|_| vec![]);
         let documentation = Self::remove_blocked_documentation_urls(documentation);
+
+        let badges = if all_versions_yanked {
+            None
+        } else {
+            badges.map(|_| vec![])
+        };
+        let top_versions = if all_versions_yanked {
+            None
+        } else {
+            top_versions
+        };
 
         let max_version = top_versions
             .and_then(|v| v.highest.as_ref())
@@ -316,6 +331,7 @@ impl EncodableCrate {
         badges: Option<Vec<Badge>>,
         exact_match: bool,
         recent_downloads: Option<i64>,
+        all_versions_yanked: bool,
     ) -> Self {
         Self::from(
             krate,
@@ -326,6 +342,7 @@ impl EncodableCrate {
             badges,
             exact_match,
             recent_downloads,
+            all_versions_yanked,
         )
     }
 


### PR DESCRIPTION
This PR reduces the information returned by the API when crates have all versions yanked. Specifically `badges`, `documentation`, `homepage` and `repository` are set to `None` and `max_version` is set to `"0.0.0"`. These changes are applied on:
 - `GET /crates/:crate_id`  (crate page)
 - `GET /crates` (search).

In this PR the definition for a crate with all versions yanked is when `crate.versions()` returns no results. The [versions](https://github.com/rust-lang/crates.io/blob/f84eda9819d2ba2699268287402d1d08fa6f0732/src/models/krate.rs#L512) method loads all non-yanked versions. 

This definition simplifies the code a bit, specifically in `src/controllers/krate/search.rs` since the versions for the queried crates are already loaded in memory, so there is no need to run yet one more query. Semantically though, this definition is not entirely correct. `crate.versions()` could also mean that all versions have been deleted.

I don't think the difference matters much for this PR, but please do let me know if this is not a valid definition for all versions yanked crates and I will update the PR. 

Fix #1058

Search page changes:

<img width="938" alt="image" src="https://user-images.githubusercontent.com/1810284/195094015-8805d8d5-f642-4d84-be96-6e7f1f6c6d18.png">
Crate with 2 yanked versions and 1 non-yanked.

<img width="932" alt="image" src="https://user-images.githubusercontent.com/1810284/195094185-a70d18bb-e8a9-4567-b083-70b662124b10.png">
Crate with all 3 versions yanked.

--------------------------
Crate page changes:
<img width="955" alt="image" src="https://user-images.githubusercontent.com/1810284/195095204-573f7247-5988-4099-bdce-4310ecf0484a.png">
Non-yanked crate.

<img width="941" alt="image" src="https://user-images.githubusercontent.com/1810284/195095119-c756bea9-ea45-40fa-a5ca-fab5c5497942.png">
Yanked crate.

