### PR TITLE
Vendor a portion of the `swirl` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,10 +418,10 @@ dependencies = [
  "serde_json",
  "sha2",
  "spdx",
- "swirl",
  "tar",
  "tempfile",
  "thiserror",
+ "threadpool",
  "tikv-jemallocator",
  "tokio",
  "toml",
@@ -820,16 +820,6 @@ dependencies = [
  "generic-array",
  "rand_core",
  "typenum",
-]
-
-[[package]]
-name = "ctor"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1242,17 +1232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghost"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41973d4c45f7a35af8753ba3457cc99d406d863941fd7f52663cff54a5ab99b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "gimli"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,28 +1564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "inventory"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb5160c60ba1e809707918ee329adb99d222888155835c6feedba19f6c3fd4"
-dependencies = [
- "ctor",
- "ghost",
- "inventory-impl",
-]
-
-[[package]]
-name = "inventory-impl"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e41b53715c6f0c4be49510bb82dee2c1e51c8586d885abe65396e82ed518548"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3133,30 +3090,6 @@ name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
-
-[[package]]
-name = "swirl"
-version = "0.1.0"
-source = "git+https://github.com/sgrif/swirl.git?rev=e87cf37#e87cf3772cd99d8edb478121c44972ea613c932f"
-dependencies = [
- "diesel",
- "inventory",
- "serde",
- "serde_derive",
- "serde_json",
- "swirl_proc_macro",
- "threadpool",
-]
-
-[[package]]
-name = "swirl_proc_macro"
-version = "0.1.0"
-source = "git+https://github.com/sgrif/swirl.git?rev=e87cf37#e87cf3772cd99d8edb478121c44972ea613c932f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ serde = { version = "=1.0.151", features = ["derive"] }
 serde_json = "=1.0.91"
 sha2 = "=0.10.6"
 spdx = "=0.10.0"
-swirl = { git = "https://github.com/sgrif/swirl.git", rev = "e87cf37" }
 tar = "=0.4.38"
 tempfile = "=3.3.0"
 thiserror = "=1.0.38"
+threadpool = "1.8"
 tokio = { version = "=1.23.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.5.10"
 tower = "=0.4.13"

--- a/src/admin/yank_version.rs
+++ b/src/admin/yank_version.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 
 use diesel::prelude::*;
-use swirl::Job;
 
 #[derive(clap::Parser, Debug)]
 #[command(

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -1,25 +1,166 @@
+use diesel::prelude::*;
 use reqwest::blocking::Client;
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
-use swirl::PerformError;
-
-use crate::db::{DieselPool, DieselPooledConn, PoolError};
+use crate::db::DieselPool;
+use crate::swirl::errors::EnqueueError;
+use crate::swirl::PerformError;
 use crate::uploaders::Uploader;
+use crate::worker;
 use crate::worker::cloudfront::CloudFront;
 use cargo_registry_index::Repository;
 
-impl<'a> swirl::db::BorrowedConnection<'a> for DieselPool {
-    type Connection = DieselPooledConn<'a>;
+pub enum Job {
+    DailyDbMaintenance(DailyDbMaintenanceJob),
+    DumpDb(DumpDbJob),
+    IndexAddCrate(IndexAddCrateJob),
+    IndexSquash(IndexSquashJob),
+    IndexSyncToHttp(IndexSyncToHttpJob),
+    IndexUpdateYanked(IndexUpdateYankedJob),
+    RenderAndUploadReadme(RenderAndUploadReadmeJob),
+    UpdateDownloads(UpdateDownloadsJob),
 }
 
-impl swirl::db::DieselPool for DieselPool {
-    type Error = PoolError;
+impl Job {
+    const DAILY_DB_MAINTENANCE: &str = "daily_db_maintenance";
+    const DUMP_DB: &str = "dump_db";
+    const INDEX_ADD_CRATE: &str = "add_crate";
+    const INDEX_SQUASH: &str = "squash_index";
+    const INDEX_SYNC_TO_HTTP: &str = "update_crate_index";
+    const INDEX_UPDATE_YANKED: &str = "sync_yanked";
+    const RENDER_AND_UPLOAD_README: &str = "render_and_upload_readme";
+    const UPDATE_DOWNLOADS: &str = "update_downloads";
 
-    fn get(&self) -> Result<swirl::db::DieselPooledConn<'_, Self>, Self::Error> {
-        self.get()
+    fn as_type_str(&self) -> &'static str {
+        match self {
+            Job::DailyDbMaintenance(_) => Self::DAILY_DB_MAINTENANCE,
+            Job::DumpDb(_) => Self::DUMP_DB,
+            Job::IndexAddCrate(_) => Self::INDEX_ADD_CRATE,
+            Job::IndexSquash(_) => Self::INDEX_SQUASH,
+            Job::IndexSyncToHttp(_) => Self::INDEX_SYNC_TO_HTTP,
+            Job::IndexUpdateYanked(_) => Self::INDEX_UPDATE_YANKED,
+            Job::RenderAndUploadReadme(_) => Self::RENDER_AND_UPLOAD_README,
+            Job::UpdateDownloads(_) => Self::UPDATE_DOWNLOADS,
+        }
+    }
+
+    fn to_value(&self) -> serde_json::Result<serde_json::Value> {
+        match self {
+            Job::DailyDbMaintenance(inner) => serde_json::to_value(inner),
+            Job::DumpDb(inner) => serde_json::to_value(inner),
+            Job::IndexAddCrate(inner) => serde_json::to_value(inner),
+            Job::IndexSquash(inner) => serde_json::to_value(inner),
+            Job::IndexSyncToHttp(inner) => serde_json::to_value(inner),
+            Job::IndexUpdateYanked(inner) => serde_json::to_value(inner),
+            Job::RenderAndUploadReadme(inner) => serde_json::to_value(inner),
+            Job::UpdateDownloads(inner) => serde_json::to_value(inner),
+        }
+    }
+
+    pub fn enqueue(&self, conn: &PgConnection) -> Result<(), EnqueueError> {
+        use crate::schema::background_jobs::dsl::*;
+
+        let job_data = self.to_value()?;
+        diesel::insert_into(background_jobs)
+            .values((job_type.eq(self.as_type_str()), data.eq(job_data)))
+            .execute(conn)?;
+        Ok(())
+    }
+
+    pub(super) fn from_value(
+        job_type: &str,
+        value: serde_json::Value,
+    ) -> Result<Self, PerformError> {
+        use serde_json::from_value;
+        Ok(match job_type {
+            Self::DAILY_DB_MAINTENANCE => Job::DailyDbMaintenance(from_value(value)?),
+            Self::DUMP_DB => Job::DumpDb(from_value(value)?),
+            Self::INDEX_ADD_CRATE => Job::IndexAddCrate(from_value(value)?),
+            Self::INDEX_SQUASH => Job::IndexSquash(from_value(value)?),
+            Self::INDEX_SYNC_TO_HTTP => Job::IndexSyncToHttp(from_value(value)?),
+            Self::INDEX_UPDATE_YANKED => Job::IndexUpdateYanked(from_value(value)?),
+            Self::RENDER_AND_UPLOAD_README => Job::RenderAndUploadReadme(from_value(value)?),
+            Self::UPDATE_DOWNLOADS => Job::UpdateDownloads(from_value(value)?),
+            job_type => Err(PerformError::from(format!("Unknown job type {job_type}")))?,
+        })
+    }
+
+    pub(super) fn perform(
+        self,
+        env: &Option<Environment>,
+        conn: &DieselPool,
+    ) -> Result<(), PerformError> {
+        let env = env
+            .as_ref()
+            .expect("Application should configure a background runner environment");
+        match self {
+            Job::DailyDbMaintenance(_) => {
+                conn.with_connection(&worker::perform_daily_db_maintenance)
+            }
+            Job::DumpDb(args) => worker::perform_dump_db(env, args.database_url, args.target_name),
+            Job::IndexAddCrate(args) => conn
+                .with_connection(&|conn| worker::perform_index_add_crate(env, conn, &args.krate)),
+            Job::IndexSquash(_) => worker::perform_index_squash(env),
+            Job::IndexSyncToHttp(args) => worker::perform_index_sync_to_http(env, args.crate_name),
+            Job::IndexUpdateYanked(args) => conn.with_connection(&|conn| {
+                worker::perform_index_update_yanked(env, conn, &args.krate, &args.version_num)
+            }),
+            Job::RenderAndUploadReadme(args) => conn.with_connection(&|conn| {
+                worker::perform_render_and_upload_readme(
+                    conn,
+                    env,
+                    args.version_id,
+                    &args.text,
+                    &args.readme_path,
+                    args.base_url.as_deref(),
+                    args.pkg_path_in_vcs.as_deref(),
+                )
+            }),
+            Job::UpdateDownloads(_) => conn.with_connection(&worker::perform_update_downloads),
+        }
     }
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct DailyDbMaintenanceJob {}
+
+#[derive(Serialize, Deserialize)]
+pub struct DumpDbJob {
+    pub(super) database_url: String,
+    pub(super) target_name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IndexAddCrateJob {
+    pub(super) krate: cargo_registry_index::Crate,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IndexSquashJob {}
+
+#[derive(Serialize, Deserialize)]
+pub struct IndexSyncToHttpJob {
+    pub(super) crate_name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IndexUpdateYankedJob {
+    pub(super) krate: String,
+    pub(super) version_num: String,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RenderAndUploadReadmeJob {
+    pub(super) version_id: i32,
+    pub(super) text: String,
+    pub(super) readme_path: String,
+    pub(super) base_url: Option<String>,
+    pub(super) pkg_path_in_vcs: Option<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct UpdateDownloadsJob {}
 
 pub struct Environment {
     index: Arc<Mutex<Repository>>,

--- a/src/bin/background-worker/main.rs
+++ b/src/bin/background-worker/main.rs
@@ -19,11 +19,12 @@ use cargo_registry::config;
 use cargo_registry::worker::cloudfront::CloudFront;
 use cargo_registry::{background_jobs::*, db};
 use cargo_registry_index::{Repository, RepositoryConfig};
-use diesel::r2d2;
 use reqwest::blocking::Client;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
+
+use cargo_registry::swirl;
 
 fn main() {
     let _sentry = cargo_registry::sentry::init();
@@ -74,11 +75,7 @@ fn main() {
             client,
             cloudfront.clone(),
         );
-        let db_config = r2d2::Pool::builder().min_idle(Some(0));
-        swirl::Runner::builder(environment)
-            .connection_pool_builder(&db_url, db_config)
-            .job_start_timeout(Duration::from_secs(job_start_timeout))
-            .build()
+        swirl::Runner::production_runner(environment, db_url.clone(), job_start_timeout)
     };
     let mut runner = build_runner();
 

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,10 +1,9 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 use anyhow::{anyhow, Result};
+use cargo_registry::schema::background_jobs::dsl::*;
 use cargo_registry::{db, env, worker};
 use diesel::prelude::*;
-use swirl::schema::background_jobs::dsl::*;
-use swirl::Job;
 
 fn main() -> Result<()> {
     let conn = db::oneoff_connection()?;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -8,7 +8,6 @@ use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
-use swirl::Job;
 
 use crate::controllers::cargo_prelude::*;
 use crate::models::{

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -1,7 +1,6 @@
 //! Endpoints for yanking and unyanking specific versions of crates
 
 use crate::auth::AuthCheck;
-use swirl::Job;
 
 use super::{extract_crate_name_and_semver, version_and_crate};
 use crate::controllers::cargo_prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub mod middleware;
 mod publish_rate_limit;
 pub mod schema;
 pub mod sql;
+pub mod swirl;
 mod test_util;
 pub mod uploaders;
 pub mod util;

--- a/src/swirl.rs
+++ b/src/swirl.rs
@@ -1,0 +1,7 @@
+mod runner;
+mod storage;
+
+pub mod errors;
+
+pub use self::runner::Runner;
+pub(crate) use errors::PerformError;

--- a/src/swirl/errors.rs
+++ b/src/swirl/errors.rs
@@ -1,0 +1,169 @@
+use diesel::result::Error as DieselError;
+use std::error::Error;
+use std::fmt;
+
+use crate::db::PoolError;
+
+/// An error occurred queueing the job
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum EnqueueError {
+    /// An error occurred serializing the job
+    SerializationError(serde_json::error::Error),
+
+    /// An error occurred inserting the job into the database
+    DatabaseError(DieselError),
+}
+
+impl From<serde_json::error::Error> for EnqueueError {
+    fn from(e: serde_json::error::Error) -> Self {
+        EnqueueError::SerializationError(e)
+    }
+}
+
+impl From<DieselError> for EnqueueError {
+    fn from(e: DieselError) -> Self {
+        EnqueueError::DatabaseError(e)
+    }
+}
+
+impl fmt::Display for EnqueueError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            EnqueueError::SerializationError(e) => e.fmt(f),
+            EnqueueError::DatabaseError(e) => e.fmt(f),
+        }
+    }
+}
+
+impl Error for EnqueueError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            EnqueueError::SerializationError(e) => Some(e),
+            EnqueueError::DatabaseError(e) => Some(e),
+        }
+    }
+}
+
+/// An error occurred performing the job
+pub(crate) type PerformError = Box<dyn Error>;
+
+/// An error occurred while attempting to fetch jobs from the queue
+pub enum FetchError {
+    /// We could not acquire a database connection from the pool.
+    ///
+    /// Either the connection pool is too small, or new connections cannot be
+    /// established.
+    NoDatabaseConnection(PoolError),
+
+    /// Could not execute the query to load a job from the database.
+    FailedLoadingJob(DieselError),
+
+    /// No message was received from the worker thread.
+    ///
+    /// Either the thread pool is too small, or jobs have hung indefinitely
+    NoMessageReceived,
+}
+
+impl fmt::Debug for FetchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FetchError::NoDatabaseConnection(e) => {
+                f.debug_tuple("NoDatabaseConnection").field(e).finish()
+            }
+            FetchError::FailedLoadingJob(e) => f.debug_tuple("FailedLoadingJob").field(e).finish(),
+            FetchError::NoMessageReceived => f.debug_struct("NoMessageReceived").finish(),
+        }
+    }
+}
+
+impl fmt::Display for FetchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FetchError::NoDatabaseConnection(e) => {
+                write!(f, "Timed out acquiring a database connection. ")?;
+                write!(f, "Try increasing the connection pool size: ")?;
+                write!(f, "{e}")?;
+            }
+            FetchError::FailedLoadingJob(e) => {
+                write!(f, "An error occurred loading a job from the database: ")?;
+                write!(f, "{e}")?;
+            }
+            FetchError::NoMessageReceived => {
+                write!(f, "No message was received from the worker thread. ")?;
+                write!(f, "Try increasing the thread pool size or timeout period.")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Error for FetchError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            FetchError::NoDatabaseConnection(e) => Some(e),
+            FetchError::FailedLoadingJob(e) => Some(e),
+            FetchError::NoMessageReceived => None,
+        }
+    }
+}
+
+/// An error returned by `Runner::check_for_failed_jobs`. Only used in tests.
+#[derive(Debug)]
+pub enum FailedJobsError {
+    /// Jobs failed to run
+    JobsFailed(
+        /// The number of failed jobs
+        i64,
+    ),
+
+    #[doc(hidden)]
+    /// Match on `_` instead, more variants may be added in the future
+    /// Some other error occurred. Worker threads may have panicked, an error
+    /// occurred counting failed jobs in the DB, or something else
+    /// unexpectedly went wrong.
+    __Unknown(Box<dyn Error + Send + Sync>),
+}
+
+pub(super) use FailedJobsError::JobsFailed;
+
+impl From<Box<dyn Error + Send + Sync>> for FailedJobsError {
+    fn from(e: Box<dyn Error + Send + Sync>) -> Self {
+        FailedJobsError::__Unknown(e)
+    }
+}
+
+impl From<DieselError> for FailedJobsError {
+    fn from(e: DieselError) -> Self {
+        FailedJobsError::__Unknown(e.into())
+    }
+}
+
+impl PartialEq for FailedJobsError {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (JobsFailed(x), JobsFailed(y)) => x == y,
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for FailedJobsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use FailedJobsError::*;
+
+        match self {
+            JobsFailed(x) => write!(f, "{x} jobs failed"),
+            FailedJobsError::__Unknown(e) => e.fmt(f),
+        }
+    }
+}
+
+impl Error for FailedJobsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            JobsFailed(_) => None,
+            FailedJobsError::__Unknown(e) => Some(&**e),
+        }
+    }
+}

--- a/src/swirl/runner.rs
+++ b/src/swirl/runner.rs
@@ -1,0 +1,403 @@
+use diesel::prelude::*;
+use diesel::r2d2;
+use diesel::r2d2::ConnectionManager;
+use std::any::Any;
+use std::error::Error;
+use std::panic::{catch_unwind, AssertUnwindSafe, PanicInfo, UnwindSafe};
+use std::sync::mpsc::{sync_channel, SyncSender};
+use std::sync::Arc;
+use std::time::Duration;
+use threadpool::ThreadPool;
+
+use super::errors::*;
+use super::storage;
+use crate::background_jobs::{Environment, Job};
+use crate::db::{DieselPool, DieselPooledConn};
+use event::Event;
+
+mod event;
+
+/// The core runner responsible for locking and running jobs
+pub struct Runner {
+    connection_pool: DieselPool,
+    thread_pool: ThreadPool,
+    environment: Arc<Option<Environment>>,
+    job_start_timeout: Duration,
+}
+
+impl Runner {
+    pub fn production_runner(
+        environment: Environment,
+        url: String,
+        job_start_timeout: u64,
+    ) -> Self {
+        let connection_pool = r2d2::Pool::builder()
+            .max_size(10)
+            .min_idle(Some(0))
+            .build_unchecked(ConnectionManager::new(url));
+        Self {
+            connection_pool: DieselPool::new_background_worker(connection_pool),
+            thread_pool: ThreadPool::new(5),
+            environment: Arc::new(Some(environment)),
+            job_start_timeout: Duration::from_secs(job_start_timeout),
+        }
+    }
+
+    #[cfg(test)]
+    fn internal_test_runner(environment: Option<Environment>, url: String) -> Self {
+        let connection_pool = r2d2::Pool::builder()
+            .max_size(4)
+            .build_unchecked(ConnectionManager::new(url));
+        Self {
+            connection_pool: DieselPool::new_background_worker(connection_pool),
+            thread_pool: ThreadPool::new(2),
+            environment: Arc::new(environment),
+            job_start_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+impl Runner {
+    pub fn test_runner(environment: Environment, connection_pool: DieselPool) -> Self {
+        Self {
+            connection_pool,
+            thread_pool: ThreadPool::new(1),
+            environment: Arc::new(Some(environment)),
+            job_start_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+impl Runner {
+    #[doc(hidden)]
+    /// For use in integration tests
+    pub(super) fn connection_pool(&self) -> &DieselPool {
+        &self.connection_pool
+    }
+}
+
+impl Runner {
+    /// Runs all pending jobs in the queue
+    ///
+    /// This function will return once all jobs in the queue have begun running,
+    /// but does not wait for them to complete. When this function returns, at
+    /// least one thread will have tried to acquire a new job, and found there
+    /// were none in the queue.
+    pub fn run_all_pending_jobs(&self) -> Result<(), FetchError> {
+        use std::cmp::max;
+
+        let max_threads = self.thread_pool.max_count();
+        let (sender, receiver) = sync_channel(max_threads);
+        let mut pending_messages = 0;
+        loop {
+            let available_threads = max_threads - self.thread_pool.active_count();
+
+            let jobs_to_queue = if pending_messages == 0 {
+                // If we have no queued jobs talking to us, and there are no
+                // available threads, we still need to queue at least one job
+                // or we'll never receive a message
+                max(available_threads, 1)
+            } else {
+                available_threads
+            };
+
+            for _ in 0..jobs_to_queue {
+                self.run_single_job(sender.clone());
+            }
+
+            pending_messages += jobs_to_queue;
+            match receiver.recv_timeout(self.job_start_timeout) {
+                Ok(Event::Working) => pending_messages -= 1,
+                Ok(Event::NoJobAvailable) => return Ok(()),
+                Ok(Event::ErrorLoadingJob(e)) => return Err(FetchError::FailedLoadingJob(e)),
+                Ok(Event::FailedToAcquireConnection(e)) => {
+                    return Err(FetchError::NoDatabaseConnection(e));
+                }
+                Err(_) => return Err(FetchError::NoMessageReceived),
+            }
+        }
+    }
+
+    fn run_single_job(&self, sender: SyncSender<Event>) {
+        let environment = self.environment.clone();
+        // FIXME: https://github.com/sfackler/r2d2/pull/70
+        let connection_pool = AssertUnwindSafe(self.connection_pool().clone());
+        self.get_single_job(sender, move |job| {
+            let job = Job::from_value(&job.job_type, job.data)?;
+
+            // Make sure to move the whole `AssertUnwindSafe`
+            let connection_pool = connection_pool;
+            job.perform(&environment, &connection_pool.0)
+        })
+    }
+
+    fn get_single_job<F>(&self, sender: SyncSender<Event>, f: F)
+    where
+        F: FnOnce(storage::BackgroundJob) -> Result<(), PerformError> + Send + UnwindSafe + 'static,
+    {
+        use diesel::result::Error::RollbackTransaction;
+
+        // The connection may not be `Send` so we need to clone the pool instead
+        let pool = self.connection_pool.clone();
+        self.thread_pool.execute(move || {
+            let conn = &*match pool.get() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    // TODO: Review error handling and possibly drop all usage of `let _ =` in this file
+                    let _ = sender.send(Event::FailedToAcquireConnection(e));
+                    return;
+                }
+            };
+
+            let job_run_result = conn.transaction::<_, diesel::result::Error, _>(|| {
+                let job = match storage::find_next_unlocked_job(conn).optional() {
+                    Ok(Some(j)) => {
+                        let _ = sender.send(Event::Working);
+                        j
+                    }
+                    Ok(None) => {
+                        let _ = sender.send(Event::NoJobAvailable);
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        let _ = sender.send(Event::ErrorLoadingJob(e));
+                        return Err(RollbackTransaction);
+                    }
+                };
+                let job_id = job.id;
+
+                let result = catch_unwind(|| f(job))
+                    .map_err(|e| try_to_extract_panic_info(&e))
+                    .and_then(|r| r);
+
+                match result {
+                    Ok(_) => storage::delete_successful_job(conn, job_id)?,
+                    Err(e) => {
+                        eprintln!("Job {job_id} failed to run: {e}");
+                        storage::update_failed_job(conn, job_id);
+                    }
+                }
+                Ok(())
+            });
+
+            match job_run_result {
+                Ok(_) | Err(RollbackTransaction) => {}
+                Err(e) => {
+                    panic!("Failed to update job: {e:?}");
+                }
+            }
+        })
+    }
+
+    fn connection(&self) -> Result<DieselPooledConn<'_>, Box<dyn Error + Send + Sync>> {
+        self.connection_pool.get().map_err(Into::into)
+    }
+
+    /// Waits for all running jobs to complete, and returns an error if any
+    /// failed
+    ///
+    /// This function is intended for use in tests. If any jobs have failed, it
+    /// will return `swirl::JobsFailed` with the number of jobs that failed.
+    ///
+    /// If any other unexpected errors occurred, such as panicked worker threads
+    /// or an error loading the job count from the database, an opaque error
+    /// will be returned.
+    // FIXME: Only public for `src/tests/util/test_app.rs`
+    pub fn check_for_failed_jobs(&self) -> Result<(), FailedJobsError> {
+        self.wait_for_jobs()?;
+        let failed_jobs = storage::failed_job_count(&*self.connection()?)?;
+        if failed_jobs == 0 {
+            Ok(())
+        } else {
+            Err(JobsFailed(failed_jobs))
+        }
+    }
+
+    fn wait_for_jobs(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.thread_pool.join();
+        let panic_count = self.thread_pool.panic_count();
+        if panic_count == 0 {
+            Ok(())
+        } else {
+            Err(format!("{panic_count} threads panicked").into())
+        }
+    }
+}
+
+/// Try to figure out what's in the box, and print it if we can.
+///
+/// The actual error type we will get from `panic::catch_unwind` is really poorly documented.
+/// However, the `panic::set_hook` functions deal with a `PanicInfo` type, and its payload is
+/// documented as "commonly but not always `&'static str` or `String`". So we can try all of those,
+/// and give up if we didn't get one of those three types.
+fn try_to_extract_panic_info(info: &(dyn Any + Send + 'static)) -> PerformError {
+    if let Some(x) = info.downcast_ref::<PanicInfo<'_>>() {
+        format!("job panicked: {x}").into()
+    } else if let Some(x) = info.downcast_ref::<&'static str>() {
+        format!("job panicked: {x}").into()
+    } else if let Some(x) = info.downcast_ref::<String>() {
+        format!("job panicked: {x}").into()
+    } else {
+        "job panicked".into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use diesel::prelude::*;
+    use once_cell::sync::Lazy;
+
+    use super::*;
+    use crate::schema::background_jobs::dsl::*;
+    use std::panic::AssertUnwindSafe;
+    use std::sync::mpsc::{sync_channel, SyncSender};
+    use std::sync::{Arc, Barrier, Mutex, MutexGuard};
+
+    fn dummy_sender<T>() -> SyncSender<T> {
+        sync_channel(1).0
+    }
+
+    #[test]
+    fn jobs_are_locked_when_fetched() {
+        let _guard = TestGuard::lock();
+
+        let runner = runner();
+        let first_job_id = create_dummy_job(&runner).id;
+        let second_job_id = create_dummy_job(&runner).id;
+        let fetch_barrier = Arc::new(AssertUnwindSafe(Barrier::new(2)));
+        let fetch_barrier2 = fetch_barrier.clone();
+        let return_barrier = Arc::new(AssertUnwindSafe(Barrier::new(2)));
+        let return_barrier2 = return_barrier.clone();
+
+        runner.get_single_job(dummy_sender(), move |job| {
+            fetch_barrier.0.wait(); // Tell thread 2 it can lock its job
+            assert_eq!(first_job_id, job.id);
+            return_barrier.0.wait(); // Wait for thread 2 to lock its job
+            Ok(())
+        });
+
+        fetch_barrier2.0.wait(); // Wait until thread 1 locks its job
+        runner.get_single_job(dummy_sender(), move |job| {
+            assert_eq!(second_job_id, job.id);
+            return_barrier2.0.wait(); // Tell thread 1 it can unlock its job
+            Ok(())
+        });
+
+        runner.wait_for_jobs().unwrap();
+    }
+
+    #[test]
+    fn jobs_are_deleted_when_successfully_run() {
+        let _guard = TestGuard::lock();
+
+        let runner = runner();
+        create_dummy_job(&runner);
+
+        runner.get_single_job(dummy_sender(), |_| Ok(()));
+        runner.wait_for_jobs().unwrap();
+
+        let remaining_jobs = background_jobs
+            .count()
+            .get_result(&*runner.connection().unwrap());
+        assert_eq!(Ok(0), remaining_jobs);
+    }
+
+    #[test]
+    fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
+        let _guard = TestGuard::lock();
+
+        let runner = runner();
+        create_dummy_job(&runner);
+        let barrier = Arc::new(AssertUnwindSafe(Barrier::new(2)));
+        let barrier2 = barrier.clone();
+
+        runner.get_single_job(dummy_sender(), move |_| {
+            barrier.0.wait();
+            // error so the job goes back into the queue
+            Err("nope".into())
+        });
+
+        let conn = &*runner.connection().unwrap();
+        // Wait for the first thread to acquire the lock
+        barrier2.0.wait();
+        // We are intentionally not using `get_single_job` here.
+        // `SKIP LOCKED` is intentionally omitted here, so we block until
+        // the lock on the first job is released.
+        // If there is any point where the row is unlocked, but the retry
+        // count is not updated, we will get a row here.
+        let available_jobs = background_jobs
+            .select(id)
+            .filter(retries.eq(0))
+            .for_update()
+            .load::<i64>(conn)
+            .unwrap();
+        assert_eq!(0, available_jobs.len());
+
+        // Sanity check to make sure the job actually is there
+        let total_jobs_including_failed = background_jobs
+            .select(id)
+            .for_update()
+            .load::<i64>(conn)
+            .unwrap();
+        assert_eq!(1, total_jobs_including_failed.len());
+
+        runner.wait_for_jobs().unwrap();
+    }
+
+    #[test]
+    fn panicking_in_jobs_updates_retry_counter() {
+        let _guard = TestGuard::lock();
+        let runner = runner();
+        let job_id = create_dummy_job(&runner).id;
+
+        runner.get_single_job(dummy_sender(), |_| panic!());
+        runner.wait_for_jobs().unwrap();
+
+        let tries = background_jobs
+            .find(job_id)
+            .select(retries)
+            .for_update()
+            .first::<i32>(&*runner.connection().unwrap())
+            .unwrap();
+        assert_eq!(1, tries);
+    }
+
+    // Since these tests deal with behavior concerning multiple connections
+    // running concurrently, they have to run outside of a transaction.
+    // Therefore we can't run more than one at a time.
+    //
+    // Rather than forcing the whole suite to be run with `--test-threads 1`,
+    // we just lock these tests instead.
+    static TEST_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+    struct TestGuard<'a>(MutexGuard<'a, ()>);
+
+    impl<'a> TestGuard<'a> {
+        fn lock() -> Self {
+            TestGuard(TEST_MUTEX.lock().unwrap())
+        }
+    }
+
+    impl<'a> Drop for TestGuard<'a> {
+        fn drop(&mut self) {
+            ::diesel::sql_query("TRUNCATE TABLE background_jobs")
+                .execute(&*runner().connection().unwrap())
+                .unwrap();
+        }
+    }
+
+    fn runner() -> Runner {
+        let database_url =
+            dotenv::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set to run tests");
+
+        super::Runner::internal_test_runner(None, database_url)
+    }
+
+    fn create_dummy_job(runner: &Runner) -> storage::BackgroundJob {
+        ::diesel::insert_into(background_jobs)
+            .values((job_type.eq("Foo"), data.eq(serde_json::json!(null))))
+            .returning((id, job_type, data))
+            .get_result(&*runner.connection().unwrap())
+            .unwrap()
+    }
+}

--- a/src/swirl/runner/event.rs
+++ b/src/swirl/runner/event.rs
@@ -1,0 +1,25 @@
+use std::fmt;
+
+use diesel::result::Error as DieselError;
+
+use crate::db::PoolError;
+
+pub(super) enum Event {
+    Working,
+    NoJobAvailable,
+    ErrorLoadingJob(DieselError),
+    FailedToAcquireConnection(PoolError),
+}
+
+impl fmt::Debug for Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Event::Working => f.debug_struct("Working").finish(),
+            Event::NoJobAvailable => f.debug_struct("NoJobAvailable").finish(),
+            Event::ErrorLoadingJob(e) => f.debug_tuple("ErrorLoadingJob").field(e).finish(),
+            Event::FailedToAcquireConnection(e) => {
+                f.debug_tuple("FailedToAcquireConnection").field(e).finish()
+            }
+        }
+    }
+}

--- a/src/swirl/storage.rs
+++ b/src/swirl/storage.rs
@@ -1,0 +1,67 @@
+use diesel::dsl::now;
+use diesel::pg::Pg;
+use diesel::prelude::*;
+use diesel::sql_types::{Bool, Integer, Interval};
+use diesel::{delete, update};
+
+use crate::schema::{self, background_jobs};
+
+#[derive(Queryable, Identifiable, Debug, Clone)]
+pub(super) struct BackgroundJob {
+    pub(super) id: i64,
+    pub(super) job_type: String,
+    pub(super) data: serde_json::Value,
+}
+
+fn retriable() -> Box<dyn BoxableExpression<background_jobs::table, Pg, SqlType = Bool>> {
+    use diesel::dsl::*;
+    use schema::background_jobs::dsl::*;
+
+    sql_function!(fn power(x: Integer, y: Integer) -> Integer);
+
+    Box::new(last_retry.lt(now - 1.minute().into_sql::<Interval>() * power(2, retries)))
+}
+
+/// Finds the next job that is unlocked, and ready to be retried. If a row is
+/// found, it will be locked.
+pub(super) fn find_next_unlocked_job(conn: &PgConnection) -> QueryResult<BackgroundJob> {
+    use schema::background_jobs::dsl::*;
+
+    background_jobs
+        .select((id, job_type, data))
+        .filter(retriable())
+        .order(id)
+        .for_update()
+        .skip_locked()
+        .first::<BackgroundJob>(conn)
+}
+
+/// The number of jobs that have failed at least once
+pub(super) fn failed_job_count(conn: &PgConnection) -> QueryResult<i64> {
+    use schema::background_jobs::dsl::*;
+
+    background_jobs
+        .count()
+        .filter(retries.gt(0))
+        .get_result(conn)
+}
+
+/// Deletes a job that has successfully completed running
+pub(super) fn delete_successful_job(conn: &PgConnection, job_id: i64) -> QueryResult<()> {
+    use schema::background_jobs::dsl::*;
+
+    delete(background_jobs.find(job_id)).execute(conn)?;
+    Ok(())
+}
+
+/// Marks that we just tried and failed to run a job.
+///
+/// Ignores any database errors that may have occurred. If the DB has gone away,
+/// we assume that just trying again with a new connection will succeed.
+pub(super) fn update_failed_job(conn: &PgConnection, job_id: i64) {
+    use schema::background_jobs::dsl::*;
+
+    let _ = update(background_jobs.find(job_id))
+        .set((retries.eq(retries + 1), last_retry.eq(now)))
+        .execute(conn);
+}

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -4,17 +4,16 @@ use std::{
 };
 
 use self::configuration::VisibilityConfig;
+use crate::{background_jobs::DumpDbJob, swirl::PerformError};
 use crate::{
-    background_jobs::Environment,
+    background_jobs::{Environment, Job},
     uploaders::{UploadBucket, Uploader},
 };
 use reqwest::header;
-use swirl::PerformError;
 
 /// Create CSV dumps of the public information in the database, wrap them in a
 /// tarball and upload to S3.
-#[swirl::background_job]
-pub fn dump_db(
+pub fn perform_dump_db(
     env: &Environment,
     database_url: String,
     target_name: String,
@@ -31,6 +30,13 @@ pub fn dump_db(
     let size = tarball.upload(&target_name, &env.uploader)?;
     info!("Database dump uploaded {} bytes to {}.", size, &target_name);
     Ok(())
+}
+
+pub fn dump_db(database_url: String, target_name: String) -> Job {
+    Job::DumpDb(DumpDbJob {
+        database_url,
+        target_name,
+    })
 }
 
 /// Manage the export directory.

--- a/src/worker/dump_db/gen_scripts.rs
+++ b/src/worker/dump_db/gen_scripts.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, path::Path};
 
+use crate::swirl::PerformError;
 use crate::worker::dump_db::configuration::{ColumnVisibility, TableConfig, VisibilityConfig};
-use swirl::PerformError;
 
 pub fn gen_scripts(export_script: &Path, import_script: &Path) -> Result<(), PerformError> {
     let config = VisibilityConfig::get();

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -15,3 +15,12 @@ pub use dump_db::dump_db;
 pub use git::{add_crate, squash_index, sync_yanked};
 pub use readmes::render_and_upload_readme;
 pub use update_downloads::update_downloads;
+
+pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
+pub(crate) use dump_db::perform_dump_db;
+pub(crate) use git::{
+    perform_index_add_crate, perform_index_squash, perform_index_sync_to_http,
+    perform_index_update_yanked,
+};
+pub(crate) use readmes::perform_render_and_upload_readme;
+pub(crate) use update_downloads::perform_update_downloads;

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -1,30 +1,25 @@
 //! Render README files to HTML.
 
+use crate::swirl::PerformError;
 use cargo_registry_markdown::text_to_html;
-use swirl::PerformError;
+use diesel::PgConnection;
 
-use crate::background_jobs::Environment;
+use crate::background_jobs::{Environment, Job, RenderAndUploadReadmeJob};
 use crate::models::Version;
 
-#[swirl::background_job]
-pub fn render_and_upload_readme(
+pub fn perform_render_and_upload_readme(
     conn: &PgConnection,
     env: &Environment,
     version_id: i32,
-    text: String,
-    readme_path: String,
-    base_url: Option<String>,
-    pkg_path_in_vcs: Option<String>,
+    text: &str,
+    readme_path: &str,
+    base_url: Option<&str>,
+    pkg_path_in_vcs: Option<&str>,
 ) -> Result<(), PerformError> {
     use crate::schema::*;
     use diesel::prelude::*;
 
-    let rendered = text_to_html(
-        &text,
-        &readme_path,
-        base_url.as_deref(),
-        pkg_path_in_vcs.as_deref(),
-    );
+    let rendered = text_to_html(text, readme_path, base_url, pkg_path_in_vcs);
 
     conn.transaction(|| {
         Version::record_readme_rendering(version_id, conn)?;
@@ -36,5 +31,21 @@ pub fn render_and_upload_readme(
         env.uploader
             .upload_readme(env.http_client(), &crate_name, &vers, rendered)?;
         Ok(())
+    })
+}
+
+pub fn render_and_upload_readme(
+    version_id: i32,
+    text: String,
+    readme_path: String,
+    base_url: Option<String>,
+    pkg_path_in_vcs: Option<String>,
+) -> Job {
+    Job::RenderAndUploadReadme(RenderAndUploadReadmeJob {
+        version_id,
+        text,
+        readme_path,
+        base_url,
+        pkg_path_in_vcs,
     })
 }

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -3,13 +3,17 @@ use crate::{
     schema::{crates, metadata, version_downloads, versions},
 };
 
+use crate::background_jobs::{Job, UpdateDownloadsJob};
+use crate::swirl::PerformError;
 use diesel::prelude::*;
-use swirl::PerformError;
 
-#[swirl::background_job]
-pub fn update_downloads(conn: &PgConnection) -> Result<(), PerformError> {
+pub fn perform_update_downloads(conn: &PgConnection) -> Result<(), PerformError> {
     update(conn)?;
     Ok(())
+}
+
+pub fn update_downloads() -> Job {
+    Job::UpdateDownloads(UpdateDownloadsJob {})
 }
 
 fn update(conn: &PgConnection) -> QueryResult<()> {


### PR DESCRIPTION
This PR vendors about 800 lines of code (of which ~150 are tests). This PR is split off from my port to diesel 2.0. In particular, the new version of diesel requires that a `&mut PgConnection` be passed around and it should be much easier to finish that port once we can modify this in-tree.

This also addresses a long standing pain point, which is that due to the use of `inventory` the background workers (and thus a lot of unnecessary dependencies) end up linked into every binary increasing build times and file sizes.

The amount of additional code for us to maintain can probably be trimmed further. For now I've simply extracted this from my `diesel2` branch and made sure it compiles and I think this is ready for initial review. Locally, 4 of the `unhealthy_database` tests are failing for me, but I'm also seeing that intermittently on master so it could be my local setup.

Reduction in release binaries:
* background-worker: 27M, unchanged
* crates-admin: 29M to 27M
* enqueue-job: 25M to 14M
* monitor: 25M to 18M
* server: 35M to 30M