### PR TITLE
cargo-deny: Run for all push events to the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,6 @@ jobs:
     needs: changed-files
     if: github.event_name != 'pull_request' || needs.changed-files.outputs.rust-lockfile == 'true'
 
-    env:
-      RUSTFLAGS: "-D warnings"
-
     steps:
       - uses: actions/checkout@v3.5.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
     name: Backend / cargo-deny
     runs-on: ubuntu-22.04
     needs: changed-files
-    if: needs.changed-files.outputs.rust-lockfile == 'true'
+    if: github.event_name != 'pull_request' || needs.changed-files.outputs.rust-lockfile == 'true'
 
     env:
       RUSTFLAGS: "-D warnings"


### PR DESCRIPTION
This PR is a small improvement on top of #6464, which ensures that the `cargo-deny` check is run for all pushes to the main repo branch, not just when the `Cargo.lock` file is changed. This ensures that external changes (e.g. new vulnerabilities) are detected and reported earlier.