### PR TITLE
Allow request handlers to return any `impl IntoResponse`

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -14,6 +14,7 @@ mod prelude {
     pub use axum::response::{IntoResponse, Response};
     pub use axum::Json;
     pub use diesel::prelude::*;
+    pub use serde_json::Value;
 
     pub use conduit_axum::ConduitRequest;
     pub use http::{header, StatusCode};

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -12,6 +12,7 @@ mod prelude {
     pub use super::helpers::ok_true;
     pub use super::util::RequestParamExt;
     pub use axum::response::{IntoResponse, Response};
+    pub use axum::Json;
     pub use diesel::prelude::*;
 
     pub use conduit_axum::ConduitRequest;
@@ -29,7 +30,7 @@ mod prelude {
         }
 
         fn json<T: Serialize>(&self, t: T) -> Response {
-            crate::util::json_response(t).into_response()
+            Json(t).into_response()
         }
 
         fn query(&self) -> IndexMap<String, String>;

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,6 +1,6 @@
 use crate::controllers::cargo_prelude::{AppResult, Response};
-use crate::util::json_response;
 use axum::response::IntoResponse;
+use axum::Json;
 
 pub(crate) mod pagination;
 
@@ -8,5 +8,5 @@ pub(crate) use self::pagination::Paginate;
 
 pub fn ok_true() -> AppResult<Response> {
     let json = json!({ "ok": true });
-    Ok(json_response(json).into_response())
+    Ok(Json(json).into_response())
 }

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -32,14 +32,14 @@ pub fn dependencies(req: ConduitRequest) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
-pub fn authors(req: ConduitRequest) -> AppResult<Response> {
+pub fn authors(_req: ConduitRequest) -> Json<Value> {
     // Currently we return the empty list.
     // Because the API is not used anymore after RFC https://github.com/rust-lang/rfcs/pull/3052.
 
-    Ok(req.json(json!({
+    Json(json!({
         "users": [],
         "meta": { "names": [] },
-    })))
+    }))
 }
 
 /// Handles the `GET /crates/:crate/:version` route.

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -12,6 +12,8 @@ pub mod session;
 mod static_or_continue;
 mod update_metrics;
 
+use app::add_app_state_extension;
+
 use ::sentry::integrations::tower as sentry_tower;
 use axum::error_handling::HandleErrorLayer;
 use axum::middleware::{from_fn, from_fn_with_state};
@@ -72,6 +74,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
         .option_layer(
             (env != Env::Test).then(|| from_fn_with_state(state.clone(), ember_html::serve_html)),
         )
+        .layer(from_fn_with_state(state.clone(), add_app_state_extension))
         // This is currently the final middleware to run. If a middleware layer requires a database
         // connection, it should be run after this middleware so that the potential pool usage can be
         // tracked here.

--- a/src/router.rs
+++ b/src/router.rs
@@ -9,8 +9,6 @@ use crate::util::errors::{not_found, AppResult};
 use crate::Env;
 
 pub fn build_axum_router(state: AppState) -> Router {
-    let conduit = |handler| ConduitAxumHandler::wrap(C(handler));
-
     let mut router = Router::new()
         // Route used by both `cargo search` and the frontend
         .route("/api/v1/crates", get(conduit(krate::search::search)))
@@ -192,6 +190,10 @@ pub fn build_axum_router(state: AppState) -> Router {
     router
         .fallback(|| async { not_found().into_response() })
         .with_state(state)
+}
+
+fn conduit(handler: fn(ConduitRequest) -> AppResult<Response>) -> ConduitAxumHandler<C> {
+    ConduitAxumHandler::wrap(C(handler))
 }
 
 struct C(pub fn(ConduitRequest) -> AppResult<Response>);

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,11 +1,11 @@
-use axum::response::{IntoResponse, Response};
+use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::Router;
 use conduit_axum::{ConduitAxumHandler, ConduitRequest, Handler, HandlerResult};
 
 use crate::app::AppState;
 use crate::controllers::*;
-use crate::util::errors::{not_found, AppResult};
+use crate::util::errors::not_found;
 use crate::Env;
 
 pub fn build_axum_router(state: AppState) -> Router {
@@ -192,19 +192,18 @@ pub fn build_axum_router(state: AppState) -> Router {
         .with_state(state)
 }
 
-fn conduit(handler: fn(ConduitRequest) -> AppResult<Response>) -> ConduitAxumHandler<C> {
+fn conduit<R: IntoResponse + 'static>(
+    handler: fn(ConduitRequest) -> R,
+) -> ConduitAxumHandler<C<R>> {
     ConduitAxumHandler::wrap(C(handler))
 }
 
-struct C(pub fn(ConduitRequest) -> AppResult<Response>);
+struct C<R>(pub fn(ConduitRequest) -> R);
 
-impl Handler for C {
+impl<R: IntoResponse + 'static> Handler for C<R> {
     fn call(&self, req: ConduitRequest) -> HandlerResult {
         let C(f) = *self;
-        match f(req) {
-            Ok(resp) => resp,
-            Err(e) => e.into_response(),
-        }
+        f(req).into_response()
     }
 }
 
@@ -227,6 +226,8 @@ mod tests {
 
     #[test]
     fn http_error_responses() {
+        type R = AppResult<()>;
+
         let req = || {
             let mut req = MockRequest::new(Method::GET, "/").into_inner();
             req.extensions_mut().insert(CustomMetadata::default());
@@ -235,37 +236,38 @@ mod tests {
 
         // Types for handling common error status codes
         assert_eq!(
-            C(|_| Err(bad_request(""))).call(req()).status(),
+            C(|_| R::Err(bad_request(""))).call(req()).status(),
             StatusCode::BAD_REQUEST
         );
         assert_eq!(
-            C(|_| Err(forbidden())).call(req()).status(),
+            C(|_| R::Err(forbidden())).call(req()).status(),
             StatusCode::FORBIDDEN
         );
         assert_eq!(
-            C(|_| Err(DieselError::NotFound.into()))
+            C(|_| R::Err(DieselError::NotFound.into()))
                 .call(req())
                 .status(),
             StatusCode::NOT_FOUND
         );
         assert_eq!(
-            C(|_| Err(not_found())).call(req()).status(),
+            C(|_| R::Err(not_found())).call(req()).status(),
             StatusCode::NOT_FOUND
         );
 
         // cargo_err errors are returned as 200 so that cargo displays this nicely on the command line
         assert_eq!(
-            C(|_| Err(cargo_err(""))).call(req()).status(),
+            C(|_| R::Err(cargo_err(""))).call(req()).status(),
             StatusCode::OK
         );
 
         // Inner errors are captured for logging when wrapped by a user facing error
         let response = C(|_| {
-            Err("-1"
-                .parse::<u8>()
-                .map_err(|err| err.chain(internal("middle error")))
-                .map_err(|err| err.chain(bad_request("outer user facing error")))
-                .unwrap_err())
+            R::Err(
+                "-1".parse::<u8>()
+                    .map_err(|err| err.chain(internal("middle error")))
+                    .map_err(|err| err.chain(bad_request("outer user facing error")))
+                    .unwrap_err(),
+            )
         })
         .call(req());
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -276,7 +278,7 @@ mod tests {
 
         // All other error types are converted to internal server errors
         assert_eq!(
-            C(|_| Err(internal(""))).call(req()).status(),
+            C(|_| R::Err(internal(""))).call(req()).status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
         assert_eq!(

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,5 +1,3 @@
-use axum::handler::Handler as AxumHandler;
-use axum::middleware::from_fn_with_state;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post, put};
 use axum::Router;
@@ -7,15 +5,11 @@ use conduit_axum::{ConduitAxumHandler, ConduitRequest, Handler, HandlerResult};
 
 use crate::app::AppState;
 use crate::controllers::*;
-use crate::middleware::app::add_app_state_extension;
 use crate::util::errors::{not_found, AppResult};
 use crate::Env;
 
 pub fn build_axum_router(state: AppState) -> Router {
-    let conduit = |handler| {
-        ConduitAxumHandler::wrap(C(handler))
-            .layer(from_fn_with_state(state.clone(), add_app_state_extension))
-    };
+    let conduit = |handler| ConduitAxumHandler::wrap(C(handler));
 
     let mut router = Router::new()
         // Route used by both `cargo search` and the frontend

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,5 @@
 use std::cmp;
 
-use axum::Json;
-use serde::Serialize;
-
 pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
 pub use self::request_helpers::*;
 
@@ -12,17 +9,6 @@ mod request_helpers;
 pub mod rfc3339;
 pub mod token;
 pub mod tracing;
-
-/// Serialize a value to JSON and build a status 200 Response
-///
-/// This helper sets appropriate values for `Content-Type` and `Content-Length`.
-///
-/// # Panics
-///
-/// This function will panic if serialization fails.
-pub fn json_response<T: Serialize>(t: T) -> Json<T> {
-    Json(t)
-}
 
 #[derive(Debug, Copy, Clone)]
 pub struct Maximums {


### PR DESCRIPTION
This PR finally makes the return types of our own request handlers compatible with the native ones from `axum`.

In other words: our own request handlers can now return `impl IntoResponse` 🎉 