### PR TITLE
Update Rust crate chrono to v0.4.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,9 +504,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ bigdecimal = "=0.4.1"
 crates_io_index = { path = "crates_io_index" }
 crates_io_markdown = { path = "crates_io_markdown" }
 crates_io_tarball = { path = "crates_io_tarball" }
-chrono = { version = "=0.4.28", default-features = false, features = ["serde"] }
+chrono = { version = "=0.4.30", default-features = false, features = ["serde"] }
 clap = { version = "=4.4.3", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.17.0", features = ["secure"] }
 crossbeam-channel = "=0.5.8"

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -49,11 +49,9 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
     let older_than = if let Some(ref time) = opts.older_than {
         NaiveDateTime::parse_from_str(time, "%Y-%m-%d %H:%M:%S")
             .expect("Could not parse --older-than argument as a time")
-            .and_utc()
     } else {
-        start_time
+        start_time.naive_utc()
     };
-    let older_than = older_than.naive_utc();
 
     println!("Start time:                   {start_time}");
     println!("Rendering readmes older than: {older_than}");

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::{io::Read, path::Path, sync::Arc, thread};
 
 use crate::storage::Storage;
-use chrono::{TimeZone, Utc};
+use chrono::{NaiveDateTime, Utc};
 use crates_io_markdown::text_to_html;
 use crates_io_tarball::{Manifest, StringOrBool};
 use diesel::prelude::*;
@@ -47,8 +47,9 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
     let start_time = Utc::now();
 
     let older_than = if let Some(ref time) = opts.older_than {
-        Utc.datetime_from_str(time, "%Y-%m-%d %H:%M:%S")
+        NaiveDateTime::parse_from_str(time, "%Y-%m-%d %H:%M:%S")
             .expect("Could not parse --older-than argument as a time")
+            .and_utc()
     } else {
         start_time
     };


### PR DESCRIPTION
close https://github.com/rust-lang/crates.io/pull/7072
See: https://github.com/chronotope/chrono/pull/1251