### PR TITLE
publish: Save build metadata containing versions to escaped path too

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -248,9 +248,12 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             }
 
             // Upload crate tarball
-            app.config
-                .uploader()
-                .upload_crate(app.http_client(), tarball_bytes, &krate, vers)?;
+            app.config.uploader().upload_crate(
+                app.http_client(),
+                tarball_bytes,
+                &krate.name,
+                &vers.to_string(),
+            )?;
 
             Job::enqueue_sync_to_index(&krate.name, conn)?;
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -248,6 +248,17 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             }
 
             // Upload crate tarball
+
+            if !vers.build.is_empty() {
+                let escaped_version = vers.to_string().replace('+', "%2B");
+                app.config.uploader().upload_crate(
+                    app.http_client(),
+                    tarball_bytes.clone(),
+                    &krate.name,
+                    &escaped_version,
+                )?;
+            }
+
             app.config.uploader().upload_crate(
                 app.http_client(),
                 tarball_bytes,

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_1.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_1.json
@@ -1,6 +1,36 @@
 [
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0%2Bfoo.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0+foo.crate",
       "method": "PUT",
       "headers": [

--- a/src/tests/http-data/krate_publish_version_with_build_metadata_3.json
+++ b/src/tests/http-data/krate_publish_version_with_build_metadata_3.json
@@ -1,6 +1,36 @@
 [
   {
     "request": {
+      "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0%2Bfoo.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://alexcrichton-test.s3.amazonaws.com/crates/foo/foo-1.0.0+foo.crate",
       "method": "PUT",
       "headers": [

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -8,8 +8,6 @@ use std::env;
 use std::fs::{self, File};
 use std::path::PathBuf;
 
-use crate::models::Crate;
-
 const CACHE_CONTROL_IMMUTABLE: &str = "public,max-age=31536000,immutable";
 const CACHE_CONTROL_README: &str = "public,max-age=604800";
 const CACHE_CONTROL_INDEX: &str = "public,max-age=600";
@@ -181,10 +179,10 @@ impl Uploader {
         &self,
         http_client: &Client,
         body: R,
-        krate: &Crate,
-        vers: &semver::Version,
+        krate: &str,
+        vers: &str,
     ) -> AppResult<()> {
-        let path = Uploader::crate_path(&krate.name, &vers.to_string());
+        let path = Uploader::crate_path(krate, vers);
         let mut extra_headers = header::HeaderMap::new();
         extra_headers.insert(
             header::CACHE_CONTROL,


### PR DESCRIPTION
This implements part one of the proposed solution in https://github.com/rust-lang/crates.io/issues/4891#issuecomment-1580879109: if a published version contains a `+` (aka. it contains build metadata), we temporarily upload the crate file to the unescaped (`+`) and escaped (`%2B`) S3 paths.