### PR TITLE
utils/license: Fix `replace()` calls

### DIFF
--- a/app/utils/license.js
+++ b/app/utils/license.js
@@ -562,10 +562,10 @@ const LICENSE_KEYWORDS = new Set(['OR', 'AND', 'WITH', '(', ')']);
 export function parseLicense(text) {
   return text
     .trim()
-    .replace('/', ' OR ')
-    .replace(/(^\(| \()/, ' ( ')
-    .replace(/(\)$|\) )/, ' ) ')
-    .replace(/ +/g, ' ')
+    .replaceAll('/', ' OR ')
+    .replaceAll(/(^\(| \()/g, ' ( ')
+    .replaceAll(/(\)$|\) )/g, ' ) ')
+    .replaceAll(/ +/g, ' ')
     .split(' ')
     .filter(Boolean)
     .map(text => {

--- a/tests/utils/license-test.js
+++ b/tests/utils/license-test.js
@@ -22,6 +22,16 @@ module('parseLicense()', function () {
       ],
     ],
     [
+      'MIT/Apache-2.0/BSD-3-Clause',
+      [
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/mit', text: 'MIT' },
+        { isKeyword: true, link: undefined, text: 'OR' },
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/apache-2.0', text: 'Apache-2.0' },
+        { isKeyword: true, link: undefined, text: 'OR' },
+        { isKeyword: false, link: 'https://choosealicense.com/licenses/bsd-3-clause', text: 'BSD-3-Clause' },
+      ],
+    ],
+    [
       'LGPL-2.1-only AND MIT AND BSD-2-Clause',
       [
         { isKeyword: false, link: 'https://spdx.org/licenses/LGPL-2.1-only.html', text: 'LGPL-2.1-only' },


### PR DESCRIPTION
`replace()` only replaces the first occurrence of the search string/regex, which is unintentional here. `replaceAll()` replaces all occurrences, as the name suggests, which is what we want in this function.

This PR should also unblock https://github.com/rust-lang/crates.io/pull/6440, which made me aware of this bug.