### PR TITLE
PublishNew was allowing 1 new crate an hour rather than every 10 minutes

### DIFF
--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -20,9 +20,9 @@ pg_enum! {
 impl LimitedAction {
     pub fn default_rate_seconds(&self) -> u64 {
         match self {
-            LimitedAction::PublishNew => 60 * 60,
-            LimitedAction::PublishUpdate => 60,
-            LimitedAction::YankUnyank => 60,
+            LimitedAction::PublishNew => 10 * 60, // 10 minutes
+            LimitedAction::PublishUpdate => 60,   // 1 minute
+            LimitedAction::YankUnyank => 60,      // 1 minute
         }
     }
 


### PR DESCRIPTION
In https://github.com/rust-lang/crates.io/pull/6875, @pietroalbini said:

> With this PR, the rate limits are:
> 
> | Action | Burst amount | Refill time |
> | --- | --- | --- |
> | Publish new crates | 5 | 1 every 10 minutes |
> | Publish updates to existing crates | 30 | 1 every minute |
> | Yanking or unyanking | 100 | 1 every minute |

but the code didn't match that intention, which explains why we were getting so many emails asking for rate limit increases since that PR went out.

The problem was that the `default_rate_seconds` for `PublishNew` was set to `60 * 60`, aka 1 hour, when the intention was that it would be set to `10 * 60`, or 10 minutes.

I added a new test, and for `PublishNew` it fails with:

```
---- rate_limiter::tests::default_rate_limits stdout ----
thread 'rate_limiter::tests::default_rate_limits' panicked at 'assertion failed: `(left == right)`
  left: `[2023-08-11T19:15:38, 2023-08-11T19:25:38, 2023-08-11T19:35:38, 2023-08-11T19:45:38, 2023-08-11T19:55:38, 2023-08-11T20:05:38, 2023-08-11T20:15:38, 2023-08-11T20:25:38, 2023-08-11T20:35:38, 2023-08-11T20:45:38]`,
 right: `[2023-08-11T19:05:38, 2023-08-11T19:05:38, 2023-08-11T19:05:38, 2023-08-11T19:05:38, 2023-08-11T19:05:38, 2023-08-11T20:05:38, 2023-08-11T20:05:38, 2023-08-11T20:05:38, 2023-08-11T20:05:38, 2023-08-11T20:05:38]`', src/rate_limiter.rs:212:9
```

because the `last_refill` times get set to the time at which you're publishing if you're not rate limited.

The CI run for the first commit shows the failure, then the second commit shows the test passing (modulo the flaky test).