### PR TITLE
middleware/static_or_continue: Migrate to `axum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "tokio",
  "toml",
  "tower",
+ "tower-http",
  "tower-service",
  "tracing",
  "tracing-subscriber",
@@ -1886,6 +1887,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minijinja"
@@ -3488,7 +3499,13 @@ dependencies = [
  "http",
  "http-body",
  "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ thiserror = "=1.0.38"
 tokio = { version = "=1.23.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.5.10"
 tower = "=0.4.13"
+tower-http = { version = "=0.3.5", features = ["fs"] }
 tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.16", features = ["env-filter"] }
 url = "=2.3.1"


### PR DESCRIPTION
This PR is migrating most of our static file serving from `conduit` to `axum`.

Previously the middleware was configurable with a path, but `axum` middlewares make this a bit more complicated (can't use `from_fn()`). Since we only need this twice at the moment it was easiest to duplicate the code for now.