### PR TITLE
Simplify `parse_traffic_patterns()` fn

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -208,14 +208,12 @@ fn blocked_traffic() -> Vec<(String, Vec<String>)> {
 
 fn parse_traffic_patterns(patterns: &str) -> impl Iterator<Item = (&str, &str)> {
     patterns.split_terminator(',').map(|pattern| {
-        if let Some(idx) = pattern.find('=') {
-            (&pattern[..idx], &pattern[(idx + 1)..])
-        } else {
+        pattern.split_once('=').unwrap_or_else(|| {
             panic!(
                 "BLOCKED_TRAFFIC must be in the form HEADER=VALUE_ENV_VAR, \
                  got invalid pattern {pattern}"
             )
-        }
+        })
     })
 }
 


### PR DESCRIPTION
`split_once()` does basically the same thing internally as what we previously did manually.