### PR TITLE
docs: Reintroduce `MIRROR.md` to keep third party links to the document working

### DIFF
--- a/docs/MIRROR.md
+++ b/docs/MIRROR.md
@@ -1,0 +1,8 @@
+Running the crates.io codebase as a mirror to the official crates.io package
+repository has always been experimental and was deprecated quite a while ago.
+The code to support this mode has been remove from the project at this point.
+
+To not favor any one company/project, we will not give any recommendation
+regarding replacements. Feel free to search our
+[Discussions](https://github.com/rust-lang/crates.io/discussions) on how to
+set up crates.io mirrors using other software.


### PR DESCRIPTION


see https://github.com/rust-lang/crates.io/pull/5324#issuecomment-1279736479