### PR TITLE
middleware::log_request: Skip `status` logging for successful download requests

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -77,8 +77,10 @@ impl Display for RequestLine<'_> {
         line.add_field("method", self.req.method())?;
         line.add_quoted_field("path", FullPath(self.req))?;
 
+        let is_download_endpoint = self.req.path().ends_with("/download");
+
         // The request_id is not logged for successful download requests
-        if !(self.req.path().ends_with("/download") && status.is_redirection()) {
+        if !(is_download_endpoint && status.is_redirection()) {
             line.add_field("request_id", request_header(self.req, "x-request-id"))?;
         }
 

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -91,7 +91,12 @@ impl Display for RequestLine<'_> {
         if let Some(response_time) = response_time {
             line.add_field("service", response_time)?;
         }
-        line.add_field("status", status.as_str())?;
+
+        // The `status` is not logged for successful download requests
+        if !is_download_redirect {
+            line.add_field("status", status.as_str())?;
+        }
+
         line.add_quoted_field("user_agent", request_header(self.req, header::USER_AGENT))?;
 
         CUSTOM_METADATA.with(|metadata| {

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -78,9 +78,10 @@ impl Display for RequestLine<'_> {
         line.add_quoted_field("path", FullPath(self.req))?;
 
         let is_download_endpoint = self.req.path().ends_with("/download");
+        let is_download_redirect = is_download_endpoint && status.is_redirection();
 
         // The request_id is not logged for successful download requests
-        if !(is_download_endpoint && status.is_redirection()) {
+        if !is_download_redirect {
             line.add_field("request_id", request_header(self.req, "x-request-id"))?;
         }
 


### PR DESCRIPTION
We are once again near the cap of what our logging provider allows us to send per day, so this PR is trying to save a few more bytes.

Our most hit endpoint is the crate download endpoint, so optimizing this can have significant returns. This PR removes the `status` field from our log lines for requests that hit the download endpoint and are regular redirections. If the request fails we'll still log it the same as we used to before this PR.