### PR TITLE
Front Page: adding "see all" to every list

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -56,8 +56,8 @@
   </button>
 {{else}}
   <div local-class='lists' data-test-lists>
-    <section data-test-new-crates>
-      <h2>New Crates</h2>
+    <section data-test-new-crates >
+      <h2>New Crates <LinkTo @route="crates" @query={{hash sort="new"}}>(see all)</LinkTo></h2>
       <ol local-class="list" aria-busy="{{this.dataTask.isRunning}}">
         {{#if this.dataTask.isRunning}}
           {{#each (placeholders 10)}}
@@ -81,7 +81,7 @@
     </section>
 
     <section data-test-most-downloaded>
-      <h2>Most Downloaded</h2>
+      <h2>Most Downloaded <LinkTo @route="crates" @query={{hash sort="downloads"}}>(see all)</LinkTo></h2>
       <ol local-class="list" aria-busy="{{this.dataTask.isRunning}}">
         {{#if this.dataTask.isRunning}}
           {{#each (placeholders 10)}}
@@ -104,7 +104,7 @@
     </section>
 
     <section data-test-just-updated>
-      <h2>Just Updated</h2>
+      <h2>Just Updated <LinkTo @route="crates" @query={{hash sort="recent-updates"}}>(see all)</LinkTo></h2>
       <ol local-class="list" aria-busy="{{this.dataTask.isRunning}}">
         {{#if this.dataTask.isRunning}}
           {{#each (placeholders 10)}}
@@ -128,7 +128,7 @@
     </section>
 
     <section data-test-most-recently-downloaded>
-      <h2>Most Recent Downloads</h2>
+      <h2>Most Recent Downloads <LinkTo @route="crates" @query={{hash sort="recent-downloads"}}>(see all)</LinkTo></h2>
       <ol local-class="list" aria-busy="{{this.dataTask.isRunning}}">
         {{#if this.dataTask.isRunning}}
           {{#each (placeholders 10)}}


### PR DESCRIPTION
this PR resolves #5403

It adds a `see all` button to every list.

![image](https://user-images.githubusercontent.com/81473300/236689018-443b6f9e-6503-4883-8b8a-50b35b930e09.png)

Maybe these buttons should be made smaller or removed completely and instead make the title clickable. simply because i think there now is a bit to much green (see all)