### PR TITLE
Simplify `SERVER_THREADS` default value

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let threads = dotenvy::var("SERVER_THREADS")
         .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"))
-        .unwrap_or(5);
+        .unwrap_or(512);
 
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
`tokio` is using 512 as the default value and our production servers are currently set to `SERVER_THREADS=100`. There does not appear to be a documented reason to keep this number lower in development, since the threads are only created on-demand.