### PR TITLE
Run tests through `conduit-hyper` layer

### DIFF
--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -6,8 +6,6 @@ use http::{header, Method, StatusCode};
 
 static URL: &str = "/api/v1/me/updates";
 static MUST_LOGIN: &[u8] = br#"{"errors":[{"detail":"must be logged in to perform that action"}]}"#;
-static INTERNAL_ERROR_NO_USER: &str =
-    "user_id from cookie not found in database caused by NotFound";
 
 #[test]
 fn anonymous_user_unauthorized() {
@@ -42,6 +40,6 @@ fn cookie_auth_cannot_find_user() {
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::COOKIE, &cookie);
 
-    let error = anon.run_err(request);
-    assert_eq!(error.to_string(), INTERNAL_ERROR_NO_USER);
+    let error = anon.run::<()>(request);
+    assert_eq!(error.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }


### PR DESCRIPTION
Previously, our test suite ignored the `hyper` wrapper and just interfaced with `conduit` directly. We would eventually like to migrate our `conduit` middlewares to `tower` middlewares though, so we will need to run our tests through as much of our full stack as possible.

This PR changes the `RequestHelper::run()` method to use `conduit_hyper::Service` to ensure that we're using the `hyper` layer too.