### PR TITLE
Prevent similar versions that only differ in build metadata from being published

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1,4 +1,4 @@
-use diesel::sql_types::{Date, Double, Interval, SingleValue, Text, Timestamp};
+use diesel::sql_types::{Date, Double, Integer, Interval, SingleValue, Text, Timestamp};
 
 sql_function!(#[aggregate] fn array_agg<T: SingleValue>(x: T) -> Array<T>);
 sql_function!(fn canon_crate_name(x: Text) -> Text);
@@ -12,3 +12,4 @@ sql_function! {
 sql_function!(fn floor(x: Double) -> Integer);
 sql_function!(fn greatest<T: SingleValue>(x: T, y: T) -> T);
 sql_function!(fn least<T: SingleValue>(x: T, y: T) -> T);
+sql_function!(fn split_part(string: Text, delimiter: Text, n: Integer) -> Text);

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_1.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_1.json
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0+foo.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "148"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"foo\",\"vers\":\"1.0.0+foo\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_2.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_2.json
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0-beta.1.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "151"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"foo\",\"vers\":\"1.0.0-beta.1\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_3.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_3.json
@@ -1,0 +1,62 @@
+[
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0+foo.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "148"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"foo\",\"vers\":\"1.0.0+foo\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/krate/snapshots/all__krate__publish__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/snapshots/all__krate__publish__version_with_build_metadata@build_metadata_1.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/krate/publish.rs
+expression: response.into_json()
+---
+crate:
+  badges: ~
+  categories: ~
+  created_at: "[datetime]"
+  description: description
+  documentation: ~
+  downloads: 0
+  exact_match: false
+  homepage: ~
+  id: foo
+  keywords: ~
+  links:
+    owner_team: /api/v1/crates/foo/owner_team
+    owner_user: /api/v1/crates/foo/owner_user
+    owners: /api/v1/crates/foo/owners
+    reverse_dependencies: /api/v1/crates/foo/reverse_dependencies
+    version_downloads: /api/v1/crates/foo/downloads
+    versions: /api/v1/crates/foo/versions
+  max_stable_version: 1.0.0+foo
+  max_version: 1.0.0+foo
+  name: foo
+  newest_version: 1.0.0+foo
+  recent_downloads: ~
+  repository: ~
+  updated_at: "[datetime]"
+  versions: ~
+warnings:
+  invalid_badges: []
+  invalid_categories: []
+  other: []
+

--- a/src/tests/krate/snapshots/all__krate__publish__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/snapshots/all__krate__publish__version_with_build_metadata@build_metadata_2.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/krate/publish.rs
+expression: response.into_json()
+---
+crate:
+  badges: ~
+  categories: ~
+  created_at: "[datetime]"
+  description: description
+  documentation: ~
+  downloads: 0
+  exact_match: false
+  homepage: ~
+  id: foo
+  keywords: ~
+  links:
+    owner_team: /api/v1/crates/foo/owner_team
+    owner_user: /api/v1/crates/foo/owner_user
+    owners: /api/v1/crates/foo/owners
+    reverse_dependencies: /api/v1/crates/foo/reverse_dependencies
+    version_downloads: /api/v1/crates/foo/downloads
+    versions: /api/v1/crates/foo/versions
+  max_stable_version: ~
+  max_version: 1.0.0-beta.1
+  name: foo
+  newest_version: 1.0.0-beta.1
+  recent_downloads: ~
+  repository: ~
+  updated_at: "[datetime]"
+  versions: ~
+warnings:
+  invalid_badges: []
+  invalid_categories: []
+  other: []
+

--- a/src/tests/krate/snapshots/all__krate__publish__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/snapshots/all__krate__publish__version_with_build_metadata@build_metadata_3.snap
@@ -1,0 +1,35 @@
+---
+source: src/tests/krate/publish.rs
+expression: response.into_json()
+---
+crate:
+  badges: ~
+  categories: ~
+  created_at: "[datetime]"
+  description: description
+  documentation: ~
+  downloads: 0
+  exact_match: false
+  homepage: ~
+  id: foo
+  keywords: ~
+  links:
+    owner_team: /api/v1/crates/foo/owner_team
+    owner_user: /api/v1/crates/foo/owner_user
+    owners: /api/v1/crates/foo/owners
+    reverse_dependencies: /api/v1/crates/foo/reverse_dependencies
+    version_downloads: /api/v1/crates/foo/downloads
+    versions: /api/v1/crates/foo/versions
+  max_stable_version: 1.0.0+foo
+  max_version: 1.0.0+foo
+  name: foo
+  newest_version: 1.0.0+foo
+  recent_downloads: ~
+  repository: ~
+  updated_at: "[datetime]"
+  versions: ~
+warnings:
+  invalid_badges: []
+  invalid_categories: []
+  other: []
+


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/1059

`cargo` does not handle these situations particularly well and the SemVer specification is a little ambiguous about how to handle build metadata.

We still have roughly 600 problematic versions in the database, so we can't introduce a unique index yet, but the query appears to be fast enough according to my local testing:

```sql
EXPLAIN SELECT * FROM versions WHERE num = '1.0.0' AND crate_id = 463;
```
```
Index Scan using unique_num on versions  (cost=0.42..8.45 rows=1 width=190)
  Index Cond: ((crate_id = 463) AND ((num)::text = '1.0.0'::text))
```

vs.

```sql
EXPLAIN SELECT * FROM versions WHERE split_part(num, '+', 1) = '1.0.0' AND crate_id = 463;
```
```
Bitmap Heap Scan on versions  (cost=4.57..79.36 rows=1 width=190)
  Recheck Cond: (crate_id = 463)
"  Filter: (split_part((num)::text, '+'::text, 1) = '1.0.0'::text)"
  ->  Bitmap Index Scan on unique_num  (cost=0.00..4.57 rows=19 width=0)
        Index Cond: (crate_id = 463)
```

The `cost` is certainly higher, but the actual wall time for these queries appears to be roughly similar in the end. Since the publish endpoint is only receiving few requests per minute this should not result in any issues AFAICT.