### PR TITLE
conduit: Remove obsolete functions from the `RequestExt` trait

### DIFF
--- a/conduit-axum/src/adaptor.rs
+++ b/conduit-axum/src/adaptor.rs
@@ -11,7 +11,7 @@
 
 use std::io::{Cursor, Read};
 
-use conduit::{Host, RequestExt};
+use conduit::RequestExt;
 use http::request::Parts as HttpParts;
 use http::{Extensions, HeaderMap, Method, Request, Version};
 use hyper::body::Bytes;
@@ -66,18 +66,6 @@ impl RequestExt for ConduitRequest {
 
     fn mut_extensions(&mut self) -> &mut Extensions {
         &mut self.parts.extensions
-    }
-
-    /// Returns the value of the `Host` header
-    ///
-    /// If the header is not present or is invalid UTF-8, then the empty string is returned
-    fn host(&self) -> Host<'_> {
-        let host = self
-            .headers()
-            .get(http::header::HOST)
-            .map(|h| h.to_str().unwrap_or(""))
-            .unwrap_or("");
-        Host::Name(host)
     }
 
     fn query_string(&self) -> Option<&str> {

--- a/conduit-axum/src/adaptor.rs
+++ b/conduit-axum/src/adaptor.rs
@@ -67,10 +67,6 @@ impl RequestExt for ConduitRequest {
         ([0, 0, 0, 0], 0).into()
     }
 
-    fn virtual_root(&self) -> Option<&str> {
-        None
-    }
-
     fn path(&self) -> &str {
         &self.path
     }

--- a/conduit-axum/src/adaptor.rs
+++ b/conduit-axum/src/adaptor.rs
@@ -12,7 +12,7 @@
 use std::io::{Cursor, Read};
 use std::net::SocketAddr;
 
-use conduit::{Host, RequestExt, Scheme};
+use conduit::{Host, RequestExt};
 use http::request::Parts as HttpParts;
 use http::{Extensions, HeaderMap, Method, Request, Version};
 use hyper::body::Bytes;
@@ -46,11 +46,6 @@ impl RequestExt for ConduitRequest {
 
     fn method(&self) -> &Method {
         &self.parts.method
-    }
-
-    /// Always returns Http
-    fn scheme(&self) -> Scheme {
-        Scheme::Http
     }
 
     fn headers(&self) -> &HeaderMap {

--- a/conduit-axum/src/adaptor.rs
+++ b/conduit-axum/src/adaptor.rs
@@ -71,10 +71,6 @@ impl RequestExt for ConduitRequest {
         &self.path
     }
 
-    fn path_mut(&mut self) -> &mut String {
-        &mut self.path
-    }
-
     fn extensions(&self) -> &Extensions {
         &self.parts.extensions
     }

--- a/conduit-axum/src/adaptor.rs
+++ b/conduit-axum/src/adaptor.rs
@@ -10,7 +10,6 @@
 //! `RequestInfo` which is `Send` and is moved into `ConduitRequest::new`.
 
 use std::io::{Cursor, Read};
-use std::net::SocketAddr;
 
 use conduit::{Host, RequestExt};
 use http::request::Parts as HttpParts;
@@ -55,11 +54,6 @@ impl RequestExt for ConduitRequest {
     /// Returns the length of the buffered body
     fn content_length(&self) -> Option<u64> {
         Some(self.body.get_ref().len() as u64)
-    }
-
-    /// Always returns an address of 0.0.0.0:0
-    fn remote_addr(&self) -> SocketAddr {
-        ([0, 0, 0, 0], 0).into()
     }
 
     fn path(&self) -> &str {

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::io::{Cursor, Read};
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
@@ -114,10 +113,6 @@ impl conduit::RequestExt for MockRequest {
         self.query_string.as_ref().map(|s| &s[..])
     }
 
-    fn remote_addr(&self) -> SocketAddr {
-        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80))
-    }
-
     fn content_length(&self) -> Option<u64> {
         self.body.as_ref().map(|b| b.len() as u64)
     }
@@ -146,8 +141,6 @@ impl conduit::RequestExt for MockRequest {
 mod tests {
     use super::MockRequest;
 
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-
     use conduit::{header, Host, Method, RequestExt, Version};
 
     #[test]
@@ -159,10 +152,6 @@ mod tests {
         assert_eq!(req.host(), Host::Name("example.com"));
         assert_eq!(req.path(), "/");
         assert_eq!(req.query_string(), None);
-        assert_eq!(
-            req.remote_addr(),
-            SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 80))
-        );
         assert_eq!(req.content_length(), None);
         assert_eq!(req.headers().len(), 0);
         let mut s = String::new();

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -4,7 +4,7 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Body, Extensions, HeaderMap, Host, Method, Response, Scheme, Version,
+    Body, Extensions, HeaderMap, Host, Method, Response, Version,
 };
 
 pub trait ResponseExt {
@@ -101,9 +101,7 @@ impl conduit::RequestExt for MockRequest {
     fn method(&self) -> &Method {
         &self.method
     }
-    fn scheme(&self) -> Scheme {
-        Scheme::Http
-    }
+
     fn host(&self) -> Host<'_> {
         Host::Name("example.com")
     }
@@ -150,7 +148,7 @@ mod tests {
 
     use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
-    use conduit::{header, Host, Method, RequestExt, Scheme, Version};
+    use conduit::{header, Host, Method, RequestExt, Version};
 
     #[test]
     fn simple_request_test() {
@@ -158,7 +156,6 @@ mod tests {
 
         assert_eq!(req.http_version(), Version::HTTP_11);
         assert_eq!(req.method(), Method::GET);
-        assert_eq!(req.scheme(), Scheme::Http);
         assert_eq!(req.host(), Host::Name("example.com"));
         assert_eq!(req.path(), "/");
         assert_eq!(req.query_string(), None);

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Body, Extensions, HeaderMap, Host, Method, Response, Version,
+    Body, Extensions, HeaderMap, Method, Response, Version,
 };
 
 pub trait ResponseExt {
@@ -101,10 +101,6 @@ impl conduit::RequestExt for MockRequest {
         &self.method
     }
 
-    fn host(&self) -> Host<'_> {
-        Host::Name("example.com")
-    }
-
     fn path(&self) -> &str {
         &self.path
     }
@@ -141,7 +137,7 @@ impl conduit::RequestExt for MockRequest {
 mod tests {
     use super::MockRequest;
 
-    use conduit::{header, Host, Method, RequestExt, Version};
+    use conduit::{header, Method, RequestExt, Version};
 
     #[test]
     fn simple_request_test() {
@@ -149,7 +145,6 @@ mod tests {
 
         assert_eq!(req.http_version(), Version::HTTP_11);
         assert_eq!(req.method(), Method::GET);
-        assert_eq!(req.host(), Host::Name("example.com"));
         assert_eq!(req.path(), "/");
         assert_eq!(req.query_string(), None);
         assert_eq!(req.content_length(), None);

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -112,10 +112,6 @@ impl conduit::RequestExt for MockRequest {
         &self.path
     }
 
-    fn path_mut(&mut self) -> &mut String {
-        &mut self.path
-    }
-
     fn query_string(&self) -> Option<&str> {
         self.query_string.as_ref().map(|s| &s[..])
     }

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -107,9 +107,6 @@ impl conduit::RequestExt for MockRequest {
     fn host(&self) -> Host<'_> {
         Host::Name("example.com")
     }
-    fn virtual_root(&self) -> Option<&str> {
-        None
-    }
 
     fn path(&self) -> &str {
         &self.path
@@ -167,7 +164,6 @@ mod tests {
         assert_eq!(req.method(), Method::GET);
         assert_eq!(req.scheme(), Scheme::Http);
         assert_eq!(req.host(), Host::Name("example.com"));
-        assert_eq!(req.virtual_root(), None);
         assert_eq!(req.path(), "/");
         assert_eq!(req.query_string(), None);
         assert_eq!(

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -4,7 +4,7 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Body, Extensions, HeaderMap, Host, Method, Response, Scheme, StartInstant, Version,
+    Body, Extensions, HeaderMap, Host, Method, Response, Scheme, Version,
 };
 
 pub trait ResponseExt {
@@ -49,8 +49,7 @@ pub struct MockRequest {
 impl MockRequest {
     pub fn new(method: Method, path: &str) -> MockRequest {
         let headers = HeaderMap::new();
-        let mut extensions = Extensions::new();
-        extensions.insert(StartInstant::now());
+        let extensions = Extensions::new();
 
         MockRequest {
             path: path.to_string(),

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -56,12 +56,6 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 }
 
 #[derive(PartialEq, Debug, Clone, Copy)]
-pub enum Scheme {
-    Http,
-    Https,
-}
-
-#[derive(PartialEq, Debug, Clone, Copy)]
 pub enum Host<'a> {
     Name(&'a str),
     Socket(SocketAddr),
@@ -76,9 +70,6 @@ pub trait RequestExt {
 
     /// The request method, such as GET, POST, PUT, DELETE or PATCH
     fn method(&self) -> &Method;
-
-    /// The scheme part of the request URL
-    fn scheme(&self) -> Scheme;
 
     /// The host part of the requested URL
     fn host(&self) -> Host<'_>;

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -80,10 +80,6 @@ pub trait RequestExt {
     /// The portion of the request URL that follows the "?"
     fn query_string(&self) -> Option<&str>;
 
-    /// The remote IP address of the client or the last proxy that
-    /// sent the request.
-    fn remote_addr(&self) -> SocketAddr;
-
     /// The byte-size of the body, if any
     fn content_length(&self) -> Option<u64>;
 

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -4,7 +4,6 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Read;
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
 
 pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Version};
 
@@ -13,18 +12,6 @@ pub type HttpResult = ResponseResult<http::Error>;
 
 pub type BoxError = Box<dyn Error + Send>;
 pub type HandlerResult = Result<Response<Body>, BoxError>;
-
-/// A type representing the instant a request was received
-///
-/// Servers must add this to the request's extensions, capturing the moment
-/// request headers were received.
-pub struct StartInstant(Instant);
-
-impl StartInstant {
-    pub fn now() -> Self {
-        Self(Instant::now())
-    }
-}
 
 /// A type representing a `Response` body.
 ///
@@ -84,16 +71,6 @@ pub enum Host<'a> {
 pub type Extensions = http::Extensions;
 
 pub trait RequestExt {
-    /// The elapsed time since the start of the request (headers received)
-    ///
-    /// # Panics
-    ///
-    /// This method may panic if the server does not add `StartInstant` to the
-    /// request extensions, or if it has been removed by the application.
-    fn elapsed(&self) -> Duration {
-        self.extensions().get::<StartInstant>().unwrap().0.elapsed()
-    }
-
     /// The version of HTTP being used
     fn http_version(&self) -> Version;
 

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -3,7 +3,6 @@
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;
-use std::net::SocketAddr;
 
 pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Version};
 
@@ -55,12 +54,6 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
     Box::new(error)
 }
 
-#[derive(PartialEq, Debug, Clone, Copy)]
-pub enum Host<'a> {
-    Name(&'a str),
-    Socket(SocketAddr),
-}
-
 /// A Dictionary for extensions provided by the server or middleware
 pub type Extensions = http::Extensions;
 
@@ -70,9 +63,6 @@ pub trait RequestExt {
 
     /// The request method, such as GET, POST, PUT, DELETE or PATCH
     fn method(&self) -> &Method;
-
-    /// The host part of the requested URL
-    fn host(&self) -> Host<'_>;
 
     /// The remainder of the path.
     fn path(&self) -> &str;

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -86,9 +86,6 @@ pub trait RequestExt {
     /// The remainder of the path.
     fn path(&self) -> &str;
 
-    /// Obtain the request path for mutation/rewrite
-    fn path_mut(&mut self) -> &mut String;
-
     /// The portion of the request URL that follows the "?"
     fn query_string(&self) -> Option<&str>;
 

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -83,11 +83,6 @@ pub trait RequestExt {
     /// The host part of the requested URL
     fn host(&self) -> Host<'_>;
 
-    /// The initial part of the request URL's path that corresponds
-    /// to a virtual root. This allows an application to have a
-    /// virtual location that consumes part of the path.
-    fn virtual_root(&self) -> Option<&str>;
-
     /// The remainder of the path.
     fn path(&self) -> &str;
 


### PR DESCRIPTION
We are not using any of these inside the `crates.io` codebase, so we might as well delete them... 🧹 