### PR TITLE
ApiToken: Remove unused `Clone` implementations

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -12,7 +12,7 @@ use crate::util::rfc3339;
 use crate::util::token::{NewSecureToken, SecureToken};
 
 /// The model representing a row in the `api_tokens` database table.
-#[derive(Clone, Debug, PartialEq, Eq, Identifiable, Queryable, Associations, Serialize)]
+#[derive(Debug, PartialEq, Eq, Identifiable, Queryable, Associations, Serialize)]
 #[diesel(belongs_to(User))]
 pub struct ApiToken {
     pub id: i32,

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -8,7 +8,7 @@ const TOKEN_LENGTH: usize = 32;
 /// revoke all the tokens, disrupting production users.
 const TOKEN_PREFIX: &str = "cio";
 
-#[derive(FromSqlRow, AsExpression, Clone, PartialEq, Eq)]
+#[derive(FromSqlRow, AsExpression, PartialEq, Eq)]
 #[diesel(sql_type = Bytea)]
 pub struct SecureToken {
     sha256: Vec<u8>,


### PR DESCRIPTION
Implementing `Clone` makes it harder for us to use the `secrecy` crate, and since we don't use `.clone()` on these structs there is no reason for us to derive an implementation for this trait.