### PR TITLE
settings/tokens/new: Disable autocomplete for "Name" field

### DIFF
--- a/app/templates/settings/tokens/new.hbs
+++ b/app/templates/settings/tokens/new.hbs
@@ -10,6 +10,7 @@
         @type="text"
         @value={{this.name}}
         disabled={{this.saveTokenTask.isRunning}}
+        autocomplete="off"
         aria-required="true"
         aria-invalid={{if this.nameInvalid "true" "false"}}
         local-class="name-input"


### PR DESCRIPTION
This should disable password managers from assuming that this input is expecting a person name. Since users shouldn't be using the same token name multiple times the disabled autocomplete shouldn't be a big issue.