### PR TITLE
conduit-test: Remove unused `with_method()` and `with_path()` fns

### DIFF
--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -53,11 +53,6 @@ impl MockRequest {
         }
     }
 
-    pub fn with_method(&mut self, method: Method) -> &mut MockRequest {
-        self.method = method;
-        self
-    }
-
     pub fn with_query(&mut self, string: &str) -> &mut MockRequest {
         let path_and_query = format!("{}?{}", self.uri.path(), string);
         self.uri = uri(&path_and_query);

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -58,14 +58,6 @@ impl MockRequest {
         self
     }
 
-    pub fn with_path(&mut self, path: &str) -> &mut MockRequest {
-        self.uri = match self.uri.query() {
-            Some(query) => uri(&format!("{}?{}", path, query)),
-            None => uri(path),
-        };
-        self
-    }
-
     pub fn with_query(&mut self, string: &str) -> &mut MockRequest {
         let path_and_query = format!("{}?{}", self.uri.path(), string);
         self.uri = uri(&path_and_query);


### PR DESCRIPTION
These two methods don't appear to be used anywhere in our project, so we might as well remove them