### PR TITLE
Revert "Update Rust crate dashmap to v5.5.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.1"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ chrono = { version = "=0.4.26", default-features = false, features = ["serde"] }
 clap = { version = "=4.4.1", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.17.0", features = ["secure"] }
 crossbeam-channel = "=0.5.8"
-dashmap = { version = "=5.5.1", features = ["raw-api"] }
+dashmap = { version = "=5.5.0", features = ["raw-api"] }
 derive_deref = "=1.1.1"
 dialoguer = "=0.10.4"
 diesel = { version = "=2.1.1", features = ["postgres", "serde_json", "chrono", "r2d2", "numeric"] }


### PR DESCRIPTION
Reverts rust-lang/crates.io#7003

A random shot in the dark to address https://github.com/rust-lang/crates.io/issues/7039 🤷‍♂️ 

The only usage of `dashmap` in our codebase is the download counter, so maaaayyyybeeee this update caused the issues? We'll see once we deploy this to production.