### PR TITLE
middleware::log_request: Use `tracing` macros instead of `println!()`

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -32,7 +32,8 @@ impl Middleware for LogRequests {
     }
 
     fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
-        println!("{}", RequestLine { req, res: &res });
+        let request_line = RequestLine::new(req, &res);
+        println!("{request_line}");
 
         res
     }
@@ -58,6 +59,15 @@ pub(crate) fn get_log_message(key: &'static str) -> String {
 struct RequestLine<'r> {
     req: &'r dyn RequestExt,
     res: &'r AfterResult,
+}
+
+impl<'a> RequestLine<'a> {
+    fn new(request: &'a dyn RequestExt, response: &'a AfterResult) -> Self {
+        RequestLine {
+            req: request,
+            res: response,
+        }
+    }
 }
 
 impl Display for RequestLine<'_> {

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -32,8 +32,7 @@ impl Middleware for LogRequests {
     }
 
     fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
-        let request_line = RequestLine::new(req, &res);
-        println!("{request_line}");
+        RequestLine::new(req, &res).log();
 
         res
     }
@@ -67,6 +66,10 @@ impl<'a> RequestLine<'a> {
             req: request,
             res: response,
         }
+    }
+
+    fn log(&self) {
+        println!("{self}");
     }
 }
 

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -58,18 +58,27 @@ pub(crate) fn get_log_message(key: &'static str) -> String {
 struct RequestLine<'r> {
     req: &'r dyn RequestExt,
     res: &'r AfterResult,
+    status: StatusCode,
 }
 
 impl<'a> RequestLine<'a> {
     fn new(request: &'a dyn RequestExt, response: &'a AfterResult) -> Self {
+        let status = response.as_ref().map(|res| res.status());
+        let status = status.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
         RequestLine {
             req: request,
             res: response,
+            status,
         }
     }
 
     fn log(&self) {
-        println!("{self}");
+        if self.status.is_server_error() {
+            error!(target: "http", "{self}");
+        } else {
+            info!(target: "http", "{self}");
+        };
     }
 }
 
@@ -77,21 +86,11 @@ impl Display for RequestLine<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut line = LogLine::new(f);
 
-        let status = self.res.as_ref().map(|res| res.status());
-        let status = status.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-
-        let at = if status.is_server_error() {
-            "error"
-        } else {
-            "info"
-        };
-
-        line.add_field("at", at)?;
         line.add_field("method", self.req.method())?;
         line.add_quoted_field("path", FullPath(self.req))?;
 
         let is_download_endpoint = self.req.path().ends_with("/download");
-        let is_download_redirect = is_download_endpoint && status.is_redirection();
+        let is_download_redirect = is_download_endpoint && self.status.is_redirection();
 
         // The request_id is not logged for successful download requests
         if !is_download_redirect {
@@ -107,7 +106,7 @@ impl Display for RequestLine<'_> {
 
         // The `status` is not logged for successful download requests
         if !is_download_redirect {
-            line.add_field("status", status.as_str())?;
+            line.add_field("status", self.status.as_str())?;
         }
 
         line.add_quoted_field("user_agent", request_header(self.req, header::USER_AGENT))?;


### PR DESCRIPTION
<img width="1126" alt="Bildschirmfoto 2022-11-22 um 18 30 10" src="https://user-images.githubusercontent.com/141300/203381835-8b40c3e7-c40c-4a1e-a3de-e2c8ad6640e2.png">

this is roughly similar to the old logging but uses tracing log levels instead of the `at` field at the front. the fields themselves are not converted to `tracing` fields (yet), because we have some fields that we only optionally log, which is a little bit harder to do with `tracing`.