### PR TITLE
fix: use new endpoint for crate owner invites

### DIFF
--- a/app/components/seek-pagination.hbs
+++ b/app/components/seek-pagination.hbs
@@ -1,0 +1,7 @@
+{{#if @pagination.nextPage}}
+  <nav local-class='seek-pagination' aria-label="Pagination navigation">
+    <LinkTo @query={{hash seek=@pagination.nextPage}} local-class="next" rel="next" title="Goes to next page" data-test-pagination-next>
+      Next Page
+    </LinkTo>
+  </nav>
+{{/if}}

--- a/app/components/seek-pagination.module.css
+++ b/app/components/seek-pagination.module.css
@@ -1,0 +1,5 @@
+.seek-pagination {
+  text-align: center;
+  font-size: 90%;
+  margin-bottom: 20px;
+}

--- a/app/controllers/me/pending-invites.js
+++ b/app/controllers/me/pending-invites.js
@@ -1,0 +1,10 @@
+import Controller from '@ember/controller';
+
+import { reads } from 'macro-decorators';
+
+import { pagination } from '../../utils/seek-pagination';
+
+export default class PendingInvitesController extends Controller {
+  @reads('model.meta.next_page') nextPage;
+  @pagination() pagination;
+}

--- a/app/routes/me/pending-invites.js
+++ b/app/routes/me/pending-invites.js
@@ -5,7 +5,11 @@ import AuthenticatedRoute from '../-authenticated-route';
 export default class PendingInvitesRoute extends AuthenticatedRoute {
   @service store;
 
-  model() {
-    return this.store.findAll('crate-owner-invite');
+  queryParams = {
+    seek: { refreshModel: true },
+  };
+
+  model(params) {
+    return this.store.query('crate-owner-invite', params);
   }
 }

--- a/app/templates/me/pending-invites.hbs
+++ b/app/templates/me/pending-invites.hbs
@@ -9,3 +9,5 @@
     <p local-class="row" data-test-empty-state>You don't seem to have any pending invitations.</p>
   {{/each}}
 </div>
+
+<SeekPagination @pagination={{this.pagination}} />

--- a/app/utils/seek-pagination.js
+++ b/app/utils/seek-pagination.js
@@ -1,0 +1,12 @@
+import macro from 'macro-decorators';
+
+export function pagination() {
+  return macro(function () {
+    const { nextPage } = this;
+    const nextPageParams = new URLSearchParams(nextPage);
+
+    return {
+      nextPage: nextPageParams.get('seek'),
+    };
+  });
+}

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -98,13 +98,20 @@ export function register(server) {
     return { ok: true };
   });
 
-  server.get('/api/v1/me/crate_owner_invitations', function (schema) {
+  server.get('/api/private/crate_owner_invitations', function (schema, request) {
     let { user } = getSession(schema);
     if (!user) {
       return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
     }
 
-    return schema.crateOwnerInvitations.where({ inviteeId: user.id });
+    const { start, end } = pageParams(request);
+    const invites = schema.crateOwnerInvitations.where({ inviteeId: user.id });
+
+    let response = this.serialize(invites.slice(start, end));
+
+    response.meta = { total: invites.length };
+
+    return response;
   });
 
   server.put('/api/v1/me/crate_owner_invitations/:crate_id', (schema, request) => {


### PR DESCRIPTION
Provides implementation on seek pagination for Pending Owner Invites page.

Previously on: https://github.com/rust-lang/crates.io/pull/5185