### PR TITLE
Update the import script to handle a couple of problematic scenarios

### DIFF
--- a/script/import-database-dump.sh
+++ b/script/import-database-dump.sh
@@ -54,3 +54,7 @@ psql -a "$DATABASE_NAME" < schema.sql
 
 echo "Importing data"
 psql -a "$DATABASE_NAME" < import.sql
+
+# Importing the database doesn't cause materialised views to be refreshed, so
+# let's do that.
+psql --command="REFRESH MATERIALIZED VIEW recent_crate_downloads" "$DATABASE_NAME"


### PR DESCRIPTION
More detail is in the individual commits, but this addresses two issues I ran into while setting up a local crates.io environment:

* The import script hard codes the database name, instead of picking it up from the environment — this now checks the environment first before falling back to the hard coded name.
* The summary API endpoint 500s after running import because `recent_crate_downloads` isn't populated.