### PR TITLE
Change request handler return type to `axum::Response`

### DIFF
--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
 use axum::routing::get;
-use conduit_axum::{box_error, ConduitAxumHandler, ConduitRequest, HandlerResult};
+use conduit_axum::{server_error_response, ConduitAxumHandler, ConduitRequest, HandlerResult};
 
 use axum::response::IntoResponse;
 use std::io;
@@ -31,7 +31,7 @@ pub fn wrap<H>(handler: H) -> ConduitAxumHandler<H> {
 fn endpoint(_: &mut ConduitRequest) -> HandlerResult {
     sleep(std::time::Duration::from_secs(2));
 
-    Ok("Hello world!".into_response())
+    "Hello world!".into_response()
 }
 
 fn panic(_: &mut ConduitRequest) -> HandlerResult {
@@ -40,5 +40,5 @@ fn panic(_: &mut ConduitRequest) -> HandlerResult {
 }
 
 fn error(_: &mut ConduitRequest) -> HandlerResult {
-    Err(io::Error::new(io::ErrorKind::Other, "io error, oops")).map_err(box_error)
+    server_error_response(&io::Error::new(io::ErrorKind::Other, "io error, oops"))
 }

--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
 use axum::routing::get;
-use conduit_axum::{ConduitAxumHandler, ConduitRequest, ResponseResult};
+use conduit_axum::{box_error, ConduitAxumHandler, ConduitRequest, HandlerResult};
 
 use axum::response::IntoResponse;
 use std::io;
@@ -28,17 +28,17 @@ pub fn wrap<H>(handler: H) -> ConduitAxumHandler<H> {
     ConduitAxumHandler::wrap(handler)
 }
 
-fn endpoint(_: &mut ConduitRequest) -> ResponseResult<http::Error> {
+fn endpoint(_: &mut ConduitRequest) -> HandlerResult {
     sleep(std::time::Duration::from_secs(2));
 
     Ok("Hello world!".into_response())
 }
 
-fn panic(_: &mut ConduitRequest) -> ResponseResult<http::Error> {
+fn panic(_: &mut ConduitRequest) -> HandlerResult {
     // For now, connection is immediately closed
     panic!("message");
 }
 
-fn error(_: &mut ConduitRequest) -> ResponseResult<io::Error> {
-    Err(io::Error::new(io::ErrorKind::Other, "io error, oops"))
+fn error(_: &mut ConduitRequest) -> HandlerResult {
+    Err(io::Error::new(io::ErrorKind::Other, "io error, oops")).map_err(box_error)
 }

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -6,10 +6,9 @@ use crate::response::AxumResponse;
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
 pub type ConduitRequest = Request<Cursor<Bytes>>;
-pub type ResponseResult<Error> = Result<AxumResponse, Error>;
 
 pub type BoxError = Box<dyn Error + Send>;
-pub type HandlerResult = ResponseResult<BoxError>;
+pub type HandlerResult = AxumResponse;
 
 /// A helper to convert a concrete error type into a `Box<dyn Error + Send>`
 ///

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -32,12 +32,11 @@ pub trait Handler: Sync + Send + 'static {
     fn call(&self, request: &mut ConduitRequest) -> HandlerResult;
 }
 
-impl<F, E> Handler for F
+impl<F> Handler for F
 where
-    F: Fn(&mut ConduitRequest) -> ResponseResult<E> + Sync + Send + 'static,
-    E: Error + Send + 'static,
+    F: Fn(&mut ConduitRequest) -> HandlerResult + Sync + Send + 'static,
 {
     fn call(&self, request: &mut ConduitRequest) -> HandlerResult {
-        (*self)(request).map_err(box_error)
+        (*self)(request)
     }
 }

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -74,9 +74,7 @@ where
             let Self(handler) = self;
             spawn_blocking(move || {
                 let mut request = request;
-                handler
-                    .call(&mut request)
-                    .unwrap_or_else(|e| server_error_response(&*e))
+                handler.call(&mut request)
             })
             .await
             .map_err(ServiceError::from)
@@ -98,7 +96,7 @@ impl IntoResponse for ServiceError {
 }
 
 /// Logs an error message and returns a generic status 500 response
-fn server_error_response<E: Error + ?Sized>(error: &E) -> AxumResponse {
+pub fn server_error_response<E: Error + ?Sized>(error: &E) -> AxumResponse {
     error!(%error, "Internal Server Error");
 
     sentry_core::capture_error(error);

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -43,7 +43,7 @@
 //! # struct Endpoint();
 //! # impl Handler for Endpoint {
 //! #     fn call(&self, _: &mut ConduitRequest) -> HandlerResult {
-//! #         Ok(().into_response())
+//! #         ().into_response()
 //! #     }
 //! # }
 //! ```
@@ -59,6 +59,8 @@ mod tokio_utils;
 
 pub use conduit::*;
 pub use error::ServiceError;
-pub use fallback::{CauseField, ConduitAxumHandler, ErrorField, RequestParamsExt};
+pub use fallback::{
+    server_error_response, CauseField, ConduitAxumHandler, ErrorField, RequestParamsExt,
+};
 pub use response::conduit_into_axum;
 pub use tokio_utils::spawn_blocking;

--- a/conduit-axum/src/tests.rs
+++ b/conduit-axum/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{ConduitRequest, Handler, HandlerResult};
+use crate::{server_error_response, ConduitRequest, Handler, HandlerResult};
 use axum::response::IntoResponse;
 use axum::Router;
 use http::header::HeaderName;
@@ -18,15 +18,14 @@ fn single_header(key: &str, value: &str) -> HeaderMap {
 struct OkResult;
 impl Handler for OkResult {
     fn call(&self, _req: &mut ConduitRequest) -> HandlerResult {
-        Ok((single_header("ok", "value"), "Hello, world!").into_response())
+        (single_header("ok", "value"), "Hello, world!").into_response()
     }
 }
 
 struct ErrorResult;
 impl Handler for ErrorResult {
     fn call(&self, _req: &mut ConduitRequest) -> HandlerResult {
-        let error = ::std::io::Error::last_os_error();
-        Err(Box::new(error))
+        server_error_response(&std::io::Error::last_os_error())
     }
 }
 
@@ -40,7 +39,7 @@ impl Handler for Panic {
 struct InvalidHeader;
 impl Handler for InvalidHeader {
     fn call(&self, _req: &mut ConduitRequest) -> HandlerResult {
-        Ok((single_header("invalid-value", "\r\n"), "discarded").into_response())
+        (single_header("invalid-value", "\r\n"), "discarded").into_response()
     }
 }
 

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -11,7 +11,7 @@ mod frontend_prelude {
 mod prelude {
     pub use super::helpers::ok_true;
     pub use super::util::RequestParamExt;
-    use axum::body::Bytes;
+    use axum::response::IntoResponse;
     pub use diesel::prelude::*;
 
     pub use conduit_axum::ConduitRequest;
@@ -27,15 +27,11 @@ mod prelude {
 
     pub trait RequestUtils {
         fn redirect(&self, url: String) -> AppResponse {
-            http::Response::builder()
-                .status(StatusCode::FOUND)
-                .header(header::LOCATION, url)
-                .body(Bytes::new())
-                .unwrap() // Should not panic unless url contains "\r\n"
+            (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
         }
 
         fn json<T: Serialize>(&self, t: T) -> AppResponse {
-            crate::util::json_response(t)
+            crate::util::json_response(t).into_response()
         }
 
         fn query(&self) -> IndexMap<String, String>;

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,4 +1,5 @@
 use crate::util::{json_response, EndpointResult};
+use axum::response::IntoResponse;
 
 pub(crate) mod pagination;
 
@@ -6,5 +7,5 @@ pub(crate) use self::pagination::Paginate;
 
 pub fn ok_true() -> EndpointResult {
     let json = json!({ "ok": true });
-    Ok(json_response(json))
+    Ok(json_response(json).into_response())
 }

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,7 +1,6 @@
 use crate::controllers::frontend_prelude::*;
 use crate::util::errors::{forbidden, not_found, MetricsDisabled};
-use axum::body::Bytes;
-use http::Response;
+use axum::response::IntoResponse;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
@@ -33,8 +32,9 @@ pub fn prometheus(req: &mut ConduitRequest) -> EndpointResult {
     let mut output = Vec::new();
     TextEncoder::new().encode(&metrics, &mut output)?;
 
-    Ok(Response::builder()
-        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .header(header::CONTENT_LENGTH, output.len())
-        .body(Bytes::from(output))?)
+    Ok((
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        output,
+    )
+        .into_response())
 }

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -5,8 +5,7 @@ use crate::schema::api_tokens;
 use crate::views::EncodableApiTokenWithToken;
 
 use crate::auth::AuthCheck;
-use axum::body::Bytes;
-use http::Response;
+use axum::response::IntoResponse;
 use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.
@@ -108,5 +107,5 @@ pub fn revoke_current(req: &mut ConduitRequest) -> EndpointResult {
         .set(api_tokens::revoked.eq(true))
         .execute(&*conn)?;
 
-    Ok(Response::builder().status(204).body(Bytes::new()).unwrap())
+    Ok(StatusCode::NO_CONTENT.into_response())
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -3,7 +3,7 @@ use axum::middleware::from_fn_with_state;
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::Router;
-use conduit_axum::{conduit_into_axum, ConduitAxumHandler, ConduitRequest, Handler, HandlerResult};
+use conduit_axum::{ConduitAxumHandler, ConduitRequest, Handler, HandlerResult};
 
 use crate::app::AppState;
 use crate::controllers::*;
@@ -207,7 +207,7 @@ impl Handler for C {
     fn call(&self, req: &mut ConduitRequest) -> HandlerResult {
         let C(f) = *self;
         match f(req) {
-            Ok(resp) => Ok(conduit_into_axum(resp)),
+            Ok(resp) => Ok(resp),
             Err(e) => Ok(e.into_response()),
         }
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -207,8 +207,8 @@ impl Handler for C {
     fn call(&self, req: &mut ConduitRequest) -> HandlerResult {
         let C(f) = *self;
         match f(req) {
-            Ok(resp) => Ok(resp),
-            Err(e) => Ok(e.into_response()),
+            Ok(resp) => resp,
+            Err(e) => e.into_response(),
         }
     }
 }
@@ -236,28 +236,27 @@ mod tests {
 
         // Types for handling common error status codes
         assert_eq!(
-            C(|_| Err(bad_request(""))).call(&mut req).unwrap().status(),
+            C(|_| Err(bad_request(""))).call(&mut req).status(),
             StatusCode::BAD_REQUEST
         );
         assert_eq!(
-            C(|_| Err(forbidden())).call(&mut req).unwrap().status(),
+            C(|_| Err(forbidden())).call(&mut req).status(),
             StatusCode::FORBIDDEN
         );
         assert_eq!(
             C(|_| Err(DieselError::NotFound.into()))
                 .call(&mut req)
-                .unwrap()
                 .status(),
             StatusCode::NOT_FOUND
         );
         assert_eq!(
-            C(|_| Err(not_found())).call(&mut req).unwrap().status(),
+            C(|_| Err(not_found())).call(&mut req).status(),
             StatusCode::NOT_FOUND
         );
 
         // cargo_err errors are returned as 200 so that cargo displays this nicely on the command line
         assert_eq!(
-            C(|_| Err(cargo_err(""))).call(&mut req).unwrap().status(),
+            C(|_| Err(cargo_err(""))).call(&mut req).status(),
             StatusCode::OK
         );
 
@@ -269,8 +268,7 @@ mod tests {
                 .map_err(|err| err.chain(bad_request("outer user facing error")))
                 .unwrap_err())
         })
-        .call(&mut req)
-        .unwrap();
+        .call(&mut req);
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
             response.extensions().get::<CauseField>().unwrap().0,
@@ -279,20 +277,18 @@ mod tests {
 
         // All other error types are converted to internal server errors
         assert_eq!(
-            C(|_| Err(internal(""))).call(&mut req).unwrap().status(),
+            C(|_| Err(internal(""))).call(&mut req).status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
         assert_eq!(
             C(|_| err::<::serde_json::Error>(::serde::de::Error::custom("ExpectedColon")))
                 .call(&mut req)
-                .unwrap()
                 .status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
         assert_eq!(
             C(|_| err(::std::io::Error::new(::std::io::ErrorKind::Other, "")))
                 .call(&mut req)
-                .unwrap()
                 .status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
 use std::cmp;
 
-use axum::body::Bytes;
-use http::{header, Response};
+use axum::Json;
 use serde::Serialize;
 
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
@@ -14,7 +13,7 @@ pub mod rfc3339;
 pub mod token;
 pub mod tracing;
 
-pub type AppResponse = Response<Bytes>;
+pub type AppResponse = axum::response::Response;
 pub type EndpointResult = Result<AppResponse, Box<dyn errors::AppError>>;
 
 /// Serialize a value to JSON and build a status 200 Response
@@ -24,13 +23,8 @@ pub type EndpointResult = Result<AppResponse, Box<dyn errors::AppError>>;
 /// # Panics
 ///
 /// This function will panic if serialization fails.
-pub fn json_response<T: Serialize>(t: T) -> AppResponse {
-    let json = serde_json::to_vec(&t).unwrap();
-    Response::builder()
-        .header(header::CONTENT_TYPE, "application/json")
-        .header(header::CONTENT_LENGTH, json.len())
-        .body(Bytes::from(json))
-        .unwrap() // Header values are well formed, so should not panic
+pub fn json_response<T: Serialize>(t: T) -> Json<T> {
+    Json(t)
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
This means we need one less conversion step in the `Handler for C` implementation, and it also means we can now use anything else that implements `IntoResponse` to build responses. 🎉

Related:
- https://github.com/rust-lang/crates.io/pull/5843