### PR TITLE
utils/license: Use `.replace()` instead of `.replaceAll()`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,6 +60,8 @@ module.exports = {
     'unicorn/prefer-reflect-apply': 'off',
     // disabled because of false positives related to `EmberArray`
     'unicorn/prefer-spread': 'off',
+    // disabled because of Sentry issues
+    'unicorn/prefer-string-replace-all': 'off',
     // disabled because switch statements in JS are quite error-prone
     'unicorn/prefer-switch': 'off',
     // disabled because of false positives

--- a/app/utils/license.js
+++ b/app/utils/license.js
@@ -562,10 +562,10 @@ const LICENSE_KEYWORDS = new Set(['OR', 'AND', 'WITH', '(', ')']);
 export function parseLicense(text) {
   return text
     .trim()
-    .replaceAll('/', ' OR ')
-    .replaceAll(/(^\(| \()/g, ' ( ')
-    .replaceAll(/(\)$|\) )/g, ' ) ')
-    .replaceAll(/ +/g, ' ')
+    .replace(/\//g, ' OR ')
+    .replace(/(^\(| \()/g, ' ( ')
+    .replace(/(\)$|\) )/g, ' ) ')
+    .replace(/ +/g, ' ')
     .split(' ')
     .filter(Boolean)
     .map(text => {


### PR DESCRIPTION
According to Sentry we have a few users that don't have browsers supporting `.replaceAll()` yet. While those browsers are technically not officially supported by us anymore they are easy enough to support in this specific case with these minor changes.