### PR TITLE
Extend smoke testing setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ name = "crates_io_smoke_test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
  "reqwest",
  "secrecy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,7 @@ dependencies = [
  "semver",
  "serde",
  "tempfile",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "=1.0.72"
+bytes = "=1.4.0"
 clap = { version = "=4.3.19", features = ["derive", "env", "unicode", "wrap_help"] }
 reqwest = { version = "=0.11.18", features = ["blocking", "gzip", "json"] }
 secrecy = "=0.8.0"

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -12,5 +12,6 @@ secrecy = "=0.8.0"
 semver = { version = "=1.0.18", features = ["serde"] }
 serde = { version = "=1.0.176", features = ["derive"] }
 tempfile = "=3.7.0"
+thiserror = "=1.0.44"
 tracing = "=0.1.37"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }

--- a/crates_io_smoke_test/src/api.rs
+++ b/crates_io_smoke_test/src/api.rs
@@ -1,0 +1,71 @@
+use reqwest::blocking::Client;
+use std::fmt::Display;
+
+pub struct ApiClient {
+    http_client: Client,
+}
+
+impl ApiClient {
+    pub fn new() -> anyhow::Result<Self> {
+        let http_client = Client::builder()
+            .user_agent("crates.io smoke test")
+            .build()?;
+
+        Ok(Self { http_client })
+    }
+
+    pub fn load_crate<N: Display>(&self, name: N) -> anyhow::Result<CrateResponse> {
+        let url = format!(
+            "https://staging.crates.io/api/v1/crates/{}?include=versions",
+            name
+        );
+
+        self.http_client
+            .get(url)
+            .send()?
+            .error_for_status()?
+            .json()
+            .map_err(Into::into)
+    }
+
+    pub fn load_version<N: Display, V: Display>(
+        &self,
+        name: N,
+        version: V,
+    ) -> anyhow::Result<VersionResponse> {
+        let url = format!(
+            "https://staging.crates.io/api/v1/crates/{}/{}",
+            name, version
+        );
+
+        self.http_client
+            .get(url)
+            .send()?
+            .error_for_status()?
+            .json()
+            .map_err(Into::into)
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CrateResponse {
+    #[serde(rename = "crate")]
+    pub krate: Crate,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Crate {
+    pub max_version: semver::Version,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct VersionResponse {
+    pub version: Version,
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct Version {
+    #[serde(rename = "crate")]
+    pub krate: String,
+    pub num: semver::Version,
+}

--- a/crates_io_smoke_test/src/api.rs
+++ b/crates_io_smoke_test/src/api.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use reqwest::blocking::Client;
 use std::fmt::Display;
 
@@ -43,6 +44,24 @@ impl ApiClient {
             .send()?
             .error_for_status()?
             .json()
+            .map_err(Into::into)
+    }
+
+    pub fn download_crate_file<N: Display, V: Display>(
+        &self,
+        name: N,
+        version: V,
+    ) -> anyhow::Result<Bytes> {
+        let url = format!(
+            "https://staging.crates.io/api/v1/crates/{}/{}/download",
+            name, version
+        );
+
+        self.http_client
+            .get(url)
+            .send()?
+            .error_for_status()?
+            .bytes()
             .map_err(Into::into)
     }
 }

--- a/crates_io_smoke_test/src/cargo.rs
+++ b/crates_io_smoke_test/src/cargo.rs
@@ -1,0 +1,29 @@
+use crate::exit_status_ext::ExitStatusExt;
+use secrecy::{ExposeSecret, SecretString};
+use std::path::Path;
+use std::process::Command;
+
+pub fn new_lib(parent_path: &Path, name: &str) -> anyhow::Result<()> {
+    Command::new("cargo")
+        .args(["new", "--lib", name])
+        .current_dir(parent_path)
+        .env("CARGO_TERM_COLOR", "always")
+        .status()?
+        .exit_ok()
+        .map_err(Into::into)
+}
+
+pub fn publish(project_path: &Path, token: &SecretString) -> anyhow::Result<()> {
+    Command::new("cargo")
+        .args(["publish", "--registry", "staging", "--allow-dirty"])
+        .current_dir(project_path)
+        .env("CARGO_TERM_COLOR", "always")
+        .env(
+            "CARGO_REGISTRIES_STAGING_INDEX",
+            "https://github.com/rust-lang/staging.crates.io-index",
+        )
+        .env("CARGO_REGISTRIES_STAGING_TOKEN", token.expose_secret())
+        .status()?
+        .exit_ok()
+        .map_err(Into::into)
+}

--- a/crates_io_smoke_test/src/exit_status_ext.rs
+++ b/crates_io_smoke_test/src/exit_status_ext.rs
@@ -1,0 +1,20 @@
+//! This is a backport of the unstable "exit_status_error" std library feature.
+
+use std::process::ExitStatus;
+
+#[derive(Debug, thiserror::Error)]
+#[error("process exited unsuccessfully: {0}")]
+pub struct ExitStatusError(ExitStatus);
+
+pub trait ExitStatusExt {
+    fn exit_ok(&self) -> Result<(), ExitStatusError>;
+}
+
+impl ExitStatusExt for ExitStatus {
+    fn exit_ok(&self) -> Result<(), ExitStatusError> {
+        match self.success() {
+            true => Ok(()),
+            false => Err(ExitStatusError(*self)),
+        }
+    }
+}

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -11,8 +11,6 @@ use crate::api::ApiClient;
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use secrecy::SecretString;
-use std::fs::File;
-use std::io::Write;
 use tempfile::tempdir;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::layer::SubscriberExt;
@@ -71,8 +69,6 @@ fn main() -> anyhow::Result<()> {
         {
             let manifest_path = project_path.join("Cargo.toml");
             info!(manifest_path = %manifest_path.display(), "Overriding `Cargo.toml` file…");
-            let mut manifest_file =
-                File::create(manifest_path).context("Failed to open `Cargo.toml` file")?;
 
             let new_content = format!(
                 r#"[package]
@@ -85,24 +81,20 @@ description = "test crate"
                 &options.crate_name, &new_version
             );
 
-            manifest_file
-                .write_all(new_content.as_bytes())
+            std::fs::write(&manifest_path, new_content)
                 .context("Failed to write `Cargo.toml` file content")?;
         }
 
         {
             let readme_path = project_path.join("README.md");
             info!(readme_path = %readme_path.display(), "Creating `README.md` file…");
-            let mut readme_file =
-                File::create(readme_path).context("Failed to open `README.md` file")?;
 
             let new_content = format!(
                 "# {} v{}\n\n![](https://media1.giphy.com/media/Ju7l5y9osyymQ/200.gif)\n",
                 &options.crate_name, &new_version
             );
 
-            readme_file
-                .write_all(new_content.as_bytes())
+            std::fs::write(&readme_path, new_content)
                 .context("Failed to write `README.md` file content")?;
         }
 

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -92,6 +92,19 @@ fn main() -> anyhow::Result<()> {
         ));
     }
 
+    info!(%version, "Checking crate file download from staging.crates.io API…");
+
+    let bytes = api_client
+        .download_crate_file(&options.crate_name, &version)
+        .context("Failed to download crate file")?;
+
+    if bytes.len() < 500 {
+        return Err(anyhow!(
+            "API returned an unexpectedly small crate file; size: {}",
+            bytes.len()
+        ));
+    }
+
     Ok(())
 }
 

--- a/crates_io_smoke_test/src/main.rs
+++ b/crates_io_smoke_test/src/main.rs
@@ -105,6 +105,11 @@ fn main() -> anyhow::Result<()> {
         ));
     }
 
+    info!(
+        "All automated smoke tests have passed.\n\nPlease visit https://staging.crates.io/crates/{}/{} for further manual testing.",
+        &options.crate_name, &version
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
This PR refactors the smoke testing setup from #6884 a little bit and adds more checks at the end. Specifically, we are now testing if the published version is visible on the API and if crate file downloads for this version are working.