### PR TITLE
github/secret_scanning: Consider revoked tokens as true positive

### DIFF
--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -171,10 +171,10 @@ impl User {
     }
 
     /// Queries for the email belonging to a particular user
-    pub fn email(&self, conn: &PgConnection) -> AppResult<Option<String>> {
-        Ok(Email::belonging_to(self)
+    pub fn email(&self, conn: &PgConnection) -> QueryResult<Option<String>> {
+        Email::belonging_to(self)
             .select(emails::email)
             .first(conn)
-            .optional()?)
+            .optional()
     }
 }

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -109,14 +109,14 @@ fn github_secret_alert_for_revoked_token() {
     let response = anon.run::<Vec<GitHubSecretAlertFeedback>>(request);
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Ensure feedback is a false positive
+    // Ensure feedback is a true positive
     let feedback = response.good();
     assert_eq!(feedback.len(), 1);
     assert_eq!(feedback[0].token_raw, "some_token");
     assert_eq!(feedback[0].token_type, "some_type");
     assert_eq!(
         feedback[0].label,
-        GitHubSecretAlertFeedbackLabel::FalsePositive
+        GitHubSecretAlertFeedbackLabel::TruePositive
     );
 
     // Ensure that the token is still revoked


### PR DESCRIPTION
When a token has already been revoked we will return to GitHub that it was a "true positive" now, but we skip sending out a notification email to the owner since we don't allow unrevoking tokens.

This PR also extracts a `send_notification_email()` function, which ensures that an error while sending emails will not cause other tokens to not be revoked.