### PR TITLE
PublishBuilder: Provide `version` upfront

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -25,9 +25,9 @@ pub struct PublishBuilder {
 }
 
 impl PublishBuilder {
-    /// Create a request to publish a crate with the given name, version 1.0.0, and no files
+    /// Create a request to publish a crate with the given name and version, and no files
     /// in its tarball.
-    pub fn new(krate_name: &str) -> Self {
+    pub fn new(krate_name: &str, version: &str) -> Self {
         PublishBuilder {
             categories: vec![],
             deps: vec![],
@@ -38,16 +38,10 @@ impl PublishBuilder {
             license: Some("MIT".to_string()),
             license_file: None,
             readme: None,
-            tarball: TarballBuilder::new(krate_name, "1.0.0").build(),
-            version: semver::Version::parse("1.0.0").unwrap(),
+            tarball: TarballBuilder::new(krate_name, version).build(),
+            version: semver::Version::parse(version).unwrap(),
             features: BTreeMap::new(),
         }
-    }
-
-    /// Set the version of the crate being published to something other than the default of 1.0.0.
-    pub fn version(mut self, version: &str) -> Self {
-        self.version = semver::Version::parse(version).unwrap();
-        self
     }
 
     /// Set the files in the crate's tarball.

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -8,7 +8,7 @@ fn yank_works_as_intended() {
     let (app, anon, cookie, token) = TestApp::full().with_token();
 
     // Upload a new crate, putting it in the git index
-    let crate_to_publish = PublishBuilder::new("fyk");
+    let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
     token.publish_crate(crate_to_publish).good();
 
     let crates = app.crates_from_index_head("fyk");
@@ -65,7 +65,7 @@ fn yank_max_version() {
     let (_, anon, _, token) = TestApp::full().with_token();
 
     // Upload a new crate
-    let crate_to_publish = PublishBuilder::new("fyk_max");
+    let crate_to_publish = PublishBuilder::new("fyk_max", "1.0.0");
     token.publish_crate(crate_to_publish).good();
 
     // double check the max version
@@ -73,7 +73,7 @@ fn yank_max_version() {
     assert_eq!(json.krate.max_version, "1.0.0");
 
     // add version 2.0.0
-    let crate_to_publish = PublishBuilder::new("fyk_max").version("2.0.0");
+    let crate_to_publish = PublishBuilder::new("fyk_max", "2.0.0");
     let json = token.publish_crate(crate_to_publish).good();
     assert_eq!(json.krate.max_version, "2.0.0");
 
@@ -119,7 +119,7 @@ fn publish_after_yank_max_version() {
     let (_, anon, _, token) = TestApp::full().with_token();
 
     // Upload a new crate
-    let crate_to_publish = PublishBuilder::new("fyk_max");
+    let crate_to_publish = PublishBuilder::new("fyk_max", "1.0.0");
     token.publish_crate(crate_to_publish).good();
 
     // double check the max version
@@ -133,7 +133,7 @@ fn publish_after_yank_max_version() {
     assert_eq!(json.krate.max_version, "0.0.0");
 
     // add version 2.0.0
-    let crate_to_publish = PublishBuilder::new("fyk_max").version("2.0.0");
+    let crate_to_publish = PublishBuilder::new("fyk_max", "2.0.0");
     let json = token.publish_crate(crate_to_publish).good();
     assert_eq!(json.krate.max_version, "2.0.0");
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -136,7 +136,7 @@ fn new_crate_owner() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     // Create a crate under one user
-    let crate_to_publish = PublishBuilder::new("foo_owner").version("1.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_owner", "1.0.0");
     token.publish_crate(crate_to_publish).good();
 
     // Add the second user as an owner (with a different case to make sure that works)
@@ -152,7 +152,7 @@ fn new_crate_owner() {
     assert_eq!(crates.crates.len(), 1);
 
     // And upload a new version as the second user
-    let crate_to_publish = PublishBuilder::new("foo_owner").version("2.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_owner", "2.0.0");
     user2
         .db_new_token("bar_token")
         .publish_crate(crate_to_publish)

--- a/src/tests/routes/crates/new.rs
+++ b/src/tests/routes/crates/new.rs
@@ -7,12 +7,11 @@ fn daily_limit() {
 
     let max_daily_versions = app.as_inner().config.new_version_rate_limit.unwrap();
     for version in 1..=max_daily_versions {
-        let crate_to_publish =
-            PublishBuilder::new("foo_daily_limit").version(&format!("0.0.{version}"));
+        let crate_to_publish = PublishBuilder::new("foo_daily_limit", &format!("0.0.{version}"));
         user.publish_crate(crate_to_publish).good();
     }
 
-    let crate_to_publish = PublishBuilder::new("foo_daily_limit").version("1.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_daily_limit", "1.0.0");
     let response = user.publish_crate(crate_to_publish);
     assert!(response.status().is_success());
     let json = response.into_json();

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -120,14 +120,12 @@ fn show_minimal() {
 fn version_size() {
     let (_, _, user) = TestApp::full().with_user();
 
-    let crate_to_publish = PublishBuilder::new("foo_version_size").version("1.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_version_size", "1.0.0");
     user.publish_crate(crate_to_publish).good();
 
     // Add a file to version 2 so that it's a different size than version 1
     let files = [("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_])];
-    let crate_to_publish = PublishBuilder::new("foo_version_size")
-        .version("2.0.0")
-        .files(&files);
+    let crate_to_publish = PublishBuilder::new("foo_version_size", "2.0.0").files(&files);
     user.publish_crate(crate_to_publish).good();
 
     let crate_json = user.show_crate("foo_version_size");

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -52,7 +52,7 @@ fn yank_records_an_audit_action() {
     let (_, anon, _, token) = TestApp::full().with_token();
 
     // Upload a new crate, putting it in the git index
-    let crate_to_publish = PublishBuilder::new("fyk");
+    let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
     token.publish_crate(crate_to_publish).good();
 
     // Yank it
@@ -73,7 +73,7 @@ fn unyank_records_an_audit_action() {
     let (_, anon, _, token) = TestApp::full().with_token();
 
     // Upload a new crate
-    let crate_to_publish = PublishBuilder::new("fyk");
+    let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
     token.publish_crate(crate_to_publish).good();
 
     // Yank version 1.0.0
@@ -104,7 +104,7 @@ mod auth {
     fn prepare() -> (TestApp, MockAnonymousUser, MockCookieUser) {
         let (app, anon, cookie) = TestApp::full().with_user();
 
-        let pb = PublishBuilder::new(CRATE_NAME).version(CRATE_VERSION);
+        let pb = PublishBuilder::new(CRATE_NAME, CRATE_VERSION);
         cookie.publish_crate(pb).good();
 
         (app, anon, cookie)

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -222,7 +222,7 @@ fn remove_team_as_named_owner() {
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team");
-    let crate_to_publish = PublishBuilder::new("foo_remove_team").version("2.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_remove_team", "2.0.0");
     let response = user_on_one_team.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
@@ -285,7 +285,7 @@ fn publish_not_owned() {
 
     let user_on_one_team = app.db_new_user("user-one-team");
 
-    let crate_to_publish = PublishBuilder::new("foo_not_owned").version("2.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_not_owned", "2.0.0");
     let response = user_on_one_team.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
@@ -310,7 +310,7 @@ fn publish_org_owner_owned() {
 
     let user_org_owner = app.db_new_user("user-org-owner");
 
-    let crate_to_publish = PublishBuilder::new("foo_not_owned").version("2.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_not_owned", "2.0.0");
     let response = user_org_owner.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
@@ -336,7 +336,7 @@ fn publish_owned() {
 
     let user_on_one_team = app.db_new_user("user-one-team");
 
-    let crate_to_publish = PublishBuilder::new("foo_team_owned").version("2.0.0");
+    let crate_to_publish = PublishBuilder::new("foo_team_owned", "2.0.0");
     user_on_one_team.publish_crate(crate_to_publish).good();
 }
 

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -12,7 +12,7 @@ fn index_smoke_test() {
 
     // Add a new crate
 
-    let body = PublishBuilder::new("serde").version("1.0.0").body();
+    let body = PublishBuilder::new("serde", "1.0.0").body();
     let response = token.put::<()>("/api/v1/crates/new", &body);
     assert_eq!(response.status(), StatusCode::OK);
 


### PR DESCRIPTION
This will make it much easier in the future to keep a stateful `TarballBuilder` around, and also simplifies the existing usages in quite a few cases.