### PR TITLE
CI: Adjust backend linting CLI flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.4.0
 
       - run: cargo fmt --check --all
-      - run: cargo clippy --all-targets --all-features --all
+      - run: cargo clippy --all-targets --all-features --workspace
 
   backend-cargo-deny:
     name: Backend / cargo-deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.4.0
 
-      - run: cargo fmt --check
+      - run: cargo fmt --check --all
       - run: cargo clippy --all-targets --all-features --all
 
   backend-cargo-deny:


### PR DESCRIPTION
Just two very minor changes to our CI setup, which ensure that it's working correctly and not using any deprecated flags.