### PR TITLE
Use `TarballBuilder` in more tests

### DIFF
--- a/crates_io_tarball/src/builder.rs
+++ b/crates_io_tarball/src/builder.rs
@@ -1,4 +1,5 @@
 use flate2::read::GzEncoder;
+use flate2::Compression;
 use std::io::Read;
 
 pub struct TarballBuilder {
@@ -32,10 +33,14 @@ impl TarballBuilder {
     }
 
     pub fn build(self) -> Vec<u8> {
+        self.build_with_compression(Compression::default())
+    }
+
+    pub fn build_with_compression(self, compression: Compression) -> Vec<u8> {
         let tarball_bytes = self.build_unzipped();
 
         let mut gzip_bytes = vec![];
-        GzEncoder::new(tarball_bytes.as_slice(), Default::default())
+        GzEncoder::new(tarball_bytes.as_slice(), compression)
             .read_to_end(&mut gzip_bytes)
             .unwrap();
 

--- a/crates_io_tarball/src/builder.rs
+++ b/crates_io_tarball/src/builder.rs
@@ -47,3 +47,9 @@ impl TarballBuilder {
         gzip_bytes
     }
 }
+
+impl AsMut<tar::Builder<Vec<u8>>> for TarballBuilder {
+    fn as_mut(&mut self) -> &mut tar::Builder<Vec<u8>> {
+        &mut self.inner
+    }
+}

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -1,24 +1,10 @@
 use crates_io::views::krate_publish as u;
 use std::{collections::BTreeMap, io::Read};
 
+use crates_io_tarball::TarballBuilder;
 use flate2::{write::GzEncoder, Compression};
-use once_cell::sync::Lazy;
 
 use super::DependencyBuilder;
-
-// The bytes of an empty tarball is not an empty vector of bytes because of tarball headers.
-// Unless files are added to a PublishBuilder, the `.crate` tarball that gets uploaded
-// will be empty, so precompute the empty tarball bytes to use as a default.
-static EMPTY_TARBALL_BYTES: Lazy<Vec<u8>> = Lazy::new(generate_empty_tarball);
-
-fn generate_empty_tarball() -> Vec<u8> {
-    let mut empty_tarball = vec![];
-    {
-        let mut ar = tar::Builder::new(GzEncoder::new(&mut empty_tarball, Compression::default()));
-        assert_ok!(ar.finish());
-    }
-    empty_tarball
-}
 
 /// A builder for constructing a crate for the purposes of testing publishing. If you only need
 /// a crate to exist and don't need to test behavior caused by the publish request, inserting
@@ -52,7 +38,7 @@ impl PublishBuilder {
             license: Some("MIT".to_string()),
             license_file: None,
             readme: None,
-            tarball: EMPTY_TARBALL_BYTES.to_vec(),
+            tarball: TarballBuilder::new(krate_name, "1.0.0").build(),
             version: semver::Version::parse("1.0.0").unwrap(),
             features: BTreeMap::new(),
         }


### PR DESCRIPTION
Instead of using the raw `tar::Builder` with `GzEncoder` we can use our `TarballBuilder` abstraction layer, which will make it easier in the future to generate valid crate manifests.