### PR TITLE
webpack: Fix `timers` import warning

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -66,8 +66,12 @@ module.exports = function (defaults) {
     packagerOptions: {
       webpackConfig: {
         resolve: {
-          // disables `crypto` import warning in `axe-core`
-          fallback: { crypto: false },
+          fallback: {
+            // disables `crypto` import warning in `axe-core`
+            crypto: false,
+            // disables `timers` import warning in `@sinon/fake-timers`
+            timers: false,
+          },
         },
       },
     },


### PR DESCRIPTION
`@sinon/fake-timers` checks if the module is available, but works fine if it is not, so we can instruct webpack to ignore this import.