### PR TITLE
s3: Use `SecretString` for `secret_key` field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,7 @@ dependencies = [
  "chrono",
  "hmac",
  "reqwest",
+ "secrecy",
  "sha-1",
  "thiserror",
  "url",

--- a/crates_io_s3/Cargo.toml
+++ b/crates_io_s3/Cargo.toml
@@ -16,6 +16,7 @@ base64 = "=0.21.2"
 chrono = { version = "=0.4.26", default-features = false, features = ["clock"] }
 hmac = "=0.12.1"
 reqwest = { version = "=0.11.18", features = ["blocking"] }
+secrecy = "=0.8.0"
 sha-1 = "=0.10.1"
 thiserror = "=1.0.40"
 url = "=2.4.0"


### PR DESCRIPTION
The `Bucket` struct has a derived `Debug` implementation, so we should not use a `String` for the `secret_key` since it would risk unintentionally leaking the key in the logs.