### PR TITLE
Replace `abbr` with `EmberTooltips`

### DIFF
--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -25,18 +25,34 @@
   <div local-class='stats'>
     <div local-class='downloads' data-test-downloads>
       {{svg-jar "download" local-class="download-icon"}}
-      <span><abbr title="Total number of downloads">All-Time:</abbr> {{ format-num @crate.downloads }}</span>
+      <span>
+        <span>
+          All-Time:
+          <EmberTooltip @text="Total number of downloads"/>
+        </span>
+        {{ format-num @crate.downloads }}
+      </span>
     </div>
     <div local-class="recent-downloads" data-test-recent-downloads>
       {{svg-jar "download" local-class="download-icon"}}
-      <span><abbr title="Downloads in the last 90 days">Recent:</abbr> {{ format-num @crate.recent_downloads }}</span>
+      <span>
+        <span>
+          Recent:
+          <EmberTooltip @text="Downloads in the last 90 days"/>
+        </span>
+        {{ format-num @crate.recent_downloads }}
+      </span>
     </div>
-    <div local-class="updated-at" >
+    <div local-class="updated-at">
       {{svg-jar "latest-updates" height="32" width="32"}}
       <span>
-        <abbr title="The last time crate was updated">Updated:</abbr>
-        <time title="Last updated: {{ @crate.updated_at }}" datetime="{{date-format-iso @crate.updated_at}}" data-test-updated-at>
+        <span>
+          Updated:
+          <EmberTooltip @text="The last time the crate was updated" />
+        </span>
+        <time datetime="{{date-format-iso @crate.updated_at}}" data-test-updated-at>
           {{date-format-distance-to-now @crate.updated_at addSuffix=true}}
+          <EmberTooltip @text={{ @crate.updated_at }}/>
         </time>
       </span>
     </div>


### PR DESCRIPTION
This PR removes some `abbr` tags and replaces them with `EmberTooltips` this is mainly for visual consistency and they should be functionally identical.
The same change was made for copy-button.

Before:
![Screenshot 2023-05-11 202407](https://github.com/rust-lang/crates.io/assets/81473300/b48beada-5af1-42d1-b695-60428b84da8c)

After:
![Screenshot 2023-05-11 202301](https://github.com/rust-lang/crates.io/assets/81473300/37c3808d-6664-4b6f-ad0f-1898d299f9c9)
