### PR TITLE
Clean up API token creation code

### DIFF
--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -1,14 +1,13 @@
 <div local-class="me-subheading">
   <h2>API Tokens</h2>
   <div local-class="right">
-    <button
-      type="button"
+    <LinkTo
+      @route="settings.tokens.new"
       local-class="new-token-button"
       data-test-new-token-button
-      {{on "click" this.startNewToken}}
     >
       New Token
-    </button>
+    </LinkTo>
   </div>
 </div>
 
@@ -134,13 +133,12 @@
       You have not generated any API tokens yet.
     </div>
 
-    <button
-      type="button"
+    <LinkTo
+      @route="settings.tokens.new"
       local-class="empty-state-button"
       data-test-empty-state-button
-      {{on "click" this.startNewToken}}
     >
       New Token
-    </button>
+    </LinkTo>
   </div>
 {{/if}}

--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -4,7 +4,6 @@
     <button
       type="button"
       local-class="new-token-button"
-      disabled={{this.newToken}}
       data-test-new-token-button
       {{on "click" this.startNewToken}}
     >
@@ -32,36 +31,6 @@
   <a href="https://doc.rust-lang.org/cargo/reference/config.html?highlight=CARGO_REGISTRY_TOKEN#credentials"><code>CARGO_REGISTRY_TOKEN</code></a>
   environment variable, but make sure that the token stays secret!
 </p>
-
-{{#if this.newToken}}
-  <form local-class="new-token-form" {{on "submit" (prevent-default (perform this.saveTokenTask))}}>
-    <Input
-      @type="text"
-      placeholder="New token name"
-      aria-label="New token name"
-      disabled={{this.newToken.isSaving}}
-      @value={{this.newToken.name}}
-      local-class="input"
-      data-test-focused-input
-      {{auto-focus}}
-    />
-
-    <div local-class="actions">
-      <button
-        type="submit"
-        local-class="save-button"
-        disabled={{or this.newToken.isSaving (not this.newToken.name)}}
-        title={{unless this.newToken.name "You must specify a name"}}
-        data-test-save-token-button
-      >
-        Create
-      </button>
-      {{#if this.newToken.isSaving}}
-        <LoadingSpinner local-class="spinner" data-test-saving-spinner />
-      {{/if}}
-    </div>
-  </form>
-{{/if}}
 
 {{#if this.sortedTokens}}
   <ul role="list" local-class="token-list">
@@ -168,7 +137,6 @@
     <button
       type="button"
       local-class="empty-state-button"
-      disabled={{this.newToken}}
       data-test-empty-state-button
       {{on "click" this.startNewToken}}
     >

--- a/app/components/settings/api-tokens.js
+++ b/app/components/settings/api-tokens.js
@@ -1,7 +1,6 @@
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
-import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';
 
@@ -11,8 +10,6 @@ export default class ApiTokens extends Component {
   @service store;
   @service notifications;
   @service router;
-
-  @tracked newToken;
 
   scopeDescription = scopeDescription;
   patternDescription = patternDescription;
@@ -29,23 +26,6 @@ export default class ApiTokens extends Component {
   @action startNewToken() {
     this.router.transitionTo('settings.tokens.new');
   }
-
-  saveTokenTask = task(async () => {
-    let token = this.newToken;
-
-    try {
-      await token.save();
-      this.args.tokens.unshift(token);
-      this.newToken = undefined;
-    } catch (error) {
-      let msg =
-        error.errors && error.errors[0] && error.errors[0].detail
-          ? `An error occurred while saving this token, ${error.errors[0].detail}`
-          : 'An unknown error occurred while saving this token';
-
-      this.notifications.error(msg);
-    }
-  });
 
   revokeTokenTask = task(async token => {
     try {

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -36,7 +36,7 @@ module('/settings/tokens/new', function (hooks) {
     await click('[data-test-settings-menu] [data-test-tokens] a');
     assert.strictEqual(currentURL(), '/settings/tokens');
 
-    await click('[data-test-new-token-button]', { altKey: true });
+    await click('[data-test-new-token-button]');
     assert.strictEqual(currentURL(), '/settings/tokens/new');
   });
 


### PR DESCRIPTION
This PR follows #6573 and cleans up the API token creation code. This should be merged once the token scopes have run in production for a number of days without significant complaints.

In other words: merge this on 2023-06-19 😉 