### PR TITLE
conduit-hyper: Remove unnecessary dependency declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,6 @@ dependencies = [
 name = "conduit-hyper"
 version = "0.4.2"
 dependencies = [
- "bytes",
  "conduit",
  "conduit-router",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tower-service",
  "tracing",
  "tracing-subscriber",
 ]

--- a/conduit-hyper/Cargo.toml
+++ b/conduit-hyper/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.56.0"
 
 [dependencies]
 conduit = "=0.10.0"
-hyper = { version = "=0.14.23", features = ["server", "http1", "stream", "tcp"] }
+hyper = { version = "=0.14.23", features = ["server", "stream"] }
 http = "=0.2.8"
 percent-encoding = "=2.2.0"
 thiserror = "=1.0.37"

--- a/conduit-hyper/Cargo.toml
+++ b/conduit-hyper/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 rust-version = "1.56.0"
 
 [dependencies]
-bytes = "=1.3.0"
 conduit = "=0.10.0"
 hyper = { version = "=0.14.23", features = ["server", "http1", "stream", "tcp"] }
 http = "=0.2.8"

--- a/conduit-hyper/Cargo.toml
+++ b/conduit-hyper/Cargo.toml
@@ -17,7 +17,6 @@ thiserror = "=1.0.37"
 tracing = "=0.1.37"
 tokio = { version = "=1.23.0", features = ["fs"] }
 tokio-stream = "=0.1.11"
-tower-service = "=0.3.2"
 
 [dev-dependencies]
 conduit-router = "=0.10.0"

--- a/conduit-hyper/src/file_stream.rs
+++ b/conduit-hyper/src/file_stream.rs
@@ -1,8 +1,7 @@
 use std::task::{Context, Poll};
 use std::{io::Error, pin::Pin};
 
-use bytes::Bytes;
-use hyper::body::Body;
+use hyper::body::{Body, Bytes};
 use tokio::{fs::File, io::AsyncRead};
 use tokio_stream::Stream;
 

--- a/conduit-hyper/src/service.rs
+++ b/conduit-hyper/src/service.rs
@@ -48,7 +48,7 @@ impl Service {
         handler: Arc<BlockingHandler<H>>,
         remote_addr: SocketAddr,
     ) -> Result<
-        impl tower_service::Service<
+        impl service::Service<
             Request<Body>,
             Response = Response<Body>,
             Error = ServiceError,


### PR DESCRIPTION
We can use the re-exported types instead, which helps to avoid potential version conflicts.