### PR TITLE
Simplify and move `content_length()` function

### DIFF
--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -32,6 +32,12 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 #[derive(Debug)]
 pub struct ConduitRequest(pub Request<Cursor<Bytes>>);
 
+impl ConduitRequest {
+    pub fn content_length(&self) -> u64 {
+        self.body().get_ref().len() as u64
+    }
+}
+
 impl Deref for ConduitRequest {
     type Target = Request<Cursor<Bytes>>;
 

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -32,7 +32,7 @@ mod prelude {
         fn query(&self) -> IndexMap<String, String>;
         fn wants_json(&self) -> bool;
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
-        fn content_length(&self) -> Option<u64>;
+        fn content_length(&self) -> u64;
     }
 
     impl RequestUtils for ConduitRequest {
@@ -58,8 +58,8 @@ mod prelude {
             format!("?{query_string}")
         }
 
-        fn content_length(&self) -> Option<u64> {
-            Some(self.body().get_ref().len() as u64)
+        fn content_length(&self) -> u64 {
+            self.body().get_ref().len() as u64
         }
     }
 }

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -32,7 +32,6 @@ mod prelude {
         fn query(&self) -> IndexMap<String, String>;
         fn wants_json(&self) -> bool;
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
-        fn content_length(&self) -> u64;
     }
 
     impl RequestUtils for ConduitRequest {
@@ -56,10 +55,6 @@ mod prelude {
                 .extend_pairs(params)
                 .finish();
             format!("?{query_string}")
-        }
-
-        fn content_length(&self) -> u64 {
-            self.body().get_ref().len() as u64
         }
     }
 }

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -235,9 +235,7 @@ pub enum GitHubSecretAlertFeedbackLabel {
 pub async fn verify(mut req: ConduitRequest) -> AppResult<Json<Vec<GitHubSecretAlertFeedback>>> {
     conduit_compat(move || {
         let max_size = 8192;
-        let length = req
-            .content_length()
-            .ok_or_else(|| bad_request("missing header: Content-Length"))?;
+        let length = req.content_length();
 
         if length > max_size {
             return Err(bad_request(&format!("max content length is: {max_size}")));

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -161,9 +161,7 @@ pub async fn publish(mut req: ConduitRequest) -> AppResult<Json<GoodCrate>> {
             // this file length.
             let file_length = read_le_u32(req.body_mut())?;
 
-            let content_length = req
-                .content_length()
-                .ok_or_else(|| cargo_err("missing header: Content-Length"))?;
+            let content_length = req.content_length();
 
             let maximums = Maximums::new(
                 krate.max_upload_size,

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -41,9 +41,7 @@ pub async fn new(mut req: ConduitRequest) -> AppResult<Json<Value>> {
         }
 
         let max_size = 2000;
-        let length = req
-            .content_length()
-            .ok_or_else(|| bad_request("missing header: Content-Length"))?;
+        let length = req.content_length();
 
         if length > max_size {
             return Err(bad_request(&format!("max content length is: {max_size}")));


### PR DESCRIPTION
see commit messages 😉 

The move to `ConduitRequest` will let us implement `RequestUtils` for any `Request<...>` instead of just `ConduitRequest`