### PR TITLE
conduit-axum: Remove obsolete `SocketAddr` handling code

### DIFF
--- a/conduit-axum/src/adaptor.rs
+++ b/conduit-axum/src/adaptor.rs
@@ -20,12 +20,11 @@ use hyper::body::Bytes;
 pub(crate) struct ConduitRequest {
     parts: HttpParts,
     path: String,
-    remote_addr: SocketAddr,
     body: Cursor<Bytes>,
 }
 
 impl ConduitRequest {
-    pub(crate) fn new(request: Request<Bytes>, remote_addr: SocketAddr, now: StartInstant) -> Self {
+    pub(crate) fn new(request: Request<Bytes>, now: StartInstant) -> Self {
         let (mut parts, body) = request.into_parts();
         let path = parts.uri.path().as_bytes();
         let path = percent_encoding::percent_decode(path)
@@ -37,7 +36,6 @@ impl ConduitRequest {
         Self {
             parts,
             path,
-            remote_addr,
             body: Cursor::new(body),
         }
     }
@@ -68,7 +66,7 @@ impl RequestExt for ConduitRequest {
 
     /// Always returns an address of 0.0.0.0:0
     fn remote_addr(&self) -> SocketAddr {
-        self.remote_addr
+        ([0, 0, 0, 0], 0).into()
     }
 
     fn virtual_root(&self) -> Option<&str> {

--- a/conduit-axum/src/tests.rs
+++ b/conduit-axum/src/tests.rs
@@ -1,7 +1,4 @@
-use std::net::SocketAddr;
-
-use axum::extract::ConnectInfo;
-use axum::{Extension, Router};
+use axum::Router;
 use conduit::{box_error, Body, Handler, HandlerResult, RequestExt};
 use http::{HeaderValue, Request, Response, StatusCode};
 use hyper::{body::to_bytes, service::Service};
@@ -74,11 +71,7 @@ impl Handler for AssertPercentDecodedPath {
 }
 
 fn make_service<H: Handler>(handler: H) -> Router {
-    let remote_addr: SocketAddr = ([0, 0, 0, 0], 0).into();
-
-    Router::new()
-        .conduit_fallback(handler)
-        .layer(Extension(ConnectInfo(remote_addr)))
+    Router::new().conduit_fallback(handler)
 }
 
 async fn simulate_request<H: Handler>(handler: H) -> AxumResponse {
@@ -167,7 +160,7 @@ async fn spawn_http_server() -> (
     let addr = ([127, 0, 0, 1], 0).into();
 
     let router = Router::new().conduit_fallback(OkResult);
-    let make_service = router.into_make_service_with_connect_info::<SocketAddr>();
+    let make_service = router.into_make_service();
     let server = hyper::Server::bind(&addr).serve(make_service);
 
     let url = format!("http://{}", server.local_addr());


### PR DESCRIPTION
The only part of crates.io that needed this was the `git-http-backend` code, which is using axum directly now, so there is no need for this anymore in the `conduit-axum` compatibility layer.