### PR TITLE
Migrate `conduit-git-http-backend` code to `axum`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,7 +376,6 @@ dependencies = [
  "conduit",
  "conduit-axum",
  "conduit-conditional-get",
- "conduit-git-http-backend",
  "conduit-middleware",
  "conduit-router",
  "conduit-static",
@@ -641,16 +640,6 @@ dependencies = [
  "conduit",
  "conduit-middleware",
  "time 0.2.27",
-]
-
-[[package]]
-name = "conduit-git-http-backend"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abf8373148fdbfdcae9ba820382c44e07c661fa6e94d2ec6fdc3cecadc1c8bd"
-dependencies = [
- "conduit",
- "flate2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ clap = { version = "=4.0.32", features = ["derive", "unicode", "wrap_help"] }
 
 conduit = "=0.10.0"
 conduit-conditional-get = "=0.10.0"
-conduit-git-http-backend = "=0.10.0"
 conduit-axum = { path = "conduit-axum" }
 conduit-middleware = "=0.10.0"
 conduit-router = "=0.10.0"

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -75,6 +75,7 @@ pub mod util;
 
 pub mod category;
 pub mod crate_owner_invitation;
+pub mod git;
 pub mod github;
 pub mod keyword;
 pub mod krate;

--- a/src/controllers/git.rs
+++ b/src/controllers/git.rs
@@ -1,0 +1,100 @@
+use axum::body::HttpBody;
+use axum::extract::{ConnectInfo, Path};
+use axum::response::{IntoResponse, Response};
+use http::header::HeaderName;
+use http::request::Parts;
+use http::{header, HeaderMap, HeaderValue, Request, StatusCode};
+use hyper::body::Buf;
+use std::io::{BufRead, Read};
+use std::net::SocketAddr;
+use std::process::{Command, Stdio};
+
+pub async fn http_backend<B: HttpBody>(
+    Path(path): Path<String>,
+    ConnectInfo(remote_addr): ConnectInfo<SocketAddr>,
+    req: Request<B>,
+) -> Result<Response, StatusCode> {
+    let path = format!("/{path}");
+
+    let (req, body) = req.into_parts();
+    let body = hyper::body::to_bytes(body)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut cmd = Command::new("git");
+    cmd.arg("http-backend");
+
+    // Required environment variables
+    cmd.env("REQUEST_METHOD", req.method.as_str());
+    cmd.env("GIT_PROJECT_ROOT", "./tmp/index-bare");
+    cmd.env("PATH_INFO", &path);
+    cmd.env("REMOTE_USER", "");
+    cmd.env("REMOTE_ADDR", remote_addr.to_string());
+    cmd.env("QUERY_STRING", req.uri.query().unwrap_or_default());
+    cmd.env("CONTENT_TYPE", header(&req, header::CONTENT_TYPE));
+
+    cmd.stderr(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stdin(Stdio::piped());
+
+    let mut p = cmd.spawn().map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    tokio::task::spawn_blocking(move || {
+        // Pass in the body of the request (if any)
+        let mut body_reader = body.reader();
+        std::io::copy(&mut body_reader, &mut p.stdin.take().unwrap())
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        // Parse the headers coming out, and the pass through the rest of the
+        // process back down the stack.
+        //
+        // Note that we have to be careful to not drop the process which will wait
+        // for the process to exit (and we haven't read stdout)
+        let mut rdr = std::io::BufReader::new(p.stdout.take().unwrap());
+
+        let mut headers = HeaderMap::new();
+        for line in rdr.by_ref().lines() {
+            let line = line.map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+            if line.is_empty() || line == "\r" {
+                break;
+            }
+
+            let (key, value) = line.split_once(':').unwrap();
+            let value = &value[1..];
+            headers.insert(
+                key.parse::<HeaderName>().unwrap(),
+                HeaderValue::from_str(value).unwrap(),
+            );
+        }
+
+        let status_code = headers
+            .remove("Status")
+            .as_ref()
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.split(' ').next())
+            .unwrap_or_default()
+            .parse()
+            .unwrap_or(StatusCode::OK);
+
+        let mut body = Vec::new();
+        rdr.read_to_end(&mut body)
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+        Ok((status_code, headers, body).into_response())
+    })
+    .await
+    .unwrap_or_else(|_| Err(StatusCode::INTERNAL_SERVER_ERROR))
+}
+
+/// Obtain the value of a header
+///
+/// If multiple headers have the same name, only one will be returned.
+///
+/// If there is no header, of if there is an error parsings it as utf8
+/// then an empty slice will be returned.
+fn header(req: &Parts, name: HeaderName) -> &str {
+    req.headers
+        .get(name)
+        .map(|value| value.to_str().unwrap_or_default())
+        .unwrap_or_default()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ pub enum Env {
 ///
 /// Called from *src/bin/server.rs*.
 pub fn build_handler(app: Arc<App>) -> axum::Router {
-    let endpoints = router::build_router(&app);
+    let endpoints = router::build_router();
     let conduit_handler = middleware::build_middleware(app.clone(), endpoints);
 
     let state = AppState(app);

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,9 +1,7 @@
-use std::sync::Arc;
-
 use axum::routing::get;
 use axum::Router;
 use conduit::{Handler, HandlerResult, RequestExt};
-use conduit_router::{RequestParams, RouteBuilder, RoutePattern};
+use conduit_router::{RouteBuilder, RoutePattern};
 
 use crate::app::AppState;
 use crate::controllers::*;
@@ -220,16 +218,6 @@ impl Handler for C {
                 }
             }
         }
-    }
-}
-
-struct R<H>(pub Arc<H>);
-
-impl<H: Handler> Handler for R<H> {
-    fn call(&self, req: &mut dyn RequestExt) -> HandlerResult {
-        *req.path_mut() = req.params()["path"].to_string();
-        let R(ref sub_router) = *self;
-        sub_router.call(req)
     }
 }
 


### PR DESCRIPTION
This migrates our dev-only git index serving code from `conduit-git-http-backend` to an `axum` route handler.