### PR TITLE
Implement basic smoke test setup

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,21 @@
+name: Smoke Test
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: smoke-test
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3.5.3
+      - uses: Swatinem/rust-cache@v2.5.1
+      - run: cargo build --manifest-path crates_io_smoke_test/Cargo.toml
+      - run: cargo run --manifest-path crates_io_smoke_test/Cargo.toml --quiet

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,3 +19,5 @@ jobs:
       - uses: Swatinem/rust-cache@v2.5.1
       - run: cargo build --manifest-path crates_io_smoke_test/Cargo.toml
       - run: cargo run --manifest-path crates_io_smoke_test/Cargo.toml --quiet
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.STAGING_SMOKE_TEST_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,8 @@ dependencies = [
 name = "crates_io_smoke_test"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
+ "secrecy",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,7 @@ dependencies = [
  "anyhow",
  "clap",
  "secrecy",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,6 +752,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "crates_io_smoke_test"
+version = "0.0.0"
+
+[[package]]
 name = "crates_io_tarball"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,6 +754,10 @@ dependencies = [
 [[package]]
 name = "crates_io_smoke_test"
 version = "0.0.0"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "crates_io_tarball"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,7 +757,10 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "reqwest",
  "secrecy",
+ "semver",
+ "serde",
  "tempfile",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ name = "crates_io_smoke_test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "clap",
  "secrecy",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 default-run = "server"
 
 [workspace]
+members = ["crates_io_smoke_test"]
 
 [profile.release]
 opt-level = 2

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "=1.0.72"
+clap = { version = "=4.3.19", features = ["derive", "env", "unicode", "wrap_help"] }
 secrecy = "=0.8.0"
 tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "crates_io_smoke_test"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[dependencies]

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -5,5 +5,7 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "=1.0.72"
+secrecy = "=0.8.0"
 tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 anyhow = "=1.0.72"
 clap = { version = "=4.3.19", features = ["derive", "env", "unicode", "wrap_help"] }
 secrecy = "=0.8.0"
+tempfile = "=3.7.0"
 tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -5,3 +5,5 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
+tracing = "=0.1.37"
+tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2021"
 [dependencies]
 anyhow = "=1.0.72"
 clap = { version = "=4.3.19", features = ["derive", "env", "unicode", "wrap_help"] }
+reqwest = { version = "=0.11.18", features = ["blocking", "gzip", "json"] }
 secrecy = "=0.8.0"
+semver = { version = "=1.0.18", features = ["serde"] }
+serde = { version = "=1.0.175", features = ["derive"] }
 tempfile = "=3.7.0"
 tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello world!");
+}

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -1,3 +1,25 @@
+#[macro_use]
+extern crate tracing;
+
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
 fn main() {
-    println!("Hello world!");
+    init_tracing();
+
+    info!("Hello world!");
+}
+
+fn init_tracing() {
+    let env_filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::INFO.into())
+        .from_env_lossy();
+
+    let log_layer = tracing_subscriber::fmt::layer()
+        .compact()
+        .with_filter(env_filter);
+
+    tracing_subscriber::registry().with(log_layer).init();
 }

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -1,15 +1,23 @@
 #[macro_use]
 extern crate tracing;
 
+use anyhow::Context;
+use secrecy::SecretString;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     init_tracing();
 
+    let _token: SecretString = std::env::var("CARGO_REGISTRY_TOKEN")
+        .context("Failed to read CARGO_REGISTRY_TOKEN environment variable")?
+        .into();
+
     info!("Hello world!");
+
+    Ok(())
 }
 
 fn init_tracing() {

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -10,6 +10,10 @@ use tracing_subscriber::{EnvFilter, Layer};
 
 #[derive(clap::Parser, Debug)]
 struct Options {
+    /// name of the test crate that will be published to staging.crates.io
+    #[arg(long, default_value = "crates-staging-test-tb")]
+    crate_name: String,
+
     /// staging.crates.io API token that will be used to publish a new version
     #[arg(long, env = "CARGO_REGISTRY_TOKEN", hide_env_values = true)]
     token: SecretString,
@@ -18,9 +22,9 @@ struct Options {
 fn main() -> anyhow::Result<()> {
     init_tracing();
 
-    let _options = Options::parse();
+    let options = Options::parse();
 
-    info!("Hello world!");
+    info!(?options);
 
     Ok(())
 }

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -1,19 +1,24 @@
 #[macro_use]
 extern crate tracing;
 
-use anyhow::Context;
+use clap::Parser;
 use secrecy::SecretString;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Layer};
 
+#[derive(clap::Parser, Debug)]
+struct Options {
+    /// staging.crates.io API token that will be used to publish a new version
+    #[arg(long, env = "CARGO_REGISTRY_TOKEN", hide_env_values = true)]
+    token: SecretString,
+}
+
 fn main() -> anyhow::Result<()> {
     init_tracing();
 
-    let _token: SecretString = std::env::var("CARGO_REGISTRY_TOKEN")
-        .context("Failed to read CARGO_REGISTRY_TOKEN environment variable")?
-        .into();
+    let _options = Options::parse();
 
     info!("Hello world!");
 


### PR DESCRIPTION
This PR adds a new `crates_io_smoke_test` project to the workspace and a "Smoke Test" GitHub Actions workflow. The latter can be manually triggered and runs the former. The new tool will query the current state of the staging environment, run `cargo new`, adjust the `version` field and then run `cargo publish` to see if publishing works correctly.

Example: https://github.com/Turbo87/crates.io/actions/runs/5670151138/job/15364394197

Note that this is just a first step. In the next step we can `cargo new` another project with a dependency on the published version to check that downloads are working as intended.

