### PR TITLE
Pass `request` ownership into the request handlers

### DIFF
--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -28,17 +28,17 @@ pub fn wrap<H>(handler: H) -> ConduitAxumHandler<H> {
     ConduitAxumHandler::wrap(handler)
 }
 
-fn endpoint(_: &mut ConduitRequest) -> HandlerResult {
+fn endpoint(_: ConduitRequest) -> HandlerResult {
     sleep(std::time::Duration::from_secs(2));
 
     "Hello world!".into_response()
 }
 
-fn panic(_: &mut ConduitRequest) -> HandlerResult {
+fn panic(_: ConduitRequest) -> HandlerResult {
     // For now, connection is immediately closed
     panic!("message");
 }
 
-fn error(_: &mut ConduitRequest) -> HandlerResult {
+fn error(_: ConduitRequest) -> HandlerResult {
     server_error_response(&io::Error::new(io::ErrorKind::Other, "io error, oops"))
 }

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -28,14 +28,14 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 /// A Handler takes a request and returns a response or an error.
 /// By default, a bare function implements `Handler`.
 pub trait Handler: Sync + Send + 'static {
-    fn call(&self, request: &mut ConduitRequest) -> HandlerResult;
+    fn call(&self, request: ConduitRequest) -> HandlerResult;
 }
 
 impl<F> Handler for F
 where
-    F: Fn(&mut ConduitRequest) -> HandlerResult + Sync + Send + 'static,
+    F: Fn(ConduitRequest) -> HandlerResult + Sync + Send + 'static,
 {
-    fn call(&self, request: &mut ConduitRequest) -> HandlerResult {
+    fn call(&self, request: ConduitRequest) -> HandlerResult {
         (*self)(request)
     }
 }

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -72,13 +72,10 @@ where
             let request = Request::from_parts(parts, Cursor::new(full_body));
 
             let Self(handler) = self;
-            spawn_blocking(move || {
-                let mut request = request;
-                handler.call(&mut request)
-            })
-            .await
-            .map_err(ServiceError::from)
-            .into_response()
+            spawn_blocking(move || handler.call(request))
+                .await
+                .map_err(ServiceError::from)
+                .into_response()
         })
     }
 }

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -42,7 +42,7 @@
 //! #
 //! # struct Endpoint();
 //! # impl Handler for Endpoint {
-//! #     fn call(&self, _: &mut ConduitRequest) -> HandlerResult {
+//! #     fn call(&self, _: ConduitRequest) -> HandlerResult {
 //! #         ().into_response()
 //! #     }
 //! # }

--- a/conduit-axum/src/tests.rs
+++ b/conduit-axum/src/tests.rs
@@ -17,35 +17,35 @@ fn single_header(key: &str, value: &str) -> HeaderMap {
 
 struct OkResult;
 impl Handler for OkResult {
-    fn call(&self, _req: &mut ConduitRequest) -> HandlerResult {
+    fn call(&self, _req: ConduitRequest) -> HandlerResult {
         (single_header("ok", "value"), "Hello, world!").into_response()
     }
 }
 
 struct ErrorResult;
 impl Handler for ErrorResult {
-    fn call(&self, _req: &mut ConduitRequest) -> HandlerResult {
+    fn call(&self, _req: ConduitRequest) -> HandlerResult {
         server_error_response(&std::io::Error::last_os_error())
     }
 }
 
 struct Panic;
 impl Handler for Panic {
-    fn call(&self, _req: &mut ConduitRequest) -> HandlerResult {
+    fn call(&self, _req: ConduitRequest) -> HandlerResult {
         panic!()
     }
 }
 
 struct InvalidHeader;
 impl Handler for InvalidHeader {
-    fn call(&self, _req: &mut ConduitRequest) -> HandlerResult {
+    fn call(&self, _req: ConduitRequest) -> HandlerResult {
         (single_header("invalid-value", "\r\n"), "discarded").into_response()
     }
 }
 
 struct Sleep;
 impl Handler for Sleep {
-    fn call(&self, req: &mut ConduitRequest) -> HandlerResult {
+    fn call(&self, req: ConduitRequest) -> HandlerResult {
         std::thread::sleep(std::time::Duration::from_millis(100));
         OkResult.call(req)
     }
@@ -53,7 +53,7 @@ impl Handler for Sleep {
 
 struct AssertPercentDecodedPath;
 impl Handler for AssertPercentDecodedPath {
-    fn call(&self, req: &mut ConduitRequest) -> HandlerResult {
+    fn call(&self, req: ConduitRequest) -> HandlerResult {
         if req.uri().path() == "/%3a" && req.uri().query() == Some("%3a") {
             OkResult.call(req)
         } else {

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,12 +6,12 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub fn index(req: &mut ConduitRequest) -> EndpointResult {
+pub fn index(req: ConduitRequest) -> EndpointResult {
     let query = req.query();
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
     // to paginate this.
-    let options = PaginationOptions::builder().gather(req)?;
+    let options = PaginationOptions::builder().gather(&req)?;
     let offset = options.offset().unwrap_or_default();
     let sort = query.get("sort").map_or("alpha", String::as_str);
 
@@ -33,7 +33,7 @@ pub fn index(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub fn show(req: &mut ConduitRequest) -> EndpointResult {
+pub fn show(req: ConduitRequest) -> EndpointResult {
     let slug = req.param("category_id").unwrap();
     let conn = req.app().db_read()?;
     let cat: Category = Category::by_slug(slug).first(&*conn)?;
@@ -64,7 +64,7 @@ pub fn show(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /category_slugs` route.
-pub fn slugs(req: &mut ConduitRequest) -> EndpointResult {
+pub fn slugs(req: ConduitRequest) -> EndpointResult {
     let conn = req.app().db_read()?;
     let slugs: Vec<Slug> = categories::table
         .select((categories::slug, categories::slug, categories::description))

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -232,7 +232,7 @@ pub enum GitHubSecretAlertFeedbackLabel {
 }
 
 /// Handles the `POST /api/github/secret-scanning/verify` route.
-pub fn verify(req: &mut ConduitRequest) -> EndpointResult {
+pub fn verify(mut req: ConduitRequest) -> EndpointResult {
     let max_size = 8192;
     let length = req
         .content_length()

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -10,7 +10,7 @@ use crate::models::Keyword;
 use crate::views::EncodableKeyword;
 
 /// Handles the `GET /keywords` route.
-pub fn index(req: &mut ConduitRequest) -> EndpointResult {
+pub fn index(req: ConduitRequest) -> EndpointResult {
     use crate::schema::keywords;
 
     let query = req.query();
@@ -24,7 +24,7 @@ pub fn index(req: &mut ConduitRequest) -> EndpointResult {
         query = query.order(keywords::keyword.asc());
     }
 
-    let query = query.pages_pagination(PaginationOptions::builder().gather(req)?);
+    let query = query.pages_pagination(PaginationOptions::builder().gather(&req)?);
     let conn = req.app().db_read()?;
     let data: Paginated<Keyword> = query.load(&conn)?;
     let total = data.total();

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,7 +13,7 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub fn downloads(req: &mut ConduitRequest) -> EndpointResult {
+pub fn downloads(req: ConduitRequest) -> EndpointResult {
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,7 +22,7 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub fn summary(req: &mut ConduitRequest) -> EndpointResult {
+pub fn summary(req: ConduitRequest) -> EndpointResult {
     use crate::schema::crates::dsl::*;
     use diesel::dsl::all;
 
@@ -125,7 +125,7 @@ pub fn summary(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id` route.
-pub fn show(req: &mut ConduitRequest) -> EndpointResult {
+pub fn show(req: ConduitRequest) -> EndpointResult {
     let name = req.param("crate_id").unwrap();
     let include = req
         .query()
@@ -298,7 +298,7 @@ impl FromStr for ShowIncludeMode {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/readme` route.
-pub fn readme(req: &mut ConduitRequest) -> EndpointResult {
+pub fn readme(req: ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let version = req.param("version").unwrap();
 
@@ -318,7 +318,7 @@ pub fn readme(req: &mut ConduitRequest) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub fn versions(req: &mut ConduitRequest) -> EndpointResult {
+pub fn versions(req: ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -346,10 +346,10 @@ pub fn versions(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/reverse_dependencies` route.
-pub fn reverse_dependencies(req: &mut ConduitRequest) -> EndpointResult {
+pub fn reverse_dependencies(req: ConduitRequest) -> EndpointResult {
     use diesel::dsl::any;
 
-    let pagination_options = PaginationOptions::builder().gather(req)?;
+    let pagination_options = PaginationOptions::builder().gather(&req)?;
     let name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(name).first(&*conn)?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -7,7 +7,7 @@ use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub fn owners(req: &mut ConduitRequest) -> EndpointResult {
+pub fn owners(req: ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -21,7 +21,7 @@ pub fn owners(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub fn owner_team(req: &mut ConduitRequest) -> EndpointResult {
+pub fn owner_team(req: ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -34,7 +34,7 @@ pub fn owner_team(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub fn owner_user(req: &mut ConduitRequest) -> EndpointResult {
+pub fn owner_user(req: ConduitRequest) -> EndpointResult {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -47,13 +47,13 @@ pub fn owner_user(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
-pub fn add_owners(req: &mut ConduitRequest) -> EndpointResult {
-    modify_owners(req, true)
+pub fn add_owners(mut req: ConduitRequest) -> EndpointResult {
+    modify_owners(&mut req, true)
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
-pub fn remove_owners(req: &mut ConduitRequest) -> EndpointResult {
-    modify_owners(req, false)
+pub fn remove_owners(mut req: ConduitRequest) -> EndpointResult {
+    modify_owners(&mut req, false)
 }
 
 /// Parse the JSON request body of requests to modify the owners of a crate.

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -42,7 +42,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// Currently blocks the HTTP thread, perhaps some function calls can spawn new
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
-pub fn publish(req: &mut ConduitRequest) -> EndpointResult {
+pub fn publish(mut req: ConduitRequest) -> EndpointResult {
     let app = req.app().clone();
 
     // The format of the req.body() of a publish request is as follows:
@@ -58,7 +58,7 @@ pub fn publish(req: &mut ConduitRequest) -> EndpointResult {
     // - Then the .crate tarball length is passed to the upload_crate function where the actual
     //   file is read and uploaded.
 
-    let new_crate = parse_new_headers(req)?;
+    let new_crate = parse_new_headers(&mut req)?;
 
     req.add_custom_metadata("crate_name", new_crate.name.to_string());
     req.add_custom_metadata("crate_version", new_crate.vers.to_string());
@@ -80,7 +80,7 @@ pub fn publish(req: &mut ConduitRequest) -> EndpointResult {
     let auth = AuthCheck::default()
         .with_endpoint_scope(endpoint_scope)
         .for_crate(&new_crate.name)
-        .check(req)?;
+        .check(&req)?;
 
     let api_token_id = auth.api_token_id();
     let user = auth.user();

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -38,7 +38,7 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub fn search(req: &mut ConduitRequest) -> EndpointResult {
+pub fn search(req: ConduitRequest) -> EndpointResult {
     use diesel::sql_types::{Bool, Text};
 
     let params = req.query();
@@ -187,7 +187,7 @@ pub fn search(req: &mut ConduitRequest) -> EndpointResult {
         // Calculating the total number of results with filters is not supported yet.
         supports_seek = false;
 
-        let user_id = AuthCheck::default().check(req)?.user_id();
+        let user_id = AuthCheck::default().check(&req)?.user_id();
 
         query = query.filter(
             crates::id.eq_any(
@@ -248,7 +248,7 @@ pub fn search(req: &mut ConduitRequest) -> EndpointResult {
     let pagination: PaginationOptions = PaginationOptions::builder()
         .limit_page_numbers()
         .enable_seek(supports_seek)
-        .gather(req)?;
+        .gather(&req)?;
     let conn = req.app().db_read()?;
 
     let (explicit_page, seek) = match pagination.page.clone() {

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -4,7 +4,7 @@ use axum::response::IntoResponse;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
-pub fn prometheus(req: &mut ConduitRequest) -> EndpointResult {
+pub fn prometheus(req: ConduitRequest) -> EndpointResult {
     let app = req.app();
 
     if let Some(expected_token) = &app.config.metrics_authorization_token {

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,7 +5,7 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub fn show_team(req: &mut ConduitRequest) -> EndpointResult {
+pub fn show_team(req: ConduitRequest) -> EndpointResult {
     use self::teams::dsl::{login, teams};
 
     let name = req.param("team_id").unwrap();

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,7 +6,7 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub fn show(req: &mut ConduitRequest) -> EndpointResult {
+pub fn show(req: ConduitRequest) -> EndpointResult {
     use self::users::dsl::{gh_login, id, users};
 
     let name = lower(req.param("user_id").unwrap());
@@ -20,7 +20,7 @@ pub fn show(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub fn stats(req: &mut ConduitRequest) -> EndpointResult {
+pub fn stats(req: ConduitRequest) -> EndpointResult {
     use diesel::dsl::sum;
 
     let user_id = req

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -25,7 +25,7 @@ use crate::util::errors::ReadOnlyMode;
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub fn begin(req: &mut ConduitRequest) -> EndpointResult {
+pub fn begin(mut req: ConduitRequest) -> EndpointResult {
     let (url, state) = req
         .app()
         .github_oauth
@@ -66,7 +66,7 @@ pub fn begin(req: &mut ConduitRequest) -> EndpointResult {
 ///     }
 /// }
 /// ```
-pub fn authorize(req: &mut ConduitRequest) -> EndpointResult {
+pub fn authorize(mut req: ConduitRequest) -> EndpointResult {
     // Parse the url query
     let mut query = req.query();
     let code = query.remove("code").unwrap_or_default();
@@ -134,7 +134,7 @@ fn save_user_to_database(
 }
 
 /// Handles the `DELETE /api/private/session` route.
-pub fn logout(req: &mut ConduitRequest) -> EndpointResult {
+pub fn logout(mut req: ConduitRequest) -> EndpointResult {
     req.session_remove("user_id");
     Ok(req.json(true))
 }

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -12,7 +12,7 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub fn index(req: &mut ConduitRequest) -> EndpointResult {
+pub fn index(req: ConduitRequest) -> EndpointResult {
     use diesel::dsl::any;
     let conn = req.app().db_read()?;
 
@@ -51,7 +51,7 @@ pub fn index(req: &mut ConduitRequest) -> EndpointResult {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub fn show_by_id(req: &mut ConduitRequest) -> EndpointResult {
+pub fn show_by_id(req: ConduitRequest) -> EndpointResult {
     let id = req.param("version_id").unwrap();
     let id = id.parse().unwrap_or(0);
     let conn = req.app().db_read()?;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -13,7 +13,7 @@ use chrono::{Duration, NaiveDate, Utc};
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
-pub fn download(req: &mut ConduitRequest) -> EndpointResult {
+pub fn download(req: ConduitRequest) -> EndpointResult {
     let app = req.app();
 
     let mut crate_name = req.param("crate_id").unwrap().to_string();
@@ -116,8 +116,8 @@ pub fn download(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
-pub fn downloads(req: &mut ConduitRequest) -> EndpointResult {
-    let (crate_name, semver) = extract_crate_name_and_semver(req)?;
+pub fn downloads(req: ConduitRequest) -> EndpointResult {
+    let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
 
     let conn = req.app().db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -18,8 +18,8 @@ use super::{extract_crate_name_and_semver, version_and_crate};
 /// In addition to returning cached data from the index, this returns
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
-pub fn dependencies(req: &mut ConduitRequest) -> EndpointResult {
-    let (crate_name, semver) = extract_crate_name_and_semver(req)?;
+pub fn dependencies(req: ConduitRequest) -> EndpointResult {
+    let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
     let conn = req.app().db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
     let deps = version.dependencies(&conn)?;
@@ -32,7 +32,7 @@ pub fn dependencies(req: &mut ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
-pub fn authors(req: &mut ConduitRequest) -> EndpointResult {
+pub fn authors(req: ConduitRequest) -> EndpointResult {
     // Currently we return the empty list.
     // Because the API is not used anymore after RFC https://github.com/rust-lang/rfcs/pull/3052.
 
@@ -46,8 +46,8 @@ pub fn authors(req: &mut ConduitRequest) -> EndpointResult {
 ///
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
-pub fn show(req: &mut ConduitRequest) -> EndpointResult {
-    let (crate_name, semver) = extract_crate_name_and_semver(req)?;
+pub fn show(req: ConduitRequest) -> EndpointResult {
+    let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
     let conn = req.app().db_read()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;
     let published_by = version.published_by(&conn);

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -19,17 +19,17 @@ use crate::worker;
 /// Crate deletion is not implemented to avoid breaking builds,
 /// and the goal of yanking a crate is to prevent crates
 /// beginning to depend on the yanked crate version.
-pub fn yank(req: &mut ConduitRequest) -> EndpointResult {
-    modify_yank(req, true)
+pub fn yank(req: ConduitRequest) -> EndpointResult {
+    modify_yank(&req, true)
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
-pub fn unyank(req: &mut ConduitRequest) -> EndpointResult {
-    modify_yank(req, false)
+pub fn unyank(req: ConduitRequest) -> EndpointResult {
+    modify_yank(&req, false)
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank(req: &mut ConduitRequest, yanked: bool) -> EndpointResult {
+fn modify_yank(req: &ConduitRequest, yanked: bool) -> EndpointResult {
     // FIXME: Should reject bad requests before authentication, but can't due to
     // lifetime issues with `req`.
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -201,12 +201,12 @@ pub fn build_axum_router(state: AppState) -> Router {
         .with_state(state)
 }
 
-struct C(pub fn(&mut ConduitRequest) -> EndpointResult);
+struct C(pub fn(ConduitRequest) -> EndpointResult);
 
 impl Handler for C {
-    fn call(&self, mut req: ConduitRequest) -> HandlerResult {
+    fn call(&self, req: ConduitRequest) -> HandlerResult {
         let C(f) = *self;
-        match f(&mut req) {
+        match f(req) {
             Ok(resp) => resp,
             Err(e) => e.into_response(),
         }


### PR DESCRIPTION
This matches what `axum` does and makes our migration a little easier :)