### PR TITLE
s3: Fix `base64::encode()` call

### DIFF
--- a/cargo-registry-s3/lib.rs
+++ b/cargo-registry-s3/lib.rs
@@ -104,7 +104,7 @@ impl Bucket {
             let mut h = Hmac::<Sha1>::new_from_slice(key).expect("HMAC can take key of any size");
             h.update(string.as_bytes());
             let res = h.finalize().into_bytes();
-            base64::encode(&res)
+            base64::encode(res)
         };
         format!("AWS {}:{}", self.access_key, signature)
     }


### PR DESCRIPTION
This should unblock the Rust 1.65 update in #5410 