### PR TITLE
Show recently expired API tokens in the UI

### DIFF
--- a/app/adapters/api-token.js
+++ b/app/adapters/api-token.js
@@ -7,13 +7,6 @@ export default class ApiTokenAdapter extends ApplicationAdapter {
     return 'tokens';
   }
 
-  buildQuery(...args) {
-    const query = super.buildQuery(...args);
-    query.expired_days = 30;
-
-    return query;
-  }
-
   createRecord(store, type, snapshot) {
     let data = {};
     let serializer = store.serializerFor(type.modelName);

--- a/app/adapters/api-token.js
+++ b/app/adapters/api-token.js
@@ -7,6 +7,13 @@ export default class ApiTokenAdapter extends ApplicationAdapter {
     return 'tokens';
   }
 
+  buildQuery(...args) {
+    const query = super.buildQuery(...args);
+    query.expired_days = 30;
+
+    return query;
+  }
+
   createRecord(store, type, snapshot) {
     let data = {};
     let serializer = store.serializerFor(type.modelName);

--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -34,7 +34,7 @@
 {{#if this.sortedTokens}}
   <ul role="list" local-class="token-list">
     {{#each this.sortedTokens as |token|}}
-      <li local-class="row" data-test-api-token={{or token.id true}}>
+      <li local-class="row {{if token.isExpired "expired"}}" data-test-api-token={{or token.id true}}>
         <h3 local-class="name" data-test-name>
           {{token.name}}
         </h3>
@@ -86,7 +86,7 @@
 
           {{#if token.expired_at}}
             <div title={{token.expired_at}} local-class="expired-at" data-test-expired-at>
-              Expires {{date-format-distance-to-now token.expired_at addSuffix=true}}
+              {{if token.isExpired "Expired" "Expires"}} {{date-format-distance-to-now token.expired_at addSuffix=true}}
             </div>
           {{/if}}
         </div>
@@ -111,18 +111,20 @@
         {{/if}}
 
         <div local-class="actions">
-          <button
-            type="button"
-            local-class="revoke-button"
-            disabled={{token.isSaving}}
-            data-test-revoke-token-button
-            {{on "click" (perform this.revokeTokenTask token)}}
-          >
-            Revoke
-          </button>
-          {{#if token.isSaving}}
-            <LoadingSpinner local-class="spinner" data-test-saving-spinner />
-          {{/if}}
+          {{#unless token.isExpired}}
+            <button
+              type="button"
+              local-class="revoke-button"
+              disabled={{token.isSaving}}
+              data-test-revoke-token-button
+              {{on "click" (perform this.revokeTokenTask token)}}
+            >
+              Revoke
+            </button>
+            {{#if token.isSaving}}
+              <LoadingSpinner local-class="spinner" data-test-saving-spinner />
+            {{/if}}
+          {{/unless}}
         </div>
       </li>
     {{/each}}

--- a/app/components/settings/api-tokens.js
+++ b/app/components/settings/api-tokens.js
@@ -15,7 +15,19 @@ export default class ApiTokens extends Component {
   patternDescription = patternDescription;
 
   get sortedTokens() {
-    return this.args.tokens.filter(t => !t.isNew).sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+    return this.args.tokens
+      .filter(t => !t.isNew)
+      .sort((a, b) => {
+        // Expired tokens are always shown after active ones.
+        if (a.isExpired && !b.isExpired) {
+          return 1;
+        } else if (b.isExpired && !a.isExpired) {
+          return -1;
+        }
+
+        // Otherwise, sort normally based on creation time.
+        return a.created_at < b.created_at ? 1 : -1;
+      });
   }
 
   listToParts(list) {

--- a/app/components/settings/api-tokens.module.css
+++ b/app/components/settings/api-tokens.module.css
@@ -155,6 +155,10 @@
     border-radius: 4px;
 }
 
+.expired {
+    opacity: 0.6;
+}
+
 @media (min-width: 640px) {
     .new-token-form {
         display: grid;

--- a/app/models/api-token.js
+++ b/app/models/api-token.js
@@ -11,4 +11,11 @@ export default class ApiToken extends Model {
   @attr endpoint_scopes;
   /** @type string | null */
   @attr('date') expired_at;
+
+  get isExpired() {
+    if (this.expired_at) {
+      return Date.now() > this.expired_at.getTime();
+    }
+    return false;
+  }
 }

--- a/app/routes/settings/tokens/index.js
+++ b/app/routes/settings/tokens/index.js
@@ -7,7 +7,7 @@ export default class TokenListRoute extends Route {
   @service store;
 
   async model() {
-    let apiTokens = await this.store.findAll('api-token', { reload: true });
+    let apiTokens = await this.store.query('api-token', { expired_days: 30 });
     return TrackedArray.from(apiTokens.slice());
   }
 

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -34,6 +34,14 @@ module('Acceptance | api-tokens', function (hooks) {
       expiredAt: '2017-12-19T17:59:22',
     });
 
+    context.server.create('api-token', {
+      user,
+      name: 'recently expired',
+      createdAt: '2017-08-01T12:34:56',
+      lastUsedAt: '2017-11-02T01:45:14',
+      expiredAt: '2017-11-19T17:59:22',
+    });
+
     context.authenticateAs(user);
   }
 
@@ -42,9 +50,9 @@ module('Acceptance | api-tokens', function (hooks) {
 
     await visit('/settings/tokens');
     assert.strictEqual(currentURL(), '/settings/tokens');
-    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
 
-    let [row1, row2] = findAll('[data-test-api-token]');
+    let [row1, row2, row3] = findAll('[data-test-api-token]');
     assert.dom('[data-test-name]', row1).hasText('BAR');
     assert.dom('[data-test-created-at]', row1).hasText('Created about 18 hours ago');
     assert.dom('[data-test-last-used-at]', row1).hasText('Never used');
@@ -64,6 +72,16 @@ module('Acceptance | api-tokens', function (hooks) {
     assert.dom('[data-test-saving-spinner]', row2).doesNotExist();
     assert.dom('[data-test-error]', row2).doesNotExist();
     assert.dom('[data-test-token]', row2).doesNotExist();
+
+    assert.dom('[data-test-name]', row3).hasText('recently expired');
+    assert.dom('[data-test-created-at]', row3).hasText('Created 4 months ago');
+    assert.dom('[data-test-last-used-at]', row3).hasText('Last used 18 days ago');
+    assert.dom('[data-test-expired-at]', row3).hasText('Expired about 18 hours ago');
+    assert.dom('[data-test-save-token-button]', row3).doesNotExist();
+    assert.dom('[data-test-revoke-token-button]', row3).doesNotExist();
+    assert.dom('[data-test-saving-spinner]', row3).doesNotExist();
+    assert.dom('[data-test-error]', row3).doesNotExist();
+    assert.dom('[data-test-token]', row3).doesNotExist();
   });
 
   test('API tokens can be revoked', async function (assert) {
@@ -71,16 +89,16 @@ module('Acceptance | api-tokens', function (hooks) {
 
     await visit('/settings/tokens');
     assert.strictEqual(currentURL(), '/settings/tokens');
-    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
 
     await click('[data-test-api-token="1"] [data-test-revoke-token-button]');
     assert.strictEqual(
       this.server.schema.apiTokens.all().length,
-      1,
+      2,
       'API token has been deleted from the backend database',
     );
 
-    assert.dom('[data-test-api-token]').exists({ count: 1 });
+    assert.dom('[data-test-api-token]').exists({ count: 2 });
     assert.dom('[data-test-api-token="2"]').exists();
     assert.dom('[data-test-error]').doesNotExist();
   });
@@ -94,10 +112,10 @@ module('Acceptance | api-tokens', function (hooks) {
 
     await visit('/settings/tokens');
     assert.strictEqual(currentURL(), '/settings/tokens');
-    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
 
     await click('[data-test-api-token="1"] [data-test-revoke-token-button]');
-    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
     assert.dom('[data-test-api-token="2"]').exists();
     assert.dom('[data-test-api-token="1"]').exists();
     assert.dom('[data-test-notification-message="error"]').includesText('An error occurred while revoking this token');
@@ -108,7 +126,7 @@ module('Acceptance | api-tokens', function (hooks) {
 
     await visit('/settings/tokens');
     assert.strictEqual(currentURL(), '/settings/tokens');
-    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
 
     await click('[data-test-new-token-button]');
     assert.strictEqual(currentURL(), '/settings/tokens/new');
@@ -122,11 +140,11 @@ module('Acceptance | api-tokens', function (hooks) {
     let token = this.server.schema.apiTokens.findBy({ name: 'the new token' });
     assert.ok(Boolean(token), 'API token has been created in the backend database');
 
-    assert.dom('[data-test-api-token="3"] [data-test-name]').hasText('the new token');
-    assert.dom('[data-test-api-token="3"] [data-test-save-token-button]').doesNotExist();
-    assert.dom('[data-test-api-token="3"] [data-test-revoke-token-button]').exists();
-    assert.dom('[data-test-api-token="3"] [data-test-saving-spinner]').doesNotExist();
-    assert.dom('[data-test-api-token="3"] [data-test-error]').doesNotExist();
+    assert.dom('[data-test-api-token="4"] [data-test-name]').hasText('the new token');
+    assert.dom('[data-test-api-token="4"] [data-test-save-token-button]').doesNotExist();
+    assert.dom('[data-test-api-token="4"] [data-test-revoke-token-button]').exists();
+    assert.dom('[data-test-api-token="4"] [data-test-saving-spinner]').doesNotExist();
+    assert.dom('[data-test-api-token="4"] [data-test-error]').doesNotExist();
     assert.dom('[data-test-token]').hasText(token.token);
   });
 
@@ -154,13 +172,13 @@ module('Acceptance | api-tokens', function (hooks) {
     prepare(this);
 
     await visit('/settings/tokens');
-    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
 
     await click('[data-test-new-token-button]');
 
     await visit('/settings/profile');
 
     await visit('/settings/tokens');
-    assert.dom('[data-test-api-token]').exists({ count: 2 });
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
   });
 });


### PR DESCRIPTION
As [previously discussed](https://github.com/rust-lang/crates.io/pull/6611#pullrequestreview-1479942646), we may want to show recently expired tokens to users so they can answer the question of "why isn't my request authenticating any more". This PR does the minimum required to provide those tokens from the API, and then use that to display them in the UI.

Be gentle with me on the Ember code; I'm still feeling my way around it!