### PR TITLE
Heroku: Update `pnpm` buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,3 @@
-https://github.com/unfold/heroku-buildpack-pnpm#9a5caa9
+https://github.com/unfold/heroku-buildpack-pnpm#b8dcee8
 https://github.com/heroku/heroku-buildpack-nginx#760407b
 https://github.com/emk/heroku-buildpack-rust#cfa0f06


### PR DESCRIPTION
This change includes https://github.com/unfold/heroku-buildpack-pnpm/pull/42, which makes the pnpm installation process a little less brittle by moving from unpkg.com to using npm instead.