### PR TITLE
conduit: Rename `mut_extensions()` to `extensions_mut()`

### DIFF
--- a/conduit-axum/src/request.rs
+++ b/conduit-axum/src/request.rs
@@ -54,7 +54,7 @@ impl RequestExt for ConduitRequest {
         &self.parts.extensions
     }
 
-    fn mut_extensions(&mut self) -> &mut Extensions {
+    fn extensions_mut(&mut self) -> &mut Extensions {
         &mut self.parts.extensions
     }
 

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -85,7 +85,7 @@ impl conduit::RequestExt for MockRequest {
     fn extensions(&self) -> &Extensions {
         self.request.extensions()
     }
-    fn mut_extensions(&mut self) -> &mut Extensions {
+    fn extensions_mut(&mut self) -> &mut Extensions {
         self.request.extensions_mut()
     }
 }

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -77,7 +77,7 @@ pub trait RequestExt {
     fn extensions(&self) -> &Extensions;
 
     /// A mutable map of extensions
-    fn mut_extensions(&mut self) -> &mut Extensions;
+    fn extensions_mut(&mut self) -> &mut Extensions;
 }
 
 /// A Handler takes a request and returns a response or an error.

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -76,7 +76,7 @@ impl<T: conduit::RequestExt + ?Sized> RequestSession for T {
 
     fn session_insert(&mut self, key: String, value: String) -> Option<String> {
         let mut session = self
-            .mut_extensions()
+            .extensions_mut()
             .get_mut::<Arc<RwLock<Session>>>()
             .expect("missing cookie session")
             .write()
@@ -87,7 +87,7 @@ impl<T: conduit::RequestExt + ?Sized> RequestSession for T {
 
     fn session_remove(&mut self, key: &str) -> Option<String> {
         let mut session = self
-            .mut_extensions()
+            .extensions_mut()
             .get_mut::<Arc<RwLock<Session>>>()
             .expect("missing cookie session")
             .write()

--- a/src/router.rs
+++ b/src/router.rs
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn http_error_responses() {
         let mut req = MockRequest::new(::conduit::Method::GET, "/");
-        req.mut_extensions().insert(CustomMetadata::default());
+        req.extensions_mut().insert(CustomMetadata::default());
 
         // Types for handling common error status codes
         assert_eq!(


### PR DESCRIPTION
This aligns us with the naming convention in the `http` crate.