### PR TITLE
Clean up type aliases

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -11,7 +11,7 @@ mod frontend_prelude {
 mod prelude {
     pub use super::helpers::ok_true;
     pub use super::util::RequestParamExt;
-    use axum::response::IntoResponse;
+    pub use axum::response::{IntoResponse, Response};
     pub use diesel::prelude::*;
 
     pub use conduit_axum::ConduitRequest;
@@ -20,17 +20,17 @@ mod prelude {
     pub use super::conduit_axum::conduit_compat;
     pub use crate::middleware::app::RequestApp;
     pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError}; // TODO: Remove cargo_err from here
-    pub use crate::util::{AppResponse, EndpointResult};
+    pub use crate::util::EndpointResult;
 
     use indexmap::IndexMap;
     use serde::Serialize;
 
     pub trait RequestUtils {
-        fn redirect(&self, url: String) -> AppResponse {
+        fn redirect(&self, url: String) -> Response {
             (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
         }
 
-        fn json<T: Serialize>(&self, t: T) -> AppResponse {
+        fn json<T: Serialize>(&self, t: T) -> Response {
             crate::util::json_response(t).into_response()
         }
 

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -19,7 +19,7 @@ mod prelude {
 
     pub use super::conduit_axum::conduit_compat;
     pub use crate::middleware::app::RequestApp;
-    pub use crate::util::errors::{cargo_err, AppError, AppResult}; // TODO: Remove cargo_err from here
+    pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError}; // TODO: Remove cargo_err from here
     pub use crate::util::{AppResponse, EndpointResult};
 
     use indexmap::IndexMap;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -19,9 +19,7 @@ mod prelude {
 
     pub use super::conduit_axum::conduit_compat;
     pub use crate::middleware::app::RequestApp;
-    pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError}; // TODO: Remove cargo_err from here
-    pub use crate::util::EndpointResult;
-
+    pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError};
     use indexmap::IndexMap;
     use serde::Serialize;
 

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub fn index(req: ConduitRequest) -> EndpointResult {
+pub fn index(req: ConduitRequest) -> AppResult<Response> {
     let query = req.query();
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
@@ -33,7 +33,7 @@ pub fn index(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub fn show(req: ConduitRequest) -> EndpointResult {
+pub fn show(req: ConduitRequest) -> AppResult<Response> {
     let slug = req.param("category_id").unwrap();
     let conn = req.app().db_read()?;
     let cat: Category = Category::by_slug(slug).first(&*conn)?;
@@ -64,7 +64,7 @@ pub fn show(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /category_slugs` route.
-pub fn slugs(req: ConduitRequest) -> EndpointResult {
+pub fn slugs(req: ConduitRequest) -> AppResult<Response> {
     let conn = req.app().db_read()?;
     let slugs: Vec<Slug> = categories::table
         .select((categories::slug, categories::slug, categories::description))

--- a/src/controllers/conduit_axum.rs
+++ b/src/controllers/conduit_axum.rs
@@ -1,4 +1,4 @@
-use crate::util::errors::AppError;
+use crate::util::errors::BoxedAppError;
 use axum::response::{IntoResponse, Response};
 use conduit_axum::{spawn_blocking, ServiceError};
 
@@ -6,7 +6,7 @@ use conduit_axum::{spawn_blocking, ServiceError};
 /// and converts any returned [AppError] into an axum [Response].
 pub async fn conduit_compat<F, R>(f: F) -> Response
 where
-    F: FnOnce() -> Result<R, Box<dyn AppError>> + Send + 'static,
+    F: FnOnce() -> Result<R, BoxedAppError> + Send + 'static,
     R: IntoResponse,
 {
     spawn_blocking(move || f().into_response())

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -16,7 +16,7 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
-pub fn list(req: ConduitRequest) -> EndpointResult {
+pub fn list(req: ConduitRequest) -> AppResult<Response> {
     let auth = AuthCheck::only_cookie().check(&req)?;
     let user_id = auth.user_id();
 
@@ -52,7 +52,7 @@ pub fn list(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /api/private/crate_owner_invitations` route.
-pub fn private_list(req: ConduitRequest) -> EndpointResult {
+pub fn private_list(req: ConduitRequest) -> AppResult<Response> {
     let auth = AuthCheck::only_cookie().check(&req)?;
 
     let filter = if let Some(crate_name) = req.query().get("crate_name") {
@@ -250,7 +250,7 @@ struct OwnerInvitation {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
-pub fn handle_invite(mut req: ConduitRequest) -> EndpointResult {
+pub fn handle_invite(mut req: ConduitRequest) -> AppResult<Response> {
     let crate_invite: OwnerInvitation =
         serde_json::from_reader(req.body_mut()).map_err(|_| bad_request("invalid json request"))?;
 
@@ -274,7 +274,7 @@ pub fn handle_invite(mut req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
-pub fn handle_invite_with_token(req: ConduitRequest) -> EndpointResult {
+pub fn handle_invite_with_token(req: ConduitRequest) -> AppResult<Response> {
     let state = req.app();
     let config = &state.config;
     let conn = state.db_write()?;

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -232,7 +232,7 @@ pub enum GitHubSecretAlertFeedbackLabel {
 }
 
 /// Handles the `POST /api/github/secret-scanning/verify` route.
-pub fn verify(mut req: ConduitRequest) -> EndpointResult {
+pub fn verify(mut req: ConduitRequest) -> AppResult<Response> {
     let max_size = 8192;
     let length = req
         .content_length()

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -75,7 +75,7 @@ fn is_cache_valid(timestamp: Option<chrono::DateTime<chrono::Utc>>) -> bool {
 }
 
 // Fetches list of public keys from GitHub API
-fn get_public_keys(state: &AppState) -> Result<Vec<GitHubPublicKey>, Box<dyn AppError>> {
+fn get_public_keys(state: &AppState) -> Result<Vec<GitHubPublicKey>, BoxedAppError> {
     // Return list from cache if populated and still valid
     if let Ok(cache) = PUBLIC_KEY_CACHE.lock() {
         if is_cache_valid(cache.timestamp) {
@@ -100,7 +100,7 @@ fn verify_github_signature(
     headers: &HeaderMap,
     state: &AppState,
     json: &[u8],
-) -> Result<(), Box<dyn AppError>> {
+) -> Result<(), BoxedAppError> {
     // Read and decode request headers
     let req_key_id = headers
         .get("GITHUB-PUBLIC-KEY-IDENTIFIER")
@@ -154,7 +154,7 @@ struct GitHubSecretAlert {
 fn alert_revoke_token(
     state: &AppState,
     alert: &GitHubSecretAlert,
-) -> Result<GitHubSecretAlertFeedbackLabel, Box<dyn AppError>> {
+) -> Result<GitHubSecretAlertFeedbackLabel, BoxedAppError> {
     let conn = state.db_write()?;
 
     let hashed_token = SecureToken::hash(&alert.token);
@@ -262,7 +262,7 @@ pub fn verify(mut req: ConduitRequest) -> EndpointResult {
                 label,
             })
         })
-        .collect::<Result<Vec<GitHubSecretAlertFeedback>, Box<dyn AppError>>>()?;
+        .collect::<Result<Vec<GitHubSecretAlertFeedback>, BoxedAppError>>()?;
 
     Ok(req.json(feedback))
 }

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,11 +1,12 @@
-use crate::util::{json_response, EndpointResult};
+use crate::controllers::cargo_prelude::{AppResult, Response};
+use crate::util::json_response;
 use axum::response::IntoResponse;
 
 pub(crate) mod pagination;
 
 pub(crate) use self::pagination::Paginate;
 
-pub fn ok_true() -> EndpointResult {
+pub fn ok_true() -> AppResult<Response> {
     let json = json!({ "ok": true });
     Ok(json_response(json).into_response())
 }

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -10,7 +10,7 @@ use crate::models::Keyword;
 use crate::views::EncodableKeyword;
 
 /// Handles the `GET /keywords` route.
-pub fn index(req: ConduitRequest) -> EndpointResult {
+pub fn index(req: ConduitRequest) -> AppResult<Response> {
     use crate::schema::keywords;
 
     let query = req.query();

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,7 +13,7 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub fn downloads(req: ConduitRequest) -> EndpointResult {
+pub fn downloads(req: ConduitRequest) -> AppResult<Response> {
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -21,7 +21,7 @@ fn follow_target(
 }
 
 /// Handles the `PUT /crates/:crate_id/follow` route.
-pub fn follow(req: ConduitRequest) -> EndpointResult {
+pub fn follow(req: ConduitRequest) -> AppResult<Response> {
     let user_id = AuthCheck::default().check(&req)?.user_id();
     let conn = req.app().db_write()?;
     let follow = follow_target(&req, &conn, user_id)?;
@@ -34,7 +34,7 @@ pub fn follow(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `DELETE /crates/:crate_id/follow` route.
-pub fn unfollow(req: ConduitRequest) -> EndpointResult {
+pub fn unfollow(req: ConduitRequest) -> AppResult<Response> {
     let user_id = AuthCheck::default().check(&req)?.user_id();
     let conn = req.app().db_write()?;
     let follow = follow_target(&req, &conn, user_id)?;
@@ -44,7 +44,7 @@ pub fn unfollow(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/following` route.
-pub fn following(req: ConduitRequest) -> EndpointResult {
+pub fn following(req: ConduitRequest) -> AppResult<Response> {
     use diesel::dsl::exists;
 
     let user_id = AuthCheck::only_cookie().check(&req)?.user_id();

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -263,7 +263,7 @@ impl ShowIncludeMode {
 }
 
 impl FromStr for ShowIncludeMode {
-    type Err = Box<dyn AppError>;
+    type Err = BoxedAppError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut mode = Self {

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,7 +22,7 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub fn summary(req: ConduitRequest) -> EndpointResult {
+pub fn summary(req: ConduitRequest) -> AppResult<Response> {
     use crate::schema::crates::dsl::*;
     use diesel::dsl::all;
 
@@ -125,7 +125,7 @@ pub fn summary(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id` route.
-pub fn show(req: ConduitRequest) -> EndpointResult {
+pub fn show(req: ConduitRequest) -> AppResult<Response> {
     let name = req.param("crate_id").unwrap();
     let include = req
         .query()
@@ -298,7 +298,7 @@ impl FromStr for ShowIncludeMode {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/readme` route.
-pub fn readme(req: ConduitRequest) -> EndpointResult {
+pub fn readme(req: ConduitRequest) -> AppResult<Response> {
     let crate_name = req.param("crate_id").unwrap();
     let version = req.param("version").unwrap();
 
@@ -318,7 +318,7 @@ pub fn readme(req: ConduitRequest) -> EndpointResult {
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub fn versions(req: ConduitRequest) -> EndpointResult {
+pub fn versions(req: ConduitRequest) -> AppResult<Response> {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -346,7 +346,7 @@ pub fn versions(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/reverse_dependencies` route.
-pub fn reverse_dependencies(req: ConduitRequest) -> EndpointResult {
+pub fn reverse_dependencies(req: ConduitRequest) -> AppResult<Response> {
     use diesel::dsl::any;
 
     let pagination_options = PaginationOptions::builder().gather(&req)?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -7,7 +7,7 @@ use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub fn owners(req: ConduitRequest) -> EndpointResult {
+pub fn owners(req: ConduitRequest) -> AppResult<Response> {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -21,7 +21,7 @@ pub fn owners(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub fn owner_team(req: ConduitRequest) -> EndpointResult {
+pub fn owner_team(req: ConduitRequest) -> AppResult<Response> {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -34,7 +34,7 @@ pub fn owner_team(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub fn owner_user(req: ConduitRequest) -> EndpointResult {
+pub fn owner_user(req: ConduitRequest) -> AppResult<Response> {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -47,12 +47,12 @@ pub fn owner_user(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
-pub fn add_owners(mut req: ConduitRequest) -> EndpointResult {
+pub fn add_owners(mut req: ConduitRequest) -> AppResult<Response> {
     modify_owners(&mut req, true)
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
-pub fn remove_owners(mut req: ConduitRequest) -> EndpointResult {
+pub fn remove_owners(mut req: ConduitRequest) -> AppResult<Response> {
     modify_owners(&mut req, false)
 }
 
@@ -78,7 +78,7 @@ fn parse_owners_request(req: &mut ConduitRequest) -> AppResult<Vec<String>> {
         .ok_or_else(|| cargo_err("invalid json request"))
 }
 
-fn modify_owners(req: &mut ConduitRequest, add: bool) -> EndpointResult {
+fn modify_owners(req: &mut ConduitRequest, add: bool) -> AppResult<Response> {
     let crate_name = req.param("crate_id").unwrap();
 
     let auth = AuthCheck::default()

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -42,7 +42,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// Currently blocks the HTTP thread, perhaps some function calls can spawn new
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
-pub fn publish(mut req: ConduitRequest) -> EndpointResult {
+pub fn publish(mut req: ConduitRequest) -> AppResult<Response> {
     let app = req.app().clone();
 
     // The format of the req.body() of a publish request is as follows:

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -38,7 +38,7 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub fn search(req: ConduitRequest) -> EndpointResult {
+pub fn search(req: ConduitRequest) -> AppResult<Response> {
     use diesel::sql_types::{Bool, Text};
 
     let params = req.query();

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -4,7 +4,7 @@ use axum::response::IntoResponse;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
-pub fn prometheus(req: ConduitRequest) -> EndpointResult {
+pub fn prometheus(req: ConduitRequest) -> AppResult<Response> {
     let app = req.app();
 
     if let Some(expected_token) = &app.config.metrics_authorization_token {

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,7 +5,7 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub fn show_team(req: ConduitRequest) -> EndpointResult {
+pub fn show_team(req: ConduitRequest) -> AppResult<Response> {
     use self::teams::dsl::{login, teams};
 
     let name = req.param("team_id").unwrap();

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -9,7 +9,7 @@ use axum::response::IntoResponse;
 use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.
-pub fn list(req: ConduitRequest) -> EndpointResult {
+pub fn list(req: ConduitRequest) -> AppResult<Response> {
     let auth = AuthCheck::only_cookie().check(&req)?;
     let conn = req.app().db_read_prefer_primary()?;
     let user = auth.user();
@@ -23,7 +23,7 @@ pub fn list(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `PUT /me/tokens` route.
-pub fn new(mut req: ConduitRequest) -> EndpointResult {
+pub fn new(mut req: ConduitRequest) -> AppResult<Response> {
     /// The incoming serialization format for the `ApiToken` model.
     #[derive(Deserialize, Serialize)]
     struct NewApiToken {
@@ -78,7 +78,7 @@ pub fn new(mut req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `DELETE /me/tokens/:id` route.
-pub fn revoke(req: ConduitRequest) -> EndpointResult {
+pub fn revoke(req: ConduitRequest) -> AppResult<Response> {
     let id = req
         .param("id")
         .unwrap()
@@ -96,7 +96,7 @@ pub fn revoke(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `DELETE /tokens/current` route.
-pub fn revoke_current(req: ConduitRequest) -> EndpointResult {
+pub fn revoke_current(req: ConduitRequest) -> AppResult<Response> {
     let auth = AuthCheck::default().check(&req)?;
     let api_token_id = auth
         .api_token_id()

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -13,7 +13,7 @@ use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
-pub fn me(req: ConduitRequest) -> EndpointResult {
+pub fn me(req: ConduitRequest) -> AppResult<Response> {
     let user_id = AuthCheck::only_cookie().check(&req)?.user_id();
     let conn = req.app().db_read_prefer_primary()?;
 
@@ -52,7 +52,7 @@ pub fn me(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /me/updates` route.
-pub fn updates(req: ConduitRequest) -> EndpointResult {
+pub fn updates(req: ConduitRequest) -> AppResult<Response> {
     use diesel::dsl::any;
 
     let auth = AuthCheck::only_cookie().check(&req)?;
@@ -93,7 +93,7 @@ pub fn updates(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `PUT /users/:user_id` route.
-pub fn update_user(mut req: ConduitRequest) -> EndpointResult {
+pub fn update_user(mut req: ConduitRequest) -> AppResult<Response> {
     use self::emails::user_id;
     use diesel::insert_into;
 
@@ -162,7 +162,7 @@ pub fn update_user(mut req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `PUT /confirm/:email_token` route
-pub fn confirm_user_email(req: ConduitRequest) -> EndpointResult {
+pub fn confirm_user_email(req: ConduitRequest) -> AppResult<Response> {
     use diesel::update;
 
     let conn = req.app().db_write()?;
@@ -180,7 +180,7 @@ pub fn confirm_user_email(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles `PUT /user/:user_id/resend` route
-pub fn regenerate_token_and_send(req: ConduitRequest) -> EndpointResult {
+pub fn regenerate_token_and_send(req: ConduitRequest) -> AppResult<Response> {
     use diesel::dsl::sql;
     use diesel::update;
 
@@ -216,7 +216,7 @@ pub fn regenerate_token_and_send(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles `PUT /me/email_notifications` route
-pub fn update_email_notifications(mut req: ConduitRequest) -> EndpointResult {
+pub fn update_email_notifications(mut req: ConduitRequest) -> AppResult<Response> {
     use self::crate_owners::dsl::*;
     use diesel::pg::upsert::excluded;
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -132,7 +132,7 @@ pub fn update_user(mut req: ConduitRequest) -> EndpointResult {
 
     let state = req.app();
     let conn = state.db_write()?;
-    conn.transaction::<_, Box<dyn AppError>, _>(|| {
+    conn.transaction::<_, BoxedAppError, _>(|| {
         let new_email = NewEmail {
             user_id: user.id,
             email: user_email,

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,7 +6,7 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub fn show(req: ConduitRequest) -> EndpointResult {
+pub fn show(req: ConduitRequest) -> AppResult<Response> {
     use self::users::dsl::{gh_login, id, users};
 
     let name = lower(req.param("user_id").unwrap());
@@ -20,7 +20,7 @@ pub fn show(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub fn stats(req: ConduitRequest) -> EndpointResult {
+pub fn stats(req: ConduitRequest) -> AppResult<Response> {
     use diesel::dsl::sum;
 
     let user_id = req

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -118,7 +118,7 @@ fn save_user_to_database(
     )
     .create_or_update(user.email.as_deref(), emails, conn)
     .map_err(Into::into)
-    .or_else(|e: Box<dyn AppError>| {
+    .or_else(|e: BoxedAppError| {
         // If we're in read only mode, we can't update their details
         // just look for an existing user
         if e.is::<ReadOnlyMode>() {

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -25,7 +25,7 @@ use crate::util::errors::ReadOnlyMode;
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub fn begin(mut req: ConduitRequest) -> EndpointResult {
+pub fn begin(mut req: ConduitRequest) -> AppResult<Response> {
     let (url, state) = req
         .app()
         .github_oauth
@@ -66,7 +66,7 @@ pub fn begin(mut req: ConduitRequest) -> EndpointResult {
 ///     }
 /// }
 /// ```
-pub fn authorize(mut req: ConduitRequest) -> EndpointResult {
+pub fn authorize(mut req: ConduitRequest) -> AppResult<Response> {
     // Parse the url query
     let mut query = req.query();
     let code = query.remove("code").unwrap_or_default();
@@ -134,7 +134,7 @@ fn save_user_to_database(
 }
 
 /// Handles the `DELETE /api/private/session` route.
-pub fn logout(mut req: ConduitRequest) -> EndpointResult {
+pub fn logout(mut req: ConduitRequest) -> AppResult<Response> {
     req.session_remove("user_id");
     Ok(req.json(true))
 }

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -12,7 +12,7 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub fn index(req: ConduitRequest) -> EndpointResult {
+pub fn index(req: ConduitRequest) -> AppResult<Response> {
     use diesel::dsl::any;
     let conn = req.app().db_read()?;
 
@@ -51,7 +51,7 @@ pub fn index(req: ConduitRequest) -> EndpointResult {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub fn show_by_id(req: ConduitRequest) -> EndpointResult {
+pub fn show_by_id(req: ConduitRequest) -> AppResult<Response> {
     let id = req.param("version_id").unwrap();
     let id = id.parse().unwrap_or(0);
     let conn = req.app().db_read()?;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -13,7 +13,7 @@ use chrono::{Duration, NaiveDate, Utc};
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
-pub fn download(req: ConduitRequest) -> EndpointResult {
+pub fn download(req: ConduitRequest) -> AppResult<Response> {
     let app = req.app();
 
     let mut crate_name = req.param("crate_id").unwrap().to_string();
@@ -116,7 +116,7 @@ pub fn download(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
-pub fn downloads(req: ConduitRequest) -> EndpointResult {
+pub fn downloads(req: ConduitRequest) -> AppResult<Response> {
     let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
 
     let conn = req.app().db_read()?;

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -18,7 +18,7 @@ use super::{extract_crate_name_and_semver, version_and_crate};
 /// In addition to returning cached data from the index, this returns
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
-pub fn dependencies(req: ConduitRequest) -> EndpointResult {
+pub fn dependencies(req: ConduitRequest) -> AppResult<Response> {
     let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
     let conn = req.app().db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
@@ -32,7 +32,7 @@ pub fn dependencies(req: ConduitRequest) -> EndpointResult {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
-pub fn authors(req: ConduitRequest) -> EndpointResult {
+pub fn authors(req: ConduitRequest) -> AppResult<Response> {
     // Currently we return the empty list.
     // Because the API is not used anymore after RFC https://github.com/rust-lang/rfcs/pull/3052.
 
@@ -46,7 +46,7 @@ pub fn authors(req: ConduitRequest) -> EndpointResult {
 ///
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
-pub fn show(req: ConduitRequest) -> EndpointResult {
+pub fn show(req: ConduitRequest) -> AppResult<Response> {
     let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
     let conn = req.app().db_read()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -19,17 +19,17 @@ use crate::worker;
 /// Crate deletion is not implemented to avoid breaking builds,
 /// and the goal of yanking a crate is to prevent crates
 /// beginning to depend on the yanked crate version.
-pub fn yank(req: ConduitRequest) -> EndpointResult {
+pub fn yank(req: ConduitRequest) -> AppResult<Response> {
     modify_yank(&req, true)
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
-pub fn unyank(req: ConduitRequest) -> EndpointResult {
+pub fn unyank(req: ConduitRequest) -> AppResult<Response> {
     modify_yank(&req, false)
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank(req: &ConduitRequest, yanked: bool) -> EndpointResult {
+fn modify_yank(req: &ConduitRequest, yanked: bool) -> AppResult<Response> {
     // FIXME: Should reject bad requests before authentication, but can't due to
     // lifetime issues with `req`.
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -8,7 +8,7 @@ use serde::de::DeserializeOwned;
 use std::str;
 
 use crate::controllers::github::secret_scanning::{GitHubPublicKey, GitHubPublicKeyList};
-use crate::util::errors::{cargo_err, internal, not_found, AppError, AppResult};
+use crate::util::errors::{cargo_err, internal, not_found, AppResult, BoxedAppError};
 use reqwest::blocking::Client;
 
 pub trait GitHubClient: Send + Sync {
@@ -152,7 +152,7 @@ impl GitHubClient for RealGitHubClient {
     }
 }
 
-fn handle_error_response(error: &reqwest::Error) -> Box<dyn AppError> {
+fn handle_error_response(error: &reqwest::Error) -> BoxedAppError {
     use reqwest::StatusCode as Status;
 
     match error.status() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
-use errors::BoxedAppError;
+use errors::AppResult;
 
 pub mod errors;
 mod io_util;
@@ -15,7 +15,7 @@ pub mod token;
 pub mod tracing;
 
 pub type AppResponse = axum::response::Response;
-pub type EndpointResult = Result<AppResponse, BoxedAppError>;
+pub type EndpointResult = AppResult<AppResponse>;
 
 /// Serialize a value to JSON and build a status 200 Response
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 
+use axum::response::Response;
 use axum::Json;
 use serde::Serialize;
 
@@ -14,8 +15,7 @@ pub mod rfc3339;
 pub mod token;
 pub mod tracing;
 
-pub type AppResponse = axum::response::Response;
-pub type EndpointResult = AppResult<AppResponse>;
+pub type EndpointResult = AppResult<Response>;
 
 /// Serialize a value to JSON and build a status 200 Response
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,12 +1,10 @@
 use std::cmp;
 
-use axum::response::Response;
 use axum::Json;
 use serde::Serialize;
 
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
-use errors::AppResult;
 
 pub mod errors;
 mod io_util;
@@ -14,8 +12,6 @@ mod request_helpers;
 pub mod rfc3339;
 pub mod token;
 pub mod tracing;
-
-pub type EndpointResult = AppResult<Response>;
 
 /// Serialize a value to JSON and build a status 200 Response
 ///

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
+use errors::BoxedAppError;
 
 pub mod errors;
 mod io_util;
@@ -14,7 +15,7 @@ pub mod token;
 pub mod tracing;
 
 pub type AppResponse = axum::response::Response;
-pub type EndpointResult = Result<AppResponse, Box<dyn errors::AppError>>;
+pub type EndpointResult = Result<AppResponse, BoxedAppError>;
 
 /// Serialize a value to JSON and build a status 200 Response
 ///

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -2,7 +2,7 @@ use axum::response::{IntoResponse, Response};
 use axum::Json;
 use std::fmt;
 
-use super::{AppError, InternalAppErrorStatic};
+use super::{AppError, BoxedAppError, InternalAppErrorStatic};
 
 use chrono::NaiveDateTime;
 use http::{header, StatusCode};
@@ -157,7 +157,7 @@ impl fmt::Display for TooManyRequests {
 pub struct InsecurelyGeneratedTokenRevoked;
 
 impl InsecurelyGeneratedTokenRevoked {
-    pub fn boxed() -> Box<dyn AppError> {
+    pub fn boxed() -> BoxedAppError {
         Box::new(Self)
     }
 }


### PR DESCRIPTION
This PR creates a new `BoxedAppError` type alias, and in return it gets rid of the `AppResponse` and `EndpointResult` type aliases. This makes it a little more obvious what types our request handlers are returning, which will be relevant for the next PR 😉 