### PR TITLE
tests/util: Remove unused `Error` struct

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -361,8 +361,3 @@ impl MockTokenUser {
         self.add_named_owner(krate_name, username).good();
     }
 }
-
-#[derive(Deserialize, Debug)]
-pub struct Error {
-    pub detail: String,
-}


### PR DESCRIPTION
I would've expected `clippy` to complain about this being unused, but apparently not... 🤷‍♂️ 