### PR TITLE
conduit::Handler: Use fixed request type

### DIFF
--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -2,7 +2,7 @@
 
 use axum::body::Bytes;
 use axum::routing::get;
-use conduit::{RequestExt, ResponseResult};
+use conduit::{ConduitRequest, ResponseResult};
 use conduit_axum::ConduitAxumHandler;
 use http::{header, Response};
 
@@ -30,7 +30,7 @@ pub fn wrap<H>(handler: H) -> ConduitAxumHandler<H> {
     ConduitAxumHandler::wrap(handler)
 }
 
-fn endpoint(_: &mut dyn RequestExt) -> ResponseResult<http::Error> {
+fn endpoint(_: &mut ConduitRequest) -> ResponseResult<http::Error> {
     let body = b"Hello world!";
 
     sleep(std::time::Duration::from_secs(2));
@@ -41,11 +41,11 @@ fn endpoint(_: &mut dyn RequestExt) -> ResponseResult<http::Error> {
         .body(Bytes::from_static(body))
 }
 
-fn panic(_: &mut dyn RequestExt) -> ResponseResult<http::Error> {
+fn panic(_: &mut ConduitRequest) -> ResponseResult<http::Error> {
     // For now, connection is immediately closed
     panic!("message");
 }
 
-fn error(_: &mut dyn RequestExt) -> ResponseResult<io::Error> {
+fn error(_: &mut ConduitRequest) -> ResponseResult<io::Error> {
     Err(io::Error::new(io::ErrorKind::Other, "io error, oops"))
 }

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -13,7 +13,7 @@ use axum::body::{Body, HttpBody};
 use axum::extract::{rejection::PathRejection, Extension, FromRequestParts, Path};
 use axum::handler::Handler as AxumHandler;
 use axum::response::IntoResponse;
-use conduit::{Handler, RequestExt};
+use conduit::{ConduitRequest, Handler};
 use http::header::CONTENT_LENGTH;
 use http::StatusCode;
 use hyper::Request;
@@ -158,7 +158,7 @@ pub trait RequestParamsExt<'a> {
     fn axum_params(self) -> Option<&'a Params>;
 }
 
-impl<'a> RequestParamsExt<'a> for &'a (dyn RequestExt + 'a) {
+impl<'a> RequestParamsExt<'a> for &'a ConduitRequest {
     fn axum_params(self) -> Option<&'a Params> {
         self.extensions().get::<Params>()
     }

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -38,11 +38,11 @@
 //! #
 //! # use std::{error, io};
 //! # use axum::body::Bytes;
-//! # use conduit::{box_error, Response, RequestExt, HandlerResult};
+//! # use conduit::{box_error, Response, ConduitRequest, HandlerResult};
 //! #
 //! # struct Endpoint();
 //! # impl Handler for Endpoint {
-//! #     fn call(&self, _: &mut dyn RequestExt) -> HandlerResult {
+//! #     fn call(&self, _: &mut ConduitRequest) -> HandlerResult {
 //! #         Response::builder().body(Bytes::new()).map_err(box_error)
 //! #     }
 //! # }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,7 +8,7 @@ use crate::util::errors::{
     account_locked, forbidden, internal, AppError, AppResult, InsecurelyGeneratedTokenRevoked,
 };
 use chrono::Utc;
-use conduit::RequestExt;
+use conduit::ConduitRequest;
 use http::header;
 
 #[derive(Debug, Clone)]
@@ -55,7 +55,7 @@ impl AuthCheck {
         }
     }
 
-    pub fn check(&self, request: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
+    pub fn check(&self, request: &ConduitRequest) -> AppResult<AuthenticatedUser> {
         controllers::util::verify_origin(request)?;
 
         let auth = authenticate_user(request)?;
@@ -153,7 +153,7 @@ impl AuthenticatedUser {
     }
 }
 
-fn authenticate_user(req: &dyn RequestExt) -> AppResult<AuthenticatedUser> {
+fn authenticate_user(req: &ConduitRequest) -> AppResult<AuthenticatedUser> {
     let conn = req.app().db_write()?;
 
     let user_id_from_session = req

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -14,7 +14,7 @@ mod prelude {
     use axum::body::Bytes;
     pub use diesel::prelude::*;
 
-    pub use conduit::RequestExt;
+    pub use conduit::{ConduitRequest, RequestExt};
     pub use http::{header, StatusCode};
 
     pub use super::conduit_axum::conduit_compat;
@@ -43,7 +43,7 @@ mod prelude {
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
     }
 
-    impl<'a> RequestUtils for dyn RequestExt + 'a {
+    impl RequestUtils for ConduitRequest {
         fn query(&self) -> IndexMap<String, String> {
             url::form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
                 .into_owned()

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn index(req: &mut ConduitRequest) -> EndpointResult {
     let query = req.query();
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
@@ -33,7 +33,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn show(req: &mut ConduitRequest) -> EndpointResult {
     let slug = req.param("category_id").unwrap();
     let conn = req.app().db_read()?;
     let cat: Category = Category::by_slug(slug).first(&*conn)?;
@@ -64,7 +64,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /category_slugs` route.
-pub fn slugs(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn slugs(req: &mut ConduitRequest) -> EndpointResult {
     let conn = req.app().db_read()?;
     let slugs: Vec<Slug> = categories::table
         .select((categories::slug, categories::slug, categories::description))

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -16,7 +16,7 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
-pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn list(req: &mut ConduitRequest) -> EndpointResult {
     let auth = AuthCheck::only_cookie().check(req)?;
     let user_id = auth.user_id();
 
@@ -52,7 +52,7 @@ pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /api/private/crate_owner_invitations` route.
-pub fn private_list(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn private_list(req: &mut ConduitRequest) -> EndpointResult {
     let auth = AuthCheck::only_cookie().check(req)?;
 
     let filter = if let Some(crate_name) = req.query().get("crate_name") {
@@ -73,7 +73,7 @@ enum ListFilter {
 }
 
 fn prepare_list(
-    req: &mut dyn RequestExt,
+    req: &mut ConduitRequest,
     auth: AuthenticatedUser,
     filter: ListFilter,
 ) -> AppResult<PrivateListResponse> {
@@ -250,7 +250,7 @@ struct OwnerInvitation {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
-pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn handle_invite(req: &mut ConduitRequest) -> EndpointResult {
     let crate_invite: OwnerInvitation =
         serde_json::from_reader(req.body()).map_err(|_| bad_request("invalid json request"))?;
 
@@ -274,7 +274,7 @@ pub fn handle_invite(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
-pub fn handle_invite_with_token(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn handle_invite_with_token(req: &mut ConduitRequest) -> EndpointResult {
     let state = req.app();
     let config = &state.config;
     let conn = state.db_write()?;

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -232,7 +232,7 @@ pub enum GitHubSecretAlertFeedbackLabel {
 }
 
 /// Handles the `POST /api/github/secret-scanning/verify` route.
-pub fn verify(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn verify(req: &mut ConduitRequest) -> EndpointResult {
     let max_size = 8192;
     let length = req
         .content_length()

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -72,7 +72,7 @@ impl PaginationOptionsBuilder {
         self
     }
 
-    pub(crate) fn gather(self, req: &dyn RequestExt) -> AppResult<PaginationOptions> {
+    pub(crate) fn gather(self, req: &ConduitRequest) -> AppResult<PaginationOptions> {
         let params = req.query();
         let page_param = params.get("page");
         let seek_param = params.get("seek");

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -10,7 +10,7 @@ use crate::models::Keyword;
 use crate::views::EncodableKeyword;
 
 /// Handles the `GET /keywords` route.
-pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn index(req: &mut ConduitRequest) -> EndpointResult {
     use crate::schema::keywords;
 
     let query = req.query();

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,7 +13,7 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn downloads(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -9,7 +9,7 @@ use crate::models::{Crate, Follow};
 use crate::schema::*;
 
 fn follow_target(
-    req: &dyn RequestExt,
+    req: &ConduitRequest,
     conn: &DieselPooledConn<'_>,
     user_id: i32,
 ) -> AppResult<Follow> {
@@ -21,7 +21,7 @@ fn follow_target(
 }
 
 /// Handles the `PUT /crates/:crate_id/follow` route.
-pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn follow(req: &mut ConduitRequest) -> EndpointResult {
     let user_id = AuthCheck::default().check(req)?.user_id();
     let conn = req.app().db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
@@ -34,7 +34,7 @@ pub fn follow(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `DELETE /crates/:crate_id/follow` route.
-pub fn unfollow(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn unfollow(req: &mut ConduitRequest) -> EndpointResult {
     let user_id = AuthCheck::default().check(req)?.user_id();
     let conn = req.app().db_write()?;
     let follow = follow_target(req, &conn, user_id)?;
@@ -44,7 +44,7 @@ pub fn unfollow(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/following` route.
-pub fn following(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn following(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::dsl::exists;
 
     let user_id = AuthCheck::only_cookie().check(req)?.user_id();

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,7 +22,7 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn summary(req: &mut ConduitRequest) -> EndpointResult {
     use crate::schema::crates::dsl::*;
     use diesel::dsl::all;
 
@@ -125,7 +125,7 @@ pub fn summary(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id` route.
-pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn show(req: &mut ConduitRequest) -> EndpointResult {
     let name = req.param("crate_id").unwrap();
     let include = req
         .query()
@@ -298,7 +298,7 @@ impl FromStr for ShowIncludeMode {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/readme` route.
-pub fn readme(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn readme(req: &mut ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let version = req.param("version").unwrap();
 
@@ -318,7 +318,7 @@ pub fn readme(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub fn versions(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn versions(req: &mut ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -346,7 +346,7 @@ pub fn versions(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/reverse_dependencies` route.
-pub fn reverse_dependencies(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn reverse_dependencies(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::dsl::any;
 
     let pagination_options = PaginationOptions::builder().gather(req)?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -7,7 +7,7 @@ use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn owners(req: &mut ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -21,7 +21,7 @@ pub fn owners(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn owner_team(req: &mut ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -34,7 +34,7 @@ pub fn owner_team(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub fn owner_user(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn owner_user(req: &mut ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -47,12 +47,12 @@ pub fn owner_user(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
-pub fn add_owners(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn add_owners(req: &mut ConduitRequest) -> EndpointResult {
     modify_owners(req, true)
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
-pub fn remove_owners(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn remove_owners(req: &mut ConduitRequest) -> EndpointResult {
     modify_owners(req, false)
 }
 
@@ -63,7 +63,7 @@ pub fn remove_owners(req: &mut dyn RequestExt) -> EndpointResult {
 /// ```json
 /// {"owners": ["username", "github:org:team", ...]}
 /// ```
-fn parse_owners_request(req: &mut dyn RequestExt) -> AppResult<Vec<String>> {
+fn parse_owners_request(req: &mut ConduitRequest) -> AppResult<Vec<String>> {
     #[derive(Deserialize)]
     struct Request {
         // identical, for back-compat (owners preferred)
@@ -78,7 +78,7 @@ fn parse_owners_request(req: &mut dyn RequestExt) -> AppResult<Vec<String>> {
         .ok_or_else(|| cargo_err("invalid json request"))
 }
 
-fn modify_owners(req: &mut dyn RequestExt, add: bool) -> EndpointResult {
+fn modify_owners(req: &mut ConduitRequest, add: bool) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
 
     let auth = AuthCheck::default()

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -42,7 +42,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// Currently blocks the HTTP thread, perhaps some function calls can spawn new
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
-pub fn publish(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn publish(req: &mut ConduitRequest) -> EndpointResult {
     let app = req.app().clone();
 
     // The format of the req.body() of a publish request is as follows:
@@ -302,7 +302,7 @@ fn count_versions_published_today(krate_id: i32, conn: &PgConnection) -> QueryRe
 ///
 /// This function parses the JSON headers to interpret the data and validates
 /// the data during and after the parsing. Returns crate metadata.
-fn parse_new_headers(req: &mut dyn RequestExt) -> AppResult<EncodableCrateUpload> {
+fn parse_new_headers(req: &mut ConduitRequest) -> AppResult<EncodableCrateUpload> {
     // Read the json upload request
     let metadata_length = u64::from(read_le_u32(req.body())?);
     req.add_custom_metadata("metadata_length", metadata_length);

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -38,7 +38,7 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub fn search(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn search(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::sql_types::{Bool, Text};
 
     let params = req.query();

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -5,7 +5,7 @@ use http::Response;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
-pub fn prometheus(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn prometheus(req: &mut ConduitRequest) -> EndpointResult {
     let app = req.app();
 
     if let Some(expected_token) = &app.config.metrics_authorization_token {

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,7 +5,7 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub fn show_team(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn show_team(req: &mut ConduitRequest) -> EndpointResult {
     use self::teams::dsl::{login, teams};
 
     let name = req.param("team_id").unwrap();

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -10,7 +10,7 @@ use http::Response;
 use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.
-pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn list(req: &mut ConduitRequest) -> EndpointResult {
     let auth = AuthCheck::only_cookie().check(req)?;
     let conn = req.app().db_read_prefer_primary()?;
     let user = auth.user();
@@ -24,7 +24,7 @@ pub fn list(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `PUT /me/tokens` route.
-pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn new(req: &mut ConduitRequest) -> EndpointResult {
     /// The incoming serialization format for the `ApiToken` model.
     #[derive(Deserialize, Serialize)]
     struct NewApiToken {
@@ -79,7 +79,7 @@ pub fn new(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `DELETE /me/tokens/:id` route.
-pub fn revoke(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn revoke(req: &mut ConduitRequest) -> EndpointResult {
     let id = req
         .param("id")
         .unwrap()
@@ -97,7 +97,7 @@ pub fn revoke(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `DELETE /tokens/current` route.
-pub fn revoke_current(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn revoke_current(req: &mut ConduitRequest) -> EndpointResult {
     let auth = AuthCheck::default().check(req)?;
     let api_token_id = auth
         .api_token_id()

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -13,7 +13,7 @@ use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
-pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn me(req: &mut ConduitRequest) -> EndpointResult {
     let user_id = AuthCheck::only_cookie().check(req)?.user_id();
     let conn = req.app().db_read_prefer_primary()?;
 
@@ -52,7 +52,7 @@ pub fn me(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /me/updates` route.
-pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn updates(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::dsl::any;
 
     let auth = AuthCheck::only_cookie().check(req)?;
@@ -93,7 +93,7 @@ pub fn updates(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `PUT /users/:user_id` route.
-pub fn update_user(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn update_user(req: &mut ConduitRequest) -> EndpointResult {
     use self::emails::user_id;
     use diesel::insert_into;
 
@@ -162,7 +162,7 @@ pub fn update_user(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `PUT /confirm/:email_token` route
-pub fn confirm_user_email(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn confirm_user_email(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::update;
 
     let conn = req.app().db_write()?;
@@ -180,7 +180,7 @@ pub fn confirm_user_email(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles `PUT /user/:user_id/resend` route
-pub fn regenerate_token_and_send(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn regenerate_token_and_send(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::dsl::sql;
     use diesel::update;
 
@@ -216,7 +216,7 @@ pub fn regenerate_token_and_send(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles `PUT /me/email_notifications` route
-pub fn update_email_notifications(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn update_email_notifications(req: &mut ConduitRequest) -> EndpointResult {
     use self::crate_owners::dsl::*;
     use diesel::pg::upsert::excluded;
 

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,7 +6,7 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn show(req: &mut ConduitRequest) -> EndpointResult {
     use self::users::dsl::{gh_login, id, users};
 
     let name = lower(req.param("user_id").unwrap());
@@ -20,7 +20,7 @@ pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub fn stats(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn stats(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::dsl::sum;
 
     let user_id = req

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -25,7 +25,7 @@ use crate::util::errors::ReadOnlyMode;
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub fn begin(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn begin(req: &mut ConduitRequest) -> EndpointResult {
     let (url, state) = req
         .app()
         .github_oauth
@@ -66,7 +66,7 @@ pub fn begin(req: &mut dyn RequestExt) -> EndpointResult {
 ///     }
 /// }
 /// ```
-pub fn authorize(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn authorize(req: &mut ConduitRequest) -> EndpointResult {
     // Parse the url query
     let mut query = req.query();
     let code = query.remove("code").unwrap_or_default();
@@ -134,7 +134,7 @@ fn save_user_to_database(
 }
 
 /// Handles the `DELETE /api/private/session` route.
-pub fn logout(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn logout(req: &mut ConduitRequest) -> EndpointResult {
     req.session_remove("user_id");
     Ok(req.json(&true))
 }

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -7,7 +7,7 @@ use conduit_axum::RequestParamsExt;
 /// We don't want to accept authenticated requests that originated from other sites, so this
 /// function returns an error if the Origin header doesn't match what we expect "this site" to
 /// be: https://crates.io in production, or http://localhost:port/ in development.
-pub fn verify_origin(req: &dyn RequestExt) -> AppResult<()> {
+pub fn verify_origin(req: &ConduitRequest) -> AppResult<()> {
     let headers = req.headers();
     let allowed_origins = &req.app().config.allowed_origins;
 
@@ -28,7 +28,7 @@ pub trait RequestParamExt<'a> {
     fn param(self, key: &str) -> Option<&'a str>;
 }
 
-impl<'a> RequestParamExt<'a> for &'a (dyn RequestExt + 'a) {
+impl<'a> RequestParamExt<'a> for &'a ConduitRequest {
     fn param(self, key: &str) -> Option<&'a str> {
         self.axum_params()
             .and_then(|params| params.0.get(key).map(|s| &s[..]))

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -18,17 +18,17 @@ fn version_and_crate(
     Ok((version, krate))
 }
 
-fn extract_crate_name_and_semver(req: &dyn RequestExt) -> AppResult<(&str, &str)> {
+fn extract_crate_name_and_semver(req: &ConduitRequest) -> AppResult<(&str, &str)> {
     let name = extract_crate_name(req);
     let version = extract_semver(req)?;
     Ok((name, version))
 }
 
-fn extract_crate_name(req: &dyn RequestExt) -> &str {
+fn extract_crate_name(req: &ConduitRequest) -> &str {
     req.param("crate_id").unwrap()
 }
 
-fn extract_semver(req: &dyn RequestExt) -> AppResult<&str> {
+fn extract_semver(req: &ConduitRequest) -> AppResult<&str> {
     let semver = req.param("version").unwrap();
     if semver::Version::parse(semver).is_err() {
         return Err(cargo_err(&format_args!("invalid semver: {semver}")));

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -12,7 +12,7 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn index(req: &mut ConduitRequest) -> EndpointResult {
     use diesel::dsl::any;
     let conn = req.app().db_read()?;
 
@@ -51,7 +51,7 @@ pub fn index(req: &mut dyn RequestExt) -> EndpointResult {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub fn show_by_id(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn show_by_id(req: &mut ConduitRequest) -> EndpointResult {
     let id = req.param("version_id").unwrap();
     let id = id.parse().unwrap_or(0);
     let conn = req.app().db_read()?;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -13,7 +13,7 @@ use chrono::{Duration, NaiveDate, Utc};
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
-pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn download(req: &mut ConduitRequest) -> EndpointResult {
     let app = req.app();
 
     let mut crate_name = req.param("crate_id").unwrap().to_string();
@@ -116,7 +116,7 @@ pub fn download(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
-pub fn downloads(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn downloads(req: &mut ConduitRequest) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
 
     let conn = req.app().db_read()?;

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -18,7 +18,7 @@ use super::{extract_crate_name_and_semver, version_and_crate};
 /// In addition to returning cached data from the index, this returns
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
-pub fn dependencies(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn dependencies(req: &mut ConduitRequest) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
     let conn = req.app().db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
@@ -32,7 +32,7 @@ pub fn dependencies(req: &mut dyn RequestExt) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
-pub fn authors(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn authors(req: &mut ConduitRequest) -> EndpointResult {
     // Currently we return the empty list.
     // Because the API is not used anymore after RFC https://github.com/rust-lang/rfcs/pull/3052.
 
@@ -46,7 +46,7 @@ pub fn authors(req: &mut dyn RequestExt) -> EndpointResult {
 ///
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
-pub fn show(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn show(req: &mut ConduitRequest) -> EndpointResult {
     let (crate_name, semver) = extract_crate_name_and_semver(req)?;
     let conn = req.app().db_read()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -19,17 +19,17 @@ use crate::worker;
 /// Crate deletion is not implemented to avoid breaking builds,
 /// and the goal of yanking a crate is to prevent crates
 /// beginning to depend on the yanked crate version.
-pub fn yank(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn yank(req: &mut ConduitRequest) -> EndpointResult {
     modify_yank(req, true)
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
-pub fn unyank(req: &mut dyn RequestExt) -> EndpointResult {
+pub fn unyank(req: &mut ConduitRequest) -> EndpointResult {
     modify_yank(req, false)
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank(req: &mut dyn RequestExt, yanked: bool) -> EndpointResult {
+fn modify_yank(req: &mut ConduitRequest, yanked: bool) -> EndpointResult {
     // FIXME: Should reject bad requests before authentication, but can't due to
     // lifetime issues with `req`.
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,6 @@
 mod prelude {
     pub use crate::middleware::log_request::CustomMetadataRequestExt;
-    pub use conduit::{box_error, Handler, RequestExt};
+    pub use conduit::{box_error, Handler};
     pub use http::{header, Response, StatusCode};
 }
 

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -1,4 +1,3 @@
-use super::prelude::*;
 use axum::extract::State;
 use axum::middleware::Next;
 use axum::response::Response;
@@ -22,7 +21,7 @@ pub trait RequestApp {
     fn app(&self) -> &AppState;
 }
 
-impl<T: RequestExt + ?Sized> RequestApp for T {
+impl<T> RequestApp for Request<T> {
     fn app(&self) -> &AppState {
         self.extensions().get::<AppState>().expect("Missing app")
     }

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -1,8 +1,6 @@
 //! Log all requests in a format similar to Heroku's router, but with additional
 //! information that we care about like User-Agent
 
-use conduit::RequestExt;
-
 use crate::headers::{XRealIp, XRequestId};
 use crate::middleware::normalize_path::OriginalPath;
 use axum::headers::UserAgent;
@@ -153,12 +151,6 @@ pub trait CustomMetadataRequestExt {
     }
 
     fn metadata_extension(&self) -> Option<&CustomMetadata>;
-}
-
-impl CustomMetadataRequestExt for dyn RequestExt + '_ {
-    fn metadata_extension(&self) -> Option<&CustomMetadata> {
-        self.extensions().get::<CustomMetadata>()
-    }
 }
 
 impl<B> CustomMetadataRequestExt for Request<B> {

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -63,7 +63,7 @@ pub trait RequestSession {
     fn session_remove(&mut self, key: &str) -> Option<String>;
 }
 
-impl<T: conduit::RequestExt + ?Sized> RequestSession for T {
+impl<T> RequestSession for Request<T> {
     fn session_get(&self, key: &str) -> Option<String> {
         let session = self
             .extensions()

--- a/src/router.rs
+++ b/src/router.rs
@@ -3,7 +3,7 @@ use axum::middleware::from_fn_with_state;
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::Router;
-use conduit::{Handler, HandlerResult, RequestExt};
+use conduit::{ConduitRequest, Handler, HandlerResult};
 use conduit_axum::{CauseField, ConduitAxumHandler};
 
 use crate::app::AppState;
@@ -202,10 +202,10 @@ pub fn build_axum_router(state: AppState) -> Router {
         .with_state(state)
 }
 
-struct C(pub fn(&mut dyn RequestExt) -> EndpointResult);
+struct C(pub fn(&mut ConduitRequest) -> EndpointResult);
 
 impl Handler for C {
-    fn call(&self, req: &mut dyn RequestExt) -> HandlerResult {
+    fn call(&self, req: &mut ConduitRequest) -> HandlerResult {
         let C(f) = *self;
         match f(req) {
             Ok(resp) => Ok(resp),


### PR DESCRIPTION
Instead of using "something that implements `RequestExt`" for `conduit` request handlers, we can use a fixed type like `http::Request<Cursor<bytes::Bytes>>` to get rid of all the trait objects. This is possible now, because there is only a single type left that implements `RequestExt`.

Note that we are not yet removing `RequestExt` since some request handlers are still relying on some of its methods.