### PR TITLE
conduit-axum: Simplify `server_error_response()` function

### DIFF
--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -96,12 +96,7 @@ fn server_error_response<E: Error + ?Sized>(error: &E) -> AxumResponse {
 
     sentry_core::capture_error(error);
 
-    let body = hyper::Body::from("Internal Server Error");
-    Response::builder()
-        .status(StatusCode::INTERNAL_SERVER_ERROR)
-        .body(body)
-        .expect("Unexpected invalid header")
-        .into_response()
+    (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
 }
 
 /// Check for `Content-Length` values that are invalid or too large

--- a/conduit-axum/src/tests.rs
+++ b/conduit-axum/src/tests.rs
@@ -88,10 +88,14 @@ async fn simulate_request<H: Handler>(handler: H) -> AxumResponse {
 
 async fn assert_generic_err(resp: AxumResponse) {
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
-    assert_eq!(resp.headers().len(), 1);
+    assert_eq!(resp.headers().len(), 2);
     assert_eq!(
         resp.headers().get("content-length"),
         Some(&HeaderValue::from_static("21"))
+    );
+    assert_eq!(
+        resp.headers().get("content-type"),
+        Some(&HeaderValue::from_static("text/plain; charset=utf-8"))
     );
     let full_body = to_bytes(resp.into_body()).await.unwrap();
     assert_eq!(&*full_body, b"Internal Server Error");


### PR DESCRIPTION
`axum` has a simpler API than the `Response::builder()`, so let's use it...! :D

As an additional bonus we now send the correct `Content-Type` header too.