### PR TITLE
db: Remove `RequestTransaction` trait

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,5 @@
 use crate::controllers;
-use crate::db::RequestTransaction;
+use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::CustomMetadataRequestExt;
 use crate::middleware::session::RequestSession;
 use crate::models::token::{CrateScope, EndpointScope};
@@ -154,7 +154,7 @@ impl AuthenticatedUser {
 }
 
 fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
-    let conn = req.db_write()?;
+    let conn = req.app().db_write()?;
 
     let user_id_from_session = req
         .session_get("user_id")

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -16,7 +16,6 @@ mod prelude {
     pub use conduit_router::RequestParams;
     pub use http::{header, StatusCode};
 
-    pub use crate::db::RequestTransaction;
     pub use crate::middleware::app::RequestApp;
     pub use crate::util::errors::{cargo_err, AppError, AppResult}; // TODO: Remove cargo_err from here
     pub use crate::util::{AppResponse, EndpointResult};

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -15,7 +15,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     let offset = options.offset().unwrap_or_default();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let categories =
         Category::toplevel(&conn, sort, i64::from(options.per_page), i64::from(offset))?;
     let categories = categories
@@ -35,7 +35,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /categories/:category_id` route.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let slug = &req.params()["category_id"];
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let cat: Category = Category::by_slug(slug).first(&*conn)?;
     let subcats = cat
         .subcategories(&conn)?
@@ -65,7 +65,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
 
 /// Handles the `GET /category_slugs` route.
 pub fn slugs(req: &mut dyn RequestExt) -> EndpointResult {
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let slugs: Vec<Slug> = categories::table
         .select((categories::slug, categories::slug, categories::description))
         .order(categories::slug)

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -21,7 +21,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     }
 
     let query = query.pages_pagination(PaginationOptions::builder().gather(req)?);
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let data: Paginated<Keyword> = query.load(&conn)?;
     let total = data.total();
     let kws = data
@@ -38,7 +38,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /keywords/:keyword_id` route.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let name = &req.params()["keyword_id"];
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
 
     let kw = Keyword::find_by_keyword(&conn, name)?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -18,7 +18,7 @@ pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::sql_types::BigInt;
 
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
 
     let mut versions: Vec<Version> = krate.all_versions().load(&*conn)?;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -23,7 +23,7 @@ fn follow_target(
 /// Handles the `PUT /crates/:crate_id/follow` route.
 pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = AuthCheck::default().check(req)?.user_id();
-    let conn = req.db_write()?;
+    let conn = req.app().db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
     diesel::insert_into(follows::table)
         .values(&follow)
@@ -36,7 +36,7 @@ pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `DELETE /crates/:crate_id/follow` route.
 pub fn unfollow(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = AuthCheck::default().check(req)?.user_id();
-    let conn = req.db_write()?;
+    let conn = req.app().db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
     diesel::delete(&follow).execute(&*conn)?;
 
@@ -48,7 +48,7 @@ pub fn following(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::exists;
 
     let user_id = AuthCheck::only_cookie().check(req)?.user_id();
-    let conn = req.db_read_prefer_primary()?;
+    let conn = req.app().db_read_prefer_primary()?;
     let follow = follow_target(req, &conn, user_id)?;
     let following =
         diesel::select(exists(follows::table.find(follow.id()))).get_result::<bool>(&*conn)?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -9,7 +9,7 @@ use crate::views::EncodableOwner;
 /// Handles the `GET /crates/:crate_id/owners` route.
 pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = krate
         .owners(&conn)?
@@ -23,7 +23,7 @@ pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id/owner_team` route.
 pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = Team::owning(&krate, &conn)?
         .into_iter()
@@ -36,7 +36,7 @@ pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id/owner_user` route.
 pub fn owner_user(req: &mut dyn RequestExt) -> EndpointResult {
     let crate_name = &req.params()["crate_id"];
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
     let owners = User::owning(&krate, &conn)?
         .into_iter()
@@ -92,7 +92,7 @@ fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
     let app = req.app();
     let crate_name = &req.params()["crate_id"];
 
-    let conn = req.db_write()?;
+    let conn = app.db_write()?;
     let user = auth.user();
 
     conn.transaction(|| {

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -249,7 +249,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         .limit_page_numbers()
         .enable_seek(supports_seek)
         .gather(req)?;
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
 
     let (explicit_page, seek) = match pagination.page.clone() {
         Page::Numeric(_) => (true, None),

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -25,7 +25,7 @@ pub fn prometheus(req: &mut dyn RequestExt) -> EndpointResult {
     }
 
     let metrics = match req.params()["kind"].as_str() {
-        "service" => app.service_metrics.gather(&*req.db_read()?)?,
+        "service" => app.service_metrics.gather(&*app.db_read()?)?,
         "instance" => app.instance_metrics.gather(app)?,
         _ => return Err(not_found()),
     };

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -9,7 +9,7 @@ pub fn show_team(req: &mut dyn RequestExt) -> EndpointResult {
     use self::teams::dsl::{login, teams};
 
     let name = &req.params()["team_id"];
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let team: Team = teams.filter(login.eq(name)).first(&*conn)?;
 
     Ok(req.json(&json!({ "team": EncodableTeam::from(team) })))

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -10,7 +10,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     use self::users::dsl::{gh_login, id, users};
 
     let name = lower(&req.params()["user_id"]);
-    let conn = req.db_read_prefer_primary()?;
+    let conn = req.app().db_read_prefer_primary()?;
     let user: User = users
         .filter(lower(gh_login).eq(name))
         .order(id.desc())
@@ -26,7 +26,7 @@ pub fn stats(req: &mut dyn RequestExt) -> EndpointResult {
     let user_id = &req.params()["user_id"]
         .parse::<i32>()
         .map_err(|err| err.chain(bad_request("invalid user_id")))?;
-    let conn = req.db_read_prefer_primary()?;
+    let conn = req.app().db_read_prefer_primary()?;
 
     let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)
         .inner_join(crates::table)

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -95,7 +95,7 @@ pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
 
     // Fetch the user info from GitHub using the access token we just got and create a user record
     let ghuser = app.github.current_user(token)?;
-    let user = save_user_to_database(&ghuser, token.secret(), &app.emails, &*req.db_write()?)?;
+    let user = save_user_to_database(&ghuser, token.secret(), &app.emails, &*app.db_write()?)?;
 
     // Log in by setting a cookie and the middleware authentication
     req.session_insert("user_id".to_string(), user.id.to_string());

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -14,7 +14,7 @@ use crate::views::EncodableVersion;
 /// Handles the `GET /versions` route.
 pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     use diesel::dsl::any;
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
 
     // Extract all ids requested.
     let query = url::form_urlencoded::parse(req.query_string().unwrap_or("").as_bytes());
@@ -54,7 +54,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn show_by_id(req: &mut dyn RequestExt) -> EndpointResult {
     let id = &req.params()["version_id"];
     let id = id.parse().unwrap_or(0);
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table
         .find(id)
         .inner_join(crates::table)

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -119,7 +119,7 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
 pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
 
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
 
     let cutoff_end_date = req

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -20,7 +20,7 @@ use super::{extract_crate_name_and_semver, version_and_crate};
 /// be 0)
 pub fn dependencies(req: &mut dyn RequestExt) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
     let deps = version.dependencies(&conn)?;
     let deps = deps
@@ -48,7 +48,7 @@ pub fn authors(req: &mut dyn RequestExt) -> EndpointResult {
 /// API route to have.
 pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
-    let conn = req.db_read()?;
+    let conn = req.app().db_read()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;
     let published_by = version.published_by(&conn);
     let actions = VersionOwnerAction::by_version(&conn, &version)?;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -40,13 +40,14 @@ fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
         .for_crate(crate_name)
         .check(req)?;
 
-    let conn = req.db_write()?;
+    let state = req.app();
+    let conn = state.db_write()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;
     let api_token_id = auth.api_token_id();
     let user = auth.user();
     let owners = krate.owners(&conn)?;
 
-    if user.rights(req.app(), &owners)? < Rights::Publish {
+    if user.rights(state, &owners)? < Rights::Publish {
         return Err(cargo_err("must already be an owner to yank or unyank"));
     }
 


### PR DESCRIPTION
We call these methods directly on the `App` instead to make the calls closer to what they will look like with `axum`