### PR TITLE
middleware/session: Remove unnecessary `mut` keywords

### DIFF
--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -26,7 +26,7 @@ use crate::views::EncodableMe;
 ///     "url": "https://github.com/login/oauth/authorize?client_id=...&state=...&scope=read%3Aorg"
 /// }
 /// ```
-pub async fn begin(mut req: Parts) -> AppResult<Json<Value>> {
+pub async fn begin(req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let (url, state) = req
             .app()
@@ -70,7 +70,7 @@ pub async fn begin(mut req: Parts) -> AppResult<Json<Value>> {
 ///     }
 /// }
 /// ```
-pub async fn authorize(mut req: Parts) -> AppResult<Json<EncodableMe>> {
+pub async fn authorize(req: Parts) -> AppResult<Json<EncodableMe>> {
     let req = conduit_compat(move || {
         // Parse the url query
         let mut query = req.query();
@@ -143,7 +143,7 @@ fn save_user_to_database(
 }
 
 /// Handles the `DELETE /api/private/session` route.
-pub async fn logout(mut req: Parts) -> Json<bool> {
+pub async fn logout(req: Parts) -> Json<bool> {
     req.session_remove("user_id");
     Json(true)
 }

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -60,8 +60,8 @@ impl Session {
 
 pub trait RequestSession {
     fn session_get(&self, key: &str) -> Option<String>;
-    fn session_insert(&mut self, key: String, value: String) -> Option<String>;
-    fn session_remove(&mut self, key: &str) -> Option<String>;
+    fn session_insert(&self, key: String, value: String) -> Option<String>;
+    fn session_remove(&self, key: &str) -> Option<String>;
 }
 
 impl<T: RequestPartsExt> RequestSession for T {
@@ -75,10 +75,10 @@ impl<T: RequestPartsExt> RequestSession for T {
         session.data.get(key).cloned()
     }
 
-    fn session_insert(&mut self, key: String, value: String) -> Option<String> {
+    fn session_insert(&self, key: String, value: String) -> Option<String> {
         let mut session = self
-            .extensions_mut()
-            .get_mut::<Arc<RwLock<Session>>>()
+            .extensions()
+            .get::<Arc<RwLock<Session>>>()
             .expect("missing cookie session")
             .write()
             .unwrap_or_else(PoisonError::into_inner);
@@ -86,10 +86,10 @@ impl<T: RequestPartsExt> RequestSession for T {
         session.data.insert(key, value)
     }
 
-    fn session_remove(&mut self, key: &str) -> Option<String> {
+    fn session_remove(&self, key: &str) -> Option<String> {
         let mut session = self
-            .extensions_mut()
-            .get_mut::<Arc<RwLock<Session>>>()
+            .extensions()
+            .get::<Arc<RwLock<Session>>>()
             .expect("missing cookie session")
             .write()
             .unwrap_or_else(PoisonError::into_inner);


### PR DESCRIPTION
The session extension is wrapped in a `RwLock`, so we don't actually need the request itself to be mutable.