### PR TITLE
conduit-test: Remove `with_query()` fn

### DIFF
--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -1,6 +1,5 @@
 use bytes::Bytes;
 use std::borrow::Cow;
-use std::convert::TryInto;
 use std::io::{Cursor, Read};
 
 use conduit::{
@@ -37,12 +36,6 @@ impl MockRequest {
             .unwrap();
 
         MockRequest { request }
-    }
-
-    pub fn with_query(&mut self, string: &str) -> &mut MockRequest {
-        let path_and_query = format!("{}?{}", self.request.uri().path(), string);
-        *self.request.uri_mut() = path_and_query.try_into().unwrap();
-        self
     }
 
     pub fn with_body(&mut self, bytes: &[u8]) -> &mut MockRequest {
@@ -124,9 +117,7 @@ mod tests {
 
     #[test]
     fn request_query_test() {
-        let mut req = MockRequest::new(Method::POST, "/articles");
-        req.with_query("foo=bar");
-
+        let req = MockRequest::new(Method::POST, "/articles?foo=bar");
         assert_eq!(req.uri().query().expect("No query string"), "foo=bar");
     }
 

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -411,9 +411,8 @@ mod tests {
     }
 
     fn mock(query: &str) -> MockRequest {
-        let mut req = MockRequest::new(http::Method::GET, "/");
-        req.with_query(query);
-        req
+        let path_and_query = format!("/?{query}");
+        MockRequest::new(http::Method::GET, &path_and_query)
     }
 
     fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -130,8 +130,8 @@ pub trait RequestHelper {
     /// Issue a GET request that includes query parameters
     #[track_caller]
     fn get_with_query<T>(&self, path: &str, query: &str) -> Response<T> {
-        let mut request = self.request_builder(Method::GET, path);
-        request.with_query(query);
+        let path_and_query = format!("{path}?{query}");
+        let request = self.request_builder(Method::GET, &path_and_query);
         self.run(request)
     }
 


### PR DESCRIPTION
We can pass the query parameters directly into the `MockRequest::new()` call instead, since that is passing the path directly into the `uri()` method of the `Request::builder()`.