### PR TITLE
conduit-axum: Remove obsolete code

### DIFF
--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -79,18 +79,3 @@ where
         Ok(ConduitRequest(request))
     }
 }
-
-/// A Handler takes a request and returns a response or an error.
-/// By default, a bare function implements `Handler`.
-pub trait Handler: Sync + Send + 'static {
-    fn call(&self, request: ConduitRequest) -> HandlerResult;
-}
-
-impl<F> Handler for F
-where
-    F: Fn(ConduitRequest) -> HandlerResult + Sync + Send + 'static,
-{
-    fn call(&self, request: ConduitRequest) -> HandlerResult {
-        (*self)(request)
-    }
-}

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -14,13 +14,13 @@
 //!
 //! ```no_run
 //! use axum::routing::get;
-//! use conduit_axum::{Handler, ConduitAxumHandler};
+//! use axum::response::IntoResponse;
 //! use tokio::runtime::Runtime;
 //!
 //! #[tokio::main]
 //! async fn main() {
 //!     let router = axum::Router::new()
-//!         .route("/", get(ConduitAxumHandler::wrap(build_conduit_handler())));
+//!         .route("/", get(handler));
 //!
 //!     let addr = ([127, 0, 0, 1], 12345).into();
 //!
@@ -30,22 +30,9 @@
 //!         .unwrap();
 //! }
 //!
-//! fn build_conduit_handler() -> impl Handler {
+//! async fn handler() -> impl IntoResponse {
 //!     // ...
-//! #     Endpoint()
 //! }
-//! #
-//! # use std::{error, io};
-//! # use axum::body::Bytes;
-//! # use axum::response::IntoResponse;
-//! # use conduit_axum::{box_error, Response, ConduitRequest, HandlerResult};
-//! #
-//! # struct Endpoint();
-//! # impl Handler for Endpoint {
-//! #     fn call(&self, _: ConduitRequest) -> HandlerResult {
-//! #         ().into_response()
-//! #     }
-//! # }
 //! ```
 
 mod conduit;
@@ -58,7 +45,5 @@ mod tokio_utils;
 
 pub use conduit::*;
 pub use error::ServiceError;
-pub use fallback::{
-    server_error_response, CauseField, ConduitAxumHandler, ErrorField, RequestParamsExt,
-};
+pub use fallback::{server_error_response, CauseField, ErrorField, RequestParamsExt};
 pub use tokio_utils::spawn_blocking;

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,7 +1,6 @@
 use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::Router;
-use conduit_axum::{ConduitRequest, Handler, HandlerResult};
 
 use crate::app::AppState;
 use crate::controllers::*;
@@ -166,15 +165,6 @@ pub fn build_axum_router(state: AppState) -> Router {
     router
         .fallback(|| async { not_found().into_response() })
         .with_state(state)
-}
-
-struct C<R>(pub fn(ConduitRequest) -> R);
-
-impl<R: IntoResponse + 'static> Handler for C<R> {
-    fn call(&self, req: ConduitRequest) -> HandlerResult {
-        let C(f) = *self;
-        f(req).into_response()
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Now that we use async request handlers everywhere, a lot of the support code in `conduit-axum` has become obsolete. This PR removes a few of the unused constructs.