### PR TITLE
Expand error messages for invalid license information

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -460,7 +460,7 @@ fn missing_metadata_error_message(missing: &[&str]) -> String {
     format!(
         "missing or empty metadata fields: {}. Please \
          see https://doc.rust-lang.org/cargo/reference/manifest.html for \
-         how to upload metadata",
+         more information on configuring these fields",
         missing.join(", ")
     )
 }
@@ -706,8 +706,8 @@ mod tests {
 
     #[test]
     fn missing_metadata_error_message_test() {
-        assert_eq!(missing_metadata_error_message(&["a"]), "missing or empty metadata fields: a. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
-        assert_eq!(missing_metadata_error_message(&["a", "b"]), "missing or empty metadata fields: a, b. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
-        assert_eq!(missing_metadata_error_message(&["a", "b", "c"]), "missing or empty metadata fields: a, b, c. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
+        assert_eq!(missing_metadata_error_message(&["a"]), "missing or empty metadata fields: a. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields");
+        assert_eq!(missing_metadata_error_message(&["a", "b"]), "missing or empty metadata fields: a, b. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields");
+        assert_eq!(missing_metadata_error_message(&["a", "b", "c"]), "missing or empty metadata fields: a, b, c. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields");
     }
 }

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -98,6 +98,12 @@ impl PublishBuilder {
         self
     }
 
+    /// Set the license from this crate.
+    pub fn license<T: Into<String>>(mut self, license: T) -> Self {
+        self.license = Some(license.into());
+        self
+    }
+
     /// Remove the license from this crate. Publish will fail unless license or license file is set.
     pub fn unset_license(mut self) -> Self {
         self.license = None;

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_license.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_license.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers"
+      "detail": "unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers\nNote: If you have a non-standard license that is not listed by SPDX, use the license-file field to specify the path to a file containing the text of the license.\nSee https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.\nMIT AND foobar\n        ^^^^^^ unknown term"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_license.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_license.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-2.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+      "detail": "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-3.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+      "detail": "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+      "detail": "missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for more information on configuring these fields"
     }
   ]
 }

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -88,6 +88,17 @@ fn license_and_description_required() {
 }
 
 #[test]
+fn invalid_license() {
+    let (app, _, _, token) = TestApp::full().with_token();
+
+    let response =
+        token.publish_crate(PublishBuilder::new("foo", "1.0.0").license("MIT AND foobar"));
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.into_json());
+    assert!(app.stored_files().is_empty());
+}
+
+#[test]
 fn invalid_urls() {
     let (app, _, _, token) = TestApp::full().with_token();
 


### PR DESCRIPTION
This expands the error message when the `license` expression is not valid. It provides some help text if the user needs a custom license, and also points to the cargo documentation. It also includes the actual error message from the validator, which can be helpful if you have a more complex expression, and it may not be clear exactly which part of the expression is invalid.

This also clarifies the wording when `license` is not specified.

The error may look something like this:

```
error: failed to publish to registry at http://localhost:8888/

Caused by:
  the remote server responded with an error: unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers
  Note: If you have a non-standard license that is not listed by SPDX, use the license-file field to specify the path to a file containing the text of the license.
  See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.
  MIT AND foobar
          ^^^^^^ unknown term
```

Closes https://github.com/rust-lang/cargo/issues/3540