### PR TITLE
Implement the documented behavior of defaulting to docs.rs links for people with XHR blockers too

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -155,7 +155,7 @@ export default class Version extends Model {
       return crateDocsLink;
     }
 
-    return null;
+    return docsRsLink;
   }
 
   yankTask = keepLatestTask(async () => {


### PR DESCRIPTION
Hey! So before anything: I don't know if this is something you actually want.

I've just noticed that the documented-on-the-cargo-book behavior of defaulting to docs.rs links does not actually work for people who have cross-site XHR blockers, whereas if people manually add the docs.rs link (an operation that should be a no-op according to the cargo book), it does get displayed.

I don't really know javascript, but my understanding is making this change makes things work for everyone, to the cost of having broken docs.rs links when the docs.rs build failed.

Honestly I don't think linking a broken docs.rs build would be a problem (it's actually good indication that the user might not want to use the crate, if the build is broken and the crate did not provide an alternate documentation link). However, I don't have really strong opinions on this, and wanted to get your thoughts.

Context: https://github.com/rust-lang/cargo/pull/11685; I've been thinking for now a few years that crates that did not provide a documentation link had no link on crates.io and wondering why they didn't make the effort of doing so… to the point that I tried submitting a PR to the docs when I noticed this written in the cargo docs. Sure it's my fault, but hopefully the proposed behavior would be more user-friendly to other people who forgot to check that because everything else on crates.io works fine with XHR blockers :)