### PR TITLE
Revert `base64` dependency upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,12 +247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,7 +320,7 @@ dependencies = [
  "anyhow",
  "aws-sigv4",
  "axum",
- "base64 0.20.0",
+ "base64",
  "cargo-registry-index",
  "cargo-registry-markdown",
  "cargo-registry-s3",
@@ -398,7 +392,7 @@ name = "cargo-registry-index"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64 0.20.0",
+ "base64",
  "dotenv",
  "git2",
  "serde",
@@ -422,7 +416,7 @@ dependencies = [
 name = "cargo-registry-s3"
 version = "0.2.0"
 dependencies = [
- "base64 0.20.0",
+ "base64",
  "chrono",
  "hmac",
  "reqwest",
@@ -608,7 +602,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f88a8f6cc0c410bea02244bfec3ad16b290be77c9d222048be44cb2d1f457f1"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "conduit",
  "conduit-middleware",
  "cookie",
@@ -705,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
 dependencies = [
  "aes-gcm",
- "base64 0.13.1",
+ "base64",
  "hkdf",
  "hmac",
  "rand",
@@ -980,7 +974,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34dd14c63662e0206599796cd5e1ad0268ab2b9d19b868d6050d688eba2bbf98"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "memchr",
 ]
 
@@ -1627,7 +1621,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eabca5e0b4d0e98e7f2243fb5b7520b6af2b65d8f87bcc86f2c75185a6ff243"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "email-encoding",
  "email_address",
  "fastrand",
@@ -1986,7 +1980,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaf26a72311c087f8c5ba617c96fac67a5c04f430e716ac8d8ab2de62e23368"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "chrono",
  "getrandom",
  "http",
@@ -2473,7 +2467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "async-compression",
- "base64 0.13.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3608,7 +3602,7 @@ version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97acb4c28a254fd7a4aeec976c46a7fa404eac4d7c134b30c75144846d7cb8f"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "chunked_transfer",
  "log",
  "native-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/tests/all.rs"
 anyhow = "=1.0.66"
 aws-sigv4 = "=0.51.0"
 axum = "=0.6.1"
-base64 = "=0.20.0"
+base64 = "=0.13.1"
 cargo-registry-index = { path = "cargo-registry-index" }
 cargo-registry-markdown = { path = "cargo-registry-markdown" }
 cargo-registry-s3 = { path = "cargo-registry-s3" }

--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -15,7 +15,7 @@ testing = ["serde_json"]
 
 [dependencies]
 anyhow = "=1.0.66"
-base64 = "=0.20.0"
+base64 = "=0.13.1"
 dotenv = "=0.15.0"
 git2 = "=0.15.0"
 serde = { version = "=1.0.150", features = ["derive"] }

--- a/cargo-registry-s3/Cargo.toml
+++ b/cargo-registry-s3/Cargo.toml
@@ -13,7 +13,7 @@ name = "s3"
 path = "lib.rs"
 
 [dependencies]
-base64 = "=0.20.0"
+base64 = "=0.13.1"
 chrono = "=0.4.23"
 sha-1 = "=0.10.1"
 hmac = "=0.12.1"

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -6,8 +6,6 @@ use crate::util::errors::{bad_request, AppResult};
 use crate::util::request_header;
 
 use crate::App;
-use base64::alphabet::URL_SAFE;
-use base64::engine::fast_portable::{FastPortable, NO_PAD};
 use diesel::pg::Pg;
 use diesel::query_builder::*;
 use diesel::query_dsl::LoadQuery;
@@ -21,8 +19,6 @@ use std::sync::Arc;
 const MAX_PAGE_BEFORE_SUSPECTED_BOT: u32 = 10;
 const DEFAULT_PER_PAGE: u32 = 10;
 const MAX_PER_PAGE: u32 = 100;
-
-const URL_SAFE_NO_PAD: FastPortable = FastPortable::from(&URL_SAFE, NO_PAD);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum Page {
@@ -297,17 +293,17 @@ fn is_useragent_or_ip_blocked(config: &Server, req: &dyn RequestExt) -> bool {
 /// technical measure to prevent API consumers for manually creating or modifying them, but
 /// hopefully the base64 will be enough to convey that doing it is unsupported.
 pub(crate) fn encode_seek<S: Serialize>(params: S) -> AppResult<String> {
-    Ok(base64::encode_engine(
+    Ok(base64::encode_config(
         serde_json::to_vec(&params)?,
-        &URL_SAFE_NO_PAD,
+        base64::URL_SAFE_NO_PAD,
     ))
 }
 
 /// Decode a list of params previously encoded with [`encode_seek`].
 pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> AppResult<D> {
-    Ok(serde_json::from_slice(&base64::decode_engine(
+    Ok(serde_json::from_slice(&base64::decode_config(
         seek,
-        &URL_SAFE_NO_PAD,
+        base64::URL_SAFE_NO_PAD,
     )?)?)
 }
 

--- a/src/metrics/log_encoder.rs
+++ b/src/metrics/log_encoder.rs
@@ -1,5 +1,3 @@
-use base64::alphabet::STANDARD;
-use base64::engine::fast_portable::{FastPortable, PAD};
 use base64::write::EncoderWriter;
 use indexmap::IndexMap;
 use prometheus::proto::{MetricFamily, MetricType};
@@ -12,8 +10,6 @@ use std::io::Write;
 use std::rc::Rc;
 
 const CHUNKS_MAX_SIZE_BYTES: usize = 5000;
-
-const BASE64_ENGINE: FastPortable = FastPortable::from(&STANDARD, PAD);
 
 /// The `LogEncoder` struct encodes Prometheus metrics in the format [`crates-io-heroku-metrics`]
 /// expects metrics to be logged. This can be used to forward instance metrics to it, allowing them
@@ -139,7 +135,7 @@ fn serialize_and_split_list<'a, S: Serialize + 'a>(
     while items.peek().is_some() {
         let mut writer = TrackedWriter::new();
         let written_count = writer.written_count.clone();
-        let mut serializer = Serializer::new(EncoderWriter::from(&mut writer, &BASE64_ENGINE));
+        let mut serializer = Serializer::new(EncoderWriter::new(&mut writer, base64::STANDARD));
 
         let mut seq = serializer.serialize_seq(None)?;
         #[allow(clippy::while_let_on_iterator)]


### PR DESCRIPTION
This should temporarily resolve https://github.com/rust-lang/crates.io/issues/5646 until we figure out what exactly went wrong and why the background worker still seems to be running correctly despite the Sentry error reports.