### PR TITLE
updated x-xss-protection header to follow owasp best practice

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -219,7 +219,7 @@ http {
 
 		add_header X-Content-Type-Options "nosniff";
 		add_header X-Frame-Options "SAMEORIGIN";
-		add_header X-XSS-Protection "1; mode=block";
+		add_header X-XSS-Protection "0";
 
 		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
 		add_header Access-Control-Allow-Origin "*" always;


### PR DESCRIPTION
Setting the `X-XSS-Protection` header value to `0` per OWASP's recommended best practice. It's counterintuitive, I know, but having the filter enabled can [cause more harm than good.](https://groups.google.com/a/chromium.org/g/blink-dev/c/TuYw-EZhO9g/m/blGViehIAwAJ)

The CSP header provides better protection against XSS.

https://owasp.org/www-project-secure-headers/#x-xss-protection

<img width="896" alt="image" src="https://user-images.githubusercontent.com/20070360/224496101-2f46c232-9801-4389-9720-33d365179c93.png">
