### PR TITLE
`derive(Selectable)` on a few diesel structs

### DIFF
--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -163,6 +163,7 @@ fn alert_revoke_token(
 
     // Not using `ApiToken::find_by_api_token()` in order to preserve `last_used_at`
     let token = api_tokens::table
+        .select(ApiToken::as_select())
         .filter(api_tokens::token.eq(hashed_token))
         .get_result::<ApiToken>(conn)
         .optional()?;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -19,8 +19,6 @@ use crate::views::{
     EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
 };
 
-use crate::models::krate::ALL_COLUMNS;
-
 /// Handles the `GET /summary` route.
 pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
     conduit_compat(move || {
@@ -61,7 +59,10 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
                 .collect()
         }
 
-        let selection = (ALL_COLUMNS, recent_crate_downloads::downloads.nullable());
+        let selection = (
+            Crate::as_select(),
+            recent_crate_downloads::downloads.nullable(),
+        );
 
         let new_crates = crates
             .left_join(recent_crate_downloads::table)

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -42,6 +42,7 @@ pub async fn list(
         let user = auth.user();
 
         let tokens: Vec<ApiToken> = ApiToken::belonging_to(user)
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .filter(
                 api_tokens::expired_at

--- a/src/controllers/version/deprecated.rs
+++ b/src/controllers/version/deprecated.rs
@@ -62,7 +62,7 @@ pub async fn show_by_id(state: AppState, Path(id): Path<i32>) -> AppResult<Json<
             .left_outer_join(users::table)
             .select((
                 versions::all_columns,
-                crate::models::krate::ALL_COLUMNS,
+                Crate::as_select(),
                 users::all_columns.nullable(),
             ))
             .first(conn)?;

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -124,7 +124,7 @@ impl<'a> CrateBuilder<'a> {
         if let Some(downloads) = self.downloads {
             krate = update(&krate)
                 .set(crates::downloads.eq(downloads))
-                .returning(crates_io::models::krate::ALL_COLUMNS)
+                .returning(Crate::as_returning())
                 .get_result(connection)?;
         }
 
@@ -162,7 +162,7 @@ impl<'a> CrateBuilder<'a> {
         if let Some(updated_at) = self.updated_at {
             krate = update(&krate)
                 .set(crates::updated_at.eq(updated_at))
-                .returning(crates_io::models::krate::ALL_COLUMNS)
+                .returning(Crate::as_returning())
                 .get_result(connection)?;
         }
 

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -27,6 +27,7 @@ fn github_secret_alert_revokes_token() {
     // Ensure that the token currently exists in the database
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 1);
@@ -62,10 +63,12 @@ fn github_secret_alert_revokes_token() {
     // Ensure that the token was revoked
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 0);
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(true))
             .load(conn));
         assert_eq!(tokens.len(), 1);
@@ -85,6 +88,7 @@ fn github_secret_alert_for_revoked_token() {
     // Ensure that the token currently exists in the database
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 1);
@@ -123,10 +127,12 @@ fn github_secret_alert_for_revoked_token() {
     // Ensure that the token is still revoked
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 0);
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(true))
             .load(conn));
         assert_eq!(tokens.len(), 1);
@@ -146,6 +152,7 @@ fn github_secret_alert_for_unknown_token() {
     // Ensure that the token currently exists in the database
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 1);
@@ -172,6 +179,7 @@ fn github_secret_alert_for_unknown_token() {
     // Ensure that the token was not revoked
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 1);

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -68,8 +68,11 @@ fn create_token_success() {
         ".api_token.token" => insta::api_token_redaction(),
     });
 
-    let tokens: Vec<ApiToken> =
-        app.db(|conn| assert_ok!(ApiToken::belonging_to(user.as_model()).load(conn)));
+    let tokens: Vec<ApiToken> = app.db(|conn| {
+        assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
+            .load(conn))
+    });
     assert_eq!(tokens.len(), 1);
     assert_eq!(tokens[0].name, "bar");
     assert!(!tokens[0].revoked);
@@ -134,8 +137,11 @@ fn create_token_with_scopes() {
         ".api_token.token" => insta::api_token_redaction(),
     });
 
-    let tokens: Vec<ApiToken> =
-        app.db(|conn| assert_ok!(ApiToken::belonging_to(user.as_model()).load(conn)));
+    let tokens: Vec<ApiToken> = app.db(|conn| {
+        assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
+            .load(conn))
+    });
     assert_eq!(tokens.len(), 1);
     assert_eq!(tokens[0].name, "bar");
     assert!(!tokens[0].revoked);
@@ -174,8 +180,11 @@ fn create_token_with_null_scopes() {
         ".api_token.token" => insta::api_token_redaction(),
     });
 
-    let tokens: Vec<ApiToken> =
-        app.db(|conn| assert_ok!(ApiToken::belonging_to(user.as_model()).load(conn)));
+    let tokens: Vec<ApiToken> = app.db(|conn| {
+        assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
+            .load(conn))
+    });
     assert_eq!(tokens.len(), 1);
     assert_eq!(tokens[0].name, "bar");
     assert!(!tokens[0].revoked);

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -21,7 +21,9 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 
     // List tokens for first user contains the token
     app.db(|conn| {
-        let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user1).load(conn));
+        let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user1)
+            .select(ApiToken::as_select())
+            .load(conn));
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].name, token.name);
     });
@@ -33,7 +35,9 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 
     // List tokens for first user still contains the token
     app.db(|conn| {
-        let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user1).load(conn));
+        let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user1)
+            .select(ApiToken::as_select())
+            .load(conn));
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].name, token.name);
     });
@@ -45,7 +49,9 @@ fn revoke_token_success() {
 
     // List tokens contains the token
     app.db(|conn| {
-        let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model()).load(conn));
+        let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
+            .load(conn));
         assert_eq!(tokens.len(), 1);
         assert_eq!(tokens[0].name, token.as_model().name);
     });

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -11,6 +11,7 @@ fn revoke_current_token_success() {
     // Ensure that the token currently exists in the database
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 1);
@@ -24,6 +25,7 @@ fn revoke_current_token_success() {
     // Ensure that the token was removed from the database
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 0);
@@ -49,6 +51,7 @@ fn revoke_current_token_with_cookie_user() {
     // Ensure that the token currently exists in the database
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 1);
@@ -66,6 +69,7 @@ fn revoke_current_token_with_cookie_user() {
     // Ensure that the token still exists in the database after the failed request
     app.db(|conn| {
         let tokens: Vec<ApiToken> = assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
             .filter(api_tokens::revoked.eq(false))
             .load(conn));
         assert_eq!(tokens.len(), 1);

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -16,8 +16,11 @@ fn using_token_updates_last_used_at() {
     // Use the token once
     token.search("following=1");
 
-    let token: ApiToken =
-        app.db(|conn| assert_ok!(ApiToken::belonging_to(user.as_model()).first(conn)));
+    let token: ApiToken = app.db(|conn| {
+        assert_ok!(ApiToken::belonging_to(user.as_model())
+            .select(ApiToken::as_select())
+            .first(conn))
+    });
     assert_some!(token.last_used_at);
 
     // Would check that it updates the timestamp here, but the timestamp is


### PR DESCRIPTION
There are a few places where we typically only query a subset of columns. The `Selectable` trait allows us to easily call `.select()` and `.returning()` with a partial list of columns.

* For the `crates` table we avoid pulling in the `textsearchable_index_col` column for performance reasons.
* For the `tokens` table we can avoid querying the user's hashed token.

I'm not yet able to completely eliminate the `ALL_COLUMNS` constant for crates, as the interaction with search pagination is causing some issues.