### PR TITLE
Move database config code from `app` to `config::database_pools`

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -103,7 +103,7 @@ impl App {
             DieselPool::new_test(&config.db, &config.db.primary.url)
         } else {
             let primary_db_connection_config = ConnectionConfig {
-                statement_timeout: config.db.connection_timeout.as_secs(),
+                statement_timeout: config.db.connection_timeout,
                 read_only: config.db.primary.read_only_mode,
             };
 
@@ -130,7 +130,7 @@ impl App {
                 Some(DieselPool::new_test(&config.db, &pool_config.url))
             } else {
                 let replica_db_connection_config = ConnectionConfig {
-                    statement_timeout: config.db.connection_timeout.as_secs(),
+                    statement_timeout: config.db.connection_timeout,
                     read_only: true,
                 };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -103,7 +103,7 @@ impl App {
             DieselPool::new_test(&config.db, &config.db.primary.url)
         } else {
             let primary_db_connection_config = ConnectionConfig {
-                statement_timeout: config.db.connection_timeout,
+                statement_timeout: config.db.statement_timeout,
                 read_only: config.db.primary.read_only_mode,
             };
 
@@ -130,7 +130,7 @@ impl App {
                 Some(DieselPool::new_test(&config.db, &pool_config.url))
             } else {
                 let replica_db_connection_config = ConnectionConfig {
-                    statement_timeout: config.db.connection_timeout,
+                    statement_timeout: config.db.statement_timeout,
                     read_only: true,
                 };
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -92,12 +92,7 @@ impl App {
             ),
         );
 
-        let db_helper_threads = match dotenvy::var("DB_HELPER_THREADS") {
-            Ok(num) => num.parse().expect("couldn't parse DB_HELPER_THREADS"),
-            _ => 3,
-        };
-
-        let thread_pool = Arc::new(ScheduledThreadPool::new(db_helper_threads));
+        let thread_pool = Arc::new(ScheduledThreadPool::new(config.db.helper_threads));
 
         let primary_database = if config.use_test_database_pool {
             DieselPool::new_test(&config.db, &config.db.primary.url)

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,10 @@
 //! Application-wide components in a struct accessible from each request
 
+use crate::config;
 use crate::db::{ConnectionConfig, DieselPool, DieselPooledConn, PoolError};
-use crate::{config, Env};
 use std::ops::Deref;
 use std::sync::atomic::AtomicUsize;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 
 use crate::downloads_counter::DownloadsCounter;
 use crate::email::Emails;
@@ -97,28 +97,20 @@ impl App {
             _ => 3,
         };
 
-        // Used as the connection and statement timeout value for the database pool(s)
-        let db_connection_timeout = match (dotenvy::var("DB_TIMEOUT"), config.env()) {
-            (Ok(num), _) => num.parse().expect("couldn't parse DB_TIMEOUT"),
-            (_, Env::Production) => 10,
-            (_, Env::Test) => 1,
-            _ => 30,
-        };
-
         let thread_pool = Arc::new(ScheduledThreadPool::new(db_helper_threads));
 
         let primary_database = if config.use_test_database_pool {
             DieselPool::new_test(&config.db, &config.db.primary.url)
         } else {
             let primary_db_connection_config = ConnectionConfig {
-                statement_timeout: db_connection_timeout,
+                statement_timeout: config.db.connection_timeout.as_secs(),
                 read_only: config.db.primary.read_only_mode,
             };
 
             let primary_db_config = r2d2::Pool::builder()
                 .max_size(config.db.primary.pool_size)
                 .min_idle(config.db.primary.min_idle)
-                .connection_timeout(Duration::from_secs(db_connection_timeout))
+                .connection_timeout(config.db.connection_timeout)
                 .connection_customizer(Box::new(primary_db_connection_config))
                 .thread_pool(thread_pool.clone());
 
@@ -138,14 +130,14 @@ impl App {
                 Some(DieselPool::new_test(&config.db, &pool_config.url))
             } else {
                 let replica_db_connection_config = ConnectionConfig {
-                    statement_timeout: db_connection_timeout,
+                    statement_timeout: config.db.connection_timeout.as_secs(),
                     read_only: true,
                 };
 
                 let replica_db_config = r2d2::Pool::builder()
                     .max_size(pool_config.pool_size)
                     .min_idle(pool_config.min_idle)
-                    .connection_timeout(Duration::from_secs(db_connection_timeout))
+                    .connection_timeout(config.db.connection_timeout)
                     .connection_customizer(Box::new(replica_db_connection_config))
                     .thread_pool(thread_pool);
 

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -31,6 +31,9 @@ pub struct DatabasePools {
     /// Time to wait for a connection to become available from the connection
     /// pool before returning an error.
     pub connection_timeout: Duration,
+    /// Time to wait for a query response before canceling the query and
+    /// returning an error.
+    pub statement_timeout: Duration,
     /// Whether to enforce that all the database connections are encrypted with TLS.
     pub enforce_tls: bool,
 }
@@ -93,6 +96,10 @@ impl DatabasePools {
         };
         let connection_timeout = Duration::from_secs(connection_timeout);
 
+        // `DB_TIMEOUT` currently configures both the connection timeout and
+        // the statement timeout, so we can copy the parsed connection timeout.
+        let statement_timeout = connection_timeout;
+
         let enforce_tls = base.env == Env::Production;
 
         match dotenvy::var("DB_OFFLINE").as_deref() {
@@ -109,6 +116,7 @@ impl DatabasePools {
                 replica: None,
                 tcp_timeout_ms,
                 connection_timeout,
+                statement_timeout,
                 enforce_tls,
             },
             // The follower is down, don't configure the replica.
@@ -122,6 +130,7 @@ impl DatabasePools {
                 replica: None,
                 tcp_timeout_ms,
                 connection_timeout,
+                statement_timeout,
                 enforce_tls,
             },
             _ => Self {
@@ -142,6 +151,7 @@ impl DatabasePools {
                 }),
                 tcp_timeout_ms,
                 connection_timeout,
+                statement_timeout,
                 enforce_tls,
             },
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -203,7 +203,7 @@ fn maybe_append_url_param(url: &mut Url, key: &str, value: &str) {
 
 #[derive(Debug, Clone, Copy)]
 pub struct ConnectionConfig {
-    pub statement_timeout: u64,
+    pub statement_timeout: Duration,
     pub read_only: bool,
 }
 
@@ -213,7 +213,7 @@ impl CustomizeConnection<PgConnection, r2d2::Error> for ConnectionConfig {
 
         sql_query(format!(
             "SET statement_timeout = {}",
-            self.statement_timeout * 1000
+            self.statement_timeout.as_millis()
         ))
         .execute(conn)
         .map_err(r2d2::Error::QueryError)?;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -369,6 +369,7 @@ fn simple_config() -> config::Server {
         },
         replica: None,
         tcp_timeout_ms: 1000, // 1 second
+        connection_timeout: Duration::from_secs(1),
         enforce_tls: false,
     };
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -371,6 +371,7 @@ fn simple_config() -> config::Server {
         tcp_timeout_ms: 1000, // 1 second
         connection_timeout: Duration::from_secs(1),
         statement_timeout: Duration::from_secs(1),
+        helper_threads: 1,
         enforce_tls: false,
     };
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -370,6 +370,7 @@ fn simple_config() -> config::Server {
         replica: None,
         tcp_timeout_ms: 1000, // 1 second
         connection_timeout: Duration::from_secs(1),
+        statement_timeout: Duration::from_secs(1),
         enforce_tls: false,
     };
 


### PR DESCRIPTION
All of our code that reads environment variables to configure the server should live in the `config` module. This allows us to easily override configuration values on a per-test basis and is generally more straight-forward to understand for new contributors. First we read, parse and validate all of the config values, and then we use them to build the actual server structs.