### PR TITLE
config: Increase dev-mode default for `DB_HELPER_THREADS`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,10 +92,9 @@ impl App {
             ),
         );
 
-        let db_helper_threads = match (dotenvy::var("DB_HELPER_THREADS"), config.env()) {
-            (Ok(num), _) => num.parse().expect("couldn't parse DB_HELPER_THREADS"),
-            (_, Env::Production) => 3,
-            _ => 1,
+        let db_helper_threads = match dotenvy::var("DB_HELPER_THREADS") {
+            Ok(num) => num.parse().expect("couldn't parse DB_HELPER_THREADS"),
+            _ => 3,
         };
 
         // Used as the connection and statement timeout value for the database pool(s)


### PR DESCRIPTION
The default value in `r2d2` is also 3 and there appears to be no documented reason why we should use less during development.