### PR TITLE
Simplify `BalanceCapacity` middleware

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -4,11 +4,13 @@ use ipnetwork::IpNetwork;
 use crate::publish_rate_limit::PublishRateLimit;
 use crate::{env, env_optional, uploaders::Uploader, Env};
 
+mod balance_capacity;
 mod base;
 mod database_pools;
 
 pub use self::base::Base;
 pub use self::database_pools::{DatabasePools, DbPoolConfig};
+pub use crate::config::balance_capacity::BalanceCapacityConfig;
 use std::collections::HashSet;
 use std::time::Duration;
 
@@ -43,6 +45,7 @@ pub struct Server {
     pub version_id_cache_size: u64,
     pub version_id_cache_ttl: Duration,
     pub cdn_user_agent: String,
+    pub balance_capacity: BalanceCapacityConfig,
 }
 
 impl Default for Server {
@@ -150,6 +153,7 @@ impl Default for Server {
             ),
             cdn_user_agent: dotenv::var("WEB_CDN_USER_AGENT")
                 .unwrap_or_else(|_| "Amazon CloudFront".into()),
+            balance_capacity: BalanceCapacityConfig::from_environment(),
         }
     }
 }

--- a/src/config/balance_capacity.rs
+++ b/src/config/balance_capacity.rs
@@ -1,0 +1,33 @@
+use crate::env_optional;
+use std::env;
+
+pub struct BalanceCapacityConfig {
+    pub report_only: bool,
+    pub log_total_at_count: usize,
+    pub log_at_percentage: usize,
+    pub throttle_at_percentage: usize,
+    pub dl_only_at_percentage: usize,
+}
+
+impl BalanceCapacityConfig {
+    pub fn from_environment() -> Self {
+        Self {
+            report_only: env::var("WEB_CAPACITY_REPORT_ONLY").is_ok(),
+            log_total_at_count: env_optional("WEB_CAPACITY_LOG_TOTAL_AT_COUNT").unwrap_or(50),
+            // The following are a percentage of `db_capacity`
+            log_at_percentage: env_optional("WEB_CAPACITY_LOG_PCT").unwrap_or(50),
+            throttle_at_percentage: env_optional("WEB_CAPACITY_THROTTLE_PCT").unwrap_or(70),
+            dl_only_at_percentage: env_optional("WEB_CAPACITY_DL_ONLY_PCT").unwrap_or(80),
+        }
+    }
+
+    pub fn for_testing() -> Self {
+        Self {
+            report_only: false,
+            log_total_at_count: 50,
+            log_at_percentage: 50,
+            throttle_at_percentage: 70,
+            dl_only_at_percentage: 80,
+        }
+    }
+}

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -108,7 +108,7 @@ pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBui
     // download counts), we consider only the primary pool here.
     if capacity >= 10 {
         info!(?capacity, "Enabling BalanceCapacity middleware");
-        m.around(balance_capacity::BalanceCapacity::new(capacity))
+        m.around(balance_capacity::BalanceCapacity::new())
     } else {
         info!("BalanceCapacity middleware not enabled. DB_PRIMARY_POOL_SIZE is too low.");
     }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -1,7 +1,7 @@
 use super::{MockAnonymousUser, MockCookieUser, MockTokenUser};
 use crate::record;
 use crate::util::{chaosproxy::ChaosProxy, fresh_schema::FreshSchema};
-use cargo_registry::config::{self, DbPoolConfig};
+use cargo_registry::config::{self, BalanceCapacityConfig, DbPoolConfig};
 use cargo_registry::{background_jobs::Environment, db::DieselPool, App, Emails};
 use cargo_registry_index::testing::UpstreamIndex;
 use cargo_registry_index::{Credentials, Repository as WorkerRepository, RepositoryConfig};
@@ -363,6 +363,7 @@ fn simple_config() -> config::Server {
         version_id_cache_size: 10000,
         version_id_cache_ttl: Duration::from_secs(5 * 60),
         cdn_user_agent: "Amazon CloudFront".to_string(),
+        balance_capacity: BalanceCapacityConfig::for_testing(),
     }
 }
 


### PR DESCRIPTION
Instead of reading all environment variables when we create the middleware, we outsource this to the server config construction and then access the relevant values via `request.app().config`.

The reason for this change is that `axum` makes it a bit harder for use to use "configurable" middlewares, so if we can rely on the server config it will make their implementation significantly easier.