### PR TITLE
tests/krate/publish: Use more snapshot tests for error responses

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -26,8 +26,7 @@ use crate::views::{
     EncodableCrate, EncodableCrateDependency, EncodableCrateUpload, GoodCrate, PublishWarnings,
 };
 
-pub const MISSING_RIGHTS_ERROR_MESSAGE: &str =
-    "this crate exists but you don't seem to be an owner. \
+const MISSING_RIGHTS_ERROR_MESSAGE: &str = "this crate exists but you don't seem to be an owner. \
      If you believe this is a mistake, perhaps you need \
      to accept an invitation to be an owner before \
      publishing.";

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -336,7 +336,7 @@ fn split_body<R: RequestPartsExt>(mut bytes: Bytes, req: &R) -> AppResult<(Bytes
     Ok((json_bytes, tarball_bytes))
 }
 
-pub fn missing_metadata_error_message(missing: &[&str]) -> String {
+fn missing_metadata_error_message(missing: &[&str]) -> String {
     format!(
         "missing or empty metadata fields: {}. Please \
          see https://doc.rust-lang.org/cargo/reference/manifest.html for \

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -1,9 +1,9 @@
 use crate::builders::{CrateBuilder, PublishBuilder};
 use crate::util::{RequestHelper, TestApp};
-use crates_io::controllers::krate::publish::MISSING_RIGHTS_ERROR_MESSAGE;
 use crates_io::schema::api_tokens;
 use diesel::{ExpressionMethods, RunQueryDsl};
 use http::StatusCode;
+use insta::assert_yaml_snapshot;
 
 #[test]
 fn new_wrong_token() {
@@ -52,10 +52,7 @@ fn new_krate_wrong_user() {
 
     let response = another_user.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(
-        response.into_json(),
-        json!({ "errors": [{ "detail": MISSING_RIGHTS_ERROR_MESSAGE }] })
-    );
+    assert_yaml_snapshot!(response.into_json());
 
     assert!(app.stored_files().is_empty());
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__auth__new_krate_wrong_user.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__auth__new_krate_wrong_user.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/auth.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing."
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-10.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-10.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: cannot upload a crate with a reserved name
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "invalid upload request: invalid value: string \"foo bar\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "invalid upload request: invalid value: string \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 75"
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "invalid upload request: invalid value: string \"snow☃\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "invalid upload request: invalid value: string \"áccênts\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 19"
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-6.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-6.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: cannot upload a crate with a reserved name
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-7.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-7.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: cannot upload a crate with a reserved name
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-8.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-8.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: cannot upload a crate with a reserved name
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-9.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-9.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: cannot upload a crate with a reserved name
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "invalid upload request: invalid value: string \"\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 10"
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-2.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-3.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required.snap
@@ -1,0 +1,7 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+errors:
+  - detail: "missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -1,8 +1,8 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
-use crates_io::controllers::krate::publish::missing_metadata_error_message;
 use crates_io::models::krate::MAX_NAME_LENGTH;
 use http::StatusCode;
+use insta::assert_yaml_snapshot;
 
 #[test]
 fn invalid_names() {
@@ -48,19 +48,13 @@ fn license_and_description_required() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(
-        response.into_json(),
-        json!({ "errors": [{ "detail": missing_metadata_error_message(&["description", "license"]) }] })
-    );
+    assert_yaml_snapshot!(response.into_json());
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0").unset_description();
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(
-        response.into_json(),
-        json!({ "errors": [{ "detail": missing_metadata_error_message(&["description"]) }] })
-    );
+    assert_yaml_snapshot!(response.into_json());
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0")
         .unset_license()
@@ -69,10 +63,7 @@ fn license_and_description_required() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(
-        response.into_json(),
-        json!({ "errors": [{ "detail": missing_metadata_error_message(&["description"]) }] })
-    );
+    assert_yaml_snapshot!(response.into_json());
 
     assert!(app.stored_files().is_empty());
 }

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -8,32 +8,24 @@ use insta::assert_yaml_snapshot;
 fn invalid_names() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let bad_name = |name: &str, error_message: &str| {
+    let bad_name = |name: &str| {
         let crate_to_publish = PublishBuilder::new(name, "1.0.0");
         let response = token.publish_crate(crate_to_publish);
         assert_eq!(response.status(), StatusCode::OK);
-
-        let json = response.into_json();
-        let json = json.as_object().unwrap();
-        let errors = json.get("errors").unwrap().as_array().unwrap();
-        let first_error = errors.first().unwrap().as_object().unwrap();
-        let detail = first_error.get("detail").unwrap().as_str().unwrap();
-        assert!(detail.contains(error_message), "{detail:?}");
+        assert_yaml_snapshot!(response.into_json());
     };
 
-    let error_message = "expected a valid crate name";
-    bad_name("", error_message);
-    bad_name("foo bar", error_message);
-    bad_name(&"a".repeat(MAX_NAME_LENGTH + 1), error_message);
-    bad_name("snow☃", error_message);
-    bad_name("áccênts", error_message);
+    bad_name("");
+    bad_name("foo bar");
+    bad_name(&"a".repeat(MAX_NAME_LENGTH + 1));
+    bad_name("snow☃");
+    bad_name("áccênts");
 
-    let error_message = "cannot upload a crate with a reserved name";
-    bad_name("std", error_message);
-    bad_name("STD", error_message);
-    bad_name("compiler-rt", error_message);
-    bad_name("compiler_rt", error_message);
-    bad_name("coMpiLer_Rt", error_message);
+    bad_name("std");
+    bad_name("STD");
+    bad_name("compiler-rt");
+    bad_name("compiler_rt");
+    bad_name("coMpiLer_Rt");
 
     assert!(app.stored_files().is_empty());
 }


### PR DESCRIPTION
Instead of using things like `missing_metadata_error_message()` in our production **and** test code, this PR switches us over to using snapshot tests instead, which are easy to update if we were to change our error messages.