### PR TITLE
Implement `EndpointScope` enum

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,3 +1,5 @@
+mod scopes;
+
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -30,7 +30,7 @@ pub struct ApiToken {
     pub crate_scopes: Option<Vec<String>>,
     /// A list of endpoint scopes or `None` for the `legacy` endpoint scope (see RFC #2947)
     #[serde(skip)]
-    pub endpoint_scopes: Option<Vec<String>>,
+    pub endpoint_scopes: Option<Vec<scopes::EndpointScope>>,
 }
 
 impl ApiToken {

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -1,0 +1,7 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EndpointScope {
+    PublishNew,
+    PublishUpdate,
+    Yank,
+    ChangeOwners,
+}

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -1,7 +1,38 @@
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+use diesel::deserialize::{self, FromSql};
+use diesel::pg::Pg;
+use diesel::serialize::{self, IsNull, Output, ToSql};
+use diesel::sql_types::Text;
+use std::io::Write;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, AsExpression)]
+#[sql_type = "Text"]
 pub enum EndpointScope {
     PublishNew,
     PublishUpdate,
     Yank,
     ChangeOwners,
+}
+
+impl ToSql<Text, Pg> for EndpointScope {
+    fn to_sql<W: Write>(&self, out: &mut Output<'_, W, Pg>) -> serialize::Result {
+        match *self {
+            EndpointScope::PublishNew => out.write_all(b"publish-new")?,
+            EndpointScope::PublishUpdate => out.write_all(b"publish-update")?,
+            EndpointScope::Yank => out.write_all(b"yank")?,
+            EndpointScope::ChangeOwners => out.write_all(b"change-owners")?,
+        }
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<Text, Pg> for EndpointScope {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        match not_none!(bytes) {
+            b"publish-new" => Ok(EndpointScope::PublishNew),
+            b"publish-update" => Ok(EndpointScope::PublishUpdate),
+            b"yank" => Ok(EndpointScope::Yank),
+            b"change-owners" => Ok(EndpointScope::ChangeOwners),
+            _ => Err("Unrecognized enum variant".into()),
+        }
+    }
 }

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -13,14 +13,20 @@ pub enum EndpointScope {
     ChangeOwners,
 }
 
+impl From<&EndpointScope> for &[u8] {
+    fn from(scope: &EndpointScope) -> Self {
+        match scope {
+            EndpointScope::PublishNew => b"publish-new",
+            EndpointScope::PublishUpdate => b"publish-update",
+            EndpointScope::Yank => b"yank",
+            EndpointScope::ChangeOwners => b"change-owners",
+        }
+    }
+}
+
 impl ToSql<Text, Pg> for EndpointScope {
     fn to_sql<W: Write>(&self, out: &mut Output<'_, W, Pg>) -> serialize::Result {
-        match *self {
-            EndpointScope::PublishNew => out.write_all(b"publish-new")?,
-            EndpointScope::PublishUpdate => out.write_all(b"publish-update")?,
-            EndpointScope::Yank => out.write_all(b"yank")?,
-            EndpointScope::ChangeOwners => out.write_all(b"change-owners")?,
-        }
+        out.write_all(self.into())?;
         Ok(IsNull::No)
     }
 }

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -31,14 +31,22 @@ impl ToSql<Text, Pg> for EndpointScope {
     }
 }
 
-impl FromSql<Text, Pg> for EndpointScope {
-    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
-        match not_none!(bytes) {
+impl TryFrom<&[u8]> for EndpointScope {
+    type Error = String;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        match bytes {
             b"publish-new" => Ok(EndpointScope::PublishNew),
             b"publish-update" => Ok(EndpointScope::PublishUpdate),
             b"yank" => Ok(EndpointScope::Yank),
             b"change-owners" => Ok(EndpointScope::ChangeOwners),
-            _ => Err("Unrecognized enum variant".into()),
+            _ => Err("Unrecognized enum variant".to_string()),
         }
+    }
+}
+
+impl FromSql<Text, Pg> for EndpointScope {
+    fn from_sql(bytes: Option<&[u8]>) -> deserialize::Result<Self> {
+        Ok(EndpointScope::try_from(not_none!(bytes))?)
     }
 }


### PR DESCRIPTION
This turns the `endpoint_scopes` column from `Option<Vec<String>>` to `Option<Vec<EndpointScope>>`, which is a bit more restrictive in the values it supports, and ensure that we're only serializing endpoint scopes to the database that actually exist in our application.