### PR TITLE
bin/crates-admin: Initialize Sentry and logging framework

### DIFF
--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -28,6 +28,11 @@ enum SubCommand {
 }
 
 fn main() -> anyhow::Result<()> {
+    let _sentry = cargo_registry::sentry::init();
+
+    // Initialize logging
+    cargo_registry::util::tracing::init();
+
     use clap::Parser;
 
     let opts: Opts = Opts::parse();


### PR DESCRIPTION
just like the `server` and `background-worker` binaries, the `crates-admin` binary should also send error details to Sentry and let `tracing` output logs