### PR TITLE
RequestParamExt: Use `axum` path parameters if available

### DIFF
--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -56,6 +56,7 @@ mod tokio_utils;
 pub use error::ServiceError;
 pub use fallback::{
     conduit_into_axum, CauseField, ConduitAxumHandler, ConduitFallback, ErrorField,
+    RequestParamsExt,
 };
 pub use server::Server;
 pub use tokio_utils::spawn_blocking;

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
 use crate::util::errors::{forbidden, internal, AppError, AppResult};
+use conduit_axum::RequestParamsExt;
 use conduit_router::RequestParams;
 
 /// The Origin header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
@@ -30,6 +31,10 @@ pub trait RequestParamExt<'a> {
 
 impl<'a> RequestParamExt<'a> for &'a (dyn RequestExt + 'a) {
     fn param(self, key: &str) -> Option<&'a str> {
-        self.params().find(key)
+        return if let Some(params) = self.axum_params() {
+            params.0.get(key).map(|s| &s[..])
+        } else {
+            self.params().find(key)
+        };
     }
 }


### PR DESCRIPTION
This PR extends the `RequestParamExt` implementation from #5801 with support for path parameters from the `axum::Router`