### PR TITLE
embroider: Enable `staticAddonTrees` option

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -66,6 +66,7 @@ module.exports = function (defaults) {
 
   const { Webpack } = require('@embroider/webpack');
   return require('@embroider/compat').compatBuild(app, Webpack, {
+    staticAddonTrees: true,
     staticAddonTestSupportTrees: true,
     staticModifiers: true,
     packagerOptions: {


### PR DESCRIPTION
see https://github.com/embroider-build/embroider/#options

This slightly decreases our JavaScript asset sizes because imports are resolved statically instead of using the AMD module system.

```
# Before

- dist/assets/chunk.514fea02e3c082d63de4.js: 620.24 kB (173.5 kB gzipped)
- dist/assets/chunk.faa54e529b84b23f258d.js: 379.93 kB (68.02 kB gzipped)
- dist/assets/chunk.fc24a4515fb363c6d8bb.js: 378.37 kB (67.43 kB gzipped)

# After

- dist/assets/chunk.96efe47e97abf8656339.js: 349.69 kB (62.98 kB gzipped)
- dist/assets/chunk.a3d896c0d6d4d34ccfd1.js: 351.24 kB (63.55 kB gzipped)
- dist/assets/chunk.bf7497a40e0cb0b8aa38.js: 574.47 kB (164.1 kB gzipped)
```