### PR TITLE
bin/server: Move env var handling to `config` module

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -156,8 +156,8 @@ impl App {
             .time_to_live(config.version_id_cache_ttl)
             .build();
 
-        let fastboot_client = match dotenvy::var("USE_FASTBOOT") {
-            Ok(val) if val == "staging-experimental" => Some(reqwest::Client::new()),
+        let fastboot_client = match config.use_fastboot.as_deref() {
+            Some("staging-experimental") => Some(reqwest::Client::new()),
             _ => None,
         };
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -42,8 +42,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let normalize_path = axum::middleware::from_fn(normalize_path);
     let axum_router = normalize_path.layer(axum_router);
 
-    let fastboot = dotenvy::var("USE_FASTBOOT").is_ok();
-
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
     builder.worker_threads(CORE_THREADS);
@@ -85,7 +83,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Creating this file tells heroku to tell nginx that the application is ready
     // to receive traffic.
     if app.config.use_nginx_wrapper {
-        let path = if fastboot {
+        let path = if app.config.use_fastboot.is_some() {
             "/tmp/backend-initialized"
         } else {
             "/tmp/app-initialized"

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -56,13 +56,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => 8888,
     };
 
-    let threads = dotenvy::var("SERVER_THREADS")
-        .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"));
-
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
     builder.worker_threads(CORE_THREADS);
-    if let Ok(threads) = threads {
+    if let Some(threads) = app.config.max_blocking_threads {
         builder.max_blocking_threads(threads);
     }
 

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -4,7 +4,7 @@
 extern crate tracing;
 
 use crates_io::middleware::normalize_path::normalize_path;
-use crates_io::{env_optional, metrics::LogEncoder, util::errors::AppResult, App};
+use crates_io::{metrics::LogEncoder, util::errors::AppResult, App};
 use std::{fs::File, process::Command, sync::Arc, time::Duration};
 
 use axum::ServiceExt;
@@ -44,11 +44,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let fastboot = dotenvy::var("USE_FASTBOOT").is_ok();
 
-    let port = match (app.config.use_nginx_wrapper, env_optional("PORT")) {
-        (false, Some(port)) => port,
-        _ => 8888,
-    };
-
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
     builder.worker_threads(CORE_THREADS);
@@ -61,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let make_service = axum_router.into_make_service_with_connect_info::<SocketAddr>();
 
     let (addr, server) = rt.block_on(async {
-        let socket_addr = (app.config.ip, port).into();
+        let socket_addr = (app.config.ip, app.config.port).into();
         let server = hyper::Server::bind(&socket_addr).serve(make_service);
 
         // When the user configures PORT=0 the operating system will allocate a random unused port.

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -42,10 +42,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let normalize_path = axum::middleware::from_fn(normalize_path);
     let axum_router = normalize_path.layer(axum_router);
 
-    let heroku = dotenvy::var("HEROKU").is_ok();
     let fastboot = dotenvy::var("USE_FASTBOOT").is_ok();
 
-    let port = match (heroku, env_optional("PORT")) {
+    let port = match (app.config.use_nginx_wrapper, env_optional("PORT")) {
         (false, Some(port)) => port,
         _ => 8888,
     };
@@ -90,7 +89,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Creating this file tells heroku to tell nginx that the application is ready
     // to receive traffic.
-    if heroku {
+    if app.config.use_nginx_wrapper {
         let path = if fastboot {
             "/tmp/backend-initialized"
         } else {

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -17,6 +17,7 @@ const DEFAULT_VERSION_ID_CACHE_TTL: u64 = 5 * 60; // 5 minutes
 
 pub struct Server {
     pub base: Base,
+    pub max_blocking_threads: Option<usize>,
     pub db: DatabasePools,
     pub session_key: cookie::Key,
     pub gh_client_id: ClientId,
@@ -114,9 +115,15 @@ impl Default for Server {
             Some(s) if s.is_empty() => vec![],
             Some(s) => s.split(',').map(String::from).collect(),
         };
+
+        let max_blocking_threads = dotenvy::var("SERVER_THREADS")
+            .map(|s| s.parse().expect("SERVER_THREADS was not a valid number"))
+            .ok();
+
         Server {
             db: DatabasePools::full_from_environment(&base),
             base,
+            max_blocking_threads,
             session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),
             gh_client_id: ClientId::new(env("GH_CLIENT_ID")),
             gh_client_secret: ClientSecret::new(env("GH_CLIENT_SECRET")),

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -20,6 +20,7 @@ pub struct Server {
     pub base: Base,
     pub ip: IpAddr,
     pub max_blocking_threads: Option<usize>,
+    pub use_nginx_wrapper: bool,
     pub db: DatabasePools,
     pub session_key: cookie::Key,
     pub gh_client_id: ClientId,
@@ -98,6 +99,8 @@ impl Default for Server {
             _ => [127, 0, 0, 1].into(),
         };
 
+        let use_nginx_wrapper = dotenvy::var("HEROKU").is_ok();
+
         let allowed_origins = AllowedOrigins::from_default_env();
         let page_offset_ua_blocklist = match env_optional::<String>("WEB_PAGE_OFFSET_UA_BLOCKLIST")
         {
@@ -132,6 +135,7 @@ impl Default for Server {
             base,
             ip,
             max_blocking_threads,
+            use_nginx_wrapper,
             session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),
             gh_client_id: ClientId::new(env("GH_CLIENT_ID")),
             gh_client_secret: ClientSecret::new(env("GH_CLIENT_SECRET")),

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -19,6 +19,7 @@ const DEFAULT_VERSION_ID_CACHE_TTL: u64 = 5 * 60; // 5 minutes
 pub struct Server {
     pub base: Base,
     pub ip: IpAddr,
+    pub port: u16,
     pub max_blocking_threads: Option<usize>,
     pub use_nginx_wrapper: bool,
     pub db: DatabasePools,
@@ -101,6 +102,11 @@ impl Default for Server {
 
         let use_nginx_wrapper = dotenvy::var("HEROKU").is_ok();
 
+        let port = match (use_nginx_wrapper, env_optional("PORT")) {
+            (false, Some(port)) => port,
+            _ => 8888,
+        };
+
         let allowed_origins = AllowedOrigins::from_default_env();
         let page_offset_ua_blocklist = match env_optional::<String>("WEB_PAGE_OFFSET_UA_BLOCKLIST")
         {
@@ -134,6 +140,7 @@ impl Default for Server {
             db: DatabasePools::full_from_environment(&base),
             base,
             ip,
+            port,
             max_blocking_threads,
             use_nginx_wrapper,
             session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -10,6 +10,7 @@ use super::database_pools::DatabasePools;
 use crate::config::balance_capacity::BalanceCapacityConfig;
 use http::HeaderValue;
 use std::collections::HashSet;
+use std::net::IpAddr;
 use std::time::Duration;
 
 const DEFAULT_VERSION_ID_CACHE_SIZE: u64 = 10_000;
@@ -17,6 +18,7 @@ const DEFAULT_VERSION_ID_CACHE_TTL: u64 = 5 * 60; // 5 minutes
 
 pub struct Server {
     pub base: Base,
+    pub ip: IpAddr,
     pub max_blocking_threads: Option<usize>,
     pub db: DatabasePools,
     pub session_key: cookie::Key,
@@ -91,6 +93,11 @@ impl Default for Server {
     ///
     /// This function panics if the Server configuration is invalid.
     fn default() -> Self {
+        let ip = match dotenvy::var("DEV_DOCKER") {
+            Ok(_) => [0, 0, 0, 0].into(),
+            _ => [127, 0, 0, 1].into(),
+        };
+
         let allowed_origins = AllowedOrigins::from_default_env();
         let page_offset_ua_blocklist = match env_optional::<String>("WEB_PAGE_OFFSET_UA_BLOCKLIST")
         {
@@ -123,6 +130,7 @@ impl Default for Server {
         Server {
             db: DatabasePools::full_from_environment(&base),
             base,
+            ip,
             max_blocking_threads,
             session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),
             gh_client_id: ClientId::new(env("GH_CLIENT_ID")),

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -55,6 +55,8 @@ pub struct Server {
     /// Should the server serve the frontend `index.html` for all
     /// non-API requests?
     pub serve_html: bool,
+
+    pub use_fastboot: Option<String>,
 }
 
 impl Default for Server {
@@ -182,6 +184,7 @@ impl Default for Server {
             balance_capacity: BalanceCapacityConfig::from_environment(),
             serve_dist: true,
             serve_html: true,
+            use_fastboot: dotenvy::var("USE_FASTBOOT").ok(),
         }
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -419,6 +419,7 @@ fn simple_config() -> config::Server {
         // The frontend code is not needed for the backend tests.
         serve_dist: false,
         serve_html: false,
+        use_fastboot: None,
     }
 }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -385,6 +385,7 @@ fn simple_config() -> config::Server {
 
     config::Server {
         base,
+        ip: [127, 0, 0, 1].into(),
         max_blocking_threads: None,
         db,
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -385,6 +385,7 @@ fn simple_config() -> config::Server {
 
     config::Server {
         base,
+        max_blocking_threads: None,
         db,
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: ClientId::new(dotenvy::var("GH_CLIENT_ID").unwrap_or_default()),

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -386,6 +386,7 @@ fn simple_config() -> config::Server {
     config::Server {
         base,
         ip: [127, 0, 0, 1].into(),
+        port: 8888,
         max_blocking_threads: None,
         use_nginx_wrapper: false,
         db,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -387,6 +387,7 @@ fn simple_config() -> config::Server {
         base,
         ip: [127, 0, 0, 1].into(),
         max_blocking_threads: None,
+        use_nginx_wrapper: false,
         db,
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: ClientId::new(dotenvy::var("GH_CLIENT_ID").unwrap_or_default()),


### PR DESCRIPTION
The only code to read environment variables should be in the `config` module (or potentially in the tests). The `server` binary should first use the `config` module to read everything and then build the server process based on the `config` content.

This PR moves all of the remaining env var calls to the `config` module.