### PR TITLE
settings/tokens: Delete plaintext tokens from memory after leaving API tokens settings page

### DIFF
--- a/app/routes/settings/tokens.js
+++ b/app/routes/settings/tokens.js
@@ -11,4 +11,16 @@ export default class TokenSettingsRoute extends AuthenticatedRoute {
     let apiTokens = await this.store.findAll('api-token');
     return TrackedArray.from(apiTokens.slice());
   }
+
+  /**
+   * Ensure that all plaintext tokens are deleted from memory after leaving
+   * the API tokens settings page.
+   */
+  resetController(controller) {
+    for (let token of controller.model) {
+      if (token.token) {
+        token.token = undefined;
+      }
+    }
+  }
 }

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -133,6 +133,25 @@ module('Acceptance | api-tokens', function (hooks) {
     assert.dom('[data-test-token]').hasText(token.token);
   });
 
+  test('API tokens are only visible in plaintext until the page is left', async function (assert) {
+    prepare(this);
+
+    await visit('/settings/tokens');
+    await click('[data-test-new-token-button]');
+    await fillIn('[data-test-focused-input]', 'the new token');
+    await click('[data-test-save-token-button]');
+
+    let token = this.server.schema.apiTokens.findBy({ name: 'the new token' });
+    assert.dom('[data-test-token]').hasText(token.token);
+
+    // leave the API tokens page
+    await visit('/settings');
+
+    // and visit it again
+    await visit('/settings/tokens');
+    assert.dom('[data-test-token]').doesNotExist();
+  });
+
   test('navigating away while creating a token does not keep it in the list', async function (assert) {
     prepare(this);
 


### PR DESCRIPTION
Even though the app claimed that the user can no longer access the plaintext token once they leave the page, this was not actually the case. Instead we still showed the plaintext token when the user navigated back to the API tokens page.

This PR adjusts the code for the `/settings/tokens` page to delete the plaintext token from memory once the users leaves the page.