### PR TITLE
models/version: Fix `msrv` regex

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -41,7 +41,7 @@ export default class Version extends Model {
   get msrv() {
     let rustVersion = this.rust_version;
     // add `.0` suffix if the `rust-version` field only has two version components
-    return /^.+\..+$/.test(rustVersion) ? `${rustVersion}.0` : rustVersion;
+    return /^[^.]+\.[^.]+$/.test(rustVersion) ? `${rustVersion}.0` : rustVersion;
   }
 
   get isNew() {

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -36,6 +36,21 @@ module('Model | Version', function (hooks) {
     assert.false(versions[0].isNew);
   });
 
+  test('msrv', async function (assert) {
+    let version = await this.store.createRecord('version');
+    assert.strictEqual(version.msrv, undefined);
+
+    version.rust_version = '1.69.1';
+    assert.strictEqual(version.msrv, '1.69.1');
+
+    version.rust_version = '1.69';
+    assert.strictEqual(version.msrv, '1.69.0');
+
+    // this is not actually allowed by the backend
+    version.rust_version = '1';
+    assert.strictEqual(version.msrv, '1');
+  });
+
   module('semver', function () {
     async function prepare(context, { num }) {
       let { server, store } = context;


### PR DESCRIPTION
`1.2.3` matches the old regex, just like `1.2` does too, so this PR fixes the regex to only match a two-part version string.