### PR TITLE
me/pending-invites: Use `GET /api/private/crate_owner_invitations` endpoint

### DIFF
--- a/app/adapters/crate-owner-invite.js
+++ b/app/adapters/crate-owner-invite.js
@@ -6,4 +6,8 @@ export default class CrateOwnerInviteAdapter extends ApplicationAdapter {
   pathForType() {
     return 'crate_owner_invitations';
   }
+
+  urlForQuery() {
+    return '/api/private/crate_owner_invitations';
+  }
 }

--- a/app/routes/me/pending-invites.js
+++ b/app/routes/me/pending-invites.js
@@ -3,9 +3,11 @@ import { inject as service } from '@ember/service';
 import AuthenticatedRoute from '../-authenticated-route';
 
 export default class PendingInvitesRoute extends AuthenticatedRoute {
+  @service session;
   @service store;
 
   model() {
-    return this.store.findAll('crate-owner-invite');
+    let user = this.session.currentUser;
+    return this.store.query('crate-owner-invite', { invitee_id: user.id });
   }
 }


### PR DESCRIPTION
This is related to https://github.com/rust-lang/crates.io/issues/4083 and switches the frontend over to the new endpoint. All that is missing after this PR is to add pagination support to the frontend.

/cc @EstebanBorai 