### PR TITLE
bump base64 to 0.21.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
  "aws-sigv4",
  "axum",
  "axum-extra",
- "base64 0.13.1",
+ "base64 0.21.2",
  "chrono",
  "claims",
  "clap",
@@ -719,7 +719,7 @@ name = "crates_io_index"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.2",
  "claims",
  "dotenvy",
  "git2",
@@ -745,7 +745,7 @@ dependencies = [
 name = "crates_io_s3"
 version = "0.0.0"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "chrono",
  "hmac",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "=1.0.71"
 aws-sigv4 = "=0.55.3"
 axum = { version = "=0.6.18", features = ["headers", "macros", "matched-path"] }
 axum-extra = { version = "=0.7.4", features = ["cookie-signed"] }
-base64 = "=0.13.1"
+base64 = "=0.21.2"
 crates_io_index = { path = "crates_io_index" }
 crates_io_markdown = { path = "crates_io_markdown" }
 crates_io_s3 = { path = "crates_io_s3" }

--- a/crates_io_index/Cargo.toml
+++ b/crates_io_index/Cargo.toml
@@ -14,7 +14,7 @@ testing = []
 
 [dependencies]
 anyhow = "=1.0.71"
-base64 = "=0.13.1"
+base64 = "=0.21.2"
 dotenvy = "=0.15.7"
 git2 = "=0.17.2"
 secrecy = "=0.8.0"

--- a/crates_io_index/repo.rs
+++ b/crates_io_index/repo.rs
@@ -1,5 +1,6 @@
 use crate::credentials::Credentials;
 use anyhow::{anyhow, Context};
+use base64::{engine::general_purpose, Engine};
 use secrecy::{ExposeSecret, SecretString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -30,7 +31,8 @@ impl RepositoryConfig {
                 let index_location =
                     Url::parse(&ssh_url).expect("failed to parse GIT_SSH_REPO_URL");
 
-                let key = base64::decode(encoded_key.expose_secret())
+                let key = general_purpose::STANDARD
+                    .decode(encoded_key.expose_secret())
                     .expect("failed to base64 decode the ssh key");
                 let key =
                     String::from_utf8(key).expect("failed to convert the ssh key to a string");

--- a/crates_io_s3/Cargo.toml
+++ b/crates_io_s3/Cargo.toml
@@ -12,7 +12,7 @@ name = "s3"
 path = "lib.rs"
 
 [dependencies]
-base64 = "=0.13.1"
+base64 = "=0.21.2"
 chrono = { version = "=0.4.26", default-features = false }
 sha-1 = "=0.10.1"
 hmac = "=0.12.1"

--- a/crates_io_s3/lib.rs
+++ b/crates_io_s3/lib.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::all, rust_2018_idioms)]
 
+use base64::{engine::general_purpose, Engine};
 use chrono::prelude::Utc;
 use hmac::{Hmac, Mac};
 use reqwest::{
@@ -103,7 +104,7 @@ impl Bucket {
             let mut h = Hmac::<Sha1>::new_from_slice(key).expect("HMAC can take key of any size");
             h.update(string.as_bytes());
             let res = h.finalize().into_bytes();
-            base64::encode(res)
+            general_purpose::STANDARD.encode(res)
         };
         format!("AWS {}:{}", self.access_key, signature)
     }


### PR DESCRIPTION
Closes #6503.

Renovate's update failed. I created a new branch and updated the deprecated function calls to their new equivalents.

Let me know if you'd rather I close this and commit to Renovate's branch.