### PR TITLE
Migrate `GET /keywords/:keyword_id` route to `axum`

### DIFF
--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -75,7 +75,7 @@ pub struct ErrorField(pub String);
 pub struct CauseField(pub String);
 
 /// Turns a `ConduitResponse` into a `AxumResponse`
-fn conduit_into_axum(response: ConduitResponse) -> AxumResponse {
+pub fn conduit_into_axum(response: ConduitResponse) -> AxumResponse {
     use conduit::Body::*;
 
     let (parts, body) = response.into_parts();

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -49,9 +49,11 @@ mod file_stream;
 mod server;
 #[cfg(test)]
 mod tests;
+mod tokio_utils;
 
 pub use fallback::{CauseField, ConduitFallback, ErrorField};
 pub use server::Server;
+pub use tokio_utils::spawn_blocking;
 
 type AxumResponse = axum::response::Response;
 type ConduitResponse = http::Response<conduit::Body>;

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -51,7 +51,7 @@ mod server;
 mod tests;
 mod tokio_utils;
 
-pub use fallback::{CauseField, ConduitFallback, ErrorField};
+pub use fallback::{conduit_into_axum, CauseField, ConduitFallback, ErrorField};
 pub use server::Server;
 pub use tokio_utils::spawn_blocking;
 

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -51,6 +51,7 @@ mod server;
 mod tests;
 mod tokio_utils;
 
+pub use error::ServiceError;
 pub use fallback::{conduit_into_axum, CauseField, ConduitFallback, ErrorField};
 pub use server::Server;
 pub use tokio_utils::spawn_blocking;

--- a/conduit-axum/src/tokio_utils.rs
+++ b/conduit-axum/src/tokio_utils.rs
@@ -1,0 +1,13 @@
+use sentry_core::Hub;
+use tokio::task::JoinHandle;
+
+/// Just like [tokio::task::spawn_blocking], but automatically runs the passed
+/// in function in the context of the current Sentry hub.
+pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let hub = Hub::current();
+    tokio::task::spawn_blocking(move || Hub::run(hub, f))
+}

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -16,6 +16,7 @@ mod prelude {
     pub use conduit_router::RequestParams;
     pub use http::{header, StatusCode};
 
+    pub use super::conduit_axum::conduit_compat;
     pub use crate::middleware::app::RequestApp;
     pub use crate::util::errors::{cargo_err, AppError, AppResult}; // TODO: Remove cargo_err from here
     pub use crate::util::{AppResponse, EndpointResult};
@@ -73,6 +74,7 @@ pub mod helpers;
 pub mod util;
 
 pub mod category;
+mod conduit_axum;
 pub mod crate_owner_invitation;
 pub mod git;
 pub mod github;

--- a/src/controllers/conduit_axum.rs
+++ b/src/controllers/conduit_axum.rs
@@ -1,0 +1,29 @@
+use crate::util::errors::AppError;
+use axum::response::{IntoResponse, Response};
+use conduit_axum::{conduit_into_axum, spawn_blocking, CauseField, ServiceError};
+
+/// This runs the passed-in function in a synchronous [spawn_blocking] context
+/// and converts any returned [AppError] into an axum [Response].
+pub async fn conduit_compat<F, R>(f: F) -> Response
+where
+    F: FnOnce() -> Result<R, Box<dyn AppError>> + Send + 'static,
+    R: IntoResponse,
+{
+    spawn_blocking(move || match f() {
+        Ok(response) => response.into_response(),
+        Err(error) => {
+            let mut response = conduit_into_axum(error.response());
+
+            if let Some(cause) = error.cause() {
+                response
+                    .extensions_mut()
+                    .insert(CauseField(cause.to_string()));
+            }
+
+            response
+        }
+    })
+    .await
+    .map_err(ServiceError::from)
+    .into_response()
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -12,10 +12,12 @@ use crate::util::EndpointResult;
 use crate::Env;
 
 pub fn build_axum_router(state: AppState) -> Router {
-    let mut router = Router::new().route(
-        "/api/v1/site_metadata",
-        get(site_metadata::show_deployed_sha),
-    );
+    let mut router = Router::new()
+        .route(
+            "/api/v1/site_metadata",
+            get(site_metadata::show_deployed_sha),
+        )
+        .route("/api/v1/keywords/:keyword_id", get(keyword::show));
 
     // Only serve the local checkout of the git index in development mode.
     // In production, for crates.io, cargo gets the index from
@@ -119,7 +121,6 @@ pub fn build_router() -> RouteBuilder {
         C(krate::metadata::reverse_dependencies),
     );
     router.get("/api/v1/keywords", C(keyword::index));
-    router.get("/api/v1/keywords/:keyword_id", C(keyword::show));
     router.get("/api/v1/categories", C(category::index));
     router.get("/api/v1/categories/:category_id", C(category::show));
     router.get("/api/v1/category_slugs", C(category::slugs));


### PR DESCRIPTION
This PR migrates the `GET /keywords/:keyword_id` route to `axum` by implementing a `conduit_compat()` function, which handles the sync/async switching and converts `AppError` into a corresponding axum `Response`.