### PR TITLE
tracing: Extract `init_for_test()` function

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -66,7 +66,7 @@ pub struct TestApp(Rc<TestAppInner>);
 impl TestApp {
     /// Initialize an application with an `Uploader` that panics
     pub fn init() -> TestAppBuilder {
-        init_logger();
+        cargo_registry::util::tracing::init_for_test();
 
         TestAppBuilder {
             config: simple_config(),
@@ -335,15 +335,6 @@ impl TestAppBuilder {
         self.test_database = test_database;
         self
     }
-}
-
-pub fn init_logger() {
-    let _ = tracing_subscriber::fmt()
-        .compact()
-        .with_max_level(tracing::Level::INFO)
-        .without_time()
-        .with_test_writer()
-        .try_init();
 }
 
 fn simple_config() -> config::Server {

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -21,3 +21,13 @@ pub fn init() {
         .with(sentry_layer)
         .init();
 }
+
+/// Initializes the `tracing` logging framework for usage in tests.
+pub fn init_for_test() {
+    let _ = tracing_subscriber::fmt()
+        .compact()
+        .with_max_level(tracing::Level::INFO)
+        .without_time()
+        .with_test_writer()
+        .try_init();
+}


### PR DESCRIPTION
This was previously only usable from within the `tests` module, but now it can also be used in unit tests.