### PR TITLE
Bump CI to use Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   changed-files:
     name: Changed Files
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3.3.0
@@ -63,7 +63,7 @@ jobs:
 
   backend-lint:
     name: Backend / Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: changed-files
     if: needs.changed-files.outputs.non-js == 'true'
 
@@ -84,7 +84,7 @@ jobs:
 
   backend-test:
     name: Backend / Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: changed-files
     if: needs.changed-files.outputs.non-js == 'true'
 
@@ -123,7 +123,7 @@ jobs:
 
   frontend-lint:
     name: Frontend / Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: changed-files
     if: needs.changed-files.outputs.non-rust == 'true'
 
@@ -147,7 +147,7 @@ jobs:
 
   frontend-test:
     name: Frontend / Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: changed-files
     if: needs.changed-files.outputs.non-rust == 'true'
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   coverage:
     name: Test Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       RUST_BACKTRACE: 1


### PR DESCRIPTION
Staging has been bumped to the heroku-22 stack. Assuming no unexpected
issues, we can bump CI to match and then upgrade production.