### PR TITLE
Revert "Merge pull request #5837 from rust-lang/share-background-worker-connection"

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -3,6 +3,7 @@ use reqwest::blocking::Client;
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
+use crate::db::DieselPool;
 use crate::swirl::errors::EnqueueError;
 use crate::swirl::PerformError;
 use crate::uploaders::Uploader;
@@ -93,31 +94,34 @@ impl Job {
     pub(super) fn perform(
         self,
         env: &Option<Environment>,
-        conn: &PgConnection,
+        conn: &DieselPool,
     ) -> Result<(), PerformError> {
         let env = env
             .as_ref()
             .expect("Application should configure a background runner environment");
         match self {
-            Job::DailyDbMaintenance => worker::perform_daily_db_maintenance(conn),
+            Job::DailyDbMaintenance => conn.with_connection(&worker::perform_daily_db_maintenance),
             Job::DumpDb(args) => worker::perform_dump_db(env, args.database_url, args.target_name),
-            Job::IndexAddCrate(args) => worker::perform_index_add_crate(env, conn, &args.krate),
+            Job::IndexAddCrate(args) => conn
+                .with_connection(&|conn| worker::perform_index_add_crate(env, conn, &args.krate)),
             Job::IndexSquash => worker::perform_index_squash(env),
             Job::IndexSyncToHttp(args) => worker::perform_index_sync_to_http(env, args.crate_name),
-            Job::IndexUpdateYanked(args) => {
+            Job::IndexUpdateYanked(args) => conn.with_connection(&|conn| {
                 worker::perform_index_update_yanked(env, conn, &args.krate, &args.version_num)
-            }
+            }),
             Job::NormalizeIndex(args) => worker::perform_normalize_index(env, args),
-            Job::RenderAndUploadReadme(args) => worker::perform_render_and_upload_readme(
-                conn,
-                env,
-                args.version_id,
-                &args.text,
-                &args.readme_path,
-                args.base_url.as_deref(),
-                args.pkg_path_in_vcs.as_deref(),
-            ),
-            Job::UpdateDownloads => worker::perform_update_downloads(conn),
+            Job::RenderAndUploadReadme(args) => conn.with_connection(&|conn| {
+                worker::perform_render_and_upload_readme(
+                    conn,
+                    env,
+                    args.version_id,
+                    &args.text,
+                    &args.readme_path,
+                    args.base_url.as_deref(),
+                    args.pkg_path_in_vcs.as_deref(),
+                )
+            }),
+            Job::UpdateDownloads => conn.with_connection(&worker::perform_update_downloads),
         }
     }
 }

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -162,11 +162,16 @@ fn new_category<'a>(category: &'a str, slug: &'a str, description: &'a str) -> N
 // This reflects the configuration of our test environment. In the production application, this
 // does not hold true.
 #[test]
-#[should_panic]
-fn recursive_get_of_db_conn_in_tests_will_panic() {
+fn multiple_live_references_to_the_same_connection_can_be_checked_out() {
+    use std::ptr;
+
     let (app, _) = TestApp::init().empty();
     let app = app.as_inner();
 
-    let _conn1 = app.primary_database.get().unwrap();
-    let _conn2 = app.primary_database.get().unwrap();
+    let conn1 = app.primary_database.get().unwrap();
+    let conn2 = app.primary_database.get().unwrap();
+    let conn1_ref: &PgConnection = &conn1;
+    let conn2_ref: &PgConnection = &conn2;
+
+    assert!(ptr::eq(conn1_ref, conn2_ref));
 }


### PR DESCRIPTION
This reverts commit 828335485f4ffe190a44e0ef83fbfc9874886527, reversing changes made to ba69940397a1fc49c39f5fec86f773231e9ddb37.

After deploying #5837 to production the `update_downloads` background job was triggering the "stuck background job" warning after a while, with the logs showing:

> Job 1212273 failed to run: deadlock detected

With the on-call team we narrowed the issue down to #5837 and deployed the same revision with that PR reverted (aka. this branch). This apparently resolved the issue on production.

@jtgeibel any clue what might have caused this? any objections on reverting #5837 for now to keep `master` deployable? :)