### PR TITLE
github/secret_scanning: Check for *hashed* tokens

### DIFF
--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -2,6 +2,7 @@ use crate::{RequestHelper, TestApp};
 use cargo_registry::controllers::github::secret_scanning::{
     GitHubSecretAlertFeedback, GitHubSecretAlertFeedbackLabel,
 };
+use cargo_registry::util::token::SecureToken;
 use cargo_registry::{models::ApiToken, schema::api_tokens};
 use conduit::StatusCode;
 use diesel::prelude::*;
@@ -33,8 +34,9 @@ fn github_secret_alert_revokes_token() {
 
     // Set token to expected value in signed request
     app.db(|conn| {
+        let hashed_token = SecureToken::hash("some_token");
         diesel::update(api_tokens::table)
-            .set(api_tokens::token.eq(b"some_token" as &[u8]))
+            .set(api_tokens::token.eq(hashed_token))
             .execute(conn)
             .unwrap();
     });

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,7 +13,7 @@ mod io_util;
 mod request_helpers;
 mod request_proxy;
 pub mod rfc3339;
-pub(crate) mod token;
+pub mod token;
 pub mod tracing;
 
 pub type AppResponse = Response<Body>;

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -18,7 +18,7 @@ impl SecureToken {
             kind.prefix(),
             generate_secure_alphanumeric_string(TOKEN_LENGTH)
         );
-        let sha256 = Sha256::digest(plaintext.as_bytes()).as_slice().to_vec();
+        let sha256 = Self::hash(&plaintext);
 
         NewSecureToken {
             plaintext,
@@ -32,8 +32,12 @@ impl SecureToken {
             return None;
         }
 
-        let sha256 = Sha256::digest(plaintext.as_bytes()).as_slice().to_vec();
+        let sha256 = Self::hash(plaintext);
         Some(Self { sha256 })
+    }
+
+    pub fn hash(plaintext: &str) -> Vec<u8> {
+        Sha256::digest(plaintext.as_bytes()).as_slice().to_vec()
     }
 }
 


### PR DESCRIPTION
We don't save tokens in plaintext in the database, so the new secret scanning endpoint needs to look for the *hashed* token instead of the plaintext token.

/cc @dangardner :)