### PR TITLE
tests: Introduce `slow-tests` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,14 @@ doctest = true
 name = "all"
 path = "src/tests/all.rs"
 
+[features]
+default = ["slow-tests"]
+
+# The `slow-tests` enables tests that take a long time to finish. It is enabled
+# by default but the test suite can be run via `cargo test --no-default-features`
+# to disable these tests.
+slow-tests = []
+
 [dependencies]
 anyhow = "=1.0.70"
 aws-sigv4 = "=0.55.1"

--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -34,6 +34,7 @@ fn normal_startup() {
         .ends_with("/crates/foo/foo-1.0.0.crate"));
 }
 
+#[cfg(feature = "slow-tests")]
 #[test]
 fn startup_without_database() {
     let server_bin = ServerBin::prepare().unwrap();


### PR DESCRIPTION
The `startup_without_database` test takes about ten seconds to run and is significantly slowing down the test of the test suite. This commit introduces a `slow-tests` cargo feature, which is enabled by default, but `cargo test --no-default-features` can be used to run the test suite without this particular test, or any future tests with this annotation.