### PR TITLE
Use `Parts` where request body is irrelevant

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -17,7 +17,7 @@ mod prelude {
     pub use serde_json::Value;
 
     pub use conduit_axum::ConduitRequest;
-    pub use http::{header, Request, StatusCode};
+    pub use http::{header, request::Parts, Request, StatusCode};
 
     pub use super::conduit_axum::conduit_compat;
     use crate::controllers::util::RequestPartsExt;

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub async fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn index(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let query = req.query();
         // FIXME: There are 69 categories, 47 top level. This isn't going to
@@ -36,7 +36,7 @@ pub async fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub async fn show(Path(slug): Path<String>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show(Path(slug): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let cat: Category = Category::by_slug(&slug).first(&*conn)?;
@@ -69,7 +69,7 @@ pub async fn show(Path(slug): Path<String>, req: ConduitRequest) -> AppResult<Js
 }
 
 /// Handles the `GET /category_slugs` route.
-pub async fn slugs(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn slugs(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let slugs: Vec<Slug> = categories::table

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -16,7 +16,7 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
-pub async fn list(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn list(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let auth = AuthCheck::only_cookie().check(&req, &conn)?;
@@ -56,7 +56,7 @@ pub async fn list(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /api/private/crate_owner_invitations` route.
-pub async fn private_list(req: ConduitRequest) -> AppResult<Json<PrivateListResponse>> {
+pub async fn private_list(req: Parts) -> AppResult<Json<PrivateListResponse>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let auth = AuthCheck::only_cookie().check(&req, &conn)?;
@@ -80,8 +80,8 @@ enum ListFilter {
     InviteeId(i32),
 }
 
-fn prepare_list<B>(
-    req: &Request<B>,
+fn prepare_list(
+    req: &Parts,
     auth: Authentication,
     filter: ListFilter,
     conn: &PgConnection,
@@ -288,7 +288,7 @@ pub async fn handle_invite(req: ConduitRequest) -> AppResult<Json<Value>> {
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
 pub async fn handle_invite_with_token(
     Path(token): Path<String>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let state = req.app();

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -17,7 +17,7 @@ pub struct IndexQuery {
 pub async fn index(
     state: State<AppState>,
     qp: Query<IndexQuery>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use crate::schema::keywords;

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,10 +13,7 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub async fn downloads(
-    Path(crate_name): Path<String>,
-    req: ConduitRequest,
-) -> AppResult<Json<Value>> {
+pub async fn downloads(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::*;
         use diesel::sql_types::BigInt;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -16,7 +16,7 @@ fn follow_target(crate_name: &str, conn: &DieselPooledConn<'_>, user_id: i32) ->
 }
 
 /// Handles the `PUT /crates/:crate_id/follow` route.
-pub async fn follow(Path(crate_name): Path<String>, req: ConduitRequest) -> AppResult<Response> {
+pub async fn follow(Path(crate_name): Path<String>, req: Parts) -> AppResult<Response> {
     conduit_compat(move || {
         let conn = req.app().db_write()?;
         let user_id = AuthCheck::default().check(&req, &conn)?.user_id();
@@ -32,7 +32,7 @@ pub async fn follow(Path(crate_name): Path<String>, req: ConduitRequest) -> AppR
 }
 
 /// Handles the `DELETE /crates/:crate_id/follow` route.
-pub async fn unfollow(Path(crate_name): Path<String>, req: ConduitRequest) -> AppResult<Response> {
+pub async fn unfollow(Path(crate_name): Path<String>, req: Parts) -> AppResult<Response> {
     conduit_compat(move || {
         let conn = req.app().db_write()?;
         let user_id = AuthCheck::default().check(&req, &conn)?.user_id();
@@ -45,10 +45,7 @@ pub async fn unfollow(Path(crate_name): Path<String>, req: ConduitRequest) -> Ap
 }
 
 /// Handles the `GET /crates/:crate_id/following` route.
-pub async fn following(
-    Path(crate_name): Path<String>,
-    req: ConduitRequest,
-) -> AppResult<Json<Value>> {
+pub async fn following(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::exists;
 

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,7 +22,7 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub async fn summary(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn summary(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use crate::schema::crates::dsl::*;
         use diesel::dsl::all;
@@ -129,7 +129,7 @@ pub async fn summary(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /crates/:crate_id` route.
-pub async fn show(Path(name): Path<String>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show(Path(name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let include = req
             .query()
@@ -307,7 +307,7 @@ impl FromStr for ShowIncludeMode {
 /// Handles the `GET /crates/:crate_id/:version/readme` route.
 pub async fn readme(
     Path((crate_name, version)): Path<(String, String)>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Response> {
     conduit_compat(move || {
         let redirect_url = req
@@ -328,10 +328,7 @@ pub async fn readme(
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub async fn versions(
-    Path(crate_name): Path<String>,
-    req: ConduitRequest,
-) -> AppResult<Json<Value>> {
+pub async fn versions(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
@@ -361,10 +358,7 @@ pub async fn versions(
 }
 
 /// Handles the `GET /crates/:crate_id/reverse_dependencies` route.
-pub async fn reverse_dependencies(
-    Path(name): Path<String>,
-    req: ConduitRequest,
-) -> AppResult<Json<Value>> {
+pub async fn reverse_dependencies(Path(name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::any;
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -9,7 +9,7 @@ use axum::body::Bytes;
 use http::Request;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub async fn owners(Path(crate_name): Path<String>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn owners(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
@@ -25,10 +25,7 @@ pub async fn owners(Path(crate_name): Path<String>, req: ConduitRequest) -> AppR
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub async fn owner_team(
-    Path(crate_name): Path<String>,
-    req: ConduitRequest,
-) -> AppResult<Json<Value>> {
+pub async fn owner_team(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
@@ -43,10 +40,7 @@ pub async fn owner_team(
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub async fn owner_user(
-    Path(crate_name): Path<String>,
-    req: ConduitRequest,
-) -> AppResult<Json<Value>> {
+pub async fn owner_user(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -38,7 +38,7 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub async fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn search(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::sql_types::{Bool, Text};
 
@@ -203,7 +203,7 @@ pub async fn search(req: ConduitRequest) -> AppResult<Json<Value>> {
             // Calculating the total number of results with filters is not supported yet.
             supports_seek = false;
 
-            let query_bytes = req.uri().query().unwrap_or("").as_bytes();
+            let query_bytes = req.uri.query().unwrap_or("").as_bytes();
             let ids: Vec<_> = url::form_urlencoded::parse(query_bytes)
                 .filter(|(key, _)| key == "ids[]")
                 .map(|(_, value)| value.to_string())

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -4,13 +4,13 @@ use axum::response::IntoResponse;
 use prometheus::{Encoder, TextEncoder};
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
-pub async fn prometheus(Path(kind): Path<String>, req: ConduitRequest) -> AppResult<Response> {
+pub async fn prometheus(Path(kind): Path<String>, req: Parts) -> AppResult<Response> {
     conduit_compat(move || {
         let app = req.app();
 
         if let Some(expected_token) = &app.config.metrics_authorization_token {
             let provided_token = req
-                .headers()
+                .headers
                 .get(header::AUTHORIZATION)
                 .and_then(|value| value.to_str().ok())
                 .and_then(|value| value.strip_prefix("Bearer "));

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,7 +5,7 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub async fn show_team(Path(name): Path<String>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show_team(Path(name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use self::teams::dsl::{login, teams};
 

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -9,7 +9,7 @@ use axum::response::IntoResponse;
 use serde_json as json;
 
 /// Handles the `GET /me/tokens` route.
-pub async fn list(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn list(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_read_prefer_primary()?;
         let auth = AuthCheck::only_cookie().check(&req, &conn)?;
@@ -76,7 +76,7 @@ pub async fn new(req: ConduitRequest) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `DELETE /me/tokens/:id` route.
-pub async fn revoke(Path(id): Path<i32>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn revoke(Path(id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = req.app().db_write()?;
         let auth = AuthCheck::default().check(&req, &conn)?;
@@ -91,7 +91,7 @@ pub async fn revoke(Path(id): Path<i32>, req: ConduitRequest) -> AppResult<Json<
 }
 
 /// Handles the `DELETE /tokens/current` route.
-pub async fn revoke_current(req: ConduitRequest) -> AppResult<Response> {
+pub async fn revoke_current(req: Parts) -> AppResult<Response> {
     conduit_compat(move || {
         let conn = req.app().db_write()?;
         let auth = AuthCheck::default().check(&req, &conn)?;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -13,7 +13,7 @@ use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
-pub async fn me(req: ConduitRequest) -> AppResult<Json<EncodableMe>> {
+pub async fn me(req: Parts) -> AppResult<Json<EncodableMe>> {
     conduit_compat(move || {
         let conn = req.app().db_read_prefer_primary()?;
         let user_id = AuthCheck::only_cookie().check(&req, &conn)?.user_id();
@@ -55,7 +55,7 @@ pub async fn me(req: ConduitRequest) -> AppResult<Json<EncodableMe>> {
 }
 
 /// Handles the `GET /me/updates` route.
-pub async fn updates(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn updates(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::any;
 
@@ -172,10 +172,7 @@ pub async fn update_user(
 }
 
 /// Handles the `PUT /confirm/:email_token` route
-pub async fn confirm_user_email(
-    Path(token): Path<String>,
-    req: ConduitRequest,
-) -> AppResult<Response> {
+pub async fn confirm_user_email(Path(token): Path<String>, req: Parts) -> AppResult<Response> {
     conduit_compat(move || {
         use diesel::update;
 
@@ -197,7 +194,7 @@ pub async fn confirm_user_email(
 /// Handles `PUT /user/:user_id/resend` route
 pub async fn regenerate_token_and_send(
     Path(param_user_id): Path<i32>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Response> {
     conduit_compat(move || {
         use diesel::dsl::sql;

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,7 +6,7 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub async fn show(Path(user_name): Path<String>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show(Path(user_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use self::users::dsl::{gh_login, id, users};
 
@@ -23,7 +23,7 @@ pub async fn show(Path(user_name): Path<String>, req: ConduitRequest) -> AppResu
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub async fn stats(Path(user_id): Path<i32>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn stats(Path(user_id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::sum;
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -26,7 +26,7 @@ use crate::views::EncodableMe;
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub async fn begin(mut req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn begin(mut req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let (url, state) = req
             .app()
@@ -70,7 +70,7 @@ pub async fn begin(mut req: ConduitRequest) -> AppResult<Json<Value>> {
 ///     }
 /// }
 /// ```
-pub async fn authorize(mut req: ConduitRequest) -> AppResult<Json<EncodableMe>> {
+pub async fn authorize(mut req: Parts) -> AppResult<Json<EncodableMe>> {
     let req = conduit_compat(move || {
         // Parse the url query
         let mut query = req.query();
@@ -143,7 +143,7 @@ fn save_user_to_database(
 }
 
 /// Handles the `DELETE /api/private/session` route.
-pub async fn logout(mut req: ConduitRequest) -> Json<bool> {
+pub async fn logout(mut req: Parts) -> Json<bool> {
     req.session_remove("user_id");
     Json(true)
 }

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -12,13 +12,13 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub async fn index(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn index(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::any;
         let conn = req.app().db_read()?;
 
         // Extract all ids requested.
-        let query = url::form_urlencoded::parse(req.uri().query().unwrap_or("").as_bytes());
+        let query = url::form_urlencoded::parse(req.uri.query().unwrap_or("").as_bytes());
         let ids = query
             .filter_map(|(ref a, ref b)| if *a == "ids[]" { b.parse().ok() } else { None })
             .collect::<Vec<i32>>();

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -15,7 +15,7 @@ use chrono::{Duration, NaiveDate, Utc};
 /// This returns a URL to the location where the crate is stored.
 pub async fn download(
     Path((mut crate_name, version)): Path<(String, String)>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Response> {
     conduit_compat(move || {
         let app = req.app();
@@ -115,7 +115,7 @@ pub async fn download(
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
 pub async fn downloads(
     Path((crate_name, version)): Path<(String, String)>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         if semver::Version::parse(&version).is_err() {

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -20,7 +20,7 @@ use super::version_and_crate;
 /// be 0)
 pub async fn dependencies(
     Path((crate_name, version)): Path<(String, String)>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         if semver::Version::parse(&version).is_err() {
@@ -57,7 +57,7 @@ pub async fn authors() -> Json<Value> {
 /// API route to have.
 pub async fn show(
     Path((crate_name, version)): Path<(String, String)>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         if semver::Version::parse(&version).is_err() {

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -21,7 +21,7 @@ use crate::worker;
 /// beginning to depend on the yanked crate version.
 pub async fn yank(
     Path((crate_name, version)): Path<(String, String)>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Response> {
     conduit_compat(move || modify_yank(&crate_name, &version, &req, true)).await
 }
@@ -29,18 +29,13 @@ pub async fn yank(
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
 pub async fn unyank(
     Path((crate_name, version)): Path<(String, String)>,
-    req: ConduitRequest,
+    req: Parts,
 ) -> AppResult<Response> {
     conduit_compat(move || modify_yank(&crate_name, &version, &req, false)).await
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank<B>(
-    crate_name: &str,
-    version: &str,
-    req: &Request<B>,
-    yanked: bool,
-) -> AppResult<Response> {
+fn modify_yank(crate_name: &str, version: &str, req: &Parts, yanked: bool) -> AppResult<Response> {
     // FIXME: Should reject bad requests before authentication, but can't due to
     // lifetime issues with `req`.
 


### PR DESCRIPTION
We can skip the request body buffering code if the request handler does not care about the body. Ideally we wouldn't need the `Parts` either, but they are still needed in a few cases for database connections, request metadata logging, etc.