### PR TITLE
rust-version: Use "kebab-case" for `Cargo.toml` field name

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -584,7 +584,7 @@ mod tests {
             "foo-0.0.1/Cargo.toml",
             br#"
 [package]
-rust_version = "1.59"
+rust-version = "1.59"
 readme = "README.md"
 repository = "https://github.com/foo/bar"
 "#,

--- a/src/util/manifest.rs
+++ b/src/util/manifest.rs
@@ -6,6 +6,7 @@ pub struct Manifest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Package {
     pub readme: Option<String>,
     pub repository: Option<String>,


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/pull/6267 added the field to the database and index, but during review I missed that it was deserializing from the `rust_version` field in the `Cargo.toml` file, instead of using `rust-version` (see https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field).

This PR fixes the issue and adjusts the corresponding test :)