### PR TITLE
Improve correctness of the reverse dependencies query

### DIFF
--- a/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/down.sql
+++ b/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/down.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION to_semver_no_prerelease(text);
+
+CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE AS $$
+  SELECT (
+    split_part($1, '.', 1)::numeric,
+    split_part($1, '.', 2)::numeric,
+    split_part(split_part($1, '+', 1), '.', 3)::numeric
+  )::semver_triple
+  WHERE strpos($1, '-') = 0
+  $$ LANGUAGE SQL;

--- a/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/up.sql
+++ b/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/up.sql
@@ -1,0 +1,10 @@
+DROP FUNCTION to_semver_no_prerelease(text);
+
+CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE PARALLEL SAFE AS $$
+  SELECT (
+    split_part($1, '.', 1)::numeric,
+    split_part($1, '.', 2)::numeric,
+    split_part(split_part($1, '+', 1), '.', 3)::numeric
+  )::semver_triple
+  WHERE strpos($1, '-') = 0
+  $$ LANGUAGE SQL SET search_path = public;

--- a/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/up.sql
+++ b/migrations/2023-08-13-175220_to_semver_no_prerelease_parallel_safe/up.sql
@@ -1,10 +1,10 @@
 DROP FUNCTION to_semver_no_prerelease(text);
 
-CREATE FUNCTION to_semver_no_prerelease(text) RETURNS semver_triple IMMUTABLE PARALLEL SAFE AS $$
+CREATE FUNCTION to_semver_no_prerelease(text) RETURNS public.semver_triple IMMUTABLE PARALLEL SAFE AS $$
   SELECT (
     split_part($1, '.', 1)::numeric,
     split_part($1, '.', 2)::numeric,
     split_part(split_part($1, '+', 1), '.', 3)::numeric
-  )::semver_triple
+  )::public.semver_triple
   WHERE strpos($1, '-') = 0
-  $$ LANGUAGE SQL SET search_path = public;
+  $$ LANGUAGE SQL;

--- a/src/models/krate_reverse_dependencies.sql
+++ b/src/models/krate_reverse_dependencies.sql
@@ -12,7 +12,9 @@ SELECT *, COUNT(*) OVER () as total FROM (
         SELECT versions.*,
         row_number() OVER (
             PARTITION BY crate_id
-            ORDER BY to_semver_no_prerelease(num) DESC NULLS LAST
+            ORDER BY
+                to_semver_no_prerelease(num) DESC NULLS LAST,
+                id DESC
         ) rn
         FROM versions
         WHERE NOT yanked

--- a/src/models/krate_reverse_dependencies.sql
+++ b/src/models/krate_reverse_dependencies.sql
@@ -37,7 +37,8 @@ SELECT *, COUNT(*) OVER () as total FROM (
     -- the `DISTINCT ON`
     ORDER BY
         crate_downloads DESC,
-        crate_name ASC
+        crate_name ASC,
+        dependencies.id ASC
 ) t
 ORDER BY
     crate_downloads DESC,

--- a/src/models/krate_reverse_dependencies.sql
+++ b/src/models/krate_reverse_dependencies.sql
@@ -31,7 +31,10 @@ SELECT *, COUNT(*) OVER () as total FROM (
       ON crates.id = versions.crate_id
     WHERE dependencies.crate_id = $1
       AND rn = 1
+    -- this ORDER BY is redundant with the outer one but benefits
+    -- the `DISTINCT ON`
     ORDER BY crate_downloads DESC
 ) t
+ORDER BY crate_downloads DESC
 OFFSET $2
 LIMIT $3

--- a/src/models/krate_reverse_dependencies.sql
+++ b/src/models/krate_reverse_dependencies.sql
@@ -35,8 +35,12 @@ SELECT *, COUNT(*) OVER () as total FROM (
       AND rn = 1
     -- this ORDER BY is redundant with the outer one but benefits
     -- the `DISTINCT ON`
-    ORDER BY crate_downloads DESC
+    ORDER BY
+        crate_downloads DESC,
+        crate_name ASC
 ) t
-ORDER BY crate_downloads DESC
+ORDER BY
+    crate_downloads DESC,
+    crate_name ASC
 OFFSET $2
 LIMIT $3


### PR DESCRIPTION
These commits have been branched out of #6910 after I kept finding improvements I could make which weren't performance related.

The last commit actually gives the reverse dependencies query a performance boost by allowing Postgres to write a query plan parallelizing most of the query to parallel worker processes, which it didn't before because of [parallel safety](https://www.postgresql.org/docs/current/parallel-safety.html).
I put it in because while it is a performance improvement it also seemed like a flag which should be present everytime the function implementation allows for it.
It also helps speed-up refreshing of indexes or materialized views.