### PR TITLE
Uploader: Remove obsolete code

### DIFF
--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -13,11 +13,6 @@ pub enum Uploader {
     Local,
 }
 
-pub enum UploadBucket {
-    Default,
-    Index,
-}
-
 impl Uploader {
     /// Returns the URL of an uploaded crate's version archive.
     ///

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -1,6 +1,3 @@
-use std::env;
-use std::path::PathBuf;
-
 #[derive(Clone, Debug)]
 pub enum Uploader {
     /// For production usage, uploads and redirects to s3.
@@ -74,14 +71,5 @@ impl Uploader {
     /// Returns the internal path of an uploaded crate's version readme.
     pub fn readme_path(name: &str, version: &str) -> String {
         format!("readmes/{name}/{name}-{version}.html")
-    }
-
-    /// Returns the absolute path to the locally uploaded file.
-    fn local_uploads_path(path: &str, upload_bucket: UploadBucket) -> PathBuf {
-        let path = match upload_bucket {
-            UploadBucket::Index => PathBuf::from("index").join(path),
-            UploadBucket::Default => PathBuf::from(path),
-        };
-        env::current_dir().unwrap().join("local_uploads").join(path)
     }
 }

--- a/src/uploaders.rs
+++ b/src/uploaders.rs
@@ -1,9 +1,4 @@
-use anyhow::Result;
-use reqwest::{blocking::Client, header};
-
-use reqwest::blocking::Body;
 use std::env;
-use std::fs::{self, File};
 use std::path::PathBuf;
 
 #[derive(Clone, Debug)]
@@ -88,53 +83,5 @@ impl Uploader {
             UploadBucket::Default => PathBuf::from(path),
         };
         env::current_dir().unwrap().join("local_uploads").join(path)
-    }
-
-    /// Uploads a file using the configured uploader (either `S3`, `Local`).
-    ///
-    /// It returns the path of the uploaded file.
-    ///
-    /// # Panics
-    ///
-    /// This function can panic on an `Self::Local` during development.
-    /// Production and tests use `Self::S3` which should not panic.
-    #[instrument(skip_all, fields(%path))]
-    pub fn upload<R: Into<Body>>(
-        &self,
-        client: &Client,
-        path: &str,
-        content: R,
-        content_type: &str,
-        extra_headers: header::HeaderMap,
-        upload_bucket: UploadBucket,
-    ) -> Result<Option<String>> {
-        match *self {
-            Uploader::S3 {
-                ref bucket,
-                ref index_bucket,
-                ..
-            } => {
-                let bucket = match upload_bucket {
-                    UploadBucket::Default => Some(bucket),
-                    UploadBucket::Index => index_bucket.as_ref(),
-                };
-
-                if let Some(bucket) = bucket {
-                    bucket.put(client, path, content, content_type, extra_headers)?;
-                }
-
-                Ok(Some(String::from(path)))
-            }
-            Uploader::Local => {
-                let filename = Self::local_uploads_path(path, upload_bucket);
-                let dir = filename.parent().unwrap();
-                fs::create_dir_all(dir)?;
-                let mut file = File::create(&filename)?;
-                let mut body = content.into();
-                let mut buffer = body.buffer()?;
-                std::io::copy(&mut buffer, &mut file)?;
-                Ok(filename.to_str().map(String::from))
-            }
-        }
     }
 }


### PR DESCRIPTION
We don't use the `Uploader` system for file uploads anymore, so the corresponding code is being removed with this PR. There is still some code left related to external URL generation, which we will soon move elsewhere though.