### PR TITLE
Replace `request_header()` fn with `HeaderMapExt` trait

### DIFF
--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -3,7 +3,7 @@ use crate::controllers::prelude::*;
 use crate::middleware::log_request::CustomMetadataRequestExt;
 use crate::models::helpers::with_count::*;
 use crate::util::errors::{bad_request, AppResult};
-use crate::util::request_header;
+use crate::util::HeaderMapExt;
 
 use diesel::pg::Pg;
 use diesel::query_builder::*;
@@ -257,8 +257,9 @@ impl RawSeekPayload {
 /// A request can be blocked if either the User Agent is on the User Agent block list or if the client
 /// IP is on the CIDR block list.
 fn is_useragent_or_ip_blocked(config: &Server, req: &dyn RequestExt) -> bool {
-    let user_agent = request_header(req, header::USER_AGENT);
-    let client_ip = request_header(req, "x-real-ip");
+    let headers = req.headers();
+    let user_agent = headers.get_str_or_default(header::USER_AGENT);
+    let client_ip = headers.get_str_or_default("x-real-ip");
 
     // check if user agent is blocked
     if config

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -1,5 +1,6 @@
 use conduit::RequestExt;
 use http::header::AsHeaderName;
+use http::HeaderMap;
 
 /// Returns the value of the request header, or an empty slice if it is not
 /// present.
@@ -11,8 +12,23 @@ pub fn request_header<K>(req: &dyn RequestExt, key: K) -> &str
 where
     K: AsHeaderName,
 {
-    req.headers()
-        .get(key)
-        .map(|value| value.to_str().unwrap_or_default())
-        .unwrap_or_default()
+    req.headers().get_str_or_default(key)
+}
+
+pub trait HeaderMapExt {
+    /// Returns the value of the request header, or an empty slice if it is not
+    /// present.
+    ///
+    /// If a header appears multiple times, this will return only one of them.
+    ///
+    /// If the header value is invalid utf8, an empty slice will be returned.
+    fn get_str_or_default<K: AsHeaderName>(&self, key: K) -> &str;
+}
+
+impl HeaderMapExt for HeaderMap {
+    fn get_str_or_default<K: AsHeaderName>(&self, key: K) -> &str {
+        self.get(key)
+            .map(|value| value.to_str().unwrap_or_default())
+            .unwrap_or_default()
+    }
 }

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -1,19 +1,5 @@
-use conduit::RequestExt;
 use http::header::AsHeaderName;
 use http::HeaderMap;
-
-/// Returns the value of the request header, or an empty slice if it is not
-/// present.
-///
-/// If a header appears multiple times, this will return only one of them.
-///
-/// If the header value is invalid utf8, an empty slice will be returned.
-pub fn request_header<K>(req: &dyn RequestExt, key: K) -> &str
-where
-    K: AsHeaderName,
-{
-    req.headers().get_str_or_default(key)
-}
 
 pub trait HeaderMapExt {
     /// Returns the value of the request header, or an empty slice if it is not


### PR DESCRIPTION
This trait extends the `HeaderMap` struct and adds a `get_str_or_default()` method to it, which behaves roughly like the old function.