### PR TITLE
CI: Remove `beta` backend scenario

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,6 @@ jobs:
     name: Backend
     runs-on: ubuntu-20.04
 
-    continue-on-error: ${{ matrix.rust != 'stable' }}
-    strategy:
-      matrix:
-        rust:
-          - stable
-          - beta
-
     env:
       RUST_BACKTRACE: 1
       DATABASE_URL: postgres://postgres:postgres@localhost/cargo_registry_test
@@ -109,17 +102,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
 
-      - name: Install ${{ env.RUST_VERSION }} Rust
-        if: matrix.rust == 'stable'
+      - name: Install Rust
         run: |
           rustup update ${{ env.RUST_VERSION }}
           rustup default ${{ env.RUST_VERSION }}
-
-      - name: Install ${{ matrix.rust }} Rust
-        if: matrix.rust != 'stable'
-        run: |
-          rustup update ${{ matrix.rust }}
-          rustup default ${{ matrix.rust }}
 
       - uses: Swatinem/rust-cache@v2.2.0
 


### PR DESCRIPTION
Since the scenario has been marked as `continue-on-error` it wouldn't show up as a failure in the GitHub UI, and the number of times that this has caught any issues with the beta cycle of Rust itself in the past few years is very close to zero. Rust is using crater runs to determine incompatibilities with public projects, which includes crates.io. In conclusion, this scenario is mostly just wasting CI resources but brings very little value.