### PR TITLE
Make it easier to debug test failures due to incorrect http-data

### DIFF
--- a/src/tests/record.rs
+++ b/src/tests/record.rs
@@ -363,10 +363,8 @@ fn replay_http(
 
     async {
         let _ = &exchange;
-        assert_eq!(
-            to_bytes(req.into_body()).await.unwrap(),
-            base64::decode(&exchange.request.body).unwrap()
-        );
+        let body = base64::encode(to_bytes(req.into_body()).await.unwrap());
+        assert_eq!(&exchange.request.body, &body,);
 
         let mut builder = Response::builder();
         for (key, value) in exchange.response.headers {


### PR DESCRIPTION
When tests fail due to a difference in the body of an HTTP request, it shows up as an escaped string vs a Vec of bytes.

This makes the assert compare the base64 encoded strings (which is what's actually in the JSON http data file).

r? @Turbo87 