### PR TITLE
Search: make status svg's always the same size 

### DIFF
--- a/app/components/crate-row.module.css
+++ b/app/components/crate-row.module.css
@@ -70,6 +70,8 @@
         width: 1em;
         margin-right: var(--space-xs);
 
+        flex-shrink: 0;
+
         &.download-icon {
             height: calc(1em + 20px);
             width: calc(1em + 20px);


### PR DESCRIPTION
This PR makes it so that the status svg's always have the same size.
this was a minor problem on small displays.

Before:
![image](https://github.com/rust-lang/crates.io/assets/81473300/cfae5af8-9f8a-454c-9c89-f0241d37c15e)

After:
![image](https://github.com/rust-lang/crates.io/assets/81473300/a6feef19-8240-40ea-87b8-7ad0d8f1dee6)

