### PR TITLE
Implement axum-based `session` middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
+dependencies = [
+ "axum",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "mime",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +365,7 @@ dependencies = [
  "anyhow",
  "aws-sigv4",
  "axum",
+ "axum-extra",
  "base64",
  "cargo-registry-index",
  "cargo-registry-markdown",
@@ -728,6 +749,7 @@ dependencies = [
  "base64",
  "hkdf",
  "hmac",
+ "percent-encoding",
  "rand",
  "sha2",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,6 @@ dependencies = [
  "conduit",
  "conduit-axum",
  "conduit-conditional-get",
- "conduit-cookie",
  "conduit-git-http-backend",
  "conduit-middleware",
  "conduit-router",
@@ -641,18 +640,6 @@ dependencies = [
  "conduit",
  "conduit-middleware",
  "time 0.2.27",
-]
-
-[[package]]
-name = "conduit-cookie"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f88a8f6cc0c410bea02244bfec3ad16b290be77c9d222048be44cb2d1f457f1"
-dependencies = [
- "base64",
- "conduit",
- "conduit-middleware",
- "cookie",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/tests/all.rs"
 anyhow = "=1.0.67"
 aws-sigv4 = "=0.52.0"
 axum = { version = "=0.6.1", features = ["headers", "macros"] }
+axum-extra = { version = "=0.4.2", features = ["cookie-signed"] }
 base64 = "=0.13.1"
 cargo-registry-index = { path = "cargo-registry-index" }
 cargo-registry-markdown = { path = "cargo-registry-markdown" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ clap = { version = "=4.0.29", features = ["derive", "unicode", "wrap_help"] }
 
 conduit = "=0.10.0"
 conduit-conditional-get = "=0.10.0"
-conduit-cookie = "=0.10.0"
 conduit-git-http-backend = "=0.10.0"
 conduit-axum = { path = "conduit-axum" }
 conduit-middleware = "=0.10.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,7 +205,7 @@ impl App {
             .expect("No HTTP client is configured.  In tests, use `TestApp::with_proxy()`.")
     }
 
-    /// A unique key used with conduit_cookie to generate signed/encrypted cookies
+    /// A unique key to generate signed cookies
     pub fn session_key(&self) -> &cookie::Key {
         &self.config.session_key
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@ use crate::downloads_counter::DownloadsCounter;
 use crate::email::Emails;
 use crate::github::{GitHubClient, RealGitHubClient};
 use crate::metrics::{InstanceMetrics, ServiceMetrics};
+use axum::extract::FromRef;
 use diesel::r2d2;
 use moka::sync::{Cache, CacheBuilder};
 use oauth2::basic::BasicClient;
@@ -219,5 +220,11 @@ impl Deref for AppState {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl FromRef<AppState> for cookie::Key {
+    fn from_ref(app: &AppState) -> Self {
+        app.session_key().clone()
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@
 
 use crate::db::{ConnectionConfig, DieselPool};
 use crate::{config, Env};
+use std::ops::Deref;
 use std::{sync::Arc, time::Duration};
 
 use crate::downloads_counter::DownloadsCounter;
@@ -206,5 +207,17 @@ impl App {
     /// A unique key used with conduit_cookie to generate signed/encrypted cookies
     pub fn session_key(&self) -> &cookie::Key {
         &self.config.session_key
+    }
+}
+
+#[derive(Clone)]
+pub struct AppState(pub Arc<App>);
+
+// deref so you can still access the inner fields easily
+impl Deref for AppState {
+    type Target = App;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -204,7 +204,7 @@ impl App {
     }
 
     /// A unique key used with conduit_cookie to generate signed/encrypted cookies
-    pub fn session_key(&self) -> &str {
+    pub fn session_key(&self) -> &cookie::Key {
         &self.config.session_key
     }
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,7 @@
 use crate::controllers;
 use crate::db::RequestTransaction;
 use crate::middleware::log_request;
+use crate::middleware::session::RequestSession;
 use crate::models::token::{CrateScope, EndpointScope};
 use crate::models::{ApiToken, User};
 use crate::util::errors::{
@@ -8,7 +9,6 @@ use crate::util::errors::{
 };
 use chrono::Utc;
 use conduit::RequestExt;
-use conduit_cookie::RequestSession;
 use http::header;
 
 #[derive(Debug, Clone)]
@@ -156,8 +156,9 @@ impl AuthenticatedUser {
 fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
     let conn = req.db_write()?;
 
-    let session = req.session();
-    let user_id_from_session = session.get("user_id").and_then(|s| s.parse::<i32>().ok());
+    let user_id_from_session = req
+        .session_get("user_id")
+        .and_then(|s| s.parse::<i32>().ok());
 
     if let Some(id) = user_id_from_session {
         let user = User::find(&conn, id)

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ const DEFAULT_VERSION_ID_CACHE_TTL: u64 = 5 * 60; // 5 minutes
 pub struct Server {
     pub base: Base,
     pub db: DatabasePools,
-    pub session_key: String,
+    pub session_key: cookie::Key,
     pub gh_client_id: String,
     pub gh_client_secret: String,
     pub gh_base_url: String,
@@ -112,7 +112,7 @@ impl Default for Server {
         Server {
             db: DatabasePools::full_from_environment(&base),
             base,
-            session_key: env("SESSION_KEY"),
+            session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),
             gh_client_id: env("GH_CLIENT_ID"),
             gh_client_secret: env("GH_CLIENT_SECRET"),
             gh_base_url: "https://api.github.com".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::{app::App, email::Emails, uploaders::Uploader};
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::app::AppState;
 use conduit_axum::ConduitFallback;
 use tikv_jemallocator::Jemalloc;
 
@@ -82,8 +83,9 @@ pub fn build_handler(app: Arc<App>) -> axum::Router {
     let endpoints = router::build_router(&app);
     let conduit_handler = middleware::build_middleware(app.clone(), endpoints);
 
-    let axum_router = axum::Router::new();
-    middleware::apply_axum_middleware(&app, axum_router.conduit_fallback(conduit_handler))
+    let state = AppState(app);
+    let axum_router = axum::Router::new().with_state(state.clone());
+    middleware::apply_axum_middleware(state, axum_router.conduit_fallback(conduit_handler))
 }
 
 /// Convenience function requiring that an environment variable is set.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -76,7 +76,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     m.add(Cookie::new());
     m.add(SessionMiddleware::new(
         "cargo_session",
-        cookie::Key::derive_from(app.session_key().as_bytes()),
+        app.session_key().clone(),
         env == Env::Production,
     ));
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -37,12 +37,13 @@ use axum::Router;
 use std::env;
 use std::sync::Arc;
 
+use crate::app::AppState;
 use crate::{App, Env};
 
-pub fn apply_axum_middleware(app: &Arc<App>, router: Router) -> Router {
+pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
     type Request = http::Request<axum::body::Body>;
 
-    let env = app.config.env();
+    let env = state.config.env();
 
     let middleware = tower::ServiceBuilder::new()
         .layer(sentry_tower::NewSentryLayer::<Request>::new_from_top())

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -22,17 +22,17 @@ mod known_error_to_json;
 pub mod log_request;
 pub mod normalize_path;
 mod require_user_agent;
+pub mod session;
 mod static_or_continue;
 mod update_metrics;
 
 use conduit_conditional_get::ConditionalGet;
-use conduit_cookie::{Middleware as Cookie, SessionMiddleware};
 use conduit_middleware::MiddlewareBuilder;
 use conduit_router::RouteBuilder;
 
 use ::sentry::integrations::tower as sentry_tower;
 use axum::error_handling::HandleErrorLayer;
-use axum::middleware::from_fn;
+use axum::middleware::{from_fn, from_fn_with_state};
 use axum::Router;
 use std::env;
 use std::sync::Arc;
@@ -53,7 +53,8 @@ pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
         .layer(HandleErrorLayer::new(dummy_error_handler))
         // Optionally print debug information for each request
         // To enable, set the environment variable: `RUST_LOG=cargo_registry::middleware=debug`
-        .option_layer((env == Env::Development).then(|| from_fn(debug::debug_requests)));
+        .option_layer((env == Env::Development).then(|| from_fn(debug::debug_requests)))
+        .layer(from_fn_with_state(state, session::attach_session));
 
     router.layer(middleware)
 }
@@ -73,13 +74,6 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     m.add(log_request::LogRequests::default());
 
     m.add(ConditionalGet);
-
-    m.add(Cookie::new());
-    m.add(SessionMiddleware::new(
-        "cargo_session",
-        app.session_key().clone(),
-        env == Env::Production,
-    ));
 
     m.add(AppMiddleware::new(app));
     m.add(KnownErrorToJson);

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -1,0 +1,102 @@
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use axum_extra::extract::SignedCookieJar;
+use conduit_cookie::SessionMiddleware;
+use cookie::time::Duration;
+use cookie::{Cookie, SameSite};
+use http::Request;
+use std::collections::HashMap;
+use std::sync::{Arc, PoisonError, RwLock};
+
+static COOKIE_NAME: &str = "cargo_session";
+static MAX_AGE_DAYS: i64 = 90;
+
+pub async fn attach_session<B>(
+    jar: SignedCookieJar,
+    mut req: Request<B>,
+    next: Next<B>,
+) -> Response {
+    // Decode session cookie
+    let data = jar
+        .get(COOKIE_NAME)
+        .map(SessionMiddleware::decode)
+        .unwrap_or_default();
+
+    // Save decoded session data in request extension,
+    // and keep an `Arc` clone for later
+    let session = Arc::new(RwLock::new(Session::new(data)));
+    req.extensions_mut().insert(session.clone());
+
+    // Process the request
+    let response = next.run(req).await;
+
+    // Check if the session data was mutated
+    let session = session.read().unwrap();
+    if session.dirty {
+        // Return response with additional `Set-Cookie` header
+        let encoded = SessionMiddleware::encode(&session.data);
+        let cookie = Cookie::build(COOKIE_NAME, encoded)
+            .http_only(true)
+            .secure(true)
+            .same_site(SameSite::Strict)
+            .max_age(Duration::days(MAX_AGE_DAYS))
+            .path("/")
+            .finish();
+
+        (jar.add(cookie), response).into_response()
+    } else {
+        response
+    }
+}
+
+/// Request extension holding the session data
+struct Session {
+    data: HashMap<String, String>,
+    dirty: bool,
+}
+
+impl Session {
+    fn new(data: HashMap<String, String>) -> Self {
+        Self { data, dirty: false }
+    }
+}
+
+pub trait RequestSession {
+    fn session_get(&self, key: &str) -> Option<String>;
+    fn session_insert(&mut self, key: String, value: String) -> Option<String>;
+    fn session_remove(&mut self, key: &str) -> Option<String>;
+}
+
+impl<T: conduit::RequestExt + ?Sized> RequestSession for T {
+    fn session_get(&self, key: &str) -> Option<String> {
+        let session = self
+            .extensions()
+            .get::<Arc<RwLock<Session>>>()
+            .expect("missing cookie session")
+            .read()
+            .unwrap_or_else(PoisonError::into_inner);
+        session.data.get(key).cloned()
+    }
+
+    fn session_insert(&mut self, key: String, value: String) -> Option<String> {
+        let mut session = self
+            .mut_extensions()
+            .get_mut::<Arc<RwLock<Session>>>()
+            .expect("missing cookie session")
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        session.dirty = true;
+        session.data.insert(key, value)
+    }
+
+    fn session_remove(&mut self, key: &str) -> Option<String> {
+        let mut session = self
+            .mut_extensions()
+            .get_mut::<Arc<RwLock<Session>>>()
+            .expect("missing cookie session")
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        session.dirty = true;
+        session.data.remove(key)
+    }
+}

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -1,7 +1,6 @@
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::SignedCookieJar;
-use conduit_cookie::SessionMiddleware;
 use cookie::time::Duration;
 use cookie::{Cookie, SameSite};
 use http::Request;
@@ -17,10 +16,7 @@ pub async fn attach_session<B>(
     next: Next<B>,
 ) -> Response {
     // Decode session cookie
-    let data = jar
-        .get(COOKIE_NAME)
-        .map(SessionMiddleware::decode)
-        .unwrap_or_default();
+    let data = jar.get(COOKIE_NAME).map(decode).unwrap_or_default();
 
     // Save decoded session data in request extension,
     // and keep an `Arc` clone for later
@@ -34,7 +30,7 @@ pub async fn attach_session<B>(
     let session = session.read().unwrap();
     if session.dirty {
         // Return response with additional `Set-Cookie` header
-        let encoded = SessionMiddleware::encode(&session.data);
+        let encoded = encode(&session.data);
         let cookie = Cookie::build(COOKIE_NAME, encoded)
             .http_only(true)
             .secure(true)
@@ -99,4 +95,35 @@ impl<T: conduit::RequestExt + ?Sized> RequestSession for T {
         session.dirty = true;
         session.data.remove(key)
     }
+}
+
+pub fn decode(cookie: Cookie<'_>) -> HashMap<String, String> {
+    let mut ret = HashMap::new();
+    let bytes = base64::decode(cookie.value().as_bytes()).unwrap_or_default();
+    let mut parts = bytes.split(|&a| a == 0xff);
+    while let (Some(key), Some(value)) = (parts.next(), parts.next()) {
+        if key.is_empty() {
+            break;
+        }
+        if let (Ok(key), Ok(value)) = (std::str::from_utf8(key), std::str::from_utf8(value)) {
+            ret.insert(key.to_string(), value.to_string());
+        }
+    }
+    ret
+}
+
+pub fn encode(h: &HashMap<String, String>) -> String {
+    let mut ret = Vec::new();
+    for (i, (k, v)) in h.iter().enumerate() {
+        if i != 0 {
+            ret.push(0xff)
+        }
+        ret.extend(k.bytes());
+        ret.push(0xff);
+        ret.extend(v.bytes());
+    }
+    while ret.len() * 8 % 6 != 0 {
+        ret.push(0xff);
+    }
+    base64::encode(&ret[..])
 }

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -34,7 +34,7 @@ fn token_auth_cannot_find_token() {
 fn cookie_auth_cannot_find_user() {
     let (app, anon) = TestApp::init().empty();
 
-    let session_key = &app.as_inner().session_key();
+    let session_key = app.as_inner().session_key();
     let cookie = encode_session_header(session_key, -1);
 
     let mut request = anon.request_builder(Method::GET, URL);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -244,9 +244,6 @@ impl RequestHelper for MockAnonymousUser {
 }
 
 /// A type that can generate cookie authenticated requests
-///
-/// The `user.id` value is directly injected into a request extension and thus the conduit_cookie
-/// session logic is not exercised.
 pub struct MockCookieUser {
     app: TestApp,
     user: User,

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -60,9 +60,8 @@ pub use test_app::{TestApp, TestDatabase};
 ///
 /// The implementation matches roughly what is happening inside of the
 /// `SessionMiddleware` from `conduit_cookie`.
-pub fn encode_session_header(session_key: &str, user_id: i32) -> String {
+pub fn encode_session_header(session_key: &cookie::Key, user_id: i32) -> String {
     let cookie_name = "cargo_session";
-    let cookie_key = cookie::Key::derive_from(session_key.as_bytes());
 
     // build session data map
     let mut map = HashMap::new();
@@ -74,7 +73,7 @@ pub fn encode_session_header(session_key: &str, user_id: i32) -> String {
     // put the cookie into a signed cookie jar
     let cookie = Cookie::build(cookie_name, encoded).finish();
     let mut jar = cookie::CookieJar::new();
-    jar.signed_mut(&cookie_key).add(cookie);
+    jar.signed_mut(session_key).add(cookie);
 
     // read the raw cookie from the cookie jar
     jar.get(cookie_name).unwrap().to_string()

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -23,10 +23,10 @@ use crate::{
     builders::PublishBuilder, CategoryListResponse, CategoryResponse, CrateList, CrateResponse,
     GoodCrate, OkBool, OwnersResponse, VersionResponse,
 };
+use cargo_registry::middleware::session;
 use cargo_registry::models::{ApiToken, CreatedApiToken, User};
 
 use conduit::RequestExt;
-use conduit_cookie::SessionMiddleware;
 use conduit_test::MockRequest;
 use http::Method;
 
@@ -58,8 +58,8 @@ pub use test_app::{TestApp, TestDatabase};
 /// request.header(header::COOKIE, &cookie);
 /// ```
 ///
-/// The implementation matches roughly what is happening inside of the
-/// `SessionMiddleware` from `conduit_cookie`.
+/// The implementation matches roughly what is happening inside of our
+/// session middleware.
 pub fn encode_session_header(session_key: &cookie::Key, user_id: i32) -> String {
     let cookie_name = "cargo_session";
 
@@ -68,7 +68,7 @@ pub fn encode_session_header(session_key: &cookie::Key, user_id: i32) -> String 
     map.insert("user_id".into(), user_id.to_string());
 
     // encode the map into a cookie value string
-    let encoded = SessionMiddleware::encode(&map);
+    let encoded = session::encode(&map);
 
     // put the cookie into a signed cookie jar
     let cookie = Cookie::build(cookie_name, encoded).finish();

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -338,7 +338,7 @@ fn simple_config() -> config::Server {
     config::Server {
         base: config::Base::test(),
         db: config::DatabasePools::test_from_environment(),
-        session_key: "test this has to be over 32 bytes long".to_string(),
+        session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: dotenv::var("GH_CLIENT_ID").unwrap_or_default(),
         gh_client_secret: dotenv::var("GH_CLIENT_SECRET").unwrap_or_default(),
         gh_base_url: "http://api.github.com".to_string(),


### PR DESCRIPTION
This PR re-implements the `SessionMiddleware` from `conduit-cookie` based on `axum` instead. 

Due to the different request lifetimes in both worlds I had to use an `Arc<RwLock<...>>` for this middleware, which makes it hard to keep the same `session()` and `session_mut()` APIs. The new APIs appear to work well enough for now though.