### PR TITLE
background-worker: Speed up index cloning by 3x

### DIFF
--- a/cargo-registry-index/lib.rs
+++ b/cargo-registry-index/lib.rs
@@ -26,6 +26,13 @@ pub enum Credentials {
 }
 
 impl Credentials {
+    fn ssh_key(&self) -> Option<&str> {
+        match self {
+            Credentials::Ssh { key } => Some(key),
+            _ => None,
+        }
+    }
+
     fn git2_callback(
         &self,
         user_from_url: Option<&str>,
@@ -73,10 +80,9 @@ impl Credentials {
     /// - If creation of the temporary file fails, `Err` is returned.
     ///
     fn write_temporary_ssh_key(&self) -> anyhow::Result<tempfile::TempPath> {
-        let key = match self {
-            Credentials::Ssh { key } => key,
-            _ => return Err(anyhow!("SSH key not available")),
-        };
+        let key = self
+            .ssh_key()
+            .ok_or_else(|| anyhow!("SSH key not available"))?;
 
         let dir = if cfg!(target_os = "linux") {
             // When running on production, ensure the file is created in tmpfs and not persisted to disk

--- a/cargo-registry-index/lib.rs
+++ b/cargo-registry-index/lib.rs
@@ -560,6 +560,7 @@ pub fn run_via_cli(command: &mut Command, credentials: &Credentials) -> anyhow::
         );
     }
 
+    debug!(?command);
     let output = command.output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -22,7 +22,7 @@ use cargo_registry_index::{Repository, RepositoryConfig};
 use reqwest::blocking::Client;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use cargo_registry::swirl;
 
@@ -60,11 +60,14 @@ fn main() {
         ssh::write_known_hosts_file().unwrap();
     }
 
+    let clone_start = Instant::now();
     let repository_config = RepositoryConfig::from_environment();
     let repository = Arc::new(Mutex::new(
         Repository::open(&repository_config).expect("Failed to clone index"),
     ));
-    info!("Index cloned");
+
+    let clone_duration = clone_start.elapsed();
+    info!(duration = ?clone_duration, "Index cloned");
 
     let cloudfront = CloudFront::from_environment();
 


### PR DESCRIPTION
Previously we were using libgit2 to clone the index, which regularly took 2-3 minutes. This PR switches us over to using the `git` CLI, which appears to be significantly faster and clones the index in just over 30 seconds.