### PR TITLE
Add `science::neuroscience` category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -493,6 +493,12 @@ description = """
 Crates related to robotics.\
 """
 
+[science.categories.neuroscience]
+name = "Neuroscience"
+description = """
+Crates related to neuroscience.\
+"""
+
 [simulation]
 name = "Simulation"
 description = """


### PR DESCRIPTION
This PR creates a category for neuroscience under science.

It is common to have a separate software category for neuroscience. Various other package managers also have a category for neuroscience [1,2]. With this change, Rust software related to the analysis or the study of brain functions can explicitly specify their category as neuroscience.

1. https://docs.fedoraproject.org/en-US/neurofedora/overview/
2. https://neuro.debian.net/