### PR TITLE
ConduitRequest: Convert into struct with `FromRequest` implementation

### DIFF
--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -1,11 +1,10 @@
 use axum::body::Bytes;
 use std::error::Error;
 use std::io::Cursor;
+use std::ops::{Deref, DerefMut};
 
 use crate::response::AxumResponse;
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
-
-pub type ConduitRequest = Request<Cursor<Bytes>>;
 
 pub type BoxError = Box<dyn Error + Send>;
 pub type HandlerResult = AxumResponse;
@@ -23,6 +22,23 @@ pub type HandlerResult = AxumResponse;
 /// ```
 pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
     Box::new(error)
+}
+
+#[derive(Debug)]
+pub struct ConduitRequest(pub Request<Cursor<Bytes>>);
+
+impl Deref for ConduitRequest {
+    type Target = Request<Cursor<Bytes>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ConduitRequest {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 /// A Handler takes a request and returns a response or an error.

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -1,9 +1,16 @@
+use axum::async_trait;
 use axum::body::Bytes;
+use axum::extract::rejection::PathRejection;
+use axum::extract::{FromRequest, FromRequestParts};
+use axum::response::IntoResponse;
+use hyper::Body;
 use std::error::Error;
 use std::io::Cursor;
 use std::ops::{Deref, DerefMut};
 
+use crate::fallback::{check_content_length, Params};
 use crate::response::AxumResponse;
+use crate::server_error_response;
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
 pub type BoxError = Box<dyn Error + Send>;
@@ -38,6 +45,38 @@ impl Deref for ConduitRequest {
 impl DerefMut for ConduitRequest {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
+    }
+}
+
+#[async_trait]
+impl<S> FromRequest<S, Body> for ConduitRequest
+where
+    S: Send + Sync,
+{
+    type Rejection = AxumResponse;
+
+    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
+        check_content_length(&req)?;
+
+        let (mut parts, body) = req.into_parts();
+
+        // Make `axum::Router` path params available to `conduit` compat
+        // handlers. (see [RequestParamsExt] below)
+        match Params::from_request_parts(&mut parts, state).await {
+            Ok(path) => {
+                parts.extensions.insert(path);
+            }
+            Err(PathRejection::MissingPathParams(_)) => {}
+            Err(err) => return Err(err.into_response()),
+        };
+
+        let full_body = match hyper::body::to_bytes(body).await {
+            Ok(body) => body,
+            Err(err) => return Err(server_error_response(&err)),
+        };
+
+        let request = Request::from_parts(parts, Cursor::new(full_body));
+        Ok(ConduitRequest(request))
     }
 }
 

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -70,6 +70,7 @@ where
             };
 
             let request = Request::from_parts(parts, Cursor::new(full_body));
+            let request = ConduitRequest(request);
 
             let Self(handler) = self;
             spawn_blocking(move || handler.call(request))

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -307,10 +307,8 @@ pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> AppResult<D
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::body::Bytes;
     use conduit_test::MockRequest;
-    use http::{Request, StatusCode};
-    use std::io::Cursor;
+    use http::StatusCode;
 
     #[test]
     fn no_pagination_param() {
@@ -411,9 +409,9 @@ mod tests {
         );
     }
 
-    fn mock(query: &str) -> Request<Cursor<Bytes>> {
+    fn mock(query: &str) -> ConduitRequest {
         let path_and_query = format!("/?{query}");
-        MockRequest::new(http::Method::GET, &path_and_query).into_inner()
+        ConduitRequest(MockRequest::new(http::Method::GET, &path_and_query).into_inner())
     }
 
     fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {

--- a/src/router.rs
+++ b/src/router.rs
@@ -231,7 +231,7 @@ mod tests {
         let req = || {
             let mut req = MockRequest::new(Method::GET, "/").into_inner();
             req.extensions_mut().insert(CustomMetadata::default());
-            req
+            ConduitRequest(req)
         };
 
         // Types for handling common error status codes


### PR DESCRIPTION
This will allow us to use `ConduitRequest` also in regular `axum` request handlers 😁 