### PR TITLE
renovate: Add missing `versioning=semver` instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=crate depName=diesel_cli
+  # renovate: datasource=crate depName=diesel_cli versioning=semver
   DIESEL_CLI_VERSION: 1.4.1
   # renovate: datasource=npm depName=pnpm
   PNPM_VERSION: 7.21.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,9 +7,9 @@ on:
       - master
 
 env:
-  # renovate: datasource=crate depName=cargo-tarpaulin
+  # renovate: datasource=crate depName=cargo-tarpaulin versioning=semver
   CARGO_TARPAULIN_VERSION: 0.23.1
-  # renovate: datasource=crate depName=diesel_cli
+  # renovate: datasource=crate depName=diesel_cli versioning=semver
   DIESEL_CLI_VERSION: 1.4.1
   # renovate: datasource=github-releases depName=rust lookupName=rust-lang/rust
   RUST_VERSION: 1.66.0


### PR DESCRIPTION
In #5775 I forgot that the default `versioning` scheme of crates in renovatebot is `cargo`. This PR adjusts it to use `semver` instead, to avoid renovatebot from updating the versions from e.g. `1.4.1` to `=1.4.1`.