### PR TITLE
Convert all request handlers to async functions

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -70,19 +70,22 @@ pub async fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /category_slugs` route.
-pub fn slugs(req: ConduitRequest) -> AppResult<Json<Value>> {
-    let conn = req.app().db_read()?;
-    let slugs: Vec<Slug> = categories::table
-        .select((categories::slug, categories::slug, categories::description))
-        .order(categories::slug)
-        .load(&*conn)?;
+pub async fn slugs(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        let conn = req.app().db_read()?;
+        let slugs: Vec<Slug> = categories::table
+            .select((categories::slug, categories::slug, categories::description))
+            .order(categories::slug)
+            .load(&*conn)?;
 
-    #[derive(Serialize, Queryable)]
-    struct Slug {
-        id: String,
-        slug: String,
-        description: String,
-    }
+        #[derive(Serialize, Queryable)]
+        struct Slug {
+            id: String,
+            slug: String,
+            description: String,
+        }
 
-    Ok(Json(json!({ "category_slugs": slugs })))
+        Ok(Json(json!({ "category_slugs": slugs })))
+    })
+    .await
 }

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -280,21 +280,24 @@ pub async fn handle_invite(mut req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
-pub fn handle_invite_with_token(req: ConduitRequest) -> AppResult<Json<Value>> {
-    let state = req.app();
-    let config = &state.config;
-    let conn = state.db_write()?;
+pub async fn handle_invite_with_token(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        let state = req.app();
+        let config = &state.config;
+        let conn = state.db_write()?;
 
-    let req_token = req.param("token").unwrap();
+        let req_token = req.param("token").unwrap();
 
-    let invitation = CrateOwnerInvitation::find_by_token(req_token, &conn)?;
-    let crate_id = invitation.crate_id;
-    invitation.accept(&conn, config)?;
+        let invitation = CrateOwnerInvitation::find_by_token(req_token, &conn)?;
+        let crate_id = invitation.crate_id;
+        invitation.accept(&conn, config)?;
 
-    Ok(Json(json!({
-        "crate_owner_invitation": {
-            "crate_id": crate_id,
-            "accepted": true,
-        },
-    })))
+        Ok(Json(json!({
+            "crate_owner_invitation": {
+                "crate_id": crate_id,
+                "accepted": true,
+            },
+        })))
+    })
+    .await
 }

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -37,13 +37,16 @@ pub async fn follow(req: ConduitRequest) -> AppResult<Response> {
 }
 
 /// Handles the `DELETE /crates/:crate_id/follow` route.
-pub fn unfollow(req: ConduitRequest) -> AppResult<Response> {
-    let user_id = AuthCheck::default().check(&req)?.user_id();
-    let conn = req.app().db_write()?;
-    let follow = follow_target(&req, &conn, user_id)?;
-    diesel::delete(&follow).execute(&*conn)?;
+pub async fn unfollow(req: ConduitRequest) -> AppResult<Response> {
+    conduit_compat(move || {
+        let user_id = AuthCheck::default().check(&req)?.user_id();
+        let conn = req.app().db_write()?;
+        let follow = follow_target(&req, &conn, user_id)?;
+        diesel::delete(&follow).execute(&*conn)?;
 
-    ok_true()
+        ok_true()
+    })
+    .await
 }
 
 /// Handles the `GET /crates/:crate_id/following` route.

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,106 +22,110 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub fn summary(req: ConduitRequest) -> AppResult<Json<Value>> {
-    use crate::schema::crates::dsl::*;
-    use diesel::dsl::all;
+pub async fn summary(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        use crate::schema::crates::dsl::*;
+        use diesel::dsl::all;
 
-    let state = req.app();
-    let config = &state.config;
+        let state = req.app();
+        let config = &state.config;
 
-    let conn = state.db_read()?;
-    let num_crates: i64 = crates.count().get_result(&*conn)?;
-    let num_downloads: i64 = metadata::table
-        .select(metadata::total_downloads)
-        .get_result(&*conn)?;
+        let conn = state.db_read()?;
+        let num_crates: i64 = crates.count().get_result(&*conn)?;
+        let num_downloads: i64 = metadata::table
+            .select(metadata::total_downloads)
+            .get_result(&*conn)?;
 
-    let encode_crates = |data: Vec<(Crate, Option<i64>)>| -> AppResult<Vec<_>> {
-        let recent_downloads = data.iter().map(|&(_, s)| s).collect::<Vec<_>>();
+        let encode_crates = |data: Vec<(Crate, Option<i64>)>| -> AppResult<Vec<_>> {
+            let recent_downloads = data.iter().map(|&(_, s)| s).collect::<Vec<_>>();
 
-        let krates = data.into_iter().map(|(c, _)| c).collect::<Vec<_>>();
+            let krates = data.into_iter().map(|(c, _)| c).collect::<Vec<_>>();
 
-        let versions: Vec<Version> = krates.versions().load(&*conn)?;
-        versions
-            .grouped_by(&krates)
+            let versions: Vec<Version> = krates.versions().load(&*conn)?;
+            versions
+                .grouped_by(&krates)
+                .into_iter()
+                .map(TopVersions::from_versions)
+                .zip(krates)
+                .zip(recent_downloads)
+                .map(|((top_versions, krate), recent_downloads)| {
+                    Ok(EncodableCrate::from_minimal(
+                        krate,
+                        Some(&top_versions),
+                        None,
+                        false,
+                        recent_downloads,
+                    ))
+                })
+                .collect()
+        };
+
+        let selection = (ALL_COLUMNS, recent_crate_downloads::downloads.nullable());
+
+        let new_crates = crates
+            .left_join(recent_crate_downloads::table)
+            .order(created_at.desc())
+            .select(selection)
+            .limit(10)
+            .load(&*conn)?;
+        let just_updated = crates
+            .left_join(recent_crate_downloads::table)
+            .filter(updated_at.ne(created_at))
+            .order(updated_at.desc())
+            .select(selection)
+            .limit(10)
+            .load(&*conn)?;
+
+        let mut most_downloaded_query =
+            crates.left_join(recent_crate_downloads::table).into_boxed();
+        if !config.excluded_crate_names.is_empty() {
+            most_downloaded_query =
+                most_downloaded_query.filter(name.ne(all(&config.excluded_crate_names)));
+        }
+        let most_downloaded = most_downloaded_query
+            .then_order_by(downloads.desc())
+            .select(selection)
+            .limit(10)
+            .load(&*conn)?;
+
+        let mut most_recently_downloaded_query = crates
+            .inner_join(recent_crate_downloads::table)
+            .into_boxed();
+        if !config.excluded_crate_names.is_empty() {
+            most_recently_downloaded_query =
+                most_recently_downloaded_query.filter(name.ne(all(&config.excluded_crate_names)));
+        }
+        let most_recently_downloaded = most_recently_downloaded_query
+            .then_order_by(recent_crate_downloads::downloads.desc())
+            .select(selection)
+            .limit(10)
+            .load(&*conn)?;
+
+        let popular_keywords = keywords::table
+            .order(keywords::crates_cnt.desc())
+            .limit(10)
+            .load(&*conn)?
             .into_iter()
-            .map(TopVersions::from_versions)
-            .zip(krates)
-            .zip(recent_downloads)
-            .map(|((top_versions, krate), recent_downloads)| {
-                Ok(EncodableCrate::from_minimal(
-                    krate,
-                    Some(&top_versions),
-                    None,
-                    false,
-                    recent_downloads,
-                ))
-            })
-            .collect()
-    };
+            .map(Keyword::into)
+            .collect::<Vec<EncodableKeyword>>();
 
-    let selection = (ALL_COLUMNS, recent_crate_downloads::downloads.nullable());
+        let popular_categories = Category::toplevel(&conn, "crates", 10, 0)?
+            .into_iter()
+            .map(Category::into)
+            .collect::<Vec<EncodableCategory>>();
 
-    let new_crates = crates
-        .left_join(recent_crate_downloads::table)
-        .order(created_at.desc())
-        .select(selection)
-        .limit(10)
-        .load(&*conn)?;
-    let just_updated = crates
-        .left_join(recent_crate_downloads::table)
-        .filter(updated_at.ne(created_at))
-        .order(updated_at.desc())
-        .select(selection)
-        .limit(10)
-        .load(&*conn)?;
-
-    let mut most_downloaded_query = crates.left_join(recent_crate_downloads::table).into_boxed();
-    if !config.excluded_crate_names.is_empty() {
-        most_downloaded_query =
-            most_downloaded_query.filter(name.ne(all(&config.excluded_crate_names)));
-    }
-    let most_downloaded = most_downloaded_query
-        .then_order_by(downloads.desc())
-        .select(selection)
-        .limit(10)
-        .load(&*conn)?;
-
-    let mut most_recently_downloaded_query = crates
-        .inner_join(recent_crate_downloads::table)
-        .into_boxed();
-    if !config.excluded_crate_names.is_empty() {
-        most_recently_downloaded_query =
-            most_recently_downloaded_query.filter(name.ne(all(&config.excluded_crate_names)));
-    }
-    let most_recently_downloaded = most_recently_downloaded_query
-        .then_order_by(recent_crate_downloads::downloads.desc())
-        .select(selection)
-        .limit(10)
-        .load(&*conn)?;
-
-    let popular_keywords = keywords::table
-        .order(keywords::crates_cnt.desc())
-        .limit(10)
-        .load(&*conn)?
-        .into_iter()
-        .map(Keyword::into)
-        .collect::<Vec<EncodableKeyword>>();
-
-    let popular_categories = Category::toplevel(&conn, "crates", 10, 0)?
-        .into_iter()
-        .map(Category::into)
-        .collect::<Vec<EncodableCategory>>();
-
-    Ok(Json(json!({
-        "num_downloads": num_downloads,
-        "num_crates": num_crates,
-        "new_crates": encode_crates(new_crates)?,
-        "most_downloaded": encode_crates(most_downloaded)?,
-        "most_recently_downloaded": encode_crates(most_recently_downloaded)?,
-        "just_updated": encode_crates(just_updated)?,
-        "popular_keywords": popular_keywords,
-        "popular_categories": popular_categories,
-    })))
+        Ok(Json(json!({
+            "num_downloads": num_downloads,
+            "num_crates": num_crates,
+            "new_crates": encode_crates(new_crates)?,
+            "most_downloaded": encode_crates(most_downloaded)?,
+            "most_recently_downloaded": encode_crates(most_recently_downloaded)?,
+            "just_updated": encode_crates(just_updated)?,
+            "popular_keywords": popular_keywords,
+            "popular_categories": popular_categories,
+        })))
+    })
+    .await
 }
 
 /// Handles the `GET /crates/:crate_id` route.

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -302,21 +302,24 @@ impl FromStr for ShowIncludeMode {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/readme` route.
-pub fn readme(req: ConduitRequest) -> AppResult<Response> {
-    let crate_name = req.param("crate_id").unwrap();
-    let version = req.param("version").unwrap();
+pub async fn readme(req: ConduitRequest) -> AppResult<Response> {
+    conduit_compat(move || {
+        let crate_name = req.param("crate_id").unwrap();
+        let version = req.param("version").unwrap();
 
-    let redirect_url = req
-        .app()
-        .config
-        .uploader()
-        .readme_location(crate_name, version);
+        let redirect_url = req
+            .app()
+            .config
+            .uploader()
+            .readme_location(crate_name, version);
 
-    if req.wants_json() {
-        Ok(Json(json!({ "url": redirect_url })).into_response())
-    } else {
-        Ok(req.redirect(redirect_url))
-    }
+        if req.wants_json() {
+            Ok(Json(json!({ "url": redirect_url })).into_response())
+        } else {
+            Ok(req.redirect(redirect_url))
+        }
+    })
+    .await
 }
 
 /// Handles the `GET /crates/:crate_id/versions` route.

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -24,16 +24,19 @@ pub async fn owners(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub fn owner_team(req: ConduitRequest) -> AppResult<Json<Value>> {
-    let crate_name = req.param("crate_id").unwrap();
-    let conn = req.app().db_read()?;
-    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
-    let owners = Team::owning(&krate, &conn)?
-        .into_iter()
-        .map(Owner::into)
-        .collect::<Vec<EncodableOwner>>();
+pub async fn owner_team(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        let crate_name = req.param("crate_id").unwrap();
+        let conn = req.app().db_read()?;
+        let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
+        let owners = Team::owning(&krate, &conn)?
+            .into_iter()
+            .map(Owner::into)
+            .collect::<Vec<EncodableOwner>>();
 
-    Ok(Json(json!({ "teams": owners })))
+        Ok(Json(json!({ "teams": owners })))
+    })
+    .await
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -7,17 +7,20 @@ use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub fn owners(req: ConduitRequest) -> AppResult<Json<Value>> {
-    let crate_name = req.param("crate_id").unwrap();
-    let conn = req.app().db_read()?;
-    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
-    let owners = krate
-        .owners(&conn)?
-        .into_iter()
-        .map(Owner::into)
-        .collect::<Vec<EncodableOwner>>();
+pub async fn owners(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        let crate_name = req.param("crate_id").unwrap();
+        let conn = req.app().db_read()?;
+        let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
+        let owners = krate
+            .owners(&conn)?
+            .into_iter()
+            .map(Owner::into)
+            .collect::<Vec<EncodableOwner>>();
 
-    Ok(Json(json!({ "users": owners })))
+        Ok(Json(json!({ "users": owners })))
+    })
+    .await
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -55,8 +55,8 @@ pub async fn add_owners(mut req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
-pub fn remove_owners(mut req: ConduitRequest) -> AppResult<Json<Value>> {
-    modify_owners(&mut req, false)
+pub async fn remove_owners(mut req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || modify_owners(&mut req, false)).await
 }
 
 /// Parse the JSON request body of requests to modify the owners of a crate.

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -50,8 +50,8 @@ pub fn owner_user(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
-pub fn add_owners(mut req: ConduitRequest) -> AppResult<Json<Value>> {
-    modify_owners(&mut req, true)
+pub async fn add_owners(mut req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || modify_owners(&mut req, true)).await
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -40,16 +40,19 @@ pub async fn owner_team(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub fn owner_user(req: ConduitRequest) -> AppResult<Json<Value>> {
-    let crate_name = req.param("crate_id").unwrap();
-    let conn = req.app().db_read()?;
-    let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
-    let owners = User::owning(&krate, &conn)?
-        .into_iter()
-        .map(Owner::into)
-        .collect::<Vec<EncodableOwner>>();
+pub async fn owner_user(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        let crate_name = req.param("crate_id").unwrap();
+        let conn = req.app().db_read()?;
+        let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
+        let owners = User::owning(&krate, &conn)?
+            .into_iter()
+            .map(Owner::into)
+            .collect::<Vec<EncodableOwner>>();
 
-    Ok(Json(json!({ "users": owners })))
+        Ok(Json(json!({ "users": owners })))
+    })
+    .await
 }
 
 /// Handles the `PUT /crates/:crate_id/owners` route.

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -38,312 +38,315 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
-    use diesel::sql_types::{Bool, Text};
+pub async fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        use diesel::sql_types::{Bool, Text};
 
-    let params = req.query();
-    let sort = params.get("sort").map(|s| &**s);
-    let include_yanked = params
-        .get("include_yanked")
-        .map(|s| s == "yes")
-        .unwrap_or(true);
+        let params = req.query();
+        let sort = params.get("sort").map(|s| &**s);
+        let include_yanked = params
+            .get("include_yanked")
+            .map(|s| s == "yes")
+            .unwrap_or(true);
 
-    // Remove 0x00 characters from the query string because Postgres can not
-    // handle them and will return an error, which would cause us to throw
-    // an Internal Server Error ourselves.
-    let q_string = params.get("q").map(|q| q.replace('\u{0}', ""));
+        // Remove 0x00 characters from the query string because Postgres can not
+        // handle them and will return an error, which would cause us to throw
+        // an Internal Server Error ourselves.
+        let q_string = params.get("q").map(|q| q.replace('\u{0}', ""));
 
-    let selection = (
-        ALL_COLUMNS,
-        false.into_sql::<Bool>(),
-        recent_crate_downloads::downloads.nullable(),
-    );
-    let mut query = crates::table
-        .left_join(recent_crate_downloads::table)
-        .select(selection)
-        .into_boxed();
+        let selection = (
+            ALL_COLUMNS,
+            false.into_sql::<Bool>(),
+            recent_crate_downloads::downloads.nullable(),
+        );
+        let mut query = crates::table
+            .left_join(recent_crate_downloads::table)
+            .select(selection)
+            .into_boxed();
 
-    let mut supports_seek = true;
+        let mut supports_seek = true;
 
-    if let Some(q_string) = &q_string {
-        // Searching with a query string always puts the exact match at the start of the results,
-        // so we can't support seek-based pagination with it.
-        supports_seek = false;
+        if let Some(q_string) = &q_string {
+            // Searching with a query string always puts the exact match at the start of the results,
+            // so we can't support seek-based pagination with it.
+            supports_seek = false;
 
-        if !q_string.is_empty() {
-            let sort = params.get("sort").map(|s| &**s).unwrap_or("relevance");
+            if !q_string.is_empty() {
+                let sort = params.get("sort").map(|s| &**s).unwrap_or("relevance");
 
-            let q = sql::<TsQuery>("plainto_tsquery('english', ")
-                .bind::<Text, _>(q_string)
-                .sql(")");
-            query = query.filter(
-                q.clone()
-                    .matches(crates::textsearchable_index_col)
-                    .or(Crate::loosly_matches_name(q_string)),
-            );
+                let q = sql::<TsQuery>("plainto_tsquery('english', ")
+                    .bind::<Text, _>(q_string)
+                    .sql(")");
+                query = query.filter(
+                    q.clone()
+                        .matches(crates::textsearchable_index_col)
+                        .or(Crate::loosly_matches_name(q_string)),
+                );
 
-            query = query.select((
-                ALL_COLUMNS,
-                Crate::with_name(q_string),
-                recent_crate_downloads::downloads.nullable(),
-            ));
-            query = query.order(Crate::with_name(q_string).desc());
+                query = query.select((
+                    ALL_COLUMNS,
+                    Crate::with_name(q_string),
+                    recent_crate_downloads::downloads.nullable(),
+                ));
+                query = query.order(Crate::with_name(q_string).desc());
 
-            if sort == "relevance" {
-                let rank = ts_rank_cd(crates::textsearchable_index_col, q);
-                query = query.then_order_by(rank.desc())
+                if sort == "relevance" {
+                    let rank = ts_rank_cd(crates::textsearchable_index_col, q);
+                    query = query.then_order_by(rank.desc())
+                }
             }
         }
-    }
 
-    if let Some(cat) = params.get("category") {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
+        if let Some(cat) = params.get("category") {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
 
-        query = query.filter(
-            crates::id.eq_any(
-                crates_categories::table
-                    .select(crates_categories::crate_id)
-                    .inner_join(categories::table)
-                    .filter(
-                        categories::slug
-                            .eq(cat)
-                            .or(categories::slug.like(format!("{cat}::%"))),
-                    ),
-            ),
-        );
-    }
-
-    if let Some(kws) = params.get("all_keywords") {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        let names: Vec<_> = kws
-            .split_whitespace()
-            .map(|name| name.to_lowercase())
-            .collect();
-
-        query = query.filter(
-            // FIXME: Just use `.contains` in Diesel 2.0
-            // https://github.com/diesel-rs/diesel/issues/2066
-            Contains::new(
-                crates_keywords::table
-                    .inner_join(keywords::table)
-                    .filter(crates_keywords::crate_id.eq(crates::id))
-                    .select(array_agg(keywords::keyword))
-                    .single_value(),
-                names.into_sql::<Array<Text>>(),
-            ),
-        );
-    } else if let Some(kw) = params.get("keyword") {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        query = query.filter(
-            crates::id.eq_any(
-                crates_keywords::table
-                    .select(crates_keywords::crate_id)
-                    .inner_join(keywords::table)
-                    .filter(lower(keywords::keyword).eq(lower(kw))),
-            ),
-        );
-    } else if let Some(letter) = params.get("letter") {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        let pattern = format!(
-            "{}%",
-            letter
-                .chars()
-                .next()
-                .ok_or_else(|| bad_request("letter value must contain 1 character"))?
-                .to_lowercase()
-                .collect::<String>()
-        );
-        query = query.filter(canon_crate_name(crates::name).like(pattern));
-    } else if let Some(user_id) = params.get("user_id").and_then(|s| s.parse::<i32>().ok()) {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        query = query.filter(
-            crates::id.eq_any(
-                CrateOwner::by_owner_kind(OwnerKind::User)
-                    .select(crate_owners::crate_id)
-                    .filter(crate_owners::owner_id.eq(user_id)),
-            ),
-        );
-    } else if let Some(team_id) = params.get("team_id").and_then(|s| s.parse::<i32>().ok()) {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        query = query.filter(
-            crates::id.eq_any(
-                CrateOwner::by_owner_kind(OwnerKind::Team)
-                    .select(crate_owners::crate_id)
-                    .filter(crate_owners::owner_id.eq(team_id)),
-            ),
-        );
-    } else if params.get("following").is_some() {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        let user_id = AuthCheck::default().check(&req)?.user_id();
-
-        query = query.filter(
-            crates::id.eq_any(
-                follows::table
-                    .select(follows::crate_id)
-                    .filter(follows::user_id.eq(user_id)),
-            ),
-        );
-    } else if params.get("ids[]").is_some() {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        let query_bytes = req.uri().query().unwrap_or("").as_bytes();
-        let ids: Vec<_> = url::form_urlencoded::parse(query_bytes)
-            .filter(|(key, _)| key == "ids[]")
-            .map(|(_, value)| value.to_string())
-            .collect();
-
-        query = query.filter(crates::name.eq(any(ids)));
-    }
-
-    if !include_yanked {
-        // Calculating the total number of results with filters is not supported yet.
-        supports_seek = false;
-
-        query = query.filter(exists(
-            versions::table
-                .filter(versions::crate_id.eq(crates::id))
-                .filter(versions::yanked.eq(false)),
-        ));
-    }
-
-    // Any sort other than 'relevance' (default) would ignore exact crate name matches
-    if sort == Some("downloads") {
-        // Custom sorting is not supported yet with seek.
-        supports_seek = false;
-
-        query = query.order(crates::downloads.desc())
-    } else if sort == Some("recent-downloads") {
-        // Custom sorting is not supported yet with seek.
-        supports_seek = false;
-
-        query = query.order(recent_crate_downloads::downloads.desc().nulls_last())
-    } else if sort == Some("recent-updates") {
-        // Custom sorting is not supported yet with seek.
-        supports_seek = false;
-
-        query = query.order(crates::updated_at.desc());
-    } else if sort == Some("new") {
-        // Custom sorting is not supported yet with seek.
-        supports_seek = false;
-
-        query = query.order(crates::created_at.desc());
-    } else {
-        query = query.then_order_by(crates::name.asc())
-    }
-
-    let pagination: PaginationOptions = PaginationOptions::builder()
-        .limit_page_numbers()
-        .enable_seek(supports_seek)
-        .gather(&req)?;
-    let conn = req.app().db_read()?;
-
-    let (explicit_page, seek) = match pagination.page.clone() {
-        Page::Numeric(_) => (true, None),
-        Page::Seek(s) => (false, Some(s.decode::<i32>()?)),
-        Page::Unspecified => (false, None),
-    };
-
-    // To avoid breaking existing users, seek-based pagination is only used if an explicit page has
-    // not been provided. This way clients relying on meta.next_page will use the faster seek-based
-    // paginations, while client hardcoding pages handling will use the slower offset-based code.
-    let (total, next_page, prev_page, data, conn) = if supports_seek && !explicit_page {
-        // Equivalent of:
-        // `WHERE name > (SELECT name FROM crates WHERE id = $1) LIMIT $2`
-        query = query.limit(pagination.per_page as i64);
-        if let Some(seek) = seek {
-            let crate_name: String = crates::table
-                .find(seek)
-                .select(crates::name)
-                .get_result(&*conn)?;
-            query = query.filter(crates::name.gt(crate_name));
+            query = query.filter(
+                crates::id.eq_any(
+                    crates_categories::table
+                        .select(crates_categories::crate_id)
+                        .inner_join(categories::table)
+                        .filter(
+                            categories::slug
+                                .eq(cat)
+                                .or(categories::slug.like(format!("{cat}::%"))),
+                        ),
+                ),
+            );
         }
 
-        // This does a full index-only scan over the crates table to gather how many crates were
-        // published. Unfortunately on PostgreSQL counting the rows in a table requires scanning
-        // the table, and the `total` field is part of the stable registries API.
-        //
-        // If this becomes a problem in the future the crates count could be denormalized, at least
-        // for the filterless happy path.
-        let total: i64 = crates::table.count().get_result(&*conn)?;
+        if let Some(kws) = params.get("all_keywords") {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
 
-        let results: Vec<(Crate, bool, Option<i64>)> = query.load(&*conn)?;
+            let names: Vec<_> = kws
+                .split_whitespace()
+                .map(|name| name.to_lowercase())
+                .collect();
 
-        let next_page = if let Some(last) = results.last() {
-            let mut params = IndexMap::new();
-            params.insert(
-                "seek".into(),
-                crate::controllers::helpers::pagination::encode_seek(last.0.id)?,
+            query = query.filter(
+                // FIXME: Just use `.contains` in Diesel 2.0
+                // https://github.com/diesel-rs/diesel/issues/2066
+                Contains::new(
+                    crates_keywords::table
+                        .inner_join(keywords::table)
+                        .filter(crates_keywords::crate_id.eq(crates::id))
+                        .select(array_agg(keywords::keyword))
+                        .single_value(),
+                    names.into_sql::<Array<Text>>(),
+                ),
             );
-            Some(req.query_with_params(params))
+        } else if let Some(kw) = params.get("keyword") {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
+
+            query = query.filter(
+                crates::id.eq_any(
+                    crates_keywords::table
+                        .select(crates_keywords::crate_id)
+                        .inner_join(keywords::table)
+                        .filter(lower(keywords::keyword).eq(lower(kw))),
+                ),
+            );
+        } else if let Some(letter) = params.get("letter") {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
+
+            let pattern = format!(
+                "{}%",
+                letter
+                    .chars()
+                    .next()
+                    .ok_or_else(|| bad_request("letter value must contain 1 character"))?
+                    .to_lowercase()
+                    .collect::<String>()
+            );
+            query = query.filter(canon_crate_name(crates::name).like(pattern));
+        } else if let Some(user_id) = params.get("user_id").and_then(|s| s.parse::<i32>().ok()) {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
+
+            query = query.filter(
+                crates::id.eq_any(
+                    CrateOwner::by_owner_kind(OwnerKind::User)
+                        .select(crate_owners::crate_id)
+                        .filter(crate_owners::owner_id.eq(user_id)),
+                ),
+            );
+        } else if let Some(team_id) = params.get("team_id").and_then(|s| s.parse::<i32>().ok()) {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
+
+            query = query.filter(
+                crates::id.eq_any(
+                    CrateOwner::by_owner_kind(OwnerKind::Team)
+                        .select(crate_owners::crate_id)
+                        .filter(crate_owners::owner_id.eq(team_id)),
+                ),
+            );
+        } else if params.get("following").is_some() {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
+
+            let user_id = AuthCheck::default().check(&req)?.user_id();
+
+            query = query.filter(
+                crates::id.eq_any(
+                    follows::table
+                        .select(follows::crate_id)
+                        .filter(follows::user_id.eq(user_id)),
+                ),
+            );
+        } else if params.get("ids[]").is_some() {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
+
+            let query_bytes = req.uri().query().unwrap_or("").as_bytes();
+            let ids: Vec<_> = url::form_urlencoded::parse(query_bytes)
+                .filter(|(key, _)| key == "ids[]")
+                .map(|(_, value)| value.to_string())
+                .collect();
+
+            query = query.filter(crates::name.eq(any(ids)));
+        }
+
+        if !include_yanked {
+            // Calculating the total number of results with filters is not supported yet.
+            supports_seek = false;
+
+            query = query.filter(exists(
+                versions::table
+                    .filter(versions::crate_id.eq(crates::id))
+                    .filter(versions::yanked.eq(false)),
+            ));
+        }
+
+        // Any sort other than 'relevance' (default) would ignore exact crate name matches
+        if sort == Some("downloads") {
+            // Custom sorting is not supported yet with seek.
+            supports_seek = false;
+
+            query = query.order(crates::downloads.desc())
+        } else if sort == Some("recent-downloads") {
+            // Custom sorting is not supported yet with seek.
+            supports_seek = false;
+
+            query = query.order(recent_crate_downloads::downloads.desc().nulls_last())
+        } else if sort == Some("recent-updates") {
+            // Custom sorting is not supported yet with seek.
+            supports_seek = false;
+
+            query = query.order(crates::updated_at.desc());
+        } else if sort == Some("new") {
+            // Custom sorting is not supported yet with seek.
+            supports_seek = false;
+
+            query = query.order(crates::created_at.desc());
         } else {
-            None
+            query = query.then_order_by(crates::name.asc())
+        }
+
+        let pagination: PaginationOptions = PaginationOptions::builder()
+            .limit_page_numbers()
+            .enable_seek(supports_seek)
+            .gather(&req)?;
+        let conn = req.app().db_read()?;
+
+        let (explicit_page, seek) = match pagination.page.clone() {
+            Page::Numeric(_) => (true, None),
+            Page::Seek(s) => (false, Some(s.decode::<i32>()?)),
+            Page::Unspecified => (false, None),
         };
 
-        (total, next_page, None, results, conn)
-    } else {
-        let query = query.pages_pagination(pagination);
-        let data: Paginated<(Crate, bool, Option<i64>)> = query.load(&conn)?;
-        (
-            data.total(),
-            data.next_page_params().map(|p| req.query_with_params(p)),
-            data.prev_page_params().map(|p| req.query_with_params(p)),
-            data.into_iter().collect::<Vec<_>>(),
-            conn,
-        )
-    };
+        // To avoid breaking existing users, seek-based pagination is only used if an explicit page has
+        // not been provided. This way clients relying on meta.next_page will use the faster seek-based
+        // paginations, while client hardcoding pages handling will use the slower offset-based code.
+        let (total, next_page, prev_page, data, conn) = if supports_seek && !explicit_page {
+            // Equivalent of:
+            // `WHERE name > (SELECT name FROM crates WHERE id = $1) LIMIT $2`
+            query = query.limit(pagination.per_page as i64);
+            if let Some(seek) = seek {
+                let crate_name: String = crates::table
+                    .find(seek)
+                    .select(crates::name)
+                    .get_result(&*conn)?;
+                query = query.filter(crates::name.gt(crate_name));
+            }
 
-    let perfect_matches = data.iter().map(|&(_, b, _)| b).collect::<Vec<_>>();
-    let recent_downloads = data
-        .iter()
-        .map(|&(_, _, s)| s.unwrap_or(0))
-        .collect::<Vec<_>>();
-    let crates = data.into_iter().map(|(c, _, _)| c).collect::<Vec<_>>();
+            // This does a full index-only scan over the crates table to gather how many crates were
+            // published. Unfortunately on PostgreSQL counting the rows in a table requires scanning
+            // the table, and the `total` field is part of the stable registries API.
+            //
+            // If this becomes a problem in the future the crates count could be denormalized, at least
+            // for the filterless happy path.
+            let total: i64 = crates::table.count().get_result(&*conn)?;
 
-    let versions: Vec<Version> = crates.versions().load(&*conn)?;
-    let versions = versions
-        .grouped_by(&crates)
-        .into_iter()
-        .map(TopVersions::from_versions);
+            let results: Vec<(Crate, bool, Option<i64>)> = query.load(&*conn)?;
 
-    let crates = versions
-        .zip(crates)
-        .zip(perfect_matches)
-        .zip(recent_downloads)
-        .map(
-            |(((max_version, krate), perfect_match), recent_downloads)| {
-                EncodableCrate::from_minimal(
-                    krate,
-                    Some(&max_version),
-                    Some(vec![]),
-                    perfect_match,
-                    Some(recent_downloads),
-                )
+            let next_page = if let Some(last) = results.last() {
+                let mut params = IndexMap::new();
+                params.insert(
+                    "seek".into(),
+                    crate::controllers::helpers::pagination::encode_seek(last.0.id)?,
+                );
+                Some(req.query_with_params(params))
+            } else {
+                None
+            };
+
+            (total, next_page, None, results, conn)
+        } else {
+            let query = query.pages_pagination(pagination);
+            let data: Paginated<(Crate, bool, Option<i64>)> = query.load(&conn)?;
+            (
+                data.total(),
+                data.next_page_params().map(|p| req.query_with_params(p)),
+                data.prev_page_params().map(|p| req.query_with_params(p)),
+                data.into_iter().collect::<Vec<_>>(),
+                conn,
+            )
+        };
+
+        let perfect_matches = data.iter().map(|&(_, b, _)| b).collect::<Vec<_>>();
+        let recent_downloads = data
+            .iter()
+            .map(|&(_, _, s)| s.unwrap_or(0))
+            .collect::<Vec<_>>();
+        let crates = data.into_iter().map(|(c, _, _)| c).collect::<Vec<_>>();
+
+        let versions: Vec<Version> = crates.versions().load(&*conn)?;
+        let versions = versions
+            .grouped_by(&crates)
+            .into_iter()
+            .map(TopVersions::from_versions);
+
+        let crates = versions
+            .zip(crates)
+            .zip(perfect_matches)
+            .zip(recent_downloads)
+            .map(
+                |(((max_version, krate), perfect_match), recent_downloads)| {
+                    EncodableCrate::from_minimal(
+                        krate,
+                        Some(&max_version),
+                        Some(vec![]),
+                        perfect_match,
+                        Some(recent_downloads),
+                    )
+                },
+            )
+            .collect::<Vec<_>>();
+
+        Ok(Json(json!({
+            "crates": crates,
+            "meta": {
+                "total": total,
+                "next_page": next_page,
+                "prev_page": prev_page,
             },
-        )
-        .collect::<Vec<_>>();
-
-    Ok(Json(json!({
-        "crates": crates,
-        "meta": {
-            "total": total,
-            "next_page": next_page,
-            "prev_page": prev_page,
-        },
-    })))
+        })))
+    })
+    .await
 }
 
 diesel_infix_operator!(Contains, "@>");

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -4,37 +4,40 @@ use axum::response::IntoResponse;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
-pub fn prometheus(req: ConduitRequest) -> AppResult<Response> {
-    let app = req.app();
+pub async fn prometheus(req: ConduitRequest) -> AppResult<Response> {
+    conduit_compat(move || {
+        let app = req.app();
 
-    if let Some(expected_token) = &app.config.metrics_authorization_token {
-        let provided_token = req
-            .headers()
-            .get(header::AUTHORIZATION)
-            .and_then(|value| value.to_str().ok())
-            .and_then(|value| value.strip_prefix("Bearer "));
+        if let Some(expected_token) = &app.config.metrics_authorization_token {
+            let provided_token = req
+                .headers()
+                .get(header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .and_then(|value| value.strip_prefix("Bearer "));
 
-        if provided_token != Some(expected_token.as_str()) {
-            return Err(forbidden());
+            if provided_token != Some(expected_token.as_str()) {
+                return Err(forbidden());
+            }
+        } else {
+            // To avoid accidentally leaking metrics if the environment variable is not set, prevent
+            // access to any metrics endpoint if the authorization token is not configured.
+            return Err(Box::new(MetricsDisabled));
         }
-    } else {
-        // To avoid accidentally leaking metrics if the environment variable is not set, prevent
-        // access to any metrics endpoint if the authorization token is not configured.
-        return Err(Box::new(MetricsDisabled));
-    }
 
-    let metrics = match req.param("kind").unwrap() {
-        "service" => app.service_metrics.gather(&*app.db_read()?)?,
-        "instance" => app.instance_metrics.gather(app)?,
-        _ => return Err(not_found()),
-    };
+        let metrics = match req.param("kind").unwrap() {
+            "service" => app.service_metrics.gather(&*app.db_read()?)?,
+            "instance" => app.instance_metrics.gather(app)?,
+            _ => return Err(not_found()),
+        };
 
-    let mut output = Vec::new();
-    TextEncoder::new().encode(&metrics, &mut output)?;
+        let mut output = Vec::new();
+        TextEncoder::new().encode(&metrics, &mut output)?;
 
-    Ok((
-        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
-        output,
-    )
-        .into_response())
+        Ok((
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            output,
+        )
+            .into_response())
+    })
+    .await
 }

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,12 +5,15 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub fn show_team(req: ConduitRequest) -> AppResult<Json<Value>> {
-    use self::teams::dsl::{login, teams};
+pub async fn show_team(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        use self::teams::dsl::{login, teams};
 
-    let name = req.param("team_id").unwrap();
-    let conn = req.app().db_read()?;
-    let team: Team = teams.filter(login.eq(name)).first(&*conn)?;
+        let name = req.param("team_id").unwrap();
+        let conn = req.app().db_read()?;
+        let team: Team = teams.filter(login.eq(name)).first(&*conn)?;
 
-    Ok(Json(json!({ "team": EncodableTeam::from(team) })))
+        Ok(Json(json!({ "team": EncodableTeam::from(team) })))
+    })
+    .await
 }

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -23,22 +23,25 @@ pub async fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub fn stats(req: ConduitRequest) -> AppResult<Json<Value>> {
-    use diesel::dsl::sum;
+pub async fn stats(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        use diesel::dsl::sum;
 
-    let user_id = req
-        .param("user_id")
-        .unwrap()
-        .parse::<i32>()
-        .map_err(|err| err.chain(bad_request("invalid user_id")))?;
-    let conn = req.app().db_read_prefer_primary()?;
+        let user_id = req
+            .param("user_id")
+            .unwrap()
+            .parse::<i32>()
+            .map_err(|err| err.chain(bad_request("invalid user_id")))?;
+        let conn = req.app().db_read_prefer_primary()?;
 
-    let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)
-        .inner_join(crates::table)
-        .filter(crate_owners::owner_id.eq(user_id))
-        .select(sum(crates::downloads))
-        .first::<Option<i64>>(&*conn)?
-        .unwrap_or(0);
+        let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)
+            .inner_join(crates::table)
+            .filter(crate_owners::owner_id.eq(user_id))
+            .select(sum(crates::downloads))
+            .first::<Option<i64>>(&*conn)?
+            .unwrap_or(0);
 
-    Ok(Json(json!({ "total_downloads": data })))
+        Ok(Json(json!({ "total_downloads": data })))
+    })
+    .await
 }

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,17 +6,20 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
-    use self::users::dsl::{gh_login, id, users};
+pub async fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        use self::users::dsl::{gh_login, id, users};
 
-    let name = lower(req.param("user_id").unwrap());
-    let conn = req.app().db_read_prefer_primary()?;
-    let user: User = users
-        .filter(lower(gh_login).eq(name))
-        .order(id.desc())
-        .first(&*conn)?;
+        let name = lower(req.param("user_id").unwrap());
+        let conn = req.app().db_read_prefer_primary()?;
+        let user: User = users
+            .filter(lower(gh_login).eq(name))
+            .order(id.desc())
+            .first(&*conn)?;
 
-    Ok(Json(json!({ "user": EncodablePublicUser::from(user) })))
+        Ok(Json(json!({ "user": EncodablePublicUser::from(user) })))
+    })
+    .await
 }
 
 /// Handles the `GET /users/:user_id/stats` route.

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -143,7 +143,7 @@ fn save_user_to_database(
 }
 
 /// Handles the `DELETE /api/private/session` route.
-pub fn logout(mut req: ConduitRequest) -> Json<bool> {
+pub async fn logout(mut req: ConduitRequest) -> Json<bool> {
     req.session_remove("user_id");
     Json(true)
 }

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -68,7 +68,7 @@ pub fn begin(mut req: ConduitRequest) -> AppResult<Json<Value>> {
 /// }
 /// ```
 pub async fn authorize(mut req: ConduitRequest) -> AppResult<Json<EncodableMe>> {
-    conduit_compat(move || {
+    let req = conduit_compat(move || {
         // Parse the url query
         let mut query = req.query();
         let code = query.remove("code").unwrap_or_default();
@@ -102,9 +102,11 @@ pub async fn authorize(mut req: ConduitRequest) -> AppResult<Json<EncodableMe>> 
         // Log in by setting a cookie and the middleware authentication
         req.session_insert("user_id".to_string(), user.id.to_string());
 
-        super::me::me(req)
+        Ok(req)
     })
-    .await
+    .await?;
+
+    super::me::me(req).await
 }
 
 fn save_user_to_database(

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -54,22 +54,25 @@ pub async fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub fn show_by_id(req: ConduitRequest) -> AppResult<Json<Value>> {
-    let id = req.param("version_id").unwrap();
-    let id = id.parse().unwrap_or(0);
-    let conn = req.app().db_read()?;
-    let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table
-        .find(id)
-        .inner_join(crates::table)
-        .left_outer_join(users::table)
-        .select((
-            versions::all_columns,
-            crate::models::krate::ALL_COLUMNS,
-            users::all_columns.nullable(),
-        ))
-        .first(&*conn)?;
-    let audit_actions = VersionOwnerAction::by_version(&conn, &version)?;
+pub async fn show_by_id(req: ConduitRequest) -> AppResult<Json<Value>> {
+    conduit_compat(move || {
+        let id = req.param("version_id").unwrap();
+        let id = id.parse().unwrap_or(0);
+        let conn = req.app().db_read()?;
+        let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table
+            .find(id)
+            .inner_join(crates::table)
+            .left_outer_join(users::table)
+            .select((
+                versions::all_columns,
+                crate::models::krate::ALL_COLUMNS,
+                users::all_columns.nullable(),
+            ))
+            .first(&*conn)?;
+        let audit_actions = VersionOwnerAction::by_version(&conn, &version)?;
 
-    let version = EncodableVersion::from(version, &krate.name, published_by, audit_actions);
-    Ok(Json(json!({ "version": version })))
+        let version = EncodableVersion::from(version, &krate.name, published_by, audit_actions);
+        Ok(Json(json!({ "version": version })))
+    })
+    .await
 }

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -13,106 +13,109 @@ use chrono::{Duration, NaiveDate, Utc};
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.
-pub fn download(req: ConduitRequest) -> AppResult<Response> {
-    let app = req.app();
+pub async fn download(req: ConduitRequest) -> AppResult<Response> {
+    conduit_compat(move || {
+        let app = req.app();
 
-    let mut crate_name = req.param("crate_id").unwrap().to_string();
-    let version = req.param("version").unwrap();
+        let mut crate_name = req.param("crate_id").unwrap().to_string();
+        let version = req.param("version").unwrap();
 
-    let mut log_metadata = None;
+        let mut log_metadata = None;
 
-    let cache_key = (crate_name.to_string(), version.to_string());
-    if let Some(version_id) = app.version_id_cacher.get(&cache_key) {
-        app.instance_metrics.version_id_cache_hits.inc();
-
-        // The increment does not happen instantly, but it's deferred to be executed in a batch
-        // along with other downloads. See crate::downloads_counter for the implementation.
-        app.downloads_counter.increment(version_id);
-    } else {
-        app.instance_metrics.version_id_cache_misses.inc();
-
-        // When no database connection is ready unconditional redirects will be performed. This could
-        // happen if the pool is not healthy or if an operator manually configured the application to
-        // always perform unconditional redirects (for example as part of the mitigations for an
-        // outage). See the comments below for a description of what unconditional redirects do.
-        let conn = if app.config.force_unconditional_redirects {
-            None
-        } else {
-            match app.db_read_prefer_primary() {
-                Ok(conn) => Some(conn),
-                Err(PoolError::UnhealthyPool) => None,
-                Err(err) => return Err(err.into()),
-            }
-        };
-
-        if let Some(conn) = &conn {
-            use self::versions::dsl::*;
-
-            // Returns the crate name as stored in the database, or an error if we could
-            // not load the version ID from the database.
-            let (version_id, canonical_crate_name) = app
-                .instance_metrics
-                .downloads_select_query_execution_time
-                .observe_closure_duration(|| {
-                    versions
-                        .inner_join(crates::table)
-                        .select((id, crates::name))
-                        .filter(Crate::with_name(&crate_name))
-                        .filter(num.eq(version))
-                        .first::<(i32, String)>(&**conn)
-                })?;
-
-            if canonical_crate_name != crate_name {
-                app.instance_metrics
-                    .downloads_non_canonical_crate_name_total
-                    .inc();
-                log_metadata = Some(("bot", "dl"));
-                crate_name = canonical_crate_name;
-            } else {
-                // The version_id is only cached if the provided crate name was canonical.
-                // Non-canonical requests fallback to the "slow" path with a DB query, but
-                // we typically only get a few hundred non-canonical requests in a day anyway.
-                app.version_id_cacher.insert(cache_key, version_id);
-            }
+        let cache_key = (crate_name.to_string(), version.to_string());
+        if let Some(version_id) = app.version_id_cacher.get(&cache_key) {
+            app.instance_metrics.version_id_cache_hits.inc();
 
             // The increment does not happen instantly, but it's deferred to be executed in a batch
             // along with other downloads. See crate::downloads_counter for the implementation.
             app.downloads_counter.increment(version_id);
         } else {
-            // The download endpoint is the most critical route in the whole crates.io application,
-            // as it's relied upon by users and automations to download crates. Keeping it working
-            // is the most important thing for us.
-            //
-            // The endpoint relies on the database to fetch the canonical crate name (with the
-            // right capitalization and hyphenation), but that's only needed to serve clients who
-            // don't call the endpoint with the crate's canonical name.
-            //
-            // Thankfully Cargo always uses the right name when calling the endpoint, and we can
-            // keep it working during a full database outage by unconditionally redirecting without
-            // checking whether the crate exists or the rigth name is used. Non-Cargo clients might
-            // get a 404 response instead of a 500, but that's worth it.
-            //
-            // Without a working database we also can't count downloads, but that's also less
-            // critical than keeping Cargo downloads operational.
+            app.instance_metrics.version_id_cache_misses.inc();
 
-            app.instance_metrics
-                .downloads_unconditional_redirects_total
-                .inc();
-            log_metadata = Some(("unconditional_redirect", "true"));
+            // When no database connection is ready unconditional redirects will be performed. This could
+            // happen if the pool is not healthy or if an operator manually configured the application to
+            // always perform unconditional redirects (for example as part of the mitigations for an
+            // outage). See the comments below for a description of what unconditional redirects do.
+            let conn = if app.config.force_unconditional_redirects {
+                None
+            } else {
+                match app.db_read_prefer_primary() {
+                    Ok(conn) => Some(conn),
+                    Err(PoolError::UnhealthyPool) => None,
+                    Err(err) => return Err(err.into()),
+                }
+            };
+
+            if let Some(conn) = &conn {
+                use self::versions::dsl::*;
+
+                // Returns the crate name as stored in the database, or an error if we could
+                // not load the version ID from the database.
+                let (version_id, canonical_crate_name) = app
+                    .instance_metrics
+                    .downloads_select_query_execution_time
+                    .observe_closure_duration(|| {
+                        versions
+                            .inner_join(crates::table)
+                            .select((id, crates::name))
+                            .filter(Crate::with_name(&crate_name))
+                            .filter(num.eq(version))
+                            .first::<(i32, String)>(&**conn)
+                    })?;
+
+                if canonical_crate_name != crate_name {
+                    app.instance_metrics
+                        .downloads_non_canonical_crate_name_total
+                        .inc();
+                    log_metadata = Some(("bot", "dl"));
+                    crate_name = canonical_crate_name;
+                } else {
+                    // The version_id is only cached if the provided crate name was canonical.
+                    // Non-canonical requests fallback to the "slow" path with a DB query, but
+                    // we typically only get a few hundred non-canonical requests in a day anyway.
+                    app.version_id_cacher.insert(cache_key, version_id);
+                }
+
+                // The increment does not happen instantly, but it's deferred to be executed in a batch
+                // along with other downloads. See crate::downloads_counter for the implementation.
+                app.downloads_counter.increment(version_id);
+            } else {
+                // The download endpoint is the most critical route in the whole crates.io application,
+                // as it's relied upon by users and automations to download crates. Keeping it working
+                // is the most important thing for us.
+                //
+                // The endpoint relies on the database to fetch the canonical crate name (with the
+                // right capitalization and hyphenation), but that's only needed to serve clients who
+                // don't call the endpoint with the crate's canonical name.
+                //
+                // Thankfully Cargo always uses the right name when calling the endpoint, and we can
+                // keep it working during a full database outage by unconditionally redirecting without
+                // checking whether the crate exists or the rigth name is used. Non-Cargo clients might
+                // get a 404 response instead of a 500, but that's worth it.
+                //
+                // Without a working database we also can't count downloads, but that's also less
+                // critical than keeping Cargo downloads operational.
+
+                app.instance_metrics
+                    .downloads_unconditional_redirects_total
+                    .inc();
+                log_metadata = Some(("unconditional_redirect", "true"));
+            }
+        };
+
+        let redirect_url = app.config.uploader().crate_location(&crate_name, version);
+
+        if let Some((key, value)) = log_metadata {
+            req.add_custom_metadata(key, value);
         }
-    };
 
-    let redirect_url = app.config.uploader().crate_location(&crate_name, version);
-
-    if let Some((key, value)) = log_metadata {
-        req.add_custom_metadata(key, value);
-    }
-
-    if req.wants_json() {
-        Ok(Json(json!({ "url": redirect_url })).into_response())
-    } else {
-        Ok(req.redirect(redirect_url))
-    }
+        if req.wants_json() {
+            Ok(Json(json!({ "url": redirect_url })).into_response())
+        } else {
+            Ok(req.redirect(redirect_url))
+        }
+    })
+    .await
 }
 
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -35,7 +35,7 @@ pub async fn dependencies(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /crates/:crate_id/:version/authors` route.
-pub fn authors(_req: ConduitRequest) -> Json<Value> {
+pub async fn authors() -> Json<Value> {
     // Currently we return the empty list.
     // Because the API is not used anymore after RFC https://github.com/rust-lang/rfcs/pull/3052.
 

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -19,8 +19,8 @@ use crate::worker;
 /// Crate deletion is not implemented to avoid breaking builds,
 /// and the goal of yanking a crate is to prevent crates
 /// beginning to depend on the yanked crate version.
-pub fn yank(req: ConduitRequest) -> AppResult<Response> {
-    modify_yank(&req, true)
+pub async fn yank(req: ConduitRequest) -> AppResult<Response> {
+    conduit_compat(move || modify_yank(&req, true)).await
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -24,8 +24,8 @@ pub async fn yank(req: ConduitRequest) -> AppResult<Response> {
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
-pub fn unyank(req: ConduitRequest) -> AppResult<Response> {
-    modify_yank(&req, false)
+pub async fn unyank(req: ConduitRequest) -> AppResult<Response> {
+    conduit_compat(move || modify_yank(&req, false)).await
 }
 
 /// Changes `yanked` flag on a crate version record

--- a/src/router.rs
+++ b/src/router.rs
@@ -16,7 +16,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/crates/new", put(krate::publish::publish))
         .route(
             "/api/v1/crates/:crate_id/owners",
-            get(conduit(krate::owners::owners))
+            get(krate::owners::owners)
                 .put(conduit(krate::owners::add_owners))
                 .delete(conduit(krate::owners::remove_owners)),
         )

--- a/src/router.rs
+++ b/src/router.rs
@@ -11,7 +11,7 @@ use crate::Env;
 pub fn build_axum_router(state: AppState) -> Router {
     let mut router = Router::new()
         // Route used by both `cargo search` and the frontend
-        .route("/api/v1/crates", get(conduit(krate::search::search)))
+        .route("/api/v1/crates", get(krate::search::search))
         // Routes used by `cargo`
         .route("/api/v1/crates/new", put(conduit(krate::publish::publish)))
         .route(

--- a/src/router.rs
+++ b/src/router.rs
@@ -141,10 +141,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route("/api/private/session", delete(user::session::logout))
         // Metrics
-        .route(
-            "/api/private/metrics/:kind",
-            get(conduit(metrics::prometheus)),
-        )
+        .route("/api/private/metrics/:kind", get(metrics::prometheus))
         // Crate ownership invitations management in the frontend
         .route(
             "/api/private/crate_owner_invitations",

--- a/src/router.rs
+++ b/src/router.rs
@@ -98,7 +98,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             get(user::other::show).put(user::me::update_user),
         )
         .route("/api/v1/users/:user_id/stats", get(user::other::stats))
-        .route("/api/v1/teams/:team_id", get(conduit(team::show_team)))
+        .route("/api/v1/teams/:team_id", get(team::show_team))
         .route("/api/v1/me", get(conduit(user::me::me)))
         .route("/api/v1/me/updates", get(conduit(user::me::updates)))
         .route(

--- a/src/router.rs
+++ b/src/router.rs
@@ -70,7 +70,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/follow",
-            put(krate::follow::follow).delete(conduit(krate::follow::unfollow)),
+            put(krate::follow::follow).delete(krate::follow::unfollow),
         )
         .route(
             "/api/v1/crates/:crate_id/following",

--- a/src/router.rs
+++ b/src/router.rs
@@ -78,7 +78,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/owner_team",
-            get(conduit(krate::owners::owner_team)),
+            get(krate::owners::owner_team),
         )
         .route(
             "/api/v1/crates/:crate_id/owner_user",

--- a/src/router.rs
+++ b/src/router.rs
@@ -26,7 +26,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/:version/unyank",
-            put(conduit(version::yank::unyank)),
+            put(version::yank::unyank),
         )
         .route(
             "/api/v1/crates/:crate_id/:version/download",

--- a/src/router.rs
+++ b/src/router.rs
@@ -50,7 +50,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/:version/dependencies",
-            get(conduit(version::metadata::dependencies)),
+            get(version::metadata::dependencies),
         )
         .route(
             "/api/v1/crates/:crate_id/:version/downloads",

--- a/src/router.rs
+++ b/src/router.rs
@@ -101,10 +101,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/teams/:team_id", get(team::show_team))
         .route("/api/v1/me", get(user::me::me))
         .route("/api/v1/me/updates", get(user::me::updates))
-        .route(
-            "/api/v1/me/tokens",
-            get(token::list).put(conduit(token::new)),
-        )
+        .route("/api/v1/me/tokens", get(token::list).put(token::new))
         .route("/api/v1/me/tokens/:id", delete(conduit(token::revoke)))
         .route(
             "/api/v1/tokens/current",

--- a/src/router.rs
+++ b/src/router.rs
@@ -86,7 +86,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/reverse_dependencies",
-            get(conduit(krate::metadata::reverse_dependencies)),
+            get(krate::metadata::reverse_dependencies),
         )
         .route("/api/v1/keywords", get(keyword::index))
         .route("/api/v1/keywords/:keyword_id", get(keyword::show))

--- a/src/router.rs
+++ b/src/router.rs
@@ -145,7 +145,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         // Crate ownership invitations management in the frontend
         .route(
             "/api/private/crate_owner_invitations",
-            get(conduit(crate_owner_invitation::private_list)),
+            get(crate_owner_invitation::private_list),
         )
         // Alerts from GitHub scanning for exposed API tokens
         .route(

--- a/src/router.rs
+++ b/src/router.rs
@@ -95,7 +95,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/category_slugs", get(category::slugs))
         .route(
             "/api/v1/users/:user_id",
-            get(conduit(user::other::show)).put(conduit(user::me::update_user)),
+            get(user::other::show).put(conduit(user::me::update_user)),
         )
         .route(
             "/api/v1/users/:user_id/stats",

--- a/src/router.rs
+++ b/src/router.rs
@@ -110,7 +110,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/me/crate_owner_invitations/:crate_id",
-            put(conduit(crate_owner_invitation::handle_invite)),
+            put(crate_owner_invitation::handle_invite),
         )
         .route(
             "/api/v1/me/crate_owner_invitations/accept/:token",

--- a/src/router.rs
+++ b/src/router.rs
@@ -58,7 +58,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/:version/authors",
-            get(conduit(version::metadata::authors)),
+            get(version::metadata::authors),
         )
         .route(
             "/api/v1/crates/:crate_id/downloads",

--- a/src/router.rs
+++ b/src/router.rs
@@ -146,7 +146,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/private/session/authorize",
-            get(conduit(user::session::authorize)),
+            get(user::session::authorize),
         )
         .route(
             "/api/private/session",

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,7 +62,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/downloads",
-            get(conduit(krate::downloads::downloads)),
+            get(krate::downloads::downloads),
         )
         .route(
             "/api/v1/crates/:crate_id/versions",

--- a/src/router.rs
+++ b/src/router.rs
@@ -95,7 +95,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/category_slugs", get(category::slugs))
         .route(
             "/api/v1/users/:user_id",
-            get(user::other::show).put(conduit(user::me::update_user)),
+            get(user::other::show).put(user::me::update_user),
         )
         .route(
             "/api/v1/users/:user_id/stats",

--- a/src/router.rs
+++ b/src/router.rs
@@ -82,7 +82,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/owner_user",
-            get(conduit(krate::owners::owner_user)),
+            get(krate::owners::owner_user),
         )
         .route(
             "/api/v1/crates/:crate_id/reverse_dependencies",

--- a/src/router.rs
+++ b/src/router.rs
@@ -114,7 +114,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/me/crate_owner_invitations/accept/:token",
-            put(conduit(crate_owner_invitation::handle_invite_with_token)),
+            put(crate_owner_invitation::handle_invite_with_token),
         )
         .route(
             "/api/v1/me/email_notifications",

--- a/src/router.rs
+++ b/src/router.rs
@@ -70,7 +70,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/follow",
-            put(conduit(krate::follow::follow)).delete(conduit(krate::follow::unfollow)),
+            put(krate::follow::follow).delete(conduit(krate::follow::unfollow)),
         )
         .route(
             "/api/v1/crates/:crate_id/following",

--- a/src/router.rs
+++ b/src/router.rs
@@ -18,7 +18,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             "/api/v1/crates/:crate_id/owners",
             get(krate::owners::owners)
                 .put(krate::owners::add_owners)
-                .delete(conduit(krate::owners::remove_owners)),
+                .delete(krate::owners::remove_owners),
         )
         .route(
             "/api/v1/crates/:crate_id/:version/yank",

--- a/src/router.rs
+++ b/src/router.rs
@@ -91,10 +91,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/keywords", get(keyword::index))
         .route("/api/v1/keywords/:keyword_id", get(keyword::show))
         .route("/api/v1/categories", get(category::index))
-        .route(
-            "/api/v1/categories/:category_id",
-            get(conduit(category::show)),
-        )
+        .route("/api/v1/categories/:category_id", get(category::show))
         .route("/api/v1/category_slugs", get(conduit(category::slugs)))
         .route(
             "/api/v1/users/:user_id",

--- a/src/router.rs
+++ b/src/router.rs
@@ -30,7 +30,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/:version/download",
-            get(conduit(version::downloads::download)),
+            get(version::downloads::download),
         )
         // Routes that appear to be unused
         .route("/api/v1/versions", get(conduit(version::deprecated::index)))

--- a/src/router.rs
+++ b/src/router.rs
@@ -36,7 +36,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/versions", get(version::deprecated::index))
         .route(
             "/api/v1/versions/:version_id",
-            get(conduit(version::deprecated::show_by_id)),
+            get(version::deprecated::show_by_id),
         )
         // Routes used by the frontend
         .route(

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,7 +1,7 @@
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::Router;
-use conduit_axum::{ConduitAxumHandler, ConduitRequest, Handler, HandlerResult};
+use conduit_axum::{ConduitRequest, Handler, HandlerResult};
 
 use crate::app::AppState;
 use crate::controllers::*;
@@ -166,12 +166,6 @@ pub fn build_axum_router(state: AppState) -> Router {
     router
         .fallback(|| async { not_found().into_response() })
         .with_state(state)
-}
-
-fn conduit<R: IntoResponse + 'static>(
-    handler: fn(ConduitRequest) -> R,
-) -> ConduitAxumHandler<C<R>> {
-    ConduitAxumHandler::wrap(C(handler))
 }
 
 struct C<R>(pub fn(ConduitRequest) -> R);

--- a/src/router.rs
+++ b/src/router.rs
@@ -103,10 +103,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/me/updates", get(user::me::updates))
         .route("/api/v1/me/tokens", get(token::list).put(token::new))
         .route("/api/v1/me/tokens/:id", delete(token::revoke))
-        .route(
-            "/api/v1/tokens/current",
-            delete(conduit(token::revoke_current)),
-        )
+        .route("/api/v1/tokens/current", delete(token::revoke_current))
         .route(
             "/api/v1/me/crate_owner_invitations",
             get(conduit(crate_owner_invitation::list)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -120,7 +120,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             "/api/v1/me/email_notifications",
             put(user::me::update_email_notifications),
         )
-        .route("/api/v1/summary", get(conduit(krate::metadata::summary)))
+        .route("/api/v1/summary", get(krate::metadata::summary))
         .route(
             "/api/v1/confirm/:email_token",
             put(conduit(user::me::confirm_user_email)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -127,7 +127,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/users/:user_id/resend",
-            put(conduit(user::me::regenerate_token_and_send)),
+            put(user::me::regenerate_token_and_send),
         )
         .route(
             "/api/v1/site_metadata",

--- a/src/router.rs
+++ b/src/router.rs
@@ -123,7 +123,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/summary", get(krate::metadata::summary))
         .route(
             "/api/v1/confirm/:email_token",
-            put(conduit(user::me::confirm_user_email)),
+            put(user::me::confirm_user_email),
         )
         .route(
             "/api/v1/users/:user_id/resend",

--- a/src/router.rs
+++ b/src/router.rs
@@ -100,7 +100,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/users/:user_id/stats", get(user::other::stats))
         .route("/api/v1/teams/:team_id", get(team::show_team))
         .route("/api/v1/me", get(user::me::me))
-        .route("/api/v1/me/updates", get(conduit(user::me::updates)))
+        .route("/api/v1/me/updates", get(user::me::updates))
         .route(
             "/api/v1/me/tokens",
             get(conduit(token::list)).put(conduit(token::new)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -103,7 +103,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/me/updates", get(user::me::updates))
         .route(
             "/api/v1/me/tokens",
-            get(conduit(token::list)).put(conduit(token::new)),
+            get(token::list).put(conduit(token::new)),
         )
         .route("/api/v1/me/tokens/:id", delete(conduit(token::revoke)))
         .route(

--- a/src/router.rs
+++ b/src/router.rs
@@ -150,7 +150,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         // Alerts from GitHub scanning for exposed API tokens
         .route(
             "/api/github/secret-scanning/verify",
-            post(conduit(github::secret_scanning::verify)),
+            post(github::secret_scanning::verify),
         );
 
     // Only serve the local checkout of the git index in development mode.

--- a/src/router.rs
+++ b/src/router.rs
@@ -90,7 +90,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route("/api/v1/keywords", get(keyword::index))
         .route("/api/v1/keywords/:keyword_id", get(keyword::show))
-        .route("/api/v1/categories", get(conduit(category::index)))
+        .route("/api/v1/categories", get(category::index))
         .route(
             "/api/v1/categories/:category_id",
             get(conduit(category::show)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -22,7 +22,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/:version/yank",
-            delete(conduit(version::yank::yank)),
+            delete(version::yank::yank),
         )
         .route(
             "/api/v1/crates/:crate_id/:version/unyank",

--- a/src/router.rs
+++ b/src/router.rs
@@ -118,7 +118,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/me/email_notifications",
-            put(conduit(user::me::update_email_notifications)),
+            put(user::me::update_email_notifications),
         )
         .route("/api/v1/summary", get(conduit(krate::metadata::summary)))
         .route(

--- a/src/router.rs
+++ b/src/router.rs
@@ -54,7 +54,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/:version/downloads",
-            get(conduit(version::downloads::downloads)),
+            get(version::downloads::downloads),
         )
         .route(
             "/api/v1/crates/:crate_id/:version/authors",

--- a/src/router.rs
+++ b/src/router.rs
@@ -17,7 +17,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route(
             "/api/v1/crates/:crate_id/owners",
             get(krate::owners::owners)
-                .put(conduit(krate::owners::add_owners))
+                .put(krate::owners::add_owners)
                 .delete(conduit(krate::owners::remove_owners)),
         )
         .route(

--- a/src/router.rs
+++ b/src/router.rs
@@ -102,7 +102,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/me", get(user::me::me))
         .route("/api/v1/me/updates", get(user::me::updates))
         .route("/api/v1/me/tokens", get(token::list).put(token::new))
-        .route("/api/v1/me/tokens/:id", delete(conduit(token::revoke)))
+        .route("/api/v1/me/tokens/:id", delete(token::revoke))
         .route(
             "/api/v1/tokens/current",
             delete(conduit(token::revoke_current)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -13,7 +13,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         // Route used by both `cargo search` and the frontend
         .route("/api/v1/crates", get(krate::search::search))
         // Routes used by `cargo`
-        .route("/api/v1/crates/new", put(conduit(krate::publish::publish)))
+        .route("/api/v1/crates/new", put(krate::publish::publish))
         .route(
             "/api/v1/crates/:crate_id/owners",
             get(conduit(krate::owners::owners))

--- a/src/router.rs
+++ b/src/router.rs
@@ -42,7 +42,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/crates/:crate_id", get(krate::metadata::show))
         .route(
             "/api/v1/crates/:crate_id/:version",
-            get(conduit(version::metadata::show)),
+            get(version::metadata::show),
         )
         .route(
             "/api/v1/crates/:crate_id/:version/readme",

--- a/src/router.rs
+++ b/src/router.rs
@@ -134,10 +134,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             get(site_metadata::show_deployed_sha),
         )
         // Session management
-        .route(
-            "/api/private/session/begin",
-            get(conduit(user::session::begin)),
-        )
+        .route("/api/private/session/begin", get(user::session::begin))
         .route(
             "/api/private/session/authorize",
             get(user::session::authorize),

--- a/src/router.rs
+++ b/src/router.rs
@@ -92,7 +92,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/keywords/:keyword_id", get(keyword::show))
         .route("/api/v1/categories", get(category::index))
         .route("/api/v1/categories/:category_id", get(category::show))
-        .route("/api/v1/category_slugs", get(conduit(category::slugs)))
+        .route("/api/v1/category_slugs", get(category::slugs))
         .route(
             "/api/v1/users/:user_id",
             get(conduit(user::other::show)).put(conduit(user::me::update_user)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -46,7 +46,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/:version/readme",
-            get(conduit(krate::metadata::readme)),
+            get(krate::metadata::readme),
         )
         .route(
             "/api/v1/crates/:crate_id/:version/dependencies",

--- a/src/router.rs
+++ b/src/router.rs
@@ -106,7 +106,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route("/api/v1/tokens/current", delete(token::revoke_current))
         .route(
             "/api/v1/me/crate_owner_invitations",
-            get(conduit(crate_owner_invitation::list)),
+            get(crate_owner_invitation::list),
         )
         .route(
             "/api/v1/me/crate_owner_invitations/:crate_id",

--- a/src/router.rs
+++ b/src/router.rs
@@ -33,7 +33,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             get(version::downloads::download),
         )
         // Routes that appear to be unused
-        .route("/api/v1/versions", get(conduit(version::deprecated::index)))
+        .route("/api/v1/versions", get(version::deprecated::index))
         .route(
             "/api/v1/versions/:version_id",
             get(conduit(version::deprecated::show_by_id)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -139,10 +139,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             "/api/private/session/authorize",
             get(user::session::authorize),
         )
-        .route(
-            "/api/private/session",
-            delete(conduit(user::session::logout)),
-        )
+        .route("/api/private/session", delete(user::session::logout))
         // Metrics
         .route(
             "/api/private/metrics/:kind",

--- a/src/router.rs
+++ b/src/router.rs
@@ -97,10 +97,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             "/api/v1/users/:user_id",
             get(user::other::show).put(user::me::update_user),
         )
-        .route(
-            "/api/v1/users/:user_id/stats",
-            get(conduit(user::other::stats)),
-        )
+        .route("/api/v1/users/:user_id/stats", get(user::other::stats))
         .route("/api/v1/teams/:team_id", get(conduit(team::show_team)))
         .route("/api/v1/me", get(conduit(user::me::me)))
         .route("/api/v1/me/updates", get(conduit(user::me::updates)))

--- a/src/router.rs
+++ b/src/router.rs
@@ -39,10 +39,7 @@ pub fn build_axum_router(state: AppState) -> Router {
             get(version::deprecated::show_by_id),
         )
         // Routes used by the frontend
-        .route(
-            "/api/v1/crates/:crate_id",
-            get(conduit(krate::metadata::show)),
-        )
+        .route("/api/v1/crates/:crate_id", get(krate::metadata::show))
         .route(
             "/api/v1/crates/:crate_id/:version",
             get(conduit(version::metadata::show)),

--- a/src/router.rs
+++ b/src/router.rs
@@ -99,7 +99,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route("/api/v1/users/:user_id/stats", get(user::other::stats))
         .route("/api/v1/teams/:team_id", get(team::show_team))
-        .route("/api/v1/me", get(conduit(user::me::me)))
+        .route("/api/v1/me", get(user::me::me))
         .route("/api/v1/me/updates", get(conduit(user::me::updates)))
         .route(
             "/api/v1/me/tokens",

--- a/src/router.rs
+++ b/src/router.rs
@@ -66,7 +66,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/versions",
-            get(conduit(krate::metadata::versions)),
+            get(krate::metadata::versions),
         )
         .route(
             "/api/v1/crates/:crate_id/follow",

--- a/src/router.rs
+++ b/src/router.rs
@@ -74,7 +74,7 @@ pub fn build_axum_router(state: AppState) -> Router {
         )
         .route(
             "/api/v1/crates/:crate_id/following",
-            get(conduit(krate::follow::following)),
+            get(krate::follow::following),
         )
         .route(
             "/api/v1/crates/:crate_id/owner_team",


### PR DESCRIPTION
This replaces the `conduit()` usage in the router with async functions, using `conduit_compat()` inside to encapsulate the synchronously blocking code.

This will finally allow us to use other `axum` extractors in these functions too :)