### PR TITLE
settings/tokens/new: Decrease negative margin on crates scope input field

### DIFF
--- a/app/styles/settings/tokens/new.module.css
+++ b/app/styles/settings/tokens/new.module.css
@@ -150,7 +150,7 @@
     }
 
     input {
-        margin: calc(-1 * var(--space-3xs) - 2px) 0;
+        margin: calc(-1 * var(--space-4xs)) 0;
         padding: var(--space-3xs) var(--space-2xs);
         border: 1px solid var(--gray-border);
         border-radius: var(--space-3xs);


### PR DESCRIPTION
https://twitter.com/HashRust/status/1672440730089033729 made me realize that the negative margin doesn't work particularly well on mobile devices, so this PR is decreasing it slightly to make it look better on all viewports.