### PR TITLE
conduit-axum: Remove obsolete `ConduitFallback` trait

### DIFF
--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -25,16 +25,6 @@ use tracing::{error, warn};
 /// See the usage section of the README if you plan to use this server in production.
 const MAX_CONTENT_LENGTH: u64 = 128 * 1024 * 1024; // 128 MB
 
-pub trait ConduitFallback {
-    fn conduit_fallback(self, handler: impl Handler) -> Self;
-}
-
-impl ConduitFallback for axum::Router {
-    fn conduit_fallback(self, handler: impl Handler) -> Self {
-        self.fallback(ConduitAxumHandler::wrap(handler))
-    }
-}
-
 #[derive(Debug)]
 pub struct ConduitAxumHandler<H>(pub Arc<H>);
 

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -57,8 +57,7 @@ mod tokio_utils;
 
 pub use error::ServiceError;
 pub use fallback::{
-    conduit_into_axum, CauseField, ConduitAxumHandler, ConduitFallback, ErrorField,
-    RequestParamsExt,
+    conduit_into_axum, CauseField, ConduitAxumHandler, ErrorField, RequestParamsExt,
 };
 pub use tokio_utils::spawn_blocking;
 


### PR DESCRIPTION
Now that we have `ConduitAxumHandler` we don't need the `ConduitFallback` trait anymore :)