### PR TITLE
tests/owners: Add tests with token scopes

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -28,6 +28,6 @@ pub mod krate;
 mod owner;
 mod rights;
 mod team;
-mod token;
+pub mod token;
 pub mod user;
 mod version;

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -36,6 +36,16 @@ pub struct ApiToken {
 impl ApiToken {
     /// Generates a new named API token for a user
     pub fn insert(conn: &PgConnection, user_id: i32, name: &str) -> AppResult<CreatedApiToken> {
+        Self::insert_with_scopes(conn, user_id, name, None, None)
+    }
+
+    pub fn insert_with_scopes(
+        conn: &PgConnection,
+        user_id: i32,
+        name: &str,
+        crate_scopes: Option<Vec<scopes::CrateScope>>,
+        endpoint_scopes: Option<Vec<scopes::EndpointScope>>,
+    ) -> AppResult<CreatedApiToken> {
         let token = SecureToken::generate(SecureTokenKind::Api);
 
         let model: ApiToken = diesel::insert_into(api_tokens::table)
@@ -43,6 +53,8 @@ impl ApiToken {
                 api_tokens::user_id.eq(user_id),
                 api_tokens::name.eq(name),
                 api_tokens::token.eq(&*token),
+                api_tokens::crate_scopes.eq(crate_scopes),
+                api_tokens::endpoint_scopes.eq(endpoint_scopes),
             ))
             .get_result(conn)?;
 

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -3,6 +3,7 @@ mod scopes;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
+pub use self::scopes::{CrateScope, EndpointScope};
 use crate::models::User;
 use crate::schema::api_tokens;
 use crate::util::errors::{AppResult, InsecurelyGeneratedTokenRevoked};
@@ -27,10 +28,10 @@ pub struct ApiToken {
     pub revoked: bool,
     /// `None` or a list of crate scope patterns (see RFC #2947)
     #[serde(skip)]
-    pub crate_scopes: Option<Vec<scopes::CrateScope>>,
+    pub crate_scopes: Option<Vec<CrateScope>>,
     /// A list of endpoint scopes or `None` for the `legacy` endpoint scope (see RFC #2947)
     #[serde(skip)]
-    pub endpoint_scopes: Option<Vec<scopes::EndpointScope>>,
+    pub endpoint_scopes: Option<Vec<EndpointScope>>,
 }
 
 impl ApiToken {
@@ -43,8 +44,8 @@ impl ApiToken {
         conn: &PgConnection,
         user_id: i32,
         name: &str,
-        crate_scopes: Option<Vec<scopes::CrateScope>>,
-        endpoint_scopes: Option<Vec<scopes::EndpointScope>>,
+        crate_scopes: Option<Vec<CrateScope>>,
+        endpoint_scopes: Option<Vec<EndpointScope>>,
     ) -> AppResult<CreatedApiToken> {
         let token = SecureToken::generate(SecureTokenKind::Api);
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -8,6 +8,7 @@ use cargo_registry_index::{Credentials, Repository as WorkerRepository, Reposito
 use std::{rc::Rc, sync::Arc, time::Duration};
 
 use crate::util::github::{MockGitHubClient, MOCK_GITHUB_DATA};
+use cargo_registry::models::token::{CrateScope, EndpointScope};
 use diesel::PgConnection;
 use reqwest::{blocking::Client, Proxy};
 use std::collections::HashSet;
@@ -289,6 +290,17 @@ impl TestAppBuilder {
         let (app, anon) = self.empty();
         let user = app.db_new_user("foo");
         let token = user.db_new_token("bar");
+        (app, anon, user, token)
+    }
+
+    pub fn with_scoped_token(
+        self,
+        crate_scopes: Option<Vec<CrateScope>>,
+        endpoint_scopes: Option<Vec<EndpointScope>>,
+    ) -> (TestApp, MockAnonymousUser, MockCookieUser, MockTokenUser) {
+        let (app, anon) = self.empty();
+        let user = app.db_new_user("foo");
+        let token = user.db_new_scoped_token("bar", crate_scopes, endpoint_scopes);
         (app, anon, user, token)
     }
 


### PR DESCRIPTION
This PR adds four additional tests for the owner change endpoint, related to the implementation of token scopes. Note that these tests are currently all returning `200 Ok` because token scope checks have not been enabled for this endpoint yet. This will be done in a follow-up PR and the tests will then be changed to account for this.