### PR TITLE
tracing: Instrument background job runner

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -1,6 +1,7 @@
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use reqwest::blocking::Client;
+use std::fmt::Display;
 use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
@@ -53,7 +54,8 @@ impl Job {
     const UPDATE_CRATE_INDEX: &str = "update_crate_index";
     const UPDATE_DOWNLOADS: &str = "update_downloads";
 
-    pub fn enqueue_sync_to_index<T: ToString>(
+    #[instrument(name = "swirl.enqueue", skip_all, fields(message = "sync_to_index", krate = %krate))]
+    pub fn enqueue_sync_to_index<T: ToString + Display>(
         krate: T,
         conn: &mut PgConnection,
     ) -> Result<(), EnqueueError> {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -173,6 +173,7 @@ impl Job {
         }
     }
 
+    #[instrument(name = "swirl.enqueue", skip(self, conn), fields(message = self.as_type_str()))]
     pub fn enqueue(&self, conn: &mut PgConnection) -> Result<(), EnqueueError> {
         use crate::schema::background_jobs::dsl::*;
 

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -1,5 +1,8 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
+#[macro_use]
+extern crate tracing;
+
 use cargo_registry::admin::{
     delete_crate, delete_version, enqueue_job, git_import, migrate, populate, render_readmes,
     test_pagerduty, transfer_crates, upload_index, verify_token, yank_version,
@@ -31,7 +34,9 @@ fn main() -> anyhow::Result<()> {
 
     use clap::Parser;
 
+    let span = info_span!("admin.command", command = tracing::field::Empty);
     let command = Command::parse();
+    span.record("command", tracing::field::debug(&command));
 
     match command {
         Command::DeleteCrate(opts) => delete_crate::run(opts),


### PR DESCRIPTION
This PR adds `tracing` instrumentation around a couple of places related to our background job code. This means Sentry will now be able to track how long our background jobs are taking and eventually also what parts make them slow.