### PR TITLE
bin/server: Use `tokio` default for `max_blocking_threads` if not set

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -57,13 +57,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let threads = dotenvy::var("SERVER_THREADS")
-        .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"))
-        .unwrap_or(512);
+        .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"));
 
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
     builder.worker_threads(CORE_THREADS);
-    builder.max_blocking_threads(threads);
+    if let Ok(threads) = threads {
+        builder.max_blocking_threads(threads);
+    }
 
     let rt = builder.build().unwrap();
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -60,12 +60,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"))
         .unwrap_or(512);
 
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .worker_threads(CORE_THREADS)
-        .max_blocking_threads(threads as usize)
-        .build()
-        .unwrap();
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+    builder.worker_threads(CORE_THREADS);
+    builder.max_blocking_threads(threads);
+
+    let rt = builder.build().unwrap();
 
     let make_service = axum_router.into_make_service_with_connect_info::<SocketAddr>();
 


### PR DESCRIPTION
Specifying our own default of 512 threads is redundant. We can rely on the default value in `tokio` if `SERVER_THREADS` is not explicitly set.