### PR TITLE
conduit-axum: Enable missing `client` feature for `sentry-core`

### DIFF
--- a/conduit-axum/Cargo.toml
+++ b/conduit-axum/Cargo.toml
@@ -15,7 +15,7 @@ conduit-router = "=0.10.0"
 hyper = { version = "=0.14.23", features = ["server", "stream"] }
 http = "=0.2.8"
 percent-encoding = "=2.2.0"
-sentry-core = "=0.29.1"
+sentry-core = { version = "=0.29.1", features = ["client"] }
 thiserror = "=1.0.38"
 tracing = "=0.1.37"
 tokio = { version = "=1.23.0", features = ["fs"] }


### PR DESCRIPTION
The `Hub::current() `and `Hub::run()` APIs are only available if the `client` feature of `sentry-core` is enabled, so let's enable it.

I'm not sure how this compiled before. I assume that it is related to us running the tests within the context of the workspace instead of compiling the libraries independently.