### PR TITLE
CI: Cancel obsolete runs for the same branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
   pull_request:
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   DIESEL_CLI_VERSION: 1.4.1
   PNPM_VERSION: 7.21.0


### PR DESCRIPTION
This makes GitHub Actions only run one CI pipeline per branch and cancels any ongoing previous runs of the same branch when a new branch head is pushed.