### PR TITLE
conduit-axum: Remove `StartInstant` extension

### DIFF
--- a/conduit-axum/src/adaptor.rs
+++ b/conduit-axum/src/adaptor.rs
@@ -12,7 +12,7 @@
 use std::io::{Cursor, Read};
 use std::net::SocketAddr;
 
-use conduit::{Host, RequestExt, Scheme, StartInstant};
+use conduit::{Host, RequestExt, Scheme};
 use http::request::Parts as HttpParts;
 use http::{Extensions, HeaderMap, Method, Request, Version};
 use hyper::body::Bytes;
@@ -24,14 +24,12 @@ pub(crate) struct ConduitRequest {
 }
 
 impl ConduitRequest {
-    pub(crate) fn new(request: Request<Bytes>, now: StartInstant) -> Self {
-        let (mut parts, body) = request.into_parts();
+    pub(crate) fn new(request: Request<Bytes>) -> Self {
+        let (parts, body) = request.into_parts();
         let path = parts.uri.path().as_bytes();
         let path = percent_encoding::percent_decode(path)
             .decode_utf8_lossy()
             .into_owned();
-
-        parts.extensions.insert(now);
 
         Self {
             parts,

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -12,7 +12,7 @@ use axum::body::{Body, HttpBody};
 use axum::extract::Extension;
 use axum::handler::Handler as AxumHandler;
 use axum::response::IntoResponse;
-use conduit::{Handler, RequestExt, StartInstant};
+use conduit::{Handler, RequestExt};
 use conduit_router::RoutePattern;
 use http::header::CONTENT_LENGTH;
 use http::StatusCode;
@@ -58,7 +58,6 @@ where
             }
 
             let (parts, body) = request.into_parts();
-            let now = StartInstant::now();
 
             let full_body = match hyper::body::to_bytes(body).await {
                 Ok(body) => body,
@@ -68,7 +67,7 @@ where
 
             let Self(handler) = self;
             spawn_blocking(move || {
-                let mut request = ConduitRequest::new(request, now);
+                let mut request = ConduitRequest::new(request);
                 handler
                     .call(&mut request)
                     .map(|mut response| {


### PR DESCRIPTION
We're not using this anywhere anymore and `conduit` does not appear to use it internally either.