### PR TITLE
Revert "Update dependency node to v18.17.1"

### DIFF
--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,5 +1,5 @@
 # renovate: datasource=node depName=node
-ARG NODE_VERSION=18.17.1
+ARG NODE_VERSION=18.17.0
 
 FROM node:${NODE_VERSION}-alpine
 

--- a/package.json
+++ b/package.json
@@ -149,13 +149,13 @@
     }
   },
   "engines": {
-    "node": "18.17.1",
+    "node": "18.17.0",
     "pnpm": "8.6.12"
   },
   "ember": {
     "edition": "octane"
   },
   "volta": {
-    "node": "18.17.1"
+    "node": "18.17.0"
   }
 }


### PR DESCRIPTION
Reverts rust-lang/crates.io#6951.

Obviously needs to wait for the buildpack to be updated. My bad.