### PR TITLE
Move `AppErrToStdErr` into the only file that uses it

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -2,12 +2,13 @@ use axum::routing::get;
 use axum::Router;
 use conduit::{Handler, HandlerResult, RequestExt};
 use conduit_router::{RouteBuilder, RoutePattern};
+use std::error::Error;
 
 use crate::app::AppState;
 use crate::controllers::*;
 use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::CustomMetadataRequestExt;
-use crate::util::errors::{std_error, AppError, RouteBlocked};
+use crate::util::errors::{AppError, RouteBlocked};
 use crate::util::EndpointResult;
 use crate::Env;
 
@@ -219,6 +220,14 @@ impl Handler for C {
             }
         }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct AppErrToStdErr(pub Box<dyn AppError>);
+
+fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
+    Box::new(AppErrToStdErr(e))
 }
 
 #[cfg(test)]

--- a/src/router.rs
+++ b/src/router.rs
@@ -2,7 +2,6 @@ use axum::routing::get;
 use axum::Router;
 use conduit::{Handler, HandlerResult, RequestExt};
 use conduit_router::{RouteBuilder, RoutePattern};
-use std::error::Error;
 
 use crate::app::AppState;
 use crate::controllers::*;
@@ -215,7 +214,7 @@ impl Handler for C {
                 };
                 match e.response() {
                     Some(response) => Ok(response),
-                    None => Err(std_error(e)),
+                    None => Err(Box::new(AppErrToStdErr(e))),
                 }
             }
         }
@@ -225,10 +224,6 @@ impl Handler for C {
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 struct AppErrToStdErr(pub Box<dyn AppError>);
-
-fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
-    Box::new(AppErrToStdErr(e))
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -233,14 +233,6 @@ pub fn internal<S: ToString + ?Sized>(error: &S) -> Box<dyn AppError> {
     })
 }
 
-#[derive(Debug, thiserror::Error)]
-#[error("{0}")]
-struct AppErrToStdErr(pub Box<dyn AppError>);
-
-pub(crate) fn std_error(e: Box<dyn AppError>) -> Box<dyn Error + Send> {
-    Box::new(AppErrToStdErr(e))
-}
-
 #[test]
 fn chain_error_internal() {
     assert_eq!(


### PR DESCRIPTION
There is no need for this struct to be exported and then imported somewhere else if only a single module is using it.