### PR TITLE
Replace unnecessary `conduit` imports

### DIFF
--- a/conduit-hyper/examples/server.rs
+++ b/conduit-hyper/examples/server.rs
@@ -1,8 +1,9 @@
 #![deny(clippy::all)]
 
-use conduit::{header, Body, Handler, RequestExt, Response, ResponseResult};
+use conduit::{Body, Handler, RequestExt, ResponseResult};
 use conduit_hyper::Server;
 use conduit_router::RouteBuilder;
+use http::{header, Response};
 
 use std::io;
 use std::thread::sleep;

--- a/conduit-hyper/src/adaptor.rs
+++ b/conduit-hyper/src/adaptor.rs
@@ -12,9 +12,9 @@
 use std::io::{Cursor, Read};
 use std::net::SocketAddr;
 
-use conduit::{Extensions, HeaderMap, Host, Method, RequestExt, Scheme, StartInstant, Version};
+use conduit::{Host, RequestExt, Scheme, StartInstant};
 use http::request::Parts as HttpParts;
-use http::Request;
+use http::{Extensions, HeaderMap, Method, Request, Version};
 use hyper::body::Bytes;
 
 pub(crate) struct ConduitRequest {

--- a/conduit-hyper/src/lib.rs
+++ b/conduit-hyper/src/lib.rs
@@ -52,5 +52,5 @@ mod tests;
 pub use server::Server;
 pub use service::{BlockingHandler, Service};
 
-type HyperResponse = hyper::Response<hyper::Body>;
-type ConduitResponse = conduit::Response<conduit::Body>;
+type HyperResponse = http::Response<hyper::Body>;
+type ConduitResponse = http::Response<conduit::Body>;

--- a/conduit-hyper/src/service/blocking_handler.rs
+++ b/conduit-hyper/src/service/blocking_handler.rs
@@ -6,8 +6,9 @@ use crate::{ConduitResponse, HyperResponse};
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use conduit::header::CONTENT_LENGTH;
-use conduit::{Handler, StartInstant, StatusCode};
+use conduit::{Handler, StartInstant};
+use http::header::CONTENT_LENGTH;
+use http::StatusCode;
 use hyper::body::HttpBody;
 use hyper::{Body, Request, Response};
 use tracing::{error, warn};

--- a/conduit-hyper/src/tests.rs
+++ b/conduit-hyper/src/tests.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use conduit::{box_error, Body, Handler, HandlerResult, RequestExt, Response, StatusCode};
+use conduit::{box_error, Body, Handler, HandlerResult, RequestExt};
 use futures_util::future::Future;
+use http::{Response, StatusCode};
 use hyper::{body::to_bytes, service::Service};
 use tokio::{sync::oneshot, task::JoinHandle};
 

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -12,8 +12,9 @@ mod prelude {
     pub use super::helpers::ok_true;
     pub use diesel::prelude::*;
 
-    pub use conduit::{header, RequestExt, StatusCode};
+    pub use conduit::RequestExt;
     pub use conduit_router::RequestParams;
+    pub use http::{header, StatusCode};
 
     pub use crate::db::RequestTransaction;
     pub use crate::middleware::app::RequestApp;
@@ -44,7 +45,7 @@ mod prelude {
         }
 
         fn redirect(&self, url: String) -> AppResponse {
-            conduit::Response::builder()
+            http::Response::builder()
                 .status(StatusCode::FOUND)
                 .header(header::LOCATION, url)
                 .body(conduit::Body::empty())

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -310,8 +310,8 @@ pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> AppResult<D
 #[cfg(test)]
 mod tests {
     use super::*;
-    use conduit::StatusCode;
     use conduit_test::{MockRequest, ResponseExt};
+    use http::StatusCode;
 
     #[test]
     fn no_pagination_param() {

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,6 +1,7 @@
 use crate::controllers::frontend_prelude::*;
 use crate::util::errors::{forbidden, not_found, MetricsDisabled};
-use conduit::{Body, Response};
+use conduit::Body;
+use http::Response;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -6,7 +6,8 @@ use crate::util::read_fill;
 use crate::views::EncodableApiTokenWithToken;
 
 use crate::auth::AuthCheck;
-use conduit::{Body, Response};
+use conduit::Body;
+use http::Response;
 use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,7 +1,8 @@
 mod prelude {
     pub use super::log_request::add_custom_metadata;
-    pub use conduit::{box_error, header, Body, Handler, RequestExt, Response, StatusCode};
+    pub use conduit::{box_error, Body, Handler, RequestExt};
     pub use conduit_middleware::{AfterResult, AroundMiddleware, BeforeResult, Middleware};
+    pub use http::{header, Response, StatusCode};
 }
 
 use self::app::AppMiddleware;

--- a/src/middleware/balance_capacity.rs
+++ b/src/middleware/balance_capacity.rs
@@ -12,7 +12,8 @@ use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::prelude::*;
-use conduit::{RequestExt, StatusCode};
+use conduit::RequestExt;
+use http::StatusCode;
 
 #[derive(Default)]
 pub(super) struct BalanceCapacity {

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -82,7 +82,7 @@ impl Handler for EmberHtml {
 /// This function can panic and should only be used in development mode.
 fn proxy_to_fastboot(client: &Client, req: &dyn RequestExt) -> Result<AppResponse> {
     ensure!(
-        req.method() == conduit::Method::GET,
+        req.method() == http::Method::GET,
         "Only support GET but request method was {}",
         req.method()
     );

--- a/src/middleware/head.rs
+++ b/src/middleware/head.rs
@@ -3,7 +3,7 @@
 use super::prelude::*;
 
 use crate::util::RequestProxy;
-use conduit::Method;
+use http::Method;
 
 #[derive(Default)]
 pub struct Head {

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -4,11 +4,11 @@
 use super::prelude::*;
 use crate::util::request_header;
 
-use conduit::{header, RequestExt, StatusCode};
+use conduit::RequestExt;
 
 use crate::middleware::normalize_path::OriginalPath;
 use crate::middleware::response_timing::ResponseTime;
-use http::Method;
+use http::{header, Method, StatusCode};
 use std::cell::RefCell;
 use std::fmt::{self, Display, Formatter};
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -221,9 +221,9 @@ mod tests {
     use crate::util::errors::{bad_request, cargo_err, forbidden, internal, not_found, AppError};
     use crate::util::EndpointResult;
 
-    use conduit::StatusCode;
     use conduit_test::MockRequest;
     use diesel::result::Error as DieselError;
+    use http::StatusCode;
 
     fn err<E: AppError>(err: E) -> EndpointResult {
         Err(Box::new(err))

--- a/src/sentry/middleware.rs
+++ b/src/sentry/middleware.rs
@@ -1,7 +1,8 @@
 use crate::middleware::response_timing::ResponseTime;
-use conduit::{RequestExt, StatusCode};
+use conduit::RequestExt;
 use conduit_cookie::RequestSession;
 use conduit_middleware::{AfterResult, BeforeResult, Middleware};
+use http::StatusCode;
 use sentry_conduit::SentryMiddleware;
 
 /// Custom wrapper around the `sentry_conduit` middleware, that adds additional

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 
-use conduit::{header, Body, Response};
+use conduit::Body;
+use http::{header, Response};
 use serde::Serialize;
 
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
@@ -15,7 +16,7 @@ pub mod rfc3339;
 pub(crate) mod token;
 pub mod tracing;
 
-pub type AppResponse = Response<conduit::Body>;
+pub type AppResponse = Response<Body>;
 pub type EndpointResult = Result<AppResponse, Box<dyn errors::AppError>>;
 
 /// Serialize a value to JSON and build a status 200 Response

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -4,7 +4,7 @@ use super::{AppError, InternalAppErrorStatic};
 use crate::util::{json_response, AppResponse};
 
 use chrono::NaiveDateTime;
-use conduit::{header, StatusCode};
+use http::{header, StatusCode};
 
 /// Generates a response with the provided status and description as JSON
 fn json_error(detail: &str, status: StatusCode) -> AppResponse {

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -1,4 +1,5 @@
-use conduit::{header::AsHeaderName, RequestExt};
+use conduit::RequestExt;
+use http::header::AsHeaderName;
 
 /// Returns the value of the request header, or an empty slice if it is not
 /// present.

--- a/src/util/request_proxy.rs
+++ b/src/util/request_proxy.rs
@@ -2,13 +2,14 @@
 
 use std::{io::Read, net::SocketAddr};
 
-use conduit::{Method, RequestExt};
+use conduit::RequestExt;
+use http::Method;
 
 type RequestMutRef<'a> = &'a mut (dyn RequestExt + 'a);
 
 pub struct RequestProxy<'a> {
     other: RequestMutRef<'a>,
-    method: conduit::Method,
+    method: Method,
 }
 
 impl<'a> RequestProxy<'a> {
@@ -19,7 +20,7 @@ impl<'a> RequestProxy<'a> {
 }
 
 impl<'a> RequestExt for RequestProxy<'a> {
-    fn method(&self) -> &conduit::Method {
+    fn method(&self) -> &Method {
         &self.method
     }
 
@@ -32,7 +33,7 @@ impl<'a> RequestExt for RequestProxy<'a> {
     }
 
     // Pass-through
-    fn http_version(&self) -> conduit::Version {
+    fn http_version(&self) -> http::Version {
         self.other.http_version()
     }
     fn scheme(&self) -> conduit::Scheme {
@@ -53,16 +54,16 @@ impl<'a> RequestExt for RequestProxy<'a> {
     fn content_length(&self) -> Option<u64> {
         self.other.content_length()
     }
-    fn headers(&self) -> &conduit::HeaderMap {
+    fn headers(&self) -> &http::HeaderMap {
         self.other.headers()
     }
     fn body(&mut self) -> &mut dyn Read {
         self.other.body()
     }
-    fn extensions(&self) -> &conduit::Extensions {
+    fn extensions(&self) -> &http::Extensions {
         self.other.extensions()
     }
-    fn mut_extensions(&mut self) -> &mut conduit::Extensions {
+    fn mut_extensions(&mut self) -> &mut http::Extensions {
         self.other.mut_extensions()
     }
 }


### PR DESCRIPTION
Most of them can use `http` directly, which helps us migrate away from `conduit` eventually

Related:

- #5611 condui