### PR TITLE
middleware/update_metrics: Migrate to `axum`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/tests/all.rs"
 [dependencies]
 anyhow = "=1.0.67"
 aws-sigv4 = "=0.52.0"
-axum = { version = "=0.6.1", features = ["headers", "macros"] }
+axum = { version = "=0.6.1", features = ["headers", "macros", "matched-path"] }
 axum-extra = { version = "=0.4.2", features = ["cookie-signed"] }
 base64 = "=0.13.1"
 cargo-registry-index = { path = "cargo-registry-index" }

--- a/conduit-axum/Cargo.toml
+++ b/conduit-axum/Cargo.toml
@@ -11,6 +11,7 @@ rust-version = "1.56.0"
 [dependencies]
 axum = "=0.6.1"
 conduit = "=0.10.0"
+conduit-router = "=0.10.0"
 hyper = { version = "=0.14.23", features = ["server", "stream"] }
 http = "=0.2.8"
 percent-encoding = "=2.2.0"

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -67,7 +67,7 @@ async fn fallback_to_conduit(
 }
 
 /// Turns a `ConduitResponse` into a `AxumResponse`
-pub fn conduit_into_axum(response: ConduitResponse) -> AxumResponse {
+fn conduit_into_axum(response: ConduitResponse) -> AxumResponse {
     use conduit::Body::*;
 
     let (parts, body) = response.into_parts();

--- a/src/middleware/update_metrics.rs
+++ b/src/middleware/update_metrics.rs
@@ -1,44 +1,41 @@
-use super::app::RequestApp;
-use super::prelude::*;
+use crate::app::AppState;
+use axum::extract::State;
+use axum::middleware::Next;
+use axum::response::Response;
 use conduit_router::RoutePattern;
+use http::Request;
+use std::time::Instant;
 
-#[derive(Debug, Default)]
-pub(super) struct UpdateMetrics;
+pub async fn update_metrics<B>(
+    State(state): State<AppState>,
+    req: Request<B>,
+    next: Next<B>,
+) -> Response {
+    let start_instant = Instant::now();
 
-impl Middleware for UpdateMetrics {
-    fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
-        let metrics = &req.app().instance_metrics;
+    let metrics = &state.instance_metrics;
+    metrics.requests_in_flight.inc();
 
-        metrics.requests_in_flight.inc();
+    let response = next.run(req).await;
 
-        Ok(())
-    }
+    metrics.requests_in_flight.dec();
+    metrics.requests_total.inc();
 
-    fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
-        let metrics = &req.app().instance_metrics;
+    let endpoint = response
+        .extensions()
+        .get::<RoutePattern>()
+        .map(|p| p.pattern())
+        .unwrap_or("<unknown>");
+    metrics
+        .response_times
+        .with_label_values(&[endpoint])
+        .observe(start_instant.elapsed().as_millis() as f64 / 1000.0);
 
-        metrics.requests_in_flight.dec();
-        metrics.requests_total.inc();
+    let status = response.status().as_u16();
+    metrics
+        .responses_by_status_code_total
+        .with_label_values(&[&status.to_string()])
+        .inc();
 
-        let endpoint = req
-            .extensions()
-            .get::<RoutePattern>()
-            .map(|p| p.pattern())
-            .unwrap_or("<unknown>");
-        metrics
-            .response_times
-            .with_label_values(&[endpoint])
-            .observe(req.elapsed().as_millis() as f64 / 1000.0);
-
-        let status = match &res {
-            Ok(res) => res.status().as_u16(),
-            Err(_) => 500,
-        };
-        metrics
-            .responses_by_status_code_total
-            .with_label_values(&[&status.to_string()])
-            .inc();
-
-        res
-    }
+    response
 }


### PR DESCRIPTION
Just like some of the previous PRs, this PR is migrating yet another conduit-based middleware to be an `axum` middleware instead :)