### PR TITLE
tracing: Use `tracing-logfmt` to output log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ dependencies = [
  "toml",
  "tower-service",
  "tracing",
+ "tracing-logfmt",
  "tracing-subscriber",
  "url",
 ]
@@ -3307,6 +3308,18 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-logfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08aacc136419ba433b3f9bfd434a1bb62fe385328935e6ac11d952122b8a8cb"
+dependencies = [
+ "time 0.3.17",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ thiserror = "=1.0.37"
 tokio = { version = "=1.21.2", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.5.9"
 tracing = "=0.1.37"
+tracing-logfmt = "=0.2.0"
 tracing-subscriber = { version = "=0.3.16", features = ["env-filter"] }
 url = "=2.3.1"
 

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -40,7 +40,7 @@ fn main() {
     let sentry_filter = filter::Targets::new().with_default(Level::INFO);
 
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_filter(log_filter))
+        .with(tracing_logfmt::layer().with_filter(log_filter))
         .with(sentry::integrations::tracing::layer().with_filter(sentry_filter))
         .init();
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let sentry_filter = filter::Targets::new().with_default(Level::INFO);
 
     tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_filter(log_filter))
+        .with(tracing_logfmt::layer().with_filter(log_filter))
         .with(sentry::integrations::tracing::layer().with_filter(sentry_filter))
         .init();
 


### PR DESCRIPTION
This matches the log message style used by Heroku itself. Unfortunately it is not quite configurable yet, but it's a step in the right direction :)

### Example

<img width="1321" alt="Bildschirmfoto 2022-11-17 um 21 47 04" src="https://user-images.githubusercontent.com/141300/202556428-a4b1e813-2f89-47bf-9a16-f8bdf99ffeee.png">
