### PR TITLE
metrics/service: Fix `background_jobs` label order

### DIFF
--- a/src/metrics/service.rs
+++ b/src/metrics/service.rs
@@ -48,7 +48,7 @@ impl ServiceMetrics {
         for (job, priority, count) in background_jobs {
             let priority = format!("{priority}");
             self.background_jobs
-                .get_metric_with_label_values(&[&job, &priority])?
+                .get_metric_with_label_values(&[&priority, &job])?
                 .set(count);
         }
 


### PR DESCRIPTION
The `background_jobs` definition is `IntGaugeVec["priority", "job"]`, not `IntGaugeVec["job", "priority"]` 😅 

/cc @pietroalbini 