### PR TITLE
controllers/token: Remove obsolete `content_length()` check

### DIFF
--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -40,13 +40,6 @@ pub async fn new(mut req: ConduitRequest) -> AppResult<Json<Value>> {
             api_token: NewApiToken,
         }
 
-        let max_size = 2000;
-        let length = req.content_length();
-
-        if length > max_size {
-            return Err(bad_request(&format!("max content length is: {max_size}")));
-        }
-
         let new: NewApiTokenRequest = json::from_reader(req.body_mut())
             .map_err(|e| bad_request(&format!("invalid new token request: {e:?}")))?;
 

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -42,18 +42,6 @@ fn create_token_no_name() {
 }
 
 #[test]
-fn create_token_long_body() {
-    let (_, _, user) = TestApp::init().with_user();
-    let too_big = &[5; 5192]; // Send a request with a 5kB body of 5's
-    let response = user.put::<()>("/api/v1/me/tokens", too_big);
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_eq!(
-        response.into_json(),
-        json!({ "errors": [{ "detail": "max content length is: 2000" }] })
-    );
-}
-
-#[test]
 fn create_token_exceeded_tokens_per_user() {
     let (app, _, user) = TestApp::init().with_user();
     let id = user.as_model().id;


### PR DESCRIPTION
We have a global request body size limit these days, so this request handler specific check is somewhat redundant now.