### PR TITLE
Migrate from docs.rs' builds API to status API

### DIFF
--- a/app/models/version.js
+++ b/app/models/version.js
@@ -133,13 +133,13 @@ export default class Version extends Model {
     }
   });
 
-  loadDocsBuildsTask = task(async () => {
-    return await ajax(`https://docs.rs/crate/${this.crateName}/${this.num}/builds.json`);
+  loadDocsStatusTask = task(async () => {
+    return await ajax(`https://docs.rs/crate/${this.crateName}/=${this.num}/status.json`);
   });
 
   get hasDocsRsLink() {
-    let docsBuilds = this.loadDocsBuildsTask.lastSuccessful?.value;
-    return docsBuilds?.[0]?.build_status === true;
+    let docsStatus = this.loadDocsStatusTask.lastSuccessful?.value;
+    return docsStatus?.doc_status === true;
   }
 
   get docsRsLink() {

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -54,7 +54,7 @@ export default class VersionRoute extends Route {
 
     let { crate, version } = model;
     if (!crate.documentation || crate.documentation.startsWith('https://docs.rs/')) {
-      version.loadDocsBuildsTask.perform().catch(error => {
+      version.loadDocsStatusTask.perform().catch(error => {
         // report unexpected errors to Sentry and ignore `ajax()` errors
         if (!didCancel(error) && !(error instanceof AjaxError)) {
           this.sentry.captureException(error);

--- a/mirage/route-handlers/docs-rs.js
+++ b/mirage/route-handlers/docs-rs.js
@@ -1,5 +1,5 @@
 export function register(server) {
-  server.get('https://docs.rs/crate/:crate/:version/builds.json', function () {
-    return [];
+  server.get('https://docs.rs/crate/:crate/:version/status.json', function () {
+    return {};
   });
 }

--- a/tests/routes/crate/version/docs-link-test.js
+++ b/tests/routes/crate/version/docs-link-test.js
@@ -18,7 +18,7 @@ module('Route | crate.version | docs link', function (hooks) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0' });
 
-    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
+    this.server.get('https://docs.rs/crate/:crate/:version/status.json', 'not found', 404);
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').doesNotExist();
@@ -28,16 +28,10 @@ module('Route | crate.version | docs link', function (hooks) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0' });
 
-    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [
-      {
-        id: 42,
-        rustc_version: 'rustc 1.50.0-nightly (1c389ffef 2020-11-24)',
-        docsrs_version: 'docsrs 0.6.0 (31c864e 2020-11-22)',
-        build_status: true,
-        build_time: '2020-12-06T09:04:36.610302Z',
-        output: null,
-      },
-    ]);
+    this.server.get('https://docs.rs/crate/:crate/:version/status.json', {
+      doc_status: true,
+      version: '1.0.0',
+    });
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/1.0.0');
@@ -47,7 +41,7 @@ module('Route | crate.version | docs link', function (hooks) {
     let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
     this.server.create('version', { crate, num: '1.0.0' });
 
-    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
+    this.server.get('https://docs.rs/crate/:crate/:version/status.json', 'not found', 404);
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
@@ -57,16 +51,10 @@ module('Route | crate.version | docs link', function (hooks) {
     let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
     this.server.create('version', { crate, num: '1.0.0' });
 
-    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [
-      {
-        id: 42,
-        rustc_version: 'rustc 1.50.0-nightly (1c389ffef 2020-11-24)',
-        docsrs_version: 'docsrs 0.6.0 (31c864e 2020-11-22)',
-        build_status: true,
-        build_time: '2020-12-06T09:04:36.610302Z',
-        output: null,
-      },
-    ]);
+    this.server.get('https://docs.rs/crate/:crate/:version/status.json', {
+      doc_status: true,
+      version: '1.0.0',
+    });
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/1.0.0');
@@ -76,27 +64,17 @@ module('Route | crate.version | docs link', function (hooks) {
     let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
     this.server.create('version', { crate, num: '1.0.0' });
 
-    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', {}, 500);
+    this.server.get('https://docs.rs/crate/:crate/:version/status.json', 'error', 500);
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
   });
 
-  test('null builds in docs.rs responses are ignored', async function (assert) {
+  test('empty docs.rs responses are ignored', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
     this.server.create('version', { crate, num: '0.6.2' });
 
-    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', [null]);
-
-    await visit('/crates/foo');
-    assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/0.6.2');
-  });
-
-  test('empty arrays in docs.rs responses are ignored', async function (assert) {
-    let crate = this.server.create('crate', { name: 'foo', documentation: 'https://docs.rs/foo/0.6.2' });
-    this.server.create('version', { crate, num: '0.6.2' });
-
-    this.server.get('https://docs.rs/crate/:crate/:version/builds.json', []);
+    this.server.get('https://docs.rs/crate/:crate/:version/status.json', {});
 
     await visit('/crates/foo');
     assert.dom('[data-test-docs-link] a').hasAttribute('href', 'https://docs.rs/foo/0.6.2');


### PR DESCRIPTION
To simplify refactoring how our builds are processed I want to remove the `/builds.json` endpoint on docs.rs. As a replacement [I added](https://github.com/rust-lang/docs.rs/pull/2147) a new endpoint simply giving the status that sites like crates.io wants: are there docs for this version available to link to. This also fixes some small issues with the old endpoint (some edgecases meant the first build was successful but there were no docs, or there were docs but the first build was marked unsuccessful; if the version in the path doesn't match an exact version it is used as a semver query, but using a `=version` path like done here on the old API would hit CORS issues).