### PR TITLE
conduit: Replace custom `Body` enum with `bytes::Bytes`

### DIFF
--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -1,7 +1,8 @@
 #![deny(clippy::all)]
 
+use axum::body::Bytes;
 use axum::routing::get;
-use conduit::{Body, RequestExt, ResponseResult};
+use conduit::{RequestExt, ResponseResult};
 use conduit_axum::ConduitAxumHandler;
 use http::{header, Response};
 
@@ -37,7 +38,7 @@ fn endpoint(_: &mut dyn RequestExt) -> ResponseResult<http::Error> {
     Response::builder()
         .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
         .header(header::CONTENT_LENGTH, body.len())
-        .body(Body::from_static(body))
+        .body(Bytes::from_static(body))
 }
 
 fn panic(_: &mut dyn RequestExt) -> ResponseResult<http::Error> {

--- a/conduit-axum/src/body.rs
+++ b/conduit-axum/src/body.rs
@@ -1,10 +1,5 @@
-use axum::body::boxed;
+use axum::body::{boxed, Body, Bytes};
 
-pub fn conduit_into_axum(body: conduit::Body) -> axum::body::BoxBody {
-    use conduit::Body::*;
-
-    match body {
-        Static(slice) => boxed(axum::body::Body::from(slice)),
-        Owned(vec) => boxed(axum::body::Body::from(vec)),
-    }
+pub fn conduit_into_axum(body: Bytes) -> axum::body::BoxBody {
+    boxed(Body::from(body))
 }

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -37,12 +37,13 @@
 //! }
 //! #
 //! # use std::{error, io};
-//! # use conduit::{box_error, Body, Response, RequestExt, HandlerResult};
+//! # use axum::body::Bytes;
+//! # use conduit::{box_error, Response, RequestExt, HandlerResult};
 //! #
 //! # struct Endpoint();
 //! # impl Handler for Endpoint {
 //! #     fn call(&self, _: &mut dyn RequestExt) -> HandlerResult {
-//! #         Response::builder().body(Body::empty()).map_err(box_error)
+//! #         Response::builder().body(Bytes::new()).map_err(box_error)
 //! #     }
 //! # }
 //! ```

--- a/conduit-axum/src/response.rs
+++ b/conduit-axum/src/response.rs
@@ -1,9 +1,10 @@
 use crate::body;
+use axum::body::Bytes;
 use axum::response::IntoResponse;
 use http::Response;
 
 pub type AxumResponse = axum::response::Response;
-pub type ConduitResponse = Response<conduit::Body>;
+pub type ConduitResponse = Response<Bytes>;
 
 /// Turns a `ConduitResponse` into a `AxumResponse`
 pub fn conduit_into_axum(response: ConduitResponse) -> AxumResponse {

--- a/conduit-axum/src/tests.rs
+++ b/conduit-axum/src/tests.rs
@@ -1,5 +1,6 @@
+use axum::body::Bytes;
 use axum::Router;
-use conduit::{box_error, Body, Handler, HandlerResult, RequestExt};
+use conduit::{box_error, Handler, HandlerResult, RequestExt};
 use http::{HeaderValue, Request, Response, StatusCode};
 use hyper::{body::to_bytes, service::Service};
 use tokio::{sync::oneshot, task::JoinHandle};
@@ -12,7 +13,7 @@ impl Handler for OkResult {
     fn call(&self, _req: &mut dyn RequestExt) -> HandlerResult {
         Response::builder()
             .header("ok", "value")
-            .body(Body::from_static(b"Hello, world!"))
+            .body(Bytes::from_static(b"Hello, world!"))
             .map_err(box_error)
     }
 }
@@ -37,7 +38,7 @@ impl Handler for InvalidHeader {
     fn call(&self, _req: &mut dyn RequestExt) -> HandlerResult {
         Response::builder()
             .header("invalid-value", "\r\n")
-            .body(Body::from_static(b"discarded"))
+            .body(Bytes::from_static(b"discarded"))
             .map_err(box_error)
     }
 }
@@ -47,7 +48,7 @@ impl Handler for InvalidStatus {
     fn call(&self, _req: &mut dyn RequestExt) -> HandlerResult {
         Response::builder()
             .status(1000)
-            .body(Body::empty())
+            .body(Bytes::new())
             .map_err(box_error)
     }
 }

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -1,27 +1,10 @@
 use bytes::Bytes;
-use std::borrow::Cow;
 use std::io::{Cursor, Read};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Body, Extensions, HeaderMap, Method, Response, Uri,
+    Extensions, HeaderMap, Method, Uri,
 };
-
-pub trait ResponseExt {
-    fn into_cow(self) -> Cow<'static, [u8]>;
-}
-
-impl ResponseExt for Response<Body> {
-    /// Convert the request into a copy-on-write body
-    fn into_cow(self) -> Cow<'static, [u8]> {
-        use conduit::Body::*;
-
-        match self.into_body() {
-            Static(slice) => slice.into(),
-            Owned(vec) => vec.into(),
-        }
-    }
-}
 
 pub struct MockRequest {
     request: conduit::Request<Cursor<Bytes>>,

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -6,46 +6,10 @@ use std::io::{Cursor, Read};
 
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
-pub type ResponseResult<Error> = Result<Response<Body>, Error>;
+pub type ResponseResult<Error> = Result<Response<Bytes>, Error>;
 
 pub type BoxError = Box<dyn Error + Send>;
-pub type HandlerResult = Result<Response<Body>, BoxError>;
-
-/// A type representing a `Response` body.
-///
-/// This type is intended exclusively for use as part of a `Response<Body>`.
-/// Each conduit server provides its own request type that implements
-/// `RequestExt` which provides the request body as a `&'a mut dyn Read`.
-pub enum Body {
-    Static(&'static [u8]),
-    Owned(Vec<u8>),
-}
-
-impl Body {
-    /// Create a new `Body` from an empty static slice.
-    pub fn empty() -> Self {
-        Self::from_static(b"")
-    }
-
-    /// Create a new `Body` from the provided static byte slice.
-    pub fn from_static(bytes: &'static [u8]) -> Self {
-        Self::Static(bytes)
-    }
-
-    /// Create a new `Body` by taking ownership of the provided bytes.
-    pub fn from_vec(bytes: Vec<u8>) -> Self {
-        Self::Owned(bytes)
-    }
-}
-
-impl From<Body> for Bytes {
-    fn from(value: Body) -> Self {
-        match value {
-            Body::Static(bytes) => bytes.into(),
-            Body::Owned(bytes) => bytes.into(),
-        }
-    }
-}
+pub type HandlerResult = Result<Response<Bytes>, BoxError>;
 
 /// A helper to convert a concrete error type into a `Box<dyn Error + Send>`
 ///
@@ -53,9 +17,10 @@ impl From<Body> for Bytes {
 ///
 /// ```
 /// # use std::error::Error;
-/// # use conduit::{box_error, Body, Response};
-/// # let _: Result<Response<Body>, Box<dyn Error + Send>> =
-/// Response::builder().body(Body::empty()).map_err(box_error);
+/// # use bytes::Bytes;
+/// # use conduit::{box_error, Response};
+/// # let _: Result<Response<Bytes>, Box<dyn Error + Send>> =
+/// Response::builder().body(Bytes::new()).map_err(box_error);
 /// ```
 pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
     Box::new(error)

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -38,6 +38,15 @@ impl Body {
     }
 }
 
+impl From<Body> for Bytes {
+    fn from(value: Body) -> Self {
+        match value {
+            Body::Static(bytes) => bytes.into(),
+            Body::Owned(bytes) => bytes.into(),
+        }
+    }
+}
+
 /// A helper to convert a concrete error type into a `Box<dyn Error + Send>`
 ///
 /// # Example

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -11,6 +11,7 @@ mod frontend_prelude {
 mod prelude {
     pub use super::helpers::ok_true;
     pub use super::util::RequestParamExt;
+    use axum::body::Bytes;
     pub use diesel::prelude::*;
 
     pub use conduit::RequestExt;
@@ -29,7 +30,7 @@ mod prelude {
             http::Response::builder()
                 .status(StatusCode::FOUND)
                 .header(header::LOCATION, url)
-                .body(conduit::Body::empty())
+                .body(Bytes::new())
                 .unwrap() // Should not panic unless url contains "\r\n"
         }
 

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -307,8 +307,9 @@ pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> AppResult<D
 #[cfg(test)]
 mod tests {
     use super::*;
-    use conduit_test::{MockRequest, ResponseExt};
+    use conduit_test::MockRequest;
     use http::StatusCode;
+    use hyper::body::Bytes;
     use serde_json::Value;
 
     #[test]
@@ -419,7 +420,8 @@ mod tests {
         let response = options.gather(&mock(query)).unwrap_err().response();
         assert_eq!(StatusCode::BAD_REQUEST, response.status());
 
-        let parsed: Value = serde_json::from_slice(&response.into_cow()).unwrap();
+        let bytes = Bytes::from(response.into_body());
+        let parsed: Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed, json!({ "errors": [{ "detail": message }] }));
     }
 }

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -309,7 +309,6 @@ mod tests {
     use super::*;
     use conduit_test::MockRequest;
     use http::StatusCode;
-    use hyper::body::Bytes;
     use serde_json::Value;
 
     #[test]
@@ -420,7 +419,7 @@ mod tests {
         let response = options.gather(&mock(query)).unwrap_err().response();
         assert_eq!(StatusCode::BAD_REQUEST, response.status());
 
-        let bytes = Bytes::from(response.into_body());
+        let bytes = response.into_body();
         let parsed: Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(parsed, json!({ "errors": [{ "detail": message }] }));
     }

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,6 +1,6 @@
 use crate::controllers::frontend_prelude::*;
 use crate::util::errors::{forbidden, not_found, MetricsDisabled};
-use conduit::Body;
+use axum::body::Bytes;
 use http::Response;
 use prometheus::{Encoder, TextEncoder};
 
@@ -36,5 +36,5 @@ pub fn prometheus(req: &mut dyn RequestExt) -> EndpointResult {
     Ok(Response::builder()
         .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
         .header(header::CONTENT_LENGTH, output.len())
-        .body(Body::from_vec(output))?)
+        .body(Bytes::from(output))?)
 }

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -6,7 +6,7 @@ use crate::util::read_fill;
 use crate::views::EncodableApiTokenWithToken;
 
 use crate::auth::AuthCheck;
-use conduit::Body;
+use axum::body::Bytes;
 use http::Response;
 use serde_json as json;
 
@@ -115,5 +115,5 @@ pub fn revoke_current(req: &mut dyn RequestExt) -> EndpointResult {
         .set(api_tokens::revoked.eq(true))
         .execute(&*conn)?;
 
-    Ok(Response::builder().status(204).body(Body::empty()).unwrap())
+    Ok(Response::builder().status(204).body(Bytes::new()).unwrap())
 }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,6 @@
 mod prelude {
     pub use crate::middleware::log_request::CustomMetadataRequestExt;
-    pub use conduit::{box_error, Body, Handler, RequestExt};
+    pub use conduit::{box_error, Handler, RequestExt};
     pub use http::{header, Response, StatusCode};
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use conduit::Body;
+use axum::body::Bytes;
 use http::{header, Response};
 use serde::Serialize;
 
@@ -14,7 +14,7 @@ pub mod rfc3339;
 pub mod token;
 pub mod tracing;
 
-pub type AppResponse = Response<Body>;
+pub type AppResponse = Response<Bytes>;
 pub type EndpointResult = Result<AppResponse, Box<dyn errors::AppError>>;
 
 /// Serialize a value to JSON and build a status 200 Response
@@ -29,7 +29,7 @@ pub fn json_response<T: Serialize>(t: &T) -> AppResponse {
     Response::builder()
         .header(header::CONTENT_TYPE, "application/json")
         .header(header::CONTENT_LENGTH, json.len())
-        .body(Body::from_vec(json))
+        .body(Bytes::from(json))
         .unwrap() // Header values are well formed, so should not panic
 }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -18,6 +18,7 @@ use std::any::{Any, TypeId};
 use std::error::Error;
 use std::fmt;
 
+use axum::body::Bytes;
 use chrono::NaiveDateTime;
 use conduit_axum::{conduit_into_axum, CauseField, ErrorField};
 use diesel::result::Error as DieselError;
@@ -328,7 +329,7 @@ fn server_error_response(error: String) -> AppResponse {
     Response::builder()
         .status(StatusCode::INTERNAL_SERVER_ERROR)
         .extension(ErrorField(error))
-        .body(conduit::Body::from_static(b"Internal Server Error"))
+        .body(Bytes::from_static(b"Internal Server Error"))
         .unwrap()
 }
 


### PR DESCRIPTION
Instead of using a custom enum, we can rely on the `bytes::Bytes` type, which brings us closer to what `hyper` and `axum` are using internally too.