### PR TITLE
Inline test config code

### DIFF
--- a/src/config/balance_capacity.rs
+++ b/src/config/balance_capacity.rs
@@ -20,14 +20,4 @@ impl BalanceCapacityConfig {
             dl_only_at_percentage: env_optional("WEB_CAPACITY_DL_ONLY_PCT").unwrap_or(80),
         }
     }
-
-    pub fn for_testing() -> Self {
-        Self {
-            report_only: false,
-            log_total_at_count: 50,
-            log_at_percentage: 50,
-            throttle_at_percentage: 70,
-            dl_only_at_percentage: 80,
-        }
-    }
 }

--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -12,7 +12,7 @@ use crate::{env, uploaders::Uploader, Env};
 
 pub struct Base {
     pub env: Env,
-    uploader: Uploader,
+    pub uploader: Uploader,
 }
 
 impl Base {
@@ -53,35 +53,6 @@ impl Base {
         };
 
         Self { env, uploader }
-    }
-
-    pub fn test() -> Self {
-        let uploader = Uploader::S3 {
-            bucket: Box::new(s3::Bucket::new(
-                dotenvy::var("TEST_S3_BUCKET").unwrap_or_else(|_err| "crates-test".into()),
-                parse_test_region(dotenvy::var("TEST_S3_REGION").ok()),
-                dotenvy::var("TEST_AWS_ACCESS_KEY").unwrap_or_default(),
-                dotenvy::var("TEST_AWS_SECRET_KEY").unwrap_or_default(),
-                // When testing we route all API traffic over HTTP so we can
-                // sniff/record it, but everywhere else we use https
-                "http",
-            )),
-            index_bucket: Some(Box::new(s3::Bucket::new(
-                dotenvy::var("TEST_S3_INDEX_BUCKET")
-                    .unwrap_or_else(|_err| "crates-index-test".into()),
-                parse_test_region(dotenvy::var("TEST_S3_INDEX_REGION").ok()),
-                dotenvy::var("TEST_AWS_ACCESS_KEY").unwrap_or_default(),
-                dotenvy::var("TEST_AWS_SECRET_KEY").unwrap_or_default(),
-                // When testing we route all API traffic over HTTP so we can
-                // sniff/record it, but everywhere else we use https
-                "http",
-            ))),
-            cdn: None,
-        };
-        Self {
-            env: Env::Test,
-            uploader,
-        }
     }
 
     pub fn uploader(&self) -> &Uploader {
@@ -137,42 +108,6 @@ impl Base {
             )),
             index_bucket,
             cdn: dotenvy::var("S3_CDN").ok(),
-        }
-    }
-}
-
-static DEFAULT_TEST_REGION: &str = "127.0.0.1:19000";
-
-fn parse_test_region(maybe_region: Option<String>) -> s3::Region {
-    match maybe_region {
-        Some(region) if region.contains("://") => {
-            let (_proto, host) = region.split_once("://").unwrap();
-            s3::Region::Host(host.to_string())
-        }
-        Some(region) if !region.is_empty() => s3::Region::Region(region),
-        // An empty or missing region will use the default. This needs to match the region
-        // configuration that was used to generate the cassettes in `src/tests/http-data`.
-        _ => s3::Region::Host(DEFAULT_TEST_REGION.to_string()),
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_region() {
-        for (input, expected) in [
-            (None, s3::Region::Host(DEFAULT_TEST_REGION.into())),
-            (Some(""), s3::Region::Host(DEFAULT_TEST_REGION.into())),
-            (Some("us-west-2"), s3::Region::Region("us-west-2".into())),
-            (Some("http://foo.bar"), s3::Region::Host("foo.bar".into())),
-            (
-                Some("https://127.0.0.1:9000"),
-                s3::Region::Host("127.0.0.1:9000".into()),
-            ),
-        ] {
-            assert_eq!(parse_test_region(input.map(String::from)), expected);
         }
     }
 }

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -133,18 +133,4 @@ impl DatabasePools {
             },
         }
     }
-
-    pub fn test_from_environment() -> Self {
-        DatabasePools {
-            primary: DbPoolConfig {
-                url: env("TEST_DATABASE_URL").into(),
-                read_only_mode: false,
-                pool_size: 1,
-                min_idle: None,
-            },
-            replica: None,
-            tcp_timeout_ms: 1000, // 1 second
-            enforce_tls: false,
-        }
-    }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -372,6 +372,14 @@ fn simple_config() -> config::Server {
         enforce_tls: false,
     };
 
+    let balance_capacity = BalanceCapacityConfig {
+        report_only: false,
+        log_total_at_count: 50,
+        log_at_percentage: 50,
+        throttle_at_percentage: 70,
+        dl_only_at_percentage: 80,
+    };
+
     config::Server {
         base,
         db,
@@ -399,7 +407,7 @@ fn simple_config() -> config::Server {
         version_id_cache_size: 10000,
         version_id_cache_ttl: Duration::from_secs(5 * 60),
         cdn_user_agent: "Amazon CloudFront".to_string(),
-        balance_capacity: BalanceCapacityConfig::for_testing(),
+        balance_capacity,
     }
 }
 


### PR DESCRIPTION
Since these functions are only run by our test suite there is no need for them to live in the production code and we can instead move them to the `tests` module.