### PR TITLE
conduit-test: Simplify `MockRequest` by relying on `http::Request`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
 name = "conduit-test"
 version = "0.10.0"
 dependencies = [
+ "bytes",
  "conduit",
 ]
 

--- a/conduit-test/Cargo.toml
+++ b/conduit-test/Cargo.toml
@@ -9,4 +9,5 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
+bytes = "1.3.0"
 conduit = { version ="0.10.0", path = "../conduit" }

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use std::borrow::Cow;
 use std::convert::TryInto;
 use std::io::{Cursor, Read};
@@ -24,7 +25,7 @@ impl ResponseExt for Response<Body> {
 }
 
 pub struct MockRequest {
-    request: conduit::Request<Cursor<Vec<u8>>>,
+    request: conduit::Request<Cursor<Bytes>>,
 }
 
 impl MockRequest {
@@ -32,7 +33,7 @@ impl MockRequest {
         let request = conduit::Request::builder()
             .method(&method)
             .uri(path)
-            .body(Cursor::new(vec![]))
+            .body(Cursor::new(Bytes::new()))
             .unwrap();
 
         MockRequest { request }
@@ -45,7 +46,7 @@ impl MockRequest {
     }
 
     pub fn with_body(&mut self, bytes: &[u8]) -> &mut MockRequest {
-        *self.request.body_mut() = Cursor::new(bytes.to_vec());
+        *self.request.body_mut() = Cursor::new(bytes.to_vec().into());
         self
     }
 

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::convert::TryInto;
 use std::io::{Cursor, Read};
 
 use conduit::{
@@ -22,13 +23,6 @@ impl ResponseExt for Response<Body> {
     }
 }
 
-fn uri(path_and_query: &str) -> Uri {
-    Uri::builder()
-        .path_and_query(path_and_query)
-        .build()
-        .unwrap()
-}
-
 pub struct MockRequest {
     request: conduit::Request<Cursor<Vec<u8>>>,
 }
@@ -37,7 +31,7 @@ impl MockRequest {
     pub fn new(method: Method, path: &str) -> MockRequest {
         let request = conduit::Request::builder()
             .method(&method)
-            .uri(uri(path))
+            .uri(path)
             .body(Cursor::new(vec![]))
             .unwrap();
 
@@ -46,7 +40,7 @@ impl MockRequest {
 
     pub fn with_query(&mut self, string: &str) -> &mut MockRequest {
         let path_and_query = format!("{}?{}", self.request.uri().path(), string);
-        *self.request.uri_mut() = uri(&path_and_query);
+        *self.request.uri_mut() = path_and_query.try_into().unwrap();
         self
     }
 

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -411,7 +411,7 @@ mod tests {
     }
 
     fn mock(query: &str) -> MockRequest {
-        let mut req = MockRequest::new(http::Method::GET, "");
+        let mut req = MockRequest::new(http::Method::GET, "/");
         req.with_query(query);
         req
     }


### PR DESCRIPTION
This simplifies the `MockRequest` struct by removing all existing fields and replacing them with a single `request: http::Request<Cursor<bytes::Bytes>>` field.