### PR TITLE
middleware/block_traffic: Remove unnecessary str conversion

### DIFF
--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -28,7 +28,6 @@ pub async fn block_traffic<B>(
             .headers()
             .get_all(header_name)
             .iter()
-            .map(|val| val.to_str().unwrap_or_default())
             .any(|value| blocked_values.iter().any(|v| v == value));
         if has_blocked_value {
             let cause = format!("blocked due to contents of header {header_name}");


### PR DESCRIPTION
`HeaderValue` has a `PartialEq` implementation for strings, so there is no need to convert it to a string before comparing.