### PR TITLE
tests: Adjust logging

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -324,7 +324,7 @@ impl TestAppBuilder {
 
 pub fn init_logger() {
     let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_max_level(tracing::Level::INFO)
         .without_time()
         .with_test_writer()
         .try_init();

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -324,6 +324,7 @@ impl TestAppBuilder {
 
 pub fn init_logger() {
     let _ = tracing_subscriber::fmt()
+        .compact()
         .with_max_level(tracing::Level::INFO)
         .without_time()
         .with_test_writer()


### PR DESCRIPTION
This PR adjusts the `tracing` logger of the test suite to also use the `compact` formatter (same as in production) and always output `info` level messages and anything above that.