### PR TITLE
tarball: Split `Invalid` error into two enum variants

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -391,7 +391,10 @@ fn tarball_to_app_error(error: TarballError) -> BoxedAppError {
         TarballError::Malformed(err) => err.chain(cargo_err(
             "uploaded tarball is malformed or too large when decompressed",
         )),
-        TarballError::Invalid => cargo_err("invalid tarball uploaded"),
+        TarballError::InvalidPath(path) => cargo_err(&format!("invalid path found: {path}")),
+        TarballError::UnexpectedSymlink(path) => {
+            cargo_err(&format!("unexpected symlink or hard link found: {path}"))
+        }
         TarballError::IO(err) => err.into(),
     }
 }

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -420,7 +420,7 @@ fn new_krate_wrong_files() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
-        json!({ "errors": [{ "detail": "invalid tarball uploaded" }] })
+        json!({ "errors": [{ "detail": "invalid path found: bar-1.0.0/a" }] })
     );
 }
 
@@ -846,7 +846,7 @@ fn new_krate_tarball_with_hard_links() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
-        json!({ "errors": [{ "detail": "invalid tarball uploaded" }] })
+        json!({ "errors": [{ "detail": "unexpected symlink or hard link found: foo-1.1.0/bar" }] })
     );
 }
 


### PR DESCRIPTION
Seeing "invalid tarball uploaded" isn't particularly helpful, so this PR splits up this error into two error enum variants with more descriptive error messages.