### PR TITLE
Show which crate violating wildcard dependency

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -32,11 +32,6 @@ pub const MISSING_RIGHTS_ERROR_MESSAGE: &str =
      to accept an invitation to be an owner before \
      publishing.";
 
-pub const WILDCARD_ERROR_MESSAGE: &str = "wildcard (`*`) dependency constraints are not allowed \
-     on crates.io. See https://doc.rust-lang.org/cargo/faq.html#can-\
-     libraries-use--as-a-version-for-their-dependencies for more \
-     information";
-
 /// Handles the `PUT /crates/new` route.
 /// Used by `cargo publish` to publish a new crate or to publish a new version of an
 /// existing crate.
@@ -367,8 +362,11 @@ pub fn add_dependencies(
                 .map_err(|_| cargo_err(&format_args!("no known crate named `{}`", &*dep.name)))?;
 
             if let Ok(version_req) = semver::VersionReq::parse(&dep.version_req.0) {
-                if version_req == semver::VersionReq::STAR {
-                    return Err(cargo_err(WILDCARD_ERROR_MESSAGE));
+                 if version_req == semver::VersionReq::STAR {
+                    return Err(cargo_err(&format_args!("wildcard (`*`) dependency constraints are not allowed \
+                        on crates.io. Crate with this problem: `{}` See https://doc.rust-lang.org/cargo/faq.html#can-\
+                        libraries-use--as-a-version-for-their-dependencies for more \
+                        information", &*dep.name)));
                 }
             }
 

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -3,7 +3,7 @@ use crate::new_category;
 use crate::util::insta::assert_yaml_snapshot;
 use crate::util::{RequestHelper, TestApp};
 use crates_io::controllers::krate::publish::{
-    missing_metadata_error_message, MISSING_RIGHTS_ERROR_MESSAGE, WILDCARD_ERROR_MESSAGE,
+    missing_metadata_error_message, MISSING_RIGHTS_ERROR_MESSAGE,
 };
 use crates_io::models::krate::MAX_NAME_LENGTH;
 use crates_io::schema::{api_tokens, emails, versions_published_by};
@@ -373,7 +373,10 @@ fn new_krate_with_wildcard_dependency() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
-        json!({ "errors": [{ "detail": WILDCARD_ERROR_MESSAGE }] })
+        json!({ "errors": [{ "detail": "wildcard (`*`) dependency constraints are not allowed \
+                        on crates.io. Crate with this problem: `foo_wild` See https://doc.rust-lang.org/cargo/faq.html#can-\
+                        libraries-use--as-a-version-for-their-dependencies for more \
+                        information" }] })
     );
 
     assert!(app.stored_files().is_empty());


### PR DESCRIPTION
This PR allows crates.io to point out the specific crate that violates the wildcard dependency constraint.