### PR TITLE
middleware/log_request: Add custom metadata fields to `axum` logging

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -71,9 +71,9 @@ impl AuthCheck {
             }
         }
 
-        log_request::add_custom_metadata("uid", auth.user_id());
+        log_request::add_custom_metadata(request, "uid", auth.user_id());
         if let Some(id) = auth.api_token_id() {
-            log_request::add_custom_metadata("tokenid", id);
+            log_request::add_custom_metadata(request, "tokenid", id);
         }
 
         if let Some(ref token) = auth.token {

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -95,7 +95,7 @@ impl PaginationOptionsBuilder {
                 }
 
                 if numeric_page > MAX_PAGE_BEFORE_SUSPECTED_BOT {
-                    add_custom_metadata("bot", "suspected");
+                    add_custom_metadata(req, "bot", "suspected");
                 }
 
                 // Block large offsets for known violators of the crawler policy
@@ -104,7 +104,7 @@ impl PaginationOptionsBuilder {
                     if numeric_page > config.max_allowed_page_offset
                         && is_useragent_or_ip_blocked(config, req)
                     {
-                        add_custom_metadata("cause", "large page offset");
+                        add_custom_metadata(req, "cause", "large page offset");
                         return Err(bad_request("requested page offset is too large"));
                     }
                 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -62,8 +62,8 @@ pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
 
     let new_crate = parse_new_headers(req)?;
 
-    add_custom_metadata("crate_name", new_crate.name.to_string());
-    add_custom_metadata("crate_version", new_crate.vers.to_string());
+    add_custom_metadata(req, "crate_name", new_crate.name.to_string());
+    add_custom_metadata(req, "crate_version", new_crate.vers.to_string());
 
     let conn = app.primary_database.get()?;
 
@@ -307,7 +307,7 @@ fn count_versions_published_today(krate_id: i32, conn: &PgConnection) -> QueryRe
 fn parse_new_headers(req: &mut dyn RequestExt) -> AppResult<EncodableCrateUpload> {
     // Read the json upload request
     let metadata_length = u64::from(read_le_u32(req.body())?);
-    add_custom_metadata("metadata_length", metadata_length);
+    add_custom_metadata(req, "metadata_length", metadata_length);
 
     let max = req.app().config.max_upload_size;
     if metadata_length > max {

--- a/src/middleware/balance_capacity.rs
+++ b/src/middleware/balance_capacity.rs
@@ -57,11 +57,11 @@ impl BalanceCapacity {
     fn handle_high_load(&self, request: &mut dyn RequestExt, note: &str) -> AfterResult {
         if self.report_only {
             // In report-only mode we serve all requests but add log metadata
-            add_custom_metadata("would_reject", note);
+            add_custom_metadata(request, "would_reject", note);
             self.handle(request)
         } else {
             // Reject the request
-            add_custom_metadata("cause", note);
+            add_custom_metadata(request, "cause", note);
             let body = "Service temporarily unavailable";
             Response::builder()
                 .status(StatusCode::SERVICE_UNAVAILABLE)
@@ -85,7 +85,7 @@ impl Handler for BalanceCapacity {
 
         // Begin logging total request count so early stages of load increase can be located
         if in_flight_total >= self.log_total_at_count {
-            add_custom_metadata("in_flight_total", in_flight_total);
+            add_custom_metadata(request, "in_flight_total", in_flight_total);
         }
 
         // Download requests are always accepted and do not affect the capacity tracking
@@ -99,7 +99,7 @@ impl Handler for BalanceCapacity {
 
         // Begin logging non-download request count so early stages of non-download load increase can be located
         if load >= self.log_at_percentage {
-            add_custom_metadata("in_flight_non_dl_requests", count);
+            add_custom_metadata(request, "in_flight_non_dl_requests", count);
         }
 
         // Reject read-only requests as load nears capacity. Bots are likely to send only safe

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -48,7 +48,7 @@ impl Handler for BlockTraffic {
             .any(|value| self.blocked_values.iter().any(|v| v == value));
         if has_blocked_value {
             let cause = format!("blocked due to contents of header {}", self.header_name);
-            add_custom_metadata("cause", cause);
+            add_custom_metadata(req, "cause", cause);
             let body = format!(
                 "We are unable to process your request at this time. \
                  This usually means that you are in violation of our crawler \

--- a/src/middleware/normalize_path.rs
+++ b/src/middleware/normalize_path.rs
@@ -43,7 +43,7 @@ impl Middleware for NormalizePath {
             .to_string_lossy()
             .to_string(); // non-Unicode is replaced with U+FFFD REPLACEMENT CHARACTER
 
-        add_custom_metadata("normalized_path", path.clone());
+        add_custom_metadata(req, "normalized_path", path.clone());
 
         *req.path_mut() = path;
         req.mut_extensions().insert(original_path);

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -32,7 +32,7 @@ impl Handler for RequireUserAgent {
         let has_user_agent = !agent.is_empty() && agent != self.cdn_user_agent;
         let is_download = req.path().ends_with("download");
         if !has_user_agent && !is_download {
-            add_custom_metadata("cause", "no user agent");
+            add_custom_metadata(req, "cause", "no user agent");
             let body = format!(
                 include_str!("no_user_agent_message.txt"),
                 request_header(req, "x-request-id"),

--- a/src/router.rs
+++ b/src/router.rs
@@ -200,7 +200,7 @@ impl Handler for C {
             Ok(resp) => Ok(resp),
             Err(e) => {
                 if let Some(cause) = e.cause() {
-                    add_custom_metadata("cause", cause.to_string())
+                    add_custom_metadata(req, "cause", cause.to_string())
                 };
                 match e.response() {
                     Some(response) => Ok(response),
@@ -224,6 +224,7 @@ impl<H: Handler> Handler for R<H> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::middleware::log_request::CustomMetadata;
     use crate::util::errors::{bad_request, cargo_err, forbidden, internal, not_found, AppError};
     use crate::util::EndpointResult;
 
@@ -238,6 +239,7 @@ mod tests {
     #[test]
     fn http_error_responses() {
         let mut req = MockRequest::new(::conduit::Method::GET, "/");
+        req.mut_extensions().insert(CustomMetadata::default());
 
         // Types for handling common error status codes
         assert_eq!(
@@ -278,7 +280,7 @@ mod tests {
         .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
-            crate::middleware::log_request::get_log_message("cause"),
+            crate::middleware::log_request::get_log_message(&req, "cause"),
             "middle error caused by invalid digit found in string"
         );
 


### PR DESCRIPTION
This requires us to go back to putting custom metadata in a request extension, but this time we're putting it in a `Arc<Mutex<Vec>>` to make it extra complicated... and compatible with axum middlewares 😅 