### PR TITLE
conduit-axum/examples: Use `ConduitAxumHandler` to implement route handlers

### DIFF
--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -12,10 +12,12 @@ use std::thread::sleep;
 async fn main() {
     tracing_subscriber::fmt::init();
 
+    let router = axum::Router::new();
+
     let app = build_conduit_handler();
     let addr = ([127, 0, 0, 1], 12345).into();
 
-    Server::serve(&addr, app).await;
+    Server::serve(&addr, router, app).await;
 }
 
 fn build_conduit_handler() -> impl Handler {

--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -1,7 +1,8 @@
 #![deny(clippy::all)]
 
+use axum::routing::get;
 use conduit::{Body, Handler, RequestExt, ResponseResult};
-use conduit_axum::Server;
+use conduit_axum::{ConduitAxumHandler, Server};
 use conduit_router::RouteBuilder;
 use http::{header, Response};
 
@@ -12,12 +13,19 @@ use std::thread::sleep;
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    let router = axum::Router::new();
+    let router = axum::Router::new()
+        .route("/axum/", get(wrap(endpoint)))
+        .route("/axum/panic", get(wrap(panic)))
+        .route("/axum/error", get(wrap(error)));
 
     let app = build_conduit_handler();
     let addr = ([127, 0, 0, 1], 12345).into();
 
     Server::serve(&addr, router, app).await;
+}
+
+pub fn wrap<H>(handler: H) -> ConduitAxumHandler<H> {
+    ConduitAxumHandler::wrap(handler)
 }
 
 fn build_conduit_handler() -> impl Handler {

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -31,12 +31,18 @@ pub trait ConduitFallback {
 
 impl ConduitFallback for axum::Router {
     fn conduit_fallback(self, handler: impl Handler) -> Self {
-        self.fallback(ConduitAxumHandler(Arc::new(handler)))
+        self.fallback(ConduitAxumHandler::wrap(handler))
     }
 }
 
 #[derive(Debug)]
 pub struct ConduitAxumHandler<H>(pub Arc<H>);
+
+impl<H> ConduitAxumHandler<H> {
+    pub fn wrap(handler: H) -> Self {
+        Self(Arc::new(handler))
+    }
+}
 
 impl<H> Clone for ConduitAxumHandler<H> {
     fn clone(&self) -> Self {

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -19,9 +19,11 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
+//!     let router = axum::Router::new();
+//!
 //!     let app = build_conduit_handler();
 //!     let addr = ([127, 0, 0, 1], 12345).into();
-//!     let server = Server::serve(&addr, app);
+//!     let server = Server::serve(&addr, router, app);
 //!
 //!     server.await;
 //! }

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -54,7 +54,9 @@ mod tests;
 mod tokio_utils;
 
 pub use error::ServiceError;
-pub use fallback::{conduit_into_axum, CauseField, ConduitFallback, ErrorField};
+pub use fallback::{
+    conduit_into_axum, CauseField, ConduitAxumHandler, ConduitFallback, ErrorField,
+};
 pub use server::Server;
 pub use tokio_utils::spawn_blocking;
 

--- a/conduit-axum/src/server.rs
+++ b/conduit-axum/src/server.rs
@@ -14,8 +14,12 @@ impl Server {
     /// `tokio::Runtime` it is not possible to furter configure the `hyper::Server`.  If more
     /// control, such as configuring a graceful shutdown is necessary, then call
     /// `Service::from_blocking` instead.
-    pub fn serve<H: conduit::Handler>(addr: &SocketAddr, handler: H) -> impl Future {
-        let router = axum::Router::new().conduit_fallback(handler);
+    pub fn serve<H: conduit::Handler>(
+        addr: &SocketAddr,
+        router: axum::Router,
+        handler: H,
+    ) -> impl Future {
+        let router = router.conduit_fallback(handler);
         let make_service = router.into_make_service_with_connect_info::<SocketAddr>();
 
         hyper::Server::bind(addr).serve(make_service)


### PR DESCRIPTION
#5798 prepared for it, and this PR demonstrates how the `ConduitAxumHandler` struct can be used as an adapter between a conduit handler function and the `axum::Router`.