### PR TITLE
Add category no-std::no-alloc

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -402,6 +402,12 @@ description = """
 Crates that are able to function without the Rust standard library.
 """
 
+[no-std.categories.no-alloc]
+name = "No dynamic allocation"
+description = """
+Crates that are able to function without the Rust alloc crate.\
+"""
+
 [os]
 name = "Operating systems"
 description = """


### PR DESCRIPTION
Ever since no_std crates gained the ability to use alloc, the usefulness of the "no-std" category has drastically declined. It used to be an indicator for whether a crate can be used in a bare metal embedded context (more precisely: where there is no OS and no dynamic memory management), but is now used for a lot of crates that rely on dynamic memory management.

Its current use is factually accurate (these crates *are* no_std), but also not very helpful.

This adds a new "no-alloc" category (under no-std, because no-alloc is not particularly meaningful when using std) with which crates that provide the "good old" no-std can advertise their properties.

It would be used primarily by embedded Rust crates, but library crates that go the extra mile to be usable on such systems could also use this category.

---

This category restores a semantic category that used to be covered by no-std before Rust 1.28.