### PR TITLE
conduit: Remove `RequestExt` trait

### DIFF
--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -27,17 +27,6 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
     Box::new(error)
 }
 
-pub trait RequestExt {
-    /// The byte-size of the body, if any
-    fn content_length(&self) -> Option<u64>;
-}
-
-impl RequestExt for ConduitRequest {
-    fn content_length(&self) -> Option<u64> {
-        Some(self.body().get_ref().len() as u64)
-    }
-}
-
 /// A Handler takes a request and returns a response or an error.
 /// By default, a bare function implements `Handler`.
 pub trait Handler: Sync + Send + 'static {

--- a/conduit/src/lib.rs
+++ b/conduit/src/lib.rs
@@ -2,7 +2,7 @@
 
 use bytes::Bytes;
 use std::error::Error;
-use std::io::{Cursor, Read};
+use std::io::Cursor;
 
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
@@ -30,23 +30,11 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 pub trait RequestExt {
     /// The byte-size of the body, if any
     fn content_length(&self) -> Option<u64>;
-
-    /// A Reader for the body of the request
-    ///
-    /// # Blocking
-    ///
-    /// The returned value implements the blocking `Read` API and should only
-    /// be read from while in a blocking context.
-    fn body(&mut self) -> &mut dyn Read;
 }
 
 impl RequestExt for ConduitRequest {
     fn content_length(&self) -> Option<u64> {
         Some(self.body().get_ref().len() as u64)
-    }
-
-    fn body(&mut self) -> &mut dyn Read {
-        self.body_mut()
     }
 }
 

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -14,7 +14,7 @@ mod prelude {
     use axum::body::Bytes;
     pub use diesel::prelude::*;
 
-    pub use conduit::{ConduitRequest, RequestExt};
+    pub use conduit::ConduitRequest;
     pub use http::{header, StatusCode};
 
     pub use super::conduit_axum::conduit_compat;
@@ -41,6 +41,7 @@ mod prelude {
         fn query(&self) -> IndexMap<String, String>;
         fn wants_json(&self) -> bool;
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
+        fn content_length(&self) -> Option<u64>;
     }
 
     impl RequestUtils for ConduitRequest {
@@ -64,6 +65,10 @@ mod prelude {
                 .extend_pairs(params)
                 .finish();
             format!("?{query_string}")
+        }
+
+        fn content_length(&self) -> Option<u64> {
+            Some(self.body().get_ref().len() as u64)
         }
     }
 }

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -252,7 +252,7 @@ struct OwnerInvitation {
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
 pub fn handle_invite(req: &mut ConduitRequest) -> EndpointResult {
     let crate_invite: OwnerInvitation =
-        serde_json::from_reader(req.body()).map_err(|_| bad_request("invalid json request"))?;
+        serde_json::from_reader(req.body_mut()).map_err(|_| bad_request("invalid json request"))?;
 
     let crate_invite = crate_invite.crate_owner_invite;
 

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -243,7 +243,7 @@ pub fn verify(req: &mut ConduitRequest) -> EndpointResult {
     }
 
     let mut json = vec![0; length as usize];
-    read_fill(req.body(), &mut json)?;
+    read_fill(req.body_mut(), &mut json)?;
 
     let state = req.app();
     verify_github_signature(req.headers(), state, &json)

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -71,7 +71,7 @@ fn parse_owners_request(req: &mut ConduitRequest) -> AppResult<Vec<String>> {
         owners: Option<Vec<String>>,
     }
     let request: Request =
-        serde_json::from_reader(req.body()).map_err(|_| cargo_err("invalid json request"))?;
+        serde_json::from_reader(req.body_mut()).map_err(|_| cargo_err("invalid json request"))?;
     request
         .owners
         .or(request.users)

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -46,7 +46,7 @@ pub fn new(req: &mut ConduitRequest) -> EndpointResult {
         return Err(bad_request(&format!("max content length is: {max_size}")));
     }
 
-    let new: NewApiTokenRequest = json::from_reader(req.body())
+    let new: NewApiTokenRequest = json::from_reader(req.body_mut())
         .map_err(|e| bad_request(&format!("invalid new token request: {e:?}")))?;
 
     let name = &new.api_token.name;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -119,7 +119,7 @@ pub fn update_user(req: &mut ConduitRequest) -> EndpointResult {
     }
 
     let user_update: UserUpdate =
-        serde_json::from_reader(req.body()).map_err(|_| bad_request("invalid json request"))?;
+        serde_json::from_reader(req.body_mut()).map_err(|_| bad_request("invalid json request"))?;
 
     let user_email = match &user_update.user.email {
         Some(email) => email.trim(),
@@ -227,7 +227,7 @@ pub fn update_email_notifications(req: &mut ConduitRequest) -> EndpointResult {
     }
 
     let updates: HashMap<i32, bool> =
-        serde_json::from_reader::<_, Vec<CrateEmailNotifications>>(req.body())
+        serde_json::from_reader::<_, Vec<CrateEmailNotifications>>(req.body_mut())
             .map_err(|_| bad_request("invalid json request"))?
             .iter()
             .map(|c| (c.id, c.email_notifications))


### PR DESCRIPTION
The end of an era... sort of 😄 

The remaining two methods are inlined and moved to the `RequestUtils` trait respectively.