### PR TITLE
renovate: Delay `pnpm` updates by 24 hours

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,6 +26,11 @@
         "matchPackageNames": ["@percy/cli", "tj-actions/changed-files", "webpack"],
         "extends": ["schedule:weekly"],
     }, {
+        // Avoid "Artifact update problem" for pnpm updates when the renovatebot
+        // setup does not support the new version yet.
+        "matchPackageNames": ["pnpm"],
+        "minimumReleaseAge": "24 hours"
+    }, {
         "matchLanguages": ["js"],
         "matchUpdateTypes": ["lockFileMaintenance"],
         "additionalBranchPrefix": "js-",


### PR DESCRIPTION
This is an attempt to prevent issues like https://github.com/rust-lang/crates.io/pull/6478#issuecomment-1547169175 by waiting for 24 hours before trying to update `pnpm`. This should give the renovatebot setup time to support the new version.

If this turns out to not work we can revert the PR again.