### PR TITLE
MockRequest: Convert to type alias with extension methods on `MockRequestExt` trait

### DIFF
--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -1,4 +1,4 @@
-use crate::util::{RequestHelper, Response};
+use crate::util::{MockRequestExt, RequestHelper, Response};
 use crate::TestApp;
 
 use crate::util::encode_session_header;

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -1,3 +1,4 @@
+use crate::util::MockRequestExt;
 use crate::{RequestHelper, TestApp};
 use cargo_registry::controllers::github::secret_scanning::{
     GitHubSecretAlertFeedback, GitHubSecretAlertFeedbackLabel,

--- a/src/tests/routes/metrics.rs
+++ b/src/tests/routes/metrics.rs
@@ -1,4 +1,4 @@
-use crate::util::{MockAnonymousUser, Response};
+use crate::util::{MockAnonymousUser, MockRequestExt, Response};
 use crate::{RequestHelper, TestApp};
 use http::StatusCode;
 

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,3 +1,4 @@
+use crate::util::MockRequestExt;
 use crate::{RequestHelper, TestApp};
 use cargo_registry::{models::ApiToken, util::errors::TOKEN_FORMAT_ERROR, views::EncodableMe};
 use diesel::prelude::*;

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -26,8 +26,9 @@ use crate::{
 use cargo_registry::middleware::session;
 use cargo_registry::models::{ApiToken, CreatedApiToken, User};
 
-use http::Method;
+use http::{Method, Request};
 
+use axum::body::Bytes;
 use cargo_registry::models::token::{CrateScope, EndpointScope};
 use cookie::Cookie;
 use http::header;
@@ -44,8 +45,8 @@ mod test_app;
 
 pub(crate) use chaosproxy::ChaosProxy;
 pub(crate) use fresh_schema::FreshSchema;
+use mock_request::MockRequest;
 pub use mock_request::MockRequestExt;
-use mock_request::{mock_request, MockRequest};
 pub use response::Response;
 pub use test_app::{TestApp, TestDatabase};
 
@@ -211,10 +212,13 @@ pub trait RequestHelper {
 }
 
 fn req(method: Method, path: &str) -> MockRequest {
-    let mut request = mock_request(method, path);
-    request.header(header::USER_AGENT, "conduit-test");
-    request.header("x-real-ip", "127.0.0.1");
-    request
+    Request::builder()
+        .method(method)
+        .uri(path)
+        .header(header::USER_AGENT, "conduit-test")
+        .header("x-real-ip", "127.0.0.1")
+        .body(Bytes::new())
+        .unwrap()
 }
 
 /// A type that can generate unauthenticated requests

--- a/src/tests/util/mock_request.rs
+++ b/src/tests/util/mock_request.rs
@@ -16,19 +16,17 @@ impl MockRequest {
         MockRequest { request }
     }
 
-    pub fn with_body(&mut self, bytes: &[u8]) -> &mut MockRequest {
+    pub fn with_body(&mut self, bytes: &[u8]) {
         *self.request.body_mut() = bytes.to_vec().into();
-        self
     }
 
-    pub fn header<K>(&mut self, name: K, value: &str) -> &mut MockRequest
+    pub fn header<K>(&mut self, name: K, value: &str)
     where
         K: IntoHeaderName,
     {
         self.request
             .headers_mut()
             .insert(name, HeaderValue::from_str(value).unwrap());
-        self
     }
 
     pub fn into_inner(self) -> Request<Bytes> {

--- a/src/tests/util/mock_request.rs
+++ b/src/tests/util/mock_request.rs
@@ -1,15 +1,7 @@
 use axum::body::Bytes;
-use http::{header::IntoHeaderName, HeaderValue, Method, Request};
+use http::{header::IntoHeaderName, HeaderValue, Request};
 
 pub type MockRequest = Request<Bytes>;
-
-pub fn mock_request(method: Method, path: &str) -> MockRequest {
-    Request::builder()
-        .method(&method)
-        .uri(path)
-        .body(Bytes::new())
-        .unwrap()
-}
 
 pub trait MockRequestExt {
     fn with_body(&mut self, bytes: &[u8]);
@@ -33,9 +25,18 @@ impl MockRequestExt for MockRequest {
 
 #[cfg(test)]
 mod tests {
-    use super::{mock_request, MockRequestExt};
+    use super::{MockRequest, MockRequestExt};
 
-    use hyper::http::{header, Method};
+    use axum::body::Bytes;
+    use hyper::http::{header, Method, Request};
+
+    pub fn mock_request(method: Method, path: &str) -> MockRequest {
+        Request::builder()
+            .method(&method)
+            .uri(path)
+            .body(Bytes::new())
+            .unwrap()
+    }
 
     #[test]
     fn simple_request_test() {


### PR DESCRIPTION
This will allow us to use `Request::builder()` directly where needed, instead of having to wrap it in a `MockRequest` instance. 🎉 