### PR TITLE
Revert "Update Rust crate tracing to v0.1.38 (#6387)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3400,10 +3400,11 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -3412,13 +3413,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ tokio = { version = "=1.28.0", features = ["net", "signal", "io-std", "io-util",
 toml = "=0.7.3"
 tower = "=0.4.13"
 tower-http = { version = "=0.4.0", features = ["fs", "catch-panic"] }
-tracing = "=0.1.38"
+tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }
 url = "=2.3.1"
 

--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -20,7 +20,7 @@ git2 = "=0.17.1"
 serde = { version = "=1.0.162", features = ["derive"] }
 serde_json = "=1.0.96"
 tempfile = "=3.5.0"
-tracing = "=0.1.38"
+tracing = "=0.1.37"
 url = "=2.3.1"
 
 [dev-dependencies]


### PR DESCRIPTION
This reverts commit dd25dabca656f0cad8998b8c6356fba48411433e.

see https://github.com/tokio-rs/tracing/issues/2578