### PR TITLE
RequestUtils: Convert `redirect()` to regular fn

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -26,11 +26,11 @@ mod prelude {
     pub use crate::util::BytesRequest;
     use indexmap::IndexMap;
 
-    pub trait RequestUtils {
-        fn redirect(&self, url: String) -> Response {
-            (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
-        }
+    pub fn redirect(url: String) -> Response {
+        (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
+    }
 
+    pub trait RequestUtils {
         fn query(&self) -> IndexMap<String, String>;
         fn wants_json(&self) -> bool;
         fn query_with_params(&self, params: IndexMap<String, String>) -> String;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -318,7 +318,7 @@ pub async fn readme(
         if req.wants_json() {
             Ok(Json(json!({ "url": redirect_url })).into_response())
         } else {
-            Ok(req.redirect(redirect_url))
+            Ok(redirect(redirect_url))
         }
     })
     .await

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -106,7 +106,7 @@ pub async fn download(
         if req.wants_json() {
             Ok(Json(json!({ "url": redirect_url })).into_response())
         } else {
-            Ok(req.redirect(redirect_url))
+            Ok(redirect(redirect_url))
         }
     })
     .await


### PR DESCRIPTION
One less reason to keep a `Request` reference around... 😅 