### PR TITLE
CSS: Set tab display size to 4 in docs section

### DIFF
--- a/app/components/rendered-html.module.css
+++ b/app/components/rendered-html.module.css
@@ -37,6 +37,7 @@
 
     code {
         font-family: var(--font-monospace);
+        tab-size: 4;
     }
 
     kbd {

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -13,7 +13,6 @@
     background-color: white;
     border-radius: var(--space-3xs);
     box-shadow: var(--shadow);
-    tab-size: 4;
 
     @media only screen and (max-width: 550px) {
         margin-left: calc(var(--main-layout-padding) * -1);

--- a/app/styles/crate/version.module.css
+++ b/app/styles/crate/version.module.css
@@ -13,6 +13,7 @@
     background-color: white;
     border-radius: var(--space-3xs);
     box-shadow: var(--shadow);
+    tab-size: 4;
 
     @media only screen and (max-width: 550px) {
         margin-left: calc(var(--main-layout-padding) * -1);


### PR DESCRIPTION
Some users have `README`s that use tabs in their Rust code examples.

Although that doesn't respect the default settings of `rustfmt`, it seems that the most sensible way to handle any tabs in Rust code in crates `README`s would be to display it in the same way `rustfmt` would normally indent: with spacing of size 4 (instead of 8 by default in the browser).

This is a one-liner.