### PR TITLE
Use `Path` extractor in request handlers

### DIFF
--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -1,12 +1,10 @@
 use crate::error::ServiceError;
 use crate::response::AxumResponse;
-use crate::ConduitRequest;
 
-use std::collections::BTreeMap;
 use std::error::Error;
 
 use axum::body::{Body, HttpBody};
-use axum::extract::{Extension, Path};
+use axum::extract::Extension;
 use axum::response::IntoResponse;
 use http::header::CONTENT_LENGTH;
 use http::StatusCode;
@@ -82,16 +80,4 @@ pub(crate) fn check_content_length(request: &Request<Body>) -> Result<(), AxumRe
     }
 
     Ok(())
-}
-
-pub type Params = Path<BTreeMap<String, String>>;
-
-pub trait RequestParamsExt<'a> {
-    fn axum_params(self) -> Option<&'a Params>;
-}
-
-impl<'a> RequestParamsExt<'a> for &'a ConduitRequest {
-    fn axum_params(self) -> Option<&'a Params> {
-        self.extensions().get::<Params>()
-    }
 }

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -45,5 +45,5 @@ mod tokio_utils;
 
 pub use conduit::*;
 pub use error::ServiceError;
-pub use fallback::{server_error_response, CauseField, ErrorField, RequestParamsExt};
+pub use fallback::{server_error_response, CauseField, ErrorField};
 pub use tokio_utils::spawn_blocking;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -11,6 +11,7 @@ mod frontend_prelude {
 mod prelude {
     pub use super::helpers::ok_true;
     pub use super::util::RequestParamExt;
+    pub use axum::extract::Path;
     pub use axum::response::{IntoResponse, Response};
     pub use axum::Json;
     pub use diesel::prelude::*;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -10,7 +10,6 @@ mod frontend_prelude {
 
 mod prelude {
     pub use super::helpers::ok_true;
-    pub use super::util::RequestParamExt;
     pub use axum::extract::Path;
     pub use axum::response::{IntoResponse, Response};
     pub use axum::Json;

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -36,11 +36,10 @@ pub async fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub async fn show(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show(Path(slug): Path<String>, req: ConduitRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let slug = req.param("category_id").unwrap();
         let conn = req.app().db_read()?;
-        let cat: Category = Category::by_slug(slug).first(&*conn)?;
+        let cat: Category = Category::by_slug(&slug).first(&*conn)?;
         let subcats = cat
             .subcategories(&conn)?
             .into_iter()

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -283,15 +283,16 @@ pub async fn handle_invite(mut req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
-pub async fn handle_invite_with_token(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn handle_invite_with_token(
+    Path(token): Path<String>,
+    req: ConduitRequest,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let state = req.app();
         let config = &state.config;
         let conn = state.db_write()?;
 
-        let req_token = req.param("token").unwrap();
-
-        let invitation = CrateOwnerInvitation::find_by_token(req_token, &conn)?;
+        let invitation = CrateOwnerInvitation::find_by_token(&token, &conn)?;
         let crate_id = invitation.crate_id;
         invitation.accept(&conn, config)?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,14 +13,16 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub async fn downloads(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn downloads(
+    Path(crate_name): Path<String>,
+    req: ConduitRequest,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::*;
         use diesel::sql_types::BigInt;
 
-        let crate_name = req.param("crate_id").unwrap();
         let conn = req.app().db_read()?;
-        let krate: Crate = Crate::by_name(crate_name).first(&*conn)?;
+        let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
 
         let mut versions: Vec<Version> = krate.all_versions().load(&*conn)?;
         versions

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -4,7 +4,7 @@ use axum::response::IntoResponse;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
-pub async fn prometheus(req: ConduitRequest) -> AppResult<Response> {
+pub async fn prometheus(Path(kind): Path<String>, req: ConduitRequest) -> AppResult<Response> {
     conduit_compat(move || {
         let app = req.app();
 
@@ -24,7 +24,7 @@ pub async fn prometheus(req: ConduitRequest) -> AppResult<Response> {
             return Err(Box::new(MetricsDisabled));
         }
 
-        let metrics = match req.param("kind").unwrap() {
+        let metrics = match kind.as_str() {
             "service" => app.service_metrics.gather(&*app.db_read()?)?,
             "instance" => app.instance_metrics.gather(app)?,
             _ => return Err(not_found()),

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,13 +5,12 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub async fn show_team(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show_team(Path(name): Path<String>, req: ConduitRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use self::teams::dsl::{login, teams};
 
-        let name = req.param("team_id").unwrap();
         let conn = req.app().db_read()?;
-        let team: Team = teams.filter(login.eq(name)).first(&*conn)?;
+        let team: Team = teams.filter(login.eq(&name)).first(&*conn)?;
 
         Ok(Json(json!({ "team": EncodableTeam::from(team) })))
     })

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -84,14 +84,8 @@ pub async fn new(mut req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `DELETE /me/tokens/:id` route.
-pub async fn revoke(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn revoke(Path(id): Path<i32>, req: ConduitRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let id = req
-            .param("id")
-            .unwrap()
-            .parse::<i32>()
-            .map_err(|e| bad_request(&format!("invalid token id: {e:?}")))?;
-
         let auth = AuthCheck::default().check(&req)?;
         let conn = req.app().db_write()?;
         let user = auth.user();

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,6 +1,5 @@
 use super::prelude::*;
 use crate::util::errors::{forbidden, internal, AppError, AppResult};
-use conduit_axum::RequestParamsExt;
 
 /// The Origin header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
 /// is sent with CORS requests and POST requests, and indicates where the request comes from.
@@ -22,15 +21,4 @@ pub fn verify_origin(req: &ConduitRequest) -> AppResult<()> {
         return Err(internal(&error_message).chain(forbidden()));
     }
     Ok(())
-}
-
-pub trait RequestParamExt<'a> {
-    fn param(self, key: &str) -> Option<&'a str>;
-}
-
-impl<'a> RequestParamExt<'a> for &'a ConduitRequest {
-    fn param(self, key: &str) -> Option<&'a str> {
-        self.axum_params()
-            .and_then(|params| params.0.get(key).map(|s| &s[..]))
-    }
 }

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -17,21 +17,3 @@ fn version_and_crate(
 
     Ok((version, krate))
 }
-
-fn extract_crate_name_and_semver(req: &ConduitRequest) -> AppResult<(&str, &str)> {
-    let name = extract_crate_name(req);
-    let version = extract_semver(req)?;
-    Ok((name, version))
-}
-
-fn extract_crate_name(req: &ConduitRequest) -> &str {
-    req.param("crate_id").unwrap()
-}
-
-fn extract_semver(req: &ConduitRequest) -> AppResult<&str> {
-    let semver = req.param("version").unwrap();
-    if semver::Version::parse(semver).is_err() {
-        return Err(cargo_err(&format_args!("invalid semver: {semver}")));
-    };
-    Ok(semver)
-}

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -54,10 +54,8 @@ pub async fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub async fn show_by_id(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show_by_id(Path(id): Path<i32>, req: ConduitRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let id = req.param("version_id").unwrap();
-        let id = id.parse().unwrap_or(0);
         let conn = req.app().db_read()?;
         let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table
             .find(id)


### PR DESCRIPTION
This PR removes the `req.param()` API in favor of using the `Path` extractor from `axum`. This makes our `FromRequest` implementation for `ConduitRequest` a bit simpler and will eventually allow us to remove `ConduitRequest` completely.