### PR TITLE
bin/crates-admin: Use INFO log level by default

### DIFF
--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -7,6 +7,7 @@ use cargo_registry::admin::{
     delete_crate, delete_version, enqueue_job, git_import, migrate, populate, render_readmes,
     test_pagerduty, transfer_crates, upload_index, verify_token, yank_version,
 };
+use tracing_subscriber::filter::LevelFilter;
 
 #[derive(clap::Parser, Debug)]
 #[command(name = "crates-admin")]
@@ -30,7 +31,7 @@ fn main() -> anyhow::Result<()> {
     let _sentry = cargo_registry::sentry::init();
 
     // Initialize logging
-    cargo_registry::util::tracing::init();
+    cargo_registry::util::tracing::init_with_default_level(LevelFilter::INFO);
 
     use clap::Parser;
 

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -12,10 +12,18 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 /// This function also sets up the Sentry error reporting integration for the
 /// `tracing` framework, which is hardcoded to include all `INFO` level events.
 pub fn init() {
+    init_with_default_level(LevelFilter::ERROR)
+}
+
+pub fn init_with_default_level(level: LevelFilter) {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(level.into())
+        .from_env_lossy();
+
     let log_layer = tracing_subscriber::fmt::layer()
         .compact()
         .without_time()
-        .with_filter(EnvFilter::from_default_env());
+        .with_filter(env_filter);
 
     let sentry_layer = sentry::integrations::tracing::layer()
         .event_filter(event_filter)


### PR DESCRIPTION
This enables us to use `info!()` and `warn!()` in the admin tools and actually see the output by default :D