### PR TITLE
Use `State` extractor where request metadata is irrelevant

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -10,7 +10,7 @@ mod frontend_prelude {
 
 mod prelude {
     pub use super::helpers::ok_true;
-    pub use axum::extract::Path;
+    pub use axum::extract::{Path, State};
     pub use axum::response::{IntoResponse, Response};
     pub use axum::Json;
     pub use diesel::prelude::*;
@@ -20,6 +20,7 @@ mod prelude {
     pub use http::{header, request::Parts, Request, StatusCode};
 
     pub use super::conduit_axum::conduit_compat;
+    pub use crate::app::AppState;
     use crate::controllers::util::RequestPartsExt;
     pub use crate::middleware::app::RequestApp;
     pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError};

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -36,9 +36,9 @@ pub async fn index(req: Parts) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub async fn show(Path(slug): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn show(state: State<AppState>, Path(slug): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let cat: Category = Category::by_slug(&slug).first(&*conn)?;
         let subcats = cat
             .subcategories(&conn)?
@@ -69,9 +69,9 @@ pub async fn show(Path(slug): Path<String>, req: Parts) -> AppResult<Json<Value>
 }
 
 /// Handles the `GET /category_slugs` route.
-pub async fn slugs(req: Parts) -> AppResult<Json<Value>> {
+pub async fn slugs(state: State<AppState>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let slugs: Vec<Slug> = categories::table
             .select((categories::slug, categories::slug, categories::description))
             .order(categories::slug)

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -287,11 +287,10 @@ pub async fn handle_invite(req: ConduitRequest) -> AppResult<Json<Value>> {
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
 pub async fn handle_invite_with_token(
+    state: State<AppState>,
     Path(token): Path<String>,
-    req: Parts,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let state = req.app();
         let config = &state.config;
         let conn = state.db_write()?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,12 +13,15 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub async fn downloads(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn downloads(
+    state: State<AppState>,
+    Path(crate_name): Path<String>,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::*;
         use diesel::sql_types::BigInt;
 
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
 
         let mut versions: Vec<Version> = krate.all_versions().load(&*conn)?;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,12 +22,11 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub async fn summary(req: Parts) -> AppResult<Json<Value>> {
+pub async fn summary(state: State<AppState>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use crate::schema::crates::dsl::*;
         use diesel::dsl::all;
 
-        let state = req.app();
         let config = &state.config;
 
         let conn = state.db_read()?;
@@ -328,9 +327,12 @@ pub async fn readme(
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub async fn versions(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn versions(
+    state: State<AppState>,
+    Path(crate_name): Path<String>,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
         let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
             .all_versions()

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -9,9 +9,12 @@ use axum::body::Bytes;
 use http::Request;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub async fn owners(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn owners(
+    state: State<AppState>,
+    Path(crate_name): Path<String>,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
         let owners = krate
             .owners(&conn)?
@@ -25,9 +28,12 @@ pub async fn owners(Path(crate_name): Path<String>, req: Parts) -> AppResult<Jso
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub async fn owner_team(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn owner_team(
+    state: State<AppState>,
+    Path(crate_name): Path<String>,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
         let owners = Team::owning(&krate, &conn)?
             .into_iter()
@@ -40,9 +46,12 @@ pub async fn owner_team(Path(crate_name): Path<String>, req: Parts) -> AppResult
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub async fn owner_user(Path(crate_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn owner_user(
+    state: State<AppState>,
+    Path(crate_name): Path<String>,
+) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
         let owners = User::owning(&krate, &conn)?
             .into_iter()

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,11 +5,11 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub async fn show_team(Path(name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn show_team(state: State<AppState>, Path(name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use self::teams::dsl::{login, teams};
 
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let team: Team = teams.filter(login.eq(&name)).first(&*conn)?;
 
         Ok(Json(json!({ "team": EncodableTeam::from(team) })))

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -172,11 +172,14 @@ pub async fn update_user(
 }
 
 /// Handles the `PUT /confirm/:email_token` route
-pub async fn confirm_user_email(Path(token): Path<String>, req: Parts) -> AppResult<Response> {
+pub async fn confirm_user_email(
+    state: State<AppState>,
+    Path(token): Path<String>,
+) -> AppResult<Response> {
     conduit_compat(move || {
         use diesel::update;
 
-        let conn = req.app().db_write()?;
+        let conn = state.db_write()?;
 
         let updated_rows = update(emails::table.filter(emails::token.eq(&token)))
             .set(emails::verified.eq(true))

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,12 +6,12 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub async fn show(Path(user_name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn show(state: State<AppState>, Path(user_name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use self::users::dsl::{gh_login, id, users};
 
         let name = lower(&user_name);
-        let conn = req.app().db_read_prefer_primary()?;
+        let conn = state.db_read_prefer_primary()?;
         let user: User = users
             .filter(lower(gh_login).eq(name))
             .order(id.desc())
@@ -23,11 +23,11 @@ pub async fn show(Path(user_name): Path<String>, req: Parts) -> AppResult<Json<V
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub async fn stats(Path(user_id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
+pub async fn stats(state: State<AppState>, Path(user_id): Path<i32>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::sum;
 
-        let conn = req.app().db_read_prefer_primary()?;
+        let conn = state.db_read_prefer_primary()?;
 
         let data: i64 = CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(crates::table)

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -54,9 +54,9 @@ pub async fn index(req: Parts) -> AppResult<Json<Value>> {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub async fn show_by_id(Path(id): Path<i32>, req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn show_by_id(state: State<AppState>, Path(id): Path<i32>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = state.db_read()?;
         let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table
             .find(id)
             .inner_join(crates::table)


### PR DESCRIPTION
When we only use the `Parts` or `Request` to get a database connection, then we might as well use the `State` extractor directly :)