### PR TITLE
Add `cargo add` instruction to crate-sidebar

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -37,7 +37,23 @@
   <div>
     <h2 local-class="heading">Install</h2>
 
-    <p local-class="copy-help">Add the following line to your Cargo.toml file:</p>
+    <p local-class="copy-help">Run the following Cargo command in your project directory:</p>
+    {{#if (is-clipboard-supported)}}
+      <CopyButton
+        @copyText={{this.cargoAddCommand}}
+        title="Copy command to clipboard"
+        local-class="copy-button"
+      >
+        <span>{{this.cargoAddCommand}}</span>
+        {{svg-jar "copy" aria-hidden="true" local-class="copy-icon"}}
+      </CopyButton>
+    {{else}}
+      <code local-class="copy-fallback">
+        {{this.cargoAddCommand}}
+      </code>
+    {{/if}}
+
+    <p local-class="copy-help">Or add the following line to your Cargo.toml:</p>
     {{#if (is-clipboard-supported)}}
       <CopyButton
         @copyText={{this.tomlSnippet}}

--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -14,6 +14,10 @@ export default class CrateSidebar extends Component {
     return homepage && (!repository || simplifyUrl(repository) !== simplifyUrl(homepage));
   }
 
+  get cargoAddCommand() {
+    return `cargo add ${this.args.crate.name}`;
+  }
+
   get tomlSnippet() {
     return `${this.args.crate.name} = "${this.args.version.num}"`;
   }

--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -15,7 +15,9 @@ export default class CrateSidebar extends Component {
   }
 
   get cargoAddCommand() {
-    return `cargo add ${this.args.crate.name}`;
+    return this.args.requestedVersion
+      ? `cargo add ${this.args.crate.name}@${this.args.requestedVersion}`
+      : `cargo add ${this.args.crate.name}`;
   }
 
   get tomlSnippet() {

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -47,6 +47,7 @@
     <CrateSidebar
       @crate={{this.crate}}
       @version={{this.currentVersion}}
+      @requestedVersion={{this.requestedVersion}}
       local-class="sidebar"
     />
   </div>


### PR DESCRIPTION
This adds a `cargo add` instruction to the crate sidebar, with clipboard support:

<img width="289" alt="Screenshot 2023-01-06 at 20 07 01" src="https://user-images.githubusercontent.com/89950/211082066-6fb14142-d5eb-4799-8aa8-15e66a092165.png">

This came about after @beeb [made a good point](https://hachyderm.io/@beeb/109641418504476058) that copying a snippet from crates.io prevents typosquatting, and not having a snippet for `cargo add` is reason to avoid it.