### PR TITLE
Revert "middleware/log_request: Add `nginx_time` field if it is non-zero"

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -111,12 +111,6 @@ impl Display for RequestLine<'_> {
         if let Some(response_time) = response_time {
             if !is_download_redirect || response_time.as_millis() > 0 {
                 line.add_field("service", response_time)?;
-
-                let conduit_time = self.req.elapsed().as_millis();
-                let nginx_time = response_time.as_millis() as i128 - conduit_time as i128;
-                if nginx_time != 0 {
-                    line.add_field("nginx_time", nginx_time)?;
-                }
             }
         }
 


### PR DESCRIPTION
Reverts rust-lang/crates.io#5655

I've seen enough... 😅 

The result of this experiment is that `nginx_time` was actually negative in all cases where it was logged, which essentially means that `req.elapsed()` is as good of a guess as using the `X-Request-Start` header. In any case it looks like the overhead from running nginx in front of our app is negligible.