### PR TITLE
RenderedHtml: Ignore syntax highlighting for mermaid blocks

### DIFF
--- a/app/components/rendered-html.hbs
+++ b/app/components/rendered-html.hbs
@@ -5,7 +5,7 @@
 <div
   local-class="wrapper"
   ...attributes
-  {{highlight-syntax selector="pre > code"}}
+  {{highlight-syntax selector="pre > code:not(.language-mermaid)"}}
   {{render-mermaids}}
 >
   {{html-safe @html}}


### PR DESCRIPTION
This change avoids the following warning:

<img width="669" alt="Bildschirmfoto 2023-07-14 um 14 58 23" src="https://github.com/rust-lang/crates.io/assets/141300/ba2f1af7-8b7b-4503-a0d0-03f5c109c10f">
