### PR TITLE
Dashboard: remove black background from following.svg

### DIFF
--- a/public/assets/following.svg
+++ b/public/assets/following.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="15px" height="15px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <circle fill="#000000" stroke="#B84D94" stroke-width="1" cx="7.5" cy="7.5" r="7"></circle>
+    <circle fill="none" stroke="#B84D94" stroke-width="1" cx="7.5" cy="7.5" r="7"></circle>
     <rect fill="#B84D94" x="6" y="3" width="3" height="9"></rect>
     <rect fill="#B84D94" x="3" y="6" width="9" height="3"></rect>
 </svg>


### PR DESCRIPTION
This PR removes the black background from `following.svg`.

Or am I missing some reason why this is the case?

Before:
![image](https://github.com/rust-lang/crates.io/assets/81473300/2c60a513-3dd4-4116-9dd0-41bcb2590257)

After:
![image](https://github.com/rust-lang/crates.io/assets/81473300/f2e3586e-528e-46b0-b78a-657a377298a3)
