### PR TITLE
badges: Remove obsolete database calls

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -193,15 +193,8 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
         None
     };
 
-    let badges = if include.badges {
-        Some(
-            badges::table
-                .filter(badges::crate_id.eq(krate.id))
-                .load(&*conn)?,
-        )
-    } else {
-        None
-    };
+    let badges = if include.badges { Some(vec![]) } else { None };
+
     let top_versions = if include.versions {
         Some(krate.top_versions(&conn)?)
     } else {

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -7,9 +7,7 @@ use indexmap::IndexMap;
 
 use crate::controllers::cargo_prelude::*;
 use crate::controllers::helpers::Paginate;
-use crate::models::{
-    Crate, CrateBadge, CrateOwner, CrateVersions, OwnerKind, TopVersions, Version,
-};
+use crate::models::{Crate, CrateOwner, CrateVersions, OwnerKind, TopVersions, Version};
 use crate::schema::*;
 use crate::util::errors::bad_request;
 use crate::views::EncodableCrate;
@@ -319,25 +317,16 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         .into_iter()
         .map(TopVersions::from_versions);
 
-    let badges: Vec<CrateBadge> = CrateBadge::belonging_to(&crates)
-        .select((badges::crate_id, badges::all_columns))
-        .load(&*conn)?;
-    let badges = badges
-        .grouped_by(&crates)
-        .into_iter()
-        .map(|badges| badges.into_iter().map(|cb| cb.badge).collect());
-
     let crates = versions
         .zip(crates)
         .zip(perfect_matches)
         .zip(recent_downloads)
-        .zip(badges)
         .map(
-            |((((max_version, krate), perfect_match), recent_downloads), badges)| {
+            |(((max_version, krate), perfect_match), recent_downloads)| {
                 EncodableCrate::from_minimal(
                     krate,
                     Some(&max_version),
-                    Some(badges),
+                    Some(vec![]),
                     perfect_match,
                     Some(recent_downloads),
                 )


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/pull/5071 changed our API to not return badges anymore, but the endpoint code was still performing the corresponding database queries for no reason. This PR removes the queries to speed up the endpoints.