### PR TITLE
Use AWS_ environment variables for authenticating to AWS services

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,27 +25,28 @@ export SESSION_KEY=badkeyabcdefghijklmnopqrstuvwxyzabcdef
 # If you don't plan on running the tests, you can leave this blank.
 export TEST_DATABASE_URL=
 
-# Credentials for uploading packages to S3. You can leave these commented
+# Credentials for AWS.
+# export AWS_ACCESS_KEY=
+# export AWS_SECRET_KEY=
+
+# Configuration for uploading packages to S3. You can leave these commented
 # out if you're not publishing to s3 from your crates.io instance.
+# Uses AWS credentials.
 # export S3_BUCKET=
-# export S3_ACCESS_KEY=
-# export S3_SECRET_KEY=
 # not needed if the S3 bucket is in US standard
 # export S3_REGION=
 
-# Credentials for uploading index metadata to S3. You can leave these commented
+# Configuration for uploading index metadata to S3. You can leave these commented
 # out if you're not publishing index metadata to s3 from your crates.io instance.
+# Uses AWS credentials.
 # export S3_INDEX_BUCKET=
-# export S3_INDEX_ACCESS_KEY=
-# export S3_INDEX_SECRET_KEY=
 # not needed if the S3 bucket is in US standard
 # export S3_INDEX_REGION=
 
-# Credentials for invalidating cached files on CloudFront. You can leave these
+# Configuration for invalidating cached files on CloudFront. You can leave these
 # commented out if you're not using CloudFront caching for the index files.
+# Uses AWS credentials.
 # export CLOUDFRONT_DISTRIBUTION=
-# export CLOUDFRONT_ACCESS_KEY=
-# export CLOUDFRONT_SECRET_KEY=
 
 # Upstream location of the registry index. Background jobs will push to
 # this URL. The default points to a local index for development.

--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -5,8 +5,8 @@
 //! - `S3_BUCKET`: The S3 bucket used to store crate files. If not present during development,
 //!    cargo_registry will fall back to a local uploader.
 //! - `S3_REGION`: The region in which the bucket was created. Optional if US standard.
-//! - `S3_ACCESS_KEY`: The access key to interact with S3. Optional if running a mirror.
-//! - `S3_SECRET_KEY`: The secret key to interact with S3. Optional if running a mirror.
+//! - `AWS_ACCESS_KEY`: The access key to interact with S3. Optional if running a mirror.
+//! - `AWS_SECRET_KEY`: The secret key to interact with S3. Optional if running a mirror.
 //! - `S3_CDN`: Optional CDN configuration for building public facing URLs.
 
 use crate::{env, uploaders::Uploader, Env, Replica};
@@ -77,8 +77,8 @@ impl Base {
             bucket: Box::new(s3::Bucket::new(
                 String::from("alexcrichton-test"),
                 None,
-                dotenv::var("S3_ACCESS_KEY").unwrap_or_default(),
-                dotenv::var("S3_SECRET_KEY").unwrap_or_default(),
+                dotenv::var("AWS_ACCESS_KEY").unwrap_or_default(),
+                dotenv::var("AWS_SECRET_KEY").unwrap_or_default(),
                 // When testing we route all API traffic over HTTP so we can
                 // sniff/record it, but everywhere else we use https
                 "http",
@@ -86,8 +86,8 @@ impl Base {
             index_bucket: Some(Box::new(s3::Bucket::new(
                 String::from("alexcrichton-test"),
                 None,
-                dotenv::var("S3_INDEX_ACCESS_KEY").unwrap_or_default(),
-                dotenv::var("S3_INDEX_SECRET_KEY").unwrap_or_default(),
+                dotenv::var("AWS_ACCESS_KEY").unwrap_or_default(),
+                dotenv::var("AWS_SECRET_KEY").unwrap_or_default(),
                 // When testing we route all API traffic over HTTP so we can
                 // sniff/record it, but everywhere else we use https
                 "http",
@@ -109,8 +109,8 @@ impl Base {
             Ok(name) => Some(Box::new(s3::Bucket::new(
                 name,
                 dotenv::var("S3_INDEX_REGION").ok(),
-                env("S3_INDEX_ACCESS_KEY"),
-                env("S3_INDEX_SECRET_KEY"),
+                env("AWS_ACCESS_KEY"),
+                env("AWS_SECRET_KEY"),
                 "https",
             ))),
             Err(_) => None,
@@ -119,8 +119,8 @@ impl Base {
             bucket: Box::new(s3::Bucket::new(
                 env("S3_BUCKET"),
                 dotenv::var("S3_REGION").ok(),
-                env("S3_ACCESS_KEY"),
-                env("S3_SECRET_KEY"),
+                env("AWS_ACCESS_KEY"),
+                env("AWS_SECRET_KEY"),
                 "https",
             )),
             index_bucket,
@@ -133,8 +133,8 @@ impl Base {
             Ok(name) => Some(Box::new(s3::Bucket::new(
                 name,
                 dotenv::var("S3_INDEX_REGION").ok(),
-                dotenv::var("S3_INDEX_ACCESS_KEY").unwrap_or_default(),
-                dotenv::var("S3_INDEX_SECRET_KEY").unwrap_or_default(),
+                dotenv::var("AWS_ACCESS_KEY").unwrap_or_default(),
+                dotenv::var("AWS_SECRET_KEY").unwrap_or_default(),
                 "https",
             ))),
             Err(_) => None,
@@ -143,8 +143,8 @@ impl Base {
             bucket: Box::new(s3::Bucket::new(
                 env("S3_BUCKET"),
                 dotenv::var("S3_REGION").ok(),
-                dotenv::var("S3_ACCESS_KEY").unwrap_or_default(),
-                dotenv::var("S3_SECRET_KEY").unwrap_or_default(),
+                dotenv::var("AWS_ACCESS_KEY").unwrap_or_default(),
+                dotenv::var("AWS_SECRET_KEY").unwrap_or_default(),
                 "https",
             )),
             index_bucket,

--- a/src/worker/cloudfront.rs
+++ b/src/worker/cloudfront.rs
@@ -16,10 +16,8 @@ pub struct CloudFront {
 impl CloudFront {
     pub fn from_environment() -> Option<Self> {
         let distribution_id = dotenv::var("CLOUDFRONT_DISTRIBUTION").ok()?;
-        let access_key =
-            dotenv::var("CLOUDFRONT_ACCESS_KEY").expect("missing CLOUDFRONT_ACCESS_KEY");
-        let secret_key =
-            dotenv::var("CLOUDFRONT_SECRET_KEY").expect("missing CLOUDFRONT_SECRET_KEY");
+        let access_key = dotenv::var("AWS_ACCESS_KEY").expect("missing AWS_ACCESS_KEY");
+        let secret_key = dotenv::var("AWS_SECRET_KEY").expect("missing AWS_SECRET_KEY");
         Some(Self {
             distribution_id,
             access_key,


### PR DESCRIPTION
Infra team has requested that we use a single environment variable set for authenticating for AWS services.

This PR standardizes on: `AWS_ACCESS_KEY` and `AWS_SECRET_KEY`.