### PR TITLE
Fix download URL generation

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -35,7 +35,7 @@ type StdPath = std::path::Path;
 #[derive(Debug)]
 pub struct StorageConfig {
     backend: StorageBackend,
-    cdn_prefix: Option<String>,
+    pub cdn_prefix: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -199,14 +199,20 @@ impl Storage {
     ///
     /// The function doesn't check for the existence of the file.
     pub fn crate_location(&self, name: &str, version: &str) -> String {
-        format!("{}{}", self.cdn_prefix, crate_file_path(name, version)).replace('+', "%2B")
+        self.with_cdn_prefix(&crate_file_path(name, version))
+            .replace('+', "%2B")
     }
 
     /// Returns the URL of an uploaded crate's version readme.
     ///
     /// The function doesn't check for the existence of the file.
     pub fn readme_location(&self, name: &str, version: &str) -> String {
-        format!("{}{}", self.cdn_prefix, readme_path(name, version)).replace('+', "%2B")
+        self.with_cdn_prefix(&readme_path(name, version))
+            .replace('+', "%2B")
+    }
+
+    fn with_cdn_prefix(&self, path: &Path) -> String {
+        format!("{}{}", self.cdn_prefix, path)
     }
 
     #[instrument(skip(self))]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -392,14 +392,17 @@ mod tests {
 
     #[test]
     fn locations() {
-        let storage = Storage::from_config(&StorageConfig::in_memory());
+        let mut config = StorageConfig::in_memory();
+        config.cdn_prefix = Some("static.crates.io".to_string());
+
+        let storage = Storage::from_config(&config);
 
         let crate_tests = vec![
-            ("foo", "1.2.3", "/crates/foo/foo-1.2.3.crate"),
+            ("foo", "1.2.3", "https://static.crates.io/crates/foo/foo-1.2.3.crate"),
             (
                 "some-long-crate-name",
                 "42.0.5-beta.1+foo",
-                "/crates/some-long-crate-name/some-long-crate-name-42.0.5-beta.1%2Bfoo.crate",
+                "https://static.crates.io/crates/some-long-crate-name/some-long-crate-name-42.0.5-beta.1%2Bfoo.crate",
             ),
         ];
         for (name, version, expected) in crate_tests {
@@ -407,11 +410,11 @@ mod tests {
         }
 
         let readme_tests = vec![
-            ("foo", "1.2.3", "/readmes/foo/foo-1.2.3.html"),
+            ("foo", "1.2.3", "https://static.crates.io/readmes/foo/foo-1.2.3.html"),
             (
                 "some-long-crate-name",
                 "42.0.5-beta.1+foo",
-                "/readmes/some-long-crate-name/some-long-crate-name-42.0.5-beta.1%2Bfoo.html",
+                "https://static.crates.io/readmes/some-long-crate-name/some-long-crate-name-42.0.5-beta.1%2Bfoo.html",
             ),
         ];
         for (name, version, expected) in readme_tests {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -50,6 +50,10 @@ pub struct S3Config {
 }
 
 impl StorageConfig {
+    pub fn in_memory() -> Self {
+        Self::InMemory
+    }
+
     pub fn from_environment() -> Self {
         if let Ok(bucket) = dotenvy::var("S3_BUCKET") {
             let region = dotenvy::var("S3_REGION").ok();
@@ -339,7 +343,7 @@ mod tests {
     use tempfile::NamedTempFile;
 
     pub async fn prepare() -> Storage {
-        let storage = Storage::from_config(&StorageConfig::InMemory);
+        let storage = Storage::from_config(&StorageConfig::in_memory());
 
         let files_to_create = vec![
             "crates/bar/bar-2.0.0.crate",
@@ -367,7 +371,7 @@ mod tests {
 
     #[test]
     fn locations() {
-        let storage = Storage::from_config(&StorageConfig::InMemory);
+        let storage = Storage::from_config(&StorageConfig::in_memory());
 
         let crate_tests = vec![
             ("foo", "1.2.3", "/crates/foo/foo-1.2.3.crate"),
@@ -458,7 +462,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_crate_file() {
-        let s = Storage::from_config(&StorageConfig::InMemory);
+        let s = Storage::from_config(&StorageConfig::in_memory());
 
         s.upload_crate_file("foo", "1.2.3", Bytes::new())
             .await
@@ -480,7 +484,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_readme() {
-        let s = Storage::from_config(&StorageConfig::InMemory);
+        let s = Storage::from_config(&StorageConfig::in_memory());
 
         let bytes = Bytes::from_static(b"hello world");
         s.upload_readme("foo", "1.2.3", bytes.clone())
@@ -501,7 +505,7 @@ mod tests {
 
     #[tokio::test]
     async fn sync_index() {
-        let s = Storage::from_config(&StorageConfig::InMemory);
+        let s = Storage::from_config(&StorageConfig::in_memory());
 
         assert!(stored_files(&s.store).await.is_empty());
 
@@ -518,7 +522,7 @@ mod tests {
 
     #[tokio::test]
     async fn upload_db_dump() {
-        let s = Storage::from_config(&StorageConfig::InMemory);
+        let s = Storage::from_config(&StorageConfig::in_memory());
 
         assert!(stored_files(&s.store).await.is_empty());
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -380,6 +380,9 @@ fn simple_config() -> config::Server {
         dl_only_at_percentage: 80,
     };
 
+    let mut storage = StorageConfig::in_memory();
+    storage.cdn_prefix = Some("static.crates.io".to_string());
+
     config::Server {
         base,
         ip: [127, 0, 0, 1].into(),
@@ -387,7 +390,7 @@ fn simple_config() -> config::Server {
         max_blocking_threads: None,
         use_nginx_wrapper: false,
         db,
-        storage: StorageConfig::in_memory(),
+        storage,
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: ClientId::new(dotenvy::var("GH_CLIENT_ID").unwrap_or_default()),
         gh_client_secret: ClientSecret::new(dotenvy::var("GH_CLIENT_SECRET").unwrap_or_default()),

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -387,7 +387,7 @@ fn simple_config() -> config::Server {
         max_blocking_threads: None,
         use_nginx_wrapper: false,
         db,
-        storage: StorageConfig::InMemory,
+        storage: StorageConfig::in_memory(),
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: ClientId::new(dotenvy::var("GH_CLIENT_ID").unwrap_or_default()),
         gh_client_secret: ClientSecret::new(dotenvy::var("GH_CLIENT_SECRET").unwrap_or_default()),


### PR DESCRIPTION
This PR fixes https://github.com/rust-lang/crates.io/issues/6850.

It also makes sure that we run the test suite with a real-world value for the `cdn_prefix` field. This required a couple of refactorings, but the commit list should make it relatively straight-forward to follow.