### PR TITLE
Add more tests for the publish workflow

### DIFF
--- a/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/categories.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 219"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"💩\", expected a valid dependency name to start with a letter or underscore, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 197"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/features.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"!bar\", expected a valid feature name at line 1 column 65"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature_name.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/features.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"~foo\", expected a valid feature name containing only letters, numbers, '-', '+', or '_' at line 1 column 57"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/keywords.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 203"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__manifest__manifest_casing.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__manifest__manifest_casing.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/manifest.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "uploaded tarball is missing a `Cargo.toml` manifest file; `CARGO.TOML` was found, but must be named `Cargo.toml` with that exact casing"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__manifest__multiple_manifests.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__manifest__multiple_manifests.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/manifest.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "uploaded tarball contains more than one `Cargo.toml` manifest file; found `Cargo.toml`, `cargo.toml`"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__empty_json.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__empty_json.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: missing field `name` at line 1 column 2"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_version.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_version.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"broken\", expected a valid semver at line 1 column 29"
+    }
+  ]
+}

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -44,6 +44,20 @@ fn invalid_names() {
 }
 
 #[test]
+fn invalid_version() {
+    let (app, _, _, token) = TestApp::init().with_token();
+
+    let (json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
+    let new_json = json.replace(r#""vers":"1.0.0""#, r#""vers":"broken""#);
+    assert_ne!(json, new_json);
+    let body = PublishBuilder::create_publish_body(&new_json, &tarball);
+
+    let response = token.put::<()>("/api/v1/crates/new", &body);
+    assert_json_snapshot!(response.into_json());
+    assert!(app.stored_files().is_empty());
+}
+
+#[test]
 fn license_and_description_required() {
     let (app, _, _, token) = TestApp::full().with_token();
 

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -5,6 +5,19 @@ use http::StatusCode;
 use insta::assert_json_snapshot;
 
 #[test]
+fn empty_json() {
+    let (app, _, _, token) = TestApp::full().with_token();
+
+    let (_json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
+    let body = PublishBuilder::create_publish_body("{}", &tarball);
+
+    let response = token.put::<()>("/api/v1/crates/new", &body);
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.into_json());
+    assert!(app.stored_files().is_empty());
+}
+
+#[test]
 fn invalid_names() {
     let (app, _, _, token) = TestApp::full().with_token();
 


### PR DESCRIPTION
While looking at https://github.com/rust-lang/crates.io/blob/f0c8f5e64acfd6e57dc2a060b2b7f09893a446c6/src/views/krate_publish.rs, I noticed that quite a few of these serde-based validations are not covered by our test suite. This PR adds a couple more tests to ensure that these cases are sufficiently tested.