### PR TITLE
middleware/balance_capacity: Migrate to `axum`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -64,7 +64,7 @@ pub struct App {
     pub fastboot_client: Option<reqwest::Client>,
 
     /// In-flight request counters for the `balance_capacity` middleware.
-    pub balance_capacity: Arc<BalanceCapacityState>,
+    pub balance_capacity: BalanceCapacityState,
 }
 
 impl App {


### PR DESCRIPTION
This is the final middleware that needed to be migrated to `axum`. The rest of the middlewares are only relevant to the `conduit` route handlers.