### PR TITLE
Allow removing deleted organizations from crate owners

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -141,7 +141,7 @@ fn modify_owners(
             msgs.join(",")
         } else {
             for login in &logins {
-                krate.owner_remove(app, conn, user, login)?;
+                krate.owner_remove(conn, login)?;
             }
             if User::owning(&krate, conn)?.is_empty() {
                 return Err(cargo_err(

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -397,14 +397,8 @@ impl Crate {
         }
     }
 
-    pub fn owner_remove(
-        &self,
-        app: &App,
-        conn: &mut PgConnection,
-        req_user: &User,
-        login: &str,
-    ) -> AppResult<()> {
-        let owner = Owner::find_or_create_by_login(app, conn, req_user, login)?;
+    pub fn owner_remove(&self, conn: &mut PgConnection, login: &str) -> AppResult<()> {
+        let owner = Owner::find_by_login(conn, login)?;
 
         let target = crate_owners::table.find((self.id(), owner.id(), owner.kind()));
         diesel::update(target)

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -1,8 +1,8 @@
 use diesel::pg::Pg;
 use diesel::prelude::*;
 
-use crate::app::App;
 use crate::util::errors::{cargo_err, AppResult};
+use crate::{app::App, schema::teams};
 
 use crate::models::{Crate, Team, User};
 use crate::schema::{crate_owners, users};
@@ -59,6 +59,7 @@ impl Owner {
     /// up-to-date GitHub ID. Fails out if the user isn't found in the
     /// database, the team isn't found on GitHub, or if the user isn't a member
     /// of the team on GitHub.
+    ///
     /// May be a user's GH login or a full team name. This is case
     /// sensitive.
     pub fn find_or_create_by_login(
@@ -71,6 +72,30 @@ impl Owner {
             Ok(Owner::Team(Team::create_or_update(
                 app, conn, name, req_user,
             )?))
+        } else {
+            users::table
+                .filter(lower(users::gh_login).eq(name.to_lowercase()))
+                .filter(users::gh_id.ne(-1))
+                .order(users::gh_id.desc())
+                .first(conn)
+                .map(Owner::User)
+                .map_err(|_| cargo_err(&format_args!("could not find user with login `{name}`")))
+        }
+    }
+
+    /// Finds the owner by name. Never recreates a team, to ensure that
+    /// organizations that were deleted after they were added can still be
+    /// removed.
+    ///
+    /// May be a user's GH login or a full team name. This is case
+    /// sensitive.
+    pub fn find_by_login(conn: &mut PgConnection, name: &str) -> AppResult<Owner> {
+        if name.contains(':') {
+            teams::table
+                .filter(lower(teams::login).eq(&name.to_lowercase()))
+                .first(conn)
+                .map(Owner::Team)
+                .map_err(|_| cargo_err(&format_args!("could not find team with login `{name}`")))
         } else {
             users::table
                 .filter(lower(users::gh_login).eq(name.to_lowercase()))

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -567,9 +567,7 @@ fn deleted_ownership_isnt_in_owner_user() {
 
     app.db(|conn| {
         let krate = CrateBuilder::new("foo_my_packages", user.id).expect_build(conn);
-        krate
-            .owner_remove(app.as_inner(), conn, user, &user.gh_login)
-            .unwrap();
+        krate.owner_remove(conn, &user.gh_login).unwrap();
     });
 
     let json: UserResponse = anon.get("/api/v1/crates/foo_my_packages/owner_user").good();

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -839,9 +839,7 @@ fn crates_by_user_id_not_including_deleted_owners() {
 
     app.db(|conn| {
         let krate = CrateBuilder::new("foo_my_packages", user.id).expect_build(conn);
-        krate
-            .owner_remove(app.as_inner(), conn, user, "foo")
-            .unwrap();
+        krate.owner_remove(conn, "foo").unwrap();
     });
 
     let response = anon.search_by_user_id(user.id);

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -42,9 +42,7 @@ fn test_user_owned_crates_doesnt_include_deleted_ownership() {
 
     app.db(|conn| {
         let krate = CrateBuilder::new("foo_my_packages", user_model.id).expect_build(conn);
-        krate
-            .owner_remove(app.as_inner(), conn, user_model, &user_model.gh_login)
-            .unwrap();
+        krate.owner_remove(conn, &user_model.gh_login).unwrap();
     });
 
     let json = user.show_me();

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -39,7 +39,7 @@ fn user_total_downloads() {
             .execute(conn)
             .unwrap();
         no_longer_my_krate
-            .owner_remove(app.as_inner(), conn, user, &user.gh_login)
+            .owner_remove(conn, &user.gh_login)
             .unwrap();
     });
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -449,9 +449,7 @@ fn crates_by_team_id_not_including_deleted_owners() {
 
         let krate = CrateBuilder::new("foo", user.id).expect_build(conn);
         add_team_to_crate(&t, &krate, user, conn).unwrap();
-        krate
-            .owner_remove(app.as_inner(), conn, user, &t.login)
-            .unwrap();
+        krate.owner_remove(conn, &t.login).unwrap();
         t
     });
 


### PR DESCRIPTION
Fixes #1818.

My intended solution here is:

- Add a parameter to decide how the team gets looked up (in the database: `true`, vs. in the GH API: `false`)
- Pass `true` when deleting owners and `false` when adding them

Unfortunately the `Crate::owner_add` and `Crate::owner_remove` methods are like four steps above the actual DB lookup, and they call into the exact same stack of methods to get an `Owner`. I could have also created a new stack of methods but this way seems like it'll require modifying less code, which is a big positive for someone who doesn't really understand how this project works.

That said, I'm not 100% confident in where I've put the branch. Right now it's right next to the error message itself but it might belong higher up, e.g. maybe in `Team::create_or_update` it should try to look up the team by name instead of passing it down to the lower-level code.

Todo:

- [x] Get `cargo test` working
- [x] Add the parameter to the call sites in `owner_add` and `owner_remove`, all the way down to `Team::create_or_update_github_team`, with a `todo!` in place of the actual implementation
- [x] Reconsider whether it should be that deep down, or whether looking up `Owner`s in the database should be higher up.
- [x] Add/modify tests as necessary to ensure you can delete non-existent org owners
- [x] Implement the `in_db` lookup branch, wherever that should terminate
