### PR TITLE
middleware/normalize_path: Migrate to `axum`

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -20,7 +20,7 @@ mod ember_html;
 mod head;
 mod known_error_to_json;
 pub mod log_request;
-mod normalize_path;
+pub mod normalize_path;
 mod require_user_agent;
 mod static_or_continue;
 mod update_metrics;
@@ -71,7 +71,6 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
 
     m.add(log_request::LogRequests::default());
 
-    m.add(normalize_path::NormalizePath);
     m.add(ConditionalGet);
 
     m.add(Cookie::new());


### PR DESCRIPTION
This PR ports our `normalize_path` middleware from `conduit` to `axum`.

Since this middleware needs to run before the axum `Router` is involved, it needs to be wrapped around the router as suggested by https://docs.rs/axum/0.6.1/axum/middleware/index.html#rewriting-request-uri-in-middleware. 

This also means that the middleware is running before the request logging middleware, so some changes there were also necessary to make it log the same field contents as before.