### PR TITLE
Add application-level rate limits for crate updates, yanking and unyanking

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -185,8 +185,6 @@ http {
 	client_body_timeout 30;
 	client_max_body_size 50m;
 
-	limit_req_zone $remote_addr zone=publish:10m rate=1r/m;
-
 	upstream app_server {
 		server localhost:8888 fail_timeout=0;
 	}
@@ -262,12 +260,5 @@ http {
 				proxy_pass http://app_server;
 			}
 		<% end %>
-
-		location ~ ^/api/v./crates/new$ {
-			proxy_pass http://app_server;
-
-			limit_req zone=publish burst=30 nodelay;
-			limit_req_status 429;
-		}
 	}
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use crate::downloads_counter::DownloadsCounter;
 use crate::email::Emails;
 use crate::github::{GitHubClient, RealGitHubClient};
 use crate::metrics::{InstanceMetrics, ServiceMetrics};
+use crate::rate_limiter::RateLimiter;
 use crate::storage::Storage;
 use axum::extract::{FromRef, FromRequestParts, State};
 use diesel::r2d2;
@@ -68,6 +69,9 @@ pub struct App {
 
     /// In-flight request counters for the `balance_capacity` middleware.
     pub balance_capacity: BalanceCapacityState,
+
+    /// Rate limit select actions.
+    pub rate_limiter: RateLimiter,
 }
 
 impl App {
@@ -178,6 +182,7 @@ impl App {
             http_client,
             fastboot_client,
             balance_capacity: Default::default(),
+            rate_limiter: RateLimiter::new(config.rate_limiter.clone()),
             config,
         }
     }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -137,7 +137,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             };
 
             let license_file = new_crate.license_file.as_deref();
-            let krate = persist.create_or_update(conn, user.id, Some(&app.config.rate_limiter))?;
+            let krate = persist.create_or_update(conn, user.id, Some(&app.rate_limiter))?;
 
             let owners = krate.owners(conn)?;
             if user.rights(&app, &owners)? < Rights::Publish {

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -439,7 +439,7 @@ mod tests {
                 name: "foo",
                 ..NewCrate::default()
             }
-            .create_or_update(conn, user.id, None)
+            .create_or_update(conn, user.id)
             .expect("failed to create crate");
 
             Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod github;
 pub mod headers;
 pub mod metrics;
 pub mod middleware;
-mod rate_limiter;
+pub mod rate_limiter;
 pub mod schema;
 pub mod sql;
 pub mod ssh;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -17,7 +17,7 @@ use crate::models::{
 use crate::util::errors::{cargo_err, AppResult};
 
 use crate::models::helpers::with_count::*;
-use crate::rate_limiter::RateLimiter;
+use crate::rate_limiter::{LimitedAction, RateLimiter};
 use crate::schema::*;
 use crate::sql::canon_crate_name;
 
@@ -119,7 +119,7 @@ impl<'a> NewCrate<'a> {
             // first so we know whether to add an owner
             if let Some(krate) = self.save_new_crate(conn, uploader)? {
                 if let Some(rate_limit) = rate_limit {
-                    rate_limit.check_rate_limit(uploader, conn)?;
+                    rate_limit.check_rate_limit(uploader, LimitedAction::PublishNew, conn)?;
                 }
                 return Ok(krate);
             }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 pg_enum! {
     pub enum LimitedAction {
         PublishNew = 0,
+        PublishUpdate = 1,
     }
 }
 
@@ -19,18 +20,21 @@ impl LimitedAction {
     pub fn default_rate_seconds(&self) -> u64 {
         match self {
             LimitedAction::PublishNew => 60 * 60,
+            LimitedAction::PublishUpdate => 60,
         }
     }
 
     pub fn default_burst(&self) -> i32 {
         match self {
             LimitedAction::PublishNew => 5,
+            LimitedAction::PublishUpdate => 30,
         }
     }
 
     pub fn env_var_key(&self) -> &'static str {
         match self {
             LimitedAction::PublishNew => "PUBLISH_NEW",
+            LimitedAction::PublishUpdate => "PUBLISH_EXISTING",
         }
     }
 
@@ -38,6 +42,9 @@ impl LimitedAction {
         match self {
             LimitedAction::PublishNew => {
                 "You have published too many new crates in a short period of time"
+            }
+            LimitedAction::PublishUpdate => {
+                "You have published too many updates to existing crates in a short period of time"
             }
         }
     }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -13,6 +13,7 @@ pg_enum! {
     pub enum LimitedAction {
         PublishNew = 0,
         PublishUpdate = 1,
+        YankUnyank = 2,
     }
 }
 
@@ -21,6 +22,7 @@ impl LimitedAction {
         match self {
             LimitedAction::PublishNew => 60 * 60,
             LimitedAction::PublishUpdate => 60,
+            LimitedAction::YankUnyank => 60,
         }
     }
 
@@ -28,13 +30,15 @@ impl LimitedAction {
         match self {
             LimitedAction::PublishNew => 5,
             LimitedAction::PublishUpdate => 30,
+            LimitedAction::YankUnyank => 100,
         }
     }
 
     pub fn env_var_key(&self) -> &'static str {
         match self {
             LimitedAction::PublishNew => "PUBLISH_NEW",
-            LimitedAction::PublishUpdate => "PUBLISH_EXISTING",
+            LimitedAction::PublishUpdate => "PUBLISH_UPDATE",
+            LimitedAction::YankUnyank => "YANK_UNYANK",
         }
     }
 
@@ -45,6 +49,9 @@ impl LimitedAction {
             }
             LimitedAction::PublishUpdate => {
                 "You have published too many updates to existing crates in a short period of time"
+            }
+            LimitedAction::YankUnyank => {
+                "You have yanked or unyanked too many versions in a short period of time"
             }
         }
     }

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -33,6 +33,14 @@ impl LimitedAction {
             LimitedAction::PublishNew => "PUBLISH_NEW",
         }
     }
+
+    pub fn error_messagge(&self) -> &'static str {
+        match self {
+            LimitedAction::PublishNew => {
+                "You have published too many new crates in a short period of time"
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -62,6 +70,7 @@ impl RateLimiter {
             Ok(())
         } else {
             Err(Box::new(TooManyRequests {
+                action: performed_action,
                 retry_after: bucket.last_refill
                     + chrono::Duration::from_std(self.config_for_action(performed_action).rate)
                         .unwrap(),

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,12 +1,13 @@
-use chrono::{NaiveDateTime, Utc};
-use diesel::data_types::PgInterval;
-use diesel::prelude::*;
-use diesel::sql_types::Interval;
-use std::time::Duration;
-
 use crate::schema::{publish_limit_buckets, publish_rate_overrides};
 use crate::sql::{date_part, floor, greatest, interval_part, least, pg_enum};
 use crate::util::errors::{AppResult, TooManyRequests};
+use chrono::{NaiveDateTime, Utc};
+use diesel::dsl::IntervalDsl;
+use diesel::prelude::*;
+use diesel::sql_types::Interval;
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::time::Duration;
 
 pg_enum! {
     pub enum LimitedAction {
@@ -14,39 +15,56 @@ pg_enum! {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub struct RateLimiter {
-    pub rate: Duration,
-    pub burst: i32,
-}
+impl LimitedAction {
+    pub fn default_rate_seconds(&self) -> u64 {
+        match self {
+            LimitedAction::PublishNew => 60 * 60,
+        }
+    }
 
-impl Default for RateLimiter {
-    fn default() -> Self {
-        let minutes = dotenvy::var("WEB_NEW_PKG_RATE_LIMIT_RATE_MINUTES")
-            .unwrap_or_default()
-            .parse()
-            .ok()
-            .unwrap_or(10);
-        let burst = dotenvy::var("WEB_NEW_PKG_RATE_LIMIT_BURST")
-            .unwrap_or_default()
-            .parse()
-            .ok()
-            .unwrap_or(5);
-        Self {
-            rate: Duration::from_secs(60) * minutes,
-            burst,
+    pub fn default_burst(&self) -> i32 {
+        match self {
+            LimitedAction::PublishNew => 5,
+        }
+    }
+
+    pub fn env_var_key(&self) -> &'static str {
+        match self {
+            LimitedAction::PublishNew => "PUBLISH_NEW",
         }
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimiterConfig {
+    pub rate: Duration,
+    pub burst: i32,
+}
+
+#[derive(Debug)]
+pub struct RateLimiter {
+    config: HashMap<LimitedAction, RateLimiterConfig>,
+}
+
 impl RateLimiter {
-    pub fn check_rate_limit(&self, uploader: i32, conn: &mut PgConnection) -> AppResult<()> {
-        let bucket = self.take_token(uploader, Utc::now().naive_utc(), conn)?;
+    pub fn new(config: HashMap<LimitedAction, RateLimiterConfig>) -> Self {
+        Self { config }
+    }
+
+    pub fn check_rate_limit(
+        &self,
+        uploader: i32,
+        performed_action: LimitedAction,
+        conn: &mut PgConnection,
+    ) -> AppResult<()> {
+        let bucket = self.take_token(uploader, performed_action, Utc::now().naive_utc(), conn)?;
         if bucket.tokens >= 1 {
             Ok(())
         } else {
             Err(Box::new(TooManyRequests {
-                retry_after: bucket.last_refill + chrono::Duration::from_std(self.rate).unwrap(),
+                retry_after: bucket.last_refill
+                    + chrono::Duration::from_std(self.config_for_action(performed_action).rate)
+                        .unwrap(),
             }))
         }
     }
@@ -62,12 +80,14 @@ impl RateLimiter {
     fn take_token(
         &self,
         uploader: i32,
+        performed_action: LimitedAction,
         now: NaiveDateTime,
         conn: &mut PgConnection,
     ) -> QueryResult<Bucket> {
         use self::publish_limit_buckets::dsl::*;
 
-        let performed_action = LimitedAction::PublishNew;
+        let config = self.config_for_action(performed_action);
+        let refill_rate = (config.rate.as_millis() as i64).milliseconds();
 
         let burst: i32 = publish_rate_overrides::table
             .find((uploader, performed_action))
@@ -79,14 +99,14 @@ impl RateLimiter {
             .select(publish_rate_overrides::burst)
             .first(conn)
             .optional()?
-            .unwrap_or(self.burst);
+            .unwrap_or(config.burst);
 
         // Interval division is poorly defined in general (what is 1 month / 30 days?)
         // However, for the intervals we're dealing with, it is always well
         // defined, so we convert to an f64 of seconds to represent this.
         let tokens_to_add = floor(
             (date_part("epoch", now) - date_part("epoch", last_refill))
-                / interval_part("epoch", self.refill_rate()),
+                / interval_part("epoch", refill_rate),
         );
 
         diesel::insert_into(publish_limit_buckets)
@@ -100,15 +120,20 @@ impl RateLimiter {
             .do_update()
             .set((
                 tokens.eq(least(burst, greatest(0, tokens - 1) + tokens_to_add)),
-                last_refill
-                    .eq(last_refill + self.refill_rate().into_sql::<Interval>() * tokens_to_add),
+                last_refill.eq(last_refill + refill_rate.into_sql::<Interval>() * tokens_to_add),
             ))
             .get_result(conn)
     }
 
-    fn refill_rate(&self) -> PgInterval {
-        use diesel::dsl::*;
-        (self.rate.as_millis() as i64).milliseconds()
+    fn config_for_action(&self, action: LimitedAction) -> Cow<'_, RateLimiterConfig> {
+        // The wrapper returns the default config for the action when not configured.
+        match self.config.get(&action) {
+            Some(config) => Cow::Borrowed(config),
+            None => Cow::Owned(RateLimiterConfig {
+                rate: Duration::from_secs(action.default_rate_seconds()),
+                burst: action.default_burst(),
+            }),
+        }
     }
 }
 
@@ -133,11 +158,18 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
-        let bucket = rate.take_token(new_user(conn, "user1")?, now, conn)?;
+            action: LimitedAction::PublishNew,
+        }
+        .create();
+        let bucket = rate.take_token(
+            new_user(conn, "user1")?,
+            LimitedAction::PublishNew,
+            now,
+            conn,
+        )?;
         let expected = Bucket {
             user_id: bucket.user_id,
             tokens: 10,
@@ -146,11 +178,18 @@ mod tests {
         };
         assert_eq!(expected, bucket);
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_millis(50),
             burst: 20,
-        };
-        let bucket = rate.take_token(new_user(conn, "user2")?, now, conn)?;
+            action: LimitedAction::PublishNew,
+        }
+        .create();
+        let bucket = rate.take_token(
+            new_user(conn, "user2")?,
+            LimitedAction::PublishNew,
+            now,
+            conn,
+        )?;
         let expected = Bucket {
             user_id: bucket.user_id,
             tokens: 20,
@@ -166,12 +205,14 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user_bucket(conn, 5, now)?.user_id;
-        let bucket = rate.take_token(user_id, now, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
         let expected = Bucket {
             user_id,
             tokens: 4,
@@ -187,13 +228,15 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user_bucket(conn, 5, now)?.user_id;
         let refill_time = now + chrono::Duration::seconds(2);
-        let bucket = rate.take_token(user_id, refill_time, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, refill_time, conn)?;
         let expected = Bucket {
             user_id,
             tokens: 6,
@@ -213,13 +256,15 @@ mod tests {
             NaiveDateTime::parse_from_str("2019-03-19T21:11:24.620401", "%Y-%m-%dT%H:%M:%S%.f")
                 .unwrap();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_millis(100),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user_bucket(conn, 5, now)?.user_id;
         let refill_time = now + chrono::Duration::milliseconds(300);
-        let bucket = rate.take_token(user_id, refill_time, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, refill_time, conn)?;
         let expected = Bucket {
             user_id,
             tokens: 7,
@@ -235,12 +280,19 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_millis(100),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user_bucket(conn, 5, now)?.user_id;
-        let bucket = rate.take_token(user_id, now + chrono::Duration::milliseconds(250), conn)?;
+        let bucket = rate.take_token(
+            user_id,
+            LimitedAction::PublishNew,
+            now + chrono::Duration::milliseconds(250),
+            conn,
+        )?;
         let expected_refill_time = now + chrono::Duration::milliseconds(200);
         let expected = Bucket {
             user_id,
@@ -257,12 +309,14 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user_bucket(conn, 1, now)?.user_id;
-        let bucket = rate.take_token(user_id, now, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
         let expected = Bucket {
             user_id,
             tokens: 0,
@@ -271,7 +325,7 @@ mod tests {
         };
         assert_eq!(expected, bucket);
 
-        let bucket = rate.take_token(user_id, now, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
         assert_eq!(expected, bucket);
         Ok(())
     }
@@ -281,13 +335,15 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user_bucket(conn, 0, now)?.user_id;
         let refill_time = now + chrono::Duration::seconds(1);
-        let bucket = rate.take_token(user_id, refill_time, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, refill_time, conn)?;
         let expected = Bucket {
             user_id,
             tokens: 1,
@@ -304,13 +360,15 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user_bucket(conn, 8, now)?.user_id;
         let refill_time = now + chrono::Duration::seconds(4);
-        let bucket = rate.take_token(user_id, refill_time, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, refill_time, conn)?;
         let expected = Bucket {
             user_id,
             tokens: 10,
@@ -327,22 +385,25 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user(conn, "user1")?;
         let other_user_id = new_user(conn, "user2")?;
 
         diesel::insert_into(publish_rate_overrides::table)
             .values((
                 publish_rate_overrides::user_id.eq(user_id),
+                publish_rate_overrides::action.eq(LimitedAction::PublishNew),
                 publish_rate_overrides::burst.eq(20),
             ))
             .execute(conn)?;
 
-        let bucket = rate.take_token(user_id, now, conn)?;
-        let other_bucket = rate.take_token(other_user_id, now, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
+        let other_bucket = rate.take_token(other_user_id, LimitedAction::PublishNew, now, conn)?;
 
         assert_eq!(20, bucket.tokens);
         assert_eq!(10, other_bucket.tokens);
@@ -354,23 +415,26 @@ mod tests {
         let conn = &mut pg_connection();
         let now = now();
 
-        let rate = RateLimiter {
+        let rate = SampleRateLimiter {
             rate: Duration::from_secs(1),
             burst: 10,
-        };
+            action: LimitedAction::PublishNew,
+        }
+        .create();
         let user_id = new_user(conn, "user1")?;
         let other_user_id = new_user(conn, "user2")?;
 
         diesel::insert_into(publish_rate_overrides::table)
             .values((
                 publish_rate_overrides::user_id.eq(user_id),
+                publish_rate_overrides::action.eq(LimitedAction::PublishNew),
                 publish_rate_overrides::burst.eq(20),
                 publish_rate_overrides::expires_at.eq(now + chrono::Duration::days(30)),
             ))
             .execute(conn)?;
 
-        let bucket = rate.take_token(user_id, now, conn)?;
-        let other_bucket = rate.take_token(other_user_id, now, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
+        let other_bucket = rate.take_token(other_user_id, LimitedAction::PublishNew, now, conn)?;
 
         assert_eq!(20, bucket.tokens);
         assert_eq!(10, other_bucket.tokens);
@@ -381,8 +445,8 @@ mod tests {
             .filter(publish_rate_overrides::user_id.eq(user_id))
             .execute(conn)?;
 
-        let bucket = rate.take_token(user_id, now, conn)?;
-        let other_bucket = rate.take_token(other_user_id, now, conn)?;
+        let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
+        let other_bucket = rate.take_token(other_user_id, LimitedAction::PublishNew, now, conn)?;
 
         // The number of tokens of user_id is 10 and not 9 because when the new burst limit is
         // lower than the amount of available tokens, the number of available tokens is reset to
@@ -417,6 +481,26 @@ mod tests {
                 action: LimitedAction::PublishNew,
             })
             .get_result(conn)
+    }
+
+    struct SampleRateLimiter {
+        rate: Duration,
+        burst: i32,
+        action: LimitedAction,
+    }
+
+    impl SampleRateLimiter {
+        fn create(self) -> RateLimiter {
+            let mut config = HashMap::new();
+            config.insert(
+                self.action,
+                RateLimiterConfig {
+                    rate: self.rate,
+                    burst: self.burst,
+                },
+            );
+            RateLimiter::new(config)
+        }
     }
 
     /// Strips ns precision from `Utc::now`. PostgreSQL only has microsecond

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -20,12 +20,16 @@ macro_rules! pg_enum {
             $($item:ident = $int:expr,)*
         }
     ) => {
-        #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, FromSqlRow, AsExpression)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, FromSqlRow, AsExpression)]
         #[diesel(sql_type = diesel::sql_types::Integer)]
         #[serde(rename_all = "snake_case")]
         #[repr(i32)]
         $vis enum $name {
             $($item = $int,)*
+        }
+
+        impl $name {
+            $vis const VARIANTS: &[$name] = &[$($name::$item),*];
         }
 
         impl diesel::deserialize::FromSql<diesel::sql_types::Integer, diesel::pg::Pg> for $name {

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -114,9 +114,7 @@ impl<'a> CrateBuilder<'a> {
     pub fn build(mut self, connection: &mut PgConnection) -> AppResult<Crate> {
         use diesel::{insert_into, select, update};
 
-        let mut krate = self
-            .krate
-            .create_or_update(connection, self.owner_id, None)?;
+        let mut krate = self.krate.create_or_update(connection, self.owner_id)?;
 
         // Since we are using `NewCrate`, we can't set all the
         // crate properties in a single DB call.

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -6,6 +6,7 @@ use crates_io::controllers::krate::publish::{
     missing_metadata_error_message, MISSING_RIGHTS_ERROR_MESSAGE,
 };
 use crates_io::models::krate::MAX_NAME_LENGTH;
+use crates_io::rate_limiter::LimitedAction;
 use crates_io::schema::{api_tokens, emails, versions_published_by};
 use crates_io::views::GoodCrate;
 use crates_io_tarball::TarballBuilder;
@@ -1004,7 +1005,7 @@ fn tarball_bigger_than_max_upload_size() {
 #[test]
 fn publish_new_crate_rate_limited() {
     let (app, anon, _, token) = TestApp::full()
-        .with_publish_rate_limit(Duration::from_millis(500), 1)
+        .with_rate_limit(LimitedAction::PublishNew, Duration::from_millis(500), 1)
         .with_token();
 
     // Upload a new crate
@@ -1038,7 +1039,7 @@ fn publish_new_crate_rate_limited() {
 #[test]
 fn publish_rate_limit_doesnt_affect_existing_crates() {
     let (_, _, _, token) = TestApp::full()
-        .with_publish_rate_limit(Duration::from_millis(500), 1)
+        .with_rate_limit(LimitedAction::PublishNew, Duration::from_millis(500), 1)
         .with_token();
 
     // Upload a new crate

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -1016,8 +1016,9 @@ fn publish_new_crate_rate_limited() {
 
     // Uploading a second crate is limited
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
-    let response = token.publish_crate(crate_to_publish);
-    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    token
+        .publish_crate(crate_to_publish)
+        .assert_rate_limited(LimitedAction::PublishNew);
 
     assert_eq!(app.stored_files().len(), 2);
 
@@ -1037,9 +1038,9 @@ fn publish_new_crate_rate_limited() {
 }
 
 #[test]
-fn publish_rate_limit_doesnt_affect_existing_crates() {
+fn publish_new_crate_rate_limit_doesnt_affect_existing_crates() {
     let (_, _, _, token) = TestApp::full()
-        .with_rate_limit(LimitedAction::PublishNew, Duration::from_millis(500), 1)
+        .with_rate_limit(LimitedAction::PublishNew, Duration::from_secs(60 * 60), 1)
         .with_token();
 
     // Upload a new crate
@@ -1048,6 +1049,69 @@ fn publish_rate_limit_doesnt_affect_existing_crates() {
 
     let new_version = PublishBuilder::new("rate_limited1", "1.0.1");
     token.publish_crate(new_version).good();
+}
+
+#[test]
+fn publish_existing_crate_rate_limited() {
+    let (app, anon, _, token) = TestApp::full()
+        .with_rate_limit(LimitedAction::PublishUpdate, Duration::from_millis(500), 1)
+        .with_token();
+
+    // Upload a new crate
+    let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
+    token.publish_crate(crate_to_publish).good();
+
+    let json = anon.show_crate("rate_limited1");
+    assert_eq!(json.krate.max_version, "1.0.0");
+    assert_eq!(app.stored_files().len(), 2);
+
+    // Uploading the first update to the crate works
+    let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.1");
+    token.publish_crate(crate_to_publish).good();
+
+    let json = anon.show_crate("rate_limited1");
+    assert_eq!(json.krate.max_version, "1.0.1");
+    assert_eq!(app.stored_files().len(), 3);
+
+    // Uploading the second update to the crate is rate limited
+    let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.2");
+    token
+        .publish_crate(crate_to_publish)
+        .assert_rate_limited(LimitedAction::PublishUpdate);
+
+    // Check that  version 1.0.2 was not published
+    let json = anon.show_crate("rate_limited1");
+    assert_eq!(json.krate.max_version, "1.0.1");
+    assert_eq!(app.stored_files().len(), 3);
+
+    // Wait for the limit to be up
+    thread::sleep(Duration::from_millis(500));
+
+    let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.2");
+    token.publish_crate(crate_to_publish).good();
+
+    let json = anon.show_crate("rate_limited1");
+    assert_eq!(json.krate.max_version, "1.0.2");
+    assert_eq!(app.stored_files().len(), 4);
+}
+
+#[test]
+fn publish_existing_crate_rate_limit_doesnt_affect_new_crates() {
+    let (_, _, _, token) = TestApp::full()
+        .with_rate_limit(
+            LimitedAction::PublishUpdate,
+            Duration::from_secs(60 * 60),
+            1,
+        )
+        .with_token();
+
+    // Upload a new crate
+    let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
+    token.publish_crate(crate_to_publish).good();
+
+    // Upload a second new crate
+    let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
+    token.publish_crate(crate_to_publish).good();
 }
 
 #[test]

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -1,6 +1,8 @@
 use crate::builders::PublishBuilder;
 use crate::routes::crates::versions::yank_unyank::YankRequestHelper;
 use crate::util::{RequestHelper, TestApp};
+use crates_io::rate_limiter::LimitedAction;
+use std::time::Duration;
 
 #[test]
 #[allow(unknown_lints, clippy::bool_assert_comparison)] // for claim::assert_some_eq! with bool
@@ -58,6 +60,48 @@ fn yank_works_as_intended() {
 
     let json = anon.show_version("fyk", "1.0.0");
     assert!(!json.version.yanked);
+}
+
+#[test]
+fn test_yank_rate_limiting() {
+    #[track_caller]
+    fn check_yanked(app: &TestApp, is_yanked: bool) {
+        let crates = app.crates_from_index_head("yankable");
+        assert_eq!(crates.len(), 1);
+        assert_some_eq!(crates[0].yanked, is_yanked);
+    }
+
+    let (app, _, _, token) = TestApp::full()
+        .with_rate_limit(LimitedAction::YankUnyank, Duration::from_millis(500), 1)
+        .with_token();
+
+    // Upload a new crate
+    let crate_to_publish = PublishBuilder::new("yankable", "1.0.0");
+    token.publish_crate(crate_to_publish).good();
+    check_yanked(&app, false);
+
+    // Yank the crate
+    token.yank("yankable", "1.0.0").good();
+    check_yanked(&app, true);
+
+    // Try unyanking the crate, will get rate limited
+    token
+        .unyank("yankable", "1.0.0")
+        .assert_rate_limited(LimitedAction::YankUnyank);
+    check_yanked(&app, true);
+
+    // Let the rate limit refill.
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Unyanking now works.
+    token.unyank("yankable", "1.0.0").good();
+    check_yanked(&app, false);
+
+    // Yanking again will trigger the rate limit.
+    token
+        .yank("yankable", "1.0.0")
+        .assert_rate_limited(LimitedAction::YankUnyank);
+    check_yanked(&app, false);
 }
 
 #[test]

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -11,6 +11,7 @@ use std::{rc::Rc, sync::Arc, time::Duration};
 use crate::util::github::{MockGitHubClient, MOCK_GITHUB_DATA};
 use anyhow::Context;
 use crates_io::models::token::{CrateScope, EndpointScope};
+use crates_io::rate_limiter::{LimitedAction, RateLimiterConfig};
 use crates_io::swirl::Runner;
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
@@ -329,10 +330,11 @@ impl TestAppBuilder {
         self
     }
 
-    pub fn with_publish_rate_limit(self, rate: Duration, burst: i32) -> Self {
+    pub fn with_rate_limit(self, action: LimitedAction, rate: Duration, burst: i32) -> Self {
         self.with_config(|config| {
-            config.rate_limiter.rate = rate;
-            config.rate_limiter.burst = burst;
+            config
+                .rate_limiter
+                .insert(action, RateLimiterConfig { rate, burst });
         })
     }
 

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -98,7 +98,7 @@ mod test {
             name: "foo",
             ..Default::default()
         }
-        .create_or_update(conn, user_id, None)
+        .create_or_update(conn, user_id)
         .unwrap();
         let version = NewVersion::new(
             krate.id,


### PR DESCRIPTION
This PR follows up on #6872 by adding support for multiple kinds of rate limits in `RateLimiter` and adding a limit for yanking and unyanking, which would've prevented last Friday's outage.

As I was already changing this code, I also moved the rate limit for publishing existing crates from nginx into the application. This makes the limit more precise (as it's not per-server anymore, potentially allowing up to 4x the limit), and allows overriding the limit just for a subset of users.

With this PR, the rate limits are:

| Action | Burst amount | Refill time |
| --- | --- | --- |
| Publish new crates | 5 | 1 every 10 minutes |
| Publish updates to existing crates | 30 | 1 every minute |
| Yanking or unyanking | 100 | 1 every minute |

Note that the environment variables also changed:

* From `WEB_NEW_PKG_RATE_LIMIT_RATE_MINUTES` to `RATE_LIMITER_PUBLISH_NEW_RATE_SECONDS`
* From `WEB_NEW_PKG_RATE_LIMIT_BURST` to `RATE_LIMITER_PUBLISH_NEW_BURST`