### PR TITLE
Ignore "exact match" for search when sorted by downloads

### DIFF
--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -220,16 +220,17 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         ));
     }
 
+    // Any sort other than 'relevance' (default) would ignore exact crate name matches
     if sort == Some("downloads") {
         // Custom sorting is not supported yet with seek.
         supports_seek = false;
 
-        query = query.then_order_by(crates::downloads.desc())
+        query = query.order(crates::downloads.desc())
     } else if sort == Some("recent-downloads") {
         // Custom sorting is not supported yet with seek.
         supports_seek = false;
 
-        query = query.then_order_by(recent_crate_downloads::downloads.desc().nulls_last())
+        query = query.order(recent_crate_downloads::downloads.desc().nulls_last())
     } else if sort == Some("recent-updates") {
         // Custom sorting is not supported yet with seek.
         supports_seek = false;

--- a/src/tests/krate/search.rs
+++ b/src/tests/krate/search.rs
@@ -287,7 +287,7 @@ fn index_sorting() {
 
 #[test]
 #[allow(clippy::cognitive_complexity)]
-fn exact_match_on_queries_with_sort() {
+fn ignore_exact_match_on_queries_with_sort() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -352,17 +352,17 @@ fn exact_match_on_queries_with_sort() {
             .unwrap();
     });
 
-    // Sort by downloads
+    // Sort by downloads, order always the same no matter the crate name query
     let json = anon.search("q=foo_sort&sort=downloads");
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "foo_sort");
-    assert_eq!(json.crates[1].name, "baz_sort");
-    assert_eq!(json.crates[2].name, "bar_sort");
+    assert_eq!(json.crates[0].name, "baz_sort");
+    assert_eq!(json.crates[1].name, "bar_sort");
+    assert_eq!(json.crates[2].name, "foo_sort");
 
     let json = anon.search("q=bar_sort&sort=downloads");
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "bar_sort");
-    assert_eq!(json.crates[1].name, "baz_sort");
+    assert_eq!(json.crates[0].name, "baz_sort");
+    assert_eq!(json.crates[1].name, "bar_sort");
     assert_eq!(json.crates[2].name, "foo_sort");
 
     let json = anon.search("q=baz_sort&sort=downloads");
@@ -378,12 +378,21 @@ fn exact_match_on_queries_with_sort() {
     assert_eq!(json.crates[2].name, "bar_sort");
     assert_eq!(json.crates[3].name, "foo_sort");
 
-    // Sort by recent-downloads
+    // Sort by recent-downloads, order always the same no matter the crate name query
     let json = anon.search("q=bar_sort&sort=recent-downloads");
     assert_eq!(json.meta.total, 3);
-    assert_eq!(json.crates[0].name, "bar_sort");
-    assert_eq!(json.crates[1].name, "foo_sort");
-    assert_eq!(json.crates[2].name, "baz_sort");
+    assert_eq!(json.crates[0].name, "foo_sort");
+    assert_eq!(json.crates[1].name, "baz_sort");
+    assert_eq!(json.crates[2].name, "bar_sort");
+
+    // Test for bug with showing null results first when sorting
+    // by descending downloads
+    let json = anon.search("sort=recent-downloads");
+    assert_eq!(json.meta.total, 4);
+    assert_eq!(json.crates[0].name, "foo_sort");
+    assert_eq!(json.crates[1].name, "baz_sort");
+    assert_eq!(json.crates[2].name, "bar_sort");
+    assert_eq!(json.crates[3].name, "other_sort");
 
     // Sort by recent-updates
     let json = anon.search("q=bar_sort&sort=recent-updates");
@@ -398,15 +407,6 @@ fn exact_match_on_queries_with_sort() {
     assert_eq!(json.crates[0].name, "bar_sort");
     assert_eq!(json.crates[1].name, "baz_sort");
     assert_eq!(json.crates[2].name, "foo_sort");
-
-    // Test for bug with showing null results first when sorting
-    // by descending downloads
-    let json = anon.search("sort=recent-downloads");
-    assert_eq!(json.meta.total, 4);
-    assert_eq!(json.crates[0].name, "foo_sort");
-    assert_eq!(json.crates[1].name, "baz_sort");
-    assert_eq!(json.crates[2].name, "bar_sort");
-    assert_eq!(json.crates[3].name, "other_sort");
 }
 
 #[test]


### PR DESCRIPTION
When searching for crates with results order specified (by all-time / recent downloads), ignore the "exact match" for the result ordering.

Resolves #5247 