### PR TITLE
tarball: Fail if `Cargo.toml` manifest is missing or invalid

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -188,7 +188,8 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
 
             let rust_version = tarball_info
                 .manifest
-                .and_then(|m| m.package.rust_version)
+                .package
+                .rust_version
                 .map(|rv| rv.deref().to_string());
 
             // Persist the new version of this crate
@@ -401,6 +402,12 @@ fn tarball_to_app_error(error: TarballError) -> BoxedAppError {
             cargo_err(&format!("unexpected symlink or hard link found: {path}"))
         }
         TarballError::IO(err) => err.into(),
+        TarballError::MissingManifest => {
+            cargo_err("uploaded tarball is missing a `Cargo.toml` manifest file")
+        }
+        TarballError::InvalidManifest(err) => cargo_err(&format!(
+            "failed to parse `Cargo.toml` manifest file\n\n{err}"
+        )),
     }
 }
 

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -28,6 +28,10 @@ impl PublishBuilder {
     /// Create a request to publish a crate with the given name and version, and no files
     /// in its tarball.
     pub fn new(krate_name: &str, version: &str) -> Self {
+        let tarball = TarballBuilder::new(krate_name, version)
+            .add_raw_manifest(b"[package]")
+            .build();
+
         PublishBuilder {
             categories: vec![],
             deps: vec![],
@@ -38,7 +42,7 @@ impl PublishBuilder {
             license: Some("MIT".to_string()),
             license_file: None,
             readme: None,
-            tarball: TarballBuilder::new(krate_name, version).build(),
+            tarball,
             version: semver::Version::parse(version).unwrap(),
             features: BTreeMap::new(),
         }

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -124,7 +124,10 @@ fn version_size() {
     user.publish_crate(crate_to_publish).good();
 
     // Add a file to version 2 so that it's a different size than version 1
-    let files = [("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_])];
+    let files = [
+        ("foo_version_size-2.0.0/Cargo.toml", b"[package]" as &[_]),
+        ("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_]),
+    ];
     let crate_to_publish = PublishBuilder::new("foo_version_size", "2.0.0").files(&files);
     user.publish_crate(crate_to_publish).good();
 
@@ -137,7 +140,7 @@ fn version_size() {
         .iter()
         .find(|v| v.num == "1.0.0")
         .expect("Could not find v1.0.0");
-    assert_eq!(version1.crate_size, Some(35));
+    assert_eq!(version1.crate_size, Some(108));
 
     let version2 = crate_json
         .versions
@@ -146,7 +149,7 @@ fn version_size() {
         .iter()
         .find(|v| v.num == "2.0.0")
         .expect("Could not find v2.0.0");
-    assert_eq!(version2.crate_size, Some(91));
+    assert_eq!(version2.crate_size, Some(135));
 }
 
 #[test]


### PR DESCRIPTION
This changes the `crates_io_tarball` package to a) require a `Cargo.toml` file to always be present in a crate file, and b) no longer silently fail if the `Cargo.toml` file can't be parsed.

This ensures that only crate files with valid manifests end up on crates.io. We previously accepted almost arbitrary tarballs, even without any manifests. Note that "valid" is still pretty vague since we currently only deserialize very few fields of the TOML file, but this will change in the near future.

Unfortunately this change also required a few changes to our test suite, which previously did not include `Cargo.toml` files in most of the tarballs sent to the server. The `Cargo.toml` that we send now is a veeeery basic manifest and is actually still lacking the required `name` and `version` fields, but, since we don't enforce this part yet, are left out for now.