### PR TITLE
tests/server_binary: Use `.context()` to enhance error message

### DIFF
--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -1,6 +1,6 @@
 use crate::builders::CrateBuilder;
 use crate::util::{ChaosProxy, FreshSchema};
-use anyhow::Error;
+use anyhow::{Context, Error};
 use cargo_registry::models::{NewUser, User};
 use diesel::prelude::*;
 use reqwest::blocking::{Client, Response};
@@ -135,7 +135,7 @@ impl ServerBin {
         // - the server binary doesn't print "listening on port {port}" anymore
         let port: u16 = port_recv
             .recv_timeout(Duration::from_secs(SERVER_BOOT_TIMEOUT_SECONDS))
-            .map_err(|_| anyhow::anyhow!("the server took too much time to initialize"))?
+            .context("the server took too much time to initialize")?
             .parse()?;
 
         let http = Client::builder()


### PR DESCRIPTION
This allows us to keep the original error message and wrap it with a more contextual one like we do in other parts of the codebase.