### PR TITLE
util/errors: Implement `response()` for all `AppError`

### DIFF
--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -67,6 +67,9 @@ async fn fallback_to_conduit(
     .map_err(Into::into)
 }
 
+#[derive(Clone, Debug)]
+pub struct ErrorField(pub String);
+
 /// Turns a `ConduitResponse` into a `AxumResponse`
 fn conduit_into_axum(mut response: ConduitResponse, mut request: ConduitRequest) -> AxumResponse {
     use conduit::Body::*;
@@ -96,7 +99,12 @@ fn server_error_response<E: Error + ?Sized>(error: &E) -> AxumResponse {
 
     sentry_core::capture_error(error);
 
-    (StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error").into_response()
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Extension(ErrorField(error.to_string())),
+        "Internal Server Error",
+    )
+        .into_response()
 }
 
 /// Check for `Content-Length` values that are invalid or too large

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -50,7 +50,7 @@ mod server;
 #[cfg(test)]
 mod tests;
 
-pub use fallback::ConduitFallback;
+pub use fallback::{ConduitFallback, ErrorField};
 pub use server::Server;
 
 type AxumResponse = axum::response::Response;

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -415,11 +415,7 @@ mod tests {
     }
 
     fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {
-        let response = options
-            .gather(&mut mock(query))
-            .unwrap_err()
-            .response()
-            .unwrap();
+        let response = options.gather(&mut mock(query)).unwrap_err().response();
 
         assert_eq!(StatusCode::BAD_REQUEST, response.status());
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -111,8 +111,6 @@ async fn dummy_error_handler(_err: axum::BoxError) -> http::StatusCode {
 pub fn build_middleware(app: AppState, endpoints: RouteBuilder) -> MiddlewareBuilder {
     let mut m = MiddlewareBuilder::new(endpoints);
 
-    m.add(log_request::LogRequests::default());
-
     m.add(AppMiddleware::new(app));
     m.add(KnownErrorToJson);
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -201,7 +201,7 @@ impl Handler for C {
             // environment variable. This is not in a middleware because we need access to
             // `RoutePattern` before executing the response handler.
             if req.app().config.blocked_routes.contains(pattern) {
-                return Ok(RouteBlocked.response().unwrap());
+                return Ok(RouteBlocked.response());
             }
         }
 
@@ -212,18 +212,11 @@ impl Handler for C {
                 if let Some(cause) = e.cause() {
                     req.add_custom_metadata("cause", cause.to_string())
                 };
-                match e.response() {
-                    Some(response) => Ok(response),
-                    None => Err(Box::new(AppErrToStdErr(e))),
-                }
+                Ok(e.response())
             }
         }
     }
 }
-
-#[derive(Debug, thiserror::Error)]
-#[error("{0}")]
-struct AppErrToStdErr(pub Box<dyn AppError>);
 
 #[cfg(test)]
 mod tests {

--- a/src/router.rs
+++ b/src/router.rs
@@ -288,17 +288,24 @@ mod tests {
             "middle error caused by invalid digit found in string"
         );
 
-        // All other error types are propogated up the middleware, eventually becoming status 500
-        assert!(C(|_| Err(internal(""))).call(&mut req).is_err());
-        assert!(
+        // All other error types are converted to internal server errors
+        assert_eq!(
+            C(|_| Err(internal(""))).call(&mut req).unwrap().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+        assert_eq!(
             C(|_| err::<::serde_json::Error>(::serde::de::Error::custom("ExpectedColon")))
                 .call(&mut req)
-                .is_err()
+                .unwrap()
+                .status(),
+            StatusCode::INTERNAL_SERVER_ERROR
         );
-        assert!(
+        assert_eq!(
             C(|_| err(::std::io::Error::new(::std::io::ErrorKind::Other, "")))
                 .call(&mut req)
-                .is_err()
+                .unwrap()
+                .status(),
+            StatusCode::INTERNAL_SERVER_ERROR
         );
     }
 }

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -85,7 +85,7 @@ pub trait AppError: Send + fmt::Display + fmt::Debug + 'static {
     ///
     /// If none is returned, the error will bubble up the middleware stack
     /// where it is eventually logged and turned into a status 500 response.
-    fn response(&self) -> Option<AppResponse>;
+    fn response(&self) -> AppResponse;
 
     /// The cause of an error response
     ///
@@ -120,7 +120,7 @@ impl dyn AppError {
 }
 
 impl AppError for Box<dyn AppError> {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         (**self).response()
     }
 
@@ -145,7 +145,7 @@ struct ChainedError<E> {
 }
 
 impl<E: AppError> AppError for ChainedError<E> {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         self.error.response()
     }
 
@@ -164,12 +164,12 @@ impl<E: AppError> fmt::Display for ChainedError<E> {
 // Error impls
 
 impl<E: Error + Send + 'static> AppError for E {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         error!(error = %self, "Internal Server Error");
 
         sentry::capture_error(self);
 
-        Some(server_error_response(self.to_string()))
+        server_error_response(self.to_string())
     }
 }
 
@@ -272,12 +272,12 @@ impl fmt::Display for InternalAppError {
 }
 
 impl AppError for InternalAppError {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         error!(error = %self.description, "Internal Server Error");
 
         sentry::capture_message(&self.description, sentry::Level::Error);
 
-        Some(server_error_response(self.description.to_string()))
+        server_error_response(self.description.to_string())
     }
 }
 
@@ -294,12 +294,12 @@ impl fmt::Display for InternalAppErrorStatic {
 }
 
 impl AppError for InternalAppErrorStatic {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         error!(error = %self.description, "Internal Server Error");
 
         sentry::capture_message(self.description, sentry::Level::Error);
 
-        Some(server_error_response(self.description.to_string()))
+        server_error_response(self.description.to_string())
     }
 }
 

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -30,8 +30,8 @@ impl From<NotFound> for AppResponse {
 }
 
 impl AppError for NotFound {
-    fn response(&self) -> Option<AppResponse> {
-        Some(Self.into())
+    fn response(&self) -> AppResponse {
+        Self.into()
     }
 }
 
@@ -47,9 +47,9 @@ pub(super) struct Forbidden;
 pub(crate) struct ReadOnlyMode;
 
 impl AppError for Forbidden {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         let detail = "must be logged in to perform that action";
-        Some(json_error(detail, StatusCode::FORBIDDEN))
+        json_error(detail, StatusCode::FORBIDDEN)
     }
 }
 
@@ -60,10 +60,10 @@ impl fmt::Display for Forbidden {
 }
 
 impl AppError for ReadOnlyMode {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         let detail = "Crates.io is currently in read-only mode for maintenance. \
                       Please try again later.";
-        Some(json_error(detail, StatusCode::SERVICE_UNAVAILABLE))
+        json_error(detail, StatusCode::SERVICE_UNAVAILABLE)
     }
 }
 
@@ -89,8 +89,8 @@ pub(crate) struct TooManyRequests {
 }
 
 impl AppError for Ok {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.0, StatusCode::OK))
+    fn response(&self) -> AppResponse {
+        json_error(&self.0, StatusCode::OK)
     }
 }
 
@@ -101,8 +101,8 @@ impl fmt::Display for Ok {
 }
 
 impl AppError for BadRequest {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.0, StatusCode::BAD_REQUEST))
+    fn response(&self) -> AppResponse {
+        json_error(&self.0, StatusCode::BAD_REQUEST)
     }
 }
 
@@ -113,8 +113,8 @@ impl fmt::Display for BadRequest {
 }
 
 impl AppError for ServerError {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.0, StatusCode::INTERNAL_SERVER_ERROR))
+    fn response(&self) -> AppResponse {
+        json_error(&self.0, StatusCode::INTERNAL_SERVER_ERROR)
     }
 }
 
@@ -125,8 +125,8 @@ impl fmt::Display for ServerError {
 }
 
 impl AppError for ServiceUnavailable {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.0, StatusCode::SERVICE_UNAVAILABLE))
+    fn response(&self) -> AppResponse {
+        json_error(&self.0, StatusCode::SERVICE_UNAVAILABLE)
     }
 }
 
@@ -137,7 +137,7 @@ impl fmt::Display for ServiceUnavailable {
 }
 
 impl AppError for TooManyRequests {
-    fn response(&self) -> Option<AppResponse> {
+    fn response(&self) -> AppResponse {
         const HTTP_DATE_FORMAT: &str = "%a, %d %b %Y %H:%M:%S GMT";
         let retry_after = self.retry_after.format(HTTP_DATE_FORMAT);
 
@@ -154,7 +154,7 @@ impl AppError for TooManyRequests {
                 .try_into()
                 .expect("HTTP_DATE_FORMAT contains invalid char"),
         );
-        Some(response)
+        response
     }
 }
 
@@ -174,8 +174,8 @@ impl InsecurelyGeneratedTokenRevoked {
 }
 
 impl AppError for InsecurelyGeneratedTokenRevoked {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.to_string(), StatusCode::UNAUTHORIZED))
+    fn response(&self) -> AppResponse {
+        json_error(&self.to_string(), StatusCode::UNAUTHORIZED)
     }
 
     fn cause(&self) -> Option<&dyn AppError> {
@@ -210,8 +210,8 @@ pub(super) struct AccountLocked {
 }
 
 impl AppError for AccountLocked {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.to_string(), StatusCode::FORBIDDEN))
+    fn response(&self) -> AppResponse {
+        json_error(&self.to_string(), StatusCode::FORBIDDEN)
     }
 }
 
@@ -240,8 +240,8 @@ pub(crate) struct OwnershipInvitationExpired {
 }
 
 impl AppError for OwnershipInvitationExpired {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.to_string(), StatusCode::GONE))
+    fn response(&self) -> AppResponse {
+        json_error(&self.to_string(), StatusCode::GONE)
     }
 }
 
@@ -260,8 +260,8 @@ impl fmt::Display for OwnershipInvitationExpired {
 pub(crate) struct MetricsDisabled;
 
 impl AppError for MetricsDisabled {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(&self.to_string(), StatusCode::NOT_FOUND))
+    fn response(&self) -> AppResponse {
+        json_error(&self.to_string(), StatusCode::NOT_FOUND)
     }
 }
 
@@ -275,11 +275,8 @@ impl fmt::Display for MetricsDisabled {
 pub(crate) struct RouteBlocked;
 
 impl AppError for RouteBlocked {
-    fn response(&self) -> Option<AppResponse> {
-        Some(json_error(
-            &self.to_string(),
-            StatusCode::SERVICE_UNAVAILABLE,
-        ))
+    fn response(&self) -> AppResponse {
+        json_error(&self.to_string(), StatusCode::SERVICE_UNAVAILABLE)
     }
 }
 


### PR DESCRIPTION
Instead of having some `AppError` implementations return a response and others be treated as some other kind of error, this PR changes the code to treat all `AppError` implementations the same way by enforcing the http response conversion.

Note that this required a refactoring of the `error` log field, which we are now setting via a response extension when we convert the error into a response.

The reason for this change is to bring us closer to how `axum` handles errors, which also requires all `Result::E` types to implement `IntoResponse`.