### PR TITLE
GET /crates/:crate_id/:version/readme: Remove unnecessary `conduit_compat()` call

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -308,16 +308,13 @@ pub async fn readme(
     app: AppState,
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,
-) -> AppResult<Response> {
-    conduit_compat(move || {
-        let redirect_url = app.config.uploader().readme_location(&crate_name, &version);
-        if req.wants_json() {
-            Ok(Json(json!({ "url": redirect_url })).into_response())
-        } else {
-            Ok(redirect(redirect_url))
-        }
-    })
-    .await
+) -> Response {
+    let redirect_url = app.config.uploader().readme_location(&crate_name, &version);
+    if req.wants_json() {
+        Json(json!({ "url": redirect_url })).into_response()
+    } else {
+        redirect(redirect_url)
+    }
 }
 
 /// Handles the `GET /crates/:crate_id/versions` route.


### PR DESCRIPTION


We are not performing any blocking operations in the call, so we can skip the worker thread in this case