### PR TITLE
auth: Reuse existing database connections

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,5 @@
 use crate::controllers;
 use crate::controllers::util::RequestPartsExt;
-use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::CustomMetadataRequestExt;
 use crate::middleware::session::RequestSession;
 use crate::models::token::{CrateScope, EndpointScope};
@@ -56,10 +55,12 @@ impl AuthCheck {
         }
     }
 
-    pub fn check<T: RequestPartsExt>(&self, request: &T) -> AppResult<Authentication> {
-        let conn = request.app().db_write()?;
-
-        let auth = authenticate(request, &conn)?;
+    pub fn check<T: RequestPartsExt>(
+        &self,
+        request: &T,
+        conn: &PgConnection,
+    ) -> AppResult<Authentication> {
+        let auth = authenticate(request, conn)?;
 
         if let Some(token) = auth.api_token() {
             if !self.allow_token {

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -103,15 +103,15 @@ fn modify_owners<B: Read>(
     req: &mut Request<B>,
     add: bool,
 ) -> AppResult<Json<Value>> {
-    let auth = AuthCheck::default()
-        .with_endpoint_scope(EndpointScope::ChangeOwners)
-        .for_crate(crate_name)
-        .check(req)?;
-
     let logins = parse_owners_request(req)?;
     let app = req.app();
 
     let conn = app.db_write()?;
+    let auth = AuthCheck::default()
+        .with_endpoint_scope(EndpointScope::ChangeOwners)
+        .for_crate(crate_name)
+        .check(req, &conn)?;
+
     let user = auth.user();
 
     conn.transaction(|| {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -82,7 +82,7 @@ pub async fn publish(mut req: ConduitRequest) -> AppResult<Json<GoodCrate>> {
         let auth = AuthCheck::default()
             .with_endpoint_scope(endpoint_scope)
             .for_crate(&new_crate.name)
-            .check(&req)?;
+            .check(&req, &conn)?;
 
         let api_token_id = auth.api_token_id();
         let user = auth.user();

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -115,6 +115,8 @@ pub async fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
             );
         }
 
+        let conn = req.app().db_read()?;
+
         if let Some(kws) = params.get("all_keywords") {
             // Calculating the total number of results with filters is not supported yet.
             supports_seek = false;
@@ -188,7 +190,7 @@ pub async fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
             // Calculating the total number of results with filters is not supported yet.
             supports_seek = false;
 
-            let user_id = AuthCheck::default().check(&req)?.user_id();
+            let user_id = AuthCheck::default().check(&req, &conn)?.user_id();
 
             query = query.filter(
                 crates::id.eq_any(
@@ -250,7 +252,6 @@ pub async fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
             .limit_page_numbers()
             .enable_seek(supports_seek)
             .gather(&req)?;
-        let conn = req.app().db_read()?;
 
         let (explicit_page, seek) = match pagination.page.clone() {
             Page::Numeric(_) => (true, None),

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -48,13 +48,14 @@ fn modify_yank<B>(
         return Err(cargo_err(&format_args!("invalid semver: {version}")));
     }
 
+    let state = req.app();
+    let conn = state.db_write()?;
+
     let auth = AuthCheck::default()
         .with_endpoint_scope(EndpointScope::Yank)
         .for_crate(crate_name)
-        .check(req)?;
+        .check(req, &conn)?;
 
-    let state = req.app();
-    let conn = state.db_write()?;
     let (version, krate) = version_and_crate(&conn, crate_name, version)?;
     let api_token_id = auth.api_token_id();
     let user = auth.user();


### PR DESCRIPTION
The authentication check previously requested a second database connection from the pool for no good reason. This PR changes it to reuse the existing database connections of these request handlers.

@jtgeibel I believe this also simplifies the Diesel v2 upgrade?