### PR TITLE
RealGitHubClient: Remove obsolete `base_url` field

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -81,10 +81,7 @@ impl App {
         let instance_metrics =
             InstanceMetrics::new().expect("could not initialize instance metrics");
 
-        let github = Box::new(RealGitHubClient::new(
-            http_client.clone(),
-            config.gh_base_url.clone(),
-        ));
+        let github = Box::new(RealGitHubClient::new(http_client.clone()));
 
         let github_oauth = BasicClient::new(
             ClientId::new(config.gh_client_id.clone()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,6 @@ pub struct Server {
     pub session_key: cookie::Key,
     pub gh_client_id: String,
     pub gh_client_secret: String,
-    pub gh_base_url: String,
     pub max_upload_size: u64,
     pub max_unpack_size: u64,
     pub publish_rate_limit: PublishRateLimit,
@@ -117,7 +116,6 @@ impl Default for Server {
             session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),
             gh_client_id: env("GH_CLIENT_ID"),
             gh_client_secret: env("GH_CLIENT_SECRET"),
-            gh_base_url: "https://api.github.com".to_string(),
             max_upload_size: 10 * 1024 * 1024, // 10 MB default file upload size limit
             max_unpack_size: 512 * 1024 * 1024, // 512 MB max when decompressed
             publish_rate_limit: Default::default(),

--- a/src/github.rs
+++ b/src/github.rs
@@ -38,13 +38,12 @@ pub trait GitHubClient: Send + Sync {
 
 #[derive(Debug)]
 pub struct RealGitHubClient {
-    base_url: String,
     client: Option<Client>,
 }
 
 impl RealGitHubClient {
-    pub fn new(client: Option<Client>, base_url: String) -> Self {
-        Self { base_url, client }
+    pub fn new(client: Option<Client>) -> Self {
+        Self { client }
     }
 
     /// Does all the nonsense for sending a GET to Github.
@@ -52,7 +51,7 @@ impl RealGitHubClient {
     where
         T: DeserializeOwned,
     {
-        let url = format!("{}{}", self.base_url, url);
+        let url = format!("https://api.github.com{}", url);
         info!("GITHUB HTTP: {url}");
 
         self.client()

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -336,7 +336,6 @@ fn simple_config() -> config::Server {
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: dotenv::var("GH_CLIENT_ID").unwrap_or_default(),
         gh_client_secret: dotenv::var("GH_CLIENT_SECRET").unwrap_or_default(),
-        gh_base_url: "http://api.github.com".to_string(),
         max_upload_size: 3000,
         max_unpack_size: 2000,
         publish_rate_limit: Default::default(),


### PR DESCRIPTION
This was previously used for testing purposes, but is always set to the same value these days, so we might as well hardcode it.