### PR TITLE
Use `AppState` in request handlers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use crate::downloads_counter::DownloadsCounter;
 use crate::email::Emails;
 use crate::github::{GitHubClient, RealGitHubClient};
 use crate::metrics::{InstanceMetrics, ServiceMetrics};
-use axum::extract::FromRef;
+use axum::extract::{FromRef, FromRequestParts, State};
 use diesel::r2d2;
 use moka::sync::{Cache, CacheBuilder};
 use oauth2::basic::BasicClient;
@@ -282,7 +282,8 @@ pub struct BalanceCapacityState {
     pub in_flight_non_dl_requests: AtomicUsize,
 }
 
-#[derive(Clone)]
+#[derive(Clone, FromRequestParts)]
+#[from_request(via(State))]
 pub struct AppState(pub Arc<App>);
 
 // deref so you can still access the inner fields easily

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -10,7 +10,7 @@ mod frontend_prelude {
 
 mod prelude {
     pub use super::helpers::ok_true;
-    pub use axum::extract::{Path, State};
+    pub use axum::extract::Path;
     pub use axum::response::{IntoResponse, Response};
     pub use axum::Json;
     pub use diesel::prelude::*;

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -36,7 +36,7 @@ pub async fn index(req: Parts) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /categories/:category_id` route.
-pub async fn show(state: State<AppState>, Path(slug): Path<String>) -> AppResult<Json<Value>> {
+pub async fn show(state: AppState, Path(slug): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
         let cat: Category = Category::by_slug(&slug).first(&*conn)?;
@@ -69,7 +69,7 @@ pub async fn show(state: State<AppState>, Path(slug): Path<String>) -> AppResult
 }
 
 /// Handles the `GET /category_slugs` route.
-pub async fn slugs(state: State<AppState>) -> AppResult<Json<Value>> {
+pub async fn slugs(state: AppState) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
         let slugs: Vec<Slug> = categories::table

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::schema::categories;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
 
 /// Handles the `GET /categories` route.
-pub async fn index(req: Parts) -> AppResult<Json<Value>> {
+pub async fn index(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let query = req.query();
         // FIXME: There are 69 categories, 47 top level. This isn't going to
@@ -16,7 +16,7 @@ pub async fn index(req: Parts) -> AppResult<Json<Value>> {
         let offset = options.offset().unwrap_or_default();
         let sort = query.get("sort").map_or("alpha", String::as_str);
 
-        let conn = req.app().db_read()?;
+        let conn = app.db_read()?;
         let categories =
             Category::toplevel(&conn, sort, i64::from(options.per_page), i64::from(offset))?;
         let categories = categories

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -16,15 +16,15 @@ use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
-pub async fn list(req: Parts) -> AppResult<Json<Value>> {
+pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = app.db_read()?;
         let auth = AuthCheck::only_cookie().check(&req, &conn)?;
         let user_id = auth.user_id();
 
         let PrivateListResponse {
             invitations, users, ..
-        } = prepare_list(&req, auth, ListFilter::InviteeId(user_id), &conn)?;
+        } = prepare_list(&app, &req, auth, ListFilter::InviteeId(user_id), &conn)?;
 
         // The schema for the private endpoints is converted to the schema used by v1 endpoints.
         let crate_owner_invitations = invitations
@@ -56,9 +56,9 @@ pub async fn list(req: Parts) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `GET /api/private/crate_owner_invitations` route.
-pub async fn private_list(req: Parts) -> AppResult<Json<PrivateListResponse>> {
+pub async fn private_list(app: AppState, req: Parts) -> AppResult<Json<PrivateListResponse>> {
     conduit_compat(move || {
-        let conn = req.app().db_read()?;
+        let conn = app.db_read()?;
         let auth = AuthCheck::only_cookie().check(&req, &conn)?;
 
         let filter = if let Some(crate_name) = req.query().get("crate_name") {
@@ -69,7 +69,7 @@ pub async fn private_list(req: Parts) -> AppResult<Json<PrivateListResponse>> {
             return Err(bad_request("missing or invalid filter"));
         };
 
-        let list = prepare_list(&req, auth, filter, &conn)?;
+        let list = prepare_list(&app, &req, auth, filter, &conn)?;
         Ok(Json(list))
     })
     .await
@@ -81,6 +81,7 @@ enum ListFilter {
 }
 
 fn prepare_list(
+    state: &AppState,
     req: &Parts,
     auth: Authentication,
     filter: ListFilter,
@@ -93,7 +94,6 @@ fn prepare_list(
 
     let user = auth.user();
 
-    let state = req.app();
     let config = &state.config;
 
     let mut crate_names = HashMap::new();
@@ -258,14 +258,13 @@ struct OwnerInvitation {
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
-pub async fn handle_invite(req: BytesRequest) -> AppResult<Json<Value>> {
+pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let crate_invite: OwnerInvitation =
             serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;
 
         let crate_invite = crate_invite.crate_owner_invite;
 
-        let state = req.app();
         let conn = state.db_write()?;
 
         let auth = AuthCheck::default().check(&req, &conn)?;

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -287,7 +287,7 @@ pub async fn handle_invite(req: BytesRequest) -> AppResult<Json<Value>> {
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
 pub async fn handle_invite_with_token(
-    state: State<AppState>,
+    state: AppState,
     Path(token): Path<String>,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -5,7 +5,6 @@ use crate::schema::api_tokens;
 use crate::util::token::SecureToken;
 use anyhow::{anyhow, Context};
 use axum::body::Bytes;
-use axum::extract::State;
 use base64;
 use http::HeaderMap;
 use once_cell::sync::Lazy;
@@ -233,7 +232,7 @@ pub enum GitHubSecretAlertFeedbackLabel {
 
 /// Handles the `POST /api/github/secret-scanning/verify` route.
 pub async fn verify(
-    state: State<AppState>,
+    state: AppState,
     headers: HeaderMap,
     body: Bytes,
 ) -> AppResult<Json<Vec<GitHubSecretAlertFeedback>>> {

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -1,6 +1,6 @@
 use super::prelude::*;
 use crate::app::AppState;
-use axum::extract::{Path, Query, State};
+use axum::extract::{Path, Query};
 use axum::Json;
 
 use crate::controllers::helpers::pagination::PaginationOptions;
@@ -14,11 +14,7 @@ pub struct IndexQuery {
 }
 
 /// Handles the `GET /keywords` route.
-pub async fn index(
-    state: State<AppState>,
-    qp: Query<IndexQuery>,
-    req: Parts,
-) -> AppResult<Json<Value>> {
+pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use crate::schema::keywords;
 
@@ -47,10 +43,7 @@ pub async fn index(
 }
 
 /// Handles the `GET /keywords/:keyword_id` route.
-pub async fn show(
-    Path(name): Path<String>,
-    State(state): State<AppState>,
-) -> AppResult<Json<Value>> {
+pub async fn show(Path(name): Path<String>, state: AppState) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -13,10 +13,7 @@ use crate::sql::to_char;
 use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
-pub async fn downloads(
-    state: State<AppState>,
-    Path(crate_name): Path<String>,
-) -> AppResult<Json<Value>> {
+pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::*;
         use diesel::sql_types::BigInt;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,7 +22,7 @@ use crate::views::{
 use crate::models::krate::ALL_COLUMNS;
 
 /// Handles the `GET /summary` route.
-pub async fn summary(state: State<AppState>) -> AppResult<Json<Value>> {
+pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use crate::schema::crates::dsl::*;
         use diesel::dsl::all;
@@ -327,10 +327,7 @@ pub async fn readme(
 /// Handles the `GET /crates/:crate_id/versions` route.
 // FIXME: Not sure why this is necessary since /crates/:crate_id returns
 // this information already, but ember is definitely requesting it
-pub async fn versions(
-    state: State<AppState>,
-    Path(crate_name): Path<String>,
-) -> AppResult<Json<Value>> {
+pub async fn versions(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -9,10 +9,7 @@ use axum::body::Bytes;
 use http::Request;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
-pub async fn owners(
-    state: State<AppState>,
-    Path(crate_name): Path<String>,
-) -> AppResult<Json<Value>> {
+pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
@@ -28,10 +25,7 @@ pub async fn owners(
 }
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
-pub async fn owner_team(
-    state: State<AppState>,
-    Path(crate_name): Path<String>,
-) -> AppResult<Json<Value>> {
+pub async fn owner_team(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;
@@ -46,10 +40,7 @@ pub async fn owner_team(
 }
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
-pub async fn owner_user(
-    state: State<AppState>,
-    Path(crate_name): Path<String>,
-) -> AppResult<Json<Value>> {
+pub async fn owner_user(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
         let krate: Crate = Crate::by_name(&crate_name).first(&*conn)?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -56,18 +56,20 @@ pub async fn owner_user(state: AppState, Path(crate_name): Path<String>) -> AppR
 
 /// Handles the `PUT /crates/:crate_id/owners` route.
 pub async fn add_owners(
+    app: AppState,
     Path(crate_name): Path<String>,
     req: BytesRequest,
 ) -> AppResult<Json<Value>> {
-    conduit_compat(move || modify_owners(&crate_name, &req, true)).await
+    conduit_compat(move || modify_owners(&app, &crate_name, &req, true)).await
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
 pub async fn remove_owners(
+    app: AppState,
     Path(crate_name): Path<String>,
     req: BytesRequest,
 ) -> AppResult<Json<Value>> {
-    conduit_compat(move || modify_owners(&crate_name, &req, false)).await
+    conduit_compat(move || modify_owners(&app, &crate_name, &req, false)).await
 }
 
 /// Parse the JSON request body of requests to modify the owners of a crate.
@@ -92,9 +94,13 @@ fn parse_owners_request(req: &Request<Bytes>) -> AppResult<Vec<String>> {
         .ok_or_else(|| cargo_err("invalid json request"))
 }
 
-fn modify_owners(crate_name: &str, req: &Request<Bytes>, add: bool) -> AppResult<Json<Value>> {
+fn modify_owners(
+    app: &AppState,
+    crate_name: &str,
+    req: &Request<Bytes>,
+    add: bool,
+) -> AppResult<Json<Value>> {
     let logins = parse_owners_request(req)?;
-    let app = req.app();
 
     let conn = app.db_write()?;
     let auth = AuthCheck::default()

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -45,7 +45,7 @@ pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints 
 /// Currently blocks the HTTP thread, perhaps some function calls can spawn new
 /// threads and return completion or error through other methods  a `cargo publish
 /// --status` command, via crates.io's front end, or email.
-pub async fn publish(req: BytesRequest) -> AppResult<Json<GoodCrate>> {
+pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCrate>> {
     let (req, bytes) = req.0.into_parts();
     let (json_bytes, tarball_bytes) = split_body(bytes, &req)?;
 
@@ -76,8 +76,6 @@ pub async fn publish(req: BytesRequest) -> AppResult<Json<GoodCrate>> {
     }
 
     conduit_compat(move || {
-        let app = req.app().clone();
-
         let conn = app.primary_database.get()?;
 
         // this query should only be used for the endpoint scope calculation

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -38,7 +38,7 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// caused the break. In the future, we should look at splitting this
 /// function out to cover the different use cases, and create unit tests
 /// for them.
-pub async fn search(req: Parts) -> AppResult<Json<Value>> {
+pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::sql_types::{Bool, Text};
 
@@ -115,7 +115,7 @@ pub async fn search(req: Parts) -> AppResult<Json<Value>> {
             );
         }
 
-        let conn = req.app().db_read()?;
+        let conn = app.db_read()?;
 
         if let Some(kws) = params.get("all_keywords") {
             // Calculating the total number of results with filters is not supported yet.

--- a/src/controllers/site_metadata.rs
+++ b/src/controllers/site_metadata.rs
@@ -1,5 +1,4 @@
 use crate::app::AppState;
-use axum::extract::State;
 use axum::response::IntoResponse;
 use axum::Json;
 
@@ -7,7 +6,7 @@ use axum::Json;
 ///
 /// The sha is contained within the `HEROKU_SLUG_COMMIT` environment variable.
 /// If `HEROKU_SLUG_COMMIT` is not set, returns `"unknown"`.
-pub async fn show_deployed_sha(State(state): State<AppState>) -> impl IntoResponse {
+pub async fn show_deployed_sha(state: AppState) -> impl IntoResponse {
     let read_only = state.config.db.are_all_read_only();
 
     let deployed_sha =

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -5,7 +5,7 @@ use crate::schema::teams;
 use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
-pub async fn show_team(state: State<AppState>, Path(name): Path<String>) -> AppResult<Json<Value>> {
+pub async fn show_team(state: AppState, Path(name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use self::teams::dsl::{login, teams};
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -169,10 +169,7 @@ pub async fn update_user(Path(param_user_id): Path<i32>, req: BytesRequest) -> A
 }
 
 /// Handles the `PUT /confirm/:email_token` route
-pub async fn confirm_user_email(
-    state: State<AppState>,
-    Path(token): Path<String>,
-) -> AppResult<Response> {
+pub async fn confirm_user_email(state: AppState, Path(token): Path<String>) -> AppResult<Response> {
     conduit_compat(move || {
         use diesel::update;
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -13,9 +13,9 @@ use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
 
 /// Handles the `GET /me` route.
-pub async fn me(req: Parts) -> AppResult<Json<EncodableMe>> {
+pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
     conduit_compat(move || {
-        let conn = req.app().db_read_prefer_primary()?;
+        let conn = app.db_read_prefer_primary()?;
         let user_id = AuthCheck::only_cookie().check(&req, &conn)?.user_id();
 
         let (user, verified, email, verification_sent): (User, Option<bool>, Option<String>, bool) =
@@ -55,11 +55,11 @@ pub async fn me(req: Parts) -> AppResult<Json<EncodableMe>> {
 }
 
 /// Handles the `GET /me/updates` route.
-pub async fn updates(req: Parts) -> AppResult<Json<Value>> {
+pub async fn updates(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::any;
 
-        let conn = req.app().db_read_prefer_primary()?;
+        let conn = app.db_read_prefer_primary()?;
         let auth = AuthCheck::only_cookie().check(&req, &conn)?;
         let user = auth.user();
 
@@ -99,12 +99,16 @@ pub async fn updates(req: Parts) -> AppResult<Json<Value>> {
 }
 
 /// Handles the `PUT /users/:user_id` route.
-pub async fn update_user(Path(param_user_id): Path<i32>, req: BytesRequest) -> AppResult<Response> {
+pub async fn update_user(
+    app: AppState,
+    Path(param_user_id): Path<i32>,
+    req: BytesRequest,
+) -> AppResult<Response> {
     conduit_compat(move || {
         use self::emails::user_id;
         use diesel::insert_into;
 
-        let state = req.app().clone();
+        let state = app.clone();
         let conn = state.db_write()?;
 
         let auth = AuthCheck::default().check(&req, &conn)?;
@@ -190,6 +194,7 @@ pub async fn confirm_user_email(state: AppState, Path(token): Path<String>) -> A
 
 /// Handles `PUT /user/:user_id/resend` route
 pub async fn regenerate_token_and_send(
+    state: AppState,
     Path(param_user_id): Path<i32>,
     req: Parts,
 ) -> AppResult<Response> {
@@ -197,7 +202,6 @@ pub async fn regenerate_token_and_send(
         use diesel::dsl::sql;
         use diesel::update;
 
-        let state = req.app();
         let conn = state.db_write()?;
 
         let auth = AuthCheck::default().check(&req, &conn)?;
@@ -225,7 +229,7 @@ pub async fn regenerate_token_and_send(
 }
 
 /// Handles `PUT /me/email_notifications` route
-pub async fn update_email_notifications(req: BytesRequest) -> AppResult<Response> {
+pub async fn update_email_notifications(app: AppState, req: BytesRequest) -> AppResult<Response> {
     conduit_compat(move || {
         use self::crate_owners::dsl::*;
         use diesel::pg::upsert::excluded;
@@ -243,7 +247,7 @@ pub async fn update_email_notifications(req: BytesRequest) -> AppResult<Response
                 .map(|c| (c.id, c.email_notifications))
                 .collect();
 
-        let conn = req.app().db_write()?;
+        let conn = app.db_write()?;
         let user_id = AuthCheck::default().check(&req, &conn)?.user_id();
 
         // Build inserts from existing crates belonging to the current user

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -6,7 +6,7 @@ use crate::sql::lower;
 use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
-pub async fn show(state: State<AppState>, Path(user_name): Path<String>) -> AppResult<Json<Value>> {
+pub async fn show(state: AppState, Path(user_name): Path<String>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use self::users::dsl::{gh_login, id, users};
 
@@ -23,7 +23,7 @@ pub async fn show(state: State<AppState>, Path(user_name): Path<String>) -> AppR
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
-pub async fn stats(state: State<AppState>, Path(user_id): Path<i32>) -> AppResult<Json<Value>> {
+pub async fn stats(state: AppState, Path(user_id): Path<i32>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::sum;
 

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -54,7 +54,7 @@ pub async fn index(req: Parts) -> AppResult<Json<Value>> {
 /// Handles the `GET /versions/:version_id` route.
 /// The frontend doesn't appear to hit this endpoint. Instead, the version information appears to
 /// be returned by `krate::show`.
-pub async fn show_by_id(state: State<AppState>, Path(id): Path<i32>) -> AppResult<Json<Value>> {
+pub async fn show_by_id(state: AppState, Path(id): Path<i32>) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         let conn = state.db_read()?;
         let (version, krate, published_by): (Version, Crate, Option<User>) = versions::table

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -12,10 +12,10 @@ use crate::schema::*;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /versions` route.
-pub async fn index(req: Parts) -> AppResult<Json<Value>> {
+pub async fn index(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         use diesel::dsl::any;
-        let conn = req.app().db_read()?;
+        let conn = app.db_read()?;
 
         // Extract all ids requested.
         let query = url::form_urlencoded::parse(req.uri.query().unwrap_or("").as_bytes());

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -19,7 +19,7 @@ use super::version_and_crate;
 /// fields for `id`, `version_id`, and `downloads` (which appears to always
 /// be 0)
 pub async fn dependencies(
-    state: State<AppState>,
+    state: AppState,
     Path((crate_name, version)): Path<(String, String)>,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
@@ -56,7 +56,7 @@ pub async fn authors() -> Json<Value> {
 /// The frontend doesn't appear to hit this endpoint, but our tests do, and it seems to be a useful
 /// API route to have.
 pub async fn show(
-    state: State<AppState>,
+    state: AppState,
     Path((crate_name, version)): Path<(String, String)>,
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {

--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -1,4 +1,3 @@
-use axum::extract::State;
 use axum::middleware::Next;
 use axum::response::Response;
 use http::Request;
@@ -8,7 +7,7 @@ use crate::controllers::util::RequestPartsExt;
 
 /// `axum` middleware that injects the `AppState` instance into the `Request` extensions.
 pub async fn add_app_state_extension<B>(
-    State(app_state): State<AppState>,
+    app_state: AppState,
     mut request: Request<B>,
     next: Next<B>,
 ) -> Response {

--- a/src/middleware/balance_capacity.rs
+++ b/src/middleware/balance_capacity.rs
@@ -12,7 +12,6 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::app::AppState;
 use crate::middleware::log_request::RequestLogExt;
-use axum::extract::State;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use http::{Request, StatusCode};
@@ -42,7 +41,7 @@ async fn handle_high_load<B>(
 }
 
 pub async fn balance_capacity<B>(
-    State(app_state): State<AppState>,
+    app_state: AppState,
     request: Request<B>,
     next: Next<B>,
 ) -> Response {

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -11,13 +11,13 @@
 use crate::app::AppState;
 use crate::middleware::log_request::RequestLogExt;
 use crate::util::errors::RouteBlocked;
-use axum::extract::{MatchedPath, State};
+use axum::extract::MatchedPath;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
 use http::StatusCode;
 
 pub async fn block_traffic<B>(
-    State(state): State<AppState>,
+    state: AppState,
     req: http::Request<B>,
     next: Next<B>,
 ) -> axum::response::Response {
@@ -59,7 +59,7 @@ pub async fn block_traffic<B>(
 /// environment variable.
 pub async fn block_routes<B>(
     matched_path: Option<MatchedPath>,
-    State(state): State<AppState>,
+    state: AppState,
     req: http::Request<B>,
     next: Next<B>,
 ) -> axum::response::Response {

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -10,7 +10,6 @@
 
 use crate::app::AppState;
 use anyhow::ensure;
-use axum::extract::State;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use http::{header, Request, StatusCode};
@@ -20,7 +19,7 @@ use tower::ServiceExt;
 use tower_http::services::ServeFile;
 
 pub async fn serve_html<B: Send + 'static>(
-    State(state): State<AppState>,
+    state: AppState,
     request: Request<B>,
     next: Next<B>,
 ) -> Response {

--- a/src/middleware/require_user_agent.rs
+++ b/src/middleware/require_user_agent.rs
@@ -9,7 +9,6 @@
 
 use crate::app::AppState;
 use crate::middleware::log_request::RequestLogExt;
-use axum::extract::State;
 use axum::headers::UserAgent;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
@@ -18,7 +17,7 @@ use http::StatusCode;
 
 pub async fn require_user_agent<B>(
     user_agent: Option<TypedHeader<UserAgent>>,
-    State(state): State<AppState>,
+    state: AppState,
     req: http::Request<B>,
     next: Next<B>,
 ) -> axum::response::Response {

--- a/src/middleware/update_metrics.rs
+++ b/src/middleware/update_metrics.rs
@@ -1,5 +1,5 @@
 use crate::app::AppState;
-use axum::extract::{MatchedPath, State};
+use axum::extract::MatchedPath;
 use axum::middleware::Next;
 use axum::response::Response;
 
@@ -8,7 +8,7 @@ use prometheus::IntGauge;
 use std::time::Instant;
 
 pub async fn update_metrics<B>(
-    State(state): State<AppState>,
+    state: AppState,
     matched_path: Option<MatchedPath>,
     req: Request<B>,
     next: Next<B>,


### PR DESCRIPTION
This 1) makes `AppState` easier to use in request handlers and 2) replaces most `req.app()` calls with `AppState` usage in the request handlers and middlewares.

This will eventually allow us to remove most of the `Request` parameters in the request handlers.