### PR TITLE
Sort crate dependencies before adding to index

### DIFF
--- a/cargo-registry-index/lib.rs
+++ b/cargo-registry-index/lib.rs
@@ -175,7 +175,26 @@ impl Ord for Dependency {
         // misinterpreted. With this manual `Ord` implementation we ensure that
         // `normal` dependencies are always first when multiple with the same
         // `name` exist.
-        (&self.name, self.kind, &self.req).cmp(&(&other.name, other.kind, &other.req))
+        (
+            &self.name,
+            self.kind,
+            &self.req,
+            self.optional,
+            self.default_features,
+            &self.target,
+            &self.package,
+            &self.features,
+        )
+            .cmp(&(
+                &other.name,
+                other.kind,
+                &other.req,
+                other.optional,
+                other.default_features,
+                &other.target,
+                &other.package,
+                &other.features,
+            ))
     }
 }
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -409,8 +409,9 @@ pub fn add_dependencies(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    let (git_deps, new_dependencies): (Vec<_>, Vec<_>) =
+    let (mut git_deps, new_dependencies): (Vec<_>, Vec<_>) =
         git_and_new_dependencies.into_iter().unzip();
+    git_deps.sort();
 
     insert_into(dependencies)
         .values(&new_dependencies)

--- a/src/tests/http-data/krate_publish_new_krate_sorts_deps.json
+++ b/src/tests/http-data/krate_publish_new_krate_sorts_deps.json
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/two-deps/two-deps-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/tw/o-/two-deps",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "376"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "eyJuYW1lIjoidHdvLWRlcHMiLCJ2ZXJzIjoiMS4wLjAiLCJkZXBzIjpbeyJuYW1lIjoiZGVwLWEiLCJyZXEiOiI+IDAiLCJmZWF0dXJlcyI6W10sIm9wdGlvbmFsIjpmYWxzZSwiZGVmYXVsdF9mZWF0dXJlcyI6dHJ1ZSwidGFyZ2V0IjpudWxsLCJraW5kIjoibm9ybWFsIn0seyJuYW1lIjoiZGVwLWIiLCJyZXEiOiI+IDAiLCJmZWF0dXJlcyI6W10sIm9wdGlvbmFsIjpmYWxzZSwiZGVmYXVsdF9mZWF0dXJlcyI6dHJ1ZSwidGFyZ2V0IjpudWxsLCJraW5kIjoibm9ybWFsIn1dLCJja3N1bSI6ImFjYjU2MDRiMTI2YWM4OTRjMWViMTFjNDU3NWJmMjA3MmZlYTYxMjMyYTg4OGU0NTM3NzBjNzlkN2VkNTY0MTkiLCJmZWF0dXJlcyI6e30sInlhbmtlZCI6ZmFsc2V9Cg=="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]


### PR DESCRIPTION
We [sorted the crate dependencies](https://github.com/rust-lang/crates.io/pull/5089) when we did the normalization, but newly published crates do not get their dependencies sorted.

* Updates the `Ord` impl on `Dependency` so all fields are included to ensure a total order.
* Adds a test that verifies newly published crates get sorted (verified this failed before the fix).

r? @Turbo87 

### Related:

- https://github.com/rust-lang/crates.io/pull/5089