### PR TITLE
swirl: Improve Sentry scoping

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -32,6 +32,8 @@ fn main() {
     // Initialize logging
     cargo_registry::util::tracing::init();
 
+    let _span = info_span!("swirl.run");
+
     info!("Booting runner");
 
     let config = config::Server::default();

--- a/src/sentry/mod.rs
+++ b/src/sentry/mod.rs
@@ -44,6 +44,9 @@ pub fn init() -> ClientInitGuard {
         } else if op == "swirl.perform" || op == "admin.command" {
             // Record all traces for background tasks and admin commands
             return 1.;
+        } else if op == "swirl.run" {
+            // Ignore top-level span from the background worker
+            return 0.;
         }
 
         traces_sample_rate


### PR DESCRIPTION
Some of the `tracing` spans were not properly associated to the parent `swirl.perform` span. This PR should fix the problem.