### PR TITLE
Use generic `Request` parameters where possible

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,8 +8,7 @@ use crate::util::errors::{
     account_locked, forbidden, internal, AppError, AppResult, InsecurelyGeneratedTokenRevoked,
 };
 use chrono::Utc;
-use conduit_axum::ConduitRequest;
-use http::header;
+use http::{header, Request};
 
 #[derive(Debug, Clone)]
 pub struct AuthCheck {
@@ -55,7 +54,7 @@ impl AuthCheck {
         }
     }
 
-    pub fn check(&self, request: &ConduitRequest) -> AppResult<AuthenticatedUser> {
+    pub fn check<B>(&self, request: &Request<B>) -> AppResult<AuthenticatedUser> {
         controllers::util::verify_origin(request)?;
 
         let auth = authenticate_user(request)?;
@@ -153,7 +152,7 @@ impl AuthenticatedUser {
     }
 }
 
-fn authenticate_user(req: &ConduitRequest) -> AppResult<AuthenticatedUser> {
+fn authenticate_user<B>(req: &Request<B>) -> AppResult<AuthenticatedUser> {
     let conn = req.app().db_write()?;
 
     let user_id_from_session = req

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -17,7 +17,7 @@ mod prelude {
     pub use serde_json::Value;
 
     pub use conduit_axum::ConduitRequest;
-    pub use http::{header, StatusCode};
+    pub use http::{header, Request, StatusCode};
 
     pub use super::conduit_axum::conduit_compat;
     pub use crate::middleware::app::RequestApp;
@@ -34,7 +34,7 @@ mod prelude {
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
     }
 
-    impl RequestUtils for ConduitRequest {
+    impl<B> RequestUtils for Request<B> {
         fn query(&self) -> IndexMap<String, String> {
             url::form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
                 .into_owned()

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -78,8 +78,8 @@ enum ListFilter {
     InviteeId(i32),
 }
 
-fn prepare_list(
-    req: &ConduitRequest,
+fn prepare_list<B>(
+    req: &Request<B>,
     auth: AuthenticatedUser,
     filter: ListFilter,
 ) -> AppResult<PrivateListResponse> {

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -72,7 +72,7 @@ impl PaginationOptionsBuilder {
         self
     }
 
-    pub(crate) fn gather(self, req: &ConduitRequest) -> AppResult<PaginationOptions> {
+    pub(crate) fn gather<B>(self, req: &Request<B>) -> AppResult<PaginationOptions> {
         let params = req.query();
         let page_param = params.get("page");
         let seek_param = params.get("seek");
@@ -307,9 +307,9 @@ pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> AppResult<D
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Bytes;
     use conduit_test::MockRequest;
     use http::StatusCode;
-    use std::io::Cursor;
 
     #[test]
     fn no_pagination_param() {
@@ -410,13 +410,9 @@ mod tests {
         );
     }
 
-    fn mock(query: &str) -> ConduitRequest {
+    fn mock(query: &str) -> Request<Bytes> {
         let path_and_query = format!("/?{query}");
-        ConduitRequest(
-            MockRequest::new(http::Method::GET, &path_and_query)
-                .into_inner()
-                .map(Cursor::new),
-        )
+        MockRequest::new(http::Method::GET, &path_and_query).into_inner()
     }
 
     fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -3,6 +3,7 @@
 use crate::auth::AuthCheck;
 use flate2::read::GzDecoder;
 use hex::ToHex;
+use http::Request;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use std::io::Read;
@@ -304,7 +305,7 @@ fn count_versions_published_today(krate_id: i32, conn: &PgConnection) -> QueryRe
 ///
 /// This function parses the JSON headers to interpret the data and validates
 /// the data during and after the parsing. Returns crate metadata.
-fn parse_new_headers(req: &mut ConduitRequest) -> AppResult<EncodableCrateUpload> {
+fn parse_new_headers<B: Read>(req: &mut Request<B>) -> AppResult<EncodableCrateUpload> {
     // Read the json upload request
     let metadata_length = u64::from(read_le_u32(req.body_mut())?);
     req.add_custom_metadata("metadata_length", metadata_length);

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,12 +1,13 @@
 use super::prelude::*;
 use crate::util::errors::{forbidden, internal, AppError, AppResult};
+use http::Request;
 
 /// The Origin header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
 /// is sent with CORS requests and POST requests, and indicates where the request comes from.
 /// We don't want to accept authenticated requests that originated from other sites, so this
 /// function returns an error if the Origin header doesn't match what we expect "this site" to
 /// be: https://crates.io in production, or http://localhost:port/ in development.
-pub fn verify_origin(req: &ConduitRequest) -> AppResult<()> {
+pub fn verify_origin<B>(req: &Request<B>) -> AppResult<()> {
     let headers = req.headers();
     let allowed_origins = &req.app().config.allowed_origins;
 

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -35,10 +35,10 @@ pub async fn unyank(
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank(
+fn modify_yank<B>(
     crate_name: &str,
     version: &str,
-    req: &ConduitRequest,
+    req: &Request<B>,
     yanked: bool,
 ) -> AppResult<Response> {
     // FIXME: Should reject bad requests before authentication, but can't due to


### PR DESCRIPTION
This makes a few of our traits and functions more reusable, by allowing them to work with any `Request`, not just `ConduitRequest` (aka. `Request<Cursor<Bytes>>`).