### PR TITLE
tests/util: Remove redundant `get_query()` fn

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -127,14 +127,6 @@ pub trait RequestHelper {
         self.run(self.get_request(path))
     }
 
-    /// Issue a GET request with a query string
-    #[track_caller]
-    fn get_query<T>(&self, path: &str, query: &str) -> Response<T> {
-        let mut req = self.get_request(path);
-        req.with_query(query);
-        self.run(req)
-    }
-
     /// Issue a GET request that includes query parameters
     #[track_caller]
     fn get_with_query<T>(&self, path: &str, query: &str) -> Response<T> {
@@ -195,7 +187,7 @@ pub trait RequestHelper {
     /// Request the JSON used for a crate's minimal page
     fn show_crate_minimal(&self, krate_name: &str) -> CrateResponse {
         let url = format!("/api/v1/crates/{krate_name}");
-        self.get_query(&url, "include=").good()
+        self.get_with_query(&url, "include=").good()
     }
 
     /// Request the JSON used to list a crate's owners


### PR DESCRIPTION
This function is doing the exact same thing as `get_with_query()` so there is really no need to have both of them 😅