### PR TITLE
crates_io_tarball: error if multiple manifests are found

### DIFF
--- a/crates_io_tarball/src/lib.rs
+++ b/crates_io_tarball/src/lib.rs
@@ -92,6 +92,8 @@ pub fn process_tarball<R: Read>(
             ));
         }
 
+        // Let's go hunting for the VCS info and crate manifest. The only valid place for these is
+        // in the package root in the tarball.
         if entry_path.parent() == Some(pkg_root) {
             let entry_file = entry_path.file_name().unwrap_or_default();
             if entry_file == ".cargo_vcs_info.json" {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -414,6 +414,27 @@ fn tarball_to_app_error(error: TarballError) -> BoxedAppError {
         TarballError::MissingManifest => {
             cargo_err("uploaded tarball is missing a `Cargo.toml` manifest file")
         }
+        TarballError::IncorrectlyCasedManifest(name) => {
+            cargo_err(&format!(
+                "uploaded tarball is missing a `Cargo.toml` manifest file; `{name}` was found, but must be named `Cargo.toml` with that exact casing",
+                name = name.to_string_lossy(),
+            ))
+        }
+        TarballError::TooManyManifests(paths) => {
+            let paths = paths
+                .into_iter()
+                .map(|path| {
+                    path.file_name()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .into_owned()
+                })
+                .collect::<Vec<_>>()
+                .join("`, `");
+            cargo_err(&format!(
+                "uploaded tarball contains more than one `Cargo.toml` manifest file; found `{paths}`"
+            ))
+        }
         TarballError::InvalidManifest(err) => cargo_err(&format!(
             "failed to parse `Cargo.toml` manifest file\n\n{err}"
         )),


### PR DESCRIPTION
This will handle both differences in case (ie a crate file that contains both `package-x.y.z/Cargo.toml` and `package-x.y.z/cargo.toml`, as may happen on a case-sensitive filesystem) and malformed tarballs that contain multiple copies of the same file.

Effort has been made to otherwise preserve the same semantics as `cargo` where, if there is only one manifest, only `Cargo.toml` and `cargo.toml` are accepted. (It's debatable if we should even accept `cargo.toml`, and recent versions of `cargo` won't allow crates to be published with that casing, but since there may be legacy setups out there that are still publishing crates with this variation and we've accepted them in the past, we may as well preserve that behaviour for now.)

In practice, this is what the user will see from `cargo publish` if there are multiple manifests:

![image](https://github.com/rust-lang/crates.io/assets/229984/18e0d1d3-868b-4fc7-b80a-a7472b75c015)

And what they'll see if they're publishing from a case insensitive filesystem and have a weirdly cased `CaRgO.tOmL`:

![image](https://github.com/rust-lang/crates.io/assets/229984/e7868bfd-b325-4705-81de-1707c87b86be)

Fixes #6978.