### PR TITLE
util/errors: Simplify `internal()` fn

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -33,7 +33,7 @@ pub async fn list(req: ConduitRequest) -> AppResult<Json<Value>> {
                     invited_by_username: users
                         .iter()
                         .find(|u| u.id == private.inviter_id)
-                        .ok_or_else(|| internal(&format!("missing user {}", private.inviter_id)))?
+                        .ok_or_else(|| internal(format!("missing user {}", private.inviter_id)))?
                         .login
                         .clone(),
                     invitee_id: private.invitee_id,
@@ -217,7 +217,7 @@ fn prepare_list<B>(
             crate_id: invitation.crate_id,
             crate_name: crate_names
                 .get(&invitation.crate_id)
-                .ok_or_else(|| internal(&format!("missing crate with id {}", invitation.crate_id)))?
+                .ok_or_else(|| internal(format!("missing crate with id {}", invitation.crate_id)))?
                 .clone(),
             created_at: invitation.created_at,
             expires_at: invitation.expires_at(config),

--- a/src/github.rs
+++ b/src/github.rs
@@ -165,9 +165,7 @@ fn handle_error_response(error: &reqwest::Error) -> BoxedAppError {
              GitHub org memberships.",
         ),
         Some(Status::NOT_FOUND) => not_found(),
-        _ => internal(&format_args!(
-            "didn't get a 200 result from github: {error}"
-        )),
+        _ => internal(format!("didn't get a 200 result from github: {error}")),
     }
 }
 

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -205,7 +205,7 @@ impl Uploader {
             extra_headers,
             UploadBucket::Default,
         )
-        .map_err(|e| internal(&format_args!("failed to upload crate: {e}")))?;
+        .map_err(|e| internal(format!("failed to upload crate: {e}")))?;
         Ok(())
     }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -327,7 +327,7 @@ impl AppError for InternalAppErrorStatic {
     }
 }
 
-pub fn internal<S: ToString + ?Sized>(error: &S) -> BoxedAppError {
+pub fn internal<S: ToString>(error: S) -> BoxedAppError {
     Box::new(InternalAppError {
         description: error.to_string(),
     })


### PR DESCRIPTION
Previously it was impossible to call this function directly with a `String`. If instead `internal(&the_string)` was used then an unnecessary clone of the original string was performed.