### PR TITLE
ApiToken: Remove unused `PartialEq` and `Eq` implementations

### DIFF
--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -12,12 +12,13 @@ use crate::util::rfc3339;
 use crate::util::token::{NewSecureToken, SecureToken};
 
 /// The model representing a row in the `api_tokens` database table.
-#[derive(Debug, PartialEq, Eq, Identifiable, Queryable, Associations, Serialize)]
+#[derive(Debug, Identifiable, Queryable, Associations, Serialize)]
 #[diesel(belongs_to(User))]
 pub struct ApiToken {
     pub id: i32,
     #[serde(skip)]
     pub user_id: i32,
+    #[allow(dead_code)]
     #[serde(skip)]
     token: SecureToken,
     pub name: String,

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -8,7 +8,7 @@ const TOKEN_LENGTH: usize = 32;
 /// revoke all the tokens, disrupting production users.
 const TOKEN_PREFIX: &str = "cio";
 
-#[derive(FromSqlRow, AsExpression, PartialEq, Eq)]
+#[derive(FromSqlRow, AsExpression)]
 #[diesel(sql_type = Bytea)]
 pub struct SecureToken {
     sha256: Vec<u8>,


### PR DESCRIPTION
It looks like we don't have any code comparing `ApiToken`, so we don't need the `Eq` implementations either. Since the only reason we had them on `SecureToken` was that it is included in `ApiToken`, I've removed them too.