### PR TITLE
middleware/ember_html: Migrate to `axum`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -60,7 +60,7 @@ pub struct App {
     pub(crate) http_client: Option<Client>,
 
     /// A client for HTTP requests to the Ember.js fastboot server
-    pub fastboot_client: Option<Client>,
+    pub fastboot_client: Option<reqwest::Client>,
 }
 
 impl App {
@@ -170,7 +170,7 @@ impl App {
             .build();
 
         let fastboot_client = match dotenv::var("USE_FASTBOOT") {
-            Ok(val) if val == "staging-experimental" => Some(Client::new()),
+            Ok(val) if val == "staging-experimental" => Some(reqwest::Client::new()),
             _ => None,
         };
 

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -8,67 +8,55 @@
 //! For now, there is an additional check to see if the `Accept` header contains "html". This is
 //! likely to be removed in the future.
 
-use super::prelude::*;
+use crate::app::AppState;
+use anyhow::ensure;
+use axum::extract::State;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use http::{header, Request, StatusCode};
+use reqwest::Client;
 use std::fmt::Write;
+use tower::ServiceExt;
+use tower_http::services::ServeFile;
 
-use crate::util::{errors::NotFound, AppResponse};
+pub async fn serve_html<B: Send + 'static>(
+    State(state): State<AppState>,
+    request: Request<B>,
+    next: Next<B>,
+) -> Response {
+    let path = &request.uri().path();
 
-use crate::middleware::app::RequestApp;
-use anyhow::{ensure, Result};
-use conduit::{Body, HandlerResult};
-use conduit_static::Static;
-use reqwest::blocking::Client;
-
-pub(super) struct EmberHtml {
-    api_handler: Option<Box<dyn Handler>>,
-    static_handler: Static,
-}
-
-impl EmberHtml {
-    pub fn new(path: &str) -> Self {
-        Self {
-            api_handler: None,
-            static_handler: Static::new(path),
+    // The "/git/" prefix is only used in development (when within a docker container)
+    if path.starts_with("/api/") || path.starts_with("/git/") {
+        next.run(request).await
+    } else {
+        if let Some(client) = &state.fastboot_client {
+            // During local fastboot development, forward requests to the local fastboot server.
+            // In prodution, including when running with fastboot, nginx proxies the requests
+            // to the correct endpoint and requests should never make it here.
+            return proxy_to_fastboot(client, request)
+                .await
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
         }
-    }
-}
 
-impl AroundMiddleware for EmberHtml {
-    fn with_handler(&mut self, handler: Box<dyn Handler>) {
-        self.api_handler = Some(handler);
-    }
-}
-
-impl Handler for EmberHtml {
-    fn call(&self, req: &mut dyn RequestExt) -> HandlerResult {
-        let api_handler = self.api_handler.as_ref().unwrap();
-
-        // The "/git/" prefix is only used in development (when within a docker container)
-        if req.path().starts_with("/api/") || req.path().starts_with("/git/") {
-            api_handler.call(req)
+        if request
+            .headers()
+            .get_all(header::ACCEPT)
+            .iter()
+            .any(|val| val.to_str().unwrap_or_default().contains("html"))
+        {
+            // Serve static Ember page to bootstrap the frontend
+            ServeFile::new("dist/index.html")
+                .oneshot(request)
+                .await
+                .map(|response| response.map(axum::body::boxed))
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
         } else {
-            if let Some(client) = &req.app().fastboot_client {
-                // During local fastboot development, forward requests to the local fastboot server.
-                // In prodution, including when running with fastboot, nginx proxies the requests
-                // to the correct endpoint and requests should never make it here.
-                return proxy_to_fastboot(client, req).map_err(From::from);
-            }
-
-            if req
-                .headers()
-                .get_all(header::ACCEPT)
-                .iter()
-                .any(|val| val.to_str().unwrap_or_default().contains("html"))
-            {
-                // Serve static Ember page to bootstrap the frontend
-                self.static_handler.lookup("index.html")
-            } else {
-                // Return a 404 to crawlers that don't send `Accept: text/hml`.
-                // This is to preserve legacy behavior and will likely change.
-                // Most of these crawlers probably won't execute our frontend JS anyway, but
-                // it would be nice to bootstrap the app for crawlers that do execute JS.
-                Ok(NotFound.into())
-            }
+            // Return a 404 to crawlers that don't send `Accept: text/hml`.
+            // This is to preserve legacy behavior and will likely change.
+            // Most of these crawlers probably won't execute our frontend JS anyway, but
+            // it would be nice to bootstrap the app for crawlers that do execute JS.
+            StatusCode::NOT_FOUND.into_response()
         }
     }
 }
@@ -80,28 +68,27 @@ impl Handler for EmberHtml {
 /// # Panics
 ///
 /// This function can panic and should only be used in development mode.
-fn proxy_to_fastboot(client: &Client, req: &dyn RequestExt) -> Result<AppResponse> {
+async fn proxy_to_fastboot<B>(client: &Client, req: Request<B>) -> anyhow::Result<Response> {
     ensure!(
         req.method() == http::Method::GET,
         "Only support GET but request method was {}",
         req.method()
     );
 
-    let mut url = format!("http://127.0.0.1:9000{}", req.path());
-    if let Some(query) = req.query_string() {
+    let mut url = format!("http://127.0.0.1:9000{}", req.uri().path());
+    if let Some(query) = req.uri().query() {
         write!(url, "?{query}")?;
     }
-    let mut fastboot_response = client
+
+    let fastboot_response = client
         .request(req.method().into(), &*url)
         .headers(req.headers().clone())
-        .send()?;
-    let mut body = Vec::new();
-    fastboot_response.copy_to(&mut body)?;
+        .send()
+        .await?;
 
-    let mut builder = Response::builder().status(fastboot_response.status());
-    builder
-        .headers_mut()
-        .unwrap()
-        .extend(fastboot_response.headers().clone());
-    Ok(builder.body(Body::from_vec(body))?)
+    let status = fastboot_response.status();
+    let headers = fastboot_response.headers().clone();
+    let bytes = fastboot_response.bytes().await?;
+
+    Ok((status, headers, bytes).into_response())
 }


### PR DESCRIPTION
Another PR, another middleware migrated from `conduit` to `axum`... 🚀 

Not much to say about this one, other than that the `fastboot_client` is now an async `reqwest::Client`
