### PR TITLE
Define admin users and extend `AuthCheck` to handle them

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -86,3 +86,6 @@ export SENTRY_ENV_API=local
 # export TEST_S3_INDEX_REGION=http://127.0.0.1:19000
 # export TEST_AWS_ACCESS_KEY=minio
 # export TEST_AWS_SECRET_KEY=miniominio
+
+# IDs of GitHub users that are admins on this instance, separated by commas.
+export ADMIN_USER_GH_IDS=

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -62,7 +62,10 @@ impl AuthCheck {
         conn: &mut PgConnection,
     ) -> AppResult<Authentication> {
         let auth = authenticate(request, conn)?;
+        self.check_authentication(auth)
+    }
 
+    pub fn check_authentication(&self, auth: Authentication) -> AppResult<Authentication> {
         if let Some(token) = auth.api_token() {
             if !self.allow_token {
                 let error_message =

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -57,6 +57,7 @@ pub struct Server {
     pub version_id_cache_ttl: Duration,
     pub cdn_user_agent: String,
     pub balance_capacity: BalanceCapacityConfig,
+    pub admin_user_github_ids: HashSet<i32>,
 
     /// Instructs the `cargo_compat` middleware whether to adjust response
     /// status codes to `200 OK` for all endpoints that are relevant for cargo.
@@ -104,6 +105,8 @@ impl Server {
     ///   endpoint even with a healthy database pool.
     /// - `BLOCKED_ROUTES`: A comma separated list of HTTP route patterns that are manually blocked
     ///   by an operator (e.g. `/crates/:crate_id/:version/download`).
+    /// - `ADMIN_USER_GH_IDS`: A comma separated list of GitHub user IDs that will be considered
+    ///   admins.
     ///
     /// # Panics
     ///
@@ -206,6 +209,10 @@ impl Server {
             balance_capacity: BalanceCapacityConfig::from_environment()?,
             cargo_compat_status_code_config: var_parsed("CARGO_COMPAT_STATUS_CODES")?
                 .unwrap_or(StatusCodeConfig::AdjustAll),
+            admin_user_github_ids: HashSet::from_iter(list_parsed(
+                "ADMIN_USER_GH_IDS",
+                i32::from_str,
+            )?),
             serve_dist: true,
             serve_html: true,
             content_security_policy: Some(content_security_policy.parse()?),

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,6 +1,7 @@
 mod scopes;
 
 use chrono::NaiveDateTime;
+use derive_builder::Builder;
 use diesel::prelude::*;
 
 pub use self::scopes::{CrateScope, EndpointScope};
@@ -11,24 +12,34 @@ use crate::util::rfc3339;
 use crate::util::token::{HashedToken, PlainToken};
 
 /// The model representing a row in the `api_tokens` database table.
-#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize)]
+#[derive(Debug, Identifiable, Queryable, Selectable, Associations, Serialize, Builder)]
 #[diesel(belongs_to(User))]
+#[builder(name = "MockApiTokenBuilder")]
 pub struct ApiToken {
+    #[builder(default)]
     pub id: i32,
     #[serde(skip)]
+    #[builder(default)]
     pub user_id: i32,
+    #[builder(default, setter(into))]
     pub name: String,
     #[serde(with = "rfc3339")]
+    #[builder(default, setter(strip_option))]
     pub created_at: NaiveDateTime,
     #[serde(with = "rfc3339::option")]
+    #[builder(default, setter(strip_option))]
     pub last_used_at: Option<NaiveDateTime>,
     #[serde(skip)]
+    #[builder(default = "false")]
     pub revoked: bool,
     /// `None` or a list of crate scope patterns (see RFC #2947)
+    #[builder(default, setter(strip_option))]
     pub crate_scopes: Option<Vec<CrateScope>>,
     /// A list of endpoint scopes or `None` for the `legacy` endpoint scope (see RFC #2947)
+    #[builder(default, setter(strip_option))]
     pub endpoint_scopes: Option<Vec<EndpointScope>>,
     #[serde(with = "rfc3339::option")]
+    #[builder(default, setter(strip_option))]
     pub expired_at: Option<NaiveDateTime>,
 }
 
@@ -95,6 +106,10 @@ impl ApiToken {
         .or_else(|_| tokens.select(ApiToken::as_select()).first(conn))
         .map_err(Into::into)
     }
+
+    pub fn mock_builder() -> MockApiTokenBuilder {
+        MockApiTokenBuilder::default()
+    }
 }
 
 #[derive(Debug)]
@@ -110,22 +125,22 @@ mod tests {
 
     #[test]
     fn api_token_serializes_to_rfc3339() {
-        let tok = ApiToken {
-            id: 12345,
-            user_id: 23456,
-            revoked: false,
-            name: "".to_string(),
-            created_at: NaiveDate::from_ymd_opt(2017, 1, 6)
-                .unwrap()
-                .and_hms_opt(14, 23, 11)
-                .unwrap(),
-            last_used_at: NaiveDate::from_ymd_opt(2017, 1, 6)
-                .unwrap()
-                .and_hms_opt(14, 23, 12),
-            crate_scopes: None,
-            endpoint_scopes: None,
-            expired_at: None,
-        };
+        let created_at = NaiveDate::from_ymd_opt(2017, 1, 6)
+            .unwrap()
+            .and_hms_opt(14, 23, 11)
+            .unwrap();
+
+        let last_used_at = NaiveDate::from_ymd_opt(2017, 1, 6)
+            .unwrap()
+            .and_hms_opt(14, 23, 12)
+            .unwrap();
+
+        let tok = ApiToken::mock_builder()
+            .created_at(created_at)
+            .last_used_at(last_used_at)
+            .build()
+            .unwrap();
+
         let json = serde_json::to_string(&tok).unwrap();
         assert_some!(json
             .as_str()

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -428,6 +428,7 @@ fn simple_config() -> config::Server {
         version_id_cache_ttl: Duration::from_secs(5 * 60),
         cdn_user_agent: "Amazon CloudFront".to_string(),
         balance_capacity,
+        admin_user_github_ids: HashSet::new(),
 
         // The middleware has its own unit tests to verify its functionality.
         // Here, we can test what would happen if we toggled the status code


### PR DESCRIPTION
This adds a concept of admin users, who are defined by their GitHub IDs, and allows them to be defined through an environment variable, falling back to a static list of the current `crates.io` team.

`AuthCheck` now has a builder method to require that the current cookie or token belong to an admin user.

In the future, this will be extended to use Rust's team API for the fallback.