### PR TITLE
Add missing `@ember/string` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/plugin-proposal-decorators": "7.21.0",
     "@ember/optional-features": "2.0.0",
     "@ember/render-modifiers": "2.0.5",
+    "@ember/string": "3.0.1",
     "@ember/test-helpers": "2.9.3",
     "@ember/test-waiters": "3.0.2",
     "@embroider/compat": "2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ devDependencies:
   '@ember/render-modifiers':
     specifier: 2.0.5
     version: 2.0.5(ember-source@4.12.0)
+  '@ember/string':
+    specifier: 3.0.1
+    version: 3.0.1
   '@ember/test-helpers':
     specifier: 2.9.3
     version: 2.9.3(ember-source@4.12.0)


### PR DESCRIPTION
With one of the latest v4.x release of Ember.js the `@ember/string` package has been declared a peer dependency. While it still worked fine without declaring it, it will soon become a hard error.

This should also unblock the build failure of https://github.com/rust-lang/crates.io/pull/5277