### PR TITLE
RequestUtils: Replace `json()` fn with direct `axum::Json` usage

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -23,15 +23,10 @@ mod prelude {
     pub use crate::middleware::app::RequestApp;
     pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError};
     use indexmap::IndexMap;
-    use serde::Serialize;
 
     pub trait RequestUtils {
         fn redirect(&self, url: String) -> Response {
             (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
-        }
-
-        fn json<T: Serialize>(&self, t: T) -> Response {
-            Json(t).into_response()
         }
 
         fn query(&self) -> IndexMap<String, String>;

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub fn index(req: ConduitRequest) -> AppResult<Response> {
+pub fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
     let query = req.query();
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
@@ -26,14 +26,14 @@ pub fn index(req: ConduitRequest) -> AppResult<Response> {
     // Query for the total count of categories
     let total = Category::count_toplevel(&conn)?;
 
-    Ok(req.json(json!({
+    Ok(Json(json!({
         "categories": categories,
         "meta": { "total": total },
     })))
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub fn show(req: ConduitRequest) -> AppResult<Response> {
+pub fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
     let slug = req.param("category_id").unwrap();
     let conn = req.app().db_read()?;
     let cat: Category = Category::by_slug(slug).first(&*conn)?;
@@ -60,11 +60,11 @@ pub fn show(req: ConduitRequest) -> AppResult<Response> {
         parent_categories: parents,
     };
 
-    Ok(req.json(json!({ "category": cat_with_subcats })))
+    Ok(Json(json!({ "category": cat_with_subcats })))
 }
 
 /// Handles the `GET /category_slugs` route.
-pub fn slugs(req: ConduitRequest) -> AppResult<Response> {
+pub fn slugs(req: ConduitRequest) -> AppResult<Json<Value>> {
     let conn = req.app().db_read()?;
     let slugs: Vec<Slug> = categories::table
         .select((categories::slug, categories::slug, categories::description))
@@ -78,5 +78,5 @@ pub fn slugs(req: ConduitRequest) -> AppResult<Response> {
         description: String,
     }
 
-    Ok(req.json(json!({ "category_slugs": slugs })))
+    Ok(Json(json!({ "category_slugs": slugs })))
 }

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -232,7 +232,7 @@ pub enum GitHubSecretAlertFeedbackLabel {
 }
 
 /// Handles the `POST /api/github/secret-scanning/verify` route.
-pub fn verify(mut req: ConduitRequest) -> AppResult<Response> {
+pub fn verify(mut req: ConduitRequest) -> AppResult<Json<Vec<GitHubSecretAlertFeedback>>> {
     let max_size = 8192;
     let length = req
         .content_length()
@@ -262,9 +262,9 @@ pub fn verify(mut req: ConduitRequest) -> AppResult<Response> {
                 label,
             })
         })
-        .collect::<Result<Vec<GitHubSecretAlertFeedback>, BoxedAppError>>()?;
+        .collect::<Result<_, BoxedAppError>>()?;
 
-    Ok(req.json(feedback))
+    Ok(Json(feedback))
 }
 
 #[cfg(test)]

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -10,7 +10,7 @@ use crate::models::Keyword;
 use crate::views::EncodableKeyword;
 
 /// Handles the `GET /keywords` route.
-pub fn index(req: ConduitRequest) -> AppResult<Response> {
+pub fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
     use crate::schema::keywords;
 
     let query = req.query();
@@ -33,7 +33,7 @@ pub fn index(req: ConduitRequest) -> AppResult<Response> {
         .map(Keyword::into)
         .collect::<Vec<EncodableKeyword>>();
 
-    Ok(req.json(json!({
+    Ok(Json(json!({
         "keywords": kws,
         "meta": { "total": total },
     })))

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,7 +13,7 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub fn downloads(req: ConduitRequest) -> AppResult<Response> {
+pub fn downloads(req: ConduitRequest) -> AppResult<Json<Value>> {
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 
@@ -50,7 +50,7 @@ pub fn downloads(req: ConduitRequest) -> AppResult<Response> {
         downloads: i64,
     }
 
-    Ok(req.json(json!({
+    Ok(Json(json!({
         "version_downloads": downloads,
         "meta": {
             "extra_downloads": extra,

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -44,7 +44,7 @@ pub fn unfollow(req: ConduitRequest) -> AppResult<Response> {
 }
 
 /// Handles the `GET /crates/:crate_id/following` route.
-pub fn following(req: ConduitRequest) -> AppResult<Response> {
+pub fn following(req: ConduitRequest) -> AppResult<Json<Value>> {
     use diesel::dsl::exists;
 
     let user_id = AuthCheck::only_cookie().check(&req)?.user_id();
@@ -53,5 +53,5 @@ pub fn following(req: ConduitRequest) -> AppResult<Response> {
     let following =
         diesel::select(exists(follows::table.find(follow.id()))).get_result::<bool>(&*conn)?;
 
-    Ok(req.json(json!({ "following": following })))
+    Ok(Json(json!({ "following": following })))
 }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -7,7 +7,7 @@ use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub fn owners(req: ConduitRequest) -> AppResult<Response> {
+pub fn owners(req: ConduitRequest) -> AppResult<Json<Value>> {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -17,11 +17,11 @@ pub fn owners(req: ConduitRequest) -> AppResult<Response> {
         .map(Owner::into)
         .collect::<Vec<EncodableOwner>>();
 
-    Ok(req.json(json!({ "users": owners })))
+    Ok(Json(json!({ "users": owners })))
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub fn owner_team(req: ConduitRequest) -> AppResult<Response> {
+pub fn owner_team(req: ConduitRequest) -> AppResult<Json<Value>> {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -30,11 +30,11 @@ pub fn owner_team(req: ConduitRequest) -> AppResult<Response> {
         .map(Owner::into)
         .collect::<Vec<EncodableOwner>>();
 
-    Ok(req.json(json!({ "teams": owners })))
+    Ok(Json(json!({ "teams": owners })))
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub fn owner_user(req: ConduitRequest) -> AppResult<Response> {
+pub fn owner_user(req: ConduitRequest) -> AppResult<Json<Value>> {
     let crate_name = req.param("crate_id").unwrap();
     let conn = req.app().db_read()?;
     let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
@@ -43,16 +43,16 @@ pub fn owner_user(req: ConduitRequest) -> AppResult<Response> {
         .map(Owner::into)
         .collect::<Vec<EncodableOwner>>();
 
-    Ok(req.json(json!({ "users": owners })))
+    Ok(Json(json!({ "users": owners })))
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
-pub fn add_owners(mut req: ConduitRequest) -> AppResult<Response> {
+pub fn add_owners(mut req: ConduitRequest) -> AppResult<Json<Value>> {
     modify_owners(&mut req, true)
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
-pub fn remove_owners(mut req: ConduitRequest) -> AppResult<Response> {
+pub fn remove_owners(mut req: ConduitRequest) -> AppResult<Json<Value>> {
     modify_owners(&mut req, false)
 }
 
@@ -78,7 +78,7 @@ fn parse_owners_request(req: &mut ConduitRequest) -> AppResult<Vec<String>> {
         .ok_or_else(|| cargo_err("invalid json request"))
 }
 
-fn modify_owners(req: &mut ConduitRequest, add: bool) -> AppResult<Response> {
+fn modify_owners(req: &mut ConduitRequest, add: bool) -> AppResult<Json<Value>> {
     let crate_name = req.param("crate_id").unwrap();
 
     let auth = AuthCheck::default()
@@ -136,6 +136,6 @@ fn modify_owners(req: &mut ConduitRequest, add: bool) -> AppResult<Response> {
             "owners successfully removed".to_owned()
         };
 
-        Ok(req.json(json!({ "ok": true, "msg": comma_sep_msg })))
+        Ok(Json(json!({ "ok": true, "msg": comma_sep_msg })))
     })
 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -42,7 +42,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// Currently blocks the HTTP thread, perhaps some function calls can spawn new
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
-pub fn publish(mut req: ConduitRequest) -> AppResult<Response> {
+pub fn publish(mut req: ConduitRequest) -> AppResult<Json<GoodCrate>> {
     let app = req.app().clone();
 
     // The format of the req.body() of a publish request is as follows:
@@ -279,7 +279,7 @@ pub fn publish(mut req: ConduitRequest) -> AppResult<Response> {
             other: vec![],
         };
 
-        Ok(req.json(GoodCrate {
+        Ok(Json(GoodCrate {
             krate: EncodableCrate::from_minimal(krate, Some(&top_versions), None, false, None),
             warnings,
         }))

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -38,7 +38,7 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub fn search(req: ConduitRequest) -> AppResult<Response> {
+pub fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
     use diesel::sql_types::{Bool, Text};
 
     let params = req.query();
@@ -336,7 +336,7 @@ pub fn search(req: ConduitRequest) -> AppResult<Response> {
         )
         .collect::<Vec<_>>();
 
-    Ok(req.json(json!({
+    Ok(Json(json!({
         "crates": crates,
         "meta": {
             "total": total,

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,12 +5,12 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub fn show_team(req: ConduitRequest) -> AppResult<Response> {
+pub fn show_team(req: ConduitRequest) -> AppResult<Json<Value>> {
     use self::teams::dsl::{login, teams};
 
     let name = req.param("team_id").unwrap();
     let conn = req.app().db_read()?;
     let team: Team = teams.filter(login.eq(name)).first(&*conn)?;
 
-    Ok(req.json(json!({ "team": EncodableTeam::from(team) })))
+    Ok(Json(json!({ "team": EncodableTeam::from(team) })))
 }

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -13,7 +13,7 @@ use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
-pub fn me(req: ConduitRequest) -> AppResult<Response> {
+pub fn me(req: ConduitRequest) -> AppResult<Json<EncodableMe>> {
     let user_id = AuthCheck::only_cookie().check(&req)?.user_id();
     let conn = req.app().db_read_prefer_primary()?;
 
@@ -45,14 +45,14 @@ pub fn me(req: ConduitRequest) -> AppResult<Response> {
 
     let verified = verified.unwrap_or(false);
     let verification_sent = verified || verification_sent;
-    Ok(req.json(EncodableMe {
+    Ok(Json(EncodableMe {
         user: EncodablePrivateUser::from(user, email, verified, verification_sent),
         owned_crates,
     }))
 }
 
 /// Handles the `GET /me/updates` route.
-pub fn updates(req: ConduitRequest) -> AppResult<Response> {
+pub fn updates(req: ConduitRequest) -> AppResult<Json<Value>> {
     use diesel::dsl::any;
 
     let auth = AuthCheck::only_cookie().check(&req)?;
@@ -86,7 +86,7 @@ pub fn updates(req: ConduitRequest) -> AppResult<Response> {
         })
         .collect::<Vec<_>>();
 
-    Ok(req.json(json!({
+    Ok(Json(json!({
         "versions": versions,
         "meta": { "more": more },
     })))

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,7 +6,7 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub fn show(req: ConduitRequest) -> AppResult<Response> {
+pub fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
     use self::users::dsl::{gh_login, id, users};
 
     let name = lower(req.param("user_id").unwrap());
@@ -16,11 +16,11 @@ pub fn show(req: ConduitRequest) -> AppResult<Response> {
         .order(id.desc())
         .first(&*conn)?;
 
-    Ok(req.json(json!({ "user": EncodablePublicUser::from(user) })))
+    Ok(Json(json!({ "user": EncodablePublicUser::from(user) })))
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub fn stats(req: ConduitRequest) -> AppResult<Response> {
+pub fn stats(req: ConduitRequest) -> AppResult<Json<Value>> {
     use diesel::dsl::sum;
 
     let user_id = req
@@ -37,5 +37,5 @@ pub fn stats(req: ConduitRequest) -> AppResult<Response> {
         .first::<Option<i64>>(&*conn)?
         .unwrap_or(0);
 
-    Ok(req.json(json!({ "total_downloads": data })))
+    Ok(Json(json!({ "total_downloads": data })))
 }

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -12,7 +12,7 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub fn index(req: ConduitRequest) -> AppResult<Response> {
+pub fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
     use diesel::dsl::any;
     let conn = req.app().db_read()?;
 
@@ -45,13 +45,13 @@ pub fn index(req: ConduitRequest) -> AppResult<Response> {
         })
         .collect::<Vec<_>>();
 
-    Ok(req.json(json!({ "versions": versions })))
+    Ok(Json(json!({ "versions": versions })))
 }
 
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub fn show_by_id(req: ConduitRequest) -> AppResult<Response> {
+pub fn show_by_id(req: ConduitRequest) -> AppResult<Json<Value>> {
     let id = req.param("version_id").unwrap();
     let id = id.parse().unwrap_or(0);
     let conn = req.app().db_read()?;
@@ -68,5 +68,5 @@ pub fn show_by_id(req: ConduitRequest) -> AppResult<Response> {
     let audit_actions = VersionOwnerAction::by_version(&conn, &version)?;
 
     let version = EncodableVersion::from(version, &krate.name, published_by, audit_actions);
-    Ok(req.json(json!({ "version": version })))
+    Ok(Json(json!({ "version": version })))
 }

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -109,14 +109,14 @@ pub fn download(req: ConduitRequest) -> AppResult<Response> {
     }
 
     if req.wants_json() {
-        Ok(req.json(json!({ "url": redirect_url })))
+        Ok(Json(json!({ "url": redirect_url })).into_response())
     } else {
         Ok(req.redirect(redirect_url))
     }
 }
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
-pub fn downloads(req: ConduitRequest) -> AppResult<Response> {
+pub fn downloads(req: ConduitRequest) -> AppResult<Json<Value>> {
     let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
 
     let conn = req.app().db_read()?;
@@ -137,5 +137,5 @@ pub fn downloads(req: ConduitRequest) -> AppResult<Response> {
         .map(VersionDownload::into)
         .collect::<Vec<EncodableVersionDownload>>();
 
-    Ok(req.json(json!({ "version_downloads": downloads })))
+    Ok(Json(json!({ "version_downloads": downloads })))
 }

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -18,7 +18,7 @@ use super::{extract_crate_name_and_semver, version_and_crate};
 /// In addition to returning cached data from the index, this returns
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
-pub fn dependencies(req: ConduitRequest) -> AppResult<Response> {
+pub fn dependencies(req: ConduitRequest) -> AppResult<Json<Value>> {
     let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
     let conn = req.app().db_read()?;
     let (version, _) = version_and_crate(&conn, crate_name, semver)?;
@@ -28,7 +28,7 @@ pub fn dependencies(req: ConduitRequest) -> AppResult<Response> {
         .map(|(dep, crate_name)| EncodableDependency::from_dep(dep, &crate_name))
         .collect::<Vec<_>>();
 
-    Ok(req.json(json!({ "dependencies": deps })))
+    Ok(Json(json!({ "dependencies": deps })))
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
@@ -46,7 +46,7 @@ pub fn authors(_req: ConduitRequest) -> Json<Value> {
 ///
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
-pub fn show(req: ConduitRequest) -> AppResult<Response> {
+pub fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
     let (crate_name, semver) = extract_crate_name_and_semver(&req)?;
     let conn = req.app().db_read()?;
     let (version, krate) = version_and_crate(&conn, crate_name, semver)?;
@@ -54,5 +54,5 @@ pub fn show(req: ConduitRequest) -> AppResult<Response> {
     let actions = VersionOwnerAction::by_version(&conn, &version)?;
 
     let version = EncodableVersion::from(version, &krate.name, published_by, actions);
-    Ok(req.json(json!({ "version": version })))
+    Ok(Json(json!({ "version": version })))
 }


### PR DESCRIPTION
This PR brings us a little closer to how request handlers with `axum` normally look like :)