### PR TITLE
Simplify request log metadata collection

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -172,7 +172,7 @@ fn authenticate_via_cookie<T: RequestPartsExt>(
 
     ensure_not_locked(&user)?;
 
-    req.add_custom_metadata("uid", id);
+    req.request_log().add("uid", id);
 
     Ok(Some(CookieAuthentication { user }))
 }
@@ -201,8 +201,8 @@ fn authenticate_via_token<T: RequestPartsExt>(
 
     ensure_not_locked(&user)?;
 
-    req.add_custom_metadata("uid", token.user_id);
-    req.add_custom_metadata("tokenid", token.id);
+    req.request_log().add("uid", token.user_id);
+    req.request_log().add("tokenid", token.id);
 
     Ok(Some(TokenAuthentication { user, token }))
 }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,6 +1,6 @@
 use crate::controllers;
 use crate::controllers::util::RequestPartsExt;
-use crate::middleware::log_request::CustomMetadataRequestExt;
+use crate::middleware::log_request::RequestLogExt;
 use crate::middleware::session::RequestSession;
 use crate::models::token::{CrateScope, EndpointScope};
 use crate::models::{ApiToken, User};

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -1,7 +1,7 @@
 use crate::config::Server;
 use crate::controllers::prelude::*;
 use crate::controllers::util::RequestPartsExt;
-use crate::middleware::log_request::CustomMetadataRequestExt;
+use crate::middleware::log_request::RequestLogExt;
 use crate::models::helpers::with_count::*;
 use crate::util::errors::{bad_request, AppResult};
 use crate::util::HeaderMapExt;

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -94,7 +94,7 @@ impl PaginationOptionsBuilder {
                 }
 
                 if numeric_page > MAX_PAGE_BEFORE_SUSPECTED_BOT {
-                    req.add_custom_metadata("bot", "suspected");
+                    req.request_log().add("bot", "suspected");
                 }
 
                 // Block large offsets for known violators of the crawler policy
@@ -103,7 +103,7 @@ impl PaginationOptionsBuilder {
                     if numeric_page > config.max_allowed_page_offset
                         && is_useragent_or_ip_blocked(config, req.headers())
                     {
-                        req.add_custom_metadata("cause", "large page offset");
+                        req.request_log().add("cause", "large page offset");
                         return Err(bad_request("requested page offset is too large"));
                     }
                 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -18,7 +18,7 @@ use crate::models::{
 };
 use crate::worker;
 
-use crate::middleware::log_request::CustomMetadataRequestExt;
+use crate::middleware::log_request::RequestLogExt;
 use crate::models::token::EndpointScope;
 use crate::schema::*;
 use crate::util::errors::{cargo_err, AppResult};

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -52,8 +52,9 @@ pub async fn publish(req: ConduitRequest) -> AppResult<Json<GoodCrate>> {
     let new_crate: EncodableCrateUpload = serde_json::from_slice(&json_bytes)
         .map_err(|e| cargo_err(&format_args!("invalid upload request: {e}")))?;
 
-    req.add_custom_metadata("crate_name", new_crate.name.to_string());
-    req.add_custom_metadata("crate_version", new_crate.vers.to_string());
+    let request_log = req.request_log();
+    request_log.add("crate_name", new_crate.name.to_string());
+    request_log.add("crate_version", new_crate.vers.to_string());
 
     // Make sure required fields are provided
     fn empty(s: Option<&String>) -> bool {
@@ -315,7 +316,7 @@ fn split_body<R: RequestPartsExt>(mut bytes: Bytes, req: &R) -> AppResult<(Bytes
     // .crate tarball file
 
     let json_len = bytes.get_u32_le() as usize;
-    req.add_custom_metadata("metadata_length", json_len);
+    req.request_log().add("metadata_length", json_len);
 
     if json_len > bytes.len() {
         return Err(cargo_err(&format!(

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -5,7 +5,7 @@
 use super::version_and_crate;
 use crate::controllers::prelude::*;
 use crate::db::PoolError;
-use crate::middleware::log_request::CustomMetadataRequestExt;
+use crate::middleware::log_request::RequestLogExt;
 use crate::models::{Crate, VersionDownload};
 use crate::schema::*;
 use crate::views::EncodableVersionDownload;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -65,7 +65,7 @@ pub async fn download(
                     app.instance_metrics
                         .downloads_non_canonical_crate_name_total
                         .inc();
-                    req.add_custom_metadata("bot", "dl");
+                    req.request_log().add("bot", "dl");
                     crate_name = canonical_crate_name;
                 } else {
                     // The version_id is only cached if the provided crate name was canonical.
@@ -98,7 +98,7 @@ pub async fn download(
                     .downloads_unconditional_redirects_total
                     .inc();
 
-                req.add_custom_metadata("unconditional_redirect", "true");
+                req.request_log().add("unconditional_redirect", "true");
             }
         };
 

--- a/src/middleware/balance_capacity.rs
+++ b/src/middleware/balance_capacity.rs
@@ -11,7 +11,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::app::AppState;
-use crate::middleware::log_request::CustomMetadataRequestExt;
+use crate::middleware::log_request::RequestLogExt;
 use axum::extract::State;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -32,7 +32,7 @@ pub async fn block_traffic<B>(
             .any(|value| blocked_values.iter().any(|v| v == value));
         if has_blocked_value {
             let cause = format!("blocked due to contents of header {header_name}");
-            req.add_custom_metadata("cause", cause);
+            req.request_log().add("cause", cause);
             let body = format!(
                 "We are unable to process your request at this time. \
                  This usually means that you are in violation of our crawler \

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -9,7 +9,7 @@
 //! examples). Values of the headers must match exactly.
 
 use crate::app::AppState;
-use crate::middleware::log_request::CustomMetadataRequestExt;
+use crate::middleware::log_request::RequestLogExt;
 use crate::util::errors::RouteBlocked;
 use axum::extract::{MatchedPath, State};
 use axum::middleware::Next;

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -146,10 +146,13 @@ pub trait CustomMetadataRequestExt {
 
 impl<T: RequestPartsExt> CustomMetadataRequestExt for T {
     fn add_custom_metadata<V: Display>(&self, key: &'static str, value: V) {
-        if let Some(metadata) = self.extensions().get::<CustomMetadata>() {
-            let mut metadata = metadata.lock();
-            metadata.push((key, value.to_string()));
-        }
+        let metadata = self
+            .extensions()
+            .get::<CustomMetadata>()
+            .expect("Failed to find `CustomMetadata` request extension");
+
+        let mut metadata = metadata.lock();
+        metadata.push((key, value.to_string()));
 
         sentry::configure_scope(|scope| scope.set_extra(key, value.to_string().into()));
     }

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -150,15 +150,14 @@ impl CustomMetadata {
 }
 
 pub trait CustomMetadataRequestExt {
-    fn add_custom_metadata<V: Display>(&self, key: &'static str, value: V);
+    fn request_log(&self) -> &CustomMetadata;
 }
 
 impl<T: RequestPartsExt> CustomMetadataRequestExt for T {
-    fn add_custom_metadata<V: Display>(&self, key: &'static str, value: V) {
+    fn request_log(&self) -> &CustomMetadata {
         self.extensions()
             .get::<CustomMetadata>()
             .expect("Failed to find `CustomMetadata` request extension")
-            .add(key, value);
     }
 }
 

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -8,7 +8,7 @@
 //! 0.17 (released alongside rustc 1.17).
 
 use crate::app::AppState;
-use crate::middleware::log_request::CustomMetadataRequestExt;
+use crate::middleware::log_request::RequestLogExt;
 use axum::extract::State;
 use axum::headers::UserAgent;
 use axum::middleware::Next;

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -33,7 +33,7 @@ pub async fn require_user_agent<B>(
     let is_download = req.uri().path().ends_with("download");
 
     if !has_user_agent && !is_download {
-        req.add_custom_metadata("cause", "no user agent");
+        req.request_log().add("cause", "no user agent");
 
         let request_id = req
             .headers()


### PR DESCRIPTION
This PR performs a few small refactorings on the `CustomMetadata` struct and related code. The goal of the PR is to make it easier to save a reference to the struct and use it to add request log metadata without having access to the `Request` itself.