### PR TITLE
Migrate more `println!()` calls to use `tracing` instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tracing",
  "url",
 ]
 

--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -20,5 +20,6 @@ dotenv = "=0.15.0"
 git2 = "=0.15.0"
 serde = { version = "=1.0.147", features = ["derive"] }
 tempfile = "=3.3.0"
+tracing = "=0.1.37"
 url = "=2.3.1"
 serde_json = { version = "=1.0.89", optional = true }

--- a/src/admin/migrate.rs
+++ b/src/admin/migrate.rs
@@ -23,7 +23,7 @@ pub fn run(_opts: Opts) -> Result<(), Error> {
         // TODO: Check `any_pending_migrations()` with a read-only connection and error if true.
         // It looks like this requires changes upstream to make this pub in `migration_macros`.
 
-        println!("==> Skipping migrations and category sync (read-only mode)");
+        warn!("Skipping migrations and category sync (read-only mode)");
 
         // The service is undergoing maintenance or mitigating an outage.
         // Exit with success to ensure configuration changes can be made.
@@ -34,10 +34,10 @@ pub fn run(_opts: Opts) -> Result<(), Error> {
     // The primary is online, access directly via `DATABASE_URL`.
     let conn = crate::db::oneoff_connection_with_config(&config)?;
 
-    println!("==> migrating the database");
+    info!("Migrating the database");
     embedded_migrations::run_with_output(&conn, &mut std::io::stdout())?;
 
-    println!("==> synchronizing crate categories");
+    info!("Synchronizing crate categories");
     crate::boot::categories::sync_with_connection(CATEGORIES_TOML, &conn).unwrap();
 
     Ok(())

--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -38,13 +38,13 @@ impl Base {
                     // for the related S3 environment variables and configure the app to upload to
                     // and read from S3 like production does. All values except for bucket are
                     // optional, like production read-only mirrors.
-                    println!("Using S3 uploader");
+                    info!("Using S3 uploader");
                     Self::s3_maybe_read_only()
                 } else {
                     // If we don't set the `S3_BUCKET` variable, we'll use a development-only
                     // uploader that makes it possible to run and publish to a locally-running
                     // crates.io instance without needing to set up an account and a bucket in S3.
-                    println!(
+                    info!(
                         "Using local uploader, crate files will be in the local_uploads directory"
                     );
                     Uploader::Local

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -90,12 +90,10 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     if let Ok(capacity) = env::var("DB_PRIMARY_POOL_SIZE") {
         if let Ok(capacity) = capacity.parse() {
             if capacity >= 10 {
-                println!("Enabling BalanceCapacity middleware with {capacity} pool capacity");
+                info!(?capacity, "Enabling BalanceCapacity middleware");
                 m.around(balance_capacity::BalanceCapacity::new(capacity))
             } else {
-                println!(
-                    "BalanceCapacity middleware not enabled. DB_PRIMARY_POOL_SIZE is too low."
-                );
+                info!("BalanceCapacity middleware not enabled. DB_PRIMARY_POOL_SIZE is too low.");
             }
         }
     }

--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -197,7 +197,10 @@ where
             // If we expect the port number to be logged into this stream, look for it and send it
             // over the channel as soon as it's found.
             if let Some(port_send) = &port_send {
-                if let Some(url) = line.strip_prefix("Listening at ") {
+                let pattern = "Listening at ";
+                if let Some(idx) = line.find(pattern) {
+                    let start = idx + pattern.len();
+                    let url = &line[start..];
                     let url = Url::parse(url).unwrap();
                     let port = url.port().unwrap();
                     port_send

--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -121,6 +121,7 @@ impl ServerBin {
         let mut process = Command::new(env!("CARGO_BIN_EXE_server"))
             .env_clear()
             .envs(self.env.into_iter())
+            .env("RUST_LOG", "info")
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()?;


### PR DESCRIPTION
This lets us turn the logging on and off with an env var, allows us to have multiple log levels, integrates well with Sentry and makes it easier to log variables in a structured way.

Note that two small changes to the `server_binary` test file were necessary, because it is listening for a specific log line, which slightly changed within the context of this PR.