### PR TITLE
conduit-test: Remove `conduit` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,7 +624,6 @@ name = "conduit-test"
 version = "0.10.0"
 dependencies = [
  "bytes",
- "conduit",
  "hyper",
 ]
 

--- a/conduit-test/Cargo.toml
+++ b/conduit-test/Cargo.toml
@@ -10,5 +10,4 @@ edition = "2018"
 
 [dependencies]
 bytes = "1.3.0"
-conduit = { version ="0.10.0", path = "../conduit" }
 hyper = "0.14.23"

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -1,10 +1,10 @@
 use bytes::Bytes;
 use hyper::Request;
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 
 use conduit::{
     header::{HeaderValue, IntoHeaderName},
-    Extensions, HeaderMap, Method, Uri,
+    Method,
 };
 
 pub struct MockRequest {
@@ -42,35 +42,6 @@ impl MockRequest {
     }
 }
 
-impl conduit::RequestExt for MockRequest {
-    fn method(&self) -> &Method {
-        self.request.method()
-    }
-
-    fn uri(&self) -> &Uri {
-        self.request.uri()
-    }
-
-    fn content_length(&self) -> Option<u64> {
-        Some(self.request.body().get_ref().len() as u64)
-    }
-
-    fn headers(&self) -> &HeaderMap {
-        self.request.headers()
-    }
-
-    fn body(&mut self) -> &mut dyn Read {
-        self.request.body_mut()
-    }
-
-    fn extensions(&self) -> &Extensions {
-        self.request.extensions()
-    }
-    fn extensions_mut(&mut self) -> &mut Extensions {
-        self.request.extensions_mut()
-    }
-}
-
 impl From<MockRequest> for Request<hyper::Body> {
     fn from(mock_request: MockRequest) -> Self {
         let (parts, body) = mock_request.request.into_parts();
@@ -82,7 +53,7 @@ impl From<MockRequest> for Request<hyper::Body> {
 mod tests {
     use super::MockRequest;
 
-    use conduit::{header, Method, RequestExt};
+    use conduit::{header, Method};
 
     #[test]
     fn simple_request_test() {
@@ -90,7 +61,6 @@ mod tests {
 
         assert_eq!(req.method(), Method::GET);
         assert_eq!(req.uri(), "/");
-        assert_eq!(req.content_length(), Some(0));
         assert_eq!(req.headers().len(), 0);
         assert_eq!(req.body().get_ref(), "");
     }
@@ -104,7 +74,6 @@ mod tests {
         assert_eq!(req.method(), Method::POST);
         assert_eq!(req.uri(), "/articles");
         assert_eq!(req.body().get_ref(), "Hello world");
-        assert_eq!(req.content_length(), Some(11));
     }
 
     #[test]

--- a/conduit-test/src/lib.rs
+++ b/conduit-test/src/lib.rs
@@ -1,19 +1,14 @@
 use bytes::Bytes;
-use hyper::Request;
+use hyper::http::{header::IntoHeaderName, HeaderValue, Method, Request};
 use std::io::Cursor;
 
-use conduit::{
-    header::{HeaderValue, IntoHeaderName},
-    Method,
-};
-
 pub struct MockRequest {
-    request: conduit::Request<Cursor<Bytes>>,
+    request: Request<Cursor<Bytes>>,
 }
 
 impl MockRequest {
     pub fn new(method: Method, path: &str) -> MockRequest {
-        let request = conduit::Request::builder()
+        let request = Request::builder()
             .method(&method)
             .uri(path)
             .body(Cursor::new(Bytes::new()))
@@ -53,7 +48,7 @@ impl From<MockRequest> for Request<hyper::Body> {
 mod tests {
     use super::MockRequest;
 
-    use conduit::{header, Method};
+    use hyper::http::{header, Method};
 
     #[test]
     fn simple_request_test() {

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -307,9 +307,11 @@ pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> AppResult<D
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Bytes;
     use conduit_test::MockRequest;
-    use http::StatusCode;
+    use http::{Request, StatusCode};
     use serde_json::Value;
+    use std::io::Cursor;
 
     #[test]
     fn no_pagination_param() {
@@ -410,9 +412,9 @@ mod tests {
         );
     }
 
-    fn mock(query: &str) -> MockRequest {
+    fn mock(query: &str) -> Request<Cursor<Bytes>> {
         let path_and_query = format!("/?{query}");
-        MockRequest::new(http::Method::GET, &path_and_query)
+        MockRequest::new(http::Method::GET, &path_and_query).into_inner()
     }
 
     fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {

--- a/src/router.rs
+++ b/src/router.rs
@@ -241,7 +241,7 @@ mod tests {
 
     #[test]
     fn http_error_responses() {
-        let mut req = MockRequest::new(::conduit::Method::GET, "/");
+        let mut req = MockRequest::new(::conduit::Method::GET, "/").into_inner();
         req.extensions_mut().insert(CustomMetadata::default());
 
         // Types for handling common error status codes


### PR DESCRIPTION
There is no reason anymore for `MockRequest` to implement `conduit::RequestExt` so this PR refactors it away and then finally removes the `conduit` dependency of the `conduit-test` package. The `MockRequest` is now mostly a request builder for our test suite and somewhat unrelated to `conduit` itself.