### PR TITLE
tests: Replace unnecessary `conduit` imports

### DIFF
--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -1,6 +1,6 @@
 use crate::{util::RequestHelper, TestApp};
 use chrono::{Duration, NaiveDateTime, Utc};
-use conduit::StatusCode;
+use http::StatusCode;
 
 const URL: &str = "/api/v1/me";
 const LOCK_REASON: &str = "test lock reason";

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -2,7 +2,7 @@ use crate::util::{RequestHelper, Response};
 use crate::TestApp;
 
 use crate::util::encode_session_header;
-use conduit::{header, Body, Method, StatusCode};
+use http::{header, Method, StatusCode};
 
 static URL: &str = "/api/v1/me/updates";
 static MUST_LOGIN: &[u8] = br#"{"errors":[{"detail":"must be logged in to perform that action"}]}"#;
@@ -12,7 +12,7 @@ static INTERNAL_ERROR_NO_USER: &str =
 #[test]
 fn anonymous_user_unauthorized() {
     let (_, anon) = TestApp::init().empty();
-    let response: Response<Body> = anon.get(URL);
+    let response: Response<()> = anon.get(URL);
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(response.into_json().to_string().as_bytes(), MUST_LOGIN);
@@ -23,7 +23,7 @@ fn token_auth_cannot_find_token() {
     let (_, anon) = TestApp::init().empty();
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::AUTHORIZATION, "cio1tkfake-token");
-    let response: Response<Body> = anon.run(request);
+    let response: Response<()> = anon.run(request);
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(response.into_json().to_string().as_bytes(), MUST_LOGIN);

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -1,6 +1,6 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
-use conduit::StatusCode;
+use http::StatusCode;
 
 #[test]
 fn test_non_blocked_download_route() {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -16,8 +16,8 @@ use cargo_registry::{
 
 use cargo_registry::models::token::{CrateScope, EndpointScope};
 use chrono::{Duration, Utc};
-use conduit::StatusCode;
 use diesel::prelude::*;
+use http::StatusCode;
 
 #[derive(Deserialize)]
 struct TeamResponse {

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -1,8 +1,8 @@
 use crate::builders::CrateBuilder;
 use crate::{RequestHelper, TestApp};
 
-use conduit::StatusCode;
 use diesel::prelude::*;
+use http::StatusCode;
 
 #[test]
 fn can_hit_read_only_endpoints_in_read_only_mode() {

--- a/src/tests/routes/metrics.rs
+++ b/src/tests/routes/metrics.rs
@@ -1,6 +1,6 @@
 use crate::util::{MockAnonymousUser, Response};
 use crate::{RequestHelper, TestApp};
-use conduit::StatusCode;
+use http::StatusCode;
 
 #[test]
 fn metrics_endpoint_works() {

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -1,7 +1,7 @@
 use crate::builders::*;
 use crate::util::*;
 
-use conduit::{header, Method, StatusCode};
+use http::{header, Method, StatusCode};
 
 #[test]
 fn user_agent_is_required() {

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -5,8 +5,8 @@ use crate::{
 };
 use cargo_registry::models::{Crate, NewTeam};
 
-use conduit::StatusCode;
 use diesel::*;
+use http::StatusCode;
 
 impl crate::util::MockAnonymousUser {
     /// List the team owners of the specified crate.

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,7 +1,7 @@
 use crate::{RequestHelper, TestApp};
 use cargo_registry::{models::ApiToken, util::errors::TOKEN_FORMAT_ERROR, views::EncodableMe};
-use conduit::{header, StatusCode};
 use diesel::prelude::*;
+use http::{header, StatusCode};
 
 #[test]
 fn using_token_updates_last_used_at() {

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -25,13 +25,14 @@ use crate::{
 };
 use cargo_registry::models::{ApiToken, CreatedApiToken, User};
 
-use conduit::{BoxError, Handler, Method};
+use conduit::{BoxError, Handler};
 use conduit_cookie::SessionMiddleware;
 use conduit_test::MockRequest;
+use http::Method;
 
 use cargo_registry::models::token::{CrateScope, EndpointScope};
-use conduit::header;
 use cookie::Cookie;
+use http::header;
 use std::collections::HashMap;
 
 mod chaosproxy;
@@ -200,7 +201,7 @@ pub trait RequestHelper {
     }
 }
 
-fn req(method: conduit::Method, path: &str) -> MockRequest {
+fn req(method: Method, path: &str) -> MockRequest {
     let mut request = MockRequest::new(method, path);
     request.header(header::USER_AGENT, "conduit-test");
     request.header("x-real-ip", "127.0.0.1");

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 use conduit::{Body, HandlerResult};
 
-use conduit::{header, StatusCode};
+use http::{header, StatusCode};
 
 /// A type providing helper methods for working with responses
 #[must_use]


### PR DESCRIPTION
Most of them can use `http` directly, which helps us migrate away from `conduit` eventually