### PR TITLE
Heroku: Update `pnpm` buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/unfold/heroku-buildpack-pnpm#76cf1fc
+https://github.com/unfold/heroku-buildpack-pnpm#9a5caa9
 https://github.com/heroku/heroku-buildpack-nginx#760407b
 https://github.com/emk/heroku-buildpack-rust#cfa0f06

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
     }
   },
   "engines": {
-    "node": "18.15.0"
+    "node": "18.15.0",
+    "pnpm": "8.1.1"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
This is an attempt to solve https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/deployments/near/346926329 and simultaneously pins the `pnpm` version that is used by Heroku.