### PR TITLE
Implement `block_traffic::block_routes` middleware

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -71,6 +71,10 @@ pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
             state.clone(),
             block_traffic::block_traffic,
         ))
+        .layer(from_fn_with_state(
+            state.clone(),
+            block_traffic::block_routes,
+        ))
         .layer(from_fn(head::support_head_requests))
         .layer(HandleErrorLayer::new(dummy_error_handler))
         .option_layer(

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -1,3 +1,5 @@
+use axum::response::{IntoResponse, Response};
+use axum::Json;
 use std::fmt;
 
 use super::{AppError, InternalAppErrorStatic};
@@ -284,5 +286,12 @@ impl AppError for RouteBlocked {
 impl fmt::Display for RouteBlocked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("This route is temporarily blocked. See https://status.crates.io.")
+    }
+}
+
+impl IntoResponse for RouteBlocked {
+    fn into_response(self) -> Response {
+        let body = Json(json!({ "errors": [{ "detail": self.to_string() }] }));
+        (StatusCode::SERVICE_UNAVAILABLE, body).into_response()
     }
 }


### PR DESCRIPTION
This corresponds roughly to https://github.com/rust-lang/crates.io/blob/bbcc09946f83eda077da4bda1ef1879e510fb195/src/router.rs#L190-L195

Note that with axum we can implement this as a middleware because axum middlewares run after the routing layer by default.