### PR TITLE
conduit: Remove obsolete `http_version()` fn from `RequestExt` trait

### DIFF
--- a/conduit-axum/src/request.rs
+++ b/conduit-axum/src/request.rs
@@ -13,7 +13,7 @@ use std::io::{Cursor, Read};
 
 use conduit::RequestExt;
 use http::request::Parts as HttpParts;
-use http::{Extensions, HeaderMap, Method, Request, Uri, Version};
+use http::{Extensions, HeaderMap, Method, Request, Uri};
 use hyper::body::Bytes;
 
 pub(crate) struct ConduitRequest {
@@ -33,10 +33,6 @@ impl ConduitRequest {
 }
 
 impl RequestExt for ConduitRequest {
-    fn http_version(&self) -> Version {
-        self.parts.version
-    }
-
     fn method(&self) -> &Method {
         &self.parts.method
     }

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -3,7 +3,7 @@ use std::io::{Cursor, Read};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Body, Extensions, HeaderMap, Method, Response, Uri, Version,
+    Body, Extensions, HeaderMap, Method, Response, Uri,
 };
 
 pub trait ResponseExt {
@@ -76,10 +76,6 @@ impl MockRequest {
 }
 
 impl conduit::RequestExt for MockRequest {
-    fn http_version(&self) -> Version {
-        Version::HTTP_11
-    }
-
     fn method(&self) -> &Method {
         &self.method
     }
@@ -116,13 +112,12 @@ impl conduit::RequestExt for MockRequest {
 mod tests {
     use super::MockRequest;
 
-    use conduit::{header, Method, RequestExt, Version};
+    use conduit::{header, Method, RequestExt};
 
     #[test]
     fn simple_request_test() {
         let mut req = MockRequest::new(Method::GET, "/");
 
-        assert_eq!(req.http_version(), Version::HTTP_11);
         assert_eq!(req.method(), Method::GET);
         assert_eq!(req.uri(), "/");
         assert_eq!(req.content_length(), None);

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -3,9 +3,7 @@
 use std::error::Error;
 use std::io::Read;
 
-pub use http::{
-    header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri, Version,
-};
+pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
 pub type ResponseResult<Error> = Result<Response<Body>, Error>;
 pub type HttpResult = ResponseResult<http::Error>;
@@ -55,9 +53,6 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 }
 
 pub trait RequestExt {
-    /// The version of HTTP being used
-    fn http_version(&self) -> Version;
-
     /// The request method, such as GET, POST, PUT, DELETE or PATCH
     fn method(&self) -> &Method;
 


### PR DESCRIPTION
Nothing is using this anymore, so we might as well remove it.

Related:
-  #5813 