### PR TITLE
Add `rust-toolchain.toml` file

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,6 +11,7 @@
         ":automergeTesters",
         "regexManagers:dockerfileVersions",
         "regexManagers:githubActionsVersions",
+        "github>Turbo87/renovate-config//rust/updateToolchain",
     ],
     "js": {
         "labels": ["A-frontend 🐹"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ env:
   DIESEL_CLI_VERSION: 2.0.1
   # renovate: datasource=npm depName=pnpm
   PNPM_VERSION: 8.4.0
-  # renovate: datasource=github-releases depName=rust lookupName=rust-lang/rust
-  RUST_VERSION: 1.69.0
 
 jobs:
   changed-files:
@@ -56,6 +54,7 @@ jobs:
             Cargo.lock
             Cargo.toml
             RustConfig
+            rust-toolchain.toml
 
     outputs:
       non-js: ${{ steps.changed-files-non-js.outputs.any_modified }}
@@ -73,7 +72,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3.5.2
 
-      - run: rustup default ${{ env.RUST_VERSION }}
       - run: rustup component add rustfmt
       - run: rustup component add clippy
 
@@ -111,8 +109,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.5.2
-
-      - run: rustup default ${{ env.RUST_VERSION }}
 
       - uses: Swatinem/rust-cache@v2.2.1
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.69.0"


### PR DESCRIPTION
This file ensures that CI and all developers, by default, use the same Rust version. This helps reduce differences between e.g. `clippy` or `rustfmt` versions.

If people prefer to use other versions (e.g. beta or nightly) they can still use `rustup override` on the crates.io project, but having a `rust-toolchain.toml` with the right version should make things a little easier for new contributors.