### PR TITLE
crates_io_s3: allow the region to be a full hostname

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,6 +751,7 @@ dependencies = [
  "reqwest",
  "sha-1",
  "thiserror",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,7 @@ dependencies = [
  "hmac",
  "reqwest",
  "sha-1",
+ "thiserror",
 ]
 
 [[package]]

--- a/crates_io_s3/Cargo.toml
+++ b/crates_io_s3/Cargo.toml
@@ -18,3 +18,4 @@ hmac = "=0.12.1"
 reqwest = { version = "=0.11.18", features = ["blocking"] }
 sha-1 = "=0.10.1"
 thiserror = "=1.0.40"
+url = "=2.4.0"

--- a/crates_io_s3/Cargo.toml
+++ b/crates_io_s3/Cargo.toml
@@ -17,3 +17,4 @@ chrono = { version = "=0.4.26", default-features = false, features = ["clock"] }
 hmac = "=0.12.1"
 reqwest = { version = "=0.11.18", features = ["blocking"] }
 sha-1 = "=0.10.1"
+thiserror = "=1.0.40"

--- a/crates_io_s3/lib.rs
+++ b/crates_io_s3/lib.rs
@@ -9,8 +9,13 @@ use reqwest::{
 };
 use sha1::Sha1;
 use std::time::Duration;
+use thiserror::Error;
 
-pub use reqwest::Error;
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Reqwest(#[from] reqwest::Error),
+}
 
 #[derive(Clone, Debug)]
 pub struct Bucket {

--- a/crates_io_s3/lib.rs
+++ b/crates_io_s3/lib.rs
@@ -10,26 +10,49 @@ use reqwest::{
 use sha1::Sha1;
 use std::time::Duration;
 use thiserror::Error;
+use url::Url;
 
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Url(#[from] url::ParseError),
 }
 
 #[derive(Clone, Debug)]
 pub struct Bucket {
     name: String,
-    region: Option<String>,
+    region: Region,
     access_key: String,
     secret_key: String,
     proto: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Region {
+    Host(String),
+    Region(String),
+    Default,
+}
+
+impl Region {
+    fn request_url(&self, proto: &str, bucket: &str, path: &str) -> Result<Url, Error> {
+        Ok(Url::parse(&match self {
+            Region::Host(host) => format!("{proto}://{host}/{bucket}/{path}"),
+            Region::Region(region) => {
+                format!("{proto}://{bucket}.s3-{region}.amazonaws.com/{path}")
+            }
+            Region::Default => format!("{proto}://{bucket}.s3.amazonaws.com/{path}"),
+        })?)
+    }
+}
+
 impl Bucket {
     pub fn new(
         name: String,
-        region: Option<String>,
+        region: Region,
         access_key: String,
         secret_key: String,
         proto: &str,
@@ -54,7 +77,7 @@ impl Bucket {
         let path = path.strip_prefix('/').unwrap_or(path);
         let date = Utc::now().to_rfc2822();
         let auth = self.auth("PUT", &date, path, "", content_type);
-        let url = self.url(path);
+        let url = self.url(path)?;
 
         client
             .put(url)
@@ -74,7 +97,7 @@ impl Bucket {
         let path = path.strip_prefix('/').unwrap_or(path);
         let date = Utc::now().to_rfc2822();
         let auth = self.auth("DELETE", &date, path, "", "");
-        let url = self.url(path);
+        let url = self.url(path)?;
 
         client
             .delete(url)
@@ -83,18 +106,6 @@ impl Bucket {
             .send()?
             .error_for_status()
             .map_err(Into::into)
-    }
-
-    pub fn host(&self) -> String {
-        format!(
-            "{}.s3{}.amazonaws.com",
-            self.name,
-            match self.region {
-                Some(ref r) if !r.is_empty() => format!("-{r}"),
-                Some(_) => String::new(),
-                None => String::new(),
-            }
-        )
     }
 
     fn auth(&self, verb: &str, date: &str, path: &str, md5: &str, content_type: &str) -> String {
@@ -114,7 +125,51 @@ impl Bucket {
         format!("AWS {}:{}", self.access_key, signature)
     }
 
-    fn url(&self, path: &str) -> String {
-        format!("{}://{}/{}", self.proto, self.host(), path)
+    pub fn url(&self, path: &str) -> Result<String, Error> {
+        self.region
+            .request_url(&self.proto, &self.name, path)
+            .map(|url| url.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_url() -> Result<(), Error> {
+        for (bucket, path, expected) in [
+            (
+                bucket("buckey", region("us-west-2"), "https"),
+                "foo/bar",
+                "https://buckey.s3-us-west-2.amazonaws.com/foo/bar",
+            ),
+            (
+                bucket("buck-rogers", host("127.0.0.1:19000"), "http"),
+                "foo/bar",
+                "http://127.0.0.1:19000/buck-rogers/foo/bar",
+            ),
+            (
+                bucket("buckminster-fuller", Region::Default, "gopher"),
+                "",
+                "gopher://buckminster-fuller.s3.amazonaws.com/",
+            ),
+        ] {
+            assert_eq!(&bucket.url(path)?, expected);
+        }
+
+        Ok(())
+    }
+
+    fn bucket(name: &str, region: Region, proto: &str) -> Bucket {
+        Bucket::new(name.into(), region, "".into(), "".into(), proto)
+    }
+
+    fn region(name: &str) -> Region {
+        Region::Region(name.into())
+    }
+
+    fn host(host: &str) -> Region {
+        Region::Host(host.into())
     }
 }

--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -59,7 +59,7 @@ impl Base {
         let uploader = Uploader::S3 {
             bucket: Box::new(s3::Bucket::new(
                 String::from("alexcrichton-test"),
-                None,
+                s3::Region::Default,
                 dotenvy::var("AWS_ACCESS_KEY").unwrap_or_default(),
                 dotenvy::var("AWS_SECRET_KEY").unwrap_or_default(),
                 // When testing we route all API traffic over HTTP so we can
@@ -68,7 +68,7 @@ impl Base {
             )),
             index_bucket: Some(Box::new(s3::Bucket::new(
                 String::from("alexcrichton-test"),
-                None,
+                s3::Region::Default,
                 dotenvy::var("AWS_ACCESS_KEY").unwrap_or_default(),
                 dotenvy::var("AWS_SECRET_KEY").unwrap_or_default(),
                 // When testing we route all API traffic over HTTP so we can
@@ -91,7 +91,8 @@ impl Base {
         let index_bucket = match dotenvy::var("S3_INDEX_BUCKET") {
             Ok(name) => Some(Box::new(s3::Bucket::new(
                 name,
-                dotenvy::var("S3_INDEX_REGION").ok(),
+                dotenvy::var("S3_INDEX_REGION")
+                    .map_or_else(|_err| s3::Region::Default, s3::Region::Region),
                 env("AWS_ACCESS_KEY"),
                 env("AWS_SECRET_KEY"),
                 "https",
@@ -101,7 +102,8 @@ impl Base {
         Uploader::S3 {
             bucket: Box::new(s3::Bucket::new(
                 env("S3_BUCKET"),
-                dotenvy::var("S3_REGION").ok(),
+                dotenvy::var("S3_REGION")
+                    .map_or_else(|_err| s3::Region::Default, s3::Region::Region),
                 env("AWS_ACCESS_KEY"),
                 env("AWS_SECRET_KEY"),
                 "https",
@@ -115,7 +117,8 @@ impl Base {
         let index_bucket = match dotenvy::var("S3_INDEX_BUCKET") {
             Ok(name) => Some(Box::new(s3::Bucket::new(
                 name,
-                dotenvy::var("S3_INDEX_REGION").ok(),
+                dotenvy::var("S3_INDEX_REGION")
+                    .map_or_else(|_err| s3::Region::Default, s3::Region::Region),
                 dotenvy::var("AWS_ACCESS_KEY").unwrap_or_default(),
                 dotenvy::var("AWS_SECRET_KEY").unwrap_or_default(),
                 "https",
@@ -125,7 +128,8 @@ impl Base {
         Uploader::S3 {
             bucket: Box::new(s3::Bucket::new(
                 env("S3_BUCKET"),
-                dotenvy::var("S3_REGION").ok(),
+                dotenvy::var("S3_REGION")
+                    .map_or_else(|_err| s3::Region::Default, s3::Region::Region),
                 dotenvy::var("AWS_ACCESS_KEY").unwrap_or_default(),
                 dotenvy::var("AWS_SECRET_KEY").unwrap_or_default(),
                 "https",

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -45,12 +45,11 @@ impl Uploader {
                 ref cdn,
                 ..
             } => {
-                let host = match *cdn {
-                    Some(ref s) => s.clone(),
-                    None => bucket.host(),
-                };
                 let path = Uploader::crate_path(crate_name, version);
-                format!("https://{host}/{path}")
+                match *cdn {
+                    Some(ref host) => format!("https://{host}/{path}"),
+                    None => bucket.url(&path).unwrap(),
+                }
             }
             Uploader::Local => format!("/{}", Uploader::crate_path(crate_name, version)),
         }
@@ -66,12 +65,11 @@ impl Uploader {
                 ref cdn,
                 ..
             } => {
-                let host = match *cdn {
-                    Some(ref s) => s.clone(),
-                    None => bucket.host(),
-                };
                 let path = Uploader::readme_path(crate_name, version);
-                format!("https://{host}/{path}")
+                match *cdn {
+                    Some(ref host) => format!("https://{host}/{path}"),
+                    None => bucket.url(&path).unwrap(),
+                }
             }
             Uploader::Local => format!("/{}", Uploader::readme_path(crate_name, version)),
         }


### PR DESCRIPTION
This is required to allow non-AWS endpoints implementing the S3 API (such as minio) to be used for testing. These changes are reasonably mechanical, and (I hope) uncontroversial.

There are a few changes in the `Cargo.toml` for this package:

1. We need `url` as a top level import so we can use `ParseError`, which isn't re-exported by `reqwest`.
2. `thiserror` is used to define a small, crate-specific error type, since there are now functions that can return `url::ParseError`.
3. This package couldn't be directly built with (eg) `cargo test -p crates_io_s3` due to `chrono` not having the `clock` feature enabled for `Utc::now`. Cargo feature unification was making this work when building from the top level, but there's no reason we can't have this be buildable by itself.
4. Sorted the dependencies alphabetically because it made my eye twitch.

The minimal changes required in crates.io proper have also been made to make this build and work.