### PR TITLE
Implement GitHub SSH certificate checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "base64 0.13.1",
  "dotenv",
  "git2",
+ "once_cell",
  "serde",
  "serde_json",
  "tempfile",

--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "=1.0.68"
 base64 = "=0.13.1"
 dotenv = "=0.15.0"
 git2 = "=0.16.0"
+once_cell = "=1.17.0"
 serde = { version = "=1.0.152", features = ["derive"] }
 tempfile = "=3.3.0"
 tracing = "=0.1.37"


### PR DESCRIPTION
Previously, we were relying on libgit2 to check the hostkey fingerprint, but since our Heroku dynos do not have a `known_hosts` file, this couldn't actually have worked, which results in us not checking the fingerprints at all. 

https://github.com/rust-lang/crates.io/pull/5996 updates libgit2, which enables fingerprint checks by default. Due to the missing `known_hosts` file this broke our background worker though.

This PR enables custom fingerprint checks for `github.com` by hardcoding the fingerprints from https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints. As the code comment says, this is most likely good enough, but could eventually be replaced by a `known_hosts`-like environment variable.