### PR TITLE
docs: Replace Discord channel links with Zulip

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ of the following ways:
 
 - [File a new issue](https://github.com/rust-lang/crates.io/issues/new)
 - Email [help@crates.io](mailto:help@crates.io)
-- Chat on web presence > #crates-io-team channel on https://discord.gg/rust-lang
+- Chat on the #t-crates-io Zulip stream on https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/
 
 A volunteer will get back to you as soon as possible.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,10 +3,10 @@
 ## Attending the weekly team meetings
 
 Each Friday at 11:00am US east coast time the crates.io team gets together
-on Zoom or [Discord] (`#crates-io-team`) for our weekly team meeting and we invite
+on Zoom or [Zulip] (`#t-crates-io`) for our weekly team meeting, and we invite
 everyone who wants to contribute to crates.io to participate.
 
-[Discord]: https://discord.gg/rust-lang
+[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/
 
 ## Finding an issue to work on
 


### PR DESCRIPTION
see https://github.com/rust-lang/team/pull/893