### PR TITLE
Simplify session extension usage

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -161,7 +161,8 @@ fn authenticate_via_cookie<T: RequestPartsExt>(
     conn: &PgConnection,
 ) -> AppResult<Option<CookieAuthentication>> {
     let user_id_from_session = req
-        .session_get("user_id")
+        .session()
+        .get("user_id")
         .and_then(|s| s.parse::<i32>().ok());
 
     let Some(id) = user_id_from_session else { return Ok(None) };

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -14,7 +14,7 @@ static COOKIE_NAME: &str = "cargo_session";
 static MAX_AGE_DAYS: i64 = 90;
 
 #[derive(Clone)]
-struct SessionExtension(Arc<RwLock<Session>>);
+pub struct SessionExtension(Arc<RwLock<Session>>);
 
 impl SessionExtension {
     fn new(session: Session) -> Self {
@@ -83,7 +83,7 @@ pub async fn attach_session<B>(
 }
 
 /// Request extension holding the session data
-struct Session {
+pub struct Session {
     data: HashMap<String, String>,
     dirty: bool,
 }
@@ -95,31 +95,14 @@ impl Session {
 }
 
 pub trait RequestSession {
-    fn session_get(&self, key: &str) -> Option<String>;
-    fn session_insert(&self, key: String, value: String) -> Option<String>;
-    fn session_remove(&self, key: &str) -> Option<String>;
+    fn session(&self) -> &SessionExtension;
 }
 
 impl<T: RequestPartsExt> RequestSession for T {
-    fn session_get(&self, key: &str) -> Option<String> {
+    fn session(&self) -> &SessionExtension {
         self.extensions()
             .get::<SessionExtension>()
             .expect("missing cookie session")
-            .get(key)
-    }
-
-    fn session_insert(&self, key: String, value: String) -> Option<String> {
-        self.extensions()
-            .get::<SessionExtension>()
-            .expect("missing cookie session")
-            .insert(key, value)
-    }
-
-    fn session_remove(&self, key: &str) -> Option<String> {
-        self.extensions()
-            .get::<SessionExtension>()
-            .expect("missing cookie session")
-            .remove(key)
     }
 }
 

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -1,4 +1,5 @@
 use crate::controllers::util::RequestPartsExt;
+use axum::extract::{Extension, FromRequestParts};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum_extra::extract::SignedCookieJar;
@@ -13,7 +14,8 @@ use std::sync::Arc;
 static COOKIE_NAME: &str = "cargo_session";
 static MAX_AGE_DAYS: i64 = 90;
 
-#[derive(Clone)]
+#[derive(Clone, FromRequestParts)]
+#[from_request(via(Extension))]
 pub struct SessionExtension(Arc<RwLock<Session>>);
 
 impl SessionExtension {


### PR DESCRIPTION
This PR extracts a `SessionExtension` struct, which wraps the `Arc<RwLock<Session>>` with a nicer API. This also allows us to derive `FromRequestParts`, which makes it even easier to use inside request handler functions.