### PR TITLE
bin/enqueue-job: Use `clap` to parse commands and generate help text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cargo-registry-index = { path = "cargo-registry-index" }
 cargo-registry-markdown = { path = "cargo-registry-markdown" }
 cargo-registry-s3 = { path = "cargo-registry-s3" }
 chrono = { version = "=0.4.23", features = ["serde"] }
-clap = { version = "=4.0.32", features = ["derive", "unicode", "wrap_help"] }
+clap = { version = "=4.0.32", features = ["derive", "env", "unicode", "wrap_help"] }
 
 conduit = "=0.10.0"
 conduit-axum = { path = "conduit-axum" }

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,19 +1,33 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use cargo_registry::schema::background_jobs::dsl::*;
-use cargo_registry::{db, env, worker};
+use cargo_registry::{db, worker};
+use clap::Parser;
 use diesel::prelude::*;
 
+#[derive(clap::Parser, Debug)]
+#[command(name = "enqueue-job", rename_all = "snake_case")]
+enum Command {
+    UpdateDownloads,
+    DumpDb {
+        #[arg(env = "READ_ONLY_REPLICA_URL")]
+        database_url: String,
+        #[arg(default_value = "db-dump.tar.gz")]
+        target_name: String,
+    },
+    DailyDbMaintenance,
+    SquashIndex,
+}
+
 fn main() -> Result<()> {
+    let command = Command::parse();
+
     let conn = db::oneoff_connection()?;
-    let mut args = std::env::args().skip(1);
+    println!("Enqueueing background job: {command:?}");
 
-    let job = args.next().unwrap_or_default();
-    println!("Enqueueing background job: {job}");
-
-    match &*job {
-        "update_downloads" => {
+    match command {
+        Command::UpdateDownloads => {
             let count: i64 = background_jobs
                 .filter(job_type.eq("update_downloads"))
                 .count()
@@ -27,15 +41,11 @@ fn main() -> Result<()> {
                 Ok(worker::update_downloads().enqueue(&conn)?)
             }
         }
-        "dump_db" => {
-            let database_url = args.next().unwrap_or_else(|| env("READ_ONLY_REPLICA_URL"));
-            let target_name = args
-                .next()
-                .unwrap_or_else(|| String::from("db-dump.tar.gz"));
-            Ok(worker::dump_db(database_url, target_name).enqueue(&conn)?)
-        }
-        "daily_db_maintenance" => Ok(worker::daily_db_maintenance().enqueue(&conn)?),
-        "squash_index" => Ok(worker::squash_index().enqueue(&conn)?),
-        other => Err(anyhow!("Unrecognized job type `{}`", other)),
+        Command::DumpDb {
+            database_url,
+            target_name,
+        } => Ok(worker::dump_db(database_url, target_name).enqueue(&conn)?),
+        Command::DailyDbMaintenance => Ok(worker::daily_db_maintenance().enqueue(&conn)?),
+        Command::SquashIndex => Ok(worker::squash_index().enqueue(&conn)?),
     }
 }


### PR DESCRIPTION
```
Usage: enqueue-job <COMMAND>

Commands:
  update_downloads      
  dump_db               
  daily_db_maintenance  
  squash_index          
  normalize_index       
  help                  Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help information
```

```
Usage: enqueue-job dump_db <DATABASE_URL> [TARGET_NAME]

Arguments:
  <DATABASE_URL>  [env: READ_ONLY_REPLICA_URL]
  [TARGET_NAME]   [default: db-dump.tar.gz]

Options:
  -h, --help  Print help information
```