### PR TITLE
middleware::ember_html: Use `lookup()` to avoid unnecessary path mutation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,9 +590,9 @@ dependencies = [
 
 [[package]]
 name = "conduit-static"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d62df0c659106efe0ecef9ce6b92a4999c602dc85a569f496cdb32482ab79a1"
+checksum = "a155756c77fa2431ab120dd47ae2038e50fbfc7cce26a0c7c7aa35d6fb7067de"
 dependencies = [
  "conduit",
  "conduit-mime-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ conduit-git-http-backend = "=0.10.0"
 conduit-hyper = "=0.4.2"
 conduit-middleware = "=0.10.0"
 conduit-router = "=0.10.0"
-conduit-static = "=0.10.0"
+conduit-static = "=0.10.1"
 
 cookie = { version = "=0.16.1", features = ["secure"] }
 dashmap = { version = "=5.4.0", features = ["raw-api"] }

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -67,8 +67,7 @@ impl Handler for EmberHtml {
                 .any(|val| val.to_str().unwrap_or_default().contains("html"))
             {
                 // Serve static Ember page to bootstrap the frontend
-                *req.path_mut() = String::from("/index.html");
-                self.static_handler.call(req)
+                self.static_handler.lookup("index.html")
             } else {
                 // Return a 404 to crawlers that don't send `Accept: text/hml`.
                 // This is to preserve legacy behavior and will likely change.


### PR DESCRIPTION
This will also have the side effect of our logs showing the correct requested path instead of `/index.html` for everything.