### PR TITLE
Updates nginx config to always send Access-Control-Allow-Origin header

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -222,7 +222,7 @@ http {
 		add_header X-XSS-Protection "1; mode=block";
 
 		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
-		add_header Access-Control-Allow-Origin "*";
+		add_header Access-Control-Allow-Origin "*" always;
 
 		add_header Strict-Transport-Security "max-age=31536000" always;
 		add_header Vary 'Accept, Accept-Encoding, Cookie';


### PR DESCRIPTION
The nginx config injects the Access-Control-Allow-Origin header to allow cross-origin API requests to crates.io. This is done using the add_header directive in the configuration. This directive only injects the header for successful response codes, as per the documentation:

http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header

This means that cross-origin requests to crates.io are allowed when a crate exists (successful status code), but denied when it does not exist (404 response).

This commit fixes that behaviour and allows other sites to make use of the crates.io API, even when looking up crates that do not exist.

This fixes #6142.

Please test this change if possible. I think this change is safe, I think the missing header was an oversight. I do not know how to add a unit test for this to prevent future regressions.