### PR TITLE
tests: fix API token test after midnight UTC

### DIFF
--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -153,7 +153,7 @@ module('/settings/tokens/new', function (hooks) {
     await fillIn('[data-test-name]', 'token-name');
     await select('[data-test-expiry]', '30');
 
-    let expiryDate = new Date('2017-12-20');
+    let expiryDate = new Date('2017-12-20T00:00:00');
     let expectedDate = expiryDate.toLocaleDateString(undefined, { dateStyle: 'long' });
     let expectedDescription = `The token will expire on ${expectedDate}`;
     assert.dom('[data-test-expiry-description]').hasText(expectedDescription);


### PR DESCRIPTION
Apparently this test was a gremlin and should not have been ~~fed~~ run after midnight.

JavaScript dates created with only a date are created in UTC, not in local time, which causes problems with the later assertions around the date as displayed in the local time zone. Quoting from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#date_time_string_format:

> When the time zone offset is absent, date-only forms are interpreted
> as a UTC time and date-time forms are interpreted as local time. This
> is due to a historical spec error that was not consistent with ISO
> 8601 but could not be changed due to web compatibility. See Broken
> Parser – A Web Reality Issue.

We can fix this by also including the time without a time zone, at which point the local time zone will be used.