### PR TITLE
tests/builders/publish: Inline `files_with_io()` and simplify `files()` fn

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -1,5 +1,5 @@
 use crates_io::views::krate_publish as u;
-use std::{collections::BTreeMap, io::Read};
+use std::collections::BTreeMap;
 
 use crates_io_tarball::TarballBuilder;
 use flate2::{write::GzEncoder, Compression};
@@ -52,25 +52,15 @@ impl PublishBuilder {
 
     /// Set the files in the crate's tarball.
     pub fn files(mut self, files: &[(&str, &[u8])]) -> Self {
-        let mut slices = files.iter().map(|p| p.1).collect::<Vec<_>>();
-        let mut files = files
-            .iter()
-            .zip(&mut slices)
-            .map(|(&(name, _), data)| {
-                let len = data.len() as u64;
-                (name, data as &mut dyn Read, len)
-            })
-            .collect::<Vec<_>>();
-
         let mut tarball = Vec::new();
         {
             let mut ar = tar::Builder::new(GzEncoder::new(&mut tarball, Compression::default()));
-            for &mut (name, ref mut data, size) in &mut files {
+            for (name, data) in files {
                 let mut header = tar::Header::new_gnu();
                 assert_ok!(header.set_path(name));
-                header.set_size(size);
+                header.set_size(data.len() as u64);
                 header.set_cksum();
-                assert_ok!(ar.append(&header, data));
+                assert_ok!(ar.append(&header, *data));
             }
             assert_ok!(ar.finish());
         }

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -51,7 +51,7 @@ impl PublishBuilder {
     }
 
     /// Set the files in the crate's tarball.
-    pub fn files(self, files: &[(&str, &[u8])]) -> Self {
+    pub fn files(mut self, files: &[(&str, &[u8])]) -> Self {
         let mut slices = files.iter().map(|p| p.1).collect::<Vec<_>>();
         let mut files = files
             .iter()
@@ -62,15 +62,10 @@ impl PublishBuilder {
             })
             .collect::<Vec<_>>();
 
-        self.files_with_io(&mut files)
-    }
-
-    /// Set the tarball from a Read trait object
-    pub fn files_with_io(mut self, files: &mut [(&str, &mut dyn Read, u64)]) -> Self {
         let mut tarball = Vec::new();
         {
             let mut ar = tar::Builder::new(GzEncoder::new(&mut tarball, Compression::default()));
-            for &mut (name, ref mut data, size) in files {
+            for &mut (name, ref mut data, size) in &mut files {
                 let mut header = tar::Header::new_gnu();
                 assert_ok!(header.set_path(name));
                 header.set_size(size);

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -57,10 +57,8 @@ impl PublishBuilder {
             let mut ar = tar::Builder::new(GzEncoder::new(&mut tarball, Compression::default()));
             for (name, data) in files {
                 let mut header = tar::Header::new_gnu();
-                assert_ok!(header.set_path(name));
                 header.set_size(data.len() as u64);
-                header.set_cksum();
-                assert_ok!(ar.append(&header, *data));
+                assert_ok!(ar.append_data(&mut header, name, *data));
             }
             assert_ok!(ar.finish());
         }

--- a/src/tests/krate/publish.rs
+++ b/src/tests/krate/publish.rs
@@ -500,11 +500,12 @@ fn new_krate_gzip_bomb() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let len = 512 * 1024;
-    let mut body = io::repeat(0).take(len);
+    let mut body = Vec::new();
+    io::repeat(0).take(len).read_to_end(&mut body).unwrap();
 
     let crate_to_publish = PublishBuilder::new("foo")
         .version("1.1.0")
-        .files_with_io(&mut [("foo-1.1.0/a", &mut body, len)]);
+        .files(&[("foo-1.1.0/a", &body)]);
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);


### PR DESCRIPTION
The `files_with_io()` fn reads the "file" content into memory anyway, so we gain nothing from passing in the `Read` impl. This PR simplifies the code a bit and keeps `files()` as the only entry point for generating a custom tarball.

Further cleanup with come in follow-up PRs :)