### PR TITLE
auth: Implement AuthCheck struct

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -27,7 +27,25 @@ impl AuthCheck {
     }
 
     pub fn check(&self, request: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
-        let auth = request.authenticate()?;
+        controllers::util::verify_origin(request)?;
+
+        let auth = authenticate_user(request)?;
+
+        if let Some(reason) = &auth.user.account_lock_reason {
+            let still_locked = if let Some(until) = auth.user.account_lock_until {
+                until > Utc::now().naive_utc()
+            } else {
+                true
+            };
+            if still_locked {
+                return Err(account_locked(reason, auth.user.account_lock_until));
+            }
+        }
+
+        log_request::add_custom_metadata("uid", auth.user_id());
+        if let Some(id) = auth.api_token_id() {
+            log_request::add_custom_metadata("tokenid", id);
+        }
 
         if !self.allow_token && auth.token_id.is_some() {
             let error_message = "API Token authentication was explicitly disallowed for this API";
@@ -100,38 +118,4 @@ fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
 
     // Unable to authenticate the user
     return Err(internal("no cookie session or auth header found").chain(forbidden()));
-}
-
-pub trait UserAuthenticationExt {
-    fn authenticate(&self) -> AppResult<AuthenticatedUser>;
-}
-
-impl<'a> UserAuthenticationExt for dyn RequestExt + 'a {
-    /// Obtain `AuthenticatedUser` for the request or return an `Forbidden` error
-    fn authenticate(&self) -> AppResult<AuthenticatedUser> {
-        controllers::util::verify_origin(self)?;
-
-        let authenticated_user = authenticate_user(self)?;
-
-        if let Some(reason) = &authenticated_user.user.account_lock_reason {
-            let still_locked = if let Some(until) = authenticated_user.user.account_lock_until {
-                until > Utc::now().naive_utc()
-            } else {
-                true
-            };
-            if still_locked {
-                return Err(account_locked(
-                    reason,
-                    authenticated_user.user.account_lock_until,
-                ));
-            }
-        }
-
-        log_request::add_custom_metadata("uid", authenticated_user.user_id());
-        if let Some(id) = authenticated_user.api_token_id() {
-            log_request::add_custom_metadata("tokenid", id);
-        }
-
-        Ok(authenticated_user)
-    }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -10,6 +10,32 @@ use conduit::RequestExt;
 use conduit_cookie::RequestSession;
 use http::header;
 
+#[derive(Debug, Clone)]
+pub struct AuthCheck {
+    allow_token: bool,
+}
+
+impl AuthCheck {
+    #[must_use]
+    pub fn default() -> Self {
+        Self { allow_token: true }
+    }
+
+    #[must_use]
+    pub fn only_cookie() -> Self {
+        Self { allow_token: false }
+    }
+
+    pub fn check(&self, request: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
+        let mut auth = request.authenticate()?;
+        if !self.allow_token {
+            auth = auth.forbid_api_token_auth()?;
+        }
+
+        Ok(auth)
+    }
+}
+
 #[derive(Debug)]
 pub struct AuthenticatedUser {
     user: User,

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -15,7 +15,6 @@ mod prelude {
     pub use conduit::{header, RequestExt, StatusCode};
     pub use conduit_router::RequestParams;
 
-    pub use crate::auth::UserAuthenticationExt;
     pub use crate::db::RequestTransaction;
     pub use crate::middleware::app::RequestApp;
     pub use crate::util::errors::{cargo_err, AppError, AppResult}; // TODO: Remove cargo_err from here

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -1,5 +1,6 @@
 //! Endpoints for managing a per user list of followed crates
 
+use crate::auth::AuthCheck;
 use diesel::associations::Identifiable;
 
 use crate::controllers::frontend_prelude::*;
@@ -21,7 +22,7 @@ fn follow_target(
 
 /// Handles the `PUT /crates/:crate_id/follow` route.
 pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
-    let user_id = req.authenticate()?.user_id();
+    let user_id = AuthCheck::default().check(req)?.user_id();
     let conn = req.db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
     diesel::insert_into(follows::table)
@@ -34,7 +35,7 @@ pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
 
 /// Handles the `DELETE /crates/:crate_id/follow` route.
 pub fn unfollow(req: &mut dyn RequestExt) -> EndpointResult {
-    let user_id = req.authenticate()?.user_id();
+    let user_id = AuthCheck::default().check(req)?.user_id();
     let conn = req.db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
     diesel::delete(&follow).execute(&*conn)?;
@@ -46,7 +47,7 @@ pub fn unfollow(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn following(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::exists;
 
-    let user_id = req.authenticate()?.forbid_api_token_auth()?.user_id();
+    let user_id = AuthCheck::only_cookie().check(req)?.user_id();
     let conn = req.db_read_prefer_primary()?;
     let follow = follow_target(req, &conn, user_id)?;
     let following =

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -1,5 +1,6 @@
 //! All routes related to managing owners of a crate
 
+use crate::auth::AuthCheck;
 use crate::controllers::prelude::*;
 use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
@@ -79,13 +80,14 @@ fn parse_owners_request(req: &mut dyn RequestExt) -> AppResult<Vec<String>> {
 }
 
 fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
-    let authenticated_user = req.authenticate()?;
+    let auth = AuthCheck::default().check(req)?;
+
     let logins = parse_owners_request(req)?;
     let app = req.app();
     let crate_name = &req.params()["crate_id"];
 
     let conn = req.db_write()?;
-    let user = authenticated_user.user();
+    let user = auth.user();
 
     conn.transaction(|| {
         let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -1,5 +1,6 @@
 //! Functionality related to publishing a new crate or version of a crate.
 
+use crate::auth::AuthCheck;
 use flate2::read::GzDecoder;
 use hex::ToHex;
 use sha2::{Digest, Sha256};
@@ -64,9 +65,9 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
     add_custom_metadata("crate_version", new_crate.vers.to_string());
 
     let conn = app.primary_database.get()?;
-    let ids = req.authenticate()?;
-    let api_token_id = ids.api_token_id();
-    let user = ids.user();
+    let auth = AuthCheck::default().check(req)?;
+    let api_token_id = auth.api_token_id();
+    let user = auth.user();
 
     let verified_email_address = user.verified_email(&conn)?;
     let verified_email_address = verified_email_address.ok_or_else(|| {

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -1,5 +1,6 @@
 //! Endpoint for searching and discovery functionality
 
+use crate::auth::AuthCheck;
 use diesel::dsl::*;
 use diesel::sql_types::Array;
 use diesel_full_text_search::*;
@@ -186,7 +187,8 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         // Calculating the total number of results with filters is not supported yet.
         supports_seek = false;
 
-        let user_id = req.authenticate()?.user_id();
+        let user_id = AuthCheck::default().check(req)?.user_id();
+
         query = query.filter(
             crates::id.eq_any(
                 follows::table

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub mod uploaders;
 pub mod util;
 pub mod worker;
 
-mod auth;
+pub mod auth;
 pub mod controllers;
 pub mod models;
 mod router;


### PR DESCRIPTION
This wraps the `req.authenticate()` calls with a builder pattern API, which can later be extended to support token scopes. 

One small downside is that it's possible to forget to call the `check()` method and only construct the `AuthCheck` struct, but that should largely be mitigated by the `#[must_use]` attribute.