### PR TITLE
Fix `undefined` in user avatar title

### DIFF
--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -20,16 +20,12 @@ export default class UserAvatar extends Component {
   get title() {
     let user = this.args.user;
 
-    switch (user.kind) {
-      case 'user': {
-        return user.name;
-      }
-      case 'team': {
-        return `${user.name} team`;
-      }
-      default: {
-        return `${user.name} (${user.kind})`;
-      }
+    if (user.kind === 'user') {
+      return user.name;
+    } else if (user.kind === 'team') {
+      return `${user.name} team`;
+    } else {
+      return `${user.name} (${user.kind})`;
     }
   }
 

--- a/app/components/user-avatar.js
+++ b/app/components/user-avatar.js
@@ -20,7 +20,7 @@ export default class UserAvatar extends Component {
   get title() {
     let user = this.args.user;
 
-    if (user.kind === 'user') {
+    if (!user.kind || user.kind === 'user') {
       return user.name;
     } else if (user.kind === 'team') {
       return `${user.name} team`;


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/6287

The `kind` field on our API only exists for owners, but not for the response from the `/me` API endpoint. Due to that, the `kind` field in that case is `undefined` which lead to "undefined" being displayed in the avatar title (see #6287).

This PR changes the title attribute logic to treat `undefined` as a `user`, which should resolve the problem.