### PR TITLE
ConduitRequest: Rename to `BytesRequest`

### DIFF
--- a/conduit-axum/src/conduit.rs
+++ b/conduit-axum/src/conduit.rs
@@ -28,9 +28,9 @@ pub fn box_error<E: Error + Send + 'static>(error: E) -> BoxError {
 }
 
 #[derive(Debug)]
-pub struct ConduitRequest(pub Request<Bytes>);
+pub struct BytesRequest(pub Request<Bytes>);
 
-impl Deref for ConduitRequest {
+impl Deref for BytesRequest {
     type Target = Request<Bytes>;
 
     fn deref(&self) -> &Self::Target {
@@ -38,14 +38,14 @@ impl Deref for ConduitRequest {
     }
 }
 
-impl DerefMut for ConduitRequest {
+impl DerefMut for BytesRequest {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }
 
 #[async_trait]
-impl<S> FromRequest<S, Body> for ConduitRequest
+impl<S> FromRequest<S, Body> for BytesRequest
 where
     S: Send + Sync,
 {
@@ -77,6 +77,6 @@ where
             }
         };
 
-        Ok(ConduitRequest(request))
+        Ok(BytesRequest(request))
     }
 }

--- a/conduit-axum/src/tests.rs
+++ b/conduit-axum/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{server_error_response, spawn_blocking, ConduitRequest, ServiceError};
+use crate::{server_error_response, spawn_blocking, BytesRequest, ServiceError};
 use axum::extract::DefaultBodyLimit;
 use axum::response::{IntoResponse, Response};
 use axum::Router;
@@ -41,7 +41,7 @@ async fn assert_percent_decode_path(uri: Uri) -> Response {
     }
 }
 
-async fn conduit_request(_req: ConduitRequest) {}
+async fn conduit_request(_req: BytesRequest) {}
 
 async fn assert_generic_err(resp: Response) {
     assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -16,7 +16,7 @@ mod prelude {
     pub use diesel::prelude::*;
     pub use serde_json::Value;
 
-    pub use conduit_axum::ConduitRequest;
+    pub use conduit_axum::BytesRequest;
     pub use http::{header, request::Parts, Request, StatusCode};
 
     pub use super::conduit_axum::conduit_compat;

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -258,7 +258,7 @@ struct OwnerInvitation {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
-pub async fn handle_invite(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn handle_invite(req: BytesRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let crate_invite: OwnerInvitation =
             serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -66,7 +66,7 @@ pub async fn owner_user(
 /// Handles the `PUT /crates/:crate_id/owners` route.
 pub async fn add_owners(
     Path(crate_name): Path<String>,
-    req: ConduitRequest,
+    req: BytesRequest,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || modify_owners(&crate_name, &req, true)).await
 }
@@ -74,7 +74,7 @@ pub async fn add_owners(
 /// Handles the `DELETE /crates/:crate_id/owners` route.
 pub async fn remove_owners(
     Path(crate_name): Path<String>,
-    req: ConduitRequest,
+    req: BytesRequest,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || modify_owners(&crate_name, &req, false)).await
 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -45,7 +45,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// Currently blocks the HTTP thread, perhaps some function calls can spawn new
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
-pub async fn publish(req: ConduitRequest) -> AppResult<Json<GoodCrate>> {
+pub async fn publish(req: BytesRequest) -> AppResult<Json<GoodCrate>> {
     let (req, bytes) = req.0.into_parts();
     let (json_bytes, tarball_bytes) = split_body(bytes, &req)?;
 

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -26,7 +26,7 @@ pub async fn list(req: Parts) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `PUT /me/tokens` route.
-pub async fn new(req: ConduitRequest) -> AppResult<Json<Value>> {
+pub async fn new(req: BytesRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         /// The incoming serialization format for the `ApiToken` model.
         #[derive(Deserialize, Serialize)]

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -99,10 +99,7 @@ pub async fn updates(req: Parts) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `PUT /users/:user_id` route.
-pub async fn update_user(
-    Path(param_user_id): Path<i32>,
-    req: ConduitRequest,
-) -> AppResult<Response> {
+pub async fn update_user(Path(param_user_id): Path<i32>, req: BytesRequest) -> AppResult<Response> {
     conduit_compat(move || {
         use self::emails::user_id;
         use diesel::insert_into;
@@ -231,7 +228,7 @@ pub async fn regenerate_token_and_send(
 }
 
 /// Handles `PUT /me/email_notifications` route
-pub async fn update_email_notifications(req: ConduitRequest) -> AppResult<Response> {
+pub async fn update_email_notifications(req: BytesRequest) -> AppResult<Response> {
     conduit_compat(move || {
         use self::crate_owners::dsl::*;
         use diesel::pg::upsert::excluded;

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -76,7 +76,7 @@ impl<B> RequestPartsExt for Request<B> {
     }
 }
 
-impl RequestPartsExt for ConduitRequest {
+impl RequestPartsExt for BytesRequest {
     fn method(&self) -> &Method {
         self.0.method()
     }


### PR DESCRIPTION
This struct is not really related to `conduit` anymore. It is instead a wrapper for `http::Request<bytes::Bytes>` for the purpose of being able to implement `FromRequest` for it without hitting the orphan rule issue.