### PR TITLE
conduit-axum: Inline `content_length()` method

### DIFF
--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -32,12 +32,6 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 #[derive(Debug)]
 pub struct ConduitRequest(pub Request<Cursor<Bytes>>);
 
-impl ConduitRequest {
-    pub fn content_length(&self) -> u64 {
-        self.body().get_ref().len() as u64
-    }
-}
-
 impl Deref for ConduitRequest {
     type Target = Request<Cursor<Bytes>>;
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -162,7 +162,7 @@ pub async fn publish(mut req: ConduitRequest) -> AppResult<Json<GoodCrate>> {
             // this file length.
             let file_length = read_le_u32(req.body_mut())?;
 
-            let content_length = req.content_length();
+            let content_length = req.body().get_ref().len() as u64;
 
             let maximums = Maximums::new(
                 krate.max_upload_size,


### PR DESCRIPTION
We're down to using this in only one place at this point, so we might as well inline and remove the method... 🧹 