### PR TITLE
Add a category for finance

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -283,6 +283,12 @@ description = """
 Crates for dealing with files and filesystems.\
 """
 
+[finance]
+name = "Finance"
+description = """
+Crates for dealing with money. Accounting, trading, investments, taxes, banking and payment processing using government-backed currencies.\
+"""
+
 [game-engines]
 name = "Game engines"
 description = """


### PR DESCRIPTION
There's one for cryptocurrencies, but not for traditional money.