### PR TITLE
middleware::EmberHtml: Move `fastboot_client` into the `App` struct

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,9 @@ pub struct App {
     /// this is either None (in which case any attempt to create an outgoing connection
     /// will panic) or a `Client` configured with a per-test replay proxy.
     pub(crate) http_client: Option<Client>,
+
+    /// A client for HTTP requests to the Ember.js fastboot server
+    pub fastboot_client: Option<Client>,
 }
 
 impl App {
@@ -164,6 +167,11 @@ impl App {
             .time_to_live(config.version_id_cache_ttl)
             .build();
 
+        let fastboot_client = match dotenv::var("USE_FASTBOOT") {
+            Ok(val) if val == "staging-experimental" => Some(Client::new()),
+            _ => None,
+        };
+
         App {
             primary_database,
             read_only_replica_database: replica_database,
@@ -175,6 +183,7 @@ impl App {
             service_metrics: ServiceMetrics::new().expect("could not initialize service metrics"),
             instance_metrics,
             http_client,
+            fastboot_client,
             config,
         }
     }

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -86,7 +86,7 @@ impl Handler for EmberHtml {
 /// # Panics
 ///
 /// This function can panic and should only be used in development mode.
-fn proxy_to_fastboot(client: &Client, req: &mut dyn RequestExt) -> Result<AppResponse> {
+fn proxy_to_fastboot(client: &Client, req: &dyn RequestExt) -> Result<AppResponse> {
     ensure!(
         req.method() == conduit::Method::GET,
         "Only support GET but request method was {}",


### PR DESCRIPTION
This would potentially allow other parts of the code to use the same `Client` instance for other fastboot requests.