### PR TITLE
Fix documentation URL blocking for substring domains

### DIFF
--- a/src/views.rs
+++ b/src/views.rs
@@ -361,11 +361,16 @@ impl EncodableCrate {
 fn domain_is_blocked(domain: &str) -> bool {
     DOCUMENTATION_BLOCKLIST
         .iter()
-        .any(|blocked| domain_is_subdomain(domain, blocked))
+        .any(|blocked| &domain == blocked || domain_is_subdomain(domain, blocked))
 }
 
 fn domain_is_subdomain(potential_subdomain: &str, root: &str) -> bool {
-    potential_subdomain.ends_with(root)
+    if !potential_subdomain.ends_with(root) {
+        return false;
+    }
+
+    let root_with_prefix = format!(".{root}");
+    potential_subdomain.ends_with(&root_with_prefix)
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -916,5 +921,12 @@ mod tests {
             ),),),
             None
         );
+    }
+
+    #[test]
+    fn documentation_blocked_non_subdomain() {
+        let input = Some(String::from("http://foorust-ci.org/"));
+        let result = EncodableCrate::remove_blocked_documentation_urls(input);
+        assert_some_eq!(result, "http://foorust-ci.org/");
     }
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -350,15 +350,18 @@ impl EncodableCrate {
         };
 
         // Match documentation URL host against blocked host array elements
-        if DOCUMENTATION_BLOCKLIST
-            .iter()
-            .any(|blocked| url_host.ends_with(blocked))
-        {
+        if domain_is_blocked(url_host) {
             None
         } else {
             Some(url)
         }
     }
+}
+
+fn domain_is_blocked(domain: &str) -> bool {
+    DOCUMENTATION_BLOCKLIST
+        .iter()
+        .any(|blocked| domain.ends_with(blocked))
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -361,7 +361,11 @@ impl EncodableCrate {
 fn domain_is_blocked(domain: &str) -> bool {
     DOCUMENTATION_BLOCKLIST
         .iter()
-        .any(|blocked| domain.ends_with(blocked))
+        .any(|blocked| domain_is_subdomain(domain, blocked))
+}
+
+fn domain_is_subdomain(potential_subdomain: &str, root: &str) -> bool {
+    potential_subdomain.ends_with(root)
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
#5502 was causing false positives due to the simplified `ends_with()` usage. This PR fixes it by checking against `.{domain}` instead, but avoids unnecessary allocations by performing the original check first.