### PR TITLE
embroider: Add resolution for `@embroider/core|compat`

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
     "webpack": "5.83.1"
   },
   "resolutions": {
+    "@embroider/compat": "2.1.1",
+    "@embroider/core": "2.1.1",
     "ember-css-modules>postcss": "8.4.16",
     "ember-get-config": "2.1.1",
     "ember-inflector": "4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,8 @@
 lockfileVersion: '6.0'
 
 overrides:
+  '@embroider/compat': 2.1.1
+  '@embroider/core': 2.1.1
   ember-css-modules>postcss: 8.4.16
   ember-get-config: 2.1.1
   ember-inflector: 4.0.2
@@ -2035,58 +2037,6 @@ packages:
       - webpack
     dev: true
 
-  /@embroider/compat@0.47.2(@embroider/core@0.47.2):
-    resolution: {integrity: sha512-E8jpBk2aSIdzCpuuDQU8So1ZYRkcinPXy3ya2P+dt6R0rP/JOsz2ggjDtQDywdMn7yLWKZcHmh31HQfDL1wKSw==}
-    engines: {node: 12.* || 14.* || >= 16}
-    hasBin: true
-    peerDependencies:
-      '@embroider/core': 0.47.2
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/core': 7.21.8(supports-color@8.1.1)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
-      '@babel/preset-env': 7.21.5(@babel/core@7.21.8)
-      '@babel/traverse': 7.21.5(supports-color@8.1.1)
-      '@embroider/core': 0.47.2
-      '@embroider/macros': 0.47.2
-      '@embroider/shared-internals': 0.47.2
-      '@types/babel__code-frame': 7.0.3
-      '@types/yargs': 17.0.24
-      assert-never: 1.2.1
-      babel-plugin-syntax-dynamic-import: 6.18.0
-      babylon: 6.18.0
-      bind-decorator: 1.0.11
-      broccoli: 3.5.2
-      broccoli-concat: 4.2.5
-      broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      chalk: 4.1.2
-      debug: 4.3.4(supports-color@8.1.1)
-      fs-extra: 9.1.0
-      fs-tree-diff: 2.0.1
-      heimdalljs: 0.2.6
-      jsdom: 16.7.0(supports-color@8.1.1)
-      lodash: 4.17.21
-      pkg-up: 3.1.0
-      resolve: 1.22.2
-      resolve-package-path: 4.0.3
-      semver: 7.5.1
-      symlink-or-copy: 1.3.1
-      tree-sync: 2.1.0
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-    dev: true
-
   /@embroider/compat@2.1.1(@embroider/core@2.1.1):
     resolution: {integrity: sha512-HNq5vv7NpQ1Jr+4slzmLBqsy5NDsIHilYeQiWboMrPAyHr5NHlKYWciIcmxdgPgz2kf/8D5nDiANgJznZedlyw==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -2131,48 +2081,6 @@ packages:
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
       yargs: 17.7.2
-    transitivePeerDependencies:
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
-    dev: true
-
-  /@embroider/core@0.47.2:
-    resolution: {integrity: sha512-93zjU1uovLFkokSWwygUZEC21lHs4pNSyTYaVqp0o0I7f6Gzh+grTjkCsaYCUjnHOIORGUb7LVX2clBnOmwTLg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@babel/core': 7.21.8(supports-color@8.1.1)
-      '@babel/parser': 7.21.8
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.21.8)
-      '@babel/plugin-transform-runtime': 7.21.4(@babel/core@7.21.8)
-      '@babel/runtime': 7.21.5
-      '@babel/traverse': 7.21.5(supports-color@8.1.1)
-      '@embroider/macros': 0.47.2
-      '@embroider/shared-internals': 0.47.2
-      assert-never: 1.2.1
-      babel-import-util: 0.2.0
-      babel-plugin-ember-template-compilation: 1.0.2
-      broccoli-node-api: 1.7.0
-      broccoli-persistent-filter: 3.1.3
-      broccoli-plugin: 4.0.7
-      broccoli-source: 3.0.1
-      debug: 4.3.4(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      fast-sourcemap-concat: 1.4.0
-      filesize: 5.0.3
-      fs-extra: 9.1.0
-      fs-tree-diff: 2.0.1
-      handlebars: 4.7.7
-      js-string-escape: 1.0.1
-      jsdom: 16.7.0(supports-color@8.1.1)
-      lodash: 4.17.21
-      resolve: 1.22.2
-      resolve-package-path: 4.0.3
-      strip-bom: 4.0.0
-      typescript-memoize: 1.1.1
-      walk-sync: 3.0.0
-      wrap-legacy-hbs-plugin-if-needed: 1.0.1
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -2231,21 +2139,6 @@ packages:
       webpack: 5.83.1
     dev: true
 
-  /@embroider/macros@0.47.2:
-    resolution: {integrity: sha512-ViNWluJCeM5OPlM3rs8kdOz3RV5rpfXX5D2rDnc/q86xRS0xf4NFEjYRV7W6fBcD0b3v5jSHDTwrjq9Kee4rHg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@embroider/shared-internals': 0.47.2
-      assert-never: 1.2.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.2
-      semver: 7.5.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@embroider/macros@1.10.0:
     resolution: {integrity: sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -2281,19 +2174,6 @@ packages:
       semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
-
-  /@embroider/shared-internals@0.47.2:
-    resolution: {integrity: sha512-SxdZYjAE0fiM5zGDz+12euWIsQZ1tsfR1k+NKmiWMyLhA5T3pNgbR2/Djvx/cVIxOtEavGGSllYbzRKBtV4xMg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      babel-import-util: 0.2.0
-      ember-rfc176-data: 0.3.18
-      fs-extra: 9.1.0
-      lodash: 4.17.21
-      resolve-package-path: 4.0.3
-      semver: 7.5.1
-      typescript-memoize: 1.1.1
-    dev: true
 
   /@embroider/shared-internals@1.8.3:
     resolution: {integrity: sha512-N5Gho6Qk8z5u+mxLCcMYAoQMbN4MmH+z2jXwQHVs859bxuZTxwF6kKtsybDAASCtd2YGxEmzcc1Ja/wM28824w==}
@@ -2455,13 +2335,6 @@ packages:
   /@glimmer/di@0.1.11:
     resolution: {integrity: sha512-moRwafNDwHTnTHzyyZC9D+mUSvYrs1Ak0tRPjjmCghdoHHIvMshVbEnwKb/1WmW5CUlKc2eL9rlAV32n3GiItg==}
 
-  /@glimmer/encoder@0.42.2:
-    resolution: {integrity: sha512-8xkdly0i0BP5HMI0suPB9ly0AnEq8x9Z8j3Gee1HYIovM5VLNtmh7a8HsaHYRs/xHmBEZcqtr8JV89w6F59YMQ==}
-    dependencies:
-      '@glimmer/interfaces': 0.42.2
-      '@glimmer/vm': 0.42.2
-    dev: true
-
   /@glimmer/env@0.1.7:
     resolution: {integrity: sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw==}
 
@@ -2471,32 +2344,10 @@ packages:
       '@glimmer/env': 0.1.7
     dev: true
 
-  /@glimmer/interfaces@0.42.2:
-    resolution: {integrity: sha512-7LOuQd02cxxNNHChzdHMAU8/qOeQvTro141CU5tXITP7z6aOv2D2gkFdau97lLQiVxezGrh8J7h8GCuF7TEqtg==}
-    dev: true
-
   /@glimmer/interfaces@0.84.3:
     resolution: {integrity: sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==}
     dependencies:
       '@simple-dom/interface': 1.4.0
-    dev: true
-
-  /@glimmer/low-level@0.42.2:
-    resolution: {integrity: sha512-s+Q44SnKdTBTnkgX0deBlVNnNPVas+Pg8xEnwky9VrUqOHKsIZRrPgfVULeC6bIdFXtXOKm5CjTajhb9qnQbXQ==}
-    dev: true
-
-  /@glimmer/program@0.42.2:
-    resolution: {integrity: sha512-XpQ6EYzA1VL9ESKoih5XW5JftFmlRvwy3bF/I1ABOa3yLIh8mApEwrRI/sIHK0Nv5s1j0uW4itVF196WxnJXgw==}
-    dependencies:
-      '@glimmer/encoder': 0.42.2
-      '@glimmer/interfaces': 0.42.2
-      '@glimmer/util': 0.42.2
-    dev: true
-
-  /@glimmer/reference@0.42.2:
-    resolution: {integrity: sha512-XuhbRjr3M9Q/DP892jGxVfPE6jaGGHu5w9ppGMnuTY7Vm/x+A+68MCiaREhDcEwJlzGg4UkfVjU3fdgmUIrc5Q==}
-    dependencies:
-      '@glimmer/util': 0.42.2
     dev: true
 
   /@glimmer/reference@0.84.3:
@@ -2507,27 +2358,6 @@ packages:
       '@glimmer/interfaces': 0.84.3
       '@glimmer/util': 0.84.3
       '@glimmer/validator': 0.84.3
-    dev: true
-
-  /@glimmer/runtime@0.42.2:
-    resolution: {integrity: sha512-52LVZJsLKM3GzI3TEmYcw2LdI9Uk0jotISc3w2ozQBWvkKoYxjDNvI/gsjyMpenj4s7FcG2ggOq0x4tNFqm1GA==}
-    dependencies:
-      '@glimmer/interfaces': 0.42.2
-      '@glimmer/low-level': 0.42.2
-      '@glimmer/program': 0.42.2
-      '@glimmer/reference': 0.42.2
-      '@glimmer/util': 0.42.2
-      '@glimmer/vm': 0.42.2
-      '@glimmer/wire-format': 0.42.2
-    dev: true
-
-  /@glimmer/syntax@0.42.2:
-    resolution: {integrity: sha512-SR26SmF/Mb5o2cc4eLHpOyoX5kwwXP4KRhq4fbWfrvan74xVWA38PLspPCzwGhyVH/JsE7tUEPMjSo2DcJge/Q==}
-    dependencies:
-      '@glimmer/interfaces': 0.42.2
-      '@glimmer/util': 0.42.2
-      handlebars: 4.7.7
-      simple-html-tokenizer: 0.5.11
     dev: true
 
   /@glimmer/syntax@0.84.3:
@@ -2544,10 +2374,6 @@ packages:
     dependencies:
       '@glimmer/env': 0.1.7
       '@glimmer/validator': 0.44.0
-    dev: true
-
-  /@glimmer/util@0.42.2:
-    resolution: {integrity: sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==}
     dev: true
 
   /@glimmer/util@0.44.0:
@@ -2578,20 +2404,6 @@ packages:
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.21.8)
     transitivePeerDependencies:
       - '@babel/core'
-
-  /@glimmer/vm@0.42.2:
-    resolution: {integrity: sha512-D2MNU5glICLqvet5SfVPrv+l6JNK2TR+CdQhch1Ew+btOoqlW+2LIJIF/5wLb1POjIMEkt+78t/7RN0mDFXGzw==}
-    dependencies:
-      '@glimmer/interfaces': 0.42.2
-      '@glimmer/util': 0.42.2
-    dev: true
-
-  /@glimmer/wire-format@0.42.2:
-    resolution: {integrity: sha512-IqUo6mdJ7GRsK7KCyZxrc17ioSg9RBniEnb418ZMQxsV/WBv9NQ359MuClUck2M24z1AOXo4TerUw0U7+pb1/A==}
-    dependencies:
-      '@glimmer/interfaces': 0.42.2
-      '@glimmer/util': 0.42.2
-    dev: true
 
   /@handlebars/parser@2.0.0:
     resolution: {integrity: sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==}
@@ -4326,16 +4138,6 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
       ember-rfc176-data: 0.3.18
-
-  /babel-plugin-ember-template-compilation@1.0.2:
-    resolution: {integrity: sha512-4HBMksmlYsWEf/C/n3uW5rkBRbUp4FNaspzdQTAHgLbfCJnkLze8R6i6sUSge48y/Wne7mx+vcImI1o6rlUwXQ==}
-    engines: {node: '>= 12.*'}
-    dependencies:
-      babel-import-util: 1.3.0
-      line-column: 1.0.2
-      magic-string: 0.26.7
-      string.prototype.matchall: 4.0.8
-    dev: true
 
   /babel-plugin-ember-template-compilation@2.0.3:
     resolution: {integrity: sha512-SIetZD/uCLnzIBTJtzYGc2Q55TPqM5WyjuOgW+Is1W3SZVljlY3JD5Add29hDMs//OvXBWoXfOopQxkfG4/pIA==}
@@ -7311,8 +7113,8 @@ packages:
     resolution: {integrity: sha512-fhowjPCe0mP+BYz6fz9GMY8/6XMIv42X6aCfM/ax7hf3iW086Qv5kRAd/8O4JLjER9kgEMFs4D6NJsrd4WZSaQ==}
     engines: {node: 14.* || 16.* || >= 18}
     dependencies:
-      '@embroider/compat': 0.47.2(@embroider/core@0.47.2)
-      '@embroider/core': 0.47.2
+      '@embroider/compat': 2.1.1(@embroider/core@2.1.1)
+      '@embroider/core': 2.1.1
       babel-plugin-istanbul: 6.1.1
       body-parser: 1.20.2
       ember-cli-babel: 7.26.11
@@ -11702,13 +11504,6 @@ packages:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
     dependencies:
       sourcemap-codec: 1.4.8
-
-  /magic-string@0.26.7:
-    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
-    engines: {node: '>=12'}
-    dependencies:
-      sourcemap-codec: 1.4.8
-    dev: true
 
   /magic-string@0.30.0:
     resolution: {integrity: sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==}
@@ -16131,15 +15926,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: true
-
-  /wrap-legacy-hbs-plugin-if-needed@1.0.1:
-    resolution: {integrity: sha512-aJjXe5WwrY0u0dcUgKW3m2SGnxosJ66LLm/QaG0YMHqgA6+J2xwAFZfhSLsQ2BmO5x8PTH+OIxoAXuGz3qBA7A==}
-    dependencies:
-      '@glimmer/reference': 0.42.2
-      '@glimmer/runtime': 0.42.2
-      '@glimmer/syntax': 0.42.2
-      '@simple-dom/interface': 1.4.0
     dev: true
 
   /wrappy@1.0.2:


### PR DESCRIPTION
This allows us to use `ember-cli-code-coverage` with a more recent version of embroider

Related: 
- https://github.com/kategengler/ember-cli-code-coverage/pull/382