### PR TITLE
tarball/Manifest: Add `project` alias for `package` table

### DIFF
--- a/cargo-registry-tarball/src/lib.rs
+++ b/cargo-registry-tarball/src/lib.rs
@@ -168,4 +168,21 @@ repository = "https://github.com/foo/bar"
         assert_some_eq!(manifest.package.repository, "https://github.com/foo/bar");
         assert_some_eq!(manifest.package.rust_version, "1.59");
     }
+
+    #[test]
+    fn process_tarball_test_manifest_with_project() {
+        let tarball = TarballBuilder::new("foo", "0.0.1")
+            .add_raw_manifest(
+                br#"
+                [project]
+                rust-version = "1.23"
+                "#,
+            )
+            .build();
+
+        let limit = 512 * 1024 * 1024;
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &tarball, limit));
+        let manifest = assert_some!(tarball_info.manifest);
+        assert_some_eq!(manifest.package.rust_version, "1.23");
+    }
 }

--- a/cargo-registry-tarball/src/manifest.rs
+++ b/cargo-registry-tarball/src/manifest.rs
@@ -3,6 +3,7 @@ use serde::{de, Deserialize, Deserializer};
 
 #[derive(Debug, Deserialize)]
 pub struct Manifest {
+    #[serde(alias = "project")]
     pub package: Package,
 }
 


### PR DESCRIPTION
According to https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/crate.20files.20with.20unusual.20.60Cargo.2Etoml.60.20files/near/362487043, `project` should be treated equivalent to `package`. It is deprecated on the cargo side though, and showing a warning for publishes that use this name.