### PR TITLE
Stop uploading to S3 with unescaped paths

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -191,24 +191,12 @@ impl Storage {
 
     #[instrument(skip(self))]
     pub async fn upload_crate_file(&self, name: &str, version: &str, bytes: Bytes) -> Result<()> {
-        if version.contains('+') {
-            let version = version.replace('+', " ");
-            let path = crate_file_path(name, &version);
-            self.crate_upload_store.put(&path, bytes.clone()).await?
-        }
-
         let path = crate_file_path(name, version);
         self.crate_upload_store.put(&path, bytes).await
     }
 
     #[instrument(skip(self))]
     pub async fn upload_readme(&self, name: &str, version: &str, bytes: Bytes) -> Result<()> {
-        if version.contains('+') {
-            let version = version.replace('+', " ");
-            let path = readme_path(name, &version);
-            self.readme_upload_store.put(&path, bytes.clone()).await?
-        }
-
         let path = readme_path(name, version);
         self.readme_upload_store.put(&path, bytes).await
     }
@@ -381,7 +369,6 @@ mod tests {
 
         let expected_files = vec![
             "crates/foo/foo-1.2.3.crate",
-            "crates/foo/foo-2.0.0 foo.crate",
             "crates/foo/foo-2.0.0+foo.crate",
         ];
         assert_eq!(stored_files(&s.store).await, expected_files);
@@ -403,7 +390,6 @@ mod tests {
 
         let expected_files = vec![
             "readmes/foo/foo-1.2.3.html",
-            "readmes/foo/foo-2.0.0 foo.html",
             "readmes/foo/foo-2.0.0+foo.html",
         ];
         assert_eq!(stored_files(&s.store).await, expected_files);

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -681,10 +681,8 @@ fn new_krate_with_readme_and_plus_version() {
     assert_eq!(json.krate.max_version, "1.0.0+foo");
 
     let expected_files = vec![
-        "crates/foo_readme/foo_readme-1.0.0 foo.crate",
         "crates/foo_readme/foo_readme-1.0.0+foo.crate",
         "index/fo/o_/foo_readme",
-        "readmes/foo_readme/foo_readme-1.0.0 foo.html",
         "readmes/foo_readme/foo_readme-1.0.0+foo.html",
     ];
     assert_eq!(app.stored_files(), expected_files);


### PR DESCRIPTION
This PR implements step 5 of https://github.com/rust-lang/crates.io/issues/4891#issuecomment-1580879109.

This essentially reverts #6649 and #6660, but keeps the escaped code paths that were added in those PRs and removes the ones that were there before.

This PR must only be merged once #6665 has been merged!