### PR TITLE
Revert "Update Rust crate git2 to v0.16.1 [SECURITY]"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "git2"
-version = "0.16.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
+checksum = "be36bc9e0546df253c0cc41fd0af34f5e92845ad8509462ec76672fac6997f5b"
 dependencies = [
  "bitflags",
  "libc",
@@ -1586,9 +1586,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.14.2+1.5.1"
+version = "0.14.1+1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
+checksum = "4a07fb2692bc3593bda59de45a502bb3071659f2c515e28c71e728306b038e17"
 dependencies = [
  "cc",
  "libc",

--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -16,7 +16,7 @@ testing = ["serde_json"]
 anyhow = "=1.0.68"
 base64 = "=0.13.1"
 dotenv = "=0.15.0"
-git2 = "=0.16.1"
+git2 = "=0.16.0"
 serde = { version = "=1.0.152", features = ["derive"] }
 tempfile = "=3.3.0"
 tracing = "=0.1.37"


### PR DESCRIPTION
Reverts rust-lang/crates.io#5968

This has been causing issues with our background worker, that have to be resolved first, before we can update:

```
 INFO background_worker: Booting runner
 INFO background_worker: Cloning index
thread 'main' panicked at 'Failed to clone index: Failed to clone index repository
Caused by:
    invalid or unknown remote ssh hostkey; class=Ssh (23); code=Certificate (-17)', src/bin/background-worker.rs:61:46
stack backtrace:
   0: rust_begin_unwind
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/std/src/panicking.rs:575:5
   1: core::panicking::panic_fmt
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/panicking.rs:65:14
   2: core::result::unwrap_failed
             at /rustc/90743e7298aca107ddaa0c202a4d3604e29bfeb6/library/core/src/result.rs:1791:5
   3: core::result::Result<T,E>::expect
   4: background_worker::main
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```