### PR TITLE
tarball/Package: Add `name` and `version` as required fields

### DIFF
--- a/crates_io_tarball/src/lib.rs
+++ b/crates_io_tarball/src/lib.rs
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn process_tarball_test() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(b"[package]")
+            .add_raw_manifest(b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n")
             .build();
 
         let limit = 512 * 1024 * 1024;
@@ -134,7 +134,7 @@ mod tests {
     #[test]
     fn process_tarball_test_incomplete_vcs_info() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(b"[package]")
+            .add_raw_manifest(b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n")
             .add_file("foo-0.0.1/.cargo_vcs_info.json", br#"{"unknown": "field"}"#)
             .build();
 
@@ -149,7 +149,7 @@ mod tests {
     #[test]
     fn process_tarball_test_vcs_info() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(b"[package]")
+            .add_raw_manifest(b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n")
             .add_file(
                 "foo-0.0.1/.cargo_vcs_info.json",
                 br#"{"path_in_vcs": "path/in/vcs"}"#,
@@ -170,6 +170,8 @@ mod tests {
             .add_raw_manifest(
                 br#"
 [package]
+name = "foo"
+version = "0.0.1"
 rust-version = "1.59"
 readme = "README.md"
 repository = "https://github.com/foo/bar"
@@ -191,6 +193,8 @@ repository = "https://github.com/foo/bar"
             .add_raw_manifest(
                 br#"
                 [project]
+                name = "foo"
+                version = "0.0.1"
                 rust-version = "1.23"
                 "#,
             )
@@ -208,6 +212,8 @@ repository = "https://github.com/foo/bar"
             .add_raw_manifest(
                 br#"
                 [package]
+                name = "foo"
+                version = "0.0.1"
                 "#,
             )
             .build();
@@ -224,6 +230,8 @@ repository = "https://github.com/foo/bar"
             .add_raw_manifest(
                 br#"
                 [package]
+                name = "foo"
+                version = "0.0.1"
                 readme = false
                 "#,
             )
@@ -242,6 +250,8 @@ repository = "https://github.com/foo/bar"
                 "foo-0.0.1/cargo.toml",
                 br#"
 [package]
+name = "foo"
+version = "0.0.1"
 repository = "https://github.com/foo/bar"
 "#,
             )

--- a/crates_io_tarball/src/manifest.rs
+++ b/crates_io_tarball/src/manifest.rs
@@ -11,6 +11,8 @@ pub struct Manifest {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct Package {
+    pub name: String,
+    pub version: String,
     #[serde(default)]
     pub readme: OptionalFile,
     pub repository: Option<String>,

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -237,6 +237,8 @@ pub mod tests {
             .add_raw_manifest(
                 br#"
 [package]
+name = "foo"
+version = "0.0.1"
 readme = "README.md"
 "#,
             )
@@ -270,6 +272,8 @@ readme = "README.md"
             .add_raw_manifest(
                 br#"
 [package]
+name = "foo"
+version = "0.0.1"
 "#,
             )
             .add_file("foo-0.0.1/README.md", b"readme")
@@ -286,6 +290,8 @@ readme = "README.md"
             .add_raw_manifest(
                 br#"
 [package]
+name = "foo"
+version = "0.0.1"
 readme = "README.md"
 repository = "https://github.com/foo/foo"
 "#,
@@ -304,6 +310,8 @@ repository = "https://github.com/foo/foo"
             .add_raw_manifest(
                 br#"
 [package]
+name = "foo"
+version = "0.0.1"
 readme = "docs/README.md"
 repository = "https://github.com/foo/foo"
 "#,

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -27,8 +27,10 @@ impl PublishBuilder {
     /// Create a request to publish a crate with the given name and version, and no files
     /// in its tarball.
     pub fn new(krate_name: &str, version: &str) -> Self {
+        let manifest = format!("[package]\nname = \"{krate_name}\"\nversion = \"{version}\"\n");
+
         let tarball = TarballBuilder::new(krate_name, version)
-            .add_raw_manifest(b"[package]")
+            .add_raw_manifest(manifest.as_bytes())
             .build();
 
         PublishBuilder {

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -125,7 +125,10 @@ fn version_size() {
 
     // Add a file to version 2 so that it's a different size than version 1
     let files = [
-        ("foo_version_size-2.0.0/Cargo.toml", b"[package]" as &[_]),
+        (
+            "foo_version_size-2.0.0/Cargo.toml",
+            b"[package]\nname = \"foo_version_size\"\nversion = \"2.0.0\"\n" as &[_],
+        ),
         ("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_]),
     ];
     let crate_to_publish = PublishBuilder::new("foo_version_size", "2.0.0").files(&files);
@@ -140,7 +143,7 @@ fn version_size() {
         .iter()
         .find(|v| v.num == "1.0.0")
         .expect("Could not find v1.0.0");
-    assert_eq!(version1.crate_size, Some(108));
+    assert_eq!(version1.crate_size, Some(134));
 
     let version2 = crate_json
         .versions
@@ -149,7 +152,7 @@ fn version_size() {
         .iter()
         .find(|v| v.num == "2.0.0")
         .expect("Could not find v2.0.0");
-    assert_eq!(version2.crate_size, Some(135));
+    assert_eq!(version2.crate_size, Some(159));
 }
 
 #[test]


### PR DESCRIPTION
This matches https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata, which says:

> The only fields required by Cargo are [name](https://doc.rust-lang.org/cargo/reference/manifest.html#the-name-field) and [version](https://doc.rust-lang.org/cargo/reference/manifest.html#the-version-field).

With this PR our publish endpoint will no longer accept tarballs with `Cargo.toml` files that are missing these fields.