### PR TITLE
Extract `cargo-registry-tarball` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
  "cargo-registry-index",
  "cargo-registry-markdown",
  "cargo-registry-s3",
+ "cargo-registry-tarball",
  "chrono",
  "claims",
  "clap",
@@ -557,6 +558,22 @@ dependencies = [
  "hmac",
  "reqwest",
  "sha-1",
+]
+
+[[package]]
+name = "cargo-registry-tarball"
+version = "0.0.0"
+dependencies = [
+ "claims",
+ "derive_deref",
+ "flate2",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ base64 = "=0.13.1"
 cargo-registry-index = { path = "cargo-registry-index" }
 cargo-registry-markdown = { path = "cargo-registry-markdown" }
 cargo-registry-s3 = { path = "cargo-registry-s3" }
+cargo-registry-tarball = { path = "cargo-registry-tarball" }
 chrono = { version = "=0.4.26", default-features = false, features = ["serde"] }
 clap = { version = "=4.3.0", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.17.0", features = ["secure"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ url = "=2.3.1"
 
 [dev-dependencies]
 cargo-registry-index = { path = "cargo-registry-index", features = ["testing"] }
+cargo-registry-tarball = { path = "cargo-registry-tarball", features = ["builder"] }
 claims = "=0.7.1"
 hyper-tls = "=0.5.0"
 insta = { version = "=1.29.0", features = ["redactions", "yaml"] }

--- a/cargo-registry-tarball/Cargo.toml
+++ b/cargo-registry-tarball/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cargo-registry-tarball"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[dependencies]
+derive_deref = "=1.1.1"
+flate2 = "=1.0.26"
+semver = { version = "=1.0.17", features = ["serde"] }
+serde = { version = "=1.0.163", features = ["derive"] }
+serde_json = "=1.0.96"
+tar = "=0.4.38"
+thiserror = "=1.0.40"
+toml = "=0.7.4"
+tracing = "=0.1.37"
+
+[dev-dependencies]
+claims = "=0.7.1"

--- a/cargo-registry-tarball/Cargo.toml
+++ b/cargo-registry-tarball/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 
+[features]
+builder = []
+
 [dependencies]
 derive_deref = "=1.1.1"
 flate2 = "=1.0.26"

--- a/cargo-registry-tarball/src/builder.rs
+++ b/cargo-registry-tarball/src/builder.rs
@@ -20,8 +20,12 @@ impl TarballBuilder {
         self
     }
 
+    pub fn build_unzipped(self) -> Vec<u8> {
+        self.inner.into_inner().unwrap()
+    }
+
     pub fn build(self) -> Vec<u8> {
-        let tarball_bytes = self.inner.into_inner().unwrap();
+        let tarball_bytes = self.build_unzipped();
 
         let mut gzip_bytes = vec![];
         GzEncoder::new(tarball_bytes.as_slice(), Default::default())

--- a/cargo-registry-tarball/src/builder.rs
+++ b/cargo-registry-tarball/src/builder.rs
@@ -1,0 +1,33 @@
+use flate2::read::GzEncoder;
+use std::io::Read;
+
+pub struct TarballBuilder {
+    inner: tar::Builder<Vec<u8>>,
+}
+
+impl TarballBuilder {
+    pub fn new() -> Self {
+        let inner = tar::Builder::new(vec![]);
+        Self { inner }
+    }
+
+    pub fn add_file(mut self, path: &str, content: &[u8]) -> Self {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_cksum();
+        self.inner.append_data(&mut header, path, content).unwrap();
+
+        self
+    }
+
+    pub fn build(self) -> Vec<u8> {
+        let tarball_bytes = self.inner.into_inner().unwrap();
+
+        let mut gzip_bytes = vec![];
+        GzEncoder::new(tarball_bytes.as_slice(), Default::default())
+            .read_to_end(&mut gzip_bytes)
+            .unwrap();
+
+        gzip_bytes
+    }
+}

--- a/cargo-registry-tarball/src/builder.rs
+++ b/cargo-registry-tarball/src/builder.rs
@@ -2,13 +2,20 @@ use flate2::read::GzEncoder;
 use std::io::Read;
 
 pub struct TarballBuilder {
+    prefix: String,
     inner: tar::Builder<Vec<u8>>,
 }
 
 impl TarballBuilder {
-    pub fn new() -> Self {
+    pub fn new(name: &str, version: &str) -> Self {
+        let prefix = format!("{name}-{version}");
         let inner = tar::Builder::new(vec![]);
-        Self { inner }
+        Self { prefix, inner }
+    }
+
+    pub fn add_raw_manifest(self, content: &[u8]) -> Self {
+        let path = format!("{}/Cargo.toml", self.prefix);
+        self.add_file(&path, content)
     }
 
     pub fn add_file(mut self, path: &str, content: &[u8]) -> Self {

--- a/cargo-registry-tarball/src/lib.rs
+++ b/cargo-registry-tarball/src/lib.rs
@@ -101,8 +101,8 @@ mod tests {
 
     #[test]
     fn process_tarball_test() {
-        let tarball = TarballBuilder::new()
-            .add_file("foo-0.0.1/Cargo.toml", b"")
+        let tarball = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(b"")
             .build();
 
         let limit = 512 * 1024 * 1024;
@@ -117,8 +117,8 @@ mod tests {
 
     #[test]
     fn process_tarball_test_incomplete_vcs_info() {
-        let tarball = TarballBuilder::new()
-            .add_file("foo-0.0.1/Cargo.toml", b"")
+        let tarball = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(b"")
             .add_file("foo-0.0.1/.cargo_vcs_info.json", br#"{"unknown": "field"}"#)
             .build();
 
@@ -132,8 +132,8 @@ mod tests {
 
     #[test]
     fn process_tarball_test_vcs_info() {
-        let tarball = TarballBuilder::new()
-            .add_file("foo-0.0.1/Cargo.toml", b"")
+        let tarball = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(b"")
             .add_file(
                 "foo-0.0.1/.cargo_vcs_info.json",
                 br#"{"path_in_vcs": "path/in/vcs"}"#,
@@ -150,9 +150,8 @@ mod tests {
 
     #[test]
     fn process_tarball_test_manifest() {
-        let tarball = TarballBuilder::new()
-            .add_file(
-                "foo-0.0.1/Cargo.toml",
+        let tarball = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(
                 br#"
 [package]
 rust-version = "1.59"

--- a/cargo-registry-tarball/src/limit_reader.rs
+++ b/cargo-registry-tarball/src/limit_reader.rs
@@ -1,0 +1,27 @@
+use std::io;
+use std::io::prelude::*;
+
+#[derive(Debug)]
+pub struct LimitErrorReader<R> {
+    inner: io::Take<R>,
+}
+
+impl<R: Read> LimitErrorReader<R> {
+    pub fn new(r: R, limit: u64) -> LimitErrorReader<R> {
+        LimitErrorReader {
+            inner: r.take(limit),
+        }
+    }
+}
+
+impl<R: Read> Read for LimitErrorReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self.inner.read(buf) {
+            Ok(0) if self.inner.limit() == 0 => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "maximum limit reached when reading",
+            )),
+            e => e,
+        }
+    }
+}

--- a/cargo-registry-tarball/src/manifest.rs
+++ b/cargo-registry-tarball/src/manifest.rs
@@ -1,3 +1,4 @@
+use derive_deref::Deref;
 use serde::{de, Deserialize, Deserializer};
 
 #[derive(Debug, Deserialize)]

--- a/cargo-registry-tarball/src/vcs_info.rs
+++ b/cargo-registry-tarball/src/vcs_info.rs
@@ -1,0 +1,44 @@
+use serde::Deserialize;
+
+/// Represents relevant contents of .cargo_vcs_info.json file when uploaded from cargo
+/// or downloaded from crates.io
+#[derive(Debug, Deserialize, Eq, PartialEq)]
+pub struct CargoVcsInfo {
+    /// Path to the package within repo (empty string if root). / not \
+    #[serde(default)]
+    pub path_in_vcs: String,
+}
+
+impl CargoVcsInfo {
+    pub fn from_contents(contents: &str) -> serde_json::Result<Self> {
+        serde_json::from_str(contents)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CargoVcsInfo;
+
+    #[test]
+    fn test_cargo_vcs_info() {
+        assert_eq!(CargoVcsInfo::from_contents("").ok(), None);
+        assert_eq!(
+            CargoVcsInfo::from_contents("{}").unwrap(),
+            CargoVcsInfo {
+                path_in_vcs: "".into()
+            }
+        );
+        assert_eq!(
+            CargoVcsInfo::from_contents(r#"{"path_in_vcs": "hi"}"#).unwrap(),
+            CargoVcsInfo {
+                path_in_vcs: "hi".into()
+            }
+        );
+        assert_eq!(
+            CargoVcsInfo::from_contents(r#"{"path_in_vcs": "hi", "future": "field"}"#).unwrap(),
+            CargoVcsInfo {
+                path_in_vcs: "hi".into()
+            }
+        );
+    }
+}

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -3,12 +3,12 @@ use crate::{
     models::Version,
     schema::{crates, readme_renderings, versions},
     uploaders::Uploader,
-    util::manifest::Manifest,
 };
 use anyhow::{anyhow, Context};
 use std::{io::Read, path::Path, sync::Arc, thread};
 
 use cargo_registry_markdown::text_to_html;
+use cargo_registry_tarball::Manifest;
 use chrono::{TimeZone, Utc};
 use diesel::prelude::*;
 use flate2::read::GzDecoder;

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -232,9 +232,8 @@ pub mod tests {
 
     #[test]
     fn test_render_pkg_readme() {
-        let serialized_archive = TarballBuilder::new()
-            .add_file(
-                "foo-0.0.1/Cargo.toml",
+        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(
                 br#"
 [package]
 readme = "README.md"
@@ -250,9 +249,8 @@ readme = "README.md"
 
     #[test]
     fn test_render_pkg_no_readme() {
-        let serialized_archive = TarballBuilder::new()
-            .add_file(
-                "foo-0.0.1/Cargo.toml",
+        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(
                 br#"
 [package]
 "#,
@@ -267,9 +265,8 @@ readme = "README.md"
 
     #[test]
     fn test_render_pkg_implicit_readme() {
-        let serialized_archive = TarballBuilder::new()
-            .add_file(
-                "foo-0.0.1/Cargo.toml",
+        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(
                 br#"
 [package]
 "#,
@@ -284,9 +281,8 @@ readme = "README.md"
 
     #[test]
     fn test_render_pkg_readme_w_link() {
-        let serialized_archive = TarballBuilder::new()
-            .add_file(
-                "foo-0.0.1/Cargo.toml",
+        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(
                 br#"
 [package]
 readme = "README.md"
@@ -303,9 +299,8 @@ repository = "https://github.com/foo/foo"
 
     #[test]
     fn test_render_pkg_readme_not_at_root() {
-        let serialized_archive = TarballBuilder::new()
-            .add_file(
-                "foo-0.0.1/Cargo.toml",
+        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(
                 br#"
 [package]
 readme = "docs/README.md"

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -3,13 +3,11 @@
 use crate::auth::AuthCheck;
 use crate::background_jobs::{Job, PRIORITY_RENDER_README};
 use axum::body::Bytes;
-use flate2::read::GzDecoder;
+use cargo_registry_tarball::{verify_tarball, TarballError};
 use hex::ToHex;
 use hyper::body::Buf;
 use sha2::{Digest, Sha256};
-use std::io::Read;
 use std::ops::Deref;
-use std::path::Path;
 
 use crate::controllers::cargo_prelude::*;
 use crate::controllers::util::RequestPartsExt;
@@ -22,8 +20,7 @@ use crate::middleware::log_request::RequestLogExt;
 use crate::models::token::EndpointScope;
 use crate::schema::*;
 use crate::util::errors::{cargo_err, AppResult};
-use crate::util::manifest::Manifest;
-use crate::util::{CargoVcsInfo, LimitErrorReader, Maximums};
+use crate::util::Maximums;
 use crate::views::{
     EncodableCrate, EncodableCrateDependency, EncodableCrateUpload, GoodCrate, PublishWarnings,
 };
@@ -389,22 +386,6 @@ pub fn add_dependencies(
     Ok(())
 }
 
-#[derive(Debug)]
-struct TarballInfo {
-    manifest: Option<Manifest>,
-    vcs_info: Option<CargoVcsInfo>,
-}
-
-#[derive(Debug, thiserror::Error)]
-enum TarballError {
-    #[error("uploaded tarball is malformed or too large when decompressed")]
-    Malformed(#[source] std::io::Error),
-    #[error("invalid tarball uploaded")]
-    Invalid,
-    #[error(transparent)]
-    IO(#[from] std::io::Error),
-}
-
 fn tarball_to_app_error(error: TarballError) -> BoxedAppError {
     match error {
         TarballError::Malformed(err) => err.chain(cargo_err(
@@ -415,164 +396,14 @@ fn tarball_to_app_error(error: TarballError) -> BoxedAppError {
     }
 }
 
-#[instrument(skip_all, fields(%pkg_name))]
-fn verify_tarball(
-    pkg_name: &str,
-    tarball: &[u8],
-    max_unpack: u64,
-) -> Result<TarballInfo, TarballError> {
-    // All our data is currently encoded with gzip
-    let decoder = GzDecoder::new(tarball);
-
-    // Don't let gzip decompression go into the weeeds, apply a fixed cap after
-    // which point we say the decompressed source is "too large".
-    let decoder = LimitErrorReader::new(decoder, max_unpack);
-
-    // Use this I/O object now to take a peek inside
-    let mut archive = tar::Archive::new(decoder);
-
-    let vcs_info_path = Path::new(&pkg_name).join(".cargo_vcs_info.json");
-    let mut vcs_info = None;
-
-    let manifest_path = Path::new(&pkg_name).join("Cargo.toml");
-    let mut manifest = None;
-
-    for entry in archive.entries()? {
-        let mut entry = entry.map_err(TarballError::Malformed)?;
-
-        // Verify that all entries actually start with `$name-$vers/`.
-        // Historically Cargo didn't verify this on extraction so you could
-        // upload a tarball that contains both `foo-0.1.0/` source code as well
-        // as `bar-0.1.0/` source code, and this could overwrite other crates in
-        // the registry!
-        let entry_path = entry.path()?;
-        if !entry_path.starts_with(pkg_name) {
-            return Err(TarballError::Invalid);
-        }
-        if entry_path == vcs_info_path {
-            let mut contents = String::new();
-            entry.read_to_string(&mut contents)?;
-            vcs_info = CargoVcsInfo::from_contents(&contents).ok();
-        } else if entry_path == manifest_path {
-            // Try to extract and read the Cargo.toml from the tarball, silently
-            // erroring if it cannot be read.
-            let mut contents = String::new();
-            entry.read_to_string(&mut contents)?;
-            manifest = toml::from_str(&contents).ok();
-        }
-
-        // Historical versions of the `tar` crate which Cargo uses internally
-        // don't properly prevent hard links and symlinks from overwriting
-        // arbitrary files on the filesystem. As a bit of a hammer we reject any
-        // tarball with these sorts of links. Cargo doesn't currently ever
-        // generate a tarball with these file types so this should work for now.
-        let entry_type = entry.header().entry_type();
-        if entry_type.is_hard_link() || entry_type.is_symlink() {
-            return Err(TarballError::Invalid);
-        }
-    }
-
-    Ok(TarballInfo { manifest, vcs_info })
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{missing_metadata_error_message, verify_tarball};
-    use crate::admin::render_readmes::tests::add_file;
-    use flate2::read::GzEncoder;
-    use std::io::Read;
+    use super::missing_metadata_error_message;
 
     #[test]
     fn missing_metadata_error_message_test() {
         assert_eq!(missing_metadata_error_message(&["a"]), "missing or empty metadata fields: a. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
         assert_eq!(missing_metadata_error_message(&["a", "b"]), "missing or empty metadata fields: a, b. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
         assert_eq!(missing_metadata_error_message(&["a", "b", "c"]), "missing or empty metadata fields: a, b, c. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata");
-    }
-
-    #[test]
-    fn verify_tarball_test() {
-        let mut pkg = tar::Builder::new(vec![]);
-        add_file(&mut pkg, "foo-0.0.1/Cargo.toml", b"");
-        let mut serialized_archive = vec![];
-        GzEncoder::new(pkg.into_inner().unwrap().as_slice(), Default::default())
-            .read_to_end(&mut serialized_archive)
-            .unwrap();
-
-        let limit = 512 * 1024 * 1024;
-        assert_eq!(
-            verify_tarball("foo-0.0.1", &serialized_archive, limit)
-                .unwrap()
-                .vcs_info,
-            None
-        );
-        assert_err!(verify_tarball("bar-0.0.1", &serialized_archive, limit));
-    }
-
-    #[test]
-    fn verify_tarball_test_incomplete_vcs_info() {
-        let mut pkg = tar::Builder::new(vec![]);
-        add_file(&mut pkg, "foo-0.0.1/Cargo.toml", b"");
-        add_file(
-            &mut pkg,
-            "foo-0.0.1/.cargo_vcs_info.json",
-            br#"{"unknown": "field"}"#,
-        );
-        let mut serialized_archive = vec![];
-        GzEncoder::new(pkg.into_inner().unwrap().as_slice(), Default::default())
-            .read_to_end(&mut serialized_archive)
-            .unwrap();
-        let limit = 512 * 1024 * 1024;
-        let vcs_info = verify_tarball("foo-0.0.1", &serialized_archive, limit)
-            .unwrap()
-            .vcs_info
-            .unwrap();
-        assert_eq!(vcs_info.path_in_vcs, "");
-    }
-
-    #[test]
-    fn verify_tarball_test_vcs_info() {
-        let mut pkg = tar::Builder::new(vec![]);
-        add_file(&mut pkg, "foo-0.0.1/Cargo.toml", b"");
-        add_file(
-            &mut pkg,
-            "foo-0.0.1/.cargo_vcs_info.json",
-            br#"{"path_in_vcs": "path/in/vcs"}"#,
-        );
-        let mut serialized_archive = vec![];
-        GzEncoder::new(pkg.into_inner().unwrap().as_slice(), Default::default())
-            .read_to_end(&mut serialized_archive)
-            .unwrap();
-        let limit = 512 * 1024 * 1024;
-        let vcs_info = verify_tarball("foo-0.0.1", &serialized_archive, limit)
-            .unwrap()
-            .vcs_info
-            .unwrap();
-        assert_eq!(vcs_info.path_in_vcs, "path/in/vcs");
-    }
-
-    #[test]
-    fn verify_tarball_test_manifest() {
-        let mut pkg = tar::Builder::new(vec![]);
-        add_file(
-            &mut pkg,
-            "foo-0.0.1/Cargo.toml",
-            br#"
-[package]
-rust-version = "1.59"
-readme = "README.md"
-repository = "https://github.com/foo/bar"
-"#,
-        );
-        let mut serialized_archive = vec![];
-        GzEncoder::new(pkg.into_inner().unwrap().as_slice(), Default::default())
-            .read_to_end(&mut serialized_archive)
-            .unwrap();
-
-        let limit = 512 * 1024 * 1024;
-        let tarball_info = assert_ok!(verify_tarball("foo-0.0.1", &serialized_archive, limit));
-        let manifest = assert_some!(tarball_info.manifest);
-        assert_some_eq!(manifest.package.readme, "README.md");
-        assert_some_eq!(manifest.package.repository, "https://github.com/foo/bar");
-        assert_some_eq!(manifest.package.rust_version, "1.59");
     }
 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -3,7 +3,7 @@
 use crate::auth::AuthCheck;
 use crate::background_jobs::{Job, PRIORITY_RENDER_README};
 use axum::body::Bytes;
-use cargo_registry_tarball::{verify_tarball, TarballError};
+use cargo_registry_tarball::{process_tarball, TarballError};
 use hex::ToHex;
 use hyper::body::Buf;
 use sha2::{Digest, Sha256};
@@ -187,7 +187,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             let hex_cksum: String = Sha256::digest(&tarball_bytes).encode_hex();
 
             let pkg_name = format!("{}-{}", krate.name, vers);
-            let tarball_info = verify_tarball(&pkg_name, &tarball_bytes, maximums.max_unpack_size)
+            let tarball_info = process_tarball(&pkg_name, &tarball_bytes, maximums.max_unpack_size)
                 .map_err(tarball_to_app_error)?;
 
             let rust_version = tarball_info

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,12 @@
 use std::cmp;
 
 pub use self::bytes_request::BytesRequest;
-pub use self::io_util::{read_fill, read_le_u32, LimitErrorReader};
+pub use self::io_util::{read_fill, read_le_u32};
 pub use self::request_helpers::*;
 
 mod bytes_request;
 pub mod errors;
 mod io_util;
-pub mod manifest;
 mod request_helpers;
 pub mod rfc3339;
 pub mod token;
@@ -31,48 +30,5 @@ impl Maximums {
             max_upload_size,
             max_unpack_size,
         }
-    }
-}
-
-/// Represents relevant contents of .cargo_vcs_info.json file when uploaded from cargo
-/// or downloaded from crates.io
-#[derive(Debug, Deserialize, Eq, PartialEq)]
-pub struct CargoVcsInfo {
-    /// Path to the package within repo (empty string if root). / not \
-    #[serde(default)]
-    pub path_in_vcs: String,
-}
-
-impl CargoVcsInfo {
-    pub fn from_contents(contents: &str) -> serde_json::Result<Self> {
-        serde_json::from_str(contents)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::CargoVcsInfo;
-
-    #[test]
-    fn test_cargo_vcs_info() {
-        assert_eq!(CargoVcsInfo::from_contents("").ok(), None);
-        assert_eq!(
-            CargoVcsInfo::from_contents("{}").unwrap(),
-            CargoVcsInfo {
-                path_in_vcs: "".into()
-            }
-        );
-        assert_eq!(
-            CargoVcsInfo::from_contents(r#"{"path_in_vcs": "hi"}"#).unwrap(),
-            CargoVcsInfo {
-                path_in_vcs: "hi".into()
-            }
-        );
-        assert_eq!(
-            CargoVcsInfo::from_contents(r#"{"path_in_vcs": "hi", "future": "field"}"#).unwrap(),
-            CargoVcsInfo {
-                path_in_vcs: "hi".into()
-            }
-        );
     }
 }

--- a/src/util/io_util.rs
+++ b/src/util/io_util.rs
@@ -2,31 +2,6 @@ use std::io;
 use std::io::prelude::*;
 use std::mem;
 
-#[derive(Debug)]
-pub struct LimitErrorReader<R> {
-    inner: io::Take<R>,
-}
-
-impl<R: Read> LimitErrorReader<R> {
-    pub fn new(r: R, limit: u64) -> LimitErrorReader<R> {
-        LimitErrorReader {
-            inner: r.take(limit),
-        }
-    }
-}
-
-impl<R: Read> Read for LimitErrorReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self.inner.read(buf) {
-            Ok(0) if self.inner.limit() == 0 => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "maximum limit reached when reading",
-            )),
-            e => e,
-        }
-    }
-}
-
 pub fn read_le_u32<R: Read + ?Sized>(r: &mut R) -> io::Result<u32> {
     let mut b = [0; 4];
     read_fill(r, &mut b)?;


### PR DESCRIPTION
This PR extracts all the crate tarball related code into a dedicated crate. This should make it easier in the future to write tools that read metadata from these tarballs for analysis or data backfilling purposes (e.g. `rust-version`).