### PR TITLE
helpers/pagination: Simplify `limit_page_numbers` API

### DIFF
--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -246,7 +246,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
     }
 
     let pagination: PaginationOptions = PaginationOptions::builder()
-        .limit_page_numbers(req.app().clone())
+        .limit_page_numbers()
         .enable_seek(supports_seek)
         .gather(req)?;
     let conn = req.db_read()?;


### PR DESCRIPTION
We can access the app state through the passed-in request. There is no need to save it in a field called `limit_page_numbers`.