### PR TITLE
middleware/require_user_agent: Move `cdn_user_agent` field into server `config`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,7 @@ pub struct Server {
     pub blocked_routes: HashSet<String>,
     pub version_id_cache_size: u64,
     pub version_id_cache_ttl: Duration,
+    pub cdn_user_agent: String,
 }
 
 impl Default for Server {
@@ -147,6 +148,8 @@ impl Default for Server {
             version_id_cache_ttl: Duration::from_secs(
                 env_optional("VERSION_ID_CACHE_TTL").unwrap_or(DEFAULT_VERSION_ID_CACHE_TTL),
             ),
+            cdn_user_agent: dotenv::var("WEB_CDN_USER_AGENT")
+                .unwrap_or_else(|_| "Amazon CloudFront".into()),
         }
     }
 }

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -8,28 +8,27 @@
 //! 0.17 (released alongside rustc 1.17).
 
 use super::prelude::*;
-use std::env;
+use crate::middleware::app::RequestApp;
 
 use crate::util::request_header;
 
 #[derive(Default)]
 pub struct RequireUserAgent {
-    cdn_user_agent: String,
     handler: Option<Box<dyn Handler>>,
 }
 
 impl AroundMiddleware for RequireUserAgent {
     fn with_handler(&mut self, handler: Box<dyn Handler>) {
-        self.cdn_user_agent =
-            env::var("WEB_CDN_USER_AGENT").unwrap_or_else(|_| "Amazon CloudFront".into());
         self.handler = Some(handler);
     }
 }
 
 impl Handler for RequireUserAgent {
     fn call(&self, req: &mut dyn RequestExt) -> AfterResult {
+        let cdn_user_agent = &req.app().config.cdn_user_agent;
+
         let agent = request_header(req, header::USER_AGENT);
-        let has_user_agent = !agent.is_empty() && agent != self.cdn_user_agent;
+        let has_user_agent = !agent.is_empty() && agent != cdn_user_agent;
         let is_download = req.path().ends_with("download");
         if !has_user_agent && !is_download {
             add_custom_metadata(req, "cause", "no user agent");

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -362,6 +362,7 @@ fn simple_config() -> config::Server {
         blocked_routes: HashSet::new(),
         version_id_cache_size: 10000,
         version_id_cache_ttl: Duration::from_secs(5 * 60),
+        cdn_user_agent: "Amazon CloudFront".to_string(),
     }
 }
 


### PR DESCRIPTION
see https://github.com/rust-lang/crates.io/commit/0ef1e2b84a11e4d569acfad7cf9b4ef8bd730148

This will make it easier to access the value from axum-based middlewares.