### PR TITLE
Use `CauseField` response extension to set `cause` log field

### DIFF
--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -76,6 +76,9 @@ async fn fallback_to_conduit(
 #[derive(Clone, Debug)]
 pub struct ErrorField(pub String);
 
+#[derive(Clone, Debug)]
+pub struct CauseField(pub String);
+
 /// Turns a `ConduitResponse` into a `AxumResponse`
 fn conduit_into_axum(response: ConduitResponse) -> AxumResponse {
     use conduit::Body::*;

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -50,7 +50,7 @@ mod server;
 #[cfg(test)]
 mod tests;
 
-pub use fallback::{ConduitFallback, ErrorField};
+pub use fallback::{CauseField, ConduitFallback, ErrorField};
 pub use server::Server;
 
 type AxumResponse = axum::response::Response;

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -167,22 +167,6 @@ impl<B> CustomMetadataRequestExt for Request<B> {
     }
 }
 
-#[cfg(test)]
-pub(crate) fn get_log_message(req: &dyn RequestExt, key: &'static str) -> String {
-    // Unwrap shouldn't panic as no other code has access to the private struct to remove it
-    if let Some(metadata) = req.extensions().get::<CustomMetadata>() {
-        if let Ok(metadata) = metadata.lock() {
-            for (k, v) in &*metadata {
-                if key == *k {
-                    return v.clone();
-                }
-            }
-        }
-    }
-
-    panic!("expected log message for {key} not found");
-}
-
 struct LogLine<'f, 'g> {
     f: &'f mut Formatter<'g>,
     first: bool,


### PR DESCRIPTION
This makes it possible to set the `cause` field when only the `response`, but not the `request` is available. 