### PR TITLE
Update `semver` JS dependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5035,7 +5035,7 @@ packages:
       '@babel/core':
         optional: true
     dependencies:
-      semver: 5.7.1
+      semver: 5.7.2
 
   /babel-plugin-debug-macros@0.3.4(@babel/core@7.22.8):
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
@@ -5047,7 +5047,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.22.8(supports-color@8.1.1)
-      semver: 5.7.1
+      semver: 5.7.2
 
   /babel-plugin-ember-data-packages-polyfill@0.1.2:
     resolution: {integrity: sha512-kTHnOwoOXfPXi00Z8yAgyD64+jdSXk3pknnS7NlqnCKAU6YDkXZ4Y7irl66kaZjZn0FBBt0P4YOZFZk85jYOww==}
@@ -5428,7 +5428,7 @@ packages:
       babel-plugin-transform-regenerator: 6.26.0
       browserslist: 3.2.8
       invariant: 2.2.4
-      semver: 5.7.1
+      semver: 5.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7250,7 +7250,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.1
+      semver: 5.7.2
       shebang-command: 1.2.0
       which: 1.3.1
     dev: true
@@ -8346,7 +8346,7 @@ packages:
       fixturify-project: 1.10.0
       resolve-package-path: 3.1.0
       rimraf: 3.0.2
-      semver: 5.7.1
+      semver: 5.7.2
     transitivePeerDependencies:
       - supports-color
 
@@ -8397,7 +8397,7 @@ packages:
       find-yarn-workspace-root: 1.2.1
       is-git-url: 1.0.0
       resolve: 1.22.2
-      semver: 5.7.1
+      semver: 5.7.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8409,7 +8409,7 @@ packages:
       archy: 1.0.0
       broccoli-plugin: 1.3.1
       chalk: 2.4.2
-      semver: 5.7.1
+      semver: 5.7.2
     dev: true
 
   /ember-cli-deprecation-workflow@2.1.0:
@@ -8657,7 +8657,7 @@ packages:
       fs-extra: 7.0.1
       resolve: 1.22.2
       rsvp: 4.8.5
-      semver: 6.3.0
+      semver: 6.3.1
       stagehand: 1.0.1
       walk-sync: 1.1.4
     transitivePeerDependencies:
@@ -8725,7 +8725,7 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       resolve: 1.22.2
-      semver: 5.7.1
+      semver: 5.7.2
     dev: true
 
   /ember-cli-version-checker@3.1.3:
@@ -8733,7 +8733,7 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dependencies:
       resolve-package-path: 1.2.7
-      semver: 5.7.1
+      semver: 5.7.2
 
   /ember-cli-version-checker@4.1.1:
     resolution: {integrity: sha512-bzEWsTMXUGEJfxcAGWPe6kI7oHEGD3jaxUWDYPTqzqGhNkgPwXTBgoWs9zG1RaSMaOPFnloWuxRcoHi4TrYS3Q==}
@@ -8924,7 +8924,7 @@ packages:
       ember-cli-version-checker: 5.1.2
       find-up: 5.0.0
       fs-extra: 9.1.0
-      semver: 5.7.1
+      semver: 5.7.2
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -12093,7 +12093,7 @@ packages:
       '@babel/parser': 7.22.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -12851,7 +12851,7 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 5.7.1
+      semver: 5.7.2
     dev: true
 
   /make-dir@3.1.0:
@@ -13668,7 +13668,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.22.2
-      semver: 5.7.1
+      semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: true
 
@@ -15718,14 +15718,9 @@ packages:
       ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
-  /semver@5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
-
-  /semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
-    hasBin: true
-    dev: true
 
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}


### PR DESCRIPTION
This should address https://github.com/advisories/GHSA-c2qf-rxjj-qqgw.

We're not really affected since the relevant version was only used at build-time, but this should shut up the security warning... 😅 