### PR TITLE
Replace `#[macro_use]` with explicit imports 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ pub mod metrics;
 pub mod middleware;
 mod rate_limiter;
 pub mod schema;
-#[macro_use]
 pub mod sql;
 pub mod ssh;
 pub mod swirl;

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -17,6 +17,7 @@
 //! As a rule of thumb, if the metric requires a database query to be updated it's probably a
 //! service-level metric, and you should add it to `src/metrics/service.rs` instead.
 
+use crate::metrics::macros::metrics;
 use crate::{app::App, db::DieselPool};
 use prometheus::{
     proto::MetricFamily, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,

--- a/src/metrics/macros.rs
+++ b/src/metrics/macros.rs
@@ -19,7 +19,6 @@ pub(super) trait MetricFromOpts: Sized {
     fn from_opts(opts: Opts) -> Result<Self, prometheus::Error>;
 }
 
-#[macro_export]
 macro_rules! metrics {
     (
         $vis:vis struct $name:ident {
@@ -69,6 +68,8 @@ macro_rules! metrics {
         }
     };
 }
+
+pub(crate) use metrics;
 
 macro_rules! load_metric_type {
     ($name:ident as single) => {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -2,9 +2,7 @@ pub use self::instance::InstanceMetrics;
 pub use self::log_encoder::LogEncoder;
 pub use self::service::ServiceMetrics;
 
-#[macro_use]
-mod macros;
-
 mod instance;
 mod log_encoder;
+mod macros;
 mod service;

--- a/src/metrics/service.rs
+++ b/src/metrics/service.rs
@@ -10,6 +10,7 @@
 //! As a rule of thumb, if the metric is not straight up fetched from the database it's probably an
 //! instance-level metric, and you should add it to `src/metrics/instance.rs`.
 
+use crate::metrics::macros::metrics;
 use crate::schema::{background_jobs, crates, versions};
 use crate::util::errors::AppResult;
 use diesel::{dsl::count_star, prelude::*, PgConnection};

--- a/src/models/action.rs
+++ b/src/models/action.rs
@@ -1,5 +1,6 @@
 use crate::models::{ApiToken, User, Version};
 use crate::schema::*;
+use crate::sql::pg_enum;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -2,6 +2,7 @@ use diesel::sql_types::{Integer, Text};
 
 use crate::models::{Crate, Version};
 use crate::schema::*;
+use crate::sql::pg_enum;
 use crates_io_index::DependencyKind as IndexDependencyKind;
 
 #[derive(Identifiable, Associations, Debug, Queryable, QueryableByName)]

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -5,10 +5,10 @@ use diesel::sql_types::Interval;
 use std::time::Duration;
 
 use crate::schema::{publish_limit_buckets, publish_rate_overrides};
-use crate::sql::{date_part, floor, greatest, interval_part, least};
+use crate::sql::{date_part, floor, greatest, interval_part, least, pg_enum};
 use crate::util::errors::{AppResult, TooManyRequests};
 
-crate::pg_enum! {
+pg_enum! {
     pub enum LimitedAction {
         PublishNew = 0,
     }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -14,7 +14,6 @@ sql_function!(fn greatest<T: SingleValue>(x: T, y: T) -> T);
 sql_function!(fn least<T: SingleValue>(x: T, y: T) -> T);
 sql_function!(fn split_part(string: Text, delimiter: Text, n: Integer) -> Text);
 
-#[macro_export]
 macro_rules! pg_enum {
     (
         $vis:vis enum $name:ident {
@@ -48,3 +47,5 @@ macro_rules! pg_enum {
         }
     }
 }
+
+pub(crate) use pg_enum;


### PR DESCRIPTION
The 2018 edition of Rust allows us to explicitly import macros, which makes the code a little easier to follow and without polluting the top-level namespace of a project.