### PR TITLE
conduit-axum: Replace `AxumResponse` and `HandlerResult` type aliases

### DIFF
--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -1,7 +1,7 @@
 #![deny(clippy::all)]
 
 use axum::routing::get;
-use conduit_axum::{server_error_response, spawn_blocking, ConduitRequest, ServiceError};
+use conduit_axum::{server_error_response, spawn_blocking, ServiceError};
 
 use axum::response::IntoResponse;
 use std::io;
@@ -24,18 +24,18 @@ async fn main() {
         .unwrap()
 }
 
-async fn endpoint(_: ConduitRequest) -> impl IntoResponse {
+async fn endpoint() -> impl IntoResponse {
     spawn_blocking(move || sleep(std::time::Duration::from_secs(2)))
         .await
         .map_err(ServiceError::from)
         .map(|_| "Hello world!")
 }
 
-async fn panic(_: ConduitRequest) -> impl IntoResponse {
+async fn panic() -> impl IntoResponse {
     // For now, connection is immediately closed
     panic!("message");
 }
 
-async fn error(_: ConduitRequest) -> impl IntoResponse {
+async fn error() -> impl IntoResponse {
     server_error_response(&io::Error::new(io::ErrorKind::Other, "io error, oops"))
 }

--- a/conduit-axum/examples/server.rs
+++ b/conduit-axum/examples/server.rs
@@ -1,9 +1,7 @@
 #![deny(clippy::all)]
 
 use axum::routing::get;
-use conduit_axum::{
-    server_error_response, spawn_blocking, ConduitRequest, HandlerResult, ServiceError,
-};
+use conduit_axum::{server_error_response, spawn_blocking, ConduitRequest, ServiceError};
 
 use axum::response::IntoResponse;
 use std::io;
@@ -26,19 +24,18 @@ async fn main() {
         .unwrap()
 }
 
-async fn endpoint(_: ConduitRequest) -> HandlerResult {
+async fn endpoint(_: ConduitRequest) -> impl IntoResponse {
     spawn_blocking(move || sleep(std::time::Duration::from_secs(2)))
         .await
         .map_err(ServiceError::from)
         .map(|_| "Hello world!")
-        .into_response()
 }
 
-async fn panic(_: ConduitRequest) -> HandlerResult {
+async fn panic(_: ConduitRequest) -> impl IntoResponse {
     // For now, connection is immediately closed
     panic!("message");
 }
 
-async fn error(_: ConduitRequest) -> HandlerResult {
+async fn error(_: ConduitRequest) -> impl IntoResponse {
     server_error_response(&io::Error::new(io::ErrorKind::Other, "io error, oops"))
 }

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -7,7 +7,6 @@ use hyper::Body;
 use std::error::Error;
 use std::ops::{Deref, DerefMut};
 
-use crate::response::AxumResponse;
 use crate::server_error_response;
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
@@ -50,7 +49,7 @@ impl<S> FromRequest<S, Body> for ConduitRequest
 where
     S: Send + Sync,
 {
-    type Rejection = AxumResponse;
+    type Rejection = axum::response::Response;
 
     async fn from_request(req: Request<Body>, _state: &S) -> Result<Self, Self::Rejection> {
         let request = match req.with_limited_body() {

--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -12,7 +12,6 @@ use crate::server_error_response;
 pub use http::{header, Extensions, HeaderMap, Method, Request, Response, StatusCode, Uri};
 
 pub type BoxError = Box<dyn Error + Send>;
-pub type HandlerResult = AxumResponse;
 
 /// A helper to convert a concrete error type into a `Box<dyn Error + Send>`
 ///

--- a/conduit-axum/src/fallback.rs
+++ b/conduit-axum/src/fallback.rs
@@ -1,10 +1,9 @@
 use crate::error::ServiceError;
-use crate::response::AxumResponse;
 
 use std::error::Error;
 
 use axum::extract::Extension;
-use axum::response::IntoResponse;
+use axum::response::{IntoResponse, Response};
 use http::StatusCode;
 use tracing::error;
 
@@ -15,13 +14,13 @@ pub struct ErrorField(pub String);
 pub struct CauseField(pub String);
 
 impl IntoResponse for ServiceError {
-    fn into_response(self) -> AxumResponse {
+    fn into_response(self) -> Response {
         server_error_response(&self)
     }
 }
 
 /// Logs an error message and returns a generic status 500 response
-pub fn server_error_response<E: Error + ?Sized>(error: &E) -> AxumResponse {
+pub fn server_error_response<E: Error + ?Sized>(error: &E) -> Response {
     error!(%error, "Internal Server Error");
 
     sentry_core::capture_error(error);

--- a/conduit-axum/src/lib.rs
+++ b/conduit-axum/src/lib.rs
@@ -38,7 +38,6 @@
 mod conduit;
 mod error;
 mod fallback;
-mod response;
 #[cfg(test)]
 mod tests;
 mod tokio_utils;

--- a/conduit-axum/src/response.rs
+++ b/conduit-axum/src/response.rs
@@ -1,1 +1,0 @@
-pub type AxumResponse = axum::response::Response;


### PR DESCRIPTION
These type aliases were at this point both point to `axum::response::Response`, which we could just use directly instead.