### PR TITLE
CreatedApiToken: Use `SecretString` to hide plaintext token

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -2,6 +2,7 @@ mod scopes;
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
+use secrecy::SecretString;
 
 pub use self::scopes::{CrateScope, EndpointScope};
 use crate::models::User;
@@ -58,7 +59,7 @@ impl ApiToken {
             .get_result(conn)?;
 
         Ok(CreatedApiToken {
-            plaintext: token.plaintext().into(),
+            plaintext: SecretString::from(token.plaintext().to_string()),
             model,
         })
     }
@@ -86,19 +87,10 @@ impl ApiToken {
     }
 }
 
+#[derive(Debug)]
 pub struct CreatedApiToken {
     pub model: ApiToken,
-    pub plaintext: String,
-}
-
-// Use a custom implementation of Debug to hide the plaintext token.
-impl std::fmt::Debug for CreatedApiToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CreatedApiToken")
-            .field("model", &self.model)
-            .field("plaintext", &"(sensitive)")
-            .finish()
-    }
+    pub plaintext: SecretString,
 }
 
 #[cfg(test)]

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use crates_io::models::{Email, NewUser, User};
 use diesel::prelude::*;
+use secrecy::ExposeSecret;
 
 impl crate::util::MockCookieUser {
     fn confirm_email(&self, email_token: &str) -> OkBool {
@@ -30,7 +31,7 @@ fn updating_existing_user_doesnt_change_api_token() {
         );
 
         // Use the original API token to find the now updated user
-        assert_ok!(User::find_by_api_token(conn, token))
+        assert_ok!(User::find_by_api_token(conn, token.expose_secret()))
     });
 
     assert_eq!("bar", user.gh_login);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -32,6 +32,7 @@ use axum::body::Bytes;
 use cookie::Cookie;
 use crates_io::models::token::{CrateScope, EndpointScope};
 use http::header;
+use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
 use tower_service::Service;
 
@@ -307,7 +308,7 @@ pub struct MockTokenUser {
 impl RequestHelper for MockTokenUser {
     fn request_builder(&self, method: Method, path: &str) -> MockRequest {
         let mut request = req(method, path);
-        request.header(header::AUTHORIZATION, &self.token.plaintext);
+        request.header(header::AUTHORIZATION, self.token.plaintext.expose_secret());
         request
     }
 
@@ -322,7 +323,7 @@ impl MockTokenUser {
         &self.token.model
     }
 
-    pub fn plaintext(&self) -> &str {
+    pub fn plaintext(&self) -> &SecretString {
         &self.token.plaintext
     }
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+use secrecy::ExposeSecret;
 use url::Url;
 
 use crate::github;
@@ -479,7 +480,7 @@ impl From<CreatedApiToken> for EncodableApiTokenWithToken {
     fn from(token: CreatedApiToken) -> Self {
         EncodableApiTokenWithToken {
             token: token.model,
-            plaintext: token.plaintext,
+            plaintext: token.plaintext.expose_secret().clone(),
         }
     }
 }


### PR DESCRIPTION
The secrets are not entirely flowing through yet, but this should be another step in the right direction.