### PR TITLE
tarball: Implement `process_tarball()` for any `Read` impl

### DIFF
--- a/crates_io_tarball/examples/read_file.rs
+++ b/crates_io_tarball/examples/read_file.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use crates_io_tarball::process_tarball;
+use std::fs::File;
 use std::path::PathBuf;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -24,13 +25,13 @@ fn main() -> anyhow::Result<()> {
         return Err(anyhow!("`{}` not found or not a file", path.display()));
     }
 
-    let content = std::fs::read(&path).context("Failed to read tarball")?;
+    let file = File::open(&path).context("Failed to read tarball")?;
 
     let path_no_ext = path.with_extension("");
     let pkg_name = path_no_ext.file_name().unwrap().to_string_lossy();
 
     let result =
-        process_tarball(&pkg_name, &content, u64::MAX).context("Failed to process tarball")?;
+        process_tarball(&pkg_name, &file, u64::MAX).context("Failed to process tarball")?;
 
     println!("{result:#?}");
 

--- a/crates_io_tarball/src/lib.rs
+++ b/crates_io_tarball/src/lib.rs
@@ -37,9 +37,9 @@ pub enum TarballError {
 }
 
 #[instrument(skip_all, fields(%pkg_name))]
-pub fn process_tarball(
+pub fn process_tarball<R: Read>(
     pkg_name: &str,
-    tarball: &[u8],
+    tarball: R,
     max_unpack: u64,
 ) -> Result<TarballInfo, TarballError> {
     // All our data is currently encoded with gzip
@@ -112,12 +112,12 @@ mod tests {
 
         let limit = 512 * 1024 * 1024;
         assert_eq!(
-            process_tarball("foo-0.0.1", &tarball, limit)
+            process_tarball("foo-0.0.1", &*tarball, limit)
                 .unwrap()
                 .vcs_info,
             None
         );
-        assert_err!(process_tarball("bar-0.0.1", &tarball, limit));
+        assert_err!(process_tarball("bar-0.0.1", &*tarball, limit));
     }
 
     #[test]
@@ -128,7 +128,7 @@ mod tests {
             .build();
 
         let limit = 512 * 1024 * 1024;
-        let vcs_info = process_tarball("foo-0.0.1", &tarball, limit)
+        let vcs_info = process_tarball("foo-0.0.1", &*tarball, limit)
             .unwrap()
             .vcs_info
             .unwrap();
@@ -146,7 +146,7 @@ mod tests {
             .build();
 
         let limit = 512 * 1024 * 1024;
-        let vcs_info = process_tarball("foo-0.0.1", &tarball, limit)
+        let vcs_info = process_tarball("foo-0.0.1", &*tarball, limit)
             .unwrap()
             .vcs_info
             .unwrap();
@@ -167,7 +167,7 @@ repository = "https://github.com/foo/bar"
             .build();
 
         let limit = 512 * 1024 * 1024;
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &tarball, limit));
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, limit));
         let manifest = assert_some!(tarball_info.manifest);
         assert_some_eq!(manifest.package.readme, "README.md");
         assert_some_eq!(manifest.package.repository, "https://github.com/foo/bar");
@@ -186,7 +186,7 @@ repository = "https://github.com/foo/bar"
             .build();
 
         let limit = 512 * 1024 * 1024;
-        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &tarball, limit));
+        let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, limit));
         let manifest = assert_some!(tarball_info.manifest);
         assert_some_eq!(manifest.package.rust_version, "1.23");
     }

--- a/src/admin/backfill/rust_version.rs
+++ b/src/admin/backfill/rust_version.rs
@@ -258,7 +258,7 @@ fn process_version(
     let crate_location = crate_location(&options.crates_path, name, version);
 
     debug!(%name, %version, crate_location = %crate_location.display(), "Reading tarball…");
-    let tarball = std::fs::read(crate_location)?;
+    let tarball = File::open(crate_location)?;
 
     debug!(%name, %version, "Processing tarball…");
     let pkg_name = format!("{name}-{version}");

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -183,8 +183,9 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             let hex_cksum: String = Sha256::digest(&tarball_bytes).encode_hex();
 
             let pkg_name = format!("{}-{}", krate.name, vers);
-            let tarball_info = process_tarball(&pkg_name, &tarball_bytes, maximums.max_unpack_size)
-                .map_err(tarball_to_app_error)?;
+            let tarball_info =
+                process_tarball(&pkg_name, &*tarball_bytes, maximums.max_unpack_size)
+                    .map_err(tarball_to_app_error)?;
 
             let rust_version = tarball_info
                 .manifest


### PR DESCRIPTION
This allows us to use `File` instead of having to read the full file contents into memory first.