### PR TITLE
Replace hardcoded credentials path with cargo docs link

### DIFF
--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -25,7 +25,8 @@
 
 <p local-class="explainer">
   To use an API token, run <a href="https://doc.rust-lang.org/cargo/commands/cargo-login.html"><code>cargo login</code></a>
-  on the command line and paste the key when prompted. This will save it to a local file (<code>~/.cargo/credentials</code> by default).
+  on the command line and paste the key when prompted. This will save it to a
+  <a href="https://doc.rust-lang.org/cargo/reference/config.html#credentials">local credentials file</a>.
   For CI systems you can use the
   <a href="https://doc.rust-lang.org/cargo/reference/config.html?highlight=CARGO_REGISTRY_TOKEN#credentials"><code>CARGO_REGISTRY_TOKEN</code></a>
   environment variable, but make sure that the token stays secret!


### PR DESCRIPTION
https://crates.io/settings/tokens incorrectly says `~/.cargo/credentials`, it's missing the `.toml` in the filename.