### PR TITLE
Remove obsolete `postcss` version resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "webpack": "5.83.1"
   },
   "resolutions": {
-    "ember-css-modules>postcss": "8.4.16",
     "ember-get-config": "2.1.1",
     "ember-inflector": "4.0.2",
     "ember-modifier": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,6 @@
 lockfileVersion: '6.0'
 
 overrides:
-  ember-css-modules>postcss: 8.4.16
   ember-get-config: 2.1.1
   ember-inflector: 4.0.2
   ember-modifier: 4.1.0


### PR DESCRIPTION
`ember-css-modules` already depends on `postcss ^8.0.0` so this resolution is no longer necessary.