### PR TITLE
PUT /me/token: Remove unused `revoked` field from response payload

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -143,7 +143,6 @@ mod tests {
             id: 12345,
             name: "".to_string(),
             token: "".to_string(),
-            revoked: false,
             created_at: NaiveDate::from_ymd_opt(2017, 1, 6)
                 .unwrap()
                 .and_hms_opt(14, 23, 11)

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success.snap
@@ -9,6 +9,5 @@ api_token:
   id: "[id]"
   last_used_at: "[datetime]"
   name: bar
-  revoked: false
   token: "[token]"
 

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes.snap
@@ -9,6 +9,5 @@ api_token:
   id: "[id]"
   last_used_at: "[datetime]"
   name: bar
-  revoked: false
   token: "[token]"
 

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes.snap
@@ -12,6 +12,5 @@ api_token:
   id: "[id]"
   last_used_at: "[datetime]"
   name: bar
-  revoked: false
   token: "[token]"
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -473,7 +473,6 @@ pub struct EncodableApiTokenWithToken {
     pub id: i32,
     pub name: String,
     pub token: String,
-    pub revoked: bool,
     #[serde(with = "rfc3339")]
     pub created_at: NaiveDateTime,
     #[serde(with = "rfc3339::option")]
@@ -490,7 +489,6 @@ impl From<CreatedApiToken> for EncodableApiTokenWithToken {
             id: token.model.id,
             name: token.model.name,
             token: token.plaintext,
-            revoked: token.model.revoked,
             created_at: token.model.created_at,
             last_used_at: token.model.last_used_at,
             crate_scopes: token.model.crate_scopes,


### PR DESCRIPTION
The `revoked` field is not used by the frontend, and the only API endpoint that returns the `revoked` field is the one that creates a brand new token, in which case it makes no sense for the token to be immediately revoked.

This is technically a breaking change, but since this endpoint is only meant to be used by the frontend when creating new tokens via the user interface the risk of breaking something should be fairly small.