### PR TITLE
Use Renovatebot regex managers for Docker files

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
         ":semanticCommitsDisabled",
         ":automergeLinters",
         ":automergeTesters",
+        "regexManagers:dockerfileVersions",
         "regexManagers:githubActionsVersions",
     ],
     "js": {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
         ":semanticCommitsDisabled",
         ":automergeLinters",
         ":automergeTesters",
-        "github>Turbo87/renovate-config//githubActions/regexManagers",
+        "regexManagers:githubActionsVersions",
     ],
     "js": {
         "labels": ["A-frontend 🐹"],

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -3,10 +3,13 @@ ARG RUST_VERSION=1.67.1
 
 FROM rust:$RUST_VERSION
 
+# renovate: datasource=crate depName=diesel_cli versioning=semver
+ARG DIESEL_CLI_VERSION=1.4.1
+
 RUN apt-get update \
     && apt-get install -y postgresql \
     && rm -rf /var/lib/apt/lists/* \
-    && cargo install diesel_cli --version 1.4.1 --no-default-features --features postgres
+    && cargo install diesel_cli --version $DIESEL_CLI_VERSION --no-default-features --features postgres
 
 WORKDIR /app
 COPY . /app

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -1,4 +1,7 @@
-FROM rust:latest
+# renovate: datasource=github-releases depName=rust lookupName=rust-lang/rust
+ARG RUST_VERSION=1.67.1
+
+FROM rust:$RUST_VERSION
 
 RUN apt-get update \
     && apt-get install -y postgresql \

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,4 +1,7 @@
-FROM node:18.14.0-alpine
+# renovate: datasource=node depName=node
+ARG NODE_VERSION=18.14.0
+
+FROM node:${NODE_VERSION}-alpine
 
 # renovate: datasource=npm depName=pnpm
 ARG PNPM_VERSION=7.27.0

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,7 +1,10 @@
 FROM node:18.14.0-alpine
 
+# renovate: datasource=npm depName=pnpm
+ARG PNPM_VERSION=7.27.0
+
 # Install `pnpm`
-RUN npm install --global pnpm@7.9.0
+RUN npm install --global pnpm@$PNPM_VERSION
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR takes advantage of https://docs.renovatebot.com/presets-regexManagers/#regexmanagersdockerfileversions to update:

- The Rust Docker image version
- The Node.js Docker image version
- The pnpm version used in the `Dockerfile`
- The Diesel CLI version used in the `Dockerfile`
