### PR TITLE
cloudfront: Retry requests on server or network error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "prometheus",
  "rand",
  "reqwest",
+ "retry",
  "scheduled-thread-pool",
  "semver 1.0.14",
  "sentry",
@@ -2377,6 +2378,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "retry"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
+dependencies = [
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ parking_lot = "=0.12.1"
 prometheus = { version = "=0.13.3", default-features = false }
 rand = "=0.8.5"
 reqwest = { version = "=0.11.12", features = ["blocking", "gzip", "json"] }
+retry = "=2.0.0"
 scheduled-thread-pool = "=0.2.6"
 semver = { version = "=1.0.14", features = ["serde"] }
 sentry = { version = "=0.28.0", features = ["tracing"] }

--- a/src/worker/cloudfront.rs
+++ b/src/worker/cloudfront.rs
@@ -6,6 +6,8 @@ use aws_sigv4::{
     SigningParams,
 };
 use reqwest::blocking::Client;
+use retry::delay::{jitter, Exponential};
+use retry::OperationResult;
 
 #[derive(Clone)]
 pub struct CloudFront {
@@ -35,9 +37,16 @@ impl CloudFront {
             "https://cloudfront.amazonaws.com/2020-05-31/distribution/{}/invalidation",
             self.distribution_id
         );
-        let now = chrono::offset::Utc::now().timestamp_micros();
-        let body = format!(
-            r#"
+
+        let backoff = Exponential::from_millis(1000).map(jitter).take(2);
+        retry::retry_with_index(backoff, |attempt| {
+            if attempt > 1 {
+                debug!(?attempt, "Retrying CloudFront invalidation…")
+            }
+
+            let now = chrono::offset::Utc::now().timestamp_micros();
+            let body = format!(
+                r#"
 <?xml version="1.0" encoding="UTF-8"?>
 <InvalidationBatch xmlns="http://cloudfront.amazonaws.com/doc/2020-05-31/">
     <CallerReference>{now}</CallerReference>
@@ -49,30 +58,61 @@ impl CloudFront {
     </Paths>
 </InvalidationBatch>
 "#
-        );
+            );
 
-        let request = http::Request::post(&url).body(&body)?;
-        let request = SignableRequest::from(&request);
-        let params = SigningParams::builder()
-            .access_key(&self.access_key)
-            .secret_key(&self.secret_key)
-            .region("us-east-1") // cloudfront is a regionless service, use the default region for signing.
-            .service_name("cloudfront")
-            .settings(SigningSettings::default())
-            .time(SystemTime::now())
-            .build()
-            .unwrap(); // all required fields are set
-        let (mut signature_headers, _) = http_request::sign(request, &params).unwrap().into_parts();
-        let response = client
-            .post(url)
-            .headers(signature_headers.take_headers().unwrap_or_default())
-            .body(body)
-            .send()?;
-        if let Some(err) = response.error_for_status_ref().err() {
-            let headers = format!("{:?}", response.headers());
-            let body = response.text()?;
-            return Err(err).context(format!("{headers}; body: {body}"));
-        }
-        Ok(())
+            let request = match http::Request::post(&url)
+                .body(&body)
+                .context("Failed to construct HTTP request")
+            {
+                Ok(request) => request,
+                Err(error) => return OperationResult::Err(error),
+            };
+
+            let request = SignableRequest::from(&request);
+            let params = SigningParams::builder()
+                .access_key(&self.access_key)
+                .secret_key(&self.secret_key)
+                .region("us-east-1") // cloudfront is a regionless service, use the default region for signing.
+                .service_name("cloudfront")
+                .settings(SigningSettings::default())
+                .time(SystemTime::now())
+                .build()
+                .unwrap(); // all required fields are set
+
+            let (mut signature_headers, _) =
+                http_request::sign(request, &params).unwrap().into_parts();
+
+            let response = match client
+                .post(&url)
+                .headers(signature_headers.take_headers().unwrap_or_default())
+                .body(body)
+                .send()
+                .context("Failed to send invalidation request")
+            {
+                Ok(response) => response,
+                Err(error) => return OperationResult::Retry(error),
+            };
+
+            let status = response.status();
+
+            let result = match response.error_for_status_ref() {
+                Ok(_) => Ok(()),
+                Err(error) => {
+                    let headers = format!("{:?}", response.headers());
+                    let body = response
+                        .text()
+                        .unwrap_or_else(|_| "Failed to decode response payload".to_string());
+
+                    Err(error).context(format!("{headers}; body: {body}"))
+                }
+            };
+
+            match result {
+                Ok(_) => OperationResult::Ok(()),
+                Err(error) if status.is_server_error() => OperationResult::Retry(error),
+                Err(error) => OperationResult::Err(error),
+            }
+        })
+        .map_err(|error| error.error)
     }
 }


### PR DESCRIPTION
While testing out invalidations for the HTTP-based crate index we noticed that the CloudFront server often returns 503 errors. The official (but still experimental) AWS SDK uses a default request retry policy (max. 3 attempts, exponential backoff with 1 sec base delay) to apparently avoid these issues. This PR introduces the `retry` dependency and uses it with a similar retry policy for the CloudFront requests.

/cc @arlosi 