### PR TITLE
settings/tokens: Make sure to always reload API tokens from the server

### DIFF
--- a/app/routes/settings/tokens/index.js
+++ b/app/routes/settings/tokens/index.js
@@ -7,7 +7,7 @@ export default class TokenListRoute extends Route {
   @service store;
 
   async model() {
-    let apiTokens = await this.store.findAll('api-token');
+    let apiTokens = await this.store.findAll('api-token', { reload: true });
     return TrackedArray.from(apiTokens.slice());
   }
 

--- a/tests/routes/settings/tokens/index-test.js
+++ b/tests/routes/settings/tokens/index-test.js
@@ -1,0 +1,44 @@
+import { click, currentURL, fillIn, findAll } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'cargo/tests/helpers';
+
+import { visit } from '../../../helpers/visit-ignoring-abort';
+
+module('/settings/tokens', function (hooks) {
+  setupApplicationTest(hooks);
+
+  function prepare(context) {
+    let user = context.server.create('user', {
+      login: 'johnnydee',
+      name: 'John Doe',
+      email: 'john@doe.com',
+      avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
+    });
+
+    context.authenticateAs(user);
+
+    return { user };
+  }
+
+  test('reloads all tokens from the server', async function (assert) {
+    let { user } = prepare(this);
+
+    this.server.create('api-token', { user, name: 'token-1' });
+
+    await visit('/settings/tokens/new');
+    assert.strictEqual(currentURL(), '/settings/tokens/new');
+
+    await fillIn('[data-test-name]', 'token-2');
+    await click('[data-test-scope="publish-update"]');
+    await click('[data-test-generate]');
+
+    assert.strictEqual(currentURL(), '/settings/tokens');
+    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    let tokens = findAll('[data-test-api-token]');
+    assert.dom('[data-test-name]', tokens[0]).hasText('token-2');
+    assert.dom('[data-test-token]', tokens[0]).exists();
+    assert.dom('[data-test-name]', tokens[1]).hasText('token-1');
+    assert.dom('[data-test-token]', tokens[1]).doesNotExist();
+  });
+});


### PR DESCRIPTION
Previously, Ember Data would perform a background reload of the tokens on the server, but that is apparently not compatible with our usage of `TrackedArray` so the list would not update correctly.

Fortunately, we can use `reload: true` to force Ember Data to reload the list of tokens from the server in the `model()` hook.