### PR TITLE
conduit_compat(): Remove unnecessary `into_response()` calls

### DIFF
--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -1,7 +1,6 @@
 use super::prelude::*;
 use crate::app::AppState;
 use axum::extract::{Path, State};
-use axum::response::IntoResponse;
 use axum::Json;
 
 use crate::controllers::helpers::pagination::PaginationOptions;
@@ -40,7 +39,10 @@ pub fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /keywords/:keyword_id` route.
-pub async fn show(Path(name): Path<String>, State(state): State<AppState>) -> impl IntoResponse {
+pub async fn show(
+    Path(name): Path<String>,
+    State(state): State<AppState>,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -23,6 +23,7 @@ use chrono::NaiveDateTime;
 use conduit_axum::{CauseField, ErrorField};
 use diesel::result::Error as DieselError;
 use http::StatusCode;
+use tokio::task::JoinError;
 
 use crate::db::PoolError;
 
@@ -269,6 +270,12 @@ impl From<std::io::Error> for BoxedAppError {
 
 impl From<crate::swirl::errors::EnqueueError> for BoxedAppError {
     fn from(err: crate::swirl::errors::EnqueueError) -> BoxedAppError {
+        Box::new(err)
+    }
+}
+
+impl From<JoinError> for BoxedAppError {
+    fn from(err: JoinError) -> BoxedAppError {
         Box::new(err)
     }
 }


### PR DESCRIPTION
Instead of dealing with axum responses we can use `AppResult`, which implements `IntoResponse` these days :)