### PR TITLE
mirage: Add support for `expiredAt` field on API token requests/responses

### DIFF
--- a/mirage/factories/api-token.js
+++ b/mirage/factories/api-token.js
@@ -4,6 +4,7 @@ export default Factory.extend({
   crateScopes: null,
   createdAt: '2017-11-19T17:59:22',
   endpointScopes: null,
+  expiredAt: null,
   lastUsedAt: null,
   name: i => `API Token ${i + 1}`,
   token: () => generateToken(),

--- a/mirage/serializers/api-token.js
+++ b/mirage/serializers/api-token.js
@@ -20,6 +20,9 @@ export default BaseSerializer.extend({
     if (hash.created_at) {
       hash.created_at = new Date(hash.created_at).toISOString();
     }
+    if (hash.expired_at) {
+      hash.expired_at = new Date(hash.expired_at).toISOString();
+    }
     if (hash.last_used_at) {
       hash.last_used_at = new Date(hash.last_used_at).toISOString();
     }

--- a/tests/mirage/me/tokens/create-test.js
+++ b/tests/mirage/me/tokens/create-test.js
@@ -28,6 +28,7 @@ module('Mirage | PUT /api/v1/me/tokens', function (hooks) {
         crate_scopes: null,
         created_at: '2017-11-20T11:23:45.000Z',
         endpoint_scopes: null,
+        expired_at: null,
         last_used_at: null,
         name: 'foooo',
         revoked: false,
@@ -61,6 +62,40 @@ module('Mirage | PUT /api/v1/me/tokens', function (hooks) {
         crate_scopes: ['serde', 'serde-*'],
         created_at: '2017-11-20T11:23:45.000Z',
         endpoint_scopes: ['publish-update'],
+        expired_at: null,
+        last_used_at: null,
+        name: 'foooo',
+        revoked: false,
+        token: token.token,
+      },
+    });
+  });
+
+  test('creates a new API token with expiry date', async function (assert) {
+    this.clock.setSystemTime(new Date('2017-11-20T11:23:45Z'));
+
+    let user = this.server.create('user');
+    this.server.create('mirage-session', { user });
+
+    let body = JSON.stringify({
+      api_token: {
+        name: 'foooo',
+        expired_at: '2023-12-24T12:34:56Z',
+      },
+    });
+    let response = await fetch('/api/v1/me/tokens', { method: 'PUT', body });
+    assert.strictEqual(response.status, 200);
+
+    let token = this.server.schema.apiTokens.all().models[0];
+    assert.ok(token);
+
+    assert.deepEqual(await response.json(), {
+      api_token: {
+        id: 1,
+        crate_scopes: null,
+        created_at: '2017-11-20T11:23:45.000Z',
+        endpoint_scopes: null,
+        expired_at: '2023-12-24T12:34:56.000Z',
         last_used_at: null,
         name: 'foooo',
         revoked: false,

--- a/tests/mirage/me/tokens/list-test.js
+++ b/tests/mirage/me/tokens/list-test.js
@@ -19,8 +19,9 @@ module('Mirage | GET /api/v1/me/tokens', function (hooks) {
       crateScopes: ['serde', 'serde-*'],
       endpointScopes: ['publish-update'],
     });
-    this.server.create('api-token', { user, createdAt: '2017-11-19T13:59:22Z' });
+    this.server.create('api-token', { user, createdAt: '2017-11-19T13:59:22Z', expiredAt: '2023-11-20T10:59:22Z' });
     this.server.create('api-token', { user, createdAt: '2017-11-19T14:59:22Z' });
+    this.server.create('api-token', { user, createdAt: '2017-11-19T15:59:22Z', expiredAt: '2017-11-20T10:59:22Z' });
 
     let response = await fetch('/api/v1/me/tokens');
     assert.strictEqual(response.status, 200);
@@ -31,6 +32,7 @@ module('Mirage | GET /api/v1/me/tokens', function (hooks) {
           crate_scopes: null,
           created_at: '2017-11-19T14:59:22.000Z',
           endpoint_scopes: null,
+          expired_at: null,
           last_used_at: null,
           name: 'API Token 3',
         },
@@ -39,6 +41,7 @@ module('Mirage | GET /api/v1/me/tokens', function (hooks) {
           crate_scopes: null,
           created_at: '2017-11-19T13:59:22.000Z',
           endpoint_scopes: null,
+          expired_at: '2023-11-20T10:59:22.000Z',
           last_used_at: null,
           name: 'API Token 2',
         },
@@ -47,6 +50,7 @@ module('Mirage | GET /api/v1/me/tokens', function (hooks) {
           crate_scopes: ['serde', 'serde-*'],
           created_at: '2017-11-19T12:59:22.000Z',
           endpoint_scopes: ['publish-update'],
+          expired_at: null,
           last_used_at: null,
           name: 'API Token 1',
         },


### PR DESCRIPTION
Related:

- https://github.com/rust-lang/crates.io/pull/6611