### PR TITLE
feat: update mirage tests and route handlers for owner invites

### DIFF
--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -98,6 +98,15 @@ export function register(server) {
     return { ok: true };
   });
 
+  server.get('/api/v1/me/crate_owner_invitations', function (schema) {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
+    return schema.crateOwnerInvitations.where({ inviteeId: user.id });
+  });
+
   server.get('/api/private/crate_owner_invitations', function (schema) {
     let { user } = getSession(schema);
     if (!user) {

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -98,7 +98,7 @@ export function register(server) {
     return { ok: true };
   });
 
-  server.get('/api/v1/me/crate_owner_invitations', function (schema) {
+  server.get('/api/private/crate_owner_invitations', function (schema) {
     let { user } = getSession(schema);
     if (!user) {
       return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });

--- a/tests/mirage/me/crate-owner-invitations/list-test.js
+++ b/tests/mirage/me/crate-owner-invitations/list-test.js
@@ -5,6 +5,101 @@ import fetch from 'fetch';
 import { setupTest } from '../../../helpers';
 import setupMirage from '../../../helpers/setup-mirage';
 
+module('Mirage | GET /api/v1/me/crate_owner_invitations', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('empty case', async function (assert) {
+    let user = this.server.create('user');
+    this.server.create('mirage-session', { user });
+
+    let response = await fetch('/api/v1/me/crate_owner_invitations');
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), { crate_owner_invitations: [] });
+  });
+
+  test('returns the list of invitations for the authenticated user', async function (assert) {
+    let nanomsg = this.server.create('crate', { name: 'nanomsg' });
+    this.server.create('version', { crate: nanomsg });
+
+    let ember = this.server.create('crate', { name: 'ember-rs' });
+    this.server.create('version', { crate: ember });
+
+    let user = this.server.create('user');
+    this.server.create('mirage-session', { user });
+
+    let inviter = this.server.create('user', { name: 'janed' });
+    this.server.create('crate-owner-invitation', {
+      crate: nanomsg,
+      createdAt: '2016-12-24T12:34:56Z',
+      invitee: user,
+      inviter,
+    });
+
+    let inviter2 = this.server.create('user', { name: 'wycats' });
+    this.server.create('crate-owner-invitation', {
+      crate: ember,
+      createdAt: '2020-12-31T12:34:56Z',
+      invitee: user,
+      inviter: inviter2,
+    });
+
+    let response = await fetch('/api/private/crate_owner_invitations');
+    assert.equal(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      crate_owner_invitations: [
+        {
+          crate_id: Number(nanomsg.id),
+          crate_name: 'nanomsg',
+          created_at: '2016-12-24T12:34:56Z',
+          invited_by_username: 'janed',
+          invitee_id: Number(user.id),
+          inviter_id: Number(inviter.id),
+        },
+        {
+          crate_id: Number(ember.id),
+          crate_name: 'ember-rs',
+          created_at: '2020-12-31T12:34:56Z',
+          invited_by_username: 'wycats',
+          invitee_id: Number(user.id),
+          inviter_id: Number(inviter2.id),
+        },
+      ],
+      users: [
+        {
+          avatar: user.avatar,
+          id: Number(user.id),
+          login: user.login,
+          name: user.name,
+          url: user.url,
+        },
+        {
+          avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
+          id: Number(inviter.id),
+          login: 'janed',
+          name: 'janed',
+          url: 'https://github.com/janed',
+        },
+        {
+          avatar: 'https://avatars1.githubusercontent.com/u/14631425?v=4',
+          id: Number(inviter2.id),
+          login: 'wycats',
+          name: 'wycats',
+          url: 'https://github.com/wycats',
+        },
+      ],
+    });
+  });
+
+  test('returns an error if unauthenticated', async function (assert) {
+    let response = await fetch('/api/private/crate_owner_invitations');
+    assert.equal(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      errors: [{ detail: 'must be logged in to perform that action' }],
+    });
+  });
+});
+
 module('Mirage | GET /api/private/crate_owner_invitations', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);

--- a/tests/mirage/me/crate-owner-invitations/list-test.js
+++ b/tests/mirage/me/crate-owner-invitations/list-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../helpers';
 import setupMirage from '../../../helpers/setup-mirage';
 
-module('Mirage | GET /api/v1/me/crate_owner_invitations', function (hooks) {
+module('Mirage | GET /api/private/crate_owner_invitations', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 
@@ -13,7 +13,7 @@ module('Mirage | GET /api/v1/me/crate_owner_invitations', function (hooks) {
     let user = this.server.create('user');
     this.server.create('mirage-session', { user });
 
-    let response = await fetch('/api/v1/me/crate_owner_invitations');
+    let response = await fetch('/api/private/crate_owner_invitations');
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), { crate_owner_invitations: [] });
   });
@@ -44,7 +44,7 @@ module('Mirage | GET /api/v1/me/crate_owner_invitations', function (hooks) {
       inviter: inviter2,
     });
 
-    let response = await fetch('/api/v1/me/crate_owner_invitations');
+    let response = await fetch('/api/private/crate_owner_invitations');
     assert.equal(response.status, 200);
     assert.deepEqual(await response.json(), {
       crate_owner_invitations: [
@@ -55,6 +55,7 @@ module('Mirage | GET /api/v1/me/crate_owner_invitations', function (hooks) {
           invited_by_username: 'janed',
           invitee_id: Number(user.id),
           inviter_id: Number(inviter.id),
+          expires_at: '2017-01-24T12:34:56Z',
         },
         {
           crate_id: Number(ember.id),
@@ -63,6 +64,7 @@ module('Mirage | GET /api/v1/me/crate_owner_invitations', function (hooks) {
           invited_by_username: 'wycats',
           invitee_id: Number(user.id),
           inviter_id: Number(inviter2.id),
+          expires_at: '2017-01-31T12:34:56Z',
         },
       ],
       users: [
@@ -92,7 +94,7 @@ module('Mirage | GET /api/v1/me/crate_owner_invitations', function (hooks) {
   });
 
   test('returns an error if unauthenticated', async function (assert) {
-    let response = await fetch('/api/v1/me/crate_owner_invitations');
+    let response = await fetch('/api/private/crate_owner_invitations');
     assert.equal(response.status, 403);
     assert.deepEqual(await response.json(), {
       errors: [{ detail: 'must be logged in to perform that action' }],

--- a/tests/mirage/me/crate-owner-invitations/list-test.js
+++ b/tests/mirage/me/crate-owner-invitations/list-test.js
@@ -55,7 +55,6 @@ module('Mirage | GET /api/private/crate_owner_invitations', function (hooks) {
           invited_by_username: 'janed',
           invitee_id: Number(user.id),
           inviter_id: Number(inviter.id),
-          expires_at: '2017-01-24T12:34:56Z',
         },
         {
           crate_id: Number(ember.id),
@@ -64,7 +63,6 @@ module('Mirage | GET /api/private/crate_owner_invitations', function (hooks) {
           invited_by_username: 'wycats',
           invitee_id: Number(user.id),
           inviter_id: Number(inviter2.id),
-          expires_at: '2017-01-31T12:34:56Z',
         },
       ],
       users: [

--- a/tests/mirage/private/crate-owner-invitations/get-test.js
+++ b/tests/mirage/private/crate-owner-invitations/get-test.js
@@ -46,6 +46,7 @@ module('Mirage | GET /api/private/crate_owner_invitations', function (hooks) {
           invited_by_username: 'janed',
           invitee_id: Number(user.id),
           inviter_id: Number(inviter.id),
+          expires_at: '2017-01-24T12:34:56Z',
         },
         {
           crate_id: Number(ember.id),
@@ -54,6 +55,7 @@ module('Mirage | GET /api/private/crate_owner_invitations', function (hooks) {
           invited_by_username: 'wycats',
           invitee_id: Number(user.id),
           inviter_id: Number(inviter2.id),
+          expires_at: '2017-01-31T12:34:56Z',
         },
       ],
       users: [


### PR DESCRIPTION
Uses `api/private` over `api/v1/me` for mirage pending owner invites endpoint.
And also adds the `expires_at` attribute as part of the payload received as
found in the `EncodableCrateOwnerInvitationV1` struct from the API.
