### PR TITLE
Remove obsolete `triagebot.toml` config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,4 +1,0 @@
-[relabel]
-allow-unauthenticated = ["*"]
-
-[assign]


### PR DESCRIPTION
We're not really using this bot (anymore?).