### PR TITLE
Extract `SentryConfig` struct

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,12 @@
 mod balance_capacity;
 mod base;
 mod database_pools;
+mod sentry;
 mod server;
 
 pub use self::balance_capacity::BalanceCapacityConfig;
 pub use self::base::Base;
 pub use self::database_pools::{DatabasePools, DbPoolConfig};
+pub use self::sentry::SentryConfig;
 pub(crate) use self::server::domain_name;
 pub use self::server::Server;

--- a/src/config/sentry.rs
+++ b/src/config/sentry.rs
@@ -1,0 +1,31 @@
+use crate::env_optional;
+use sentry::types::Dsn;
+use sentry::IntoDsn;
+
+pub struct SentryConfig {
+    pub dsn: Option<Dsn>,
+    pub environment: Option<String>,
+    pub release: Option<String>,
+    pub traces_sample_rate: f32,
+}
+
+impl SentryConfig {
+    pub fn from_environment() -> Self {
+        let dsn = dotenvy::var("SENTRY_DSN_API")
+            .ok()
+            .into_dsn()
+            .expect("SENTRY_DSN_API is not a valid Sentry DSN value");
+
+        let environment = dsn.as_ref().map(|_| {
+            dotenvy::var("SENTRY_ENV_API")
+                .expect("SENTRY_ENV_API must be set when using SENTRY_DSN_API")
+        });
+
+        Self {
+            dsn,
+            environment,
+            release: dotenvy::var("HEROKU_SLUG_COMMIT").ok(),
+            traces_sample_rate: env_optional("SENTRY_TRACES_SAMPLE_RATE").unwrap_or(0.0),
+        }
+    }
+}


### PR DESCRIPTION
Just like previous PRs: the only environment variable reading should happen in the `config` module, so this PR extracts a `config::sentry` module and corresponding `SentryConfig` struct, which is then used by the Sentry initialization code.

This is still somewhat unusual in that the `SentryConfig` struct is not part of `config::Server`, because the Sentry initialization happens before we read the rest of the config. It is implemented this way to ensure that we get Sentry issues if a regular config value happens to break the server somehow.