### PR TITLE
Upgrade to latest embroider

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
     "@ember/string": "3.1.1",
     "@ember/test-helpers": "3.2.0",
     "@ember/test-waiters": "3.0.2",
-    "@embroider/compat": "2.1.1",
-    "@embroider/core": "2.1.1",
-    "@embroider/webpack": "2.1.1",
+    "@embroider/compat": "3.2.1",
+    "@embroider/core": "3.2.1",
+    "@embroider/webpack": "3.1.5",
     "@glimmer/component": "1.1.2",
     "@glimmer/tracking": "1.1.2",
     "@mainmatter/ember-api-actions": "0.6.0",
@@ -144,8 +144,13 @@
   },
   "pnpm": {
     "peerDependencyRules": {
-      "allowAny": ["eslint"],
-      "ignoreMissing": ["@babel/core", "postcss"]
+      "allowAny": [
+        "eslint"
+      ],
+      "ignoreMissing": [
+        "@babel/core",
+        "postcss"
+      ]
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,14 +78,14 @@ devDependencies:
     specifier: 3.0.2
     version: 3.0.2
   '@embroider/compat':
-    specifier: 2.1.1
-    version: 2.1.1(@embroider/core@2.1.1)
+    specifier: 3.2.1
+    version: 3.2.1(@embroider/core@3.2.1)
   '@embroider/core':
-    specifier: 2.1.1
-    version: 2.1.1
+    specifier: 3.2.1
+    version: 3.2.1
   '@embroider/webpack':
-    specifier: 2.1.1
-    version: 2.1.1(@embroider/core@2.1.1)(webpack@5.88.2)
+    specifier: 3.1.5
+    version: 3.1.5(@embroider/core@3.2.1)(webpack@5.88.2)
   '@glimmer/component':
     specifier: 1.1.2
     version: 1.1.2
@@ -2503,20 +2503,20 @@ packages:
     resolution: {integrity: sha512-siC9kP78uucEbpDcVyxjkwa76pcs5rVzDVpWO4PDc9EAXRX+pzmUuSTLAK3GztUwx7/PWhz1BenAivqdSvSgfg==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
-      '@embroider/shared-internals': 2.4.0
+      '@embroider/shared-internals': 2.4.0(supports-color@8.1.1)
       broccoli-funnel: 3.0.8
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/babel-loader-8@2.0.0(@embroider/core@2.1.1)(supports-color@8.1.1)(webpack@5.88.2):
-    resolution: {integrity: sha512-a1bLodfox8JEgNHuhiIBIcXJ4b8NNnKWYkMIpJx216pn80Jf1jcFosQpxnqC8hYHrnG0XRKzQ9zJYgJXoa1wfg==}
+  /@embroider/babel-loader-8@3.0.1(@embroider/core@3.2.1)(supports-color@8.1.1)(webpack@5.88.2):
+    resolution: {integrity: sha512-SQYJ7UnKh2GpsnSTHVZ178ZriK+B5kqlh4kWZhH1DFTyguJ89dCCm4zrjOe7iJDPZxw9R/Vmj+MR2NDxKTofYw==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
-      '@embroider/core': ^2.0.0
+      '@embroider/core': ^3.2.1
     dependencies:
       '@babel/core': 7.22.10(supports-color@8.1.1)
-      '@embroider/core': 2.1.1
+      '@embroider/core': 3.2.1
       babel-loader: 8.3.0(@babel/core@7.22.10)(webpack@5.88.2)
     transitivePeerDependencies:
       - supports-color
@@ -2575,23 +2575,26 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@embroider/compat@2.1.1(@embroider/core@2.1.1):
-    resolution: {integrity: sha512-HNq5vv7NpQ1Jr+4slzmLBqsy5NDsIHilYeQiWboMrPAyHr5NHlKYWciIcmxdgPgz2kf/8D5nDiANgJznZedlyw==}
+  /@embroider/compat@3.2.1(@embroider/core@3.2.1):
+    resolution: {integrity: sha512-nni6oQTPkSuZZKjXTFTZchO7chFBGKEN0O/xMGn9SxifM7EDl7+y6JlPQFchQcmLGi2DxglsystV0E/jTyc11Q==}
     engines: {node: 12.* || 14.* || >= 16}
     hasBin: true
     peerDependencies:
-      '@embroider/core': ^2.0.0
+      '@embroider/core': ^3.2.1
     dependencies:
       '@babel/code-frame': 7.22.10
       '@babel/core': 7.22.10(supports-color@8.1.1)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.10)
+      '@babel/plugin-transform-runtime': 7.22.10(@babel/core@7.22.10)
       '@babel/preset-env': 7.22.10(@babel/core@7.22.10)
+      '@babel/runtime': 7.22.10
       '@babel/traverse': 7.22.10(supports-color@8.1.1)
-      '@embroider/core': 2.1.1
-      '@embroider/macros': 1.10.0
+      '@embroider/core': 3.2.1
+      '@embroider/macros': 1.13.1
       '@types/babel__code-frame': 7.0.3
       '@types/yargs': 17.0.24
       assert-never: 1.2.1
+      babel-import-util: 2.0.0
       babel-plugin-ember-template-compilation: 2.2.0
       babel-plugin-syntax-dynamic-import: 6.18.0
       babylon: 6.18.0
@@ -2606,6 +2609,8 @@ packages:
       broccoli-source: 3.0.1
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      fast-sourcemap-concat: 1.4.0
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
       jsdom: 16.7.0(supports-color@8.1.1)
@@ -2620,6 +2625,7 @@ packages:
       walk-sync: 3.0.0
       yargs: 17.7.2
     transitivePeerDependencies:
+      - '@glint/template'
       - bufferutil
       - canvas
       - supports-color
@@ -2668,29 +2674,24 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@embroider/core@2.1.1:
-    resolution: {integrity: sha512-N4rz+r8WjHYmwprvBYC0iUT4EWNpdDjF7JLl8PEYlWbhXDEJL+Ma/aP78S7spMhIpJX9SHK7nbgNxmZAqAe34A==}
+  /@embroider/core@3.2.1:
+    resolution: {integrity: sha512-GhKc9pqPcbKpvUkhTnRqJhr3Pc4xslnzhrGQqBDBNwOZ0/zUU02wpiB+PmiA3+mZFTZNQoUCq4A7vm5dXraQug==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
       '@babel/core': 7.22.10(supports-color@8.1.1)
       '@babel/parser': 7.22.10
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.22.10)
-      '@babel/plugin-transform-runtime': 7.22.10(@babel/core@7.22.10)
-      '@babel/runtime': 7.22.10
       '@babel/traverse': 7.22.10(supports-color@8.1.1)
-      '@embroider/macros': 1.10.0
-      '@embroider/shared-internals': 2.0.0
+      '@embroider/macros': 1.13.1
+      '@embroider/shared-internals': 2.4.0(supports-color@8.1.1)
       assert-never: 1.2.1
-      babel-import-util: 1.4.1
       babel-plugin-ember-template-compilation: 2.2.0
       broccoli-node-api: 1.7.0
       broccoli-persistent-filter: 3.1.3
       broccoli-plugin: 4.0.7
       broccoli-source: 3.0.1
       debug: 4.3.4(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
       fast-sourcemap-concat: 1.4.0
-      filesize: 5.0.3
+      filesize: 10.0.12
       fs-extra: 9.1.0
       fs-tree-diff: 2.0.1
       handlebars: 4.7.8
@@ -2702,20 +2703,21 @@ packages:
       typescript-memoize: 1.1.1
       walk-sync: 3.0.0
     transitivePeerDependencies:
+      - '@glint/template'
       - bufferutil
       - canvas
       - supports-color
       - utf-8-validate
     dev: true
 
-  /@embroider/hbs-loader@2.0.0(@embroider/core@2.1.1)(webpack@5.88.2):
-    resolution: {integrity: sha512-rWcZyZ3n35LwlPTS6/fYsdHqPWUh4QO/cVTIJOSeLqJCATNTho7tjBXS6pBvV9cZgvqP/Xph/08xjdUyOWUOxQ==}
+  /@embroider/hbs-loader@3.0.2(@embroider/core@3.2.1)(webpack@5.88.2):
+    resolution: {integrity: sha512-uN0w4rbes0xJUvC8YrhkwoTEbMD5wIMPMWF8+3BnLmHcATSFZ34hEmOGorgBB1lLAkv5Vo7xhBulWGwigEvBUg==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
-      '@embroider/core': ^2.0.0
+      '@embroider/core': ^3.2.0
       webpack: ^5
     dependencies:
-      '@embroider/core': 2.1.1
+      '@embroider/core': 3.2.1
       webpack: 5.88.2
     dev: true
 
@@ -2734,22 +2736,6 @@ packages:
       - supports-color
     dev: true
 
-  /@embroider/macros@1.10.0:
-    resolution: {integrity: sha512-LMbfQGk/a+f6xtvAv5fq/wf2LRxETnbgSCLUf/z6ebzmuskOUxrke+uP55chF/loWrARi9g6erFQ7RDOUoBMSg==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      '@embroider/shared-internals': 2.0.0
-      assert-never: 1.2.1
-      babel-import-util: 1.4.1
-      ember-cli-babel: 7.26.11
-      find-up: 5.0.0
-      lodash: 4.17.21
-      resolve: 1.22.4
-      semver: 7.5.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@embroider/macros@1.13.1:
     resolution: {integrity: sha512-4htraP/rNIht8uCxXoc59Bw2EsBFfc4YUQD9XSpzJ4xUr1V0GQf9wL/noeSuYSxIhwRfZOErnJhsdyf1hH+I/A==}
     engines: {node: 12.* || 14.* || >= 16}
@@ -2759,7 +2745,7 @@ packages:
       '@glint/template':
         optional: true
     dependencies:
-      '@embroider/shared-internals': 2.4.0
+      '@embroider/shared-internals': 2.4.0(supports-color@8.1.1)
       assert-never: 1.2.1
       babel-import-util: 2.0.0
       ember-cli-babel: 7.26.11
@@ -2797,21 +2783,7 @@ packages:
       typescript-memoize: 1.1.1
     dev: true
 
-  /@embroider/shared-internals@2.0.0:
-    resolution: {integrity: sha512-qZ2/xky9mWm5YC6noOa6AiAwgISEQ78YTZNv4SNu2PFgEK/H+Ha/3ddngzGSsnXkVnIHZyxIBzhxETonQYHY9g==}
-    engines: {node: 12.* || 14.* || >= 16}
-    dependencies:
-      babel-import-util: 1.4.1
-      ember-rfc176-data: 0.3.18
-      fs-extra: 9.1.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.21
-      resolve-package-path: 4.0.3
-      semver: 7.5.4
-      typescript-memoize: 1.1.1
-    dev: true
-
-  /@embroider/shared-internals@2.4.0:
+  /@embroider/shared-internals@2.4.0(supports-color@8.1.1):
     resolution: {integrity: sha512-pFE05ebenWMC9XAPRjadYCXXb6VmqjkhYN5uqkhPo+VUmMHnx7sZYYxqGjxfVuhC/ghS/BNlOffOCXDOoE7k7g==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
@@ -2827,25 +2799,26 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@embroider/webpack@2.1.1(@embroider/core@2.1.1)(webpack@5.88.2):
-    resolution: {integrity: sha512-1IzXXexv/QxDyk4N6kamtiTk92HszlaQZXGB+xhnRCMY4F7Hgxad4gSPvnSy/oSkbHTMWSGjCTS5e4tQcUC8Cg==}
+  /@embroider/webpack@3.1.5(@embroider/core@3.2.1)(webpack@5.88.2):
+    resolution: {integrity: sha512-J4NinNlxPzM4GeUoqnDzOVex2TxtEYjq7fVSxOKefj1bm/V3vzR6Dqwq2sxJmGfNbaTXbMVz6kpbz4bxZz8DOw==}
     engines: {node: 12.* || 14.* || >= 16}
     peerDependencies:
-      '@embroider/core': ^2.0.0
+      '@embroider/core': ^3.2.1
       webpack: ^5.0.0
     dependencies:
       '@babel/core': 7.22.10(supports-color@8.1.1)
-      '@embroider/babel-loader-8': 2.0.0(@embroider/core@2.1.1)(supports-color@8.1.1)(webpack@5.88.2)
-      '@embroider/core': 2.1.1
-      '@embroider/hbs-loader': 2.0.0(@embroider/core@2.1.1)(webpack@5.88.2)
-      '@embroider/shared-internals': 2.0.0
-      '@types/source-map': 0.5.7
+      '@embroider/babel-loader-8': 3.0.1(@embroider/core@3.2.1)(supports-color@8.1.1)(webpack@5.88.2)
+      '@embroider/core': 3.2.1
+      '@embroider/hbs-loader': 3.0.2(@embroider/core@3.2.1)(webpack@5.88.2)
+      '@embroider/shared-internals': 2.4.0(supports-color@8.1.1)
       '@types/supports-color': 8.1.1
+      assert-never: 1.2.1
       babel-loader: 8.3.0(@babel/core@7.22.10)(webpack@5.88.2)
       babel-preset-env: 1.7.0(supports-color@8.1.1)
       css-loader: 5.2.7(webpack@5.88.2)
       csso: 4.2.0
       debug: 4.3.4(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
       fs-extra: 9.1.0
       jsdom: 16.7.0(supports-color@8.1.1)
       lodash: 4.17.21
@@ -4016,13 +3989,6 @@ packages:
     resolution: {integrity: sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==}
     dev: true
 
-  /@types/source-map@0.5.7:
-    resolution: {integrity: sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==}
-    deprecated: This is a stub types definition for source-map (https://github.com/mozilla/source-map). source-map provides its own type definitions, so you don't need @types/source-map installed!
-    dependencies:
-      source-map: 0.7.4
-    dev: true
-
   /@types/supports-color@8.1.1:
     resolution: {integrity: sha512-dPWnWsf+kzIG140B8z2w3fr5D03TLWbOAFQl45xUpI3vcizeXriNR5VYkWZ+WTMsUHqZ9Xlt3hrxGNANFyNQfw==}
     dev: true
@@ -5107,7 +5073,7 @@ packages:
     dependencies:
       '@babel/core': 7.22.10(supports-color@8.1.1)
       '@babel/helper-define-polyfill-provider': 0.4.2(@babel/core@7.22.10)
-      core-js-compat: 3.32.0
+      core-js-compat: 3.32.1
     transitivePeerDependencies:
       - supports-color
 
@@ -6284,8 +6250,8 @@ packages:
     resolution: {integrity: sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001520
-      electron-to-chromium: 1.4.490
+      caniuse-lite: 1.0.30001522
+      electron-to-chromium: 1.4.496
     dev: true
 
   /browserslist@4.21.10:
@@ -6458,6 +6424,10 @@ packages:
 
   /caniuse-lite@1.0.30001520:
     resolution: {integrity: sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==}
+
+  /caniuse-lite@1.0.30001522:
+    resolution: {integrity: sha512-TKiyTVZxJGhsTszLuzb+6vUZSjVOAhClszBr2Ta2k9IwtNBT/4dzmL6aywt0HCgEZlmwJzXJd8yNiob6HgwTRg==}
+    dev: true
 
   /capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
@@ -7135,6 +7105,11 @@ packages:
 
   /core-js-compat@3.32.0:
     resolution: {integrity: sha512-7a9a3D1k4UCVKnLhrgALyFcP7YCsLOQIxPd0dKjf/6GuPcgyiGP70ewWdCGrSK7evyhymi0qO4EqCmSJofDeYw==}
+    dependencies:
+      browserslist: 4.21.10
+
+  /core-js-compat@3.32.1:
+    resolution: {integrity: sha512-GSvKDv4wE0bPnQtjklV101juQ85g6H3rm5PDP20mqlS5j0kXF3pP97YvAu5hl+uFHqMictp3b2VxOHljWMAtuA==}
     dependencies:
       browserslist: 4.21.10
 
@@ -8113,6 +8088,10 @@ packages:
   /electron-to-chromium@1.4.490:
     resolution: {integrity: sha512-6s7NVJz+sATdYnIwhdshx/N/9O6rvMxmhVoDSDFdj6iA45gHR8EQje70+RYsF4GeB+k0IeNSBnP7yG9ZXJFr7A==}
 
+  /electron-to-chromium@1.4.496:
+    resolution: {integrity: sha512-qeXC3Zbykq44RCrBa4kr8v/dWzYJA8rAwpyh9Qd+NKWoJfjG5vvJqy9XOJ9H4P/lqulZBCgUWAYi+FeK5AuJ8g==}
+    dev: true
+
   /elkjs@0.8.2:
     resolution: {integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==}
     dev: false
@@ -8224,7 +8203,7 @@ packages:
       '@babel/plugin-proposal-decorators': 7.22.10(@babel/core@7.22.10)
       '@babel/preset-env': 7.22.10(@babel/core@7.22.10)
       '@embroider/macros': 1.13.1
-      '@embroider/shared-internals': 2.4.0
+      '@embroider/shared-internals': 2.4.0(supports-color@8.1.1)
       babel-loader: 8.3.0(@babel/core@7.22.10)(webpack@5.88.2)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.2.0


### PR DESCRIPTION
I saw: https://github.com/rust-lang/crates.io/pull/6508
But I wanted to see if the latest versions have changed anything.
But also, that the [ember-data library may be a problem](https://github.com/rust-lang/crates.io/pull/6508#issuecomment-1632019921) -- which appears to be currently [failing over here](https://github.com/rust-lang/crates.io/pull/6592) 

~~basically, :crossed_fingers: ~~
~~(all tests pass locally for me)~~

Success!!
Closes: #6508

reason why I'm trying to upgrade embroider manually is so that we can get closer to having this frontend powered by [Vite](http://vite.dev/), which will significantlny improve the local build times.