### PR TITLE
config: Extract `serve_dist` and `serve_html` flags

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,13 @@ pub struct Server {
     pub version_id_cache_ttl: Duration,
     pub cdn_user_agent: String,
     pub balance_capacity: BalanceCapacityConfig,
+
+    /// Should the server serve the frontend assets in the `dist` directory?
+    pub serve_dist: bool,
+
+    /// Should the server serve the frontend `index.html` for all
+    /// non-API requests?
+    pub serve_html: bool,
 }
 
 impl Default for Server {
@@ -151,6 +158,8 @@ impl Default for Server {
             cdn_user_agent: dotenvy::var("WEB_CDN_USER_AGENT")
                 .unwrap_or_else(|_| "Amazon CloudFront".into()),
             balance_capacity: BalanceCapacityConfig::from_environment(),
+            serve_dist: true,
+            serve_html: true,
         }
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -408,6 +408,10 @@ fn simple_config() -> config::Server {
         version_id_cache_ttl: Duration::from_secs(5 * 60),
         cdn_user_agent: "Amazon CloudFront".to_string(),
         balance_capacity,
+
+        // The frontend code is not needed for the backend tests.
+        serve_dist: false,
+        serve_html: false,
     }
 }
 


### PR DESCRIPTION
Instead of relying on the `env != Env::Test` check we can use explicit flags. This will allow us to selectively enable this behavior for certain tests in the future.