### PR TITLE
add panic-handling axum middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ threadpool = "=1.8.1"
 tokio = { version = "=1.26.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.7.2"
 tower = "=0.4.13"
-tower-http = { version = "=0.4.0", features = ["fs"] }
+tower-http = { version = "=0.4.0", features = ["fs", "catch-panic"] }
 tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.16", features = ["env-filter"] }
 url = "=2.3.1"

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -20,6 +20,7 @@ use axum::Router;
 use axum_extra::either::Either;
 use axum_extra::middleware::option_layer;
 use tower::layer::util::Identity;
+use tower_http::catch_panic::CatchPanicLayer;
 
 use crate::app::AppState;
 use crate::Env;
@@ -41,6 +42,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
         .layer(sentry_tower::SentryHttpLayer::with_transaction())
         .layer(from_fn(self::sentry::set_transaction))
         .layer(from_fn(log_request::log_requests))
+        .layer(CatchPanicLayer::new())
         .layer(from_fn_with_state(
             state.clone(),
             update_metrics::update_metrics,


### PR DESCRIPTION
while digging into some errro around panic-handling in docs.rs ( https://github.com/rust-lang/docs.rs/pull/2072 ) I saw that the default behaviour in axum is that when there is a panic while handling the web request, the connection is just closed without any error. 

To me it seems like a normal server error is the better behaviour here. 

The panic will also be logged using `tracing::error`, so as long as `tower_http` as source is not filtered, the panic will also be shown in sentry, including the correct request context. 

( [it's also possible to adapt the error page, if needed](https://github.com/tower-rs/tower-http/blob/master/tower-http/src/catch_panic.rs))