### PR TITLE
Update the data access page on crates.io

### DIFF
--- a/app/templates/data-access.hbs
+++ b/app/templates/data-access.hbs
@@ -1,32 +1,90 @@
-<PageHeader @title="Accessing the Crates.io Data" />
+<PageHeader @title="Accessing crates.io data" />
 
 <p>
-  There are several ways of accessing the Crates.io data. You should try the
-  options in the order listed.
+  crates.io provides several ways of accessing crate data and metadata,
+  depending on what you specifically need. Please try them in the order below.
+</p>
+
+<h2 id="crate-index"><a href="#crate-index">Crate index</a></h2>
+
+<p>
+  The crates.io sparse index is available at
+  <a href="https://index.crates.io">index.crates.io</a>, which adheres to the
+  <a href="https://doc.rust-lang.org/cargo/reference/registry-index.html">Cargo index format</a>.
+  The sparse index provides an extremely efficient way of accessing metadata on
+  a single or small number of crates.
+</p>
+
+<p>
+  Each index file provides newline delimited JSON metadata on all published
+  versions of the crate, organised into
+  <a href="https://doc.rust-lang.org/cargo/reference/registry-index.html#index-files">index files</a>.
+  For example, information on the <code>base64</code> crate can be found at
+  <a href="https://index.crates.io/ba/se/base64">https://index.crates.io/ba/se/base64</a>.
+</p>
+
+<p>
+  No rate limits are required to use data from the sparse crate index.
+</p>
+
+<h3 id="legacy-git-index"><a href="#legacy-git-index">Legacy Git crate index</a></h3>
+
+<p>
+  Older versions of Cargo use the crate index provided in the
+  <a href="https://github.com/rust-lang/crates.io-index"><code>rust-lang/crates.io-index</code> repository on GitHub</a>.
+  This remains available for use, and may be a more efficient way of accessing
+  crate metadata for projects that require most or all crates to be included
+  than the sparse index.
+</p>
+
+<p>
+  As the Git index is hosted on GitHub, GitHub's
+  <a href="https://docs.github.com/en/site-policy/acceptable-use-policies/github-acceptable-use-policies">Acceptable Use Policies</a>
+  apply.
+</p>
+
+<h2 id="database-dumps"><a href="#database-dumps">Database dumps</a></h2>
+
+<p>
+  crates.io database dumps contain all information available through the
+  crates.io API in a single download. They are updated every 24 hours.
+</p>
+
+<p>
+  The latest dump is available at the address
+  <a href="https://static.crates.io/db-dump.tar.gz">https://static.crates.io/db-dump.tar.gz</a>.
+  Information on using the dump is contained in the tarball. You can find the changelog for database dumps in
+  <a href="https://github.com/rust-lang/crates.io/issues/3617">GitHub issue #3617</a>.
+</p>
+
+<h2 id="api"><a href="#api">crates.io API</a></h2>
+
+<p>
+  crates.io provides an API that is a superset of the functionality required by
+  the
+  <a href="https://doc.rust-lang.org/cargo/reference/registry-web-api.html">Cargo Web API</a>.
+  Should you be unable to use one of the previous options, you are welcome to
+  use the crates.io API provided you abide by the same limits as
+  <LinkTo @route="policies">the crawling policy</LinkTo>. In summary:
 </p>
 
 <ol>
+  <li>A maximum of 1 request per second, and</li>
   <li>
-    <b>
-      The <a href='https://github.com/rust-lang/crates.io-index'>crates.io index</a>.
-    </b>
-    This git repository is updated by crates.io, and it is used
-    by Cargo to speed up local dependency resolution. It contains the majority
-    of the data exposed by crates.io and is cheap to clone and get updates.
-  </li>
-  <li>
-    <b>The database dumps (experimental).</b> The dump contains all information
-    exposed by the API in a single download. It is updated every 24 hours.
-    The latest dump is available at the address
-    <a href='https://static.crates.io/db-dump.tar.gz'>https://static.crates.io/db-dump.tar.gz</a>.
-    Information on using the dump is contained in the tarball.
-    You can find the changelog for the database dumps in GitHub Issue <a href='https://github.com/rust-lang/crates.io/issues/3617'>#3617</a>.
-  </li>
-  <li>
-    <b>Crawl the crates.io API.</b> This should be used as a last resort, and
-    doing so is subject to our <LinkTo @route="policies">crawling policy</LinkTo>.
-    If the index and the database dumps do not satisfy your needs, we're happy to
-    discuss solutions that don't require you to crawl the registry.
-    You can email us at <a href="mailto:help@crates.io">help@crates.io</a>.
+    A <code>user-agent</code> header that identifies your application. We
+    strongly suggest providing a way for us to contact you (whether through a
+    repository, or an e-mail address, or whatever is appropriate) so that we can
+    reach out to work with you should there be issues.
   </li>
 </ol>
+
+<h2 id="questions"><a href="#questions">Questions</a></h2>
+
+<p>
+  If none of the above options suit your needs, please contact the crates.io
+  team either at <a href="mailto:help@crates.io">help@crates.io</a>, or by
+  starting
+  <a href="https://github.com/rust-lang/crates.io/discussions">a discussion on GitHub</a>,
+  and we'll be happy to discuss solutions that might exist outside of the above
+  guidelines.
+</p>


### PR DESCRIPTION
The motivation for this is a couple of recent requests and discussions where it's been clear that (a) we need to document the sparse index as an option, and (b) it's unclear if the crawling limits apply to regular API usage as well.

This integrates the sparse index into the data access recommendations, and makes it clearer that the limits described in the crawling policy also apply to regular API usage.

Cosmetically, the page is now less dense, with some new verbiage particularly around index and API usage.

There should be no change in the actual expectations we have of users in this commit; this is simply trying to more accurately codify what our expectations really are.