### PR TITLE
conduit: Remove unused `HttpResult` type

### DIFF
--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -6,7 +6,6 @@ use std::io::Read;
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
 pub type ResponseResult<Error> = Result<Response<Body>, Error>;
-pub type HttpResult = ResponseResult<http::Error>;
 
 pub type BoxError = Box<dyn Error + Send>;
 pub type HandlerResult = Result<Response<Body>, BoxError>;


### PR DESCRIPTION
what more to say... if we don't use something, then we should probably remove it 😅 