### PR TITLE
config: Use `ClientId` and `ClientSecret` wrappers for GitHub OAuth fields

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -76,7 +76,7 @@ impl App {
     /// - Database connection pools
     /// - A `git2::Repository` instance from the index repo checkout (that server.rs ensures exists)
     pub fn new(config: config::Server, http_client: Option<Client>) -> App {
-        use oauth2::{AuthUrl, ClientId, ClientSecret, TokenUrl};
+        use oauth2::{AuthUrl, TokenUrl};
 
         let instance_metrics =
             InstanceMetrics::new().expect("could not initialize instance metrics");
@@ -84,8 +84,8 @@ impl App {
         let github = Box::new(RealGitHubClient::new(http_client.clone()));
 
         let github_oauth = BasicClient::new(
-            ClientId::new(config.gh_client_id.clone()),
-            Some(ClientSecret::new(config.gh_client_secret.clone())),
+            config.gh_client_id.clone(),
+            Some(config.gh_client_secret.clone()),
             AuthUrl::new(String::from("https://github.com/login/oauth/authorize")).unwrap(),
             Some(
                 TokenUrl::new(String::from("https://github.com/login/oauth/access_token")).unwrap(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context};
 use ipnetwork::IpNetwork;
+use oauth2::{ClientId, ClientSecret};
 
 use crate::publish_rate_limit::PublishRateLimit;
 use crate::{env, env_optional, uploaders::Uploader, Env};
@@ -22,8 +23,8 @@ pub struct Server {
     pub base: Base,
     pub db: DatabasePools,
     pub session_key: cookie::Key,
-    pub gh_client_id: String,
-    pub gh_client_secret: String,
+    pub gh_client_id: ClientId,
+    pub gh_client_secret: ClientSecret,
     pub max_upload_size: u64,
     pub max_unpack_size: u64,
     pub publish_rate_limit: PublishRateLimit,
@@ -114,8 +115,8 @@ impl Default for Server {
             db: DatabasePools::full_from_environment(&base),
             base,
             session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),
-            gh_client_id: env("GH_CLIENT_ID"),
-            gh_client_secret: env("GH_CLIENT_SECRET"),
+            gh_client_id: ClientId::new(env("GH_CLIENT_ID")),
+            gh_client_secret: ClientSecret::new(env("GH_CLIENT_SECRET")),
             max_upload_size: 10 * 1024 * 1024, // 10 MB default file upload size limit
             max_unpack_size: 512 * 1024 * 1024, // 512 MB max when decompressed
             publish_rate_limit: Default::default(),

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -84,9 +84,10 @@ fn get_public_keys(state: &AppState) -> Result<Vec<GitHubPublicKey>, BoxedAppErr
         }
     }
     // Fetch from GitHub API
-    let keys = state
-        .github
-        .public_keys(&state.config.gh_client_id, &state.config.gh_client_secret)?;
+    let keys = state.github.public_keys(
+        &state.config.gh_client_id,
+        state.config.gh_client_secret.secret(),
+    )?;
 
     // Populate cache
     if let Ok(mut cache) = PUBLIC_KEY_CACHE.lock() {

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -11,6 +11,7 @@ use crate::util::github::{MockGitHubClient, MOCK_GITHUB_DATA};
 use cargo_registry::models::token::{CrateScope, EndpointScope};
 use cargo_registry::swirl::Runner;
 use diesel::PgConnection;
+use oauth2::{ClientId, ClientSecret};
 use reqwest::{blocking::Client, Proxy};
 use std::collections::HashSet;
 
@@ -334,8 +335,8 @@ fn simple_config() -> config::Server {
         base: config::Base::test(),
         db: config::DatabasePools::test_from_environment(),
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
-        gh_client_id: dotenv::var("GH_CLIENT_ID").unwrap_or_default(),
-        gh_client_secret: dotenv::var("GH_CLIENT_SECRET").unwrap_or_default(),
+        gh_client_id: ClientId::new(dotenv::var("GH_CLIENT_ID").unwrap_or_default()),
+        gh_client_secret: ClientSecret::new(dotenv::var("GH_CLIENT_SECRET").unwrap_or_default()),
         max_upload_size: 3000,
         max_unpack_size: 2000,
         publish_rate_limit: Default::default(),


### PR DESCRIPTION


This ensures that debug logging `gh_client_secret` will not unintentionally leak our authentication credentials.