### PR TITLE
Simplify `format!()` call

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -51,7 +51,7 @@ impl RealGitHubClient {
     where
         T: DeserializeOwned,
     {
-        let url = format!("https://api.github.com{}", url);
+        let url = format!("https://api.github.com{url}");
         info!("GITHUB HTTP: {url}");
 
         self.client()


### PR DESCRIPTION
This should unblock the [Rust v1.67](https://github.com/rust-lang/crates.io/pull/6003) upgrade