### PR TITLE
tarball: Use `cargo_toml` to parse `Cargo.toml` file

### DIFF
--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -177,11 +177,14 @@ fn render_pkg_readme<R: Read>(mut archive: Archive<R>, pkg_name: &str) -> anyhow
         let contents = find_file_by_path(&mut entries, Path::new(&path))
             .context("Failed to read Cargo.toml file")?;
 
-        toml::from_str(&contents).context("Failed to parse manifest file")?
+        Manifest::from_str(&contents).context("Failed to parse manifest file")?
+
+        // We don't call `validate_manifest()` here since the additional validation is not needed
+        // and it would prevent us from reading a couple of legacy crate files.
     };
 
     let rendered = {
-        let readme = manifest.package.readme;
+        let readme = manifest.package().readme();
         if !readme.is_some() {
             return Ok("".to_string());
         }
@@ -198,7 +201,7 @@ fn render_pkg_readme<R: Read>(mut archive: Archive<R>, pkg_name: &str) -> anyhow
         text_to_html(
             &contents,
             &readme_path,
-            manifest.package.repository.as_deref(),
+            manifest.package().repository(),
             pkg_path_in_vcs,
         )
     };

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -197,8 +197,8 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
 
             let rust_version = tarball_info
                 .manifest
-                .package
-                .rust_version
+                .package()
+                .rust_version()
                 .map(|rv| rv.deref().to_string());
 
             // Persist the new version of this crate


### PR DESCRIPTION
This PR switches the `crates_io_tarball` package over to using the https://crates.io/crates/cargo_toml for `Cargo.toml` file parsing.

This should significantly lower the chances of invalid `Cargo.toml` files ending up on crates.io, since a lot more fields are now properly validated.

Note that `cargo_toml` supports workspace inheritance by default, so we have to run an additional validation step to ensure that our server only accepts manifest files without any workspace inheritance.

Similarly, the crate accepts `rust-version` as any random `String`, so I had to move our validation check out of the `serde` deserialization code path.