### PR TITLE
index/repo: Use `git` CLI for fetching and pushing

### DIFF
--- a/cargo-registry-index/credentials.rs
+++ b/cargo-registry-index/credentials.rs
@@ -1,8 +1,6 @@
 use anyhow::{anyhow, Context};
 use std::io::Write;
 
-static DEFAULT_GIT_SSH_USERNAME: &str = "git";
-
 #[derive(Clone)]
 pub enum Credentials {
     Missing,
@@ -15,38 +13,6 @@ impl Credentials {
         match self {
             Credentials::Ssh { key } => Some(key),
             _ => None,
-        }
-    }
-
-    pub(crate) fn git2_callback(
-        &self,
-        user_from_url: Option<&str>,
-        cred_type: git2::CredentialType,
-    ) -> Result<git2::Cred, git2::Error> {
-        match self {
-            Credentials::Missing => Err(git2::Error::from_str("no authentication set")),
-            Credentials::Http { username, password } => {
-                git2::Cred::userpass_plaintext(username, password)
-            }
-            Credentials::Ssh { key } => {
-                // git2 might call the callback two times when requesting credentials:
-                //
-                // 1. If the username is not specified in the URL, the first call will request it,
-                //    without asking for the SSH key.
-                //
-                // 2. The other call will request the proper SSH key, and the username must be the
-                //    same one either specified in the URL or the previous call.
-                //
-                // More information on this behavior is available at the following links:
-                // - https://github.com/rust-lang/git2-rs/issues/329
-                // - https://libgit2.org/docs/guides/authentication/
-                let user = user_from_url.unwrap_or(DEFAULT_GIT_SSH_USERNAME);
-                if cred_type.contains(git2::CredentialType::USERNAME) {
-                    git2::Cred::username(user)
-                } else {
-                    git2::Cred::ssh_key_from_memory(user, None, key, None)
-                }
-            }
         }
     }
 


### PR DESCRIPTION
Using the `git` CLI seems significantly less complex compared to using libgit2, and, as we discovered in the past, it can also have performance advantages in some situations.