### PR TITLE
axum: Simplify `conduit_compat()` function

### DIFF
--- a/src/controllers/conduit_axum.rs
+++ b/src/controllers/conduit_axum.rs
@@ -9,11 +9,8 @@ where
     F: FnOnce() -> Result<R, Box<dyn AppError>> + Send + 'static,
     R: IntoResponse,
 {
-    spawn_blocking(move || match f() {
-        Ok(response) => response.into_response(),
-        Err(error) => error.into_response(),
-    })
-    .await
-    .map_err(ServiceError::from)
-    .into_response()
+    spawn_blocking(move || f().into_response())
+        .await
+        .map_err(ServiceError::from)
+        .into_response()
 }

--- a/src/controllers/conduit_axum.rs
+++ b/src/controllers/conduit_axum.rs
@@ -1,6 +1,6 @@
 use crate::util::errors::AppError;
 use axum::response::{IntoResponse, Response};
-use conduit_axum::{conduit_into_axum, spawn_blocking, CauseField, ServiceError};
+use conduit_axum::{spawn_blocking, ServiceError};
 
 /// This runs the passed-in function in a synchronous [spawn_blocking] context
 /// and converts any returned [AppError] into an axum [Response].
@@ -11,17 +11,7 @@ where
 {
     spawn_blocking(move || match f() {
         Ok(response) => response.into_response(),
-        Err(error) => {
-            let mut response = conduit_into_axum(error.response());
-
-            if let Some(cause) = error.cause() {
-                response
-                    .extensions_mut()
-                    .insert(CauseField(cause.to_string()));
-            }
-
-            response
-        }
+        Err(error) => error.into_response(),
     })
     .await
     .map_err(ServiceError::from)


### PR DESCRIPTION
By implementing `IntoResponse` for `Box<dyn AppError>` we can simplify the `conduit_compat()` function a little bit :)