### PR TITLE
worker/readmes: Save the README of build metadata containing versions to escaped path too

### DIFF
--- a/src/tests/http-data/krate_publish_new_krate_with_readme_and_plus_version.json
+++ b/src/tests/http-data/krate_publish_new_krate_with_readme_and_plus_version.json
@@ -250,6 +250,89 @@
   },
   {
     "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/readmes/foo_readme/foo_readme-1.0.0%2Bfoo.html",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-type",
+          "text/html"
+        ]
+      ],
+      "body": ""
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"d41d8cd98f00b204e9800998ecf8427e\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A61677EBE"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://127.0.0.1:19000/crates-test/readmes/foo_readme/foo_readme-1.0.0+foo.html",
       "method": "PUT",
       "headers": [

--- a/src/tests/http-data/krate_publish_new_krate_with_readme_and_plus_version.json
+++ b/src/tests/http-data/krate_publish_new_krate_with_readme_and_plus_version.json
@@ -1,0 +1,334 @@
+[
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_readme/foo_readme-1.0.0%2Bfoo.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5C13BF3C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_readme/foo_readme-1.0.0+foo.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5C13BF3C"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_readme",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "155"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"foo_readme\",\"vers\":\"1.0.0+foo\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"cf380f14a440ced148f97ac8a6d0bc0d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A60B5472D"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/readmes/foo_readme/foo_readme-1.0.0+foo.html",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-type",
+          "text/html"
+        ]
+      ],
+      "body": ""
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"d41d8cd98f00b204e9800998ecf8427e\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A61677EBE"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  }
+]

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -596,6 +596,19 @@ fn new_krate_with_readme() {
 }
 
 #[test]
+fn new_krate_with_readme_and_plus_version() {
+    let (_, _, _, token) = TestApp::full().with_token();
+
+    let crate_to_publish = PublishBuilder::new("foo_readme")
+        .version("1.0.0+foo")
+        .readme("");
+    let json = token.publish_crate(crate_to_publish).good();
+
+    assert_eq!(json.krate.name, "foo_readme");
+    assert_eq!(json.krate.max_version, "1.0.0+foo");
+}
+
+#[test]
 fn new_krate_without_any_email_fails() {
     let (app, _, _, token) = TestApp::full().with_token();
 

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -34,8 +34,19 @@ pub fn perform_render_and_upload_readme(
 
         tracing::Span::current().record("krate.name", tracing::field::display(&crate_name));
 
+        if vers.contains('+') {
+            let escaped_version = vers.replace('+', "%2B");
+            env.uploader.upload_readme(
+                env.http_client(),
+                &crate_name,
+                &escaped_version,
+                rendered.clone(),
+            )?;
+        }
+
         env.uploader
             .upload_readme(env.http_client(), &crate_name, &vers, rendered)?;
+
         Ok(())
     })
 }


### PR DESCRIPTION
This PR is similar to https://github.com/rust-lang/crates.io/pull/6649, but this time for the rendered README files, which have the same [problem](https://github.com/rust-lang/crates.io/issues/4891) as the crate tarball files.