### PR TITLE
tests: define `assert_forbidden` and `assert_not_found` for any response

### DIFF
--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -589,7 +589,7 @@ fn api_token_cannot_list_invitations_v1() {
     let (_, _, _, token) = TestApp::init().with_token();
 
     token
-        .get("/api/v1/me/crate_owner_invitations")
+        .get::<()>("/api/v1/me/crate_owner_invitations")
         .assert_forbidden();
 }
 

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -11,7 +11,7 @@ fn show() {
     let url = "/api/v1/categories/foo-bar";
 
     // Return not found if a category doesn't exist
-    anon.get(url).assert_not_found();
+    anon.get::<()>(url).assert_not_found();
 
     // Create a category and a subcategory
     app.db(|conn| {

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -5,7 +5,7 @@ use crate::util::{RequestHelper, TestApp};
 fn diesel_not_found_results_in_404() {
     let (_, _, user) = TestApp::init().with_user();
 
-    user.get("/api/v1/crates/foo_following/following")
+    user.get::<()>("/api/v1/crates/foo_following/following")
         .assert_not_found();
 }
 
@@ -22,6 +22,6 @@ fn disallow_api_token_auth_for_get_crate_following_status() {
 
     // Token auth on GET for get following status is disallowed
     token
-        .get(&format!("/api/v1/crates/{a_crate}/following"))
+        .get::<()>(&format!("/api/v1/crates/{a_crate}/following"))
         .assert_forbidden();
 }

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -10,7 +10,7 @@ fn download_nonexistent_version_of_existing_crate_404s() {
         CrateBuilder::new("foo_bad", user.id).expect_build(conn);
     });
 
-    anon.get("/api/v1/crates/foo_bad/0.1.0/download")
+    anon.get::<()>("/api/v1/crates/foo_bad/0.1.0/download")
         .assert_not_found();
 }
 

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -12,7 +12,7 @@ struct GoodKeyword {
 fn show() {
     let url = "/api/v1/keywords/foo";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_not_found();
+    anon.get::<()>(url).assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
@@ -25,7 +25,7 @@ fn show() {
 fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_not_found();
+    anon.get::<()>(url).assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -19,7 +19,7 @@ pub struct UserShowPrivateResponse {
 fn me() {
     let url = "/api/v1/me";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_forbidden();
+    anon.get::<()>(url).assert_forbidden();
 
     let user = app.db_new_user("foo");
     let json = user.show_me();

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -11,7 +11,8 @@ static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;
 #[test]
 fn create_token_logged_out() {
     let (_, anon) = TestApp::init().empty();
-    anon.put("/api/v1/me/tokens", NEW_BAR).assert_forbidden();
+    anon.put::<()>("/api/v1/me/tokens", NEW_BAR)
+        .assert_forbidden();
 }
 
 #[test]

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -7,13 +7,13 @@ use http::StatusCode;
 #[test]
 fn list_logged_out() {
     let (_, anon) = TestApp::init().empty();
-    anon.get("/api/v1/me/tokens").assert_forbidden();
+    anon.get::<()>("/api/v1/me/tokens").assert_forbidden();
 }
 
 #[test]
 fn list_with_api_token_is_forbidden() {
     let (_, _, _, token) = TestApp::init().with_token();
-    token.get("/api/v1/me/tokens").assert_forbidden();
+    token.get::<()>("/api/v1/me/tokens").assert_forbidden();
 }
 
 #[test]

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -10,7 +10,7 @@ use http::StatusCode;
 #[test]
 fn api_token_cannot_get_user_updates() {
     let (_, _, _, token) = TestApp::init().with_token();
-    token.get("/api/v1/me/updates").assert_forbidden();
+    token.get::<()>("/api/v1/me/updates").assert_forbidden();
 }
 
 #[test]

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -9,7 +9,7 @@ fn using_token_updates_last_used_at() {
     let url = "/api/v1/me";
     let (app, anon, user, token) = TestApp::init().with_token();
 
-    anon.get(url).assert_forbidden();
+    anon.get::<()>(url).assert_forbidden();
     user.get::<EncodableMe>(url).good();
     assert_none!(token.as_model().last_used_at);
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -23,6 +23,18 @@ where
         }
         json(self.response)
     }
+
+    /// Assert that the status code is 404
+    #[track_caller]
+    pub fn assert_not_found(&self) {
+        assert_eq!(StatusCode::NOT_FOUND, self.status());
+    }
+
+    /// Assert that the status code is 403
+    #[track_caller]
+    pub fn assert_forbidden(&self) {
+        assert_eq!(StatusCode::FORBIDDEN, self.status());
+    }
 }
 
 impl<T> Response<T> {
@@ -56,20 +68,6 @@ impl<T> Response<T> {
             .unwrap()
             .ends_with(target));
         self
-    }
-}
-
-impl Response<()> {
-    /// Assert that the status code is 404
-    #[track_caller]
-    pub fn assert_not_found(&self) {
-        assert_eq!(StatusCode::NOT_FOUND, self.status());
-    }
-
-    /// Assert that the status code is 403
-    #[track_caller]
-    pub fn assert_forbidden(&self) {
-        assert_eq!(StatusCode::FORBIDDEN, self.status());
     }
 }
 


### PR DESCRIPTION
The existing uses of these functions meant that uses of `get` and `post` didn't have to explicitly turbofish into `()`, but defining them this way means they can't be used on other responses (for example, the ones returned from `yank` and `unyank`). Moving the definitions into `Response<T>` means we can now use these assertion helpers on any response type, at the cost of having some more turbofish.

(This is obviously a prep PR for the PR I'll be opening Real Soon Now for the `admin-minininja` branch. The more I can move out of that PR, the better.)