### PR TITLE
bin/background-worker: Replace unnecessary clones with `Arc` usage

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -299,18 +299,6 @@ pub struct Environment {
     fastly: Option<Fastly>,
 }
 
-impl Clone for Environment {
-    fn clone(&self) -> Self {
-        Self {
-            index: self.index.clone(),
-            uploader: self.uploader.clone(),
-            http_client: AssertUnwindSafe(self.http_client.0.clone()),
-            cloudfront: self.cloudfront.clone(),
-            fastly: self.fastly.clone(),
-        }
-    }
-}
-
 impl Environment {
     pub fn new(
         index: Repository,

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -76,20 +76,19 @@ fn main() {
     let cloudfront = CloudFront::from_environment();
     let fastly = Fastly::from_environment();
 
-    let build_runner = || {
-        let client = Client::builder()
-            .timeout(Duration::from_secs(45))
-            .build()
-            .expect("Couldn't build client");
-        let environment = Environment::new_shared(
-            repository.clone(),
-            uploader.clone(),
-            client,
-            cloudfront.clone(),
-            fastly.clone(),
-        );
-        swirl::Runner::production_runner(environment, db_url.clone(), job_start_timeout)
-    };
+    let client = Client::builder()
+        .timeout(Duration::from_secs(45))
+        .build()
+        .expect("Couldn't build client");
+
+    let environment =
+        Environment::new_shared(repository, uploader.clone(), client, cloudfront, fastly);
+
+    let environment = Arc::new(Some(environment));
+
+    let build_runner =
+        || swirl::Runner::production_runner(environment.clone(), db_url.clone(), job_start_timeout);
+
     let mut runner = build_runner();
 
     info!("Runner booted, running jobs");

--- a/src/swirl/runner.rs
+++ b/src/swirl/runner.rs
@@ -28,7 +28,7 @@ pub struct Runner {
 
 impl Runner {
     pub fn production_runner(
-        environment: Environment,
+        environment: Arc<Option<Environment>>,
         url: String,
         job_start_timeout: u64,
     ) -> Self {
@@ -39,7 +39,7 @@ impl Runner {
         Self {
             connection_pool: DieselPool::new_background_worker(connection_pool),
             thread_pool: ThreadPool::new(5),
-            environment: Arc::new(Some(environment)),
+            environment,
             job_start_timeout: Duration::from_secs(job_start_timeout),
         }
     }


### PR DESCRIPTION
The runner was already using `Arc` internally, so we might as well use it on the outside too, to prevent the unnecessary `.clone()` calls on all of the internal fields.