### PR TITLE
mirage: Add crate and endpoint scope fields

### DIFF
--- a/mirage/factories/api-token.js
+++ b/mirage/factories/api-token.js
@@ -1,7 +1,9 @@
 import { Factory } from 'miragejs';
 
 export default Factory.extend({
+  crateScopes: null,
   createdAt: '2017-11-19T17:59:22',
+  endpointScopes: null,
   lastUsedAt: null,
   name: i => `API Token ${i + 1}`,
   token: () => generateToken(),

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -37,8 +37,14 @@ export function register(server) {
       return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
     }
 
-    let { name } = this.normalizedRequestAttrs('api-token');
-    let token = server.create('api-token', { user, name, createdAt: new Date().toISOString() });
+    let { name, crateScopes = null, endpointScopes = null } = this.normalizedRequestAttrs('api-token');
+    let token = server.create('api-token', {
+      user,
+      name,
+      crateScopes,
+      endpointScopes,
+      createdAt: new Date().toISOString(),
+    });
 
     let json = this.serialize(token);
     json.api_token.revoked = false;

--- a/tests/mirage/me/tokens/create-test.js
+++ b/tests/mirage/me/tokens/create-test.js
@@ -25,7 +25,42 @@ module('Mirage | PUT /api/v1/me/tokens', function (hooks) {
     assert.deepEqual(await response.json(), {
       api_token: {
         id: 1,
+        crate_scopes: null,
         created_at: '2017-11-20T11:23:45.000Z',
+        endpoint_scopes: null,
+        last_used_at: null,
+        name: 'foooo',
+        revoked: false,
+        token: token.token,
+      },
+    });
+  });
+
+  test('creates a new API token with scopes', async function (assert) {
+    this.clock.setSystemTime(new Date('2017-11-20T11:23:45Z'));
+
+    let user = this.server.create('user');
+    this.server.create('mirage-session', { user });
+
+    let body = JSON.stringify({
+      api_token: {
+        name: 'foooo',
+        crate_scopes: ['serde', 'serde-*'],
+        endpoint_scopes: ['publish-update'],
+      },
+    });
+    let response = await fetch('/api/v1/me/tokens', { method: 'PUT', body });
+    assert.strictEqual(response.status, 200);
+
+    let token = this.server.schema.apiTokens.all().models[0];
+    assert.ok(token);
+
+    assert.deepEqual(await response.json(), {
+      api_token: {
+        id: 1,
+        crate_scopes: ['serde', 'serde-*'],
+        created_at: '2017-11-20T11:23:45.000Z',
+        endpoint_scopes: ['publish-update'],
         last_used_at: null,
         name: 'foooo',
         revoked: false,

--- a/tests/mirage/me/tokens/list-test.js
+++ b/tests/mirage/me/tokens/list-test.js
@@ -13,7 +13,12 @@ module('Mirage | GET /api/v1/me/tokens', function (hooks) {
     let user = this.server.create('user');
     this.server.create('mirage-session', { user });
 
-    this.server.create('api-token', { user, createdAt: '2017-11-19T12:59:22Z' });
+    this.server.create('api-token', {
+      user,
+      createdAt: '2017-11-19T12:59:22Z',
+      crateScopes: ['serde', 'serde-*'],
+      endpointScopes: ['publish-update'],
+    });
     this.server.create('api-token', { user, createdAt: '2017-11-19T13:59:22Z' });
     this.server.create('api-token', { user, createdAt: '2017-11-19T14:59:22Z' });
 
@@ -23,19 +28,25 @@ module('Mirage | GET /api/v1/me/tokens', function (hooks) {
       api_tokens: [
         {
           id: 3,
+          crate_scopes: null,
           created_at: '2017-11-19T14:59:22.000Z',
+          endpoint_scopes: null,
           last_used_at: null,
           name: 'API Token 3',
         },
         {
           id: 2,
+          crate_scopes: null,
           created_at: '2017-11-19T13:59:22.000Z',
+          endpoint_scopes: null,
           last_used_at: null,
           name: 'API Token 2',
         },
         {
           id: 1,
+          crate_scopes: ['serde', 'serde-*'],
           created_at: '2017-11-19T12:59:22.000Z',
+          endpoint_scopes: ['publish-update'],
           last_used_at: null,
           name: 'API Token 1',
         },


### PR DESCRIPTION
This PR adds the `crate_scopes` and `endpoint_scopes` fields to the API token endpoints of our [MirageJS](https://miragejs.com) server, which lets us use these fields in the frontend test suite.

This is the first step in adding token scopes support to our frontend! 🎉 

### Related:

- https://github.com/rust-lang/crates.io/issues/5443
- https://github.com/rust-lang/rfcs/pull/2947
- https://github.com/rust-lang/crates.io/pull/5973
- https://github.com/rust-lang/crates.io/pull/6310
- https://github.com/rust-lang/crates.io/pull/6315