### PR TITLE
Use `secrecy` structs for API token handling code

### DIFF
--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -2,7 +2,7 @@ use crate::app::AppState;
 use crate::controllers::frontend_prelude::*;
 use crate::models::{ApiToken, User};
 use crate::schema::api_tokens;
-use crate::util::token::SecureToken;
+use crate::util::token::HashedToken;
 use anyhow::{anyhow, Context};
 use axum::body::Bytes;
 use base64::{engine::general_purpose, Engine};
@@ -159,7 +159,7 @@ fn alert_revoke_token(
 ) -> Result<GitHubSecretAlertFeedbackLabel, BoxedAppError> {
     let conn = &mut *state.db_write()?;
 
-    let hashed_token = SecureToken::hash(&alert.token);
+    let hashed_token = HashedToken::hash(&alert.token);
 
     // Not using `ApiToken::find_by_api_token()` in order to preserve `last_used_at`
     let token = api_tokens::table

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -9,7 +9,7 @@ use crate::models::User;
 use crate::schema::api_tokens;
 use crate::util::errors::{AppResult, InsecurelyGeneratedTokenRevoked};
 use crate::util::rfc3339;
-use crate::util::token::{HashedToken, NewSecureToken};
+use crate::util::token::{HashedToken, PlainToken};
 
 /// The model representing a row in the `api_tokens` database table.
 #[derive(Debug, Identifiable, Queryable, Associations, Serialize)]
@@ -50,7 +50,7 @@ impl ApiToken {
         endpoint_scopes: Option<Vec<EndpointScope>>,
         expired_at: Option<NaiveDateTime>,
     ) -> AppResult<CreatedApiToken> {
-        let token = NewSecureToken::generate();
+        let token = PlainToken::generate();
 
         let model: ApiToken = diesel::insert_into(api_tokens::table)
             .values((
@@ -109,7 +109,7 @@ mod tests {
         let tok = ApiToken {
             id: 12345,
             user_id: 23456,
-            token: NewSecureToken::generate().hashed(),
+            token: PlainToken::generate().hashed(),
             revoked: false,
             name: "".to_string(),
             created_at: NaiveDate::from_ymd_opt(2017, 1, 6)

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -9,7 +9,7 @@ use crate::models::User;
 use crate::schema::api_tokens;
 use crate::util::errors::{AppResult, InsecurelyGeneratedTokenRevoked};
 use crate::util::rfc3339;
-use crate::util::token::{NewSecureToken, SecureToken};
+use crate::util::token::{HashedToken, NewSecureToken};
 
 /// The model representing a row in the `api_tokens` database table.
 #[derive(Debug, Identifiable, Queryable, Associations, Serialize)]
@@ -20,7 +20,7 @@ pub struct ApiToken {
     pub user_id: i32,
     #[allow(dead_code)]
     #[serde(skip)]
-    token: SecureToken,
+    token: HashedToken,
     pub name: String,
     #[serde(with = "rfc3339")]
     pub created_at: NaiveDateTime,
@@ -74,7 +74,7 @@ impl ApiToken {
         use diesel::{dsl::now, update};
 
         let token_ =
-            SecureToken::parse(token_).ok_or_else(InsecurelyGeneratedTokenRevoked::boxed)?;
+            HashedToken::parse(token_).ok_or_else(InsecurelyGeneratedTokenRevoked::boxed)?;
 
         let tokens = api_tokens
             .filter(revoked.eq(false))

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -2,7 +2,7 @@ mod scopes;
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 
 pub use self::scopes::{CrateScope, EndpointScope};
 use crate::models::User;
@@ -64,7 +64,7 @@ impl ApiToken {
             .get_result(conn)?;
 
         Ok(CreatedApiToken {
-            plaintext: SecretString::from(token.plaintext().to_string()),
+            plaintext: SecretString::from(token.expose_secret().to_string()),
             model,
         })
     }

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -2,7 +2,6 @@ mod scopes;
 
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
-use secrecy::{ExposeSecret, SecretString};
 
 pub use self::scopes::{CrateScope, EndpointScope};
 use crate::models::User;
@@ -64,7 +63,7 @@ impl ApiToken {
             .get_result(conn)?;
 
         Ok(CreatedApiToken {
-            plaintext: SecretString::from(token.expose_secret().to_string()),
+            plaintext: token,
             model,
         })
     }
@@ -96,7 +95,7 @@ impl ApiToken {
 #[derive(Debug)]
 pub struct CreatedApiToken {
     pub model: ApiToken,
-    pub plaintext: SecretString,
+    pub plaintext: PlainToken,
 }
 
 #[cfg(test)]

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -56,7 +56,7 @@ impl ApiToken {
             .values((
                 api_tokens::user_id.eq(user_id),
                 api_tokens::name.eq(name),
-                api_tokens::token.eq(&*token),
+                api_tokens::token.eq(token.hashed()),
                 api_tokens::crate_scopes.eq(crate_scopes),
                 api_tokens::endpoint_scopes.eq(endpoint_scopes),
                 api_tokens::expired_at.eq(expired_at),
@@ -109,7 +109,7 @@ mod tests {
         let tok = ApiToken {
             id: 12345,
             user_id: 23456,
-            token: NewSecureToken::generate().into_inner(),
+            token: NewSecureToken::generate().hashed(),
             revoked: false,
             name: "".to_string(),
             created_at: NaiveDate::from_ymd_opt(2017, 1, 6)

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -3,7 +3,7 @@ use crate::{RequestHelper, TestApp};
 use crates_io::controllers::github::secret_scanning::{
     GitHubSecretAlertFeedback, GitHubSecretAlertFeedbackLabel,
 };
-use crates_io::util::token::SecureToken;
+use crates_io::util::token::HashedToken;
 use crates_io::{models::ApiToken, schema::api_tokens};
 use diesel::prelude::*;
 use http::StatusCode;
@@ -35,7 +35,7 @@ fn github_secret_alert_revokes_token() {
 
     // Set token to expected value in signed request
     app.db(|conn| {
-        let hashed_token = SecureToken::hash("some_token");
+        let hashed_token = HashedToken::hash("some_token");
         diesel::update(api_tokens::table)
             .set(api_tokens::token.eq(hashed_token))
             .execute(conn)
@@ -93,7 +93,7 @@ fn github_secret_alert_for_revoked_token() {
 
     // Set token to expected value in signed request and revoke it
     app.db(|conn| {
-        let hashed_token = SecureToken::hash("some_token");
+        let hashed_token = HashedToken::hash("some_token");
         diesel::update(api_tokens::table)
             .set((
                 api_tokens::token.eq(hashed_token),

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -32,8 +32,9 @@ use axum::body::Bytes;
 use chrono::NaiveDateTime;
 use cookie::Cookie;
 use crates_io::models::token::{CrateScope, EndpointScope};
+use crates_io::util::token::PlainToken;
 use http::header;
-use secrecy::{ExposeSecret, SecretString};
+use secrecy::ExposeSecret;
 use std::collections::HashMap;
 use tower_service::Service;
 
@@ -332,7 +333,7 @@ impl MockTokenUser {
         &self.token.model
     }
 
-    pub fn plaintext(&self) -> &SecretString {
+    pub fn plaintext(&self) -> &PlainToken {
         &self.token.plaintext
     }
 

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -67,13 +67,15 @@ impl PlainToken {
         Self { plaintext }
     }
 
-    pub(crate) fn plaintext(&self) -> &str {
-        self.plaintext.expose_secret()
-    }
-
     pub fn hashed(&self) -> HashedToken {
-        let sha256 = HashedToken::hash(self.plaintext());
+        let sha256 = HashedToken::hash(self.plaintext.expose_secret());
         HashedToken { sha256 }
+    }
+}
+
+impl ExposeSecret<String> for PlainToken {
+    fn expose_secret(&self) -> &String {
+        self.plaintext.expose_secret()
     }
 }
 
@@ -94,13 +96,14 @@ mod tests {
     #[test]
     fn test_generated_and_parse() {
         let token = PlainToken::generate();
-        assert!(token.plaintext().starts_with(TOKEN_PREFIX));
+        assert!(token.expose_secret().starts_with(TOKEN_PREFIX));
         assert_eq!(
             token.hashed().sha256,
-            Sha256::digest(token.plaintext().as_bytes()).as_slice()
+            Sha256::digest(token.expose_secret().as_bytes()).as_slice()
         );
 
-        let parsed = HashedToken::parse(token.plaintext()).expect("failed to parse back the token");
+        let parsed =
+            HashedToken::parse(token.expose_secret()).expect("failed to parse back the token");
         assert_eq!(parsed.sha256, token.hashed().sha256);
     }
 

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -51,7 +51,8 @@ impl FromSql<Bytea, Pg> for HashedToken {
     }
 }
 
-pub(crate) struct PlainToken {
+#[derive(Debug)]
+pub struct PlainToken {
     plaintext: SecretString,
 }
 

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -53,9 +53,7 @@ impl FromSql<Bytea, Pg> for HashedToken {
 }
 
 #[derive(Debug)]
-pub struct PlainToken {
-    plaintext: SecretString,
-}
+pub struct PlainToken(SecretString);
 
 impl PlainToken {
     pub(crate) fn generate() -> Self {
@@ -66,18 +64,18 @@ impl PlainToken {
         )
         .into();
 
-        Self { plaintext }
+        Self(plaintext)
     }
 
     pub fn hashed(&self) -> HashedToken {
-        let sha256 = HashedToken::hash(self.plaintext.expose_secret()).into();
+        let sha256 = HashedToken::hash(self.expose_secret()).into();
         HashedToken { sha256 }
     }
 }
 
 impl ExposeSecret<String> for PlainToken {
     fn expose_secret(&self) -> &String {
-        self.plaintext.expose_secret()
+        self.0.expose_secret()
     }
 }
 

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -50,11 +50,11 @@ impl FromSql<Bytea, Pg> for HashedToken {
     }
 }
 
-pub(crate) struct NewSecureToken {
+pub(crate) struct PlainToken {
     plaintext: String,
 }
 
-impl NewSecureToken {
+impl PlainToken {
     pub(crate) fn generate() -> Self {
         let plaintext = format!(
             "{}{}",
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn test_generated_and_parse() {
-        let token = NewSecureToken::generate();
+        let token = PlainToken::generate();
         assert!(token.plaintext().starts_with(TOKEN_PREFIX));
         assert_eq!(
             token.hashed().sha256,


### PR DESCRIPTION
This renames and cleans up our API token handling structs, and then ultimately introduces the `secrecy` structs into them, to ensure that we don't accidentally leak any tokens via debug logging or other methods.