### PR TITLE
renovate: Throttle `tj-actions/changed-files` action updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
         "matchPackageNames": ["ember-cli", "ember-data", "ember-source"],
         "separateMinorPatch": true,
     }, {
-        "matchPackageNames": ["@percy/cli", "webpack"],
+        "matchPackageNames": ["@percy/cli", "tj-actions/changed-files", "webpack"],
         "extends": ["schedule:weekly"],
     }, {
         "matchLanguages": ["js"],


### PR DESCRIPTION
The action is working well for us as-is. There does not appear to be a need for us to keep this updated quite as often as it is apparently released.