### PR TITLE
CrateSidebar: Hide "Install" section for yanked versions

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -44,41 +44,43 @@
     {{/if}}
   </div>
 
-  <div>
-    <h2 local-class="heading">Install</h2>
+  {{#unless @version.yanked}}
+    <div data-test-install>
+      <h2 local-class="heading">Install</h2>
 
-    <p local-class="copy-help">Run the following Cargo command in your project directory:</p>
-    {{#if (is-clipboard-supported)}}
-      <CopyButton
-        @copyText={{this.cargoAddCommand}}
-        title="Copy command to clipboard"
-        local-class="copy-button"
-      >
-        <span>{{this.cargoAddCommand}}</span>
-        {{svg-jar "copy" aria-hidden="true" local-class="copy-icon"}}
-      </CopyButton>
-    {{else}}
-      <code local-class="copy-fallback">
-        {{this.cargoAddCommand}}
-      </code>
-    {{/if}}
+      <p local-class="copy-help">Run the following Cargo command in your project directory:</p>
+      {{#if (is-clipboard-supported)}}
+        <CopyButton
+          @copyText={{this.cargoAddCommand}}
+          title="Copy command to clipboard"
+          local-class="copy-button"
+        >
+          <span>{{this.cargoAddCommand}}</span>
+          {{svg-jar "copy" aria-hidden="true" local-class="copy-icon"}}
+        </CopyButton>
+      {{else}}
+        <code local-class="copy-fallback">
+          {{this.cargoAddCommand}}
+        </code>
+      {{/if}}
 
-    <p local-class="copy-help">Or add the following line to your Cargo.toml:</p>
-    {{#if (is-clipboard-supported)}}
-      <CopyButton
-        @copyText={{this.tomlSnippet}}
-        title="Copy Cargo.toml snippet to clipboard"
-        local-class="copy-button"
-      >
-        <span>{{this.tomlSnippet}}</span>
-        {{svg-jar "copy" aria-hidden="true" local-class="copy-icon"}}
-      </CopyButton>
-    {{else}}
-      <code local-class="copy-fallback">
-        {{this.tomlSnippet}}
-      </code>
-    {{/if}}
-  </div>
+      <p local-class="copy-help">Or add the following line to your Cargo.toml:</p>
+      {{#if (is-clipboard-supported)}}
+        <CopyButton
+          @copyText={{this.tomlSnippet}}
+          title="Copy Cargo.toml snippet to clipboard"
+          local-class="copy-button"
+        >
+          <span>{{this.tomlSnippet}}</span>
+          {{svg-jar "copy" aria-hidden="true" local-class="copy-icon"}}
+        </CopyButton>
+      {{else}}
+        <code local-class="copy-fallback">
+          {{this.tomlSnippet}}
+        </code>
+      {{/if}}
+    </div>
+  {{/unless}}
 
   <div local-class="links">
     {{#if this.showHomepage}}

--- a/tests/routes/crate/version/model-test.js
+++ b/tests/routes/crate/version/model-test.js
@@ -21,6 +21,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.dom('[data-test-crate-version]').hasText('v1.2.3');
       assert.dom('[data-test-yanked]').exists();
       assert.dom('[data-test-docs]').exists();
+      assert.dom('[data-test-install]').doesNotExist();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -53,6 +54,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.dom('[data-test-crate-version]').hasText('v2.0.0');
       assert.dom('[data-test-yanked]').doesNotExist();
       assert.dom('[data-test-docs]').exists();
+      assert.dom('[data-test-install]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -68,6 +70,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.dom('[data-test-crate-version]').hasText('v1.0.0');
       assert.dom('[data-test-yanked]').doesNotExist();
       assert.dom('[data-test-docs]').exists();
+      assert.dom('[data-test-install]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -85,6 +88,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.dom('[data-test-crate-version]').hasText('v2.0.0-beta.2');
       assert.dom('[data-test-yanked]').doesNotExist();
       assert.dom('[data-test-docs]').exists();
+      assert.dom('[data-test-install]').exists();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
 
@@ -100,6 +104,7 @@ module('Route | crate.version | model() hook', function (hooks) {
       assert.dom('[data-test-crate-version]').hasText('v2.0.0-beta.1');
       assert.dom('[data-test-yanked]').exists();
       assert.dom('[data-test-docs]').exists();
+      assert.dom('[data-test-install]').doesNotExist();
       assert.dom('[data-test-notification-message]').doesNotExist();
     });
   });


### PR DESCRIPTION
Yanked versions are only available if a lockfile is still referencing them. We shouldn't show installation instructions for these versions.