### PR TITLE
Move `Job` constructors into `Job` impl

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -1,5 +1,6 @@
+use crate::background_jobs::Job;
+use crate::db;
 use crate::schema::background_jobs::dsl::*;
-use crate::{db, worker};
 use anyhow::Result;
 use diesel::prelude::*;
 
@@ -41,15 +42,15 @@ pub fn run(command: Command) -> Result<()> {
                 println!("Did not enqueue update_downloads, existing job already in progress");
                 Ok(())
             } else {
-                Ok(worker::update_downloads().enqueue(conn)?)
+                Ok(Job::update_downloads().enqueue(conn)?)
             }
         }
         Command::DumpDb {
             database_url,
             target_name,
-        } => Ok(worker::dump_db(database_url, target_name).enqueue(conn)?),
-        Command::DailyDbMaintenance => Ok(worker::daily_db_maintenance().enqueue(conn)?),
-        Command::SquashIndex => Ok(worker::squash_index().enqueue(conn)?),
-        Command::NormalizeIndex { dry_run } => Ok(worker::normalize_index(dry_run).enqueue(conn)?),
+        } => Ok(Job::dump_db(database_url, target_name).enqueue(conn)?),
+        Command::DailyDbMaintenance => Ok(Job::daily_db_maintenance().enqueue(conn)?),
+        Command::SquashIndex => Ok(Job::squash_index().enqueue(conn)?),
+        Command::NormalizeIndex { dry_run } => Ok(Job::normalize_index(dry_run).enqueue(conn)?),
     }
 }

--- a/src/admin/yank_version.rs
+++ b/src/admin/yank_version.rs
@@ -68,8 +68,6 @@ fn yank(opts: Opts, conn: &mut PgConnection) {
     if dotenv::var("FEATURE_INDEX_SYNC").is_ok() {
         Job::enqueue_sync_to_index(&krate.name, conn).unwrap();
     } else {
-        crate::worker::sync_yanked(krate.name, v.num)
-            .enqueue(conn)
-            .unwrap();
+        Job::sync_yanked(krate.name, v.num).enqueue(conn).unwrap();
     }
 }

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -78,16 +78,67 @@ impl Job {
         Ok(())
     }
 
-    pub fn sync_to_git_index<T: ToString>(krate: T) -> Job {
-        Job::SyncToGitIndex(SyncToIndexJob {
+    pub fn add_crate(krate: cargo_registry_index::Crate) -> Self {
+        Self::IndexAddCrate(IndexAddCrateJob { krate })
+    }
+
+    pub fn daily_db_maintenance() -> Self {
+        Self::DailyDbMaintenance
+    }
+
+    pub fn dump_db(database_url: String, target_name: String) -> Self {
+        Self::DumpDb(DumpDbJob {
+            database_url,
+            target_name,
+        })
+    }
+
+    pub fn normalize_index(dry_run: bool) -> Self {
+        Self::NormalizeIndex(NormalizeIndexJob { dry_run })
+    }
+
+    pub fn render_and_upload_readme(
+        version_id: i32,
+        text: String,
+        readme_path: String,
+        base_url: Option<String>,
+        pkg_path_in_vcs: Option<String>,
+    ) -> Self {
+        Self::RenderAndUploadReadme(RenderAndUploadReadmeJob {
+            version_id,
+            text,
+            readme_path,
+            base_url,
+            pkg_path_in_vcs,
+        })
+    }
+
+    pub fn squash_index() -> Self {
+        Self::IndexSquash
+    }
+
+    pub fn sync_to_git_index<T: ToString>(krate: T) -> Self {
+        Self::SyncToGitIndex(SyncToIndexJob {
             krate: krate.to_string(),
         })
     }
 
-    pub fn sync_to_sparse_index<T: ToString>(krate: T) -> Job {
-        Job::SyncToSparseIndex(SyncToIndexJob {
+    pub fn sync_to_sparse_index<T: ToString>(krate: T) -> Self {
+        Self::SyncToSparseIndex(SyncToIndexJob {
             krate: krate.to_string(),
         })
+    }
+
+    pub fn sync_yanked(krate: String, version_num: String) -> Self {
+        Self::IndexUpdateYanked(IndexUpdateYankedJob { krate, version_num })
+    }
+
+    pub fn update_crate_index(crate_name: String) -> Self {
+        Self::IndexSyncToHttp(IndexSyncToHttpJob { crate_name })
+    }
+
+    pub fn update_downloads() -> Self {
+        Self::UpdateDownloads
     }
 
     fn as_type_str(&self) -> &'static str {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -17,7 +17,6 @@ use crate::models::{
     insert_version_owner_action, Category, Crate, DependencyKind, Keyword, NewCrate, NewVersion,
     Rights, VersionAction,
 };
-use crate::worker;
 
 use crate::middleware::log_request::RequestLogExt;
 use crate::models::token::EndpointScope;
@@ -231,7 +230,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             let pkg_path_in_vcs = cargo_vcs_info.map(|info| info.path_in_vcs);
 
             if let Some(readme) = new_crate.readme {
-                worker::render_and_upload_readme(
+                Job::render_and_upload_readme(
                     version.id,
                     readme,
                     new_crate
@@ -276,7 +275,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             if app.config.feature_index_sync {
                 Job::enqueue_sync_to_index(&krate.name, conn)?;
             } else {
-                worker::add_crate(git_crate).enqueue(conn)?;
+                Job::add_crate(git_crate).enqueue(conn)?;
             }
 
             // The `other` field on `PublishWarnings` was introduced to handle a temporary warning

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -9,7 +9,6 @@ use crate::models::token::EndpointScope;
 use crate::models::Rights;
 use crate::models::{insert_version_owner_action, VersionAction};
 use crate::schema::versions;
-use crate::worker;
 
 /// Handles the `DELETE /crates/:crate_id/:version/yank` route.
 /// This does not delete a crate version, it makes the crate
@@ -88,7 +87,7 @@ fn modify_yank(
     if state.config.feature_index_sync {
         Job::enqueue_sync_to_index(&krate.name, conn)?;
     } else {
-        worker::sync_yanked(krate.name, version.num).enqueue(conn)?;
+        Job::sync_yanked(krate.name, version.num).enqueue(conn)?;
     }
 
     ok_true()

--- a/src/worker/daily_db_maintenance.rs
+++ b/src/worker/daily_db_maintenance.rs
@@ -1,4 +1,3 @@
-use crate::background_jobs::Job;
 use crate::swirl::PerformError;
 /// Run daily database maintenance tasks
 ///
@@ -16,8 +15,4 @@ pub(crate) fn perform_daily_db_maintenance(conn: &mut PgConnection) -> Result<()
     sql_query("VACUUM version_downloads;").execute(conn)?;
     info!("Finished running VACUUM on version_downloads table");
     Ok(())
-}
-
-pub fn daily_db_maintenance() -> Job {
-    Job::DailyDbMaintenance
 }

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use self::configuration::VisibilityConfig;
-use crate::{background_jobs::DumpDbJob, swirl::PerformError};
+use crate::swirl::PerformError;
 use crate::{
-    background_jobs::{Environment, Job},
+    background_jobs::Environment,
     uploaders::{UploadBucket, Uploader},
 };
 use reqwest::header;
@@ -31,13 +31,6 @@ pub fn perform_dump_db(
     let size = tarball.upload(&target_name, &env.uploader)?;
     info!("Database dump uploaded {} bytes to {}.", size, &target_name);
     Ok(())
-}
-
-pub fn dump_db(database_url: String, target_name: String) -> Job {
-    Job::DumpDb(DumpDbJob {
-        database_url,
-        target_name,
-    })
 }
 
 /// Manage the export directory.

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -10,12 +10,6 @@ mod git;
 mod readmes;
 mod update_downloads;
 
-pub use daily_db_maintenance::daily_db_maintenance;
-pub use dump_db::dump_db;
-pub use git::{add_crate, normalize_index, squash_index, sync_yanked};
-pub use readmes::render_and_upload_readme;
-pub use update_downloads::update_downloads;
-
 pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
 pub(crate) use dump_db::perform_dump_db;
 pub(crate) use git::{

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -4,7 +4,7 @@ use crate::swirl::PerformError;
 use cargo_registry_markdown::text_to_html;
 use diesel::PgConnection;
 
-use crate::background_jobs::{Environment, Job, RenderAndUploadReadmeJob};
+use crate::background_jobs::Environment;
 use crate::models::Version;
 
 pub fn perform_render_and_upload_readme(
@@ -31,21 +31,5 @@ pub fn perform_render_and_upload_readme(
         env.uploader
             .upload_readme(env.http_client(), &crate_name, &vers, rendered)?;
         Ok(())
-    })
-}
-
-pub fn render_and_upload_readme(
-    version_id: i32,
-    text: String,
-    readme_path: String,
-    base_url: Option<String>,
-    pkg_path_in_vcs: Option<String>,
-) -> Job {
-    Job::RenderAndUploadReadme(RenderAndUploadReadmeJob {
-        version_id,
-        text,
-        readme_path,
-        base_url,
-        pkg_path_in_vcs,
     })
 }

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -3,17 +3,12 @@ use crate::{
     schema::{crates, metadata, version_downloads, versions},
 };
 
-use crate::background_jobs::Job;
 use crate::swirl::PerformError;
 use diesel::prelude::*;
 
 pub fn perform_update_downloads(conn: &mut PgConnection) -> Result<(), PerformError> {
     update(conn)?;
     Ok(())
-}
-
-pub fn update_downloads() -> Job {
-    Job::UpdateDownloads
 }
 
 fn update(conn: &mut PgConnection) -> QueryResult<()> {


### PR DESCRIPTION
This makes it a little easier to understand that these functions are creating `Job` instances that need to be enqueued afterwards. It also means we have all the constructors in one place instead of being spread out across multiple files.