### PR TITLE
tarball/Package: Change `readme` field to `Option<PathBuf>`

### DIFF
--- a/crates_io_markdown/lib.rs
+++ b/crates_io_markdown/lib.rs
@@ -253,13 +253,17 @@ static MARKDOWN_EXTENSIONS: [&str; 7] =
 /// let rendered = text_to_html(text, "README.md", None, None);
 /// assert_eq!(rendered, "<p><a href=\"https://rust-lang.org/\" rel=\"nofollow noopener noreferrer\">Rust</a> is an awesome <em>systems programming</em> language!</p>\n");
 /// ```
-pub fn text_to_html(
+pub fn text_to_html<P: AsRef<Path>>(
     text: &str,
-    readme_path_in_pkg: &str,
+    readme_path_in_pkg: P,
     base_url: Option<&str>,
-    pkg_path_in_vcs: Option<&str>,
+    pkg_path_in_vcs: Option<P>,
 ) -> String {
-    let path_in_vcs = Path::new(pkg_path_in_vcs.unwrap_or("")).join(readme_path_in_pkg);
+    let path_in_vcs = match pkg_path_in_vcs {
+        None => readme_path_in_pkg.as_ref().to_path_buf(),
+        Some(pkg_path_in_vcs) => pkg_path_in_vcs.as_ref().join(readme_path_in_pkg),
+    };
+
     let base_dir = path_in_vcs.parent().and_then(|p| p.to_str()).unwrap_or("");
 
     if path_in_vcs.extension().is_none() {

--- a/crates_io_tarball/src/lib.rs
+++ b/crates_io_tarball/src/lib.rs
@@ -103,6 +103,7 @@ pub fn process_tarball<R: Read>(
 mod tests {
     use super::process_tarball;
     use crate::TarballBuilder;
+    use std::path::Path;
 
     #[test]
     fn process_tarball_test() {
@@ -169,7 +170,7 @@ repository = "https://github.com/foo/bar"
         let limit = 512 * 1024 * 1024;
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, limit));
         let manifest = assert_some!(tarball_info.manifest);
-        assert_some_eq!(manifest.package.readme, "README.md");
+        assert_some_eq!(manifest.package.readme, Path::new("README.md"));
         assert_some_eq!(manifest.package.repository, "https://github.com/foo/bar");
         assert_some_eq!(manifest.package.rust_version, "1.59");
     }

--- a/crates_io_tarball/src/manifest.rs
+++ b/crates_io_tarball/src/manifest.rs
@@ -1,5 +1,6 @@
 use derive_deref::Deref;
 use serde::{de, Deserialize, Deserializer};
+use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct Manifest {
@@ -10,7 +11,7 @@ pub struct Manifest {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Package {
-    pub readme: Option<String>,
+    pub readme: Option<PathBuf>,
     pub repository: Option<String>,
     pub rust_version: Option<RustVersion>,
 }

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -184,11 +184,10 @@ fn render_pkg_readme<R: Read>(mut archive: Archive<R>, pkg_name: &str) -> anyhow
         let readme_path = manifest
             .package
             .readme
-            .clone()
-            .unwrap_or_else(|| "README.md".into());
-        let path = format!("{pkg_name}/{readme_path}");
+            .unwrap_or_else(|| Path::new("README.md").to_path_buf());
+        let path = Path::new(pkg_name).join(&readme_path);
         let contents = find_file_by_path(&mut entries, Path::new(&path))
-            .with_context(|| format!("Failed to read {readme_path} file"))?;
+            .with_context(|| format!("Failed to read {} file", readme_path.display()))?;
 
         // pkg_path_in_vcs Unsupported from admin::render_readmes. See #4095
         // Would need access to cargo_vcs_info


### PR DESCRIPTION
This brings us one step closer to the structure that `cargo_toml` is using: https://docs.rs/cargo_toml/0.15.3/cargo_toml/enum.OptionalFile.html

It still does not support `true` and `false` values, but this will be added in a follow-up PR.