### PR TITLE
ConduitRequest: Remove `Cursor` wrapper

### DIFF
--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -5,7 +5,6 @@ use axum::{async_trait, RequestExt};
 use http_body::LengthLimitError;
 use hyper::Body;
 use std::error::Error;
-use std::io::Cursor;
 use std::ops::{Deref, DerefMut};
 
 use crate::response::AxumResponse;
@@ -31,10 +30,10 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 }
 
 #[derive(Debug)]
-pub struct ConduitRequest(pub Request<Cursor<Bytes>>);
+pub struct ConduitRequest(pub Request<Bytes>);
 
 impl Deref for ConduitRequest {
-    type Target = Request<Cursor<Bytes>>;
+    type Target = Request<Bytes>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -80,6 +79,6 @@ where
             }
         };
 
-        Ok(ConduitRequest(request.map(Cursor::new)))
+        Ok(ConduitRequest(request))
     }
 }

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -258,10 +258,10 @@ struct OwnerInvitation {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
-pub async fn handle_invite(mut req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn handle_invite(req: ConduitRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let crate_invite: OwnerInvitation = serde_json::from_reader(req.body_mut())
-            .map_err(|_| bad_request("invalid json request"))?;
+        let crate_invite: OwnerInvitation =
+            serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;
 
         let crate_invite = crate_invite.crate_owner_invite;
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -46,8 +46,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
 pub async fn publish(req: ConduitRequest) -> AppResult<Json<GoodCrate>> {
-    let (req, body) = req.0.into_parts();
-    let bytes = body.into_inner();
+    let (req, bytes) = req.0.into_parts();
     let (json_bytes, tarball_bytes) = split_body(bytes, &req)?;
 
     let new_crate: EncodableCrateUpload = serde_json::from_slice(&json_bytes)

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -26,7 +26,7 @@ pub async fn list(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `PUT /me/tokens` route.
-pub async fn new(mut req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn new(req: ConduitRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         /// The incoming serialization format for the `ApiToken` model.
         #[derive(Deserialize, Serialize)]
@@ -40,7 +40,7 @@ pub async fn new(mut req: ConduitRequest) -> AppResult<Json<Value>> {
             api_token: NewApiToken,
         }
 
-        let new: NewApiTokenRequest = json::from_reader(req.body_mut())
+        let new: NewApiTokenRequest = json::from_slice(req.body())
             .map_err(|e| bad_request(&format!("invalid new token request: {e:?}")))?;
 
         let name = &new.api_token.name;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -101,7 +101,7 @@ pub async fn updates(req: ConduitRequest) -> AppResult<Json<Value>> {
 /// Handles the `PUT /users/:user_id` route.
 pub async fn update_user(
     Path(param_user_id): Path<i32>,
-    mut req: ConduitRequest,
+    req: ConduitRequest,
 ) -> AppResult<Response> {
     conduit_compat(move || {
         use self::emails::user_id;
@@ -128,8 +128,8 @@ pub async fn update_user(
             email: Option<String>,
         }
 
-        let user_update: UserUpdate = serde_json::from_reader(req.body_mut())
-            .map_err(|_| bad_request("invalid json request"))?;
+        let user_update: UserUpdate =
+            serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;
 
         let user_email = match &user_update.user.email {
             Some(email) => email.trim(),
@@ -231,7 +231,7 @@ pub async fn regenerate_token_and_send(
 }
 
 /// Handles `PUT /me/email_notifications` route
-pub async fn update_email_notifications(mut req: ConduitRequest) -> AppResult<Response> {
+pub async fn update_email_notifications(req: ConduitRequest) -> AppResult<Response> {
     conduit_compat(move || {
         use self::crate_owners::dsl::*;
         use diesel::pg::upsert::excluded;
@@ -243,7 +243,7 @@ pub async fn update_email_notifications(mut req: ConduitRequest) -> AppResult<Re
         }
 
         let updates: HashMap<i32, bool> =
-            serde_json::from_reader::<_, Vec<CrateEmailNotifications>>(req.body_mut())
+            serde_json::from_slice::<Vec<CrateEmailNotifications>>(req.body())
                 .map_err(|_| bad_request("invalid json request"))?
                 .iter()
                 .map(|c| (c.id, c.email_notifications))


### PR DESCRIPTION
Our request handlers don't need this extra wrapper anymore and can use the `Bytes` instance directly.

Related:

- #5903 