### PR TITLE
Improve debugability of the `dump_db` background worker task

### DIFF
--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -3,6 +3,8 @@ use cargo_registry::worker::dump_db;
 
 #[test]
 fn dump_db_and_reimport_dump() {
+    cargo_registry::util::tracing::init_for_test();
+
     let database_url = crate::env("TEST_DATABASE_URL");
 
     // TODO prefill database with some data


### PR DESCRIPTION
When setting up my new machine I used `brew install libpq` to install the necessary PostgreSQL CLI tools and updated my shell startup script accordingly. Unfortunately, my IDE (IntelliJ) was not aware of this path and the CLI tools were not automatically linked into the default `bin` folder of homebrew. This lead to the `dump_db_and_reimport_dump` test failing when run from within the IDE, as opposed to running successfully when run from the terminal.

The test just failed with "No such file or directory (os error 2)" though, which wasn't exactly helpful in figuring the above out... 😅 

This PR switches some of the code over from `swirl`-specific errors to using [anyhow](https://github.com/dtolnay/anyhow), which allows us to use the `.context()` method to add essentially an error stack trace to the errors. Additionally, this PR enables `RUST_LOG`-based debug output to the test mentioned above.