### PR TITLE
Extract `tracing::init()` function

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -18,12 +18,9 @@ use cargo_registry::{background_jobs::*, db};
 use cargo_registry_index::{Repository, RepositoryConfig};
 use diesel::r2d2;
 use reqwest::blocking::Client;
-use std::env;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
-use tracing::Level;
-use tracing_subscriber::{filter, prelude::*};
 
 fn main() {
     println!("Booting runner");
@@ -31,18 +28,7 @@ fn main() {
     let _sentry = cargo_registry::sentry::init();
 
     // Initialize logging
-
-    let log_filter = env::var("RUST_LOG")
-        .unwrap_or_default()
-        .parse::<filter::Targets>()
-        .expect("Invalid RUST_LOG value");
-
-    let sentry_filter = filter::Targets::new().with_default(Level::INFO);
-
-    tracing_subscriber::registry()
-        .with(tracing_logfmt::layer().with_filter(log_filter))
-        .with(sentry::integrations::tracing::layer().with_filter(sentry_filter))
-        .init();
+    cargo_registry::util::tracing::init();
 
     let config = config::Server::default();
     let uploader = config.base.uploader();

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::{env_optional, metrics::LogEncoder, util::errors::AppResult, App, Env};
-use std::{env, fs::File, process::Command, sync::Arc, time::Duration};
+use std::{fs::File, process::Command, sync::Arc, time::Duration};
 
 use conduit_hyper::Service;
 use futures_util::future::FutureExt;
@@ -10,8 +10,6 @@ use reqwest::blocking::Client;
 use std::io::{self, Write};
 use tokio::io::AsyncWriteExt;
 use tokio::signal::unix::{signal, SignalKind};
-use tracing::Level;
-use tracing_subscriber::{filter, prelude::*};
 
 const CORE_THREADS: usize = 4;
 
@@ -19,18 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _sentry = cargo_registry::sentry::init();
 
     // Initialize logging
-
-    let log_filter = env::var("RUST_LOG")
-        .unwrap_or_default()
-        .parse::<filter::Targets>()
-        .expect("Invalid RUST_LOG value");
-
-    let sentry_filter = filter::Targets::new().with_default(Level::INFO);
-
-    tracing_subscriber::registry()
-        .with(tracing_logfmt::layer().with_filter(log_filter))
-        .with(sentry::integrations::tracing::layer().with_filter(sentry_filter))
-        .init();
+    cargo_registry::util::tracing::init();
 
     let config = cargo_registry::config::Server::default();
     let env = config.env();

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,6 +13,7 @@ mod request_helpers;
 mod request_proxy;
 pub mod rfc3339;
 pub(crate) mod token;
+pub mod tracing;
 
 pub type AppResponse = Response<conduit::Body>;
 pub type EndpointResult = Result<AppResponse, Box<dyn errors::AppError>>;

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,6 +1,5 @@
-use std::env;
 use tracing::Level;
-use tracing_subscriber::{filter, prelude::*};
+use tracing_subscriber::{filter, prelude::*, EnvFilter};
 
 /// Initializes the `tracing` logging framework.
 ///
@@ -10,10 +9,7 @@ use tracing_subscriber::{filter, prelude::*};
 /// This function also sets up the Sentry error reporting integration for the
 /// `tracing` framework, which is hardcoded to include all `INFO` level events.
 pub fn init() {
-    let log_filter = env::var("RUST_LOG")
-        .unwrap_or_default()
-        .parse::<filter::Targets>()
-        .expect("Invalid RUST_LOG value");
+    let log_filter = EnvFilter::from_default_env();
 
     let sentry_filter = filter::Targets::new().with_default(Level::INFO);
 

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,5 +1,5 @@
-use tracing::Level;
-use tracing_subscriber::{filter, prelude::*, EnvFilter};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::{prelude::*, EnvFilter};
 
 /// Initializes the `tracing` logging framework.
 ///
@@ -11,7 +11,7 @@ use tracing_subscriber::{filter, prelude::*, EnvFilter};
 pub fn init() {
     let log_filter = EnvFilter::from_default_env();
 
-    let sentry_filter = filter::Targets::new().with_default(Level::INFO);
+    let sentry_filter = LevelFilter::INFO;
 
     tracing_subscriber::registry()
         .with(tracing_logfmt::layer().with_filter(log_filter))

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -9,12 +9,12 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 /// This function also sets up the Sentry error reporting integration for the
 /// `tracing` framework, which is hardcoded to include all `INFO` level events.
 pub fn init() {
-    let log_filter = EnvFilter::from_default_env();
+    let log_layer = tracing_logfmt::layer().with_filter(EnvFilter::from_default_env());
 
-    let sentry_filter = LevelFilter::INFO;
+    let sentry_layer = sentry::integrations::tracing::layer().with_filter(LevelFilter::INFO);
 
     tracing_subscriber::registry()
-        .with(tracing_logfmt::layer().with_filter(log_filter))
-        .with(sentry::integrations::tracing::layer().with_filter(sentry_filter))
+        .with(log_layer)
+        .with(sentry_layer)
         .init();
 }

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,0 +1,24 @@
+use std::env;
+use tracing::Level;
+use tracing_subscriber::{filter, prelude::*};
+
+/// Initializes the `tracing` logging framework.
+///
+/// Regular CLI output is influenced by the
+/// [`RUST_LOG`](tracing_subscriber::filter::EnvFilter) environment variable.
+///
+/// This function also sets up the Sentry error reporting integration for the
+/// `tracing` framework, which is hardcoded to include all `INFO` level events.
+pub fn init() {
+    let log_filter = env::var("RUST_LOG")
+        .unwrap_or_default()
+        .parse::<filter::Targets>()
+        .expect("Invalid RUST_LOG value");
+
+    let sentry_filter = filter::Targets::new().with_default(Level::INFO);
+
+    tracing_subscriber::registry()
+        .with(tracing_logfmt::layer().with_filter(log_filter))
+        .with(sentry::integrations::tracing::layer().with_filter(sentry_filter))
+        .init();
+}


### PR DESCRIPTION
This allows us to share the same code between the `server` and `background-worker` binary.