### PR TITLE
background_jobs: Use macros to generate `as_type_str()`, `to_value()` and `from_value()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,7 @@ dependencies = [
  "oauth2",
  "once_cell",
  "parking_lot",
+ "paste",
  "prometheus",
  "rand",
  "reqwest",
@@ -2124,6 +2125,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "percent-encoding"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ moka = { version = "=0.10.2", features = ["future"]  }
 oauth2 = { version = "=4.3.0", default-features = false, features = ["reqwest"] }
 once_cell = "=1.17.1"
 parking_lot = "=0.12.1"
+paste = "=1.0.12"
 prometheus = { version = "=0.13.3", default-features = false }
 rand = "=0.8.5"
 reqwest = { version = "=0.11.16", features = ["blocking", "gzip", "json"] }


### PR DESCRIPTION
Is this better? Who knows...

Does it work? Yes, it does...

The expanded code looks like this:

```rs
pub enum Job {
    AddCrate(AddCrateJob),
    DailyDbMaintenance,
    DumpDb(DumpDbJob),
    NormalizeIndex(NormalizeIndexJob),
    RenderAndUploadReadme(RenderAndUploadReadmeJob),
    SquashIndex,
    SyncToGitIndex(SyncToIndexJob),
    SyncToSparseIndex(SyncToIndexJob),
    SyncYanked(SyncYankedJob),
    UpdateCrateIndex(UpdateCrateIndexJob),
    UpdateDownloads,
}
impl 
    Job {
    fn as_type_str(&self) -> &'static str {
        match self {
            Self::AddCrate(_add_crate_job) => "add_crate",
            Self::DailyDbMaintenance => "daily_db_maintenance",
            Self::DumpDb(_dump_db_job) => "dump_db",
            Self::NormalizeIndex(_normalize_index_job) => "normalize_index",
            Self::RenderAndUploadReadme(_render_and_upload_readme_job) =>
                "render_and_upload_readme",
            Self::SquashIndex => "squash_index",
            Self::SyncToGitIndex(_sync_to_index_job) => "sync_to_git_index",
            Self::SyncToSparseIndex(_sync_to_index_job) =>
                "sync_to_sparse_index",
            Self::SyncYanked(_sync_yanked_job) => "sync_yanked",
            Self::UpdateCrateIndex(_update_crate_index_job) =>
                "update_crate_index",
            Self::UpdateDownloads => "update_downloads",
        }
    }
    fn to_value(&self) -> serde_json::Result<serde_json::Value> {
        match self {
            Self::AddCrate(add_crate_job) =>
                serde_json::to_value(add_crate_job),
            Self::DailyDbMaintenance => Ok(serde_json::Value::Null),
            Self::DumpDb(dump_db_job) => serde_json::to_value(dump_db_job),
            Self::NormalizeIndex(normalize_index_job) =>
                serde_json::to_value(normalize_index_job),
            Self::RenderAndUploadReadme(render_and_upload_readme_job) =>
                serde_json::to_value(render_and_upload_readme_job),
            Self::SquashIndex => Ok(serde_json::Value::Null),
            Self::SyncToGitIndex(sync_to_index_job) =>
                serde_json::to_value(sync_to_index_job),
            Self::SyncToSparseIndex(sync_to_index_job) =>
                serde_json::to_value(sync_to_index_job),
            Self::SyncYanked(sync_yanked_job) =>
                serde_json::to_value(sync_yanked_job),
            Self::UpdateCrateIndex(update_crate_index_job) =>
                serde_json::to_value(update_crate_index_job),
            Self::UpdateDownloads => Ok(serde_json::Value::Null),
        }
    }
    pub fn from_value(job_type: &str, value: serde_json::Value)
        -> Result<Self, PerformError> {
        Ok(match job_type {
                "add_crate" => Self::AddCrate(serde_json::from_value(value)?),
                "daily_db_maintenance" => Self::DailyDbMaintenance,
                "dump_db" => Self::DumpDb(serde_json::from_value(value)?),
                "normalize_index" =>
                    Self::NormalizeIndex(serde_json::from_value(value)?),
                "render_and_upload_readme" =>
                    Self::RenderAndUploadReadme(serde_json::from_value(value)?),
                "squash_index" => Self::SquashIndex,
                "sync_to_git_index" =>
                    Self::SyncToGitIndex(serde_json::from_value(value)?),
                "sync_to_sparse_index" =>
                    Self::SyncToSparseIndex(serde_json::from_value(value)?),
                "sync_yanked" =>
                    Self::SyncYanked(serde_json::from_value(value)?),
                "update_crate_index" =>
                    Self::UpdateCrateIndex(serde_json::from_value(value)?),
                "update_downloads" => Self::UpdateDownloads,
                job_type =>
                    Err(PerformError::from(format!("Unknown job type {job_type}")))?,
            })
    }
}
```

Note that I've inlined the `const` strings since they were only used within these functions and nowhere else.

The main advantage of using a macro to generate these functions is that we can't introduce subtle typo bugs anymore or e.g. forget to add a job type to the `from_value()` function.

The implementation of this was certainly not quite straight-forward, but I'm reasonably happy with the result now.