### PR TITLE
Show README and metadata for yanked crates/versions

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -8,6 +8,11 @@
         <span local-class="yanked-badge">
           {{svg-jar "trash"}}
           Yanked
+
+          <EmberTooltip>
+            This crate has been yanked, but it is still available for download for other crates that
+            may be depending on it.
+          </EmberTooltip>
         </span>
       {{/if}}
     {{/if}}

--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -5,7 +5,7 @@
       <small data-test-crate-version>v{{@version.num}}</small>
 
       {{#if @version.yanked}}
-        <span local-class="yanked-badge">
+        <span local-class="yanked-badge" data-test-yanked>
           {{svg-jar "trash"}}
           Yanked
 

--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -3,6 +3,13 @@
     <span data-test-crate-name>{{@crate.name}}</span>
     {{#if @version}}
       <small data-test-crate-version>v{{@version.num}}</small>
+
+      {{#if @version.yanked}}
+        <span local-class="yanked-badge">
+          {{svg-jar "trash"}}
+          Yanked
+        </span>
+      {{/if}}
     {{/if}}
   </h1>
 

--- a/app/components/crate-header.module.css
+++ b/app/components/crate-header.module.css
@@ -12,6 +12,25 @@
     }
 }
 
+.yanked-badge {
+    background: #d30000;
+    border-radius: 99999px;
+    padding: var(--space-3xs) var(--space-s);
+    font-size: var(--space-s);
+    color: white;
+    align-self: center;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-3xs);
+    white-space: nowrap;
+
+    svg {
+        width: 1em;
+        height: 1em;
+        flex-shrink: 0;
+    }
+}
+
 .description {
     margin-top: var(--space-xs);
     line-height: 1.35;

--- a/app/components/crate-header.module.css
+++ b/app/components/crate-header.module.css
@@ -23,6 +23,7 @@
     align-items: center;
     gap: var(--space-3xs);
     white-space: nowrap;
+    cursor: default;
 
     svg {
         width: 1em;

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -180,3 +180,7 @@ noscript {
     flex-direction: column;
     padding: var(--main-layout-padding);
 }
+
+:global(.ember-tooltip) {
+    font-weight: normal;
+}

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -6,115 +6,102 @@
   @versionNum={{this.requestedVersion}}
 />
 
-{{#if this.currentVersion.yanked}}
-  <div>
-    <p>
-      This crate has been yanked, but it is still available for download for other crates that
-      may be depending on it.
-    </p>
-    <p>
-      You may wish to <LinkTo @route="crate.versions" @model={{this.crate}}>view all versions</LinkTo> to find
-      one that has not been yanked.
-    </p>
-  </div>
-{{else}}
-  <div local-class='crate-info'>
-    <div local-class="docs">
-      {{#if this.loadReadmeTask.isRunning}}
-        <div local-class="readme-spinner">
-          <Placeholder local-class="placeholder-title" />
-          <Placeholder local-class="placeholder-text" />
-          <Placeholder local-class="placeholder-text" />
-          <Placeholder local-class="placeholder-text" />
-          <Placeholder local-class="placeholder-text" />
-          <Placeholder local-class="placeholder-text" />
-          <Placeholder local-class="placeholder-subtitle" />
-          <Placeholder local-class="placeholder-text" />
-          <Placeholder local-class="placeholder-text" />
-          <Placeholder local-class="placeholder-text" />
-        </div>
-      {{else if this.readme}}
-        <article aria-label="Readme" data-test-readme>
-          <RenderedHtml @html={{this.readme}} local-class="readme" />
-        </article>
-      {{else}}
-        <div local-class="no-readme" data-test-no-readme>
-          {{this.crate.name}} v{{this.currentVersion.num}} appears to have no <code>README.md</code> file
-        </div>
-      {{/if}}
-    </div>
-
-    <CrateSidebar
-      @crate={{this.crate}}
-      @version={{this.currentVersion}}
-      @requestedVersion={{this.requestedVersion}}
-      local-class="sidebar"
-    />
+<div local-class='crate-info'>
+  <div local-class="docs">
+    {{#if this.loadReadmeTask.isRunning}}
+      <div local-class="readme-spinner">
+        <Placeholder local-class="placeholder-title" />
+        <Placeholder local-class="placeholder-text" />
+        <Placeholder local-class="placeholder-text" />
+        <Placeholder local-class="placeholder-text" />
+        <Placeholder local-class="placeholder-text" />
+        <Placeholder local-class="placeholder-text" />
+        <Placeholder local-class="placeholder-subtitle" />
+        <Placeholder local-class="placeholder-text" />
+        <Placeholder local-class="placeholder-text" />
+        <Placeholder local-class="placeholder-text" />
+      </div>
+    {{else if this.readme}}
+      <article aria-label="Readme" data-test-readme>
+        <RenderedHtml @html={{this.readme}} local-class="readme" />
+      </article>
+    {{else}}
+      <div local-class="no-readme" data-test-no-readme>
+        {{this.crate.name}} v{{this.currentVersion.num}} appears to have no <code>README.md</code> file
+      </div>
+    {{/if}}
   </div>
 
-  <div local-class='crate-downloads'>
-    <div local-class='stats'>
-      {{#if this.downloadsContext.num}}
-        <h3 data-test-crate-stats-label>
-          Stats Overview for {{this.downloadsContext.num}}
-          <LinkTo @route="crate" @model={{this.crate}}>(see all)</LinkTo>
-        </h3>
+  <CrateSidebar
+    @crate={{this.crate}}
+    @version={{this.currentVersion}}
+    @requestedVersion={{this.requestedVersion}}
+    local-class="sidebar"
+  />
+</div>
 
-      {{else}}
-        <h3 data-test-crate-stats-label>Stats Overview</h3>
-      {{/if}}
-      <div local-class='stat'>
-        <span local-class='num'>
-          {{svg-jar "download"}}
-          <span local-class="num__align">{{ format-num this.downloadsContext.downloads }}</span>
-        </span>
-        <span local-class="stat-description">Downloads all time</span>
-      </div>
-      <div local-class='stat'>
-        <span local-class="num">
-          {{svg-jar "crate"}}
-          <span local-class="num__align">{{ this.crate.versions.length }}</span>
-        </span>
-        <span local-class="stat-description">Versions published</span>
-      </div>
+<div local-class='crate-downloads'>
+  <div local-class='stats'>
+    {{#if this.downloadsContext.num}}
+      <h3 data-test-crate-stats-label>
+        Stats Overview for {{this.downloadsContext.num}}
+        <LinkTo @route="crate" @model={{this.crate}}>(see all)</LinkTo>
+      </h3>
+
+    {{else}}
+      <h3 data-test-crate-stats-label>Stats Overview</h3>
+    {{/if}}
+    <div local-class='stat'>
+      <span local-class='num'>
+        {{svg-jar "download"}}
+        <span local-class="num__align">{{ format-num this.downloadsContext.downloads }}</span>
+      </span>
+      <span local-class="stat-description">Downloads all time</span>
     </div>
-    <div local-class='graph'>
-      <h4>Downloads over the last 90 days</h4>
-      <div local-class="toggle-stacked">
-        <span local-class="toggle-stacked-label">Display as </span>
-        <Dropdown as |dd|>
-          <dd.Trigger local-class="trigger">
-            <span local-class="trigger-label">
-              {{#if this.stackedGraph}}
-                Stacked
-              {{else}}
-                Unstacked
-              {{/if}}
-            </span>
-          </dd.Trigger>
-          <dd.Menu as |menu|>
-            <menu.Item>
-              <button
-                type="button"
-                local-class="dropdown-button"
-                {{on "click" this.setStackedGraph}}
-              >
-                Stacked
-              </button>
-            </menu.Item>
-            <menu.Item>
-              <button
-                type="button"
-                local-class="dropdown-button"
-                {{on "click" this.setUnstackedGraph}}
-              >
-                Unstacked
-              </button>
-            </menu.Item>
-          </dd.Menu>
-        </Dropdown>
-      </div>
-      <DownloadGraph @data={{this.downloads}} @stacked={{this.stackedGraph}} local-class="graph-data" />
+    <div local-class='stat'>
+      <span local-class="num">
+        {{svg-jar "crate"}}
+        <span local-class="num__align">{{ this.crate.versions.length }}</span>
+      </span>
+      <span local-class="stat-description">Versions published</span>
     </div>
   </div>
-{{/if}}
+  <div local-class='graph'>
+    <h4>Downloads over the last 90 days</h4>
+    <div local-class="toggle-stacked">
+      <span local-class="toggle-stacked-label">Display as </span>
+      <Dropdown as |dd|>
+        <dd.Trigger local-class="trigger">
+          <span local-class="trigger-label">
+            {{#if this.stackedGraph}}
+              Stacked
+            {{else}}
+              Unstacked
+            {{/if}}
+          </span>
+        </dd.Trigger>
+        <dd.Menu as |menu|>
+          <menu.Item>
+            <button
+              type="button"
+              local-class="dropdown-button"
+              {{on "click" this.setStackedGraph}}
+            >
+              Stacked
+            </button>
+          </menu.Item>
+          <menu.Item>
+            <button
+              type="button"
+              local-class="dropdown-button"
+              {{on "click" this.setUnstackedGraph}}
+            >
+              Unstacked
+            </button>
+          </menu.Item>
+        </dd.Menu>
+      </Dropdown>
+    </div>
+    <DownloadGraph @data={{this.downloads}} @stacked={{this.stackedGraph}} local-class="graph-data" />
+  </div>
+</div>

--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -7,7 +7,7 @@
 />
 
 <div local-class='crate-info'>
-  <div local-class="docs">
+  <div local-class="docs" data-test-docs>
     {{#if this.loadReadmeTask.isRunning}}
       <div local-class="readme-spinner">
         <Placeholder local-class="placeholder-title" />

--- a/tests/routes/crate/version/model-test.js
+++ b/tests/routes/crate/version/model-test.js
@@ -19,6 +19,8 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.strictEqual(currentURL(), `/crates/foo/1.2.3`);
       assert.dom('[data-test-crate-name]').hasText('foo');
       assert.dom('[data-test-crate-version]').hasText('v1.2.3');
+      assert.dom('[data-test-yanked]').exists();
+      assert.dom('[data-test-docs]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -49,6 +51,8 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.strictEqual(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
       assert.dom('[data-test-crate-version]').hasText('v2.0.0');
+      assert.dom('[data-test-yanked]').doesNotExist();
+      assert.dom('[data-test-docs]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -62,6 +66,8 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.strictEqual(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
       assert.dom('[data-test-crate-version]').hasText('v1.0.0');
+      assert.dom('[data-test-yanked]').doesNotExist();
+      assert.dom('[data-test-docs]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -77,6 +83,8 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.strictEqual(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
       assert.dom('[data-test-crate-version]').hasText('v2.0.0-beta.2');
+      assert.dom('[data-test-yanked]').doesNotExist();
+      assert.dom('[data-test-docs]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -90,6 +98,8 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.strictEqual(currentURL(), `/crates/foo`);
       assert.dom('[data-test-crate-name]').hasText('foo');
       assert.dom('[data-test-crate-version]').hasText('v2.0.0-beta.1');
+      assert.dom('[data-test-yanked]').exists();
+      assert.dom('[data-test-docs]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
   });


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/6414

### Before

<img width="962" alt="Bildschirmfoto 2023-05-02 um 13 30 16" src="https://user-images.githubusercontent.com/141300/235654287-ee4453c9-99d5-4cf7-8bfc-4370c93d4cbf.png">

### After

<img width="945" alt="Bildschirmfoto 2023-05-02 um 13 29 45" src="https://user-images.githubusercontent.com/141300/235654219-4a4cb921-b5b6-410a-ba72-79d2d5e508c8.png">

I'm opening this as a draft PR for discussion among the team. Also, tests are still missing for this change.