### PR TITLE
EncodableApiTokenWithToken: Use `serde(flatten)` to reuse `ApiToken` serialization

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -104,7 +104,6 @@ impl std::fmt::Debug for CreatedApiToken {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::views::EncodableApiTokenWithToken;
     use chrono::NaiveDate;
 
     #[test]
@@ -115,34 +114,6 @@ mod tests {
             token: SecureToken::generate(SecureTokenKind::Api).into_inner(),
             revoked: false,
             name: "".to_string(),
-            created_at: NaiveDate::from_ymd_opt(2017, 1, 6)
-                .unwrap()
-                .and_hms_opt(14, 23, 11)
-                .unwrap(),
-            last_used_at: Some(
-                NaiveDate::from_ymd_opt(2017, 1, 6)
-                    .unwrap()
-                    .and_hms_opt(14, 23, 12),
-            )
-            .unwrap(),
-            crate_scopes: None,
-            endpoint_scopes: None,
-        };
-        let json = serde_json::to_string(&tok).unwrap();
-        assert_some!(json
-            .as_str()
-            .find(r#""created_at":"2017-01-06T14:23:11+00:00""#));
-        assert_some!(json
-            .as_str()
-            .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#));
-    }
-
-    #[test]
-    fn encodeable_api_token_with_token_serializes_to_rfc3339() {
-        let tok = EncodableApiTokenWithToken {
-            id: 12345,
-            name: "".to_string(),
-            token: "".to_string(),
             created_at: NaiveDate::from_ymd_opt(2017, 1, 6)
                 .unwrap()
                 .and_hms_opt(14, 23, 11)

--- a/src/views.rs
+++ b/src/views.rs
@@ -2,10 +2,9 @@ use chrono::NaiveDateTime;
 use url::Url;
 
 use crate::github;
-use crate::models::token::{CrateScope, EndpointScope};
 use crate::models::{
-    Category, Crate, CrateOwnerInvitation, CreatedApiToken, Dependency, DependencyKind, Keyword,
-    Owner, ReverseDependency, Team, TopVersions, User, Version, VersionDownload,
+    ApiToken, Category, Crate, CrateOwnerInvitation, CreatedApiToken, Dependency, DependencyKind,
+    Keyword, Owner, ReverseDependency, Team, TopVersions, User, Version, VersionDownload,
     VersionOwnerAction,
 };
 use crate::util::rfc3339;
@@ -470,29 +469,17 @@ impl From<Team> for EncodableTeam {
 /// the chance of token leaks.
 #[derive(Serialize, Debug)]
 pub struct EncodableApiTokenWithToken {
-    pub id: i32,
-    pub name: String,
-    pub token: String,
-    #[serde(with = "rfc3339")]
-    pub created_at: NaiveDateTime,
-    #[serde(with = "rfc3339::option")]
-    pub last_used_at: Option<NaiveDateTime>,
-    /// `None` or a list of crate scope patterns (see RFC #2947)
-    pub crate_scopes: Option<Vec<CrateScope>>,
-    /// A list of endpoint scopes or `None` for the `legacy` endpoint scope (see RFC #2947)
-    pub endpoint_scopes: Option<Vec<EndpointScope>>,
+    #[serde(flatten)]
+    pub token: ApiToken,
+    #[serde(rename = "token")]
+    pub plaintext: String,
 }
 
 impl From<CreatedApiToken> for EncodableApiTokenWithToken {
     fn from(token: CreatedApiToken) -> Self {
         EncodableApiTokenWithToken {
-            id: token.model.id,
-            name: token.model.name,
-            token: token.plaintext,
-            created_at: token.model.created_at,
-            last_used_at: token.model.last_used_at,
-            crate_scopes: token.model.crate_scopes,
-            endpoint_scopes: token.model.endpoint_scopes,
+            token: token.model,
+            plaintext: token.plaintext,
         }
     }
 }


### PR DESCRIPTION
This seems a bit easier than repeating all the fields and potentially causing inconsistencies (see https://github.com/rust-lang/crates.io/pull/6316).