### PR TITLE
GET /me/tokens: Add `crate_scopes` and `endpoint_scopes` fields

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -27,10 +27,8 @@ pub struct ApiToken {
     #[serde(skip)]
     pub revoked: bool,
     /// `None` or a list of crate scope patterns (see RFC #2947)
-    #[serde(skip)]
     pub crate_scopes: Option<Vec<CrateScope>>,
     /// A list of endpoint scopes or `None` for the `legacy` endpoint scope (see RFC #2947)
-    #[serde(skip)]
     pub endpoint_scopes: Option<Vec<EndpointScope>>,
 }
 

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -54,7 +54,8 @@ impl FromSql<Text, Pg> for EndpointScope {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
 pub struct CrateScope {
     pattern: String,
 }
@@ -136,6 +137,22 @@ mod tests {
         assert(EndpointScope::PublishNew, "\"publish-new\"");
         assert(EndpointScope::PublishUpdate, "\"publish-update\"");
         assert(EndpointScope::Yank, "\"yank\"");
+    }
+
+    #[test]
+    fn crate_scope_serialization() {
+        fn assert(scope: &str, expected: &str) {
+            let scope = assert_ok!(CrateScope::try_from(scope));
+            assert_ok_eq!(serde_json::to_string(&scope), expected);
+        }
+
+        assert("foo", "\"foo\"");
+        assert("foo*", "\"foo*\"");
+        assert("f*", "\"f*\"");
+        assert("*", "\"*\"");
+        assert("foo-bar", "\"foo-bar\"");
+        assert("foo_bar", "\"foo_bar\"");
+        assert("FooBar", "\"FooBar\"");
     }
 
     #[test]

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -5,8 +5,9 @@ use diesel::serialize::{self, IsNull, Output, ToSql};
 use diesel::sql_types::Text;
 use std::io::Write;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, AsExpression)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, AsExpression, Serialize)]
 #[diesel(sql_type = Text)]
+#[serde(rename_all = "kebab-case")]
 pub enum EndpointScope {
     PublishNew,
     PublishUpdate,
@@ -124,6 +125,18 @@ impl CrateScope {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn endpoint_scope_serialization() {
+        fn assert(scope: EndpointScope, expected: &str) {
+            assert_ok_eq!(serde_json::to_string(&scope), expected);
+        }
+
+        assert(EndpointScope::ChangeOwners, "\"change-owners\"");
+        assert(EndpointScope::PublishNew, "\"publish-new\"");
+        assert(EndpointScope::PublishUpdate, "\"publish-update\"");
+        assert(EndpointScope::Yank, "\"yank\"");
+    }
 
     #[test]
     fn crate_scope_validation() {

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -1,5 +1,6 @@
 use crate::util::insta::{self, assert_yaml_snapshot};
 use crate::util::{RequestHelper, TestApp};
+use cargo_registry::models::token::{CrateScope, EndpointScope};
 use cargo_registry::models::ApiToken;
 use http::StatusCode;
 
@@ -32,7 +33,16 @@ fn list_tokens() {
     app.db(|conn| {
         vec![
             assert_ok!(ApiToken::insert(conn, id, "bar")),
-            assert_ok!(ApiToken::insert(conn, id, "baz")),
+            assert_ok!(ApiToken::insert_with_scopes(
+                conn,
+                id,
+                "baz",
+                Some(vec![
+                    CrateScope::try_from("serde").unwrap(),
+                    CrateScope::try_from("serde-*").unwrap()
+                ]),
+                Some(vec![EndpointScope::PublishUpdate])
+            )),
         ]
     });
 

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
@@ -1,0 +1,14 @@
+---
+source: src/tests/routes/me/tokens/list.rs
+expression: response.into_json()
+---
+api_tokens:
+  - created_at: "[datetime]"
+    id: "[id]"
+    last_used_at: "[datetime]"
+    name: bar
+  - created_at: "[datetime]"
+    id: "[id]"
+    last_used_at: "[datetime]"
+    name: baz
+

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
@@ -3,11 +3,18 @@ source: src/tests/routes/me/tokens/list.rs
 expression: response.into_json()
 ---
 api_tokens:
-  - created_at: "[datetime]"
+  - crate_scopes: ~
+    created_at: "[datetime]"
+    endpoint_scopes: ~
     id: "[id]"
     last_used_at: "[datetime]"
     name: bar
-  - created_at: "[datetime]"
+  - crate_scopes:
+      - serde
+      - serde-*
+    created_at: "[datetime]"
+    endpoint_scopes:
+      - publish-update
     id: "[id]"
     last_used_at: "[datetime]"
     name: baz


### PR DESCRIPTION
These fields will be `null` if the token was created without any crate or endpoint scopes, or they will be arrays of the chosen scopes.

Note that these fields are considered **experimental** and we don't give any stability guarantees for now!

### Example:

```json5
{
  // ...
  "crate_scopes": ["serde", "serde-*"]
  "endpoint_scopes": ["publish-new", "publish-update"],
}
```

### Related:

- https://github.com/rust-lang/crates.io/issues/5443
- https://github.com/rust-lang/rfcs/pull/2947
- https://github.com/rust-lang/crates.io/pull/5973