### PR TITLE
middleware/app: Use `AppState` struct instead of raw `Arc<App>`

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -7,7 +7,6 @@ use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::Path;
-use std::sync::Arc;
 
 use crate::controllers::cargo_prelude::*;
 use crate::models::{
@@ -44,7 +43,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
 pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
-    let app = Arc::clone(req.app());
+    let app = req.app().clone();
 
     // The format of the req.body() of a publish request is as follows:
     //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,10 +82,11 @@ pub enum Env {
 ///
 /// Called from *src/bin/server.rs*.
 pub fn build_handler(app: Arc<App>) -> axum::Router {
-    let endpoints = router::build_router();
-    let conduit_handler = middleware::build_middleware(app.clone(), endpoints);
-
     let state = AppState(app);
+
+    let endpoints = router::build_router();
+    let conduit_handler = middleware::build_middleware(state.clone(), endpoints);
+
     let axum_router = build_axum_router(state.clone());
     middleware::apply_axum_middleware(state, axum_router.conduit_fallback(conduit_handler))
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -30,10 +30,9 @@ use ::sentry::integrations::tower as sentry_tower;
 use axum::error_handling::HandleErrorLayer;
 use axum::middleware::{from_fn, from_fn_with_state};
 use axum::Router;
-use std::sync::Arc;
 
 use crate::app::AppState;
-use crate::{App, Env};
+use crate::Env;
 
 pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
     type Request = http::Request<axum::body::Body>;
@@ -109,7 +108,7 @@ async fn dummy_error_handler(_err: axum::BoxError) -> http::StatusCode {
     http::StatusCode::INTERNAL_SERVER_ERROR
 }
 
-pub fn build_middleware(app: Arc<App>, endpoints: RouteBuilder) -> MiddlewareBuilder {
+pub fn build_middleware(app: AppState, endpoints: RouteBuilder) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);
 
     m.add(log_request::LogRequests::default());

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -1,38 +1,37 @@
 use super::prelude::*;
 
-use crate::App;
-use std::sync::Arc;
+use crate::app::AppState;
 
 /// Middleware that injects the `App` instance into the `Request` extensions
 pub struct AppMiddleware {
-    app: Arc<App>,
+    app: AppState,
 }
 
 impl AppMiddleware {
-    pub fn new(app: Arc<App>) -> AppMiddleware {
+    pub fn new(app: AppState) -> AppMiddleware {
         AppMiddleware { app }
     }
 }
 
 impl Middleware for AppMiddleware {
     fn before(&self, req: &mut dyn RequestExt) -> BeforeResult {
-        req.mut_extensions().insert(Arc::clone(&self.app));
+        req.mut_extensions().insert(self.app.clone());
         Ok(())
     }
 
     fn after(&self, req: &mut dyn RequestExt, res: AfterResult) -> AfterResult {
-        req.mut_extensions().remove::<Arc<App>>().unwrap();
+        req.mut_extensions().remove::<AppState>().unwrap();
         res
     }
 }
 
 /// Adds an `app()` method to the `Request` type returning the global `App` instance
 pub trait RequestApp {
-    fn app(&self) -> &Arc<App>;
+    fn app(&self) -> &AppState;
 }
 
 impl<T: RequestExt + ?Sized> RequestApp for T {
-    fn app(&self) -> &Arc<App> {
-        self.extensions().get::<Arc<App>>().expect("Missing app")
+    fn app(&self) -> &AppState {
+        self.extensions().get::<AppState>().expect("Missing app")
     }
 }


### PR DESCRIPTION
This brings us closer to what the `axum` implementation uses :)