### PR TITLE
conduit: Replace `path()` and `query_string()` with `uri()`

### DIFF
--- a/conduit-axum/src/tests.rs
+++ b/conduit-axum/src/tests.rs
@@ -63,7 +63,7 @@ impl Handler for Sleep {
 struct AssertPercentDecodedPath;
 impl Handler for AssertPercentDecodedPath {
     fn call(&self, req: &mut dyn RequestExt) -> HandlerResult {
-        if req.path() == "/:" && req.query_string() == Some("%3a") {
+        if req.uri().path() == "/%3a" && req.uri().query() == Some("%3a") {
             OkResult.call(req)
         } else {
             ErrorResult.call(req)

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Body, Extensions, HeaderMap, Method, Response, Version,
+    Body, Extensions, HeaderMap, Method, Response, Uri, Version,
 };
 
 pub trait ResponseExt {
@@ -35,10 +35,16 @@ impl ResponseExt for Response<Body> {
     }
 }
 
+fn uri(path_and_query: &str) -> Uri {
+    Uri::builder()
+        .path_and_query(path_and_query)
+        .build()
+        .unwrap()
+}
+
 pub struct MockRequest {
-    path: String,
     method: Method,
-    query_string: Option<String>,
+    uri: Uri,
     body: Option<Vec<u8>>,
     headers: HeaderMap,
     extensions: Extensions,
@@ -51,9 +57,8 @@ impl MockRequest {
         let extensions = Extensions::new();
 
         MockRequest {
-            path: path.to_string(),
+            uri: uri(path),
             extensions,
-            query_string: None,
             body: None,
             headers,
             method,
@@ -67,12 +72,16 @@ impl MockRequest {
     }
 
     pub fn with_path(&mut self, path: &str) -> &mut MockRequest {
-        self.path = path.to_string();
+        self.uri = match self.uri.query() {
+            Some(query) => uri(&format!("{}?{}", path, query)),
+            None => uri(path),
+        };
         self
     }
 
     pub fn with_query(&mut self, string: &str) -> &mut MockRequest {
-        self.query_string = Some(string.to_string());
+        let path_and_query = format!("{}?{}", self.uri.path(), string);
+        self.uri = uri(&path_and_query);
         self
     }
 
@@ -101,12 +110,8 @@ impl conduit::RequestExt for MockRequest {
         &self.method
     }
 
-    fn path(&self) -> &str {
-        &self.path
-    }
-
-    fn query_string(&self) -> Option<&str> {
-        self.query_string.as_ref().map(|s| &s[..])
+    fn uri(&self) -> &Uri {
+        &self.uri
     }
 
     fn content_length(&self) -> Option<u64> {
@@ -145,8 +150,7 @@ mod tests {
 
         assert_eq!(req.http_version(), Version::HTTP_11);
         assert_eq!(req.method(), Method::GET);
-        assert_eq!(req.path(), "/");
-        assert_eq!(req.query_string(), None);
+        assert_eq!(req.uri(), "/");
         assert_eq!(req.content_length(), None);
         assert_eq!(req.headers().len(), 0);
         let mut s = String::new();
@@ -160,7 +164,7 @@ mod tests {
         req.with_body(b"Hello world");
 
         assert_eq!(req.method(), Method::POST);
-        assert_eq!(req.path(), "/articles");
+        assert_eq!(req.uri(), "/articles");
         let mut s = String::new();
         req.body().read_to_string(&mut s).expect("No body");
         assert_eq!(s, "Hello world".to_string());
@@ -172,7 +176,7 @@ mod tests {
         let mut req = MockRequest::new(Method::POST, "/articles");
         req.with_query("foo=bar");
 
-        assert_eq!(req.query_string().expect("No query string"), "foo=bar");
+        assert_eq!(req.uri().query().expect("No query string"), "foo=bar");
     }
 
     #[test]

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Read;
 
-pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Version};
+pub use http::{header, HeaderMap, Method, Request, Response, StatusCode, Uri, Version};
 
 pub type ResponseResult<Error> = Result<Response<Body>, Error>;
 pub type HttpResult = ResponseResult<http::Error>;
@@ -64,11 +64,8 @@ pub trait RequestExt {
     /// The request method, such as GET, POST, PUT, DELETE or PATCH
     fn method(&self) -> &Method;
 
-    /// The remainder of the path.
-    fn path(&self) -> &str;
-
-    /// The portion of the request URL that follows the "?"
-    fn query_string(&self) -> Option<&str>;
+    /// The request URI
+    fn uri(&self) -> &Uri;
 
     /// The byte-size of the body, if any
     fn content_length(&self) -> Option<u64>;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -44,7 +44,7 @@ mod prelude {
 
     impl<'a> RequestUtils for dyn RequestExt + 'a {
         fn query(&self) -> IndexMap<String, String> {
-            url::form_urlencoded::parse(self.query_string().unwrap_or("").as_bytes())
+            url::form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
                 .into_owned()
                 .collect()
         }

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -200,7 +200,7 @@ pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
         // Calculating the total number of results with filters is not supported yet.
         supports_seek = false;
 
-        let query_bytes = req.query_string().unwrap_or("").as_bytes();
+        let query_bytes = req.uri().query().unwrap_or("").as_bytes();
         let ids: Vec<_> = url::form_urlencoded::parse(query_bytes)
             .filter(|(key, _)| key == "ids[]")
             .map(|(_, value)| value.to_string())

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -17,7 +17,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
     let conn = req.app().db_read()?;
 
     // Extract all ids requested.
-    let query = url::form_urlencoded::parse(req.query_string().unwrap_or("").as_bytes());
+    let query = url::form_urlencoded::parse(req.uri().query().unwrap_or("").as_bytes());
     let ids = query
         .filter_map(|(ref a, ref b)| if *a == "ids[]" { b.parse().ok() } else { None })
         .collect::<Vec<i32>>();

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -379,15 +379,9 @@ fn convert_request(mut mock_request: MockRequest) -> http::Request<hyper::Body> 
 
     let body = hyper::Body::from(buffer);
 
-    let mut path = mock_request.path().to_string();
-    if let Some(query) = mock_request.query_string() {
-        path += "?";
-        path += query;
-    }
-
     let mut req = http::Request::builder()
         .method(mock_request.method())
-        .uri(path);
+        .uri(mock_request.uri());
 
     for (name, value) in mock_request.headers() {
         req = req.header(name, value)


### PR DESCRIPTION
This brings the `conduit` API closer to the `http::Request` struct 