### PR TITLE
insta: Use `json` snapshots

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ crates_io_index = { path = "crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates_io_tarball", features = ["builder"] }
 claims = "=0.7.1"
 hyper-tls = "=0.5.0"
-insta = { version = "=1.31.0", features = ["redactions", "yaml"] }
+insta = { version = "=1.31.0", features = ["json", "redactions"] }
 tokio = "=1.32.0"
 tower-service = "=0.3.2"
 

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -3,7 +3,7 @@ use crate::util::{RequestHelper, TestApp};
 use crates_io::schema::api_tokens;
 use diesel::{ExpressionMethods, RunQueryDsl};
 use http::StatusCode;
-use insta::assert_yaml_snapshot;
+use insta::assert_json_snapshot;
 
 #[test]
 fn new_wrong_token() {
@@ -52,7 +52,7 @@ fn new_krate_wrong_user() {
 
     let response = another_user.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json());
+    assert_json_snapshot!(response.into_json());
 
     assert!(app.stored_files().is_empty());
 }

--- a/src/tests/krate/publish/build_metadata.rs
+++ b/src/tests/krate/publish/build_metadata.rs
@@ -1,14 +1,14 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
-use insta::assert_yaml_snapshot;
+use insta::assert_json_snapshot;
 
 fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token.publish_crate(PublishBuilder::new("foo", v1));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.into_json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });

--- a/src/tests/krate/publish/snapshots/all__krate__publish__auth__new_krate_wrong_user.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__auth__new_krate_wrong_user.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/auth.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing."
-
+{
+  "errors": [
+    {
+      "detail": "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing."
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
@@ -2,34 +2,38 @@
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.into_json()
 ---
-crate:
-  badges: ~
-  categories: ~
-  created_at: "[datetime]"
-  description: description
-  documentation: ~
-  downloads: 0
-  exact_match: false
-  homepage: ~
-  id: foo
-  keywords: ~
-  links:
-    owner_team: /api/v1/crates/foo/owner_team
-    owner_user: /api/v1/crates/foo/owner_user
-    owners: /api/v1/crates/foo/owners
-    reverse_dependencies: /api/v1/crates/foo/reverse_dependencies
-    version_downloads: /api/v1/crates/foo/downloads
-    versions: /api/v1/crates/foo/versions
-  max_stable_version: 1.0.0+foo
-  max_version: 1.0.0+foo
-  name: foo
-  newest_version: 1.0.0+foo
-  recent_downloads: ~
-  repository: ~
-  updated_at: "[datetime]"
-  versions: ~
-warnings:
-  invalid_badges: []
-  invalid_categories: []
-  other: []
-
+{
+  "crate": {
+    "badges": null,
+    "categories": null,
+    "created_at": "[datetime]",
+    "description": "description",
+    "documentation": null,
+    "downloads": 0,
+    "exact_match": false,
+    "homepage": null,
+    "id": "foo",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/foo/owner_team",
+      "owner_user": "/api/v1/crates/foo/owner_user",
+      "owners": "/api/v1/crates/foo/owners",
+      "reverse_dependencies": "/api/v1/crates/foo/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/foo/downloads",
+      "versions": "/api/v1/crates/foo/versions"
+    },
+    "max_stable_version": "1.0.0+foo",
+    "max_version": "1.0.0+foo",
+    "name": "foo",
+    "newest_version": "1.0.0+foo",
+    "recent_downloads": null,
+    "repository": null,
+    "updated_at": "[datetime]",
+    "versions": null
+  },
+  "warnings": {
+    "invalid_badges": [],
+    "invalid_categories": [],
+    "other": []
+  }
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
@@ -2,34 +2,38 @@
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.into_json()
 ---
-crate:
-  badges: ~
-  categories: ~
-  created_at: "[datetime]"
-  description: description
-  documentation: ~
-  downloads: 0
-  exact_match: false
-  homepage: ~
-  id: foo
-  keywords: ~
-  links:
-    owner_team: /api/v1/crates/foo/owner_team
-    owner_user: /api/v1/crates/foo/owner_user
-    owners: /api/v1/crates/foo/owners
-    reverse_dependencies: /api/v1/crates/foo/reverse_dependencies
-    version_downloads: /api/v1/crates/foo/downloads
-    versions: /api/v1/crates/foo/versions
-  max_stable_version: ~
-  max_version: 1.0.0-beta.1
-  name: foo
-  newest_version: 1.0.0-beta.1
-  recent_downloads: ~
-  repository: ~
-  updated_at: "[datetime]"
-  versions: ~
-warnings:
-  invalid_badges: []
-  invalid_categories: []
-  other: []
-
+{
+  "crate": {
+    "badges": null,
+    "categories": null,
+    "created_at": "[datetime]",
+    "description": "description",
+    "documentation": null,
+    "downloads": 0,
+    "exact_match": false,
+    "homepage": null,
+    "id": "foo",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/foo/owner_team",
+      "owner_user": "/api/v1/crates/foo/owner_user",
+      "owners": "/api/v1/crates/foo/owners",
+      "reverse_dependencies": "/api/v1/crates/foo/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/foo/downloads",
+      "versions": "/api/v1/crates/foo/versions"
+    },
+    "max_stable_version": null,
+    "max_version": "1.0.0-beta.1",
+    "name": "foo",
+    "newest_version": "1.0.0-beta.1",
+    "recent_downloads": null,
+    "repository": null,
+    "updated_at": "[datetime]",
+    "versions": null
+  },
+  "warnings": {
+    "invalid_badges": [],
+    "invalid_categories": [],
+    "other": []
+  }
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
@@ -2,34 +2,38 @@
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.into_json()
 ---
-crate:
-  badges: ~
-  categories: ~
-  created_at: "[datetime]"
-  description: description
-  documentation: ~
-  downloads: 0
-  exact_match: false
-  homepage: ~
-  id: foo
-  keywords: ~
-  links:
-    owner_team: /api/v1/crates/foo/owner_team
-    owner_user: /api/v1/crates/foo/owner_user
-    owners: /api/v1/crates/foo/owners
-    reverse_dependencies: /api/v1/crates/foo/reverse_dependencies
-    version_downloads: /api/v1/crates/foo/downloads
-    versions: /api/v1/crates/foo/versions
-  max_stable_version: 1.0.0+foo
-  max_version: 1.0.0+foo
-  name: foo
-  newest_version: 1.0.0+foo
-  recent_downloads: ~
-  repository: ~
-  updated_at: "[datetime]"
-  versions: ~
-warnings:
-  invalid_badges: []
-  invalid_categories: []
-  other: []
-
+{
+  "crate": {
+    "badges": null,
+    "categories": null,
+    "created_at": "[datetime]",
+    "description": "description",
+    "documentation": null,
+    "downloads": 0,
+    "exact_match": false,
+    "homepage": null,
+    "id": "foo",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/foo/owner_team",
+      "owner_user": "/api/v1/crates/foo/owner_user",
+      "owners": "/api/v1/crates/foo/owners",
+      "reverse_dependencies": "/api/v1/crates/foo/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/foo/downloads",
+      "versions": "/api/v1/crates/foo/versions"
+    },
+    "max_stable_version": "1.0.0+foo",
+    "max_version": "1.0.0+foo",
+    "name": "foo",
+    "newest_version": "1.0.0+foo",
+    "recent_downloads": null,
+    "repository": null,
+    "updated_at": "[datetime]",
+    "versions": null
+  },
+  "warnings": {
+    "invalid_badges": [],
+    "invalid_categories": [],
+    "other": []
+  }
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-10.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-10.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: cannot upload a crate with a reserved name
-
+{
+  "errors": [
+    {
+      "detail": "cannot upload a crate with a reserved name"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "invalid upload request: invalid value: string \"foo bar\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
-
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"foo bar\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "invalid upload request: invalid value: string \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 75"
-
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 75"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "invalid upload request: invalid value: string \"snow☃\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
-
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"snow☃\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "invalid upload request: invalid value: string \"áccênts\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 19"
-
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 19"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-6.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-6.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: cannot upload a crate with a reserved name
-
+{
+  "errors": [
+    {
+      "detail": "cannot upload a crate with a reserved name"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-7.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-7.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: cannot upload a crate with a reserved name
-
+{
+  "errors": [
+    {
+      "detail": "cannot upload a crate with a reserved name"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-8.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-8.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: cannot upload a crate with a reserved name
-
+{
+  "errors": [
+    {
+      "detail": "cannot upload a crate with a reserved name"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-9.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-9.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: cannot upload a crate with a reserved name
-
+{
+  "errors": [
+    {
+      "detail": "cannot upload a crate with a reserved name"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "invalid upload request: invalid value: string \"\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 10"
-
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 10"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-2.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
-
+{
+  "errors": [
+    {
+      "detail": "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required-3.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
-
+{
+  "errors": [
+    {
+      "detail": "missing or empty metadata fields: description. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__license_and_description_required.snap
@@ -2,6 +2,10 @@
 source: src/tests/krate/publish/validation.rs
 expression: response.into_json()
 ---
-errors:
-  - detail: "missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
-
+{
+  "errors": [
+    {
+      "detail": "missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata"
+    }
+  ]
+}

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -2,7 +2,7 @@ use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
 use crates_io::models::krate::MAX_NAME_LENGTH;
 use http::StatusCode;
-use insta::assert_yaml_snapshot;
+use insta::assert_json_snapshot;
 
 #[test]
 fn invalid_names() {
@@ -12,7 +12,7 @@ fn invalid_names() {
         let crate_to_publish = PublishBuilder::new(name, "1.0.0");
         let response = token.publish_crate(crate_to_publish);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_yaml_snapshot!(response.into_json());
+        assert_json_snapshot!(response.into_json());
     };
 
     bad_name("");
@@ -40,13 +40,13 @@ fn license_and_description_required() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json());
+    assert_json_snapshot!(response.into_json());
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0").unset_description();
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json());
+    assert_json_snapshot!(response.into_json());
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0")
         .unset_license()
@@ -55,7 +55,7 @@ fn license_and_description_required() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json());
+    assert_json_snapshot!(response.into_json());
 
     assert!(app.stored_files().is_empty());
 }

--- a/src/tests/models/krate.rs
+++ b/src/tests/models/krate.rs
@@ -1,5 +1,5 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
-use crate::util::insta::assert_yaml_snapshot;
+use crate::util::insta::assert_json_snapshot;
 use crate::TestApp;
 use chrono::{Days, Utc};
 
@@ -24,7 +24,7 @@ fn index_metadata() {
             .expect_build(conn);
 
         let metadata = fooo.index_metadata(conn).unwrap();
-        assert_yaml_snapshot!(metadata);
+        assert_json_snapshot!(metadata);
 
         let bar = CrateBuilder::new("bar", user.id)
             .version(
@@ -42,6 +42,6 @@ fn index_metadata() {
             .expect_build(conn);
 
         let metadata = bar.index_metadata(conn).unwrap();
-        assert_yaml_snapshot!(metadata);
+        assert_json_snapshot!(metadata);
     });
 }

--- a/src/tests/models/snapshots/all__models__krate__index_metadata-2.snap
+++ b/src/tests/models/snapshots/all__models__krate__index_metadata-2.snap
@@ -2,35 +2,47 @@
 source: src/tests/models/krate.rs
 expression: metadata
 ---
-- name: bar
-  vers: 1.0.0-beta.1
-  deps: []
-  cksum: "                                                                "
-  features: {}
-  yanked: true
-- name: bar
-  vers: 1.0.0
-  deps: []
-  cksum: "                                                                "
-  features: {}
-  yanked: false
-- name: bar
-  vers: 2.0.0
-  deps:
-    - name: foo
-      req: ">= 0"
-      features: []
-      optional: false
-      default_features: false
-      target: ~
-      kind: normal
-  cksum: "                                                                "
-  features: {}
-  yanked: false
-- name: bar
-  vers: 1.0.1
-  deps: []
-  cksum: "0123456789abcdef                                                "
-  features: {}
-  yanked: false
-
+[
+  {
+    "name": "bar",
+    "vers": "1.0.0-beta.1",
+    "deps": [],
+    "cksum": "                                                                ",
+    "features": {},
+    "yanked": true
+  },
+  {
+    "name": "bar",
+    "vers": "1.0.0",
+    "deps": [],
+    "cksum": "                                                                ",
+    "features": {},
+    "yanked": false
+  },
+  {
+    "name": "bar",
+    "vers": "2.0.0",
+    "deps": [
+      {
+        "name": "foo",
+        "req": ">= 0",
+        "features": [],
+        "optional": false,
+        "default_features": false,
+        "target": null,
+        "kind": "normal"
+      }
+    ],
+    "cksum": "                                                                ",
+    "features": {},
+    "yanked": false
+  },
+  {
+    "name": "bar",
+    "vers": "1.0.1",
+    "deps": [],
+    "cksum": "0123456789abcdef                                                ",
+    "features": {},
+    "yanked": false
+  }
+]

--- a/src/tests/models/snapshots/all__models__krate__index_metadata.snap
+++ b/src/tests/models/snapshots/all__models__krate__index_metadata.snap
@@ -2,10 +2,13 @@
 source: src/tests/models/krate.rs
 expression: metadata
 ---
-- name: foo
-  vers: 0.1.0
-  deps: []
-  cksum: "                                                                "
-  features: {}
-  yanked: false
-
+[
+  {
+    "name": "foo",
+    "vers": "0.1.0",
+    "deps": [],
+    "cksum": "                                                                ",
+    "features": {},
+    "yanked": false
+  }
+]

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -2,7 +2,7 @@ use crate::builders::CrateBuilder;
 use crate::new_category;
 use crate::util::{MockAnonymousUser, RequestHelper, TestApp};
 use crates_io::models::Category;
-use insta::assert_yaml_snapshot;
+use insta::assert_json_snapshot;
 use serde_json::Value;
 
 #[test]
@@ -23,7 +23,7 @@ fn show() {
 
     // The category and its subcategories should be in the json
     let json: Value = anon.get(url).good();
-    assert_yaml_snapshot!(json, {
+    assert_json_snapshot!(json, {
         ".**.created_at" => "[datetime]",
     });
 }

--- a/src/tests/routes/categories/list.rs
+++ b/src/tests/routes/categories/list.rs
@@ -1,6 +1,6 @@
 use crate::new_category;
 use crate::util::{RequestHelper, TestApp};
-use insta::assert_yaml_snapshot;
+use insta::assert_json_snapshot;
 use serde_json::Value;
 
 #[test]
@@ -9,7 +9,7 @@ fn index() {
 
     // List 0 categories if none exist
     let json: Value = anon.get("/api/v1/categories").good();
-    assert_yaml_snapshot!(json);
+    assert_json_snapshot!(json);
 
     // Create a category and a subcategory
     app.db(|conn| {
@@ -23,7 +23,7 @@ fn index() {
 
     // Only the top-level categories should be on the page
     let json: Value = anon.get("/api/v1/categories").good();
-    assert_yaml_snapshot!(json, {
+    assert_json_snapshot!(json, {
         ".categories[].created_at" => "[datetime]",
     });
 }

--- a/src/tests/routes/categories/snapshots/all__routes__categories__get__show.snap
+++ b/src/tests/routes/categories/snapshots/all__routes__categories__get__show.snap
@@ -1,21 +1,25 @@
 ---
 source: src/tests/routes/categories/get.rs
-assertion_line: 26
 expression: json
 ---
-category:
-  category: Foo Bar
-  crates_cnt: 0
-  created_at: "[datetime]"
-  description: Foo Bar crates
-  id: foo-bar
-  parent_categories: []
-  slug: foo-bar
-  subcategories:
-    - category: Baz
-      crates_cnt: 0
-      created_at: "[datetime]"
-      description: Baz crates
-      id: "foo-bar::baz"
-      slug: "foo-bar::baz"
-
+{
+  "category": {
+    "category": "Foo Bar",
+    "crates_cnt": 0,
+    "created_at": "[datetime]",
+    "description": "Foo Bar crates",
+    "id": "foo-bar",
+    "parent_categories": [],
+    "slug": "foo-bar",
+    "subcategories": [
+      {
+        "category": "Baz",
+        "crates_cnt": 0,
+        "created_at": "[datetime]",
+        "description": "Baz crates",
+        "id": "foo-bar::baz",
+        "slug": "foo-bar::baz"
+      }
+    ]
+  }
+}

--- a/src/tests/routes/categories/snapshots/all__routes__categories__list__index-2.snap
+++ b/src/tests/routes/categories/snapshots/all__routes__categories__list__index-2.snap
@@ -1,15 +1,19 @@
 ---
 source: src/tests/routes/categories/list.rs
-assertion_line: 26
 expression: json
 ---
-categories:
-  - category: foo
-    crates_cnt: 0
-    created_at: "[datetime]"
-    description: Foo crates
-    id: foo
-    slug: foo
-meta:
-  total: 1
-
+{
+  "categories": [
+    {
+      "category": "foo",
+      "crates_cnt": 0,
+      "created_at": "[datetime]",
+      "description": "Foo crates",
+      "id": "foo",
+      "slug": "foo"
+    }
+  ],
+  "meta": {
+    "total": 1
+  }
+}

--- a/src/tests/routes/categories/snapshots/all__routes__categories__list__index.snap
+++ b/src/tests/routes/categories/snapshots/all__routes__categories__list__index.snap
@@ -1,9 +1,10 @@
 ---
 source: src/tests/routes/categories/list.rs
-assertion_line: 12
 expression: json
 ---
-categories: []
-meta:
-  total: 0
-
+{
+  "categories": [],
+  "meta": {
+    "total": 0
+  }
+}

--- a/src/tests/routes/category_slugs/list.rs
+++ b/src/tests/routes/category_slugs/list.rs
@@ -1,6 +1,6 @@
 use crate::new_category;
 use crate::util::{RequestHelper, TestApp};
-use insta::assert_yaml_snapshot;
+use insta::assert_json_snapshot;
 use serde_json::Value;
 
 #[test]
@@ -16,5 +16,5 @@ fn category_slugs_returns_all_slugs_in_alphabetical_order() {
     });
 
     let response: Value = anon.get("/api/v1/category_slugs").good();
-    assert_yaml_snapshot!(response);
+    assert_json_snapshot!(response);
 }

--- a/src/tests/routes/category_slugs/snapshots/all__routes__category_slugs__list__category_slugs_returns_all_slugs_in_alphabetical_order.snap
+++ b/src/tests/routes/category_slugs/snapshots/all__routes__category_slugs__list__category_slugs_returns_all_slugs_in_alphabetical_order.snap
@@ -1,13 +1,18 @@
 ---
 source: src/tests/routes/category_slugs/list.rs
-assertion_line: 19
 expression: response
 ---
-category_slugs:
-  - description: For crates that bar
-    id: bar
-    slug: bar
-  - description: For crates that foo
-    id: foo
-    slug: foo
-
+{
+  "category_slugs": [
+    {
+      "description": "For crates that bar",
+      "id": "bar",
+      "slug": "bar"
+    },
+    {
+      "description": "For crates that foo",
+      "id": "foo",
+      "slug": "foo"
+    }
+  ]
+}

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -1,6 +1,6 @@
 use crate::builders::CrateBuilder;
 use crate::util::{RequestHelper, TestApp};
-use insta::assert_yaml_snapshot;
+use insta::assert_json_snapshot;
 use serde_json::Value;
 
 #[test]
@@ -16,5 +16,5 @@ fn authors() {
 
     let json: Value = anon.get("/api/v1/crates/foo_authors/1.0.0/authors").good();
     let json = json.as_object().unwrap();
-    assert_yaml_snapshot!(json);
+    assert_json_snapshot!(json);
 }

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -1,5 +1,5 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
-use crate::util::insta::{self, assert_yaml_snapshot};
+use crate::util::insta::{self, assert_json_snapshot};
 use crate::util::{RequestHelper, TestApp};
 use diesel::prelude::*;
 use serde_json::Value;
@@ -20,7 +20,7 @@ fn show_by_crate_name_and_version() {
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
     let json: Value = anon.get(url).good();
-    assert_yaml_snapshot!(json, {
+    assert_json_snapshot!(json, {
         ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
@@ -52,7 +52,7 @@ fn show_by_crate_name_and_semver_no_published_by() {
 
     let url = "/api/v1/crates/foo_vers_show_no_pb/1.0.0";
     let json: Value = anon.get(url).good();
-    assert_yaml_snapshot!(json, {
+    assert_json_snapshot!(json, {
         ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__authors__authors.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__authors__authors.snap
@@ -1,9 +1,10 @@
 ---
 source: src/tests/routes/crates/versions/authors.rs
-assertion_line: 19
 expression: json
 ---
-meta:
-  names: []
-users: []
-
+{
+  "meta": {
+    "names": []
+  },
+  "users": []
+}

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
@@ -1,27 +1,29 @@
 ---
 source: src/tests/routes/crates/versions/read.rs
-assertion_line: 54
 expression: json
 ---
-version:
-  audit_actions: []
-  checksum: "                                                                "
-  crate: foo_vers_show_no_pb
-  crate_size: 0
-  created_at: "[datetime]"
-  dl_path: /api/v1/crates/foo_vers_show_no_pb/1.0.0/download
-  downloads: 0
-  features: {}
-  id: "[id]"
-  license: ~
-  links:
-    authors: /api/v1/crates/foo_vers_show_no_pb/1.0.0/authors
-    dependencies: /api/v1/crates/foo_vers_show_no_pb/1.0.0/dependencies
-    version_downloads: /api/v1/crates/foo_vers_show_no_pb/1.0.0/downloads
-  num: 1.0.0
-  published_by: ~
-  readme_path: /api/v1/crates/foo_vers_show_no_pb/1.0.0/readme
-  rust_version: ~
-  updated_at: "[datetime]"
-  yanked: false
-
+{
+  "version": {
+    "audit_actions": [],
+    "checksum": "                                                                ",
+    "crate": "foo_vers_show_no_pb",
+    "crate_size": 0,
+    "created_at": "[datetime]",
+    "dl_path": "/api/v1/crates/foo_vers_show_no_pb/1.0.0/download",
+    "downloads": 0,
+    "features": {},
+    "id": "[id]",
+    "license": null,
+    "links": {
+      "authors": "/api/v1/crates/foo_vers_show_no_pb/1.0.0/authors",
+      "dependencies": "/api/v1/crates/foo_vers_show_no_pb/1.0.0/dependencies",
+      "version_downloads": "/api/v1/crates/foo_vers_show_no_pb/1.0.0/downloads"
+    },
+    "num": "1.0.0",
+    "published_by": null,
+    "readme_path": "/api/v1/crates/foo_vers_show_no_pb/1.0.0/readme",
+    "rust_version": null,
+    "updated_at": "[datetime]",
+    "yanked": false
+  }
+}

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -1,32 +1,35 @@
 ---
 source: src/tests/routes/crates/versions/read.rs
-assertion_line: 23
 expression: json
 ---
-version:
-  audit_actions: []
-  checksum: c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4
-  crate: foo_vers_show
-  crate_size: 1234
-  created_at: "[datetime]"
-  dl_path: /api/v1/crates/foo_vers_show/2.0.0/download
-  downloads: 0
-  features: {}
-  id: "[id]"
-  license: ~
-  links:
-    authors: /api/v1/crates/foo_vers_show/2.0.0/authors
-    dependencies: /api/v1/crates/foo_vers_show/2.0.0/dependencies
-    version_downloads: /api/v1/crates/foo_vers_show/2.0.0/downloads
-  num: 2.0.0
-  published_by:
-    avatar: ~
-    id: "[id]"
-    login: foo
-    name: ~
-    url: "https://github.com/foo"
-  readme_path: /api/v1/crates/foo_vers_show/2.0.0/readme
-  rust_version: "1.64"
-  updated_at: "[datetime]"
-  yanked: false
-
+{
+  "version": {
+    "audit_actions": [],
+    "checksum": "c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4",
+    "crate": "foo_vers_show",
+    "crate_size": 1234,
+    "created_at": "[datetime]",
+    "dl_path": "/api/v1/crates/foo_vers_show/2.0.0/download",
+    "downloads": 0,
+    "features": {},
+    "id": "[id]",
+    "license": null,
+    "links": {
+      "authors": "/api/v1/crates/foo_vers_show/2.0.0/authors",
+      "dependencies": "/api/v1/crates/foo_vers_show/2.0.0/dependencies",
+      "version_downloads": "/api/v1/crates/foo_vers_show/2.0.0/downloads"
+    },
+    "num": "2.0.0",
+    "published_by": {
+      "avatar": null,
+      "id": "[id]",
+      "login": "foo",
+      "name": null,
+      "url": "https://github.com/foo"
+    },
+    "readme_path": "/api/v1/crates/foo_vers_show/2.0.0/readme",
+    "rust_version": "1.64",
+    "updated_at": "[datetime]",
+    "yanked": false
+  }
+}

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -1,4 +1,4 @@
-use crate::util::insta::{self, assert_yaml_snapshot};
+use crate::util::insta::{self, assert_json_snapshot};
 use crate::util::{RequestHelper, TestApp};
 use crates_io::models::token::{CrateScope, EndpointScope};
 use crates_io::models::ApiToken;
@@ -61,7 +61,7 @@ fn create_token_success() {
 
     let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.into_json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",
@@ -130,7 +130,7 @@ fn create_token_with_scopes() {
 
     let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.into_json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",
@@ -173,7 +173,7 @@ fn create_token_with_null_scopes() {
 
     let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.into_json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",
@@ -248,7 +248,7 @@ fn create_token_with_expiry_date() {
 
     let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.into_json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -1,4 +1,4 @@
-use crate::util::insta::{self, assert_yaml_snapshot};
+use crate::util::insta::{self, assert_json_snapshot};
 use crate::util::{RequestHelper, TestApp};
 use chrono::{Duration, Utc};
 use crates_io::models::token::{CrateScope, EndpointScope};
@@ -58,7 +58,7 @@ fn list_tokens() {
 
     let response = user.get::<()>("/api/v1/me/tokens");
     assert_eq!(response.status(), StatusCode::OK);
-    assert_yaml_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.into_json(), {
         ".api_tokens[].id" => insta::any_id_redaction(),
         ".api_tokens[].created_at" => "[datetime]",
         ".api_tokens[].last_used_at" => "[datetime]",

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success.snap
@@ -2,13 +2,15 @@
 source: src/tests/routes/me/tokens/create.rs
 expression: response.into_json()
 ---
-api_token:
-  crate_scopes: ~
-  created_at: "[datetime]"
-  endpoint_scopes: ~
-  expired_at: ~
-  id: "[id]"
-  last_used_at: "[datetime]"
-  name: bar
-  token: "[token]"
-
+{
+  "api_token": {
+    "crate_scopes": null,
+    "created_at": "[datetime]",
+    "endpoint_scopes": null,
+    "expired_at": null,
+    "id": "[id]",
+    "last_used_at": "[datetime]",
+    "name": "bar",
+    "token": "[token]"
+  }
+}

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date.snap
@@ -2,13 +2,15 @@
 source: src/tests/routes/me/tokens/create.rs
 expression: response.into_json()
 ---
-api_token:
-  crate_scopes: ~
-  created_at: "[datetime]"
-  endpoint_scopes: ~
-  expired_at: "2024-12-24T07:34:56+00:00"
-  id: "[id]"
-  last_used_at: "[datetime]"
-  name: bar
-  token: "[token]"
-
+{
+  "api_token": {
+    "crate_scopes": null,
+    "created_at": "[datetime]",
+    "endpoint_scopes": null,
+    "expired_at": "2024-12-24T07:34:56+00:00",
+    "id": "[id]",
+    "last_used_at": "[datetime]",
+    "name": "bar",
+    "token": "[token]"
+  }
+}

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes.snap
@@ -2,13 +2,15 @@
 source: src/tests/routes/me/tokens/create.rs
 expression: response.into_json()
 ---
-api_token:
-  crate_scopes: ~
-  created_at: "[datetime]"
-  endpoint_scopes: ~
-  expired_at: ~
-  id: "[id]"
-  last_used_at: "[datetime]"
-  name: bar
-  token: "[token]"
-
+{
+  "api_token": {
+    "crate_scopes": null,
+    "created_at": "[datetime]",
+    "endpoint_scopes": null,
+    "expired_at": null,
+    "id": "[id]",
+    "last_used_at": "[datetime]",
+    "name": "bar",
+    "token": "[token]"
+  }
+}

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes.snap
@@ -2,16 +2,20 @@
 source: src/tests/routes/me/tokens/create.rs
 expression: response.into_json()
 ---
-api_token:
-  crate_scopes:
-    - tokio
-    - tokio-*
-  created_at: "[datetime]"
-  endpoint_scopes:
-    - publish-update
-  expired_at: ~
-  id: "[id]"
-  last_used_at: "[datetime]"
-  name: bar
-  token: "[token]"
-
+{
+  "api_token": {
+    "crate_scopes": [
+      "tokio",
+      "tokio-*"
+    ],
+    "created_at": "[datetime]",
+    "endpoint_scopes": [
+      "publish-update"
+    ],
+    "expired_at": null,
+    "id": "[id]",
+    "last_used_at": "[datetime]",
+    "name": "bar",
+    "token": "[token]"
+  }
+}

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
@@ -2,22 +2,30 @@
 source: src/tests/routes/me/tokens/list.rs
 expression: response.into_json()
 ---
-api_tokens:
-  - crate_scopes: ~
-    created_at: "[datetime]"
-    endpoint_scopes: ~
-    expired_at: ~
-    id: "[id]"
-    last_used_at: "[datetime]"
-    name: bar
-  - crate_scopes:
-      - serde
-      - serde-*
-    created_at: "[datetime]"
-    endpoint_scopes:
-      - publish-update
-    expired_at: ~
-    id: "[id]"
-    last_used_at: "[datetime]"
-    name: baz
-
+{
+  "api_tokens": [
+    {
+      "crate_scopes": null,
+      "created_at": "[datetime]",
+      "endpoint_scopes": null,
+      "expired_at": null,
+      "id": "[id]",
+      "last_used_at": "[datetime]",
+      "name": "bar"
+    },
+    {
+      "crate_scopes": [
+        "serde",
+        "serde-*"
+      ],
+      "created_at": "[datetime]",
+      "endpoint_scopes": [
+        "publish-update"
+      ],
+      "expired_at": null,
+      "id": "[id]",
+      "last_used_at": "[datetime]",
+      "name": "baz"
+    }
+  ]
+}

--- a/src/tests/routes/versions/list.rs
+++ b/src/tests/routes/versions/list.rs
@@ -1,5 +1,5 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
-use crate::util::insta::{self, assert_yaml_snapshot};
+use crate::util::insta::{self, assert_json_snapshot};
 use crate::util::{RequestHelper, TestApp};
 use crates_io::schema::versions;
 use diesel::{QueryDsl, RunQueryDsl};
@@ -13,7 +13,7 @@ fn index() {
     let url = "/api/v1/versions";
 
     let json: Value = anon.get(url).good();
-    assert_yaml_snapshot!(json);
+    assert_json_snapshot!(json);
 
     let (v1, v2) = app.db(|conn| {
         CrateBuilder::new("foo_vers_index", user.id)
@@ -26,7 +26,7 @@ fn index() {
 
     let query = format!("ids[]={v1}&ids[]={v2}");
     let json: Value = anon.get_with_query(url, &query).good();
-    assert_yaml_snapshot!(json, {
+    assert_json_snapshot!(json, {
         ".versions" => insta::sorted_redaction(),
         ".versions[].id" => insta::any_id_redaction(),
         ".versions[].created_at" => "[datetime]",

--- a/src/tests/routes/versions/read.rs
+++ b/src/tests/routes/versions/read.rs
@@ -1,5 +1,5 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
-use crate::util::insta::{self, assert_yaml_snapshot};
+use crate::util::insta::{self, assert_json_snapshot};
 use crate::util::{RequestHelper, TestApp};
 use serde_json::Value;
 
@@ -17,7 +17,7 @@ fn show_by_id() {
 
     let url = format!("/api/v1/versions/{}", v.id);
     let json: Value = anon.get(&url).good();
-    assert_yaml_snapshot!(json, {
+    assert_json_snapshot!(json, {
         ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",

--- a/src/tests/routes/versions/snapshots/all__routes__versions__list__index-2.snap
+++ b/src/tests/routes/versions/snapshots/all__routes__versions__list__index-2.snap
@@ -1,57 +1,66 @@
 ---
 source: src/tests/routes/versions/list.rs
-assertion_line: 29
 expression: json
 ---
-versions:
-  - audit_actions: []
-    checksum: "                                                                "
-    crate: foo_vers_index
-    crate_size: 0
-    created_at: "[datetime]"
-    dl_path: /api/v1/crates/foo_vers_index/2.0.0/download
-    downloads: 0
-    features: {}
-    id: "[id]"
-    license: MIT
-    links:
-      authors: /api/v1/crates/foo_vers_index/2.0.0/authors
-      dependencies: /api/v1/crates/foo_vers_index/2.0.0/dependencies
-      version_downloads: /api/v1/crates/foo_vers_index/2.0.0/downloads
-    num: 2.0.0
-    published_by:
-      avatar: ~
-      id: "[id]"
-      login: foo
-      name: ~
-      url: "https://github.com/foo"
-    readme_path: /api/v1/crates/foo_vers_index/2.0.0/readme
-    rust_version: ~
-    updated_at: "[datetime]"
-    yanked: false
-  - audit_actions: []
-    checksum: "                                                                "
-    crate: foo_vers_index
-    crate_size: 0
-    created_at: "[datetime]"
-    dl_path: /api/v1/crates/foo_vers_index/2.0.1/download
-    downloads: 0
-    features: {}
-    id: "[id]"
-    license: MIT/Apache-2.0
-    links:
-      authors: /api/v1/crates/foo_vers_index/2.0.1/authors
-      dependencies: /api/v1/crates/foo_vers_index/2.0.1/dependencies
-      version_downloads: /api/v1/crates/foo_vers_index/2.0.1/downloads
-    num: 2.0.1
-    published_by:
-      avatar: ~
-      id: "[id]"
-      login: foo
-      name: ~
-      url: "https://github.com/foo"
-    readme_path: /api/v1/crates/foo_vers_index/2.0.1/readme
-    rust_version: ~
-    updated_at: "[datetime]"
-    yanked: false
-
+{
+  "versions": [
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "foo_vers_index",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/foo_vers_index/2.0.0/download",
+      "downloads": 0,
+      "features": {},
+      "id": "[id]",
+      "license": "MIT",
+      "links": {
+        "authors": "/api/v1/crates/foo_vers_index/2.0.0/authors",
+        "dependencies": "/api/v1/crates/foo_vers_index/2.0.0/dependencies",
+        "version_downloads": "/api/v1/crates/foo_vers_index/2.0.0/downloads"
+      },
+      "num": "2.0.0",
+      "published_by": {
+        "avatar": null,
+        "id": "[id]",
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/foo_vers_index/2.0.0/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    },
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "foo_vers_index",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/foo_vers_index/2.0.1/download",
+      "downloads": 0,
+      "features": {},
+      "id": "[id]",
+      "license": "MIT/Apache-2.0",
+      "links": {
+        "authors": "/api/v1/crates/foo_vers_index/2.0.1/authors",
+        "dependencies": "/api/v1/crates/foo_vers_index/2.0.1/dependencies",
+        "version_downloads": "/api/v1/crates/foo_vers_index/2.0.1/downloads"
+      },
+      "num": "2.0.1",
+      "published_by": {
+        "avatar": null,
+        "id": "[id]",
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/foo_vers_index/2.0.1/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    }
+  ]
+}

--- a/src/tests/routes/versions/snapshots/all__routes__versions__list__index.snap
+++ b/src/tests/routes/versions/snapshots/all__routes__versions__list__index.snap
@@ -1,7 +1,7 @@
 ---
 source: src/tests/routes/versions/list.rs
-assertion_line: 16
 expression: json
 ---
-versions: []
-
+{
+  "versions": []
+}

--- a/src/tests/routes/versions/snapshots/all__routes__versions__read__show_by_id.snap
+++ b/src/tests/routes/versions/snapshots/all__routes__versions__read__show_by_id.snap
@@ -1,32 +1,35 @@
 ---
 source: src/tests/routes/versions/read.rs
-assertion_line: 20
 expression: json
 ---
-version:
-  audit_actions: []
-  checksum: "                                                                "
-  crate: foo_vers_show_id
-  crate_size: 1234
-  created_at: "[datetime]"
-  dl_path: /api/v1/crates/foo_vers_show_id/2.0.0/download
-  downloads: 0
-  features: {}
-  id: "[id]"
-  license: ~
-  links:
-    authors: /api/v1/crates/foo_vers_show_id/2.0.0/authors
-    dependencies: /api/v1/crates/foo_vers_show_id/2.0.0/dependencies
-    version_downloads: /api/v1/crates/foo_vers_show_id/2.0.0/downloads
-  num: 2.0.0
-  published_by:
-    avatar: ~
-    id: "[id]"
-    login: foo
-    name: ~
-    url: "https://github.com/foo"
-  readme_path: /api/v1/crates/foo_vers_show_id/2.0.0/readme
-  rust_version: ~
-  updated_at: "[datetime]"
-  yanked: false
-
+{
+  "version": {
+    "audit_actions": [],
+    "checksum": "                                                                ",
+    "crate": "foo_vers_show_id",
+    "crate_size": 1234,
+    "created_at": "[datetime]",
+    "dl_path": "/api/v1/crates/foo_vers_show_id/2.0.0/download",
+    "downloads": 0,
+    "features": {},
+    "id": "[id]",
+    "license": null,
+    "links": {
+      "authors": "/api/v1/crates/foo_vers_show_id/2.0.0/authors",
+      "dependencies": "/api/v1/crates/foo_vers_show_id/2.0.0/dependencies",
+      "version_downloads": "/api/v1/crates/foo_vers_show_id/2.0.0/downloads"
+    },
+    "num": "2.0.0",
+    "published_by": {
+      "avatar": null,
+      "id": "[id]",
+      "login": "foo",
+      "name": null,
+      "url": "https://github.com/foo"
+    },
+    "readme_path": "/api/v1/crates/foo_vers_show_id/2.0.0/readme",
+    "rust_version": null,
+    "updated_at": "[datetime]",
+    "yanked": false
+  }
+}


### PR DESCRIPTION
Since our API returns JSON responses, it seems better to also save these snapshots in JSON format. This has the disadvantage of making diffs slightly larger due to (missing) trailing commas and other things like that, but it is ultimately closer to the real world.


