### PR TITLE
tarball: Add `check_all_crates` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,8 @@ dependencies = [
  "clap",
  "derive_deref",
  "flate2",
+ "indicatif",
+ "rayon",
  "semver",
  "serde",
  "serde_json",
@@ -773,6 +775,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
 ]
 
 [[package]]
@@ -791,6 +794,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -1594,6 +1608,7 @@ dependencies = [
  "instant",
  "number_prefix",
  "portable-atomic",
+ "rayon",
  "unicode-width",
 ]
 
@@ -2533,6 +2548,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]

--- a/crates_io_tarball/Cargo.toml
+++ b/crates_io_tarball/Cargo.toml
@@ -22,4 +22,7 @@ tracing = "=0.1.37"
 anyhow = "=1.0.72"
 claims = "=0.7.1"
 clap = { version = "=4.3.17", features = ["derive", "unicode", "wrap_help"] }
+indicatif = { version = "=0.17.5", features = ["rayon"] }
+rayon = "=1.7.0"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }
+walkdir = "=2.3.3"

--- a/crates_io_tarball/examples/check_all_crates.rs
+++ b/crates_io_tarball/examples/check_all_crates.rs
@@ -1,0 +1,89 @@
+use anyhow::anyhow;
+use clap::Parser;
+use crates_io_tarball::process_tarball;
+use indicatif::{ParallelProgressIterator, ProgressBar, ProgressStyle};
+use rayon::prelude::*;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use tracing::{debug, info, warn};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::EnvFilter;
+use walkdir::WalkDir;
+
+/// Runs through all crate files in a folder and shows parsing errors.
+#[derive(clap::Parser, Debug, Clone)]
+pub struct Options {
+    /// Path to the folder to scan for crate files
+    path: PathBuf,
+}
+
+fn main() -> anyhow::Result<()> {
+    setup_tracing();
+
+    let options = Options::parse();
+
+    let path = options.path;
+    if !path.is_dir() {
+        return Err(anyhow!("`{}` not found or not a directory", path.display()));
+    }
+
+    info!(path = %path.display(), "Searching for crate files");
+
+    let pb = ProgressBar::new(u64::MAX);
+    pb.set_style(ProgressStyle::with_template("{human_pos} crate files found").unwrap());
+
+    let mut paths = WalkDir::new(path)
+        .into_iter()
+        .par_bridge()
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.into_path())
+        .filter(|path| path.is_file() && path.extension().unwrap_or_default() == "crate")
+        .progress_with(pb)
+        .collect::<Vec<_>>();
+
+    paths.par_sort();
+
+    let num_files = paths.len();
+    info!(%num_files, "Processing crate files");
+
+    let pb = ProgressBar::new(num_files as u64);
+    pb.set_style(
+        ProgressStyle::with_template("{bar:60} ({pos}/{len}, ETA {eta}) {wide_msg}").unwrap(),
+    );
+
+    paths
+        .par_iter()
+        .progress_with(pb.clone())
+        .for_each(|path| process_path(path, &pb));
+
+    Ok(())
+}
+
+fn process_path(path: &Path, pb: &ProgressBar) {
+    let file =
+        File::open(path).map_err(|error| pb.suspend(|| warn!(%error, "Failed to read crate file")));
+
+    let Ok(file) = file else { return; };
+
+    let path_no_ext = path.with_extension("");
+    let pkg_name = path_no_ext.file_name().unwrap().to_string_lossy();
+    pb.set_message(format!("{pkg_name}"));
+
+    let result = process_tarball(&pkg_name, &file, u64::MAX);
+    pb.suspend(|| match result {
+        Ok(result) => debug!(%pkg_name, path = %path.display(), ?result),
+        Err(error) => warn!(%pkg_name, path = %path.display(), %error, "Failed to process tarball"),
+    })
+}
+
+fn setup_tracing() {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .without_time()
+        .with_target(false)
+        .init();
+}


### PR DESCRIPTION
This tool can be run on a `get-all-crates` output folder to verify that our code can successfully process all currently existing crate files.