### PR TITLE
views/krate_publish: Fix docs typos

### DIFF
--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -1,6 +1,6 @@
 //! This module handles the expected information a crate should have
-//! and manages the serialising and deserialising of this information
-//! to and from structs. The serlializing is only utilised in
+//! and manages the serialising and deserializing of this information
+//! to and from structs. The serializing is only utilised in
 //! integration tests.
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
yeah, I know some countries spell it "deserialising" but since the trait is using the American way of spelling it, I guess our docs should do the same. also, "serlializing" definitely seems wrong :D