### PR TITLE
tracing: Use `compact` formatter instead of `logfmt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,6 @@ dependencies = [
  "toml",
  "tower-service",
  "tracing",
- "tracing-logfmt",
  "tracing-subscriber",
  "url",
 ]
@@ -3307,18 +3306,6 @@ dependencies = [
  "lazy_static",
  "log",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-logfmt"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08aacc136419ba433b3f9bfd434a1bb62fe385328935e6ac11d952122b8a8cb"
-dependencies = [
- "time 0.3.17",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ thiserror = "=1.0.37"
 tokio = { version = "=1.22.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.5.9"
 tracing = "=0.1.37"
-tracing-logfmt = "=0.2.0"
 tracing-subscriber = { version = "=0.3.16", features = ["env-filter"] }
 url = "=2.3.1"
 

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -9,7 +9,10 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 /// This function also sets up the Sentry error reporting integration for the
 /// `tracing` framework, which is hardcoded to include all `INFO` level events.
 pub fn init() {
-    let log_layer = tracing_logfmt::layer().with_filter(EnvFilter::from_default_env());
+    let log_layer = tracing_subscriber::fmt::layer()
+        .compact()
+        .without_time()
+        .with_filter(EnvFilter::from_default_env());
 
     let sentry_layer = sentry::integrations::tracing::layer().with_filter(LevelFilter::INFO);
 


### PR DESCRIPTION
The `logfmt` formatter was introduced in https://github.com/rust-lang/crates.io/pull/5491, but after discussing this with the crates.io team last week we figured that we're not necessarily fixed on this format.

The built-in [`compact` format](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Compact.html) is a bit easier on the eyes, but still allows us to extract context variables, if necessary, so we're switching to that for now.