### PR TITLE
Remove redundant `charset` from `application/json` content type response header

### DIFF
--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -90,7 +90,7 @@ where
         .get(header::CONTENT_TYPE)
         .expect("Missing content-type header");
 
-    assert_eq!(content_type, "application/json; charset=utf-8");
+    assert_eq!(content_type, "application/json");
 
     let content_length: usize = r
         .headers()

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,7 +27,7 @@ pub type EndpointResult = Result<AppResponse, Box<dyn errors::AppError>>;
 pub fn json_response<T: Serialize>(t: &T) -> AppResponse {
     let json = serde_json::to_string(t).unwrap();
     Response::builder()
-        .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
+        .header(header::CONTENT_TYPE, "application/json")
         .header(header::CONTENT_LENGTH, json.len())
         .body(Body::from_vec(json.into_bytes()))
         .unwrap() // Header values are well formed, so should not panic


### PR DESCRIPTION
`application/json` is defined as unicode (see https://www.ietf.org/rfc/rfc4627.txt) and the media type has no `charset` support defined for it (see https://www.iana.org/assignments/media-types/application/json)

also, this makes the header the same as what `axum` sends by default... 😅