### PR TITLE
middleware/block_traffic: Migrate to `axum`

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -59,9 +59,10 @@ pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
         .option_layer((env == Env::Development).then(|| from_fn(debug::debug_requests)))
         .layer(from_fn_with_state(state.clone(), session::attach_session))
         .layer(from_fn_with_state(
-            state,
+            state.clone(),
             require_user_agent::require_user_agent,
-        ));
+        ))
+        .layer(from_fn_with_state(state, block_traffic::block_traffic));
 
     router.layer(middleware)
 }
@@ -117,7 +118,6 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     }
 
     m.around(Head::default());
-    m.around(block_traffic::BlockTraffic::new());
 
     m
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -76,7 +76,6 @@ async fn dummy_error_handler(_err: axum::BoxError) -> http::StatusCode {
 pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);
     let env = app.config.env();
-    let blocked_traffic = app.config.blocked_traffic.clone();
 
     m.add(log_request::LogRequests::default());
 
@@ -118,10 +117,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     }
 
     m.around(Head::default());
-
-    for (header, blocked_values) in blocked_traffic {
-        m.around(block_traffic::BlockTraffic::new(header, blocked_values));
-    }
+    m.around(block_traffic::BlockTraffic::new());
 
     m
 }

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -64,13 +64,13 @@ impl Handler for BlockTraffic {
                     .unwrap_or_default()
             );
 
-            Response::builder()
+            return Response::builder()
                 .status(StatusCode::FORBIDDEN)
                 .header(header::CONTENT_LENGTH, body.len())
                 .body(Body::from_vec(body.into_bytes()))
-                .map_err(box_error)
-        } else {
-            self.handler.as_ref().unwrap().call(req)
+                .map_err(box_error);
         }
+
+        self.handler.as_ref().unwrap().call(req)
     }
 }

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -1,6 +1,7 @@
 use crate::builders::*;
 use crate::util::*;
 
+use ::insta::assert_display_snapshot;
 use http::{header, Method, StatusCode};
 
 #[test]
@@ -63,6 +64,7 @@ fn block_traffic_via_arbitrary_header_and_value() {
     req.header("x-request-id", "abcd");
     let resp = anon.run::<()>(req);
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_display_snapshot!(resp.into_text());
 
     let mut req = anon.request_builder(Method::GET, "/api/v1/crates/dl_no_ua/0.99.0/download");
     // A request with a header value we don't want to block is allowed, even though there might

--- a/src/tests/snapshots/all__server__block_traffic_via_arbitrary_header_and_value.snap
+++ b/src/tests/snapshots/all__server__block_traffic_via_arbitrary_header_and_value.snap
@@ -1,0 +1,6 @@
+---
+source: src/tests/server.rs
+assertion_line: 67
+expression: resp.into_text()
+---
+We are unable to process your request at this time. This usually means that you are in violation of our crawler policy (https://crates.io/policies#crawlers). Please open an issue at https://github.com/rust-lang/crates.io or email help@crates.io and provide the request id abcd

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -41,6 +41,11 @@ impl<T> Response<T> {
     }
 
     #[track_caller]
+    pub fn into_text(self) -> String {
+        assert_ok!(self.response.text())
+    }
+
+    #[track_caller]
     pub fn assert_redirect_ends_with(&self, target: &str) -> &Self {
         assert!(self
             .response


### PR DESCRIPTION
This PR migrates our header-based traffic blocking middleware to axum. It is slightly different from the original `conduit` middleware in that we perform the iteration inside the middleware instead of applying the middleware N times.