### PR TITLE
Avoid worker thread for cached download requests

### DIFF
--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -20,8 +20,8 @@ pub async fn download(
 ) -> AppResult<Response> {
     let wants_json = req.wants_json();
 
+    let cache_key = (crate_name.to_string(), version.to_string());
     let redirect_url = conduit_compat(move || {
-        let cache_key = (crate_name.to_string(), version.to_string());
         if let Some(version_id) = app.version_id_cacher.get(&cache_key) {
             app.instance_metrics.version_id_cache_hits.inc();
 

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -21,7 +21,7 @@ pub async fn download(
     let wants_json = req.wants_json();
 
     let cache_key = (crate_name.to_string(), version.to_string());
-    let redirect_url = conduit_compat(move || {
+    let (crate_name, version, app) = conduit_compat(move || {
         if let Some(version_id) = app.version_id_cacher.get(&cache_key) {
             app.instance_metrics.version_id_cache_hits.inc();
 
@@ -105,11 +105,11 @@ pub async fn download(
             }
         };
 
-        let redirect_url = app.config.uploader().crate_location(&crate_name, &version);
-        Ok(redirect_url)
+        Ok((crate_name, version, app))
     })
     .await?;
 
+    let redirect_url = app.config.uploader().crate_location(&crate_name, &version);
     if wants_json {
         Ok(Json(json!({ "url": redirect_url })).into_response())
     } else {


### PR DESCRIPTION
By shifting things around a bit we can avoid calling the `conduit_compat()` function if we already have a cached `version_id`. This should slightly speed up the 80-90% case where the ID is already in our cache :)