### PR TITLE
router: Extract `build_axum_router()` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,12 +26,11 @@ extern crate serde_json;
 extern crate tracing;
 
 pub use crate::{app::App, email::Emails, uploaders::Uploader};
-use axum::routing::get;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::app::AppState;
-use crate::controllers::site_metadata;
+use crate::router::build_axum_router;
 use conduit_axum::ConduitFallback;
 use tikv_jemallocator::Jemalloc;
 
@@ -87,12 +86,7 @@ pub fn build_handler(app: Arc<App>) -> axum::Router {
     let conduit_handler = middleware::build_middleware(app.clone(), endpoints);
 
     let state = AppState(app);
-    let axum_router = axum::Router::new()
-        .route(
-            "/api/v1/site_metadata",
-            get(site_metadata::show_deployed_sha),
-        )
-        .with_state(state.clone());
+    let axum_router = build_axum_router(state.clone());
     middleware::apply_axum_middleware(state, axum_router.conduit_fallback(conduit_handler))
 }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,14 +1,26 @@
 use std::sync::Arc;
 
+use axum::routing::get;
+use axum::Router;
 use conduit::{Handler, HandlerResult, RequestExt};
 use conduit_router::{RequestParams, RouteBuilder, RoutePattern};
 
+use crate::app::AppState;
 use crate::controllers::*;
 use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::CustomMetadataRequestExt;
 use crate::util::errors::{std_error, AppError, RouteBlocked};
 use crate::util::EndpointResult;
 use crate::{App, Env};
+
+pub fn build_axum_router(state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/api/v1/site_metadata",
+            get(site_metadata::show_deployed_sha),
+        )
+        .with_state(state)
+}
 
 pub fn build_router(app: &App) -> RouteBuilder {
     let mut router = RouteBuilder::new();


### PR DESCRIPTION
This PR moves the `axum::Router` creation code closer to the code that builds the `conduit` router. This will make it easier to move route handlers from one router to the other.