### PR TITLE
package.json: Migrate `pnpm.overrides` back to `resolutions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,14 +134,14 @@
     "qunit-dom": "2.0.0",
     "webpack": "5.75.0"
   },
+  "resolutions": {
+    "ember-css-modules>postcss": "8.4.16",
+    "ember-get-config": "2.1.1",
+    "ember-inflector": "4.0.2",
+    "ember-modifier": "3.2.7",
+    "miragejs": "0.1.45"
+  },
   "pnpm": {
-    "overrides": {
-      "ember-css-modules>postcss": "8.4.16",
-      "ember-get-config": "2.1.1",
-      "ember-inflector": "4.0.2",
-      "ember-modifier": "3.2.7",
-      "miragejs": "0.1.45"
-    },
     "peerDependencyRules": {
       "allowAny": ["eslint"],
       "ignoreMissing": ["@babel/core", "postcss"]


### PR DESCRIPTION
It looks like renovatebot only supports version updates in `resolutions`, so we'll revert to using that for now until support for updating `pnpm.overrides` is added.