### PR TITLE
Add `FixFeature2` background worker job

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -23,6 +23,10 @@ pub enum Command {
         #[arg(long = "dry-run")]
         dry_run: bool,
     },
+    FixFeatures2 {
+        #[arg(long = "dry-run")]
+        dry_run: bool,
+    },
 }
 
 pub fn run(command: Command) -> Result<()> {
@@ -51,5 +55,6 @@ pub fn run(command: Command) -> Result<()> {
         Command::DailyDbMaintenance => Ok(worker::daily_db_maintenance().enqueue(conn)?),
         Command::SquashIndex => Ok(worker::squash_index().enqueue(conn)?),
         Command::NormalizeIndex { dry_run } => Ok(worker::normalize_index(dry_run).enqueue(conn)?),
+        Command::FixFeatures2 { dry_run } => Ok(worker::fix_features2(dry_run).enqueue(conn)?),
     }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -12,15 +12,15 @@ mod update_downloads;
 
 pub use daily_db_maintenance::daily_db_maintenance;
 pub use dump_db::dump_db;
-pub use git::{add_crate, normalize_index, squash_index, sync_yanked};
+pub use git::{add_crate, fix_features2, normalize_index, squash_index, sync_yanked};
 pub use readmes::render_and_upload_readme;
 pub use update_downloads::update_downloads;
 
 pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
 pub(crate) use dump_db::perform_dump_db;
 pub(crate) use git::{
-    perform_index_add_crate, perform_index_squash, perform_index_sync_to_http,
-    perform_index_update_yanked, perform_normalize_index,
+    perform_fix_features2, perform_index_add_crate, perform_index_squash,
+    perform_index_sync_to_http, perform_index_update_yanked, perform_normalize_index,
 };
 pub(crate) use readmes::perform_render_and_upload_readme;
 pub(crate) use update_downloads::perform_update_downloads;


### PR DESCRIPTION
This job "fixes" the `features2` entries by moving all `features` into `feature2` if `feature2` already has content. This should avoid a mismatch of `features` pointing to `features2` for older cargo versions.

Related:
- https://github.com/rust-lang/crates.io/issues/6135
- https://github.com/rust-lang/crates.io/pull/6168/