### PR TITLE
tracing: Use `INFO` as default level

### DIFF
--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -7,7 +7,6 @@ use crates_io::admin::{
     backfill, delete_crate, delete_version, enqueue_job, git_import, migrate, populate,
     render_readmes, test_pagerduty, transfer_crates, upload_index, verify_token, yank_version,
 };
-use tracing_subscriber::filter::LevelFilter;
 
 #[derive(clap::Parser, Debug)]
 #[command(name = "crates-admin")]
@@ -33,7 +32,7 @@ fn main() -> anyhow::Result<()> {
     let _sentry = crates_io::sentry::init();
 
     // Initialize logging
-    crates_io::util::tracing::init_with_default_level(LevelFilter::INFO);
+    crates_io::util::tracing::init();
 
     use clap::Parser;
 

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -6,16 +6,17 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 
 /// Initializes the `tracing` logging framework.
 ///
-/// Regular CLI output is influenced by the
-/// [`RUST_LOG`](tracing_subscriber::filter::EnvFilter) environment variable.
+/// Regular CLI output is influenced by the optional
+/// [`RUST_LOG`](tracing_subscriber::filter::EnvFilter) environment variable
+/// and is showing all `INFO` level events by default.
 ///
 /// This function also sets up the Sentry error reporting integration for the
 /// `tracing` framework, which is hardcoded to include all `INFO` level events.
 pub fn init() {
-    init_with_default_level(LevelFilter::ERROR)
+    init_with_default_level(LevelFilter::INFO)
 }
 
-pub fn init_with_default_level(level: LevelFilter) {
+fn init_with_default_level(level: LevelFilter) {
     let env_filter = EnvFilter::builder()
         .with_default_directive(level.into())
         .from_env_lossy();


### PR DESCRIPTION
This is what we're using in production, so we might as well make it the default.