### PR TITLE
middleware: Enable `LogRequests` middleware in test mode

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -48,9 +48,9 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
 
     if env != Env::Test {
         m.add(SentryMiddleware::with_transactions());
-        m.add(log_request::LogRequests::default());
     }
 
+    m.add(log_request::LogRequests::default());
     m.add(ResponseTiming::default());
 
     if env == Env::Development {


### PR DESCRIPTION
Since we use `tracing` for the HTTP logs now and that uses the test writer we don't have to disable this anymore.