### PR TITLE
background_jobs: Remove empty structs

### DIFF
--- a/src/worker/daily_db_maintenance.rs
+++ b/src/worker/daily_db_maintenance.rs
@@ -1,4 +1,4 @@
-use crate::background_jobs::{DailyDbMaintenanceJob, Job};
+use crate::background_jobs::Job;
 use crate::swirl::PerformError;
 /// Run daily database maintenance tasks
 ///
@@ -19,5 +19,5 @@ pub(crate) fn perform_daily_db_maintenance(conn: &PgConnection) -> Result<(), Pe
 }
 
 pub fn daily_db_maintenance() -> Job {
-    Job::DailyDbMaintenance(DailyDbMaintenanceJob {})
+    Job::DailyDbMaintenance
 }

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -1,6 +1,5 @@
 use crate::background_jobs::{
-    Environment, IndexAddCrateJob, IndexSquashJob, IndexSyncToHttpJob, IndexUpdateYankedJob, Job,
-    NormalizeIndexJob,
+    Environment, IndexAddCrateJob, IndexSyncToHttpJob, IndexUpdateYankedJob, Job, NormalizeIndexJob,
 };
 use crate::schema;
 use crate::swirl::PerformError;
@@ -177,7 +176,7 @@ pub fn perform_index_squash(env: &Environment) -> Result<(), PerformError> {
 }
 
 pub fn squash_index() -> Job {
-    Job::IndexSquash(IndexSquashJob {})
+    Job::IndexSquash
 }
 
 pub fn perform_normalize_index(

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -3,7 +3,7 @@ use crate::{
     schema::{crates, metadata, version_downloads, versions},
 };
 
-use crate::background_jobs::{Job, UpdateDownloadsJob};
+use crate::background_jobs::Job;
 use crate::swirl::PerformError;
 use diesel::prelude::*;
 
@@ -13,7 +13,7 @@ pub fn perform_update_downloads(conn: &PgConnection) -> Result<(), PerformError>
 }
 
 pub fn update_downloads() -> Job {
-    Job::UpdateDownloads(UpdateDownloadsJob {})
+    Job::UpdateDownloads
 }
 
 fn update(conn: &PgConnection) -> QueryResult<()> {


### PR DESCRIPTION
We only need structs like this when we want to save parameters for the queued job, but for a job without parameters these appear to be unnecessary.