### PR TITLE
downloads_counter: Remove `hashbrown` reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,6 @@ dependencies = [
  "flate2",
  "futures-channel",
  "futures-util",
- "hashbrown",
  "hex",
  "http",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ dotenv = "=0.15.0"
 flate2 = "=1.0.24"
 futures-channel = { version = "=0.3.25", default-features = false }
 futures-util = "=0.3.25"
-hashbrown = { version = "=0.12.3", default-features = false }
 hex = "=0.4.3"
 http = "=0.2.8"
 hyper = { version = "=0.14.23", features = ["client", "http1"] }

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -97,10 +97,10 @@ impl DownloadsCounter {
         Ok(stats)
     }
 
-    fn persist_shard(
+    fn persist_shard<'a, Iter: Iterator<Item = (&'a i32, &'a SharedValue<AtomicUsize>)>>(
         &self,
         conn: &PgConnection,
-        shard: hashbrown::hash_map::Iter<'_, i32, SharedValue<AtomicUsize>>,
+        shard: Iter,
     ) -> Result<PersistStats, Error> {
         use crate::schema::{version_downloads, versions};
 


### PR DESCRIPTION
Ideally `dashmap` would reexport the iterator types so that we can use them directly, but instead we will use generics to pass the iterator into the `persist_shard()` function. This allows us to get rid of the direct `hashbrown` dependency, which solves the version conflict with their latest release.