### PR TITLE
SecureToken: Move `generate()` to the `NewSecureToken` impl

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -9,7 +9,7 @@ use crate::models::User;
 use crate::schema::api_tokens;
 use crate::util::errors::{AppResult, InsecurelyGeneratedTokenRevoked};
 use crate::util::rfc3339;
-use crate::util::token::SecureToken;
+use crate::util::token::{NewSecureToken, SecureToken};
 
 /// The model representing a row in the `api_tokens` database table.
 #[derive(Clone, Debug, PartialEq, Eq, Identifiable, Queryable, Associations, Serialize)]
@@ -46,7 +46,7 @@ impl ApiToken {
         crate_scopes: Option<Vec<CrateScope>>,
         endpoint_scopes: Option<Vec<EndpointScope>>,
     ) -> AppResult<CreatedApiToken> {
-        let token = SecureToken::generate();
+        let token = NewSecureToken::generate();
 
         let model: ApiToken = diesel::insert_into(api_tokens::table)
             .values((
@@ -103,7 +103,7 @@ mod tests {
         let tok = ApiToken {
             id: 12345,
             user_id: 23456,
-            token: SecureToken::generate().into_inner(),
+            token: NewSecureToken::generate().into_inner(),
             revoked: false,
             name: "".to_string(),
             created_at: NaiveDate::from_ymd_opt(2017, 1, 6)

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -15,20 +15,6 @@ pub struct SecureToken {
 }
 
 impl SecureToken {
-    pub(crate) fn generate() -> NewSecureToken {
-        let plaintext = format!(
-            "{}{}",
-            TOKEN_PREFIX,
-            generate_secure_alphanumeric_string(TOKEN_LENGTH)
-        );
-        let sha256 = Self::hash(&plaintext);
-
-        NewSecureToken {
-            plaintext,
-            inner: Self { sha256 },
-        }
-    }
-
     pub(crate) fn parse(plaintext: &str) -> Option<Self> {
         // This will both reject tokens without a prefix and tokens of the wrong kind.
         if !plaintext.starts_with(TOKEN_PREFIX) {
@@ -70,6 +56,20 @@ pub(crate) struct NewSecureToken {
 }
 
 impl NewSecureToken {
+    pub(crate) fn generate() -> Self {
+        let plaintext = format!(
+            "{}{}",
+            TOKEN_PREFIX,
+            generate_secure_alphanumeric_string(TOKEN_LENGTH)
+        );
+        let sha256 = SecureToken::hash(&plaintext);
+
+        Self {
+            plaintext,
+            inner: SecureToken { sha256 },
+        }
+    }
+
     pub(crate) fn plaintext(&self) -> &str {
         &self.plaintext
     }
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_generated_and_parse() {
-        let token = SecureToken::generate();
+        let token = NewSecureToken::generate();
         assert!(token.plaintext().starts_with(TOKEN_PREFIX));
         assert_eq!(
             token.sha256,


### PR DESCRIPTION
While the `generate()` fn is generating a `SecureToken`, it is also returning the plaintext representation inside a `NewSecureToken` struct, so it makes more sense for this method to be on the corresponding impl block.