### PR TITLE
Fix broken URL in error message

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -102,7 +102,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         let verified_email_address = verified_email_address.ok_or_else(|| {
             cargo_err(&format!(
                 "A verified email address is required to publish crates to crates.io. \
-             Visit https://{}/me to set and verify your email address.",
+             Visit https://{}/settings/profile to set and verify your email address.",
                 app.config.domain_name,
             ))
         })?;

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -608,7 +608,7 @@ fn new_krate_without_any_email_fails() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
-        json!({ "errors": [{ "detail": "A verified email address is required to publish crates to crates.io. Visit https://crates.io/me to set and verify your email address." }] })
+        json!({ "errors": [{ "detail": "A verified email address is required to publish crates to crates.io. Visit https://crates.io/settings/profile to set and verify your email address." }] })
     );
 }
 
@@ -629,7 +629,7 @@ fn new_krate_with_unverified_email_fails() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
-        json!({ "errors": [{ "detail": "A verified email address is required to publish crates to crates.io. Visit https://crates.io/me to set and verify your email address." }] })
+        json!({ "errors": [{ "detail": "A verified email address is required to publish crates to crates.io. Visit https://crates.io/settings/profile to set and verify your email address." }] })
     );
 }
 


### PR DESCRIPTION
The `/me` route has been changed into a redirect to `/settings/tokens` due to it being hardcoded in cargo for a specific purpose. The email address field has moved to `/settings/profile` though, so this commit fixes the error message to point to the correct page.

Resolves https://github.com/rust-lang/crates.io/issues/6364