### PR TITLE
admin/enqueue-job: Redact `database_url` in `Debug` output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -486,6 +486,7 @@ dependencies = [
  "retry",
  "ring",
  "scheduled-thread-pool",
+ "secrecy",
  "semver",
  "sentry",
  "serde",
@@ -2636,6 +2637,15 @@ name = "scratch"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ reqwest = { version = "=0.11.16", features = ["blocking", "gzip", "json"] }
 retry = "=2.0.0"
 ring = "=0.16.20"
 scheduled-thread-pool = "=0.2.7"
+secrecy = "=0.8.0"
 semver = { version = "=1.0.17", features = ["serde"] }
 sentry = { version = "=0.31.0", features = ["tracing", "tower", "tower-http"] }
 serde = { version = "=1.0.160", features = ["derive"] }


### PR DESCRIPTION
When this admin tool was migrated to use `clap` we missed that the subfields of the variants would now also be printed to the logs. Since we don't want our database URL to end up in the logs we will use `SecretString` here to redact it from the derived `Debug` implementation.

Note that this has already been reviewed and deployed before this public PR was opened, and the group of people with access to the logs of crates.io is the same as the one with access to Heroku and the database, so nothing was actually leaked. Out of caution we have also rotated the credentials to the database and we are investigating other measures that should prevent these issues in the future.