### PR TITLE
Heroku: Add DataDog buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,4 @@
+https://github.com/DataDog/heroku-buildpack-datadog.git#8d0b795
 https://github.com/unfold/heroku-buildpack-pnpm#b8dcee8
 https://github.com/heroku/heroku-buildpack-nginx#760407b
 https://github.com/Turbo87/heroku-buildpack-rust#30429b2


### PR DESCRIPTION
Following https://docs.datadoghq.com/agent/basic_agent_usage/heroku/, this PR adds the DataDog Heroku integration to our list of buildpacks.

@jdno and me have tested this out on staging already and it appears to work :)