### PR TITLE
Implement token scope restrictions for our endpoints

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -2,6 +2,7 @@
 
 use crate::auth::AuthCheck;
 use crate::controllers::prelude::*;
+use crate::models::token::EndpointScope;
 use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
@@ -80,7 +81,12 @@ fn parse_owners_request(req: &mut dyn RequestExt) -> AppResult<Vec<String>> {
 }
 
 fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
-    let auth = AuthCheck::default().check(req)?;
+    let crate_name = &req.params()["crate_id"];
+
+    let auth = AuthCheck::default()
+        .with_endpoint_scope(EndpointScope::ChangeOwners)
+        .for_crate(crate_name)
+        .check(req)?;
 
     let logins = parse_owners_request(req)?;
     let app = req.app();

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_crate_scope.json
@@ -1,0 +1,122 @@
+[
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "35"
+                ],
+                [
+                    "content-type",
+                    "application/gzip"
+                ]
+            ],
+            "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "157"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "156"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjp0cnVlLCJsaW5rcyI6bnVsbH0K"
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "157"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    }
+]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_endpoint_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_endpoint_scope.json
@@ -1,0 +1,122 @@
+[
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "35"
+                ],
+                [
+                    "content-type",
+                    "application/gzip"
+                ]
+            ],
+            "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "157"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "156"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjp0cnVlLCJsaW5rcyI6bnVsbH0K"
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "157"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    }
+]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_wildcard_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_wildcard_crate_scope.json
@@ -1,0 +1,122 @@
+[
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "35"
+                ],
+                [
+                    "content-type",
+                    "application/gzip"
+                ]
+            ],
+            "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "157"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "156"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjp0cnVlLCJsaW5rcyI6bnVsbH0K"
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    },
+    {
+        "request": {
+            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+            "method": "PUT",
+            "headers": [
+                [
+                    "accept",
+                    "*/*"
+                ],
+                [
+                    "accept-encoding",
+                    "gzip"
+                ],
+                [
+                    "content-length",
+                    "157"
+                ],
+                [
+                    "content-type",
+                    "text/plain"
+                ]
+            ],
+            "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+        },
+        "response": {
+            "status": 200,
+            "headers": [],
+            "body": ""
+        }
+    }
+]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_crate_scope.json
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "157"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_endpoint_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_endpoint_scope.json
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "157"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_wildcard_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_wildcard_crate_scope.json
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "157"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoiZnlrIiwidmVycyI6IjEuMC4wIiwiZGVwcyI6W10sImNrc3VtIjoiYWNiNTYwNGIxMjZhYzg5NGMxZWIxMWM0NTc1YmYyMDcyZmVhNjEyMzJhODg4ZTQ1Mzc3MGM3OWQ3ZWQ1NjQxOSIsImZlYXR1cmVzIjp7fSwieWFua2VkIjpmYWxzZSwibGlua3MiOm51bGx9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -321,17 +321,11 @@ fn owner_change_via_change_owner_token() {
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, &body);
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
-        json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
+        json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
     );
-    // TODO swap these assertions once token scopes are activated for this endpoint
-    // assert_eq!(response.status(), StatusCode::OK);
-    // assert_eq!(
-    //     response.into_json(),
-    //     json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
-    // );
 }
 
 #[test]
@@ -350,17 +344,11 @@ fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, &body);
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
-        json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
+        json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
     );
-    // TODO swap these assertions once token scopes are activated for this endpoint
-    // assert_eq!(response.status(), StatusCode::OK);
-    // assert_eq!(
-    //     response.into_json(),
-    //     json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
-    // );
 }
 
 #[test]


### PR DESCRIPTION
This PR adjusts our `AuthCheck` calls for the three relevant endpoints (publish, change owner, yank) to check the token scope restrictions if the token has any.

Note that for the publish operation we unfortunately need an extra database query to determine if the request is trying to publish a new crate or a new version for an existing crate. This query is performed outside of the existing database transaction since we have somewhat relaxed consistency requirements here.

In the worst case, two new crates with the same name are published concurrently, which would require both requests to have a `publish-new` token scope.

Related: 
- https://github.com/rust-lang/crates.io/issues/5443