### PR TITLE
tests/Response: Replace `conduit::Response` with `reqwest::blocking::Response`

### DIFF
--- a/conduit-hyper/src/lib.rs
+++ b/conduit-hyper/src/lib.rs
@@ -50,7 +50,7 @@ mod service;
 mod tests;
 
 pub use server::Server;
-pub use service::{BlockingHandler, Service};
+pub use service::{conduit_into_hyper, BlockingHandler, Service};
 
 type HyperResponse = http::Response<hyper::Body>;
 type ConduitResponse = http::Response<conduit::Body>;

--- a/conduit-hyper/src/service.rs
+++ b/conduit-hyper/src/service.rs
@@ -7,7 +7,7 @@ use hyper::{service, Body, Request, Response};
 mod blocking_handler;
 mod error;
 
-pub use blocking_handler::BlockingHandler;
+pub use blocking_handler::{conduit_into_hyper, BlockingHandler};
 pub use error::ServiceError;
 
 /// A builder for a `hyper::Service`.

--- a/conduit-hyper/src/service/blocking_handler.rs
+++ b/conduit-hyper/src/service/blocking_handler.rs
@@ -61,7 +61,7 @@ impl<H: Handler> BlockingHandler<H> {
 }
 
 /// Turns a `ConduitResponse` into a `HyperResponse`
-fn conduit_into_hyper(response: ConduitResponse) -> HyperResponse {
+pub fn conduit_into_hyper(response: ConduitResponse) -> HyperResponse {
     use conduit::Body::*;
 
     let (parts, body) = response.into_parts();

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -27,6 +27,7 @@ use cargo_registry::models::{ApiToken, CreatedApiToken, User};
 
 use conduit::{BoxError, Handler};
 use conduit_cookie::SessionMiddleware;
+use conduit_hyper::conduit_into_hyper;
 use conduit_test::MockRequest;
 use http::Method;
 
@@ -87,7 +88,10 @@ pub trait RequestHelper {
     /// Run a request that is expected to succeed
     #[track_caller]
     fn run<T>(&self, mut request: MockRequest) -> Response<T> {
-        Response::new(self.app().as_middleware().call(&mut request))
+        let conduit_response = assert_ok!(self.app().as_middleware().call(&mut request));
+        let hyper_response = conduit_into_hyper(conduit_response);
+
+        Response::new(hyper_response.into())
     }
 
     /// Run a request that is expected to error

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -1,9 +1,6 @@
 use serde_json::Value;
 use std::marker::PhantomData;
 
-use conduit::HandlerResult;
-use conduit_hyper::conduit_into_hyper;
-
 use http::{header, StatusCode};
 
 /// A type providing helper methods for working with responses
@@ -29,13 +26,9 @@ where
 
 impl<T> Response<T> {
     #[track_caller]
-    pub(super) fn new(response: HandlerResult) -> Self {
-        let conduit_response = assert_ok!(response);
-        let hyper_response = conduit_into_hyper(conduit_response);
-        let reqwest_response = hyper_response.into();
-
+    pub(super) fn new(response: reqwest::blocking::Response) -> Self {
         Self {
-            response: reqwest_response,
+            response,
             return_type: PhantomData,
         }
     }

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -40,10 +40,6 @@ impl<T> Response<T> {
         json(self.response)
     }
 
-    pub fn status(&self) -> StatusCode {
-        self.response.status()
-    }
-
     #[track_caller]
     pub fn assert_redirect_ends_with(&self, target: &str) -> &Self {
         assert!(self

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::marker::PhantomData;
+use std::ops::Deref;
 
 use http::{header, StatusCode};
 
@@ -68,6 +69,14 @@ impl Response<()> {
     #[track_caller]
     pub fn assert_forbidden(&self) {
         assert_eq!(StatusCode::FORBIDDEN, self.status());
+    }
+}
+
+impl<T> Deref for Response<T> {
+    type Target = reqwest::blocking::Response;
+
+    fn deref(&self) -> &Self::Target {
+        &self.response
     }
 }
 


### PR DESCRIPTION
We are using our own `Response` struct from `src/tests/util/response.rs` to wrap around a `conduit::Response` to make it more ergonomic to use in our test suite. This however creates a tight coupling between `conduit` and our test suite.

This PR changes our own `Response` to wrap `reqwest::blocking::Response` instead. This should make it possible to do actual HTTP requests in the future, and still use the same test-related methods and structs.