### PR TITLE
bin/crates-admin: Add `enqueue-job` subcommand

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -1,0 +1,50 @@
+use crate::schema::background_jobs::dsl::*;
+use crate::{db, worker};
+use anyhow::Result;
+use diesel::prelude::*;
+
+#[derive(clap::Parser, Debug)]
+#[command(
+    name = "enqueue-job",
+    about = "Add a job to the background worker queue",
+    rename_all = "snake_case"
+)]
+pub enum Command {
+    UpdateDownloads,
+    DumpDb {
+        #[arg(env = "READ_ONLY_REPLICA_URL")]
+        database_url: String,
+        #[arg(default_value = "db-dump.tar.gz")]
+        target_name: String,
+    },
+    DailyDbMaintenance,
+    SquashIndex,
+}
+
+pub fn run(command: Command) -> Result<()> {
+    let conn = db::oneoff_connection()?;
+    println!("Enqueueing background job: {command:?}");
+
+    match command {
+        Command::UpdateDownloads => {
+            let count: i64 = background_jobs
+                .filter(job_type.eq("update_downloads"))
+                .count()
+                .get_result(&conn)
+                .unwrap();
+
+            if count > 0 {
+                println!("Did not enqueue update_downloads, existing job already in progress");
+                Ok(())
+            } else {
+                Ok(worker::update_downloads().enqueue(&conn)?)
+            }
+        }
+        Command::DumpDb {
+            database_url,
+            target_name,
+        } => Ok(worker::dump_db(database_url, target_name).enqueue(&conn)?),
+        Command::DailyDbMaintenance => Ok(worker::daily_db_maintenance().enqueue(&conn)?),
+        Command::SquashIndex => Ok(worker::squash_index().enqueue(&conn)?),
+    }
+}

--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,6 +1,7 @@
 pub mod delete_crate;
 pub mod delete_version;
 pub mod dialoguer;
+pub mod enqueue_job;
 pub mod git_import;
 pub mod migrate;
 pub mod on_call;

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -1,8 +1,8 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 use cargo_registry::admin::{
-    delete_crate, delete_version, git_import, migrate, populate, render_readmes, test_pagerduty,
-    transfer_crates, upload_index, verify_token, yank_version,
+    delete_crate, delete_version, enqueue_job, git_import, migrate, populate, render_readmes,
+    test_pagerduty, transfer_crates, upload_index, verify_token, yank_version,
 };
 
 #[derive(clap::Parser, Debug)]
@@ -19,6 +19,8 @@ enum Command {
     UploadIndex(upload_index::Opts),
     YankVersion(yank_version::Opts),
     GitImport(git_import::Opts),
+    #[clap(subcommand)]
+    EnqueueJob(enqueue_job::Command),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -43,6 +45,7 @@ fn main() -> anyhow::Result<()> {
         Command::UploadIndex(opts) => upload_index::run(opts)?,
         Command::YankVersion(opts) => yank_version::run(opts),
         Command::GitImport(opts) => git_import::run(opts)?,
+        Command::EnqueueJob(command) => enqueue_job::run(command)?,
     }
 
     Ok(())

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -1,54 +1,10 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
 use anyhow::Result;
-use cargo_registry::schema::background_jobs::dsl::*;
-use cargo_registry::{db, worker};
+use cargo_registry::admin::enqueue_job::{run, Command};
 use clap::Parser;
-use diesel::prelude::*;
-
-#[derive(clap::Parser, Debug)]
-#[command(name = "enqueue-job", rename_all = "snake_case")]
-enum Command {
-    UpdateDownloads,
-    DumpDb {
-        #[arg(env = "READ_ONLY_REPLICA_URL")]
-        database_url: String,
-        #[arg(default_value = "db-dump.tar.gz")]
-        target_name: String,
-    },
-    DailyDbMaintenance,
-    SquashIndex,
-}
 
 fn main() -> Result<()> {
     let command = Command::parse();
     run(command)
-}
-
-fn run(command: Command) -> Result<()> {
-    let conn = db::oneoff_connection()?;
-    println!("Enqueueing background job: {command:?}");
-
-    match command {
-        Command::UpdateDownloads => {
-            let count: i64 = background_jobs
-                .filter(job_type.eq("update_downloads"))
-                .count()
-                .get_result(&conn)
-                .unwrap();
-
-            if count > 0 {
-                println!("Did not enqueue update_downloads, existing job already in progress");
-                Ok(())
-            } else {
-                Ok(worker::update_downloads().enqueue(&conn)?)
-            }
-        }
-        Command::DumpDb {
-            database_url,
-            target_name,
-        } => Ok(worker::dump_db(database_url, target_name).enqueue(&conn)?),
-        Command::DailyDbMaintenance => Ok(worker::daily_db_maintenance().enqueue(&conn)?),
-        Command::SquashIndex => Ok(worker::squash_index().enqueue(&conn)?),
-    }
 }

--- a/src/bin/enqueue-job.rs
+++ b/src/bin/enqueue-job.rs
@@ -22,7 +22,10 @@ enum Command {
 
 fn main() -> Result<()> {
     let command = Command::parse();
+    run(command)
+}
 
+fn run(command: Command) -> Result<()> {
     let conn = db::oneoff_connection()?;
     println!("Enqueueing background job: {command:?}");
 


### PR DESCRIPTION
This should allow us to get rid of the `enqueue-job` binary, which should hopefully improve link and compile times a little bit.