### PR TITLE
crates_io_s3: Add missing `chrono/clock` feature

### DIFF
--- a/crates_io_s3/Cargo.toml
+++ b/crates_io_s3/Cargo.toml
@@ -13,7 +13,7 @@ path = "lib.rs"
 
 [dependencies]
 base64 = "=0.21.2"
-chrono = { version = "=0.4.26", default-features = false }
+chrono = { version = "=0.4.26", default-features = false, features = ["clock"] }
 sha-1 = "=0.10.1"
 hmac = "=0.12.1"
 reqwest = { version = "=0.11.18", features = ["blocking"] }


### PR DESCRIPTION
This package couldn't be directly built with (eg) `cargo test -p crates_io_s3` due to `chrono` not having the `clock` feature enabled for `Utc::now`. Cargo feature unification was making this work when building from the top level, but there's no reason we can't have this be buildable by itself.

Extracted from https://github.com/rust-lang/crates.io/pull/6606