### PR TITLE
tests: allow arbitrary S3 hosts, and use minio for cassettes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -72,3 +72,17 @@ export GH_CLIENT_SECRET=
 # Credentials for connecting to the Sentry error reporting service.
 # export SENTRY_DSN_API=
 export SENTRY_ENV_API=local
+
+# Credentials and bucket configuration used when running integration tests
+# against live S3 servers. These credentials aren't used when running the tests
+# normally: they are only used if new HTTP cassettes are being recorded into
+# `src/tests/http-data`. See `docs/BACKEND.md` for more information on how this
+# works.
+#
+# If you don't know if you need to set these environment variables, you don't.
+# export TEST_S3_BUCKET=crates-test
+# export TEST_S3_REGION=http://127.0.0.1:19000
+# export TEST_S3_INDEX_BUCKET=crates-index-test
+# export TEST_S3_INDEX_REGION=http://127.0.0.1:19000
+# export TEST_AWS_ACCESS_KEY=minio
+# export TEST_AWS_SECRET_KEY=miniominio

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -114,4 +114,86 @@ matter what language or framework crates.io was implemented in.
 
 ## Tests
 
+### Integration tests
+
+A suite of integration tests that require a full crates.io app to be
+instantiated and available live in `src/tests`. These are a mixture of tests
+that exercise routes and controllers like normal API consumers, and other tests
+that require a full blown application and database to be available.
+
+Tests that interact with HTTP services — for example, S3 to upload packages or
+index entries — do so by routing requests through a HTTP proxy configured within
+`TestApp`. This proxy implements similar behaviour to the [`vcr` Ruby
+gem](https://github.com/vcr/vcr): by default, requests are not forwarded to the
+actual upstream service, but instead the request is checked against a
+"cassette", which is a JSON file in `src/tests/http-data` that contains the
+expected request and response. If the request matches, then the saved response
+is returned. If the request doesn't match, then an error is returned and the
+test fails.
+
+#### Updating test cassettes
+
+When updating integration tests that make HTTP requests, you may need to update
+the test cassette associated with that test. This is controlled by the `RECORD`
+environment variable: when set to `yes`, the request will actually be forwarded
+to the upstream service, and the cassette will be updated with the new response.
+
+In addition to setting `RECORD`, you will also need to set a number of other
+environment variables to handle any requests to S3. These are in `.env.sample`,
+but are also reproduced here for convenience:
+
+* `TEST_S3_BUCKET`: the S3 bucket used for package uploads.
+* `TEST_S3_REGION`: the S3 region used to package uploads. This may also be an
+  absolute URL (such as `http://127.0.0.1:19000`), in which that will be used as
+  the endpoint. If this is an S3 region name, then it must be one that supports
+  what [AWS documents as `s3-Region` host names][s3-region].
+* `TEST_S3_INDEX_BUCKET`: the S3 bucket used for sparse index uploads.
+* `TEST_S3_INDEX_REGION`: the S3 region used for sparse index uploads. This has
+  the same semantics as `TEST_S3_REGION`.
+* `TEST_AWS_ACCESS_KEY`: the AWS access key used with S3.
+* `TEST_AWS_SECRET_KEY`: the AWS secret key used with S3.
+
+Note that, if the bucket and region environment variables are set, they _must_
+match the values used when `src/tests/http-data` was regenerated for existing
+tests to pass.
+
+In practice, we use [Minio](https://min.io/) to mock the S3 API when generating
+test cassettes, since this means we don't have to share S3 credentials or pay
+for an actual bucket. You can run Minio locally on port 19000 with `crates-test`
+and `crates-index-test` buckets to match the existing test cassettes. To do this
+in Docker with the access key `minio` and secret key `miniominio`, run the
+following command:
+
+```sh
+docker run --rm \
+    -p 19000:9000 -p 19001:9001 \
+    -e MINIO_ROOT_USER=minio -e MINIO_ROOT_PASSWORD=miniominio \
+    --entrypoint /bin/sh \
+    quay.io/minio/minio \
+    -c 'mkdir /data/crates-test /data/crates-index-test && exec env minio server /data --console-address :9001'
+```
+
+This will give you an S3 compatible Minio instance listening on port 19000, and
+a management console on port 19001.
+
+#### Running tests against S3
+
+If you want to run the test suite against an actual S3 bucket, you must do so
+with the `RECORD` environment variable set to `yes`, otherwise tests will fail
+before any requests are actually sent because the URL in the test cassette
+doesn't match the request URL. For example:
+
+```sh
+RECORD=yes \
+    TEST_S3_REGION=us-east-1 TEST_S3_BUCKET=my-test-bucket \
+    TEST_S3_INDEX_REGION=us-east-1 TEST_S3_INDEX_BUCKET=my-test-bucket \
+    TEST_AWS_ACCESS_KEY=an-actual-AWS-key TEST_AWS_SECRET_KEY=an-actual-secret-key \
+    cargo test
+```
+
+Please do not commit any updated test cassettes generated as a result of running
+the test suite against S3.
+
 ## Scripts
+
+[s3-region]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-dash-region

--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -59,7 +59,7 @@ impl Base {
         let uploader = Uploader::S3 {
             bucket: Box::new(s3::Bucket::new(
                 dotenvy::var("TEST_S3_BUCKET").unwrap_or_else(|_err| "crates-test".into()),
-                parse_region(dotenvy::var("TEST_S3_REGION").ok()),
+                parse_test_region(dotenvy::var("TEST_S3_REGION").ok()),
                 dotenvy::var("TEST_AWS_ACCESS_KEY").unwrap_or_default(),
                 dotenvy::var("TEST_AWS_SECRET_KEY").unwrap_or_default(),
                 // When testing we route all API traffic over HTTP so we can
@@ -69,7 +69,7 @@ impl Base {
             index_bucket: Some(Box::new(s3::Bucket::new(
                 dotenvy::var("TEST_S3_INDEX_BUCKET")
                     .unwrap_or_else(|_err| "crates-index-test".into()),
-                parse_region(dotenvy::var("TEST_S3_INDEX_REGION").ok()),
+                parse_test_region(dotenvy::var("TEST_S3_INDEX_REGION").ok()),
                 dotenvy::var("TEST_AWS_ACCESS_KEY").unwrap_or_default(),
                 dotenvy::var("TEST_AWS_SECRET_KEY").unwrap_or_default(),
                 // When testing we route all API traffic over HTTP so we can
@@ -143,7 +143,7 @@ impl Base {
 
 static DEFAULT_TEST_REGION: &str = "127.0.0.1:19000";
 
-fn parse_region(maybe_region: Option<String>) -> s3::Region {
+fn parse_test_region(maybe_region: Option<String>) -> s3::Region {
     match maybe_region {
         Some(region) if region.contains("://") => {
             let (_proto, host) = region.split_once("://").unwrap();
@@ -172,7 +172,7 @@ mod tests {
                 s3::Region::Host("127.0.0.1:9000".into()),
             ),
         ] {
-            assert_eq!(parse_region(input.map(String::from)), expected);
+            assert_eq!(parse_test_region(input.map(String::from)), expected);
         }
     }
 }

--- a/src/tests/http-data/krate_publish_features_version_2.json
+++ b/src/tests/http-data/krate_publish_features_version_2.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo/foo-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A2A0E3A7F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/foo",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"91e9d1e0bf191b756a20546abd3e30d1\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A2E55F0FB"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_good_categories.json
+++ b/src/tests/http-data/krate_publish_good_categories.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_good_cat/foo_good_cat-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_good_cat/foo_good_cat-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A28E6C7B9"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_good_cat",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_good_cat",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"42d2b7804832bf74c1bf0cf09190213a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A2D92FAD3"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_good_keywords.json
+++ b/src/tests/http-data/krate_publish_good_keywords.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_good_key/foo_good_key-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_good_key/foo_good_key-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A29B94906"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_good_key",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_good_key",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"8b82fc0251e6eff6290ada439c24d55f\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A2D639068"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_ignored_categories.json
+++ b/src/tests/http-data/krate_publish_ignored_categories.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_ignored_cat/foo_ignored_cat-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_ignored_cat/foo_ignored_cat-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A2C9A2184"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_ignored_cat",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_ignored_cat",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"ca28dd48f952494724ddae6773d7346c\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A3082032D"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency.json
+++ b/src/tests/http-data/krate_publish_new_crate_allow_empty_alternative_registry_dependency.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo/foo-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A32F5580A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/foo",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"e006cfd00f054b8934fd982c96ef28e6\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A3774A7B9"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate.json
+++ b/src/tests/http-data/krate_publish_new_krate.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_new/foo_new-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_new/foo_new-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A3BDD03C4"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_new",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_new",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"b4e21e4b784ccc50e1369ecfc761669c\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A41270B3B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_git_upload.json
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fgt/fgt-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fgt/fgt-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A4418DAC0"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fgt",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fgt",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"5ca4b538003ccb93a9cdee34d1716838\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A48C26EE8"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_appends.json
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_appends.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/FPP/FPP-0.0.1.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/FPP/FPP-0.0.1.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A4650914F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fpp",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fpp",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"652e8d9b8b4def88c158e09ec156fbbc\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A4A54C84A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/FPP/FPP-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/FPP/FPP-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A4C01C345"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fpp",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fpp",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"ce0fd468f67b43eac83a0f268a768e32\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5117DBE9"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts.json
+++ b/src/tests/http-data/krate_publish_new_krate_git_upload_with_conflicts.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_conflicts/foo_conflicts-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_conflicts/foo_conflicts-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A45DD5486"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_conflicts",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_conflicts",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"ee8faaa864135f33148e869155ba6602\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A4A5C620E"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_records_verified_email.json
+++ b/src/tests/http-data/krate_publish_new_krate_records_verified_email.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_verified_email/foo_verified_email-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_verified_email/foo_verified_email-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A45C7EBD1"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_verified_email",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_verified_email",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"291822a4d154bfe5d426bd04d01068df\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A4A5DE879"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_sorts_deps.json
+++ b/src/tests/http-data/krate_publish_new_krate_sorts_deps.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/two-deps/two-deps-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/two-deps/two-deps-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:32 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A491DF54B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/tw/o-/two-deps",
+      "uri": "http://127.0.0.1:19000/crates-index-test/tw/o-/two-deps",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"e212a36924e7dd5cb603e96f226b3792\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A4DE8521B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted.json
+++ b/src/tests/http-data/krate_publish_new_krate_too_big_but_whitelisted.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_whitelist/foo_whitelist-1.1.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_whitelist/foo_whitelist-1.1.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"674058ab0e55bad385cc2c1a7ce5ee6a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A55380E8B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_whitelist",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_whitelist",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"8d1b54ea6ebe2909d3bce2729646f04e\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5A09D2E6"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_twice.json
+++ b/src/tests/http-data/krate_publish_new_krate_twice.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_twice/foo_twice-2.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_twice/foo_twice-2.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A57EFE497"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_twice",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_twice",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"867f2d19037d9ed49ae307633e4e343d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5C0F6D25"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_weird_version.json
+++ b/src/tests/http-data/krate_publish_new_krate_weird_version.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_weird/foo_weird-0.0.0-pre.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_weird/foo_weird-0.0.0-pre.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A57E46B3D"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_weird",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_weird",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"3cc4a743ed817f1fea173f0f63624100\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5C3FD94A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_with_dependency.json
+++ b/src/tests/http-data/krate_publish_new_krate_with_dependency.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/new_dep/new_dep-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/new_dep/new_dep-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5B347467"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ne/w_/new_dep",
+      "uri": "http://127.0.0.1:19000/crates-index-test/ne/w_/new_dep",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"1833d8ca0b186661f576ca9150cfdfb4\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A60243106"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_with_readme.json
+++ b/src/tests/http-data/krate_publish_new_krate_with_readme.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_readme/foo_readme-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_readme/foo_readme-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5C13BF3C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_readme",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_readme",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"cf380f14a440ced148f97ac8a6d0bc0d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A60B5472D"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/readmes/foo_readme/foo_readme-1.0.0.html",
+      "uri": "http://127.0.0.1:19000/crates-test/readmes/foo_readme/foo_readme-1.0.0.html",
       "method": "PUT",
       "headers": [
         [
@@ -85,7 +191,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"d41d8cd98f00b204e9800998ecf8427e\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A61677EBE"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_krate_with_token.json
+++ b/src/tests/http-data/krate_publish_new_krate_with_token.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_new/foo_new-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_new/foo_new-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5DDED8DD"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_new",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_new",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"b4e21e4b784ccc50e1369ecfc761669c\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A64079C15"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_with_renamed_dependency.json
+++ b/src/tests/http-data/krate_publish_new_with_renamed_dependency.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/new-krate/new-krate-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/new-krate/new-krate-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A6D330D3F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ne/w-/new-krate",
+      "uri": "http://127.0.0.1:19000/crates-index-test/ne/w-/new-krate",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"96330417dc3eb068daa43e1ab37bf58d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A7288C3E3"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency.json
+++ b/src/tests/http-data/krate_publish_new_with_underscore_renamed_dependency.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/new-krate/new-krate-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/new-krate/new-krate-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A77111548"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ne/w-/new-krate",
+      "uri": "http://127.0.0.1:19000/crates-index-test/ne/w-/new-krate",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"407fa215c73bd9e97cb335416d64045d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A7AFE2A28"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_publish_after_removing_documentation.json
+++ b/src/tests/http-data/krate_publish_publish_after_removing_documentation.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/docscrate/docscrate-0.2.1.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/docscrate/docscrate-0.2.1.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A71D782D9"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/do/cs/docscrate",
+      "uri": "http://127.0.0.1:19000/crates-index-test/do/cs/docscrate",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"c623a158eddcecf86ad4d6408c464eb1\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A76A0429A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/docscrate/docscrate-0.2.2.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/docscrate/docscrate-0.2.2.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A78761B3A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/do/cs/docscrate",
+      "uri": "http://127.0.0.1:19000/crates-index-test/do/cs/docscrate",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"fc78eca33ff6201f02533a692eab6236\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A7C6BDA06"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_publish_new_crate_rate_limited.json
+++ b/src/tests/http-data/krate_publish_publish_new_crate_rate_limited.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/rate_limited1/rate_limited1-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/rate_limited1/rate_limited1-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A72799F8A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
+      "uri": "http://127.0.0.1:19000/crates-index-test/ra/te/rate_limited1",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"81497921d39ca124bdbd065fdf0467de\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A76135526"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/rate_limited2/rate_limited2-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/rate_limited2/rate_limited2-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A96843840"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited2",
+      "uri": "http://127.0.0.1:19000/crates-index-test/ra/te/rate_limited2",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"edda4f9938b789c6faac82cd8e42410e\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A996228A3"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates.json
+++ b/src/tests/http-data/krate_publish_publish_rate_limit_doesnt_affect_existing_crates.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/rate_limited1/rate_limited1-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/rate_limited1/rate_limited1-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A9CDCDDE7"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
+      "uri": "http://127.0.0.1:19000/crates-index-test/ra/te/rate_limited1",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"81497921d39ca124bdbd065fdf0467de\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AA097102F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/rate_limited1/rate_limited1-1.0.1.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/rate_limited1/rate_limited1-1.0.1.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AA204CDC1"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/ra/te/rate_limited1",
+      "uri": "http://127.0.0.1:19000/crates-index-test/ra/te/rate_limited1",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"22ae1a72a0f1a2cdf10f96b8bedada84\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AA5C71944"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_publish_records_an_audit_action.json
+++ b/src/tests/http-data/krate_publish_publish_records_an_audit_action.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A74664D2C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A786CAFCD"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_uploading_new_version_touches_crate.json
+++ b/src/tests/http-data/krate_publish_uploading_new_version_touches_crate.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_versions_updated_at/foo_versions_updated_at-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_versions_updated_at/foo_versions_updated_at-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A83C102F6"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_versions_updated_at",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_versions_updated_at",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"4afc9afaf3f16678d828f30bd45c9e55\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A87251AC8"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_versions_updated_at/foo_versions_updated_at-2.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_versions_updated_at/foo_versions_updated_at-2.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A88D61902"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_versions_updated_at",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_versions_updated_at",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"61dd383e4c6e2a0694b5aa4829b09d19\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A8B9EDFD0"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_1.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_1.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0%2Bfoo.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo/foo-1.0.0%2Bfoo.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 17:23:27 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A6DDD42A007DD"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0+foo.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo/foo-1.0.0+foo.crate",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 17:23:27 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A6DDD42CB8B6E"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/foo",
       "method": "PUT",
       "headers": [
         [
@@ -85,7 +191,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 17:23:27 GMT"
+        ],
+        [
+          "etag",
+          "\"1902ae97b65af1bff9e4b9a088c4ebb8\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A6DDD446BD7EF"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_2.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_2.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0-beta.1.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo/foo-1.0.0-beta.1.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A944C2D50"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/foo",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"a66c3eb8ad2341ad8138341d74e3d3e3\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A9834CEA3"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_3.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_3.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0%2Bfoo.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo/foo-1.0.0%2Bfoo.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 17:23:28 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A6DDD92935C36"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0+foo.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo/foo-1.0.0+foo.crate",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 17:23:28 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A6DDD92B8EF74"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/foo",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/foo",
       "method": "PUT",
       "headers": [
         [
@@ -85,7 +191,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 17:23:28 GMT"
+        ],
+        [
+          "etag",
+          "\"1902ae97b65af1bff9e4b9a088c4ebb8\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A6DDD945F13DD"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_yanking_publish_after_yank_max_version.json
+++ b/src/tests/http-data/krate_yanking_publish_after_yank_max_version.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk_max/fyk_max-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A95E42D9C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"20426f96823b995f56332ccc9a5793d4\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A99622895"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"8cbbbd5ea45136d59d9e9aeeded187c4\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A9F89E00C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-2.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk_max/fyk_max-2.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -115,13 +274,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AA18CEDF8"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -145,13 +357,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"22b90d2befb76e9bfb93bb97dc7278aa\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AA577F550"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -175,7 +440,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"fc2a01e6fd339b8653c6badd2e67381d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AAA14A848"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_yanking_yank_max_version.json
+++ b/src/tests/http-data/krate_yanking_yank_max_version.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk_max/fyk_max-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AAEB44DDB"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"20426f96823b995f56332ccc9a5793d4\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AB2706EF0"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk_max/fyk_max-2.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk_max/fyk_max-2.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AB4E5BAE5"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -115,13 +274,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"fc2a01e6fd339b8653c6badd2e67381d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AB8CF7148"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -145,13 +357,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"22b90d2befb76e9bfb93bb97dc7278aa\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6ABD463E78"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -175,13 +440,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"fc2a01e6fd339b8653c6badd2e67381d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AC2B71DCC"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -205,13 +523,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"0605434d582e1dbc83255d0f72b1c3a5\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AC6DB132C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -235,13 +606,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"919d88519c55cb98d2aea7372271abcb\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6ACB5A1C9A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -265,13 +689,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"22b90d2befb76e9bfb93bb97dc7278aa\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AD07A1ECF"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fy/k_/fyk_max",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fy/k_/fyk_max",
       "method": "PUT",
       "headers": [
         [
@@ -295,7 +772,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"fc2a01e6fd339b8653c6badd2e67381d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AD5E49983"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/krate_yanking_yank_works_as_intended.json
+++ b/src/tests/http-data/krate_yanking_yank_works_as_intended.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A9C0DFC54"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AA1859883"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AA68F4679"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -115,13 +274,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AAC3A362B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -145,13 +357,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AB24A2BE7"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -175,7 +440,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:34 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AB648D52F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/owners_new_crate_owner.json
+++ b/src/tests/http-data/owners_new_crate_owner.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_owner/foo_owner-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_owner/foo_owner-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AC63A3F34"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_owner",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_owner",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"e083cf311568ae77bb308673935ab225\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6ACA0FB42B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_owner/foo_owner-2.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_owner/foo_owner-2.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6ACD47B02F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_owner",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_owner",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:35 GMT"
+        ],
+        [
+          "etag",
+          "\"79f102637c8404a3342093af041929b0\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AD1390E4D"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_new_daily_limit.json
+++ b/src/tests/http-data/routes_crates_new_daily_limit.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.1.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.1.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6AFC8D0C97"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"fe7dee3cbb802cc7e9a08d63c86081ad\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B001B0E88"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.2.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.2.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B01389434"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -115,13 +274,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"9e56bb97add63496075c1c3bc03784a9\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B0429E38F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.3.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.3.crate",
       "method": "PUT",
       "headers": [
         [
@@ -145,13 +357,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B054537F0"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -175,13 +440,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"5d72b4742e057895bd0436fe2d46cee5\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B08A813A8"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.4.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.4.crate",
       "method": "PUT",
       "headers": [
         [
@@ -205,13 +523,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B09D9DC3F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -235,13 +606,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"e175f71912f12be855380d7039fe9986\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B0E3C8685"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.5.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.5.crate",
       "method": "PUT",
       "headers": [
         [
@@ -265,13 +689,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B0F903867"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -295,13 +772,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"57e0777e31f3a96cda073a466b134056\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B13ECAF24"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.6.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.6.crate",
       "method": "PUT",
       "headers": [
         [
@@ -325,13 +855,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B14C0DC6B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -355,13 +938,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"428341d93d1bc228b4c0374c4fa90af3\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B175B4550"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.7.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.7.crate",
       "method": "PUT",
       "headers": [
         [
@@ -385,13 +1021,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B18644144"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -415,13 +1104,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"a511c1aa494215c1342e625cb8b866b9\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B1A75AA17"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.8.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.8.crate",
       "method": "PUT",
       "headers": [
         [
@@ -445,13 +1187,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B1B184615"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -475,13 +1270,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"a4d57123977b3b31e7e2a875f8291c09\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B1D41D306"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.9.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.9.crate",
       "method": "PUT",
       "headers": [
         [
@@ -505,13 +1353,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B1DF2A940"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -535,13 +1436,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"81908fbd7b50c668011c89a81040f5e9\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B2044BA65"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_daily_limit/foo_daily_limit-0.0.10.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_daily_limit/foo_daily_limit-0.0.10.crate",
       "method": "PUT",
       "headers": [
         [
@@ -565,13 +1519,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B20F96912"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_daily_limit",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_daily_limit",
       "method": "PUT",
       "headers": [
         [
@@ -595,7 +1602,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"469878878dcf35072574ac72363bb37a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B234ECDE4"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_read_version_size.json
+++ b/src/tests/http-data/routes_crates_read_version_size.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_version_size/foo_version_size-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_version_size/foo_version_size-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B005869A3"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_version_size",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_version_size",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"cdf27e9192ae3a0313a6eb155417ad71\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B03810C0A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_version_size/foo_version_size-2.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_version_size/foo_version_size-2.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"7966fe91ebaca88d059d51d77def3c64\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B04DE1A7D"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_version_size",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_version_size",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"53a222d850d5bb656dd35e0114f6239e\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B088D56DF"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_cookie_user.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_cookie_user.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B147AA2DA"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B175ABC90"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B1A2C1B30"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B1C853748"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B3F9AD33E"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B42CB9954"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B460346FB"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B48E13113"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_expired.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_expired.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 00:53:18 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A37D50592801A"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 00:53:18 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A37D507390DB1"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_not_expired.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_not_expired.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 00:53:18 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A37D508BF96D5"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 00:53:18 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A37D50A78237E"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 00:53:18 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A37D50C615291"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 20 Jun 2023 00:53:18 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "176A37D50E0E6B63"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_crate_scope.json
@@ -1,122 +1,334 @@
 [
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "35"
-                ],
-                [
-                    "content-type",
-                    "application/gzip"
-                ]
-            ],
-            "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "144"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
-    },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "143"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":true}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
-    },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "144"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B6361BC00"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
     }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "144"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B674846D4"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "143"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":true}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B6B3464CB"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "144"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B6F4CA709"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  }
 ]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_endpoint_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_endpoint_scope.json
@@ -1,122 +1,334 @@
 [
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "35"
-                ],
-                [
-                    "content-type",
-                    "application/gzip"
-                ]
-            ],
-            "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "144"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
-    },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "143"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":true}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
-    },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "144"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B4B26C58D"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
     }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "144"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B4E727BCA"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "143"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":true}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B51D71FE4"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "144"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B5537BD98"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  }
 ]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_wildcard_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_correct_wildcard_crate_scope.json
@@ -1,122 +1,334 @@
 [
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "35"
-                ],
-                [
-                    "content-type",
-                    "application/gzip"
-                ]
-            ],
-            "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
     },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "144"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
-    },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "143"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":true}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
-    },
-    {
-        "request": {
-            "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
-            "method": "PUT",
-            "headers": [
-                [
-                    "accept",
-                    "*/*"
-                ],
-                [
-                    "accept-encoding",
-                    "gzip"
-                ],
-                [
-                    "content-length",
-                    "144"
-                ],
-                [
-                    "content-type",
-                    "text/plain"
-                ]
-            ],
-            "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
-        },
-        "response": {
-            "status": 200,
-            "headers": [],
-            "body": ""
-        }
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B2E128D24"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
     }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "144"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B30CADF99"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "143"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":true}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B33E38A74"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "144"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"fyk\",\"vers\":\"1.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B3653FB2F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  }
 ]

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_crate_scope.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B296EF64C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B2BE49F3F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_endpoint_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_endpoint_scope.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B1E94C79B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B20F5CB00"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_wildcard_crate_scope.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_token_user_with_incorrect_wildcard_crate_scope.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B23512B50"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:36 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B26173ECD"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_auth_unauthenticated.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_auth_unauthenticated.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B3825121F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B3B494E76"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_unyank_records_an_audit_action.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_unyank_records_an_audit_action.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B729CEE63"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B76D462F6"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B7BF05BEC"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -115,7 +274,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B80D2B23F"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/routes_crates_versions_yank_unyank_yank_records_an_audit_action.json
+++ b/src/tests/http-data/routes_crates_versions_yank_unyank_yank_records_an_audit_action.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/fyk/fyk-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/fyk/fyk-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B579DF476"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"134db012c3d8c43621b636616a105314\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B5B202581"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/3/f/fyk",
+      "uri": "http://127.0.0.1:19000/crates-index-test/3/f/fyk",
       "method": "PUT",
       "headers": [
         [
@@ -85,7 +191,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:37 GMT"
+        ],
+        [
+          "etag",
+          "\"538b58c710749dbfdc5631fe7b565e9a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B5F211042"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/team_publish_owned.json
+++ b/src/tests/http-data/team_publish_owned.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo_team_owned/foo_team_owned-2.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_team_owned/foo_team_owned-2.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B7A0E1134"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/fo/o_/foo_team_owned",
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_team_owned",
       "method": "PUT",
       "headers": [
         [
@@ -55,7 +108,60 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"a323a0789176ce2d50264717cedeb20a\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6B7E0FE8DC"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }

--- a/src/tests/http-data/worker_git_index_smoke_test.json
+++ b/src/tests/http-data/worker_git_index_smoke_test.json
@@ -1,7 +1,7 @@
 [
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/serde/serde-1.0.0.crate",
+      "uri": "http://127.0.0.1:19000/crates-test/crates/serde/serde-1.0.0.crate",
       "method": "PUT",
       "headers": [
         [
@@ -25,13 +25,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6BA1D62BE0"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/se/rd/serde",
+      "uri": "http://127.0.0.1:19000/crates-index-test/se/rd/serde",
       "method": "PUT",
       "headers": [
         [
@@ -55,13 +108,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"6317a377e2456539427c1d40618e7b1b\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6BA5A72657"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/se/rd/serde",
+      "uri": "http://127.0.0.1:19000/crates-index-test/se/rd/serde",
       "method": "PUT",
       "headers": [
         [
@@ -85,13 +191,66 @@
     },
     "response": {
       "status": 200,
-      "headers": [],
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "etag",
+          "\"5304246c9aa2da026545ff4d1fb2e790\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6BA938A80B"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   },
   {
     "request": {
-      "uri": "http://alexcrichton-test.s3.amazonaws.com/se/rd/serde",
+      "uri": "http://127.0.0.1:19000/crates-index-test/se/rd/serde",
       "method": "DELETE",
       "headers": [
         [
@@ -106,8 +265,53 @@
       "body": ""
     },
     "response": {
-      "status": 200,
-      "headers": [],
+      "status": 204,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:38 GMT"
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6BAC9892FA"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
       "body": ""
     }
   }


### PR DESCRIPTION
As part of this work, I've chosen to streamline the `RECORD` environment variable down to only allowing `yes` as an option: the `passthrough`/`force` split added in #5040 doesn't really make sense to me, and it feels unnecessary in practice. Either we're using the cassettes or we're updating them.

I've also written some new documentation on integration tests. Right now it's basically just covering the `vcr` pattern and how we use it, but it's a starting point. There should be enough there for a contributor to be able to regenerate the entire set of cassettes, should they wish to.

I've tested this against both a local minio (which has been used to regenerate the cassettes) and a real S3 bucket. Both appear to work as expected. Nevertheless, I strongly believe that we should make the cassettes included in the repository be based on a local minio in future to improve the developer experience and make it easier to update these for real.

One lingering thing I'm not so sure about are the actual cassette updates themselves: minio evidently returns a bunch of response headers that we didn't previously have encoded in the cassettes. I'm happy to add them to the ignored headers list and regenerate the cassettes if we want to get rid of the noise.