### PR TITLE
Use `secrecy` crate for database URLs and git credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "claims",
  "dotenvy",
  "git2",
+ "secrecy",
  "serde",
  "serde_json",
  "tempfile",

--- a/cargo-registry-index/Cargo.toml
+++ b/cargo-registry-index/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "=1.0.71"
 base64 = "=0.13.1"
 dotenvy = "=0.15.7"
 git2 = "=0.17.1"
+secrecy = "=0.8.0"
 serde = { version = "=1.0.163", features = ["derive"] }
 serde_json = "=1.0.96"
 tempfile = "=3.5.0"

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -20,6 +20,7 @@ use cargo_registry::worker::cloudfront::CloudFront;
 use cargo_registry::{background_jobs::*, db, ssh};
 use cargo_registry_index::{Repository, RepositoryConfig};
 use reqwest::blocking::Client;
+use secrecy::ExposeSecret;
 use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
@@ -49,7 +50,7 @@ fn main() {
         }
     }
 
-    let db_url = db::connection_url(&config.db, &config.db.primary.url);
+    let db_url = db::connection_url(&config.db, config.db.primary.url.expose_secret());
 
     let job_start_timeout = dotenvy::var("BACKGROUND_JOB_TIMEOUT")
         .unwrap_or_else(|_| "30".into())


### PR DESCRIPTION
This should make it a little harder for us to accidentally leak the credentials via a `Debug` implementation.

Note that the GitHub credentials do not need this, as they are already using the corresponding `oauth` structures, that provide similar properties.