### PR TITLE
admin: add a new admin backend to yank and unyank crates

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -86,3 +86,7 @@ export SENTRY_ENV_API=local
 # export TEST_S3_INDEX_REGION=http://127.0.0.1:19000
 # export TEST_AWS_ACCESS_KEY=minio
 # export TEST_AWS_SECRET_KEY=miniominio
+
+# IDs of GitHub users that are admins on this instance, separated by commas.
+# Whitespace will be ignored.
+export GH_ADMIN_USER_IDS=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ dependencies = [
  "ipnetwork",
  "lettre",
  "minijinja",
+ "minijinja-autoreload",
  "moka",
  "oauth2",
  "object_store",
@@ -692,6 +693,7 @@ dependencies = [
  "reqwest",
  "retry",
  "ring",
+ "rust-embed",
  "scheduled-thread-pool",
  "secrecy",
  "semver",
@@ -1124,6 +1126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1598,6 +1609,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1699,6 +1730,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8fc60ba15bf51257aa9807a48a61013db043fcf3a78cb0d916e8e396dcad98"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8367585489f01bc55dd27404dcf56b95e6da061a256a666ab23be9ba96a2e587"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -1873,6 +1924,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memo-map"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aec276c09560ce4447087aaefc19eb0c18d97e31bd05ebac38881c4723400c40"
+
+[[package]]
 name = "memoffset"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1981,19 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "822ebf53abf914648234330ca59b88226ed278551b1b42b47e472957c12660d6"
 dependencies = [
+ "memo-map",
+ "self_cell",
  "serde",
+]
+
+[[package]]
+name = "minijinja-autoreload"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3c1e0fe1a3a8a88778f4d9624514c35529813b73d2780d832b08fd13fb0799"
+dependencies = [
+ "minijinja",
+ "notify",
 ]
 
 [[package]]
@@ -1949,6 +2018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
@@ -2010,6 +2080,23 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "729f63e1ca555a43fe3efa4f3efdf4801c479da85b432242a7b726f353c88486"
+dependencies = [
+ "bitflags 1.3.2",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "mio",
+ "walkdir",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2667,6 +2754,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a36224c3276f8c4ebc8c20f158eca7ca4359c8db89991c4925132aaaf6702661"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b94b81e5b2c284684141a2fb9e2a31be90638caf040bf9afbc5a0416afe1ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.25",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d38ff6bf570dc3bb7100fce9f7b60c33fa71d80e88da3f2580df4ff2bdded74"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,6 +2946,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c309e515543e67811222dbc9e3dd7e1056279b782e1dacffe4242b718734fb6"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ indicatif = "=0.17.5"
 ipnetwork = "=0.20.0"
 tikv-jemallocator = { version = "=0.5.0", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "=0.10.4", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
-minijinja = "=1.0.4"
+minijinja = { version = "=1.0.4", features = ["loader"] }
+minijinja-autoreload = "=1.0.4"
 moka = { version = "=0.11.2", features = ["future"]  }
 oauth2 = { version = "=4.4.1", default-features = false, features = ["reqwest"] }
 object_store = { version = "=0.6.1", features = ["aws"] }
@@ -75,6 +76,7 @@ rand = "=0.8.5"
 reqwest = { version = "=0.11.18", features = ["blocking", "gzip", "json"] }
 retry = "=2.0.0"
 ring = "=0.16.20"
+rust-embed = "=6.8.1"
 scheduled-thread-pool = "=0.2.7"
 secrecy = "=0.8.0"
 semver = { version = "=1.0.17", features = ["serde"] }

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -1,0 +1,56 @@
+<!DOCTYPE HTML>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      {% block title %}
+
+      {% endblock %}:: crates.io
+    </title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ"
+      crossorigin="anonymous" />
+    <link rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.4/font/bootstrap-icons.css"
+      integrity="sha384-LrVLJJYk9OiJmjNDakUBU7kS9qCT8wk1j2OU7ncpsfB3QS37UPdkCuq3ZD1MugNY"
+      crossorigin="anonymous" />
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-ENjdO4Dr2bkBIFxQpeoTz1HIcje39Wm4jDKdf19U8gI4ddQ3GYNS7NTKfAdVQSZe"
+      crossorigin="anonymous"></script>
+    {% block head %}
+
+    {% endblock %}
+  </head>
+
+  <body>
+    <nav class="navbar sticky-top navbar-expand-lg bg-dark"
+      data-bs-theme="dark">
+      <div class="container-fluid">
+        <a class="navbar-brand" href="/admin/">crates.io admin</a>
+        <button class="navbar-toggler"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+            <li class="nav-item">
+              <a class="nav-link" href="/admin/crates/">Recent uploads</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+    <div class="container">
+      {% block content %}
+
+      {% endblock %}
+    </div>
+  </body>
+</html>

--- a/admin/templates/crates/index.html
+++ b/admin/templates/crates/index.html
@@ -1,0 +1,136 @@
+{% extends 'base.html' %}
+{% from 'macros.html' import datetime, page_list, user %}
+
+{% block head %}
+  <script src="https://unpkg.com/htmx.org@1.9.2"
+    integrity="sha384-L6OqL9pRWyyFU3+/bjdSri+iIphTN/bvYyM37tICVyOJkWZLpP2vGn6VUEXgzg6h"
+    crossorigin="anonymous"></script>
+
+  <!--
+    htmx doesn't load its styles until after the initial render, so we need
+    to hide the indicators ourselves.
+  -->
+  <style>
+    .htmx-indicator {
+      opacity: 0;
+    }
+    .htmx-request .htmx-indicator {
+      opacity: 1;
+    }
+  </style>
+{% endblock %}
+
+{% block title %}
+  Crates
+{% endblock %}
+
+{% block content %}
+  <div class="d-flex align-items-end mt-3 mb-3">
+    <h1 class="me-auto">Crates</h1>
+    <form class="d-flex align-items-center" method="GET">
+      <input class="form-control"
+        name="q"
+        type="search"
+        placeholder="crate name"
+        spellcheck="false"
+        value="{{ view.q }}" />
+    </form>
+  </div>
+
+  <div id="error-alert" class="alert alert-danger d-none">
+    <h3>Error</h3>
+
+    <pre></pre>
+  </div>
+
+  <table class="table align-middle">
+    <thead>
+      <tr>
+        <th>Crate</th>
+        <th>Version</th>
+        <th>Published</th>
+        <th />
+      </tr>
+    </thead>
+    <tbody>
+      {% for version in view.versions %}
+        <tr>
+          <td>
+            <div>
+              <a href="/crates/{{ version.name }}">
+                {% if version.yanked %}
+                  <s>{{ version.name }}</s>
+                {% else %}
+                  {{ version.name }}
+                {% endif %}
+              </a>
+              {% if version.yanked %}
+                <i title="Yanked" class="bi bi-trash-fill"></i>
+              {% endif %}
+            </div>
+            <div style="font-size: 80%">
+              <a href="https://index.crates.io/{{ version.name|crate_index_path }}">
+                View in sparse index
+              </a>
+            </div>
+          </td>
+          <td>{{ version.num }}</td>
+          <td>
+            <em>{{ datetime(version.created_at) }}</em>
+            by
+            {{ user(version.publisher) }}
+          </td>
+          <td class="text-end">
+            <div id="action-spinner"
+              class="spinner-border htmx-indicator"
+              role="status"></div>
+            {% if version.yanked %}
+              <button type="button"
+                class="btn btn-outline-primary unyank"
+                hx-put="/api/v1/crates/{{ version.name }}/{{
+                version.num
+                }}/unyank"
+                hx-swap="none"
+                hx-indicator="#action-spinner"
+                hx-confirm="Are you sure you want to unyank {{
+                version.name
+                }} {{ version.num }}?">
+                Unyank
+              </button>
+            {% else %}
+              <button type="button"
+                class="btn btn-danger yank"
+                hx-delete="/api/v1/crates/{{ version.name }}/{{
+                version.num
+                }}/yank"
+                hx-swap="none"
+                hx-indicator="#action-spinner"
+                hx-confirm="Are you sure you want to yank {{ version.name }} {{
+                version.num
+                }}?">
+                Yank
+              </button>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  {{ page_list(view.page) }}
+
+  <script>
+    window.addEventListener('DOMContentLoaded', () => {
+      document.body.addEventListener('htmx:beforeSwap', event => {
+        if (event.detail.xhr.status >= 400) {
+          const container = document.getElementById('error-alert');
+          container.style.display = 'block';
+          container.querySelector('pre').innerText =
+            event.detail.xhr.responseText;
+        } else {
+          window.location.reload();
+        }
+      });
+    });
+  </script>
+{% endblock %}

--- a/admin/templates/macros.html
+++ b/admin/templates/macros.html
@@ -1,0 +1,53 @@
+{% macro datetime(dt) %}
+  <span title="{{ dt.absolute }}">{{ dt.human }}</span>
+{% endmacro %}
+
+{% macro page_list(page) %}
+  {% if page.paginated %}
+    <nav>
+      <ul class="pagination">
+        {% if page.previous %}
+          <li class="page-item">
+            <a class="page-link" href="{{ page.previous }}">
+              <span>&laquo;</span>
+            </a>
+          </li>
+        {% endif %}
+
+        {% for page in page.pages %}
+          <li class="page-item">
+            {% if page.active %}
+              <a class="page-link active" href="{{ page.url }}">
+                <span>{{ page.number }}</span>
+              </a>
+            {% else %}
+              <a class="page-link" href="{{ page.url }}">
+                <span>{{ page.number }}</span>
+              </a>
+            {% endif %}
+          </li>
+        {% endfor %}
+
+        {% if page.next %}
+          <li class="page-item">
+            <a class="page-link" href="{{ page.next }}"><span>&raquo;</span></a>
+          </li>
+        {% endif %}
+      </ul>
+    </nav>
+  {% endif %}
+{% endmacro %}
+
+{% macro user(user) %}
+  <a href="/users/{{ user.username }}">
+    {% if user.avatar %}
+      <img src="{{ user.avatar }}"
+        alt="{{ user.username }}"
+        aria-hidden="true"
+        width="32"
+        height="32"
+        class="d-inline-block me-1" />
+    {%- endif -%}
+    {{- user.username }}
+  </a>
+{% endmacro %}

--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -29,6 +29,9 @@
             <menu.Item><LinkTo @route="dashboard">Dashboard</LinkTo></menu.Item>
             <menu.Item><LinkTo @route="settings" data-test-settings>Account Settings</LinkTo></menu.Item>
             <menu.Item><LinkTo @route="me.pending-invites">Owner Invites</LinkTo></menu.Item>
+            {{#if this.session.currentUser.admin}}
+              <menu.Item><a href="/admin/">Site Admin</a></menu.Item>
+            {{/if}}
             <menu.Item local-class="menu-item-with-separator">
               <button
                 type="button"

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -15,6 +15,7 @@ export default class User extends Model {
   @attr avatar;
   @attr url;
   @attr kind;
+  @attr admin;
 
   async stats() {
     return await waitForPromise(apiAction(this, { method: 'GET', path: 'stats' }));

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -241,6 +241,10 @@ http {
 				proxy_pass http://app_server;
 			}
 
+			location /admin/ {
+					proxy_pass http://app_server;
+			}
+
 			# FastBoot
 			location / {
 				proxy_pass http://localhost:9000;

--- a/deny.toml
+++ b/deny.toml
@@ -109,6 +109,7 @@ allow = [
     #"Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",
     "ISC",
     "MIT",
     "OpenSSL",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,20 @@
     "printWidth": 120,
     "singleQuote": true,
     "tabWidth": 2,
-    "trailingComma": "all"
+    "trailingComma": "all",
+    "overrides": [
+      {
+        "files": [
+          "admin/templates/**/*.html"
+        ],
+        "options": {
+          "parser": "melody"
+        }
+      }
+    ],
+    "plugins": [
+      "prettier-plugin-django"
+    ]
   },
   "dependencies": {
     "@juggle/resize-observer": "3.4.0",
@@ -129,6 +142,7 @@
     "nyc": "15.1.0",
     "postcss-nested": "6.0.1",
     "prettier": "3.0.0",
+    "prettier-plugin-django": "^0.5.7",
     "qunit": "2.19.4",
     "qunit-console-grouper": "0.3.0",
     "qunit-dom": "2.0.0",
@@ -144,8 +158,13 @@
   },
   "pnpm": {
     "peerDependencyRules": {
-      "allowAny": ["eslint"],
-      "ignoreMissing": ["@babel/core", "postcss"]
+      "allowAny": [
+        "eslint"
+      ],
+      "ignoreMissing": [
+        "@babel/core",
+        "postcss"
+      ]
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -284,6 +284,9 @@ devDependencies:
   prettier:
     specifier: 3.0.0
     version: 3.0.0
+  prettier-plugin-django:
+    specifier: ^0.5.7
+    version: 0.5.7
   qunit:
     specifier: 2.19.4
     version: 2.19.4
@@ -12985,6 +12988,32 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  /melody-code-frame@1.7.5:
+    resolution: {integrity: sha512-q/Do+7ZFxRHLN7IhT5RIJrTKh7xNmX3JG4+AD1ZST9iB8gUPYs6yfgGexDRDvtOAAGgLfFbT1DlMWJtldqYaPQ==}
+    dependencies:
+      lodash: 4.17.21
+    dev: true
+
+  /melody-idom@1.7.5:
+    resolution: {integrity: sha512-CsMg+vPyaIs9Wl/pTEgevQs+DfPzEpsNnHcaZNBGgQo3GvLItVgrg3Z8z3obVkPikRrHyRnwBPWIWiRyeh6KHg==}
+    dependencies:
+      lodash: 4.17.21
+    dev: true
+
+  /melody-traverse@1.7.5(melody-types@1.7.5):
+    resolution: {integrity: sha512-k9agECp5qEyIDybedgMNHPalb6wfwy5WlczJriOAn/swggeoq3+HojXSABo3uKM7K8xXNmpVhW/wOJA86oqjIQ==}
+    peerDependencies:
+      melody-types: ^1.1.0
+    dependencies:
+      melody-types: 1.7.5
+    dev: true
+
+  /melody-types@1.7.5:
+    resolution: {integrity: sha512-KkZmYlkmHtK10Hyx0mVNBZg1OXctIzZo2w3Vyc5AOV+KLA5lRiG6Z3Lp+G8o1LD6UZY0PC83/57hw3gs2Qj+Tg==}
+    dependencies:
+      babel-types: 6.26.0
+    dev: true
+
   /mem@5.1.1:
     resolution: {integrity: sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==}
     engines: {node: '>=8'}
@@ -14822,6 +14851,21 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: 1.3.0
+    dev: true
+
+  /prettier-plugin-django@0.5.7:
+    resolution: {integrity: sha512-kO86NWFpF2xRM/Fzg+crPSsLiT+xuJFOnqTIp2W/+qshnsQW5XV/3Ef4UtRchdtvn/K99eox+BDIxHq1blIN1w==}
+    engines: {node: '>=6'}
+    dependencies:
+      babel-template: 6.26.0(supports-color@8.1.1)
+      entities: 4.5.0
+      melody-code-frame: 1.7.5
+      melody-idom: 1.7.5
+      melody-traverse: 1.7.5(melody-types@1.7.5)
+      melody-types: 1.7.5
+      resolve: 1.22.2
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /prettier@2.8.8:

--- a/server/index.js
+++ b/server/index.js
@@ -18,7 +18,7 @@
 //
 // This list must be kept up to date with the nginx configuration _and_ the list
 // of prefixes in `middleware::ember_html::serve_html`.
-const proxyPaths = ['/api/'];
+const proxyPaths = ['/admin/', '/api/'];
 
 function installBackendProxy(app) {
   // Load the proxy backend from the environment.

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@
 
 use crate::config;
 use crate::db::{ConnectionConfig, DieselPool, DieselPooledConn, PoolError};
+use crate::views::admin::templating;
 use std::ops::Deref;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
@@ -68,6 +69,9 @@ pub struct App {
 
     /// In-flight request counters for the `balance_capacity` middleware.
     pub balance_capacity: BalanceCapacityState,
+
+    /// Admin templating engine.
+    pub admin_engine: templating::Engine,
 }
 
 impl App {
@@ -179,6 +183,8 @@ impl App {
             fastboot_client,
             balance_capacity: Default::default(),
             config,
+            admin_engine: templating::engine()
+                .expect("could not initialize admin templating engine"),
         }
     }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,5 +1,8 @@
+use std::collections::HashSet;
+
 use crate::controllers;
 use crate::controllers::util::RequestPartsExt;
+use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::RequestLogExt;
 use crate::middleware::session::RequestSession;
 use crate::models::token::{CrateScope, EndpointScope};
@@ -16,6 +19,7 @@ pub struct AuthCheck {
     allow_token: bool,
     endpoint_scope: Option<EndpointScope>,
     crate_name: Option<String>,
+    require_admin: bool,
 }
 
 impl AuthCheck {
@@ -27,6 +31,7 @@ impl AuthCheck {
             allow_token: true,
             endpoint_scope: None,
             crate_name: None,
+            require_admin: false,
         }
     }
 
@@ -36,6 +41,7 @@ impl AuthCheck {
             allow_token: false,
             endpoint_scope: None,
             crate_name: None,
+            require_admin: false,
         }
     }
 
@@ -44,6 +50,7 @@ impl AuthCheck {
             allow_token: self.allow_token,
             endpoint_scope: Some(endpoint_scope),
             crate_name: self.crate_name.clone(),
+            require_admin: self.require_admin,
         }
     }
 
@@ -52,6 +59,16 @@ impl AuthCheck {
             allow_token: self.allow_token,
             endpoint_scope: self.endpoint_scope,
             crate_name: Some(crate_name.to_string()),
+            require_admin: self.require_admin,
+        }
+    }
+
+    pub fn require_admin(&self) -> Self {
+        Self {
+            allow_token: self.allow_token,
+            endpoint_scope: self.endpoint_scope,
+            crate_name: self.crate_name.clone(),
+            require_admin: true,
         }
     }
 
@@ -61,8 +78,17 @@ impl AuthCheck {
         request: &T,
         conn: &mut PgConnection,
     ) -> AppResult<Authentication> {
-        let auth = authenticate(request, conn)?;
+        self.check_authentication(
+            authenticate(request, conn)?,
+            &request.app().config.gh_admin_user_ids,
+        )
+    }
 
+    fn check_authentication(
+        &self,
+        auth: Authentication,
+        gh_admin_user_ids: &HashSet<i32>,
+    ) -> AppResult<Authentication> {
         if let Some(token) = auth.api_token() {
             if !self.allow_token {
                 let error_message =
@@ -79,6 +105,11 @@ impl AuthCheck {
                 let error_message = "Crate scope mismatch";
                 return Err(internal(error_message).chain(forbidden()));
             }
+        }
+
+        if self.require_admin && !gh_admin_user_ids.contains(&auth.user().gh_id) {
+            let error_message = "User is unauthorized";
+            return Err(internal(error_message).chain(forbidden()));
         }
 
         Ok(auth)
@@ -346,5 +377,44 @@ mod tests {
         assert!(auth_check.crate_scope_matches(Some(&vec![cs("tokio-*")])));
         assert!(!auth_check.crate_scope_matches(Some(&vec![cs("anyhow")])));
         assert!(!auth_check.crate_scope_matches(Some(&vec![cs("actix-*")])));
+    }
+
+    #[test]
+    fn require_admin() {
+        let auth_check = AuthCheck::default().require_admin();
+        let gh_admin_user_ids = [42, 43].into_iter().collect();
+
+        assert_ok!(auth_check.check_authentication(mock_cookie(42), &gh_admin_user_ids));
+        assert_err!(auth_check.check_authentication(mock_cookie(44), &gh_admin_user_ids));
+        assert_ok!(auth_check.check_authentication(mock_token(43), &gh_admin_user_ids));
+        assert_err!(auth_check.check_authentication(mock_token(45), &gh_admin_user_ids));
+    }
+
+    fn mock_user(gh_id: i32) -> User {
+        User {
+            id: 3,
+            gh_access_token: "arbitrary".into(),
+            gh_login: "literally_anything".into(),
+            name: None,
+            gh_avatar: None,
+            gh_id,
+            account_lock_reason: None,
+            account_lock_until: None,
+        }
+    }
+
+    fn mock_cookie(gh_id: i32) -> Authentication {
+        Authentication::Cookie(CookieAuthentication {
+            user: mock_user(gh_id),
+        })
+    }
+
+    fn mock_token(gh_id: i32) -> Authentication {
+        Authentication::Token(TokenAuthentication {
+            token: crate::models::token::tests::build_mock()
+                .user_id(gh_id)
+                .token(),
+            user: mock_user(gh_id),
+        })
     }
 }

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -64,6 +64,7 @@ mod prelude {
 pub mod helpers;
 pub mod util;
 
+pub mod admin;
 pub mod category;
 mod conduit_axum;
 pub mod crate_owner_invitation;

--- a/src/controllers/admin.rs
+++ b/src/controllers/admin.rs
@@ -1,0 +1,100 @@
+use axum::extract::Query;
+use axum::response::IntoResponse;
+use diesel::sql_types::Text;
+use diesel_full_text_search::TsQuery;
+use diesel_full_text_search::TsQueryExtensions;
+
+use crate::auth::AuthCheck;
+use crate::controllers::frontend_prelude::*;
+use crate::controllers::helpers::pagination::Page;
+use crate::controllers::helpers::pagination::Paginated;
+use crate::controllers::helpers::pagination::PaginationOptions;
+use crate::controllers::helpers::*;
+use crate::models::Crate;
+use crate::models::User;
+use crate::models::Version;
+use crate::util::errors::AppResult;
+use crate::views;
+
+/// Handles the `GET /admin/` route.
+pub async fn index(app: AppState, req: Parts) -> impl IntoResponse {
+    conduit_compat(move || {
+        let conn = &mut *app.db_read()?;
+        let _auth = AuthCheck::default().require_admin().check(&req, conn)?;
+
+        Ok(redirect("/admin/crates/".to_string()))
+    })
+    .await
+}
+
+#[derive(Deserialize)]
+pub struct CrateQuery {
+    q: Option<String>,
+    page: Option<u32>,
+}
+
+impl CrateQuery {
+    fn page(&self) -> u32 {
+        self.page.unwrap_or(1)
+    }
+
+    fn query_string(&self) -> Option<&str> {
+        match &self.q {
+            Some(q) if !q.is_empty() => Some(q.as_str()),
+            _ => None,
+        }
+    }
+}
+
+/// Handles the `GET /admin/crates/` route.
+pub async fn crates(app: AppState, q: Query<CrateQuery>) -> AppResult<impl IntoResponse> {
+    const PER_PAGE: u32 = 50;
+
+    let pagination = PaginationOptions {
+        page: Page::Numeric(q.page()),
+        per_page: PER_PAGE as i64,
+    };
+
+    conduit_compat(move || {
+        use crate::schema::{crates, users, versions};
+        use diesel::dsl::*;
+
+        let conn = &mut *app.db_read()?;
+
+        let mut query = versions::table
+            .inner_join(crates::table)
+            .inner_join(users::table)
+            .order(versions::created_at.desc())
+            .select((
+                versions::all_columns,
+                crate::models::krate::ALL_COLUMNS,
+                users::all_columns,
+            ))
+            .into_boxed();
+
+        if let Some(q_string) = q.query_string() {
+            // FIXME: this is stolen from the public search controller, and
+            // should be refactored into a common helper.
+            let q = sql::<TsQuery>("plainto_tsquery('english', ")
+                .bind::<Text, _>(q_string)
+                .sql(")");
+            query = query
+                .filter(
+                    q.clone()
+                        .matches(crates::textsearchable_index_col)
+                        .or(Crate::loosly_matches_name(q_string)),
+                )
+                .order(Crate::with_name(q_string).desc())
+                .then_order_by(versions::created_at.desc());
+        }
+
+        let data: Paginated<(Version, Crate, User)> =
+            query.pages_pagination(pagination).load(conn)?;
+        Ok(views::admin::crates::render(
+            &app.admin_engine,
+            q.query_string(),
+            data,
+        ))
+    })
+    .await
+}

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -46,8 +46,9 @@ pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
 
         let verified = verified.unwrap_or(false);
         let verification_sent = verified || verification_sent;
+        let admin = app.config.gh_admin_user_ids.contains(&user.gh_id);
         Ok(Json(EncodableMe {
-            user: EncodablePrivateUser::from(user, email, verified, verification_sent),
+            user: EncodablePrivateUser::from(user, email, verified, verification_sent, admin),
             owned_crates,
         }))
     })

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -63,7 +63,9 @@ fn modify_yank(
     let user = auth.user();
     let owners = krate.owners(conn)?;
 
-    if user.rights(state, &owners)? < Rights::Publish {
+    if user.rights(state, &owners)? < Rights::Publish
+        && !state.config.gh_admin_user_ids.contains(&user.gh_id)
+    {
         return Err(cargo_err("must already be an owner to yank or unyank"));
     }
 

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -25,8 +25,11 @@ pub async fn serve_html<B: Send + 'static>(
 ) -> Response {
     let path = &request.uri().path();
 
-    // The "/git/" prefix is only used in development (when within a docker container)
-    if path.starts_with("/api/") || path.starts_with("/git/") {
+    // The "/git/" prefix is only used in development (when within a docker container).
+    //
+    // The other prefixes must be kept in sync with the `proxyPaths` defined in `server/index.js`
+    // and the nginx configuration.
+    if path.starts_with("/admin/") || path.starts_with("/api/") || path.starts_with("/git/") {
         next.run(request).await
     } else {
         if let Some(client) = &state.fastboot_client {

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -98,28 +98,28 @@ pub struct CreatedApiToken {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use chrono::NaiveDate;
 
     #[test]
     fn api_token_serializes_to_rfc3339() {
-        let tok = ApiToken {
-            id: 12345,
-            user_id: 23456,
-            revoked: false,
-            name: "".to_string(),
-            created_at: NaiveDate::from_ymd_opt(2017, 1, 6)
-                .unwrap()
-                .and_hms_opt(14, 23, 11)
+        let tok = build_mock()
+            .created_at(
+                NaiveDate::from_ymd_opt(2017, 1, 6)
+                    .unwrap()
+                    .and_hms_opt(14, 23, 11)
+                    .unwrap(),
+            )
+            .last_used_at(
+                Some(
+                    NaiveDate::from_ymd_opt(2017, 1, 6)
+                        .unwrap()
+                        .and_hms_opt(14, 23, 12),
+                )
                 .unwrap(),
-            last_used_at: NaiveDate::from_ymd_opt(2017, 1, 6)
-                .unwrap()
-                .and_hms_opt(14, 23, 12),
-            crate_scopes: None,
-            endpoint_scopes: None,
-            expired_at: None,
-        };
+            )
+            .token();
         let json = serde_json::to_string(&tok).unwrap();
         assert_some!(json
             .as_str()
@@ -127,5 +127,67 @@ mod tests {
         assert_some!(json
             .as_str()
             .find(r#""last_used_at":"2017-01-06T14:23:12+00:00""#));
+    }
+
+    pub struct MockBuilder(ApiToken);
+
+    impl MockBuilder {
+        pub fn token(self) -> ApiToken {
+            self.0
+        }
+
+        pub fn id(mut self, id: i32) -> Self {
+            self.0.id = id;
+            self
+        }
+
+        pub fn user_id(mut self, user_id: i32) -> Self {
+            self.0.user_id = user_id;
+            self
+        }
+
+        pub fn name(mut self, name: String) -> Self {
+            self.0.name = name;
+            self
+        }
+
+        pub fn created_at(mut self, created_at: NaiveDateTime) -> Self {
+            self.0.created_at = created_at;
+            self
+        }
+
+        pub fn last_used_at(mut self, last_used_at: Option<NaiveDateTime>) -> Self {
+            self.0.last_used_at = last_used_at;
+            self
+        }
+
+        pub fn revoked(mut self, revoked: bool) -> Self {
+            self.0.revoked = revoked;
+            self
+        }
+
+        pub fn crate_scopes(mut self, crate_scopes: Option<Vec<CrateScope>>) -> Self {
+            self.0.crate_scopes = crate_scopes;
+            self
+        }
+
+        pub fn endpoint_scopes(mut self, endpoint_scopes: Option<Vec<EndpointScope>>) -> Self {
+            self.0.endpoint_scopes = endpoint_scopes;
+            self
+        }
+    }
+
+    pub fn build_mock() -> MockBuilder {
+        MockBuilder(ApiToken {
+            id: 12345,
+            user_id: 23456,
+            revoked: false,
+            name: "".to_string(),
+            created_at: NaiveDateTime::default(),
+            last_used_at: None,
+            crate_scopes: None,
+            endpoint_scopes: None,
+            expired_at: None,
+        })
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -156,7 +156,9 @@ pub fn build_axum_router(state: AppState) -> Router {
         .route(
             "/api/github/secret-scanning/verify",
             post(github::secret_scanning::verify),
-        );
+        )
+        .route("/admin/", get(admin::index))
+        .route("/admin/crates/", get(admin::crates));
 
     // Only serve the local checkout of the git index in development mode.
     // In production, for crates.io, cargo gets the index from

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -589,7 +589,7 @@ fn api_token_cannot_list_invitations_v1() {
     let (_, _, _, token) = TestApp::init().with_token();
 
     token
-        .get("/api/v1/me/crate_owner_invitations")
+        .get::<()>("/api/v1/me/crate_owner_invitations")
         .assert_forbidden();
 }
 

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -11,7 +11,7 @@ fn show() {
     let url = "/api/v1/categories/foo-bar";
 
     // Return not found if a category doesn't exist
-    anon.get(url).assert_not_found();
+    anon.get::<()>(url).assert_not_found();
 
     // Create a category and a subcategory
     app.db(|conn| {

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -5,7 +5,7 @@ use crate::util::{RequestHelper, TestApp};
 fn diesel_not_found_results_in_404() {
     let (_, _, user) = TestApp::init().with_user();
 
-    user.get("/api/v1/crates/foo_following/following")
+    user.get::<()>("/api/v1/crates/foo_following/following")
         .assert_not_found();
 }
 
@@ -22,6 +22,6 @@ fn disallow_api_token_auth_for_get_crate_following_status() {
 
     // Token auth on GET for get following status is disallowed
     token
-        .get(&format!("/api/v1/crates/{a_crate}/following"))
+        .get::<()>(&format!("/api/v1/crates/{a_crate}/following"))
         .assert_forbidden();
 }

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -10,7 +10,7 @@ fn download_nonexistent_version_of_existing_crate_404s() {
         CrateBuilder::new("foo_bad", user.id).expect_build(conn);
     });
 
-    anon.get("/api/v1/crates/foo_bad/0.1.0/download")
+    anon.get::<()>("/api/v1/crates/foo_bad/0.1.0/download")
         .assert_not_found();
 }
 

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -12,7 +12,7 @@ struct GoodKeyword {
 fn show() {
     let url = "/api/v1/keywords/foo";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_not_found();
+    anon.get::<()>(url).assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
@@ -25,7 +25,7 @@ fn show() {
 fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_not_found();
+    anon.get::<()>(url).assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -19,7 +19,7 @@ pub struct UserShowPrivateResponse {
 fn me() {
     let url = "/api/v1/me";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_forbidden();
+    anon.get::<()>(url).assert_forbidden();
 
     let user = app.db_new_user("foo");
     let json = user.show_me();

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -11,7 +11,8 @@ static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;
 #[test]
 fn create_token_logged_out() {
     let (_, anon) = TestApp::init().empty();
-    anon.put("/api/v1/me/tokens", NEW_BAR).assert_forbidden();
+    anon.put::<()>("/api/v1/me/tokens", NEW_BAR)
+        .assert_forbidden();
 }
 
 #[test]

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -8,13 +8,13 @@ use http::StatusCode;
 #[test]
 fn list_logged_out() {
     let (_, anon) = TestApp::init().empty();
-    anon.get("/api/v1/me/tokens").assert_forbidden();
+    anon.get::<()>("/api/v1/me/tokens").assert_forbidden();
 }
 
 #[test]
 fn list_with_api_token_is_forbidden() {
     let (_, _, _, token) = TestApp::init().with_token();
-    token.get("/api/v1/me/tokens").assert_forbidden();
+    token.get::<()>("/api/v1/me/tokens").assert_forbidden();
 }
 
 #[test]

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -10,7 +10,7 @@ use http::StatusCode;
 #[test]
 fn api_token_cannot_get_user_updates() {
     let (_, _, _, token) = TestApp::init().with_token();
-    token.get("/api/v1/me/updates").assert_forbidden();
+    token.get::<()>("/api/v1/me/updates").assert_forbidden();
 }
 
 #[test]

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -9,7 +9,7 @@ fn using_token_updates_last_used_at() {
     let url = "/api/v1/me";
     let (app, anon, user, token) = TestApp::init().with_token();
 
-    anon.get(url).assert_forbidden();
+    anon.get::<()>(url).assert_forbidden();
     user.get::<EncodableMe>(url).good();
     assert_none!(token.as_model().last_used_at);
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -23,6 +23,18 @@ where
         }
         json(self.response)
     }
+
+    /// Assert that the status code is 404
+    #[track_caller]
+    pub fn assert_not_found(&self) {
+        assert_eq!(StatusCode::NOT_FOUND, self.status());
+    }
+
+    /// Assert that the status code is 403
+    #[track_caller]
+    pub fn assert_forbidden(&self) {
+        assert_eq!(StatusCode::FORBIDDEN, self.status());
+    }
 }
 
 impl<T> Response<T> {
@@ -56,20 +68,6 @@ impl<T> Response<T> {
             .unwrap()
             .ends_with(target));
         self
-    }
-}
-
-impl Response<()> {
-    /// Assert that the status code is 404
-    #[track_caller]
-    pub fn assert_not_found(&self) {
-        assert_eq!(StatusCode::NOT_FOUND, self.status());
-    }
-
-    /// Assert that the status code is 403
-    #[track_caller]
-    pub fn assert_forbidden(&self) {
-        assert_eq!(StatusCode::FORBIDDEN, self.status());
     }
 }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -439,6 +439,7 @@ fn simple_config() -> config::Server {
         version_id_cache_ttl: Duration::from_secs(5 * 60),
         cdn_user_agent: "Amazon CloudFront".to_string(),
         balance_capacity,
+        gh_admin_user_ids: HashSet::new(),
 
         // The frontend code is not needed for the backend tests.
         serve_dist: false,

--- a/src/views.rs
+++ b/src/views.rs
@@ -10,6 +10,7 @@ use crate::models::{
 };
 use crate::util::rfc3339;
 
+pub mod admin;
 pub mod krate_publish;
 pub use self::krate_publish::{EncodableCrateDependency, EncodableCrateUpload};
 
@@ -498,9 +499,8 @@ pub struct EncodableMe {
     pub owned_crates: Vec<OwnedCrate>,
 }
 
-/// The serialization format for the `User` model.
-/// Same as public user, except for addition of
-/// email field
+/// The serialization format for the `User` model. Same as public user, except for addition of
+/// email and admin fields.
 #[derive(Deserialize, Serialize, Debug)]
 pub struct EncodablePrivateUser {
     pub id: i32,
@@ -511,6 +511,7 @@ pub struct EncodablePrivateUser {
     pub email: Option<String>,
     pub avatar: Option<String>,
     pub url: Option<String>,
+    pub admin: bool,
 }
 
 impl EncodablePrivateUser {
@@ -520,6 +521,7 @@ impl EncodablePrivateUser {
         email: Option<String>,
         email_verified: bool,
         email_verification_sent: bool,
+        admin: bool,
     ) -> Self {
         let User {
             id,
@@ -539,6 +541,7 @@ impl EncodablePrivateUser {
             login: gh_login,
             name,
             url: Some(url),
+            admin,
         }
     }
 }

--- a/src/views/admin.rs
+++ b/src/views/admin.rs
@@ -1,0 +1,2 @@
+pub mod crates;
+pub mod templating;

--- a/src/views/admin/crates.rs
+++ b/src/views/admin/crates.rs
@@ -1,0 +1,59 @@
+use axum::response::IntoResponse;
+use minijinja::context;
+
+use crate::{
+    controllers::helpers::pagination::Paginated,
+    models::{Crate, User, Version},
+};
+
+use super::templating::{self, components, Renderer};
+
+#[derive(Serialize)]
+struct View {
+    page: components::Page,
+    q: String,
+    versions: Vec<CrateVersion>,
+}
+
+#[derive(Serialize)]
+struct CrateVersion {
+    id: i32,
+    name: String,
+    num: String,
+    created_at: components::DateTime,
+    publisher: components::User,
+    yanked: bool,
+}
+
+impl CrateVersion {
+    fn new(version: Version, krate: Crate, user: User) -> Self {
+        Self {
+            id: version.id,
+            name: krate.name,
+            num: version.num,
+            created_at: version.created_at.into(),
+            publisher: user.into(),
+            yanked: version.yanked,
+        }
+    }
+}
+
+pub fn render<R>(
+    env: &R,
+    q: Option<&str>,
+    page: Paginated<(Version, Crate, User)>,
+) -> impl IntoResponse
+where
+    R: Renderer,
+{
+    let view = View {
+        q: q.map(|s| s.to_string()).unwrap_or_default(),
+        page: components::Page::new(&page, q),
+        versions: page
+            .into_iter()
+            .map(|(version, krate, user)| CrateVersion::new(version, krate, user))
+            .collect(),
+    };
+
+    templating::render_response(env, "crates/index.html", context!(view => view))
+}

--- a/src/views/admin/templating.rs
+++ b/src/views/admin/templating.rs
@@ -1,0 +1,156 @@
+use axum::response::{IntoResponse, Response};
+use http::{header, StatusCode};
+use minijinja::Environment;
+use serde::Serialize;
+use thiserror::Error;
+
+pub mod components;
+mod helpers;
+
+// If this all feels overly complicated, it is.
+//
+// The goal here is simple. In debug builds, we want to hot reload templates as they are changed on
+// the disk, since that makes template development easier. In release builds, we want to embed the
+// templates into the binary, compile them once on startup, and then never think about them again
+// except to use them for rendering.
+//
+// The only interface we need at the view level is the ability to render an arbitrary template with
+// arbitrary context data.
+//
+// Unfortunately, the underlying types to facilitate this don't look much like each other. The
+// debug version is AutoReloader (no lifetime), while the release version is Environment<'source>
+// (complete with lifetime). We can't just box this behind a trait because the render methods
+// aren't object safe, since the context data can be anything serde can serialise.
+//
+// Instead, we'll do some compile time detection to make the debug and release implementations look
+// similar enough that they can be used interchangably by calling code, and provide a trait that
+// they both implement that smoothes over the differences.
+
+pub trait Renderer {
+    fn render<S>(&self, key: &str, data: S) -> Result<String, Error>
+    where
+        S: Serialize;
+}
+
+#[cfg(debug_assertions)]
+pub type Engine = debug::Engine;
+
+#[cfg(not(debug_assertions))]
+pub type Engine = release::Engine<'static>;
+
+pub fn engine() -> Result<Engine, Error> {
+    Engine::new()
+}
+
+pub fn render_response<R, S>(env: &R, key: &str, data: S) -> Response
+where
+    R: Renderer,
+    S: Serialize,
+{
+    match env.render(key, data) {
+        Ok(content) => (
+            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            content,
+        )
+            .into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
+mod debug {
+    use std::{path::PathBuf, str::FromStr};
+
+    use minijinja::{path_loader, Environment};
+    use minijinja_autoreload::AutoReloader;
+
+    use super::{register_filters, Error, Renderer};
+
+    pub struct Engine(AutoReloader);
+
+    impl Engine {
+        #[allow(dead_code)]
+        pub(super) fn new() -> Result<Self, Error> {
+            let template_path = PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
+                .expect("PathBuf::from_str is infallible")
+                .join("admin")
+                .join("templates");
+
+            Ok(Self(AutoReloader::new(move |notifier| {
+                notifier.watch_path(&template_path, true);
+
+                let mut env = Environment::new();
+                env.set_debug(true);
+                env.set_loader(path_loader(&template_path));
+                register_filters(&mut env);
+                Ok(env)
+            })))
+        }
+    }
+
+    impl Renderer for Engine {
+        fn render<S>(&self, key: &str, data: S) -> Result<String, Error>
+        where
+            S: serde::Serialize,
+        {
+            Ok(self.0.acquire_env()?.get_template(key)?.render(data)?)
+        }
+    }
+}
+
+mod release {
+    use minijinja::Environment;
+    use rust_embed::RustEmbed;
+    use serde::Serialize;
+
+    use super::{register_filters, Error, Renderer};
+
+    #[derive(RustEmbed)]
+    #[folder = "admin/templates/"]
+    struct Assets;
+
+    pub struct Engine<'a>(Environment<'a>);
+
+    impl<'a> Engine<'a> {
+        #[allow(dead_code)]
+        pub(super) fn new() -> Result<Self, Error> {
+            let mut env = Environment::new();
+
+            for name in Assets::iter() {
+                env.add_template_owned(
+                    name.to_string(),
+                    String::from_utf8(Assets::get(&name).expect("embedded template").data.to_vec())
+                        .expect("template must be valid UTF-8"),
+                )?;
+            }
+
+            register_filters(&mut env);
+            Ok(Self(env))
+        }
+    }
+
+    impl<'a> Renderer for Engine<'a> {
+        fn render<S>(&self, key: &str, data: S) -> Result<String, Error>
+        where
+            S: Serialize,
+        {
+            Ok(self.0.get_template(key)?.render(data)?)
+        }
+    }
+}
+
+fn register_filters(env: &mut Environment<'_>) {
+    env.add_filter("crate_index_path", helpers::crate_index_path);
+}
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(transparent)]
+    Minijinja(#[from] minijinja::Error),
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> axum::response::Response {
+        // FIXME: don't necessarily output the full error in prod.
+        (StatusCode::INTERNAL_SERVER_ERROR, format!("{:?}", &self)).into_response()
+    }
+}

--- a/src/views/admin/templating/components.rs
+++ b/src/views/admin/templating/components.rs
@@ -1,0 +1,8 @@
+mod datetime;
+pub use datetime::DateTime;
+
+mod page;
+pub use page::Page;
+
+mod user;
+pub use user::User;

--- a/src/views/admin/templating/components/datetime.rs
+++ b/src/views/admin/templating/components/datetime.rs
@@ -1,0 +1,161 @@
+use chrono::{Duration, NaiveDateTime, Utc};
+use serde::{ser::SerializeMap, Serialize};
+
+#[derive(Debug, Clone, Copy)]
+pub struct DateTime {
+    time: NaiveDateTime,
+    #[cfg(test)]
+    now: chrono::DateTime<Utc>,
+}
+
+impl DateTime {
+    fn now(&self) -> chrono::DateTime<Utc> {
+        #[cfg(test)]
+        return self.now;
+
+        #[cfg(not(test))]
+        return Utc::now();
+    }
+}
+
+impl From<NaiveDateTime> for DateTime {
+    fn from(time: NaiveDateTime) -> Self {
+        Self {
+            time,
+            #[cfg(test)]
+            now: Utc::now(),
+        }
+    }
+}
+
+impl Serialize for DateTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("absolute", &format_time(self.time))?;
+        map.serialize_entry(
+            "human",
+            &format_duration(self.now().naive_utc() - self.time),
+        )?;
+        map.end()
+    }
+}
+
+fn format_time(time: NaiveDateTime) -> String {
+    time.format("%a %-d %b %Y %H:%M:%S").to_string()
+}
+
+fn format_duration(duration: Duration) -> String {
+    // This originally delegated out to chrono-human-duration or
+    // pretty-duration, but the former had bugs around handling plurals and the
+    // latter could only handle std::time::Duration and didn't have any options
+    // to not include every unit. What we really need is so simple that it's
+    // easier to just implement it here.
+    let abs = if duration < Duration::zero() {
+        -duration
+    } else {
+        duration
+    };
+    let adverb = adverb(duration);
+
+    match (
+        abs.num_weeks(),
+        abs.num_days(),
+        abs.num_hours(),
+        abs.num_minutes(),
+        abs.num_seconds(),
+    ) {
+        (_, days, _, _, _) if days >= 365 => {
+            // Technically, leap years exist. Practically, it doesn't matter for
+            // a fuzzy duration anyway.
+            format!("{} year{} {}", days / 365, plural(days / 365), adverb)
+        }
+        (_, days, _, _, _) if days >= 30 => {
+            // Same for months, honestly.
+            format!("{} month{} {}", days / 30, plural(days / 30), adverb)
+        }
+        (weeks, _, _, _, _) if weeks > 0 => {
+            format!("{} week{} {}", weeks, plural(weeks), adverb)
+        }
+        (_, days, _, _, _) if days > 0 => {
+            format!("{} day{} {}", days, plural(days), adverb)
+        }
+        (_, _, hours, _, _) if hours > 0 => {
+            format!("{} hour{} {}", hours, plural(hours), adverb)
+        }
+        (_, _, _, minutes, _) if minutes > 0 => {
+            format!("{} minute{} {}", minutes, plural(minutes), adverb)
+        }
+        (_, _, _, _, seconds) if seconds > 0 => {
+            format!("{} second{} {}", seconds, plural(seconds), adverb)
+        }
+        _ => String::from("just now"),
+    }
+}
+
+fn plural(value: i64) -> &'static str {
+    if value == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+fn adverb(duration: Duration) -> &'static str {
+    // These durations are technically reversed; see the code in
+    // `DateTime::serialize` for the full details of how the durations are
+    // calculated.
+    if duration > Duration::zero() {
+        "ago"
+    } else {
+        "from now"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+    use serde_json::Value;
+
+    use super::*;
+
+    #[test]
+    fn datetime_formatting() -> anyhow::Result<()> {
+        let now = Utc
+            .with_ymd_and_hms(2023, 5, 31, 21, 43, 42)
+            .single()
+            .unwrap();
+
+        for (input, human) in [
+            ("2023-05-31T21:43:42Z", "just now"),
+            ("2023-05-31T21:43:32Z", "10 seconds ago"),
+            ("2023-05-31T21:42:42Z", "1 minute ago"),
+            ("2023-05-31T20:43:42Z", "1 hour ago"),
+            ("2023-05-31T19:43:42Z", "2 hours ago"),
+            ("2023-05-30T21:43:42Z", "1 day ago"),
+            ("2023-05-24T21:43:42Z", "1 week ago"),
+            ("2023-05-17T21:43:42Z", "2 weeks ago"),
+            ("2022-06-01T21:43:42Z", "12 months ago"),
+            ("2021-05-31T21:43:42Z", "2 years ago"),
+            ("2024-05-31T21:43:42Z", "1 year from now"),
+        ] {
+            let dt = DateTime {
+                time: NaiveDateTime::parse_from_str(input, "%Y-%m-%dT%H:%M:%SZ")?,
+                now,
+            };
+
+            let out = serde_json::to_value(dt)?;
+            match out {
+                Value::Object(map) => {
+                    assert_eq!(map.get("absolute").unwrap(), &format_time(dt.time));
+                    assert_eq!(map.get("human").unwrap(), human);
+                }
+                _ => panic!("unexpected JSON value type: {out:?}"),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/views/admin/templating/components/page.rs
+++ b/src/views/admin/templating/components/page.rs
@@ -1,0 +1,80 @@
+use crate::controllers::helpers::pagination::{self, Paginated};
+use serde::{ser::SerializeMap, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct Page {
+    current: u32,
+    total: u32,
+    q: Option<String>,
+}
+
+impl Page {
+    pub fn new<T>(resultset: &Paginated<T>, q: Option<&str>) -> Self {
+        Self {
+            current: if let pagination::Page::Numeric(n) = resultset.current_page() {
+                *n
+            } else {
+                // We just don't support seek pagination right now in the admin, and if it's not
+                // specific, we want to default to 1 regardless.
+                1
+            },
+            total: resultset.total_pages() as u32,
+            q: q.map(|s| s.to_string()),
+        }
+    }
+
+    fn page_url(&self, page: u32) -> String {
+        use url::form_urlencoded::Serializer;
+
+        let mut s = Serializer::new(String::from("?"));
+        s.append_pair("page", &page.to_string());
+        if let Some(q) = &self.q {
+            s.append_pair("q", q);
+        }
+        s.finish()
+    }
+}
+
+impl Serialize for Page {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(Serialize)]
+        struct PageView {
+            number: u32,
+            active: bool,
+            url: String,
+        }
+
+        let mut map = serializer.serialize_map(Some(4))?;
+        map.serialize_entry("paginated", &(self.total > 1))?;
+        map.serialize_entry(
+            "previous",
+            &if self.current < 2 {
+                None
+            } else {
+                Some(self.page_url(self.current - 1))
+            },
+        )?;
+        map.serialize_entry(
+            "next",
+            &if self.current >= self.total {
+                None
+            } else {
+                Some(self.page_url(self.current + 1))
+            },
+        )?;
+        map.serialize_entry(
+            "pages",
+            &((1..=self.total)
+                .map(|page| PageView {
+                    number: page,
+                    active: page == self.current,
+                    url: self.page_url(page),
+                })
+                .collect::<Vec<_>>()),
+        )?;
+        map.end()
+    }
+}

--- a/src/views/admin/templating/components/user.rs
+++ b/src/views/admin/templating/components/user.rs
@@ -1,0 +1,18 @@
+use crate::models;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct User {
+    id: i32,
+    avatar: Option<String>,
+    username: String,
+}
+
+impl From<models::User> for User {
+    fn from(value: models::User) -> Self {
+        Self {
+            id: value.id,
+            avatar: value.gh_avatar,
+            username: value.gh_login,
+        }
+    }
+}

--- a/src/views/admin/templating/helpers.rs
+++ b/src/views/admin/templating/helpers.rs
@@ -1,0 +1,9 @@
+use crates_io_index::Repository;
+
+pub(super) fn crate_index_path(name: &str) -> String {
+    String::from(
+        Repository::relative_index_file(name)
+            .to_str()
+            .expect("invalid UTF-8 in crate name"),
+    )
+}


### PR DESCRIPTION
## PR administrivia

This is kind of a "draw the rest of the owl" PR. It depends on (and currently includes) these other PRs:

* #6456 
* #6585 

From there, it's hard to split anything else out, but I'll have a go if we really want that. (Maybe some of the foundational templating stuff could be separated, I guess.)

Finally, this (obviously) supersedes #6353, which I'll close momentarily. I believe I've addressed all the open points in there in some form. (And it no longer requires the awful caddy hackery used to handle my lack of knowledge of the dev server routing at the time.)

## Description

This uses our existing `minijinja` dependency to implement a (mostly) static HTML admin console that the crates.io team can use to administer crates without needing direct database access. For now, the only administrative action allowed is yanking and unyanking crate versions, but further actions are anticipated to be added in the near future.

The spiciest part of this commit is probably the routing changes, rather than the actual templating code and controller changes, since these need to be applied across the development server, nginx, and anything else that's in front of our frontend and backend servers.

## Licensing administrivia

A transitive dependency of `minijinja-autoreload` is licensed as CC0 OR Artistic 2.0 — AFAIK, CC0 should be fine, since it's more permissive than MIT, but I had to update our cargo-deny configuration accordingly.

## Likely problems

I don't have access to Heroku and have little knowledge of our deployments, so we'll need to figure out a testing plan on staging to verify that defining admins and routing happens as we expect.

## Next steps after this PR is (hopefully) merged

Here's my planned work in the near future (hopefully much faster than this project):

* Crate deletion
* Basic user administration
* Quarantine admin, assuming the RFC is accepted