### PR TITLE
sentry: Fix `is_download_endpoint` logic

### DIFF
--- a/src/sentry/mod.rs
+++ b/src/sentry/mod.rs
@@ -28,7 +28,7 @@ pub fn init() -> ClientInitGuard {
 
     let traces_sampler = move |ctx: &TransactionContext| -> f32 {
         let is_download_endpoint =
-            ctx.name().starts_with("/api/v1/crates/") && ctx.name().ends_with("/download");
+            ctx.name().starts_with("GET /api/v1/crates/") && ctx.name().ends_with("/download");
 
         if is_download_endpoint {
             // Reduce the sample rate for the download endpoint, since we have significantly


### PR DESCRIPTION
The transaction name includes the HTTP method these days, so `is_download_endpoint` was always false... 🙈