### PR TITLE
conduit::Handler: Expect `axum::Response` return values

### DIFF
--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -1,10 +1,9 @@
 #![deny(clippy::all)]
 
-use axum::body::Bytes;
 use axum::routing::get;
 use conduit_axum::{ConduitAxumHandler, ConduitRequest, ResponseResult};
-use http::{header, Response};
 
+use axum::response::IntoResponse;
 use std::io;
 use std::thread::sleep;
 
@@ -30,14 +29,9 @@ pub fn wrap<H>(handler: H) -> ConduitAxumHandler<H> {
 }
 
 fn endpoint(_: &mut ConduitRequest) -> ResponseResult<http::Error> {
-    let body = b"Hello world!";
-
     sleep(std::time::Duration::from_secs(2));
 
-    Response::builder()
-        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .header(header::CONTENT_LENGTH, body.len())
-        .body(Bytes::from_static(body))
+    Ok("Hello world!".into_response())
 }
 
 fn panic(_: &mut ConduitRequest) -> ResponseResult<http::Error> {

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -2,10 +2,11 @@ use axum::body::Bytes;
 use std::error::Error;
 use std::io::Cursor;
 
+use crate::response::AxumResponse;
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
 pub type ConduitRequest = Request<Cursor<Bytes>>;
-pub type ResponseResult<Error> = Result<Response<Bytes>, Error>;
+pub type ResponseResult<Error> = Result<AxumResponse, Error>;
 
 pub type BoxError = Box<dyn Error + Send>;
 pub type HandlerResult = ResponseResult<BoxError>;

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -8,7 +8,7 @@ pub type ConduitRequest = Request<Cursor<Bytes>>;
 pub type ResponseResult<Error> = Result<Response<Bytes>, Error>;
 
 pub type BoxError = Box<dyn Error + Send>;
-pub type HandlerResult = Result<Response<Bytes>, BoxError>;
+pub type HandlerResult = ResponseResult<BoxError>;
 
 /// A helper to convert a concrete error type into a `Box<dyn Error + Send>`
 ///

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -1,5 +1,5 @@
 use crate::error::ServiceError;
-use crate::response::{conduit_into_axum, AxumResponse};
+use crate::response::AxumResponse;
 use crate::{spawn_blocking, ConduitRequest, Handler};
 
 use std::collections::BTreeMap;
@@ -76,7 +76,6 @@ where
                 let mut request = request;
                 handler
                     .call(&mut request)
-                    .map(conduit_into_axum)
                     .unwrap_or_else(|e| server_error_response(&*e))
             })
             .await

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -37,12 +37,13 @@
 //! #
 //! # use std::{error, io};
 //! # use axum::body::Bytes;
+//! # use axum::response::IntoResponse;
 //! # use conduit_axum::{box_error, Response, ConduitRequest, HandlerResult};
 //! #
 //! # struct Endpoint();
 //! # impl Handler for Endpoint {
 //! #     fn call(&self, _: &mut ConduitRequest) -> HandlerResult {
-//! #         Response::builder().body(Bytes::new()).map_err(box_error)
+//! #         Ok(().into_response())
 //! #     }
 //! # }
 //! ```


### PR DESCRIPTION
Instead of using `http::Response<Bytes>` we can use `axum::Response` to bring us closer to being able to return `axum` responses from the crates.io request handlers.