### PR TITLE
middleware: Remove obsolete `prelude` module

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,9 +1,3 @@
-mod prelude {
-    pub use crate::middleware::log_request::CustomMetadataRequestExt;
-    pub use conduit::{box_error, Handler};
-    pub use http::{header, Response, StatusCode};
-}
-
 pub mod app;
 mod balance_capacity;
 mod block_traffic;

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -8,12 +8,13 @@
 //! the versions of curl or Cargo specified or from either of the IPs (values are nonsensical
 //! examples). Values of the headers must match exactly.
 
-use super::prelude::*;
 use crate::app::AppState;
+use crate::middleware::log_request::CustomMetadataRequestExt;
 use crate::util::errors::RouteBlocked;
 use axum::extract::{MatchedPath, State};
 use axum::middleware::Next;
 use axum::response::IntoResponse;
+use http::StatusCode;
 
 pub async fn block_traffic<B>(
     State(state): State<AppState>,

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -7,8 +7,8 @@
 //! Requests to the download endpoint are always allowed, to support versions of cargo older than
 //! 0.17 (released alongside rustc 1.17).
 
-use super::prelude::*;
 use crate::app::AppState;
+use crate::middleware::log_request::CustomMetadataRequestExt;
 use axum::extract::State;
 use axum::headers::UserAgent;
 use axum::middleware::Next;


### PR DESCRIPTION
It's easier to import what we need directly and IDE completion makes this quite straight-forward :)