### PR TITLE
metrics/instance: Narrow return types

### DIFF
--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -17,7 +17,6 @@
 //! As a rule of thumb, if the metric requires a database query to be updated it's probably a
 //! service-level metric, and you should add it to `src/metrics/service.rs` instead.
 
-use crate::util::errors::AppResult;
 use crate::{app::App, db::DieselPool};
 use prometheus::{
     proto::MetricFamily, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
@@ -64,7 +63,7 @@ metrics! {
 }
 
 impl InstanceMetrics {
-    pub fn gather(&self, app: &App) -> AppResult<Vec<MetricFamily>> {
+    pub fn gather(&self, app: &App) -> prometheus::Result<Vec<MetricFamily>> {
         // Database pool stats
         self.refresh_pool_stats("primary", &app.primary_database)?;
         if let Some(follower) = &app.read_only_replica_database {

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -77,7 +77,7 @@ impl InstanceMetrics {
         Ok(self.registry.gather())
     }
 
-    fn refresh_pool_stats(&self, name: &str, pool: &DieselPool) -> AppResult<()> {
+    fn refresh_pool_stats(&self, name: &str, pool: &DieselPool) -> prometheus::Result<()> {
         let state = pool.state();
 
         self.database_idle_conns


### PR DESCRIPTION
`AppResult` is a complicated type due to its error type. For the `metrics` module there is no need to use it since we can just return the original `prometheus::Result<_>` instead.