### PR TITLE
Remove obsolete `conduit` references

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,13 +50,6 @@
         "labels": ["A-backend ⚙️"],
     }, {
         "matchPackagePatterns": [
-            "^conduit$",
-            "^conduit-",
-            "^sentry-conduit$",
-        ],
-        "groupName": "conduit packages",
-    }, {
-        "matchPackagePatterns": [
             "^diesel$",
             "^diesel_",
         ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
         with:
           files_ignore: |
             cargo-registry-*/**
-            conduit/**
-            conduit-*/**
             migrations/**
             src/**
             build.rs


### PR DESCRIPTION
We migrated to `axum` a few months ago, so we no longer need these obsolete `conduit` references in our codebase :)