### PR TITLE
tracing: Remove obsolete `conduit_axum::fallback` filter

### DIFF
--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -30,7 +30,6 @@ pub fn init() {
 pub fn event_filter(metadata: &Metadata<'_>) -> EventFilter {
     match metadata.level() {
         &Level::ERROR if metadata.target() == "http" => EventFilter::Breadcrumb,
-        &Level::ERROR if metadata.target() == "conduit_axum::fallback" => EventFilter::Ignore,
         &Level::ERROR => EventFilter::Exception,
         &Level::WARN | &Level::INFO => EventFilter::Breadcrumb,
         &Level::DEBUG | &Level::TRACE => EventFilter::Ignore,


### PR DESCRIPTION
This module does not exist anymore, so there is no need to keep this filter around... :D