### PR TITLE
conduit-test: Simplify `MockRequest` conversion code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -625,6 +625,7 @@ version = "0.10.0"
 dependencies = [
  "bytes",
  "conduit",
+ "hyper",
 ]
 
 [[package]]

--- a/conduit-test/Cargo.toml
+++ b/conduit-test/Cargo.toml
@@ -11,3 +11,4 @@ edition = "2018"
 [dependencies]
 bytes = "1.3.0"
 conduit = { version ="0.10.0", path = "../conduit" }
+hyper = "0.14.23"

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -4,7 +4,7 @@ use std::io::{Cursor, Read};
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Extensions, HeaderMap, Method, RequestExt, Uri,
+    Extensions, HeaderMap, Method, Uri,
 };
 
 pub struct MockRequest {
@@ -68,21 +68,9 @@ impl conduit::RequestExt for MockRequest {
 }
 
 impl From<MockRequest> for Request<hyper::Body> {
-    fn from(mut mock_request: MockRequest) -> Self {
-        let mut buffer = Vec::new();
-        mock_request.body().read_to_end(&mut buffer).unwrap();
-
-        let body = hyper::Body::from(buffer);
-
-        let mut req = Request::builder()
-            .method(mock_request.method())
-            .uri(mock_request.uri());
-
-        for (name, value) in mock_request.headers() {
-            req = req.header(name, value)
-        }
-
-        req.body(body).unwrap()
+    fn from(mock_request: MockRequest) -> Self {
+        let (parts, body) = mock_request.request.into_parts();
+        Request::from_parts(parts, hyper::Body::from(body.into_inner()))
     }
 }
 


### PR DESCRIPTION
There is no need to buffer in between anymore. We can just convert the body directly.