### PR TITLE
Upgrade edition to 2021 on all the subcrates

### DIFF
--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 description = "crates.io package index utilities"
-edition = "2018"
-resolver = "2"
+edition = "2021"
 
 [lib]
 path = "lib.rs"

--- a/cargo-registry-markdown/Cargo.toml
+++ b/cargo-registry-markdown/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 description = "crates.io markdown renderer"
-edition = "2018"
-resolver = "2"
+edition = "2021"
 
 [lib]
 path = "lib.rs"

--- a/cargo-registry-s3/Cargo.toml
+++ b/cargo-registry-s3/Cargo.toml
@@ -5,8 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/crates.io"
 description = "Interaction between crates.io and S3 for storing crate files"
-edition = "2018"
-resolver = "2"
+edition = "2021"
 
 [lib]
 name = "s3"


### PR DESCRIPTION
This allows us to remove `resolver = 2`.

Signed-off-by: Yuki Okushi <jtitor@2k36.org>