### PR TITLE
Clarify a11y category description

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -245,7 +245,7 @@ Crates to help you verify the correctness of your code.\
 [email]
 name = "Email"
 description = """
-Crates to help with Sending, receiving, formatting, and parsing email.\
+Crates to help with sending, receiving, formatting, and parsing email.\
 """
 
 [embedded]

--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -29,7 +29,7 @@
 [accessibility]
 name = "Accessibility"
 description = """
-Tools for making your creations usable by as many people as possible. \
+Assistive technology that helps overcome disabilities and impairments to make software usable by as many people as possible. \
 """
 
 [aerospace]


### PR DESCRIPTION
The accessibility category has many crates not related to assistive technologies (web crawlers, internationalization, audio parsers, date and time):

https://crates.io/categories/accessibility

I suspect that the description is too broad and not understood by people who aren't already familiar with the "accessibility" term.
