### PR TITLE
tests/publish: Merge redundant tests

### DIFF
--- a/src/tests/http-data/krate_publish_new_krate_twice.json
+++ b/src/tests/http-data/krate_publish_new_krate_twice.json
@@ -1,6 +1,172 @@
 [
   {
     "request": {
+      "uri": "http://127.0.0.1:19000/crates-test/crates/foo_twice/foo_twice-0.99.0.crate",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "35"
+        ],
+        [
+          "content-type",
+          "application/gzip"
+        ]
+      ],
+      "body": "H4sIAAAAAAAA/+3AAQEAAACCIP+vbkhQwKsBLq+17wAEAAA="
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"f9016ad360cebb4fe2e6e96e5949f022\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A57EFE497"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
+      "uri": "http://127.0.0.1:19000/crates-index-test/fo/o_/foo_twice",
+      "method": "PUT",
+      "headers": [
+        [
+          "accept",
+          "*/*"
+        ],
+        [
+          "accept-encoding",
+          "gzip"
+        ],
+        [
+          "content-length",
+          "151"
+        ],
+        [
+          "content-type",
+          "text/plain"
+        ]
+      ],
+      "body": "{\"name\":\"foo_twice\",\"vers\":\"0.99.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+    },
+    "response": {
+      "status": 200,
+      "headers": [
+        [
+          "accept-ranges",
+          "bytes"
+        ],
+        [
+          "content-length",
+          "0"
+        ],
+        [
+          "content-security-policy",
+          "block-all-mixed-content"
+        ],
+        [
+          "date",
+          "Tue, 13 Jun 2023 23:04:33 GMT"
+        ],
+        [
+          "etag",
+          "\"867f2d19037d9ed49ae307633e4e343d\""
+        ],
+        [
+          "server",
+          "MinIO"
+        ],
+        [
+          "strict-transport-security",
+          "max-age=31536000; includeSubDomains"
+        ],
+        [
+          "vary",
+          "Accept-Encoding"
+        ],
+        [
+          "vary",
+          "Origin"
+        ],
+        [
+          "x-amz-id-2",
+          "dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8"
+        ],
+        [
+          "x-amz-request-id",
+          "17685A6A5C0F6D25"
+        ],
+        [
+          "x-content-type-options",
+          "nosniff"
+        ],
+        [
+          "x-xss-protection",
+          "1; mode=block"
+        ]
+      ],
+      "body": ""
+    }
+  },
+  {
+    "request": {
       "uri": "http://127.0.0.1:19000/crates-test/crates/foo_twice/foo_twice-2.0.0.crate",
       "method": "PUT",
       "headers": [
@@ -104,7 +270,7 @@
           "text/plain"
         ]
       ],
-      "body": "{\"name\":\"foo_twice\",\"vers\":\"0.99.0\",\"deps\":[],\"cksum\":\"                                                                \",\"features\":{},\"yanked\":false}\n{\"name\":\"foo_twice\",\"vers\":\"2.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
+      "body": "{\"name\":\"foo_twice\",\"vers\":\"0.99.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n{\"name\":\"foo_twice\",\"vers\":\"2.0.0\",\"deps\":[],\"cksum\":\"acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419\",\"features\":{},\"yanked\":false}\n"
     },
     "response": {
       "status": 200,

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -115,13 +115,23 @@ fn invalid_names() {
 
 #[test]
 fn new_krate() {
-    let (_, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user();
 
     let crate_to_publish = PublishBuilder::new("foo_new").version("1.0.0");
     let json: GoodCrate = user.publish_crate(crate_to_publish).good();
 
     assert_eq!(json.krate.name, "foo_new");
     assert_eq!(json.krate.max_version, "1.0.0");
+
+    let crates = app.crates_from_index_head("foo_new");
+    assert_eq!(crates.len(), 1);
+    assert_eq!(crates[0].name, "foo_new");
+    assert_eq!(crates[0].vers, "1.0.0");
+    assert!(crates[0].deps.is_empty());
+    assert_eq!(
+        crates[0].cksum,
+        "acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419"
+    );
 }
 
 #[test]
@@ -339,12 +349,10 @@ fn new_krate_with_wildcard_dependency() {
 
 #[test]
 fn new_krate_twice() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database and then we'll try to publish another version
-        CrateBuilder::new("foo_twice", user.as_model().id).expect_build(conn);
-    });
+    let crate_to_publish = PublishBuilder::new("foo_twice").version("0.99.0");
+    token.publish_crate(crate_to_publish).good();
 
     let crate_to_publish = PublishBuilder::new("foo_twice")
         .version("2.0.0")
@@ -353,6 +361,15 @@ fn new_krate_twice() {
 
     assert_eq!(json.krate.name, "foo_twice");
     assert_eq!(json.krate.description.unwrap(), "2.0.0 description");
+
+    let crates = app.crates_from_index_head("foo_twice");
+    assert_eq!(crates.len(), 2);
+    assert_eq!(crates[0].name, "foo_twice");
+    assert_eq!(crates[0].vers, "0.99.0");
+    assert!(crates[0].deps.is_empty());
+    assert_eq!(crates[1].name, "foo_twice");
+    assert_eq!(crates[1].vers, "2.0.0");
+    assert!(crates[1].deps.is_empty());
 }
 
 #[test]
@@ -518,43 +535,6 @@ fn new_crate_similar_name_underscore() {
         response.into_json(),
         json!({ "errors": [{ "detail": "crate was previously named `foo-bar-underscore`" }] })
     );
-}
-
-#[test]
-fn new_krate_git_upload() {
-    let (app, _, _, token) = TestApp::full().with_token();
-
-    let crate_to_publish = PublishBuilder::new("fgt");
-    token.publish_crate(crate_to_publish).good();
-
-    let crates = app.crates_from_index_head("fgt");
-    assert_eq!(crates.len(), 1);
-    assert_eq!(crates[0].name, "fgt");
-    assert_eq!(crates[0].vers, "1.0.0");
-    assert!(crates[0].deps.is_empty());
-    assert_eq!(
-        crates[0].cksum,
-        "acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419"
-    );
-}
-
-#[test]
-fn new_krate_git_upload_appends() {
-    let (app, _, _, token) = TestApp::full().with_token();
-
-    let crate_to_publish = PublishBuilder::new("FPP").version("0.0.1");
-    token.publish_crate(crate_to_publish).good();
-    let crate_to_publish = PublishBuilder::new("FPP").version("1.0.0");
-    token.publish_crate(crate_to_publish).good();
-
-    let crates = app.crates_from_index_head("fpp");
-    assert!(crates.len() == 2);
-    assert_eq!(crates[0].name, "FPP");
-    assert_eq!(crates[0].vers, "0.0.1");
-    assert!(crates[0].deps.is_empty());
-    assert_eq!(crates[1].name, "FPP");
-    assert_eq!(crates[1].vers, "1.0.0");
-    assert!(crates[1].deps.is_empty());
 }
 
 #[test]

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -132,6 +132,14 @@ fn new_krate() {
         crates[0].cksum,
         "acb5604b126ac894c1eb11c4575bf2072fea61232a888e453770c79d7ed56419"
     );
+
+    app.db(|conn| {
+        let email: String = versions_published_by::table
+            .select(versions_published_by::email)
+            .first(conn)
+            .unwrap();
+        assert_eq!(email, "something@example.com");
+    });
 }
 
 #[test]
@@ -625,23 +633,6 @@ fn new_krate_with_unverified_email_fails() {
         response.into_json(),
         json!({ "errors": [{ "detail": "A verified email address is required to publish crates to crates.io. Visit https://crates.io/settings/profile to set and verify your email address." }] })
     );
-}
-
-#[test]
-fn new_krate_records_verified_email() {
-    let (app, _, _, token) = TestApp::full().with_token();
-
-    let crate_to_publish = PublishBuilder::new("foo_verified_email");
-
-    token.publish_crate(crate_to_publish).good();
-
-    app.db(|conn| {
-        let email: String = versions_published_by::table
-            .select(versions_published_by::email)
-            .first(conn)
-            .unwrap();
-        assert_eq!(email, "something@example.com");
-    });
 }
 
 #[test]


### PR DESCRIPTION
These tests have all done the same work, but then run different assertions afterwards. We can merge them instead to have the test suite run slightly faster.