### PR TITLE
docs: Restrict `diesel_cli` to version 1.x

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -164,7 +164,7 @@ In order to run the backend, you will need to have installed:
 - [Rust](https://www.rust-lang.org/en-US/) stable >= 1.16.0 and cargo, which comes with Rust
 - [Postgres](https://www.postgresql.org/) >= 9.5
 - [OpenSSL](https://www.openssl.org/) >= 1.0.2k
-- 2.0.0 > [diesel_cli](http://diesel.rs/guides/getting-started/) >= 1.2.0
+- [diesel_cli](http://diesel.rs/guides/getting-started/) >= 1.2.0 and < 2.0.0
 
 ##### Rust
 
@@ -285,7 +285,7 @@ by typing `\q`) without any errors to connect to your running Postgres server.
 On all platforms, install through `cargo` by running:
 
 ```
-cargo install diesel_cli --no-default-features --features postgres --version 1.2.0
+cargo install diesel_cli --no-default-features --features postgres --version 1
 ```
 
 This will install a binary named `diesel`, so you should be able to run `diesel

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -164,7 +164,7 @@ In order to run the backend, you will need to have installed:
 - [Rust](https://www.rust-lang.org/en-US/) stable >= 1.16.0 and cargo, which comes with Rust
 - [Postgres](https://www.postgresql.org/) >= 9.5
 - [OpenSSL](https://www.openssl.org/) >= 1.0.2k
-- [diesel_cli](http://diesel.rs/guides/getting-started/) >= 1.2.0
+- 2.0.0 > [diesel_cli](http://diesel.rs/guides/getting-started/) >= 1.2.0
 
 ##### Rust
 
@@ -285,7 +285,7 @@ by typing `\q`) without any errors to connect to your running Postgres server.
 On all platforms, install through `cargo` by running:
 
 ```
-cargo install diesel_cli --no-default-features --features postgres
+cargo install diesel_cli --no-default-features --features postgres --version 1.2.0
 ```
 
 This will install a binary named `diesel`, so you should be able to run `diesel


### PR DESCRIPTION
Compatibility is broken with diesel 2.0, so the current code must use diesel before 2.0.

Mentioned in the discussion below.
https://github.com/rust-lang/crates.io/discussions/5348