### PR TITLE
README: Add styling for `<kbd>` tags

### DIFF
--- a/app/components/rendered-html.module.css
+++ b/app/components/rendered-html.module.css
@@ -39,6 +39,21 @@
         font-family: var(--font-monospace);
     }
 
+    kbd {
+        font-family: var(--font-monospace);
+        font-size: 11px;
+
+        padding: 2px 5px 3px 5px;
+
+        border-radius: 7px;
+
+        position: relative;
+        bottom: 2px;
+
+        border: 1px solid var(--grey700);
+        box-shadow: inset 0 -2px 0 var(--grey600);
+    }
+
     table {
         border-collapse: collapse;
         display: block;

--- a/cargo-registry-markdown/lib.rs
+++ b/cargo-registry-markdown/lib.rs
@@ -330,6 +330,13 @@ mod tests {
     }
 
     #[test]
+    fn text_with_kbd_tag() {
+        let text = "foo_readme\n\nHello <kbd>alert('Hello World')</kbd>";
+        let result = markdown_to_html(text, None, "");
+        assert_eq!(result, "<p>foo_readme</p>\n<p>Hello <kbd>alert(\'Hello World\')</kbd></p>\n");
+    }
+
+    #[test]
     fn text_with_inline_javascript() {
         let text = r#"foo_readme\n\n<a href="https://crates.io/crates/cargo-registry" onclick="window.alert('Got you')">Crate page</a>"#;
         let result = markdown_to_html(text, None, "");

--- a/cargo-registry-markdown/lib.rs
+++ b/cargo-registry-markdown/lib.rs
@@ -333,7 +333,10 @@ mod tests {
     fn text_with_kbd_tag() {
         let text = "foo_readme\n\nHello <kbd>alert('Hello World')</kbd>";
         let result = markdown_to_html(text, None, "");
-        assert_eq!(result, "<p>foo_readme</p>\n<p>Hello <kbd>alert(\'Hello World\')</kbd></p>\n");
+        assert_eq!(
+            result,
+            "<p>foo_readme</p>\n<p>Hello <kbd>alert(\'Hello World\')</kbd></p>\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION

## Before
![img](https://user-images.githubusercontent.com/81473300/236012998-cb0527d9-394f-41f2-9f62-9e5f174a7345.png)

## After
![image](https://user-images.githubusercontent.com/81473300/236012825-f20b8eff-4666-41d3-87dc-ac91b2433c77.png)

This is a small PR adding some style for the \<kbd> tag in the the markdown display.
It was created after a short discussion #6420.