### PR TITLE
EncodableCrateUpload: Remove obsolete `badges` field

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -1,5 +1,5 @@
 use cargo_registry::views::krate_publish as u;
-use std::{collections::BTreeMap, collections::HashMap, io::Read};
+use std::{collections::BTreeMap, io::Read};
 
 use flate2::{write::GzEncoder, Compression};
 use once_cell::sync::Lazy;
@@ -24,7 +24,6 @@ fn generate_empty_tarball() -> Vec<u8> {
 /// a crate to exist and don't need to test behavior caused by the publish request, inserting
 /// a crate into the database directly by using CrateBuilder will be faster.
 pub struct PublishBuilder {
-    badges: HashMap<String, HashMap<String, String>>,
     categories: Vec<String>,
     deps: Vec<u::EncodableCrateDependency>,
     desc: Option<String>,
@@ -44,7 +43,6 @@ impl PublishBuilder {
     /// in its tarball.
     pub fn new(krate_name: &str) -> Self {
         PublishBuilder {
-            badges: HashMap::new(),
             categories: vec![],
             deps: vec![],
             desc: Some("description".to_string()),
@@ -150,12 +148,6 @@ impl PublishBuilder {
         self
     }
 
-    /// Add badges to this crate.
-    pub fn badges(mut self, badges: HashMap<String, HashMap<String, String>>) -> Self {
-        self.badges = badges;
-        self
-    }
-
     /// Remove the license from this crate. Publish will fail unless license or license file is set.
     pub fn unset_license(mut self) -> Self {
         self.license = None;
@@ -202,7 +194,6 @@ impl PublishBuilder {
             license: self.license,
             license_file: self.license_file,
             repository: None,
-            badges: Some(self.badges),
             links: None,
         };
 

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -11,7 +11,7 @@ use diesel::{delete, update, ExpressionMethods, QueryDsl, RunQueryDsl};
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use http::StatusCode;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::iter::FromIterator;
 use std::time::Duration;
@@ -779,57 +779,6 @@ fn ignored_categories() {
     assert_eq!(json.krate.name, "foo_ignored_cat");
     assert_eq!(json.krate.max_version, "1.0.0");
     assert_eq!(json.warnings.invalid_categories, vec!["bar"]);
-}
-
-#[test]
-fn good_badges() {
-    let (_, anon, _, token) = TestApp::full().with_token();
-
-    let mut badges = HashMap::new();
-    let mut badge_attributes = HashMap::new();
-    badge_attributes.insert(
-        String::from("repository"),
-        String::from("rust-lang/crates.io"),
-    );
-    badges.insert(String::from("travis-ci"), badge_attributes);
-
-    let crate_to_publish = PublishBuilder::new("foobadger").badges(badges);
-
-    let json = token.publish_crate(crate_to_publish).good();
-    assert_eq!(json.krate.name, "foobadger");
-    assert_eq!(json.krate.max_version, "1.0.0");
-
-    let json = anon.show_crate("foobadger");
-    let badges = json.krate.badges.unwrap();
-    assert_eq!(badges.len(), 0);
-}
-
-#[test]
-fn ignored_badges() {
-    let (_, anon, _, token) = TestApp::full().with_token();
-
-    let mut badges = HashMap::new();
-
-    // Known badge type, missing required repository attribute
-    let mut badge_attributes = HashMap::new();
-    badge_attributes.insert(String::from("branch"), String::from("master"));
-    badges.insert(String::from("travis-ci"), badge_attributes);
-
-    // Unknown badge type
-    let mut unknown_badge_attributes = HashMap::new();
-    unknown_badge_attributes.insert(String::from("repository"), String::from("rust-lang/rust"));
-    badges.insert(String::from("not-a-badge"), unknown_badge_attributes);
-
-    let crate_to_publish = PublishBuilder::new("foo_ignored_badge").badges(badges);
-
-    let json = token.publish_crate(crate_to_publish).good();
-    assert_eq!(json.krate.name, "foo_ignored_badge");
-    assert_eq!(json.krate.max_version, "1.0.0");
-    assert_eq!(json.warnings.invalid_badges.len(), 0);
-
-    let json = anon.show_crate("foo_ignored_badge");
-    let badges = json.krate.badges.unwrap();
-    assert_eq!(badges.len(), 0);
 }
 
 #[test]

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -2,7 +2,7 @@
 //! and manages the serialising and deserialising of this information
 //! to and from structs. The serlializing is only utilised in
 //! integration tests.
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -30,7 +30,6 @@ pub struct EncodableCrateUpload {
     pub license: Option<String>,
     pub license_file: Option<String>,
     pub repository: Option<String>,
-    pub badges: Option<HashMap<String, HashMap<String, String>>>,
     #[serde(default)]
     pub links: Option<String>,
 }


### PR DESCRIPTION
We are no longer saving these into the database (see https://github.com/rust-lang/crates.io/pull/5074), so there is no need to deserialize them from the JSON payload anymore.