### PR TITLE
bin/crates-admin: Simplify `clap` usage

### DIFF
--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -7,13 +7,7 @@ use cargo_registry::admin::{
 
 #[derive(clap::Parser, Debug)]
 #[command(name = "crates-admin")]
-struct Opts {
-    #[clap(subcommand)]
-    command: SubCommand,
-}
-
-#[derive(clap::Parser, Debug)]
-enum SubCommand {
+enum Command {
     DeleteCrate(delete_crate::Opts),
     DeleteVersion(delete_version::Opts),
     Populate(populate::Opts),
@@ -35,20 +29,20 @@ fn main() -> anyhow::Result<()> {
 
     use clap::Parser;
 
-    let opts: Opts = Opts::parse();
+    let command = Command::parse();
 
-    match opts.command {
-        SubCommand::DeleteCrate(opts) => delete_crate::run(opts),
-        SubCommand::DeleteVersion(opts) => delete_version::run(opts),
-        SubCommand::Populate(opts) => populate::run(opts),
-        SubCommand::RenderReadmes(opts) => render_readmes::run(opts)?,
-        SubCommand::TestPagerduty(opts) => test_pagerduty::run(opts)?,
-        SubCommand::TransferCrates(opts) => transfer_crates::run(opts),
-        SubCommand::VerifyToken(opts) => verify_token::run(opts).unwrap(),
-        SubCommand::Migrate(opts) => migrate::run(opts)?,
-        SubCommand::UploadIndex(opts) => upload_index::run(opts)?,
-        SubCommand::YankVersion(opts) => yank_version::run(opts),
-        SubCommand::GitImport(opts) => git_import::run(opts)?,
+    match command {
+        Command::DeleteCrate(opts) => delete_crate::run(opts),
+        Command::DeleteVersion(opts) => delete_version::run(opts),
+        Command::Populate(opts) => populate::run(opts),
+        Command::RenderReadmes(opts) => render_readmes::run(opts)?,
+        Command::TestPagerduty(opts) => test_pagerduty::run(opts)?,
+        Command::TransferCrates(opts) => transfer_crates::run(opts),
+        Command::VerifyToken(opts) => verify_token::run(opts).unwrap(),
+        Command::Migrate(opts) => migrate::run(opts)?,
+        Command::UploadIndex(opts) => upload_index::run(opts)?,
+        Command::YankVersion(opts) => yank_version::run(opts),
+        Command::GitImport(opts) => git_import::run(opts)?,
     }
 
     Ok(())


### PR DESCRIPTION
We don't need the extra `Opts` struct, we can instead just use the enum directly.