### PR TITLE
helpers/pagination: Simplify `assert_pagination_error()` fn

### DIFF
--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -310,7 +310,6 @@ mod tests {
     use axum::body::Bytes;
     use conduit_test::MockRequest;
     use http::{Request, StatusCode};
-    use serde_json::Value;
     use std::io::Cursor;
 
     #[test]
@@ -418,11 +417,10 @@ mod tests {
     }
 
     fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {
-        let response = options.gather(&mock(query)).unwrap_err().response();
-        assert_eq!(StatusCode::BAD_REQUEST, response.status());
+        let error = options.gather(&mock(query)).unwrap_err();
+        assert_eq!(error.to_string(), message);
 
-        let bytes = response.into_body();
-        let parsed: Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(parsed, json!({ "errors": [{ "detail": message }] }));
+        let response = error.response();
+        assert_eq!(StatusCode::BAD_REQUEST, response.status());
     }
 }


### PR DESCRIPTION
We are already checking the error serialization elsewhere. In this case it is sufficient to check for the error message.

This also allows us to be more flexible with the `response.body()`, since using `hyper::Body` would cause quite a bit of async issues for this assertion.