### PR TITLE
header: correctly align baselines when logged in

### DIFF
--- a/app/components/header.module.css
+++ b/app/components/header.module.css
@@ -101,7 +101,7 @@
 .nav {
     grid-area: nav;
     display: flex;
-    align-items: center;
+    align-items: stretch;
     justify-self: end;
 
     @media only screen and (max-width: 900px) {
@@ -166,7 +166,8 @@
     padding: 0;
 
     img {
-        vertical-align: top;
+        /* 22px is the hard coded size of a UserAvatar when @size="small" */
+        margin-top: calc((22px - 1em) * -0.5);
     }
 }
 


### PR DESCRIPTION
Warning: you won't be able to unsee what I'm about to show you.

<details><summary>Disturbing animation</summary>
<p>

![cursed](https://github.com/rust-lang/crates.io/assets/229984/2446e740-f2e5-45ba-a30a-2323d98d1c76)

</p>
</details> 

When a user is logged out of crates.io, the text `Browse All Crates` is nicely aligned with `Log In With GitHub`. Awesome.

When a user is logged _in_ to crates.io, the baseline of the user's name is three pixels higher than the `Browse All Crates` link. Ruinous.

The reason for this is that the `UserAvatar` component ends up being taller than the `Browse All Crates` element due to the extra height of the avatar image (22px vs the 16px font size). If we apply a small negative `margin-top` to the avatar and make all the `.nav` elements stretch to the same height by using `align-items: stretch`, then both elements are then rendered with the same baseline.