### PR TITLE
Implement experimental `log_requests` axum middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ checksum = "08b108ad2665fa3f6e6a517c3d80ec3e77d224c47d605167aefaa5d7ef97fa48"
 dependencies = [
  "async-trait",
  "axum-core",
+ "axum-macros",
  "bitflags",
  "bytes",
  "futures-util",
@@ -219,6 +220,18 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4df0fc33ada14a338b799002f7e8657711422b25d4e16afb032708d6b185621"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "hyper",
@@ -1292,6 +1293,31 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1 0.10.5",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/tests/all.rs"
 [dependencies]
 anyhow = "=1.0.66"
 aws-sigv4 = "=0.52.0"
-axum = "=0.6.1"
+axum = { version = "=0.6.1", features = ["macros"] }
 base64 = "=0.13.1"
 cargo-registry-index = { path = "cargo-registry-index" }
 cargo-registry-markdown = { path = "cargo-registry-markdown" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/tests/all.rs"
 [dependencies]
 anyhow = "=1.0.66"
 aws-sigv4 = "=0.52.0"
-axum = { version = "=0.6.1", features = ["macros"] }
+axum = { version = "=0.6.1", features = ["headers", "macros"] }
 base64 = "=0.13.1"
 cargo-registry-index = { path = "cargo-registry-index" }
 cargo-registry-markdown = { path = "cargo-registry-markdown" }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,0 +1,37 @@
+use axum::headers::{Error, Header};
+use http::header::{HeaderName, HeaderValue};
+
+static X_REQUEST_ID: HeaderName = HeaderName::from_static("x-request-id");
+
+pub struct XRequestId(String);
+
+impl XRequestId {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Header for XRequestId {
+    fn name() -> &'static HeaderName {
+        &X_REQUEST_ID
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        values
+            .next()
+            .and_then(|value| value.to_str().ok())
+            .map(|value| Self(value.to_string()))
+            .ok_or_else(Error::invalid)
+    }
+
+    fn encode<E>(&self, values: &mut E)
+    where
+        E: Extend<HeaderValue>,
+    {
+        let value = HeaderValue::from_str(&self.0).unwrap();
+        values.extend(std::iter::once(value));
+    }
+}

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -35,3 +35,38 @@ impl Header for XRequestId {
         values.extend(std::iter::once(value));
     }
 }
+
+static X_REAL_IP: HeaderName = HeaderName::from_static("x-request-id");
+
+pub struct XRealIp(String);
+
+impl XRealIp {
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl Header for XRealIp {
+    fn name() -> &'static HeaderName {
+        &X_REAL_IP
+    }
+
+    fn decode<'i, I>(values: &mut I) -> Result<Self, Error>
+    where
+        I: Iterator<Item = &'i HeaderValue>,
+    {
+        values
+            .next()
+            .and_then(|value| value.to_str().ok())
+            .map(|value| Self(value.to_string()))
+            .ok_or_else(Error::invalid)
+    }
+
+    fn encode<E>(&self, values: &mut E)
+    where
+        E: Extend<HeaderValue>,
+    {
+        let value = HeaderValue::from_str(&self.0).unwrap();
+        values.extend(std::iter::once(value));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,11 +85,13 @@ pub fn build_handler(app: Arc<App>) -> axum::Router {
 
     type Request = http::Request<axum::body::Body>;
 
-    axum::Router::new().conduit_fallback(conduit_handler).layer(
-        tower::ServiceBuilder::new()
-            .layer(sentry_tower::NewSentryLayer::<Request>::new_from_top())
-            .layer(sentry_tower::SentryHttpLayer::with_transaction()),
-    )
+    let middleware = tower::ServiceBuilder::new()
+        .layer(sentry_tower::NewSentryLayer::<Request>::new_from_top())
+        .layer(sentry_tower::SentryHttpLayer::with_transaction());
+
+    axum::Router::new()
+        .conduit_fallback(conduit_handler)
+        .layer(middleware)
 }
 
 /// Convenience function requiring that an environment variable is set.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod db;
 mod downloads_counter;
 pub mod email;
 pub mod github;
+pub mod headers;
 pub mod metrics;
 pub mod middleware;
 mod publish_rate_limit;

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -6,7 +6,7 @@ use crate::util::request_header;
 
 use conduit::RequestExt;
 
-use crate::headers::XRequestId;
+use crate::headers::{XRealIp, XRequestId};
 use crate::middleware::normalize_path::OriginalPath;
 use axum::headers::UserAgent;
 use axum::middleware::Next;
@@ -50,6 +50,7 @@ pub struct RequestMetadata {
     uri: Uri,
     user_agent: TypedHeader<UserAgent>,
     request_id: Option<TypedHeader<XRequestId>>,
+    real_ip: Option<TypedHeader<XRealIp>>,
 }
 
 pub struct Metadata {
@@ -83,7 +84,10 @@ impl Display for Metadata {
             };
         }
 
-        // line.add_quoted_field("fwd", request_header(self.req, "x-real-ip"))?;
+        match &self.request.real_ip {
+            Some(header) => line.add_quoted_field("fwd", header.as_str())?,
+            None => line.add_quoted_field("fwd", "")?,
+        };
 
         let response_time_in_ms = self.duration.as_millis();
         if !is_download_redirect || response_time_in_ms > 0 {

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -52,6 +52,7 @@ pub struct RequestMetadata {
 
 pub struct Metadata {
     request: RequestMetadata,
+    status: StatusCode,
     duration: Duration,
 }
 
@@ -62,6 +63,7 @@ impl Display for Metadata {
         line.add_field("method", &self.request.method)?;
         line.add_quoted_field("path", &self.request.uri)?;
         line.add_field("service", format!("{}ms", self.duration.as_millis()))?;
+        line.add_field("status", self.status.as_str())?;
         line.add_quoted_field("user_agent", self.request.user_agent.as_str())?;
 
         Ok(())
@@ -79,6 +81,7 @@ pub async fn log_requests<B>(
 
     let metadata = Metadata {
         request: request_metadata,
+        status: response.status(),
         duration: start_instant.elapsed(),
     };
     debug!(target: "axum", "{metadata}");

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -6,6 +6,7 @@ use crate::util::request_header;
 
 use conduit::RequestExt;
 
+use crate::headers::XRequestId;
 use crate::middleware::normalize_path::OriginalPath;
 use axum::headers::UserAgent;
 use axum::middleware::Next;
@@ -48,6 +49,7 @@ pub struct RequestMetadata {
     method: Method,
     uri: Uri,
     user_agent: TypedHeader<UserAgent>,
+    request_id: Option<TypedHeader<XRequestId>>,
 }
 
 pub struct Metadata {
@@ -74,10 +76,13 @@ impl Display for Metadata {
 
         line.add_quoted_field("path", &self.request.uri)?;
 
-        // if !is_download_redirect {
-        //     line.add_field("request_id", request_header(self.req, "x-request-id"))?;
-        // }
-        //
+        if !is_download_redirect {
+            match &self.request.request_id {
+                Some(header) => line.add_field("request_id", header.as_str())?,
+                None => line.add_field("request_id", "")?,
+            };
+        }
+
         // line.add_quoted_field("fwd", request_header(self.req, "x-real-ip"))?;
 
         let response_time_in_ms = self.duration.as_millis();

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -60,11 +60,51 @@ impl Display for Metadata {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let mut line = LogLine::new(f);
 
-        line.add_field("method", &self.request.method)?;
+        // The download endpoint is our most requested endpoint by 1-2 orders of
+        // magnitude. Since we pay per logged GB we try to reduce the amount of
+        // bytes per log line for this endpoint.
+
+        let is_download_endpoint = self.request.uri.path().ends_with("/download");
+        let is_download_redirect = is_download_endpoint && self.status.is_redirection();
+
+        let method = &self.request.method;
+        if !is_download_redirect || method != Method::GET {
+            line.add_field("method", method)?;
+        }
+
         line.add_quoted_field("path", &self.request.uri)?;
-        line.add_field("service", format!("{}ms", self.duration.as_millis()))?;
-        line.add_field("status", self.status.as_str())?;
+
+        // if !is_download_redirect {
+        //     line.add_field("request_id", request_header(self.req, "x-request-id"))?;
+        // }
+        //
+        // line.add_quoted_field("fwd", request_header(self.req, "x-real-ip"))?;
+
+        let response_time_in_ms = self.duration.as_millis();
+        if !is_download_redirect || response_time_in_ms > 0 {
+            line.add_field("service", format!("{}ms", response_time_in_ms))?;
+        }
+
+        if !is_download_redirect {
+            line.add_field("status", self.status.as_str())?;
+        }
+
         line.add_quoted_field("user_agent", self.request.user_agent.as_str())?;
+
+        // CUSTOM_METADATA.with(|metadata| {
+        //     for (key, value) in &*metadata.borrow() {
+        //         line.add_quoted_field(key, value)?;
+        //     }
+        //     fmt::Result::Ok(())
+        // })?;
+        //
+        // if let Err(err) = self.res {
+        //     line.add_quoted_field("error", err)?;
+        // }
+
+        if response_time_in_ms > SLOW_REQUEST_THRESHOLD_MS {
+            line.add_marker("SLOW REQUEST")?;
+        }
 
         Ok(())
     }

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -40,13 +40,18 @@ impl Middleware for LogRequests {
     }
 }
 
-pub async fn log_requests<B>(
+#[derive(axum::extract::FromRequestParts)]
+pub struct RequestMetadata {
     method: Method,
     uri: Uri,
+}
+
+pub async fn log_requests<B>(
+    request_metadata: RequestMetadata,
     req: Request<B>,
     next: Next<B>,
 ) -> impl IntoResponse {
-    debug!(target: "axum", "method={} path=\"{}\"", method, uri);
+    debug!(target: "axum", "method={} path=\"{}\"", request_metadata.method, request_metadata.uri);
     next.run(req).await
 }
 

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -7,7 +7,9 @@ use crate::util::request_header;
 use conduit::RequestExt;
 
 use crate::middleware::normalize_path::OriginalPath;
-use http::{header, Method, StatusCode};
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use http::{header, Method, Request, StatusCode, Uri};
 use std::cell::RefCell;
 use std::fmt::{self, Display, Formatter};
 
@@ -36,6 +38,16 @@ impl Middleware for LogRequests {
 
         res
     }
+}
+
+pub async fn log_requests<B>(
+    method: Method,
+    uri: Uri,
+    req: Request<B>,
+    next: Next<B>,
+) -> impl IntoResponse {
+    debug!(target: "axum", "method={} path=\"{}\"", method, uri);
+    next.run(req).await
 }
 
 pub fn add_custom_metadata<V: Display>(key: &'static str, value: V) {

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -55,6 +55,19 @@ pub struct Metadata {
     duration: Duration,
 }
 
+impl Display for Metadata {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut line = LogLine::new(f);
+
+        line.add_field("method", &self.request.method)?;
+        line.add_quoted_field("path", &self.request.uri)?;
+        line.add_field("service", format!("{}ms", self.duration.as_millis()))?;
+        line.add_quoted_field("user_agent", self.request.user_agent.as_str())?;
+
+        Ok(())
+    }
+}
+
 pub async fn log_requests<B>(
     request_metadata: RequestMetadata,
     req: Request<B>,
@@ -68,14 +81,7 @@ pub async fn log_requests<B>(
         request: request_metadata,
         duration: start_instant.elapsed(),
     };
-    debug!(
-        target: "axum",
-        "method={} path=\"{}\" service={}ms user_agent=\"{}\"",
-        metadata.request.method,
-        metadata.request.uri,
-        metadata.duration.as_millis(),
-        metadata.request.user_agent.as_str(),
-    );
+    debug!(target: "axum", "{metadata}");
 
     response
 }

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -7,8 +7,10 @@ use crate::util::request_header;
 use conduit::RequestExt;
 
 use crate::middleware::normalize_path::OriginalPath;
+use axum::headers::UserAgent;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
+use axum::TypedHeader;
 use http::{header, Method, Request, StatusCode, Uri};
 use std::cell::RefCell;
 use std::fmt::{self, Display, Formatter};
@@ -45,6 +47,7 @@ impl Middleware for LogRequests {
 pub struct RequestMetadata {
     method: Method,
     uri: Uri,
+    user_agent: TypedHeader<UserAgent>,
 }
 
 pub struct Metadata {
@@ -65,7 +68,14 @@ pub async fn log_requests<B>(
         request: request_metadata,
         duration: start_instant.elapsed(),
     };
-    debug!(target: "axum", "method={} path=\"{}\" service={}ms", metadata.request.method, metadata.request.uri, metadata.duration.as_millis());
+    debug!(
+        target: "axum",
+        "method={} path=\"{}\" service={}ms user_agent=\"{}\"",
+        metadata.request.method,
+        metadata.request.uri,
+        metadata.duration.as_millis(),
+        metadata.request.user_agent.as_str(),
+    );
 
     response
 }


### PR DESCRIPTION
This is meant to eventually replace the equivalent `conduit` middleware once it is feature complete. Until then we only log with `debug` level, which does not show up in production logs.

The two missing pieces are custom metadata and the `error` field. I've decided to put those into dedicated PRs since these changes are a bit more involved... 😅 