### PR TITLE
Implement `RequestPartsExt` trait

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,4 +1,5 @@
 use crate::controllers;
+use crate::controllers::util::RequestPartsExt;
 use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::CustomMetadataRequestExt;
 use crate::middleware::session::RequestSession;
@@ -8,7 +9,7 @@ use crate::util::errors::{
     account_locked, forbidden, internal, AppError, AppResult, InsecurelyGeneratedTokenRevoked,
 };
 use chrono::Utc;
-use http::{header, Request};
+use http::header;
 
 #[derive(Debug, Clone)]
 pub struct AuthCheck {
@@ -54,7 +55,7 @@ impl AuthCheck {
         }
     }
 
-    pub fn check<B>(&self, request: &Request<B>) -> AppResult<Authentication> {
+    pub fn check<T: RequestPartsExt>(&self, request: &T) -> AppResult<Authentication> {
         let auth = authenticate_user(request)?;
 
         if let Some(token) = auth.api_token() {
@@ -151,7 +152,7 @@ impl Authentication {
     }
 }
 
-fn authenticate_user<B>(req: &Request<B>) -> AppResult<Authentication> {
+fn authenticate_user<T: RequestPartsExt>(req: &T) -> AppResult<Authentication> {
     controllers::util::verify_origin(req)?;
 
     let conn = req.app().db_write()?;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -20,6 +20,7 @@ mod prelude {
     pub use http::{header, Request, StatusCode};
 
     pub use super::conduit_axum::conduit_compat;
+    use crate::controllers::util::RequestPartsExt;
     pub use crate::middleware::app::RequestApp;
     pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError};
     use indexmap::IndexMap;
@@ -34,7 +35,7 @@ mod prelude {
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;
     }
 
-    impl<B> RequestUtils for Request<B> {
+    impl<T: RequestPartsExt> RequestUtils for T {
         fn query(&self) -> IndexMap<String, String> {
             url::form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
                 .into_owned()

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -1,5 +1,6 @@
 use crate::config::Server;
 use crate::controllers::prelude::*;
+use crate::controllers::util::RequestPartsExt;
 use crate::middleware::log_request::CustomMetadataRequestExt;
 use crate::models::helpers::with_count::*;
 use crate::util::errors::{bad_request, AppResult};
@@ -72,7 +73,7 @@ impl PaginationOptionsBuilder {
         self
     }
 
-    pub(crate) fn gather<B>(self, req: &Request<B>) -> AppResult<PaginationOptions> {
+    pub(crate) fn gather<T: RequestPartsExt>(self, req: &T) -> AppResult<PaginationOptions> {
         let params = req.query();
         let page_param = params.get("page");
         let seek_param = params.get("seek");

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,6 +1,7 @@
 use super::prelude::*;
 use crate::util::errors::{forbidden, internal, AppError, AppResult};
-use http::Request;
+use http::request::Parts;
+use http::{Extensions, HeaderMap, HeaderValue, Method, Request, Uri, Version};
 
 /// The Origin header (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin)
 /// is sent with CORS requests and POST requests, and indicates where the request comes from.
@@ -22,4 +23,76 @@ pub fn verify_origin<B>(req: &Request<B>) -> AppResult<()> {
         return Err(internal(&error_message).chain(forbidden()));
     }
     Ok(())
+}
+
+pub trait RequestPartsExt {
+    fn method(&self) -> &Method;
+    fn uri(&self) -> &Uri;
+    fn version(&self) -> Version;
+    fn headers(&self) -> &HeaderMap<HeaderValue>;
+    fn extensions(&self) -> &Extensions;
+    fn extensions_mut(&mut self) -> &mut Extensions;
+}
+
+impl RequestPartsExt for Parts {
+    fn method(&self) -> &Method {
+        &self.method
+    }
+    fn uri(&self) -> &Uri {
+        &self.uri
+    }
+    fn version(&self) -> Version {
+        self.version
+    }
+    fn headers(&self) -> &HeaderMap<HeaderValue> {
+        &self.headers
+    }
+    fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+    fn extensions_mut(&mut self) -> &mut Extensions {
+        &mut self.extensions
+    }
+}
+
+impl<B> RequestPartsExt for Request<B> {
+    fn method(&self) -> &Method {
+        self.method()
+    }
+    fn uri(&self) -> &Uri {
+        self.uri()
+    }
+    fn version(&self) -> Version {
+        self.version()
+    }
+    fn headers(&self) -> &HeaderMap<HeaderValue> {
+        self.headers()
+    }
+    fn extensions(&self) -> &Extensions {
+        self.extensions()
+    }
+    fn extensions_mut(&mut self) -> &mut Extensions {
+        self.extensions_mut()
+    }
+}
+
+impl RequestPartsExt for ConduitRequest {
+    fn method(&self) -> &Method {
+        self.0.method()
+    }
+    fn uri(&self) -> &Uri {
+        self.0.uri()
+    }
+    fn version(&self) -> Version {
+        self.0.version()
+    }
+    fn headers(&self) -> &HeaderMap<HeaderValue> {
+        self.0.headers()
+    }
+    fn extensions(&self) -> &Extensions {
+        self.0.extensions()
+    }
+    fn extensions_mut(&mut self) -> &mut Extensions {
+        self.0.extensions_mut()
+    }
 }

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -8,7 +8,7 @@ use http::{Extensions, HeaderMap, HeaderValue, Method, Request, Uri, Version};
 /// We don't want to accept authenticated requests that originated from other sites, so this
 /// function returns an error if the Origin header doesn't match what we expect "this site" to
 /// be: https://crates.io in production, or http://localhost:port/ in development.
-pub fn verify_origin<B>(req: &Request<B>) -> AppResult<()> {
+pub fn verify_origin<T: RequestPartsExt>(req: &T) -> AppResult<()> {
     let headers = req.headers();
     let allowed_origins = &req.app().config.allowed_origins;
 

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -4,6 +4,7 @@ use axum::response::Response;
 use http::Request;
 
 use crate::app::AppState;
+use crate::controllers::util::RequestPartsExt;
 
 /// `axum` middleware that injects the `AppState` instance into the `Request` extensions.
 pub async fn add_app_state_extension<B>(
@@ -21,7 +22,7 @@ pub trait RequestApp {
     fn app(&self) -> &AppState;
 }
 
-impl<T> RequestApp for Request<T> {
+impl<T: RequestPartsExt> RequestApp for T {
     fn app(&self) -> &AppState {
         self.extensions().get::<AppState>().expect("Missing app")
     }

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -1,3 +1,4 @@
+use crate::controllers::util::RequestPartsExt;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::SignedCookieJar;
@@ -63,7 +64,7 @@ pub trait RequestSession {
     fn session_remove(&mut self, key: &str) -> Option<String>;
 }
 
-impl<T> RequestSession for Request<T> {
+impl<T: RequestPartsExt> RequestSession for T {
     fn session_get(&self, key: &str) -> Option<String> {
         let session = self
             .extensions()


### PR DESCRIPTION
This trait allows us to implement things independent from passing in `Parts` or a full `Request`. This makes it easier to reuse code when implementing the `FromRequestParts` trait of `axum`.