### PR TITLE
Extract and improve `storage::from_environment()` fn

### DIFF
--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -1,9 +1,9 @@
 use crate::background_jobs::Job;
-use crate::{admin::dialoguer, db, env, schema::crates};
+use crate::{admin::dialoguer, db, schema::crates, storage};
 use anyhow::Context;
 use diesel::prelude::*;
 use futures_util::{StreamExt, TryStreamExt};
-use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::aws::AmazonS3;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use std::collections::HashMap;
@@ -29,19 +29,7 @@ pub fn run(opts: Opts) {
         .context("Failed to establish database connection")
         .unwrap();
 
-    let region = dotenvy::var("S3_REGION").unwrap_or("us-west-1".to_string());
-    let bucket = env("S3_BUCKET");
-    let access_key = env("AWS_ACCESS_KEY");
-    let secret_key = env("AWS_SECRET_KEY");
-
-    let s3 = AmazonS3Builder::new()
-        .with_region(region)
-        .with_bucket_name(bucket)
-        .with_access_key_id(access_key)
-        .with_secret_access_key(secret_key)
-        .build()
-        .context("Failed to initialize S3 code")
-        .unwrap();
+    let s3 = storage::from_environment();
 
     let mut crate_names = opts.crate_names;
     crate_names.sort();

--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -3,7 +3,6 @@ use crate::{admin::dialoguer, db, schema::crates, storage};
 use anyhow::Context;
 use diesel::prelude::*;
 use futures_util::{StreamExt, TryStreamExt};
-use object_store::aws::AmazonS3;
 use object_store::path::Path;
 use object_store::ObjectStore;
 use std::collections::HashMap;
@@ -29,7 +28,7 @@ pub fn run(opts: Opts) {
         .context("Failed to establish database connection")
         .unwrap();
 
-    let s3 = storage::from_environment();
+    let store = storage::from_environment();
 
     let mut crate_names = opts.crate_names;
     crate_names.sort();
@@ -80,23 +79,26 @@ pub fn run(opts: Opts) {
 
         info!(%name, "Deleting crate files from S3");
         let prefix = format!("crates/{name}").into();
-        if let Err(error) = rt.block_on(delete_from_s3(&s3, &prefix)) {
+        if let Err(error) = rt.block_on(delete_from_store(&store, &prefix)) {
             warn!(%name, ?error, "Failed to delete crate files from S3");
         }
 
         info!(%name, "Deleting readme files from S3");
         let prefix = format!("readmes/{name}").into();
-        if let Err(error) = rt.block_on(delete_from_s3(&s3, &prefix)) {
+        if let Err(error) = rt.block_on(delete_from_store(&store, &prefix)) {
             warn!(%name, ?error, "Failed to delete readme files from S3");
         }
     }
 }
 
-async fn delete_from_s3(s3: &AmazonS3, prefix: &Path) -> anyhow::Result<()> {
-    let objects = s3.list(Some(prefix)).await?;
+async fn delete_from_store<S: ObjectStore>(store: &S, prefix: &Path) -> anyhow::Result<()> {
+    let objects = store.list(Some(prefix)).await?;
     let locations = objects.map(|meta| meta.map(|m| m.location)).boxed();
 
-    s3.delete_stream(locations).try_collect::<Vec<_>>().await?;
+    store
+        .delete_stream(locations)
+        .try_collect::<Vec<_>>()
+        .await?;
 
     Ok(())
 }

--- a/src/admin/delete_version.rs
+++ b/src/admin/delete_version.rs
@@ -31,7 +31,7 @@ pub fn run(opts: Opts) {
         .context("Failed to establish database connection")
         .unwrap();
 
-    let s3 = storage::from_environment();
+    let store = storage::from_environment();
 
     let crate_id: i32 = crates::table
         .select(crates::id)
@@ -88,14 +88,14 @@ pub fn run(opts: Opts) {
         let path = Uploader::crate_path(crate_name, version);
         let path = object_store::path::Path::from(path);
         debug!(%crate_name, %version, ?path, "Deleting crate file from S3");
-        if let Err(error) = rt.block_on(s3.delete(&path)) {
+        if let Err(error) = rt.block_on(store.delete(&path)) {
             warn!(%crate_name, %version, ?error, "Failed to delete crate file from S3");
         }
 
         let path = Uploader::readme_path(crate_name, version);
         let path = object_store::path::Path::from(path);
         debug!(%crate_name, %version, ?path, "Deleting readme file from S3");
-        match rt.block_on(s3.delete(&path)) {
+        match rt.block_on(store.delete(&path)) {
             Err(object_store::Error::NotFound { .. }) => {}
             Err(error) => {
                 warn!(%crate_name, %version, ?error, "Failed to delete readme file from S3")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod controllers;
 pub mod models;
 mod router;
 pub mod sentry;
+pub mod storage;
 pub mod views;
 
 /// Used for setting different values depending on whether the app is being run in production,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,19 @@
+use crate::env;
+use anyhow::Context;
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+
+pub fn from_environment() -> AmazonS3 {
+    let region = dotenvy::var("S3_REGION").unwrap_or("us-west-1".to_string());
+    let bucket = env("S3_BUCKET");
+    let access_key = env("AWS_ACCESS_KEY");
+    let secret_key = env("AWS_SECRET_KEY");
+
+    AmazonS3Builder::new()
+        .with_region(region)
+        .with_bucket_name(bucket)
+        .with_access_key_id(access_key)
+        .with_secret_access_key(secret_key)
+        .build()
+        .context("Failed to initialize S3 code")
+        .unwrap()
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -3,8 +3,10 @@ use anyhow::Context;
 use object_store::aws::AmazonS3Builder;
 use object_store::ObjectStore;
 
+const DEFAULT_REGION: &str = "us-west-1";
+
 pub fn from_environment() -> Box<dyn ObjectStore> {
-    let region = dotenvy::var("S3_REGION").unwrap_or("us-west-1".to_string());
+    let region = dotenvy::var("S3_REGION").unwrap_or(DEFAULT_REGION.to_string());
     let bucket = env("S3_BUCKET");
     let access_key = env("AWS_ACCESS_KEY");
     let secret_key = env("AWS_SECRET_KEY");

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,19 +1,22 @@
 use crate::env;
 use anyhow::Context;
-use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::aws::AmazonS3Builder;
+use object_store::ObjectStore;
 
-pub fn from_environment() -> AmazonS3 {
+pub fn from_environment() -> Box<dyn ObjectStore> {
     let region = dotenvy::var("S3_REGION").unwrap_or("us-west-1".to_string());
     let bucket = env("S3_BUCKET");
     let access_key = env("AWS_ACCESS_KEY");
     let secret_key = env("AWS_SECRET_KEY");
 
-    AmazonS3Builder::new()
+    let s3 = AmazonS3Builder::new()
         .with_region(region)
         .with_bucket_name(bucket)
         .with_access_key_id(access_key)
         .with_secret_access_key(secret_key)
         .build()
         .context("Failed to initialize S3 code")
-        .unwrap()
+        .unwrap();
+
+    Box::new(s3)
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,24 +1,44 @@
 use crate::env;
 use anyhow::Context;
 use object_store::aws::AmazonS3Builder;
+use object_store::local::LocalFileSystem;
 use object_store::ObjectStore;
+use std::fs;
 
 const DEFAULT_REGION: &str = "us-west-1";
 
 pub fn from_environment() -> Box<dyn ObjectStore> {
-    let region = dotenvy::var("S3_REGION").unwrap_or(DEFAULT_REGION.to_string());
-    let bucket = env("S3_BUCKET");
-    let access_key = env("AWS_ACCESS_KEY");
-    let secret_key = env("AWS_SECRET_KEY");
+    if let Ok(bucket) = dotenvy::var("S3_BUCKET") {
+        let region = dotenvy::var("S3_REGION").unwrap_or(DEFAULT_REGION.to_string());
+        let access_key = env("AWS_ACCESS_KEY");
+        let secret_key = env("AWS_SECRET_KEY");
 
-    let s3 = AmazonS3Builder::new()
-        .with_region(region)
-        .with_bucket_name(bucket)
-        .with_access_key_id(access_key)
-        .with_secret_access_key(secret_key)
-        .build()
-        .context("Failed to initialize S3 code")
+        let s3 = AmazonS3Builder::new()
+            .with_region(region)
+            .with_bucket_name(bucket)
+            .with_access_key_id(access_key)
+            .with_secret_access_key(secret_key)
+            .build()
+            .context("Failed to initialize S3 code")
+            .unwrap();
+
+        return Box::new(s3);
+    }
+
+    let current_dir = std::env::current_dir()
+        .context("Failed to read the current directory")
         .unwrap();
 
-    Box::new(s3)
+    let path = current_dir.join("local_uploads");
+
+    fs::create_dir_all(&path)
+        .context("Failed to create `local_uploads` directory")
+        .unwrap();
+
+    warn!(?path, "Using local file system for file storage");
+    let local = LocalFileSystem::new_with_prefix(path)
+        .context("Failed to initialize local file system storage")
+        .unwrap();
+
+    Box::new(local)
 }


### PR DESCRIPTION
This PR extracts the common `object_store` setup code from our admin tools into a shared module and enables it to use the local file system for storage if the `S3_BUCKET` environment variable is not set.