### PR TITLE
Set backend dockerfile to install diesel version 1.4.1

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -3,7 +3,7 @@ FROM rust:latest
 RUN apt-get update \
     && apt-get install -y postgresql \
     && rm -rf /var/lib/apt/lists/* \
-    && cargo install diesel_cli --no-default-features --features postgres
+    && cargo install diesel_cli --version 1.4.1 --no-default-features --features postgres
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
Partially fixes #6018 by installing the same version of diesel_cli as the CICD pipeline. 🙂 