### PR TITLE
tests/routes/categories/get: Avoid database connection deadlock

### DIFF
--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -40,67 +40,72 @@ fn update_crate() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
-    app.db(|conn| {
+    let krate = app.db(|conn| {
         assert_ok!(new_category("cat1", "cat1", "Category 1 crates").create_or_update(conn));
         assert_ok!(
             new_category("Category 2", "category-2", "Category 2 crates").create_or_update(conn)
         );
-        let krate = CrateBuilder::new("foo_crate", user.id).expect_build(conn);
 
-        // Updating with no categories has no effect
-        Category::update_crate(conn, &krate, &[]).unwrap();
-        assert_eq!(count(&anon, "cat1"), 0);
-        assert_eq!(count(&anon, "category-2"), 0);
+        CrateBuilder::new("foo_crate", user.id).expect_build(conn)
+    });
 
-        // Happy path adding one category
-        Category::update_crate(conn, &krate, &["cat1"]).unwrap();
-        assert_eq!(count(&anon, "cat1"), 1);
-        assert_eq!(count(&anon, "category-2"), 0);
+    // Updating with no categories has no effect
+    app.db(|conn| Category::update_crate(conn, &krate, &[]).unwrap());
+    assert_eq!(count(&anon, "cat1"), 0);
+    assert_eq!(count(&anon, "category-2"), 0);
 
-        // Replacing one category with another
-        Category::update_crate(conn, &krate, &["category-2"]).unwrap();
-        assert_eq!(count(&anon, "cat1"), 0);
-        assert_eq!(count(&anon, "category-2"), 1);
+    // Happy path adding one category
+    app.db(|conn| Category::update_crate(conn, &krate, &["cat1"]).unwrap());
+    assert_eq!(count(&anon, "cat1"), 1);
+    assert_eq!(count(&anon, "category-2"), 0);
 
-        // Removing one category
-        Category::update_crate(conn, &krate, &[]).unwrap();
-        assert_eq!(count(&anon, "cat1"), 0);
-        assert_eq!(count(&anon, "category-2"), 0);
+    // Replacing one category with another
+    app.db(|conn| Category::update_crate(conn, &krate, &["category-2"]).unwrap());
+    assert_eq!(count(&anon, "cat1"), 0);
+    assert_eq!(count(&anon, "category-2"), 1);
 
-        // Adding 2 categories
-        Category::update_crate(conn, &krate, &["cat1", "category-2"]).unwrap();
-        assert_eq!(count(&anon, "cat1"), 1);
-        assert_eq!(count(&anon, "category-2"), 1);
+    // Removing one category
+    app.db(|conn| Category::update_crate(conn, &krate, &[]).unwrap());
+    assert_eq!(count(&anon, "cat1"), 0);
+    assert_eq!(count(&anon, "category-2"), 0);
 
-        // Removing all categories
-        Category::update_crate(conn, &krate, &[]).unwrap();
-        assert_eq!(count(&anon, "cat1"), 0);
-        assert_eq!(count(&anon, "category-2"), 0);
+    // Adding 2 categories
+    app.db(|conn| Category::update_crate(conn, &krate, &["cat1", "category-2"]).unwrap());
+    assert_eq!(count(&anon, "cat1"), 1);
+    assert_eq!(count(&anon, "category-2"), 1);
 
-        // Attempting to add one valid category and one invalid category
+    // Removing all categories
+    app.db(|conn| Category::update_crate(conn, &krate, &[]).unwrap());
+    assert_eq!(count(&anon, "cat1"), 0);
+    assert_eq!(count(&anon, "category-2"), 0);
+
+    // Attempting to add one valid category and one invalid category
+    app.db(|conn| {
         let invalid_categories =
             Category::update_crate(conn, &krate, &["cat1", "catnope"]).unwrap();
         assert_eq!(invalid_categories, vec!["catnope"]);
-        assert_eq!(count(&anon, "cat1"), 1);
-        assert_eq!(count(&anon, "category-2"), 0);
+    });
+    assert_eq!(count(&anon, "cat1"), 1);
+    assert_eq!(count(&anon, "category-2"), 0);
 
-        // Does not add the invalid category to the category list
-        // (unlike the behavior of keywords)
-        let json = anon.show_category_list();
-        assert_eq!(json.categories.len(), 2);
-        assert_eq!(json.meta.total, 2);
+    // Does not add the invalid category to the category list
+    // (unlike the behavior of keywords)
+    let json = anon.show_category_list();
+    assert_eq!(json.categories.len(), 2);
+    assert_eq!(json.meta.total, 2);
 
-        // Attempting to add a category by display text; must use slug
-        Category::update_crate(conn, &krate, &["Category 2"]).unwrap();
-        assert_eq!(count(&anon, "cat1"), 0);
-        assert_eq!(count(&anon, "category-2"), 0);
+    // Attempting to add a category by display text; must use slug
+    app.db(|conn| Category::update_crate(conn, &krate, &["Category 2"]).unwrap());
+    assert_eq!(count(&anon, "cat1"), 0);
+    assert_eq!(count(&anon, "category-2"), 0);
 
-        // Add a category and its subcategory
+    // Add a category and its subcategory
+    app.db(|conn| {
         assert_ok!(new_category("cat1::bar", "cat1::bar", "bar crates").create_or_update(conn));
         Category::update_crate(conn, &krate, &["cat1", "cat1::bar"]).unwrap();
-
-        assert_eq!(count(&anon, "cat1"), 1);
-        assert_eq!(count(&anon, "cat1::bar"), 1);
-        assert_eq!(count(&anon, "category-2"), 0);
     });
+
+    assert_eq!(count(&anon, "cat1"), 1);
+    assert_eq!(count(&anon, "cat1::bar"), 1);
+    assert_eq!(count(&anon, "category-2"), 0);
 }


### PR DESCRIPTION
The `app.db()` closure takes the only existing database connection and any API requests inside the closure can deadlock waiting on the connection. For some reason this does not appear to cause any issues in the current state, but once the API requests are going through an async layer this is starting to cause issues.