### PR TITLE
Fix `readme` field parsing of `Cargo.toml` files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_toml"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f83bc2e401ed041b7057345ebc488c005efa0341d5541ce7004d30458d0090b"
+dependencies = [
+ "serde",
+ "toml",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +756,7 @@ name = "crates_io_tarball"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "cargo_toml",
  "claims",
  "clap",
  "derive_deref",

--- a/crates_io_tarball/Cargo.toml
+++ b/crates_io_tarball/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 builder = []
 
 [dependencies]
+cargo_toml = "=0.15.2"
 derive_deref = "=1.1.1"
 flate2 = "=1.0.26"
 semver = { version = "=1.0.18", features = ["serde"] }

--- a/crates_io_tarball/src/manifest.rs
+++ b/crates_io_tarball/src/manifest.rs
@@ -1,6 +1,6 @@
+use cargo_toml::OptionalFile;
 use derive_deref::Deref;
 use serde::{de, Deserialize, Deserializer};
-use std::path::PathBuf;
 
 #[derive(Debug, Deserialize)]
 pub struct Manifest {
@@ -11,7 +11,8 @@ pub struct Manifest {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Package {
-    pub readme: Option<PathBuf>,
+    #[serde(default)]
+    pub readme: OptionalFile,
     pub repository: Option<String>,
     pub rust_version: Option<RustVersion>,
 }

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -181,11 +181,13 @@ fn render_pkg_readme<R: Read>(mut archive: Archive<R>, pkg_name: &str) -> anyhow
     };
 
     let rendered = {
-        let readme_path = manifest
-            .package
-            .readme
-            .unwrap_or_else(|| Path::new("README.md").to_path_buf());
-        let path = Path::new(pkg_name).join(&readme_path);
+        let readme = manifest.package.readme;
+        if !readme.is_some() {
+            return Ok("".to_string());
+        }
+
+        let readme_path = readme.as_path().unwrap_or_else(|| Path::new("README.md"));
+        let path = Path::new(pkg_name).join(readme_path);
         let contents = find_file_by_path(&mut entries, Path::new(&path))
             .with_context(|| format!("Failed to read {} file", readme_path.display()))?;
 


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/6847

This PR fixes the parsing and processing of the `readme` field inside `Cargo.toml` files by using the `OptionalFile` enum from the `cargo_toml` crate. In the future we can consider migrating more of our code to use the `cargo_toml` structures.