### PR TITLE
publish: Avoid redundant buffer copies

### DIFF
--- a/cargo-registry-s3/lib.rs
+++ b/cargo-registry-s3/lib.rs
@@ -37,12 +37,11 @@ impl Bucket {
         }
     }
 
-    pub fn put<R: std::io::Read + Send + 'static>(
+    pub fn put<R: Into<Body>>(
         &self,
         client: &Client,
         path: &str,
         content: R,
-        content_length: u64,
         content_type: &str,
         extra_headers: header::HeaderMap,
     ) -> Result<Response, Error> {
@@ -58,7 +57,7 @@ impl Bucket {
             .header(header::DATE, date)
             .header(header::USER_AGENT, "crates.io (https://crates.io)")
             .headers(extra_headers)
-            .body(Body::sized(content, content_length))
+            .body(content.into())
             .timeout(Duration::from_secs(60))
             .send()?
             .error_for_status()


### PR DESCRIPTION
Previously, we were buffering the incoming `hyper::Body` into a `bytes::Bytes` instance, which we then wrapped in a `Cursor`, which we then used as a `Read` implementation to fill a `Vec<u8>`. This was somewhat wasteful because it meant that we were buffering the tarball payload twice: once in the `Bytes` and once more in the `Vec<u8>`.

This PR changes the implementation to take more advantage of the `Arc`-like behavior of `bytes::Bytes`. We implement a `split_body()` function, which turns one `Bytes` instance into two `Bytes`, one for the JSON metadata, and one for the tarball payload. This will just shuffle around a few pointers underneath, without performing any additional memory allocation.

In this PR we also slightly refactor the S3 uploader implementation to not require a redundant seek operation, which makes the above implementation a bit easier.