### PR TITLE
tests/util: Avoid unnecessary cloning

### DIFF
--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -44,7 +44,7 @@ fn github_secret_alert_revokes_token() {
     });
 
     let mut request = anon.post_request(URL);
-    request.with_body(GITHUB_ALERT);
+    *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
     let response = anon.run::<Vec<GitHubSecretAlertFeedback>>(request);
@@ -108,7 +108,7 @@ fn github_secret_alert_for_revoked_token() {
     });
 
     let mut request = anon.post_request(URL);
-    request.with_body(GITHUB_ALERT);
+    *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
     let response = anon.run::<Vec<GitHubSecretAlertFeedback>>(request);
@@ -160,7 +160,7 @@ fn github_secret_alert_for_unknown_token() {
     });
 
     let mut request = anon.post_request(URL);
-    request.with_body(GITHUB_ALERT);
+    *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
     let response = anon.run::<Vec<GitHubSecretAlertFeedback>>(request);
@@ -201,7 +201,7 @@ fn github_secret_alert_invalid_signature_fails() {
 
     // Request body but no headers
     let mut request = anon.post_request(URL);
-    request.with_body(GITHUB_ALERT);
+    *request.body_mut() = GITHUB_ALERT.into();
     let response = anon.run::<()>(request);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
@@ -214,14 +214,14 @@ fn github_secret_alert_invalid_signature_fails() {
 
     // Request body but only key identifier header
     let mut request = anon.post_request(URL);
-    request.with_body(GITHUB_ALERT);
+    *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     let response = anon.run::<()>(request);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Invalid signature
     let mut request = anon.post_request(URL);
-    request.with_body(GITHUB_ALERT);
+    *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", "bad signature");
     let response = anon.run::<()>(request);
@@ -229,7 +229,7 @@ fn github_secret_alert_invalid_signature_fails() {
 
     // Invalid signature that is valid base64
     let mut request = anon.post_request(URL);
-    request.with_body(GITHUB_ALERT);
+    *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", "YmFkIHNpZ25hdHVyZQ==");
     let response = anon.run::<()>(request);

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -24,7 +24,7 @@ fn following() {
 
     let follow = || {
         assert!(
-            user.put::<OkBool>("/api/v1/crates/foo_following/follow", b"")
+            user.put::<OkBool>("/api/v1/crates/foo_following/follow", b"" as &[u8])
                 .good()
                 .ok
         );
@@ -78,7 +78,7 @@ fn getting_followed_crates_allows_api_token_auth() {
     let follow = |crate_name: &str| {
         assert!(
             token
-                .put::<OkBool>(&format!("/api/v1/crates/{crate_name}/follow"), b"")
+                .put::<OkBool>(&format!("/api/v1/crates/{crate_name}/follow"), b"" as &[u8])
                 .good()
                 .ok
         );

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -120,7 +120,7 @@ fn new_krate_with_broken_dependency_requirement() {
     let body = PublishBuilder::create_publish_body(&new_json, &tarball);
 
     let response = token
-        .put::<serde_json::Value>("/api/v1/crates/new", &body)
+        .put::<serde_json::Value>("/api/v1/crates/new", body)
         .good();
 
     assert_eq!(

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -55,7 +55,7 @@ fn new_krate_tarball_with_hard_links() {
 fn empty() {
     let (app, _, user) = TestApp::full().with_user();
 
-    let response = user.put::<()>("/api/v1/crates/new", &[]);
+    let response = user.put::<()>("/api/v1/crates/new", &[] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -65,7 +65,7 @@ fn empty() {
 fn json_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.put::<()>("/api/v1/crates/new", &[0, 0]);
+    let response = token.put::<()>("/api/v1/crates/new", &[0u8, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -75,7 +75,7 @@ fn json_len_truncated() {
 fn json_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.put::<()>("/api/v1/crates/new", &[100, 0, 0, 0, 0]);
+    let response = token.put::<()>("/api/v1/crates/new", &[100u8, 0, 0, 0, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -85,7 +85,10 @@ fn json_bytes_truncated() {
 fn tarball_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.put::<()>("/api/v1/crates/new", &[2, 0, 0, 0, b'{', b'}', 0, 0]);
+    let response = token.put::<()>(
+        "/api/v1/crates/new",
+        &[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8],
+    );
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -97,7 +100,7 @@ fn tarball_bytes_truncated() {
 
     let response = token.put::<()>(
         "/api/v1/crates/new",
-        &[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0],
+        &[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8],
     );
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -11,7 +11,7 @@ fn empty_json() {
     let (_json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
     let body = PublishBuilder::create_publish_body("{}", &tarball);
 
-    let response = token.put::<()>("/api/v1/crates/new", &body);
+    let response = token.put::<()>("/api/v1/crates/new", body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -52,7 +52,7 @@ fn invalid_version() {
     assert_ne!(json, new_json);
     let body = PublishBuilder::create_publish_body(&new_json, &tarball);
 
-    let response = token.put::<()>("/api/v1/crates/new", &body);
+    let response = token.put::<()>("/api/v1/crates/new", body);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -61,7 +61,7 @@ impl MockCookieUser {
         });
 
         let url = format!("/api/v1/me/crate_owner_invitations/{krate_id}");
-        self.put(&url, body.to_string().as_bytes())
+        self.put(&url, body.to_string())
     }
 
     /// As the currently logged in user, accept an invitation to become an owner of the named
@@ -99,8 +99,7 @@ impl MockCookieUser {
         }
 
         let url = format!("/api/v1/me/crate_owner_invitations/{krate_id}");
-        let crate_owner_invite: CrateOwnerInvitation =
-            self.put(&url, body.to_string().as_bytes()).good();
+        let crate_owner_invite: CrateOwnerInvitation = self.put(&url, body.to_string()).good();
         assert!(!crate_owner_invite.crate_owner_invitation.accepted);
         assert_eq!(crate_owner_invite.crate_owner_invitation.crate_id, krate_id);
     }
@@ -127,7 +126,7 @@ impl MockAnonymousUser {
         token: &str,
     ) -> Response<T> {
         let url = format!("/api/v1/me/crate_owner_invitations/accept/{token}");
-        self.put(&url, &[])
+        self.put(&url, &[] as &[u8])
     }
 }
 
@@ -277,7 +276,7 @@ fn owner_change_via_cookie() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = cookie.put::<()>(&url, &body);
+    let response = cookie.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -298,7 +297,7 @@ fn owner_change_via_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, &body);
+    let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -320,7 +319,7 @@ fn owner_change_via_change_owner_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, &body);
+    let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -343,7 +342,7 @@ fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, &body);
+    let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -366,7 +365,7 @@ fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, &body);
+    let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.into_json(),
@@ -388,7 +387,7 @@ fn owner_change_via_publish_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, &body);
+    let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.into_json(),
@@ -409,7 +408,7 @@ fn owner_change_without_auth() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = anon.put::<()>(&url, &body);
+    let response = anon.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.into_json(),

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -28,7 +28,7 @@ fn test_cargo_invite_owners() {
         owners: Some(vec![new_user.as_model().gh_login.clone()]),
     });
     let json: OwnerResp = owner
-        .put("/api/v1/crates/guacamole/owners", body.unwrap().as_bytes())
+        .put("/api/v1/crates/guacamole/owners", body.unwrap())
         .good();
 
     // this ok:true field is what old versions of Cargo

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -21,7 +21,7 @@ impl<T: RequestHelper> YankRequestHelper for T {
 
     fn unyank(&self, krate_name: &str, version: &str) -> Response<OkBool> {
         let url = format!("/api/v1/crates/{krate_name}/{version}/unyank");
-        let response = self.put(&url, &[]);
+        let response = self.put(&url, &[] as &[u8]);
         self.app().run_pending_background_jobs();
         response
     }

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -12,11 +12,8 @@ struct EmailNotificationsUpdate {
 
 impl crate::util::MockCookieUser {
     fn update_email_notifications(&self, updates: Vec<EmailNotificationsUpdate>) -> OkBool {
-        self.put(
-            "/api/v1/me/email_notifications",
-            json!(updates).to_string().as_bytes(),
-        )
-        .good()
+        self.put("/api/v1/me/email_notifications", json!(updates).to_string())
+            .good()
     }
 }
 

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -17,7 +17,7 @@ fn create_token_logged_out() {
 #[test]
 fn create_token_invalid_request() {
     let (_, _, user) = TestApp::init().with_user();
-    let invalid = br#"{ "name": "" }"#;
+    let invalid: &[u8] = br#"{ "name": "" }"#;
     let response = user.put::<()>("/api/v1/me/tokens", invalid);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
@@ -29,7 +29,7 @@ fn create_token_invalid_request() {
 #[test]
 fn create_token_no_name() {
     let (_, _, user) = TestApp::init().with_user();
-    let empty_name = br#"{ "api_token": { "name": "" } }"#;
+    let empty_name: &[u8] = br#"{ "api_token": { "name": "" } }"#;
     let response = user.put::<()>("/api/v1/me/tokens", empty_name);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
@@ -107,7 +107,7 @@ fn cannot_create_token_with_token() {
     let (_, _, _, token) = TestApp::init().with_token();
     let response = token.put::<()>(
         "/api/v1/me/tokens",
-        br#"{ "api_token": { "name": "baz" } }"#,
+        br#"{ "api_token": { "name": "baz" } }"# as &[u8],
     );
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
@@ -128,7 +128,7 @@ fn create_token_with_scopes() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
+    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json(), {
         ".api_token.id" => insta::any_id_redaction(),
@@ -171,7 +171,7 @@ fn create_token_with_null_scopes() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
+    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json(), {
         ".api_token.id" => insta::any_id_redaction(),
@@ -205,7 +205,7 @@ fn create_token_with_empty_crate_scope() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
+    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.into_json(),
@@ -225,7 +225,7 @@ fn create_token_with_invalid_endpoint_scope() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
+    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.into_json(),
@@ -246,7 +246,7 @@ fn create_token_with_expiry_date() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", &serde_json::to_vec(&json).unwrap());
+    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json(), {
         ".api_token.id" => insta::any_id_redaction(),

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -50,9 +50,9 @@ fn following() {
     assert_eq!(r.versions.len(), 0);
     assert!(!r.meta.more);
 
-    user.put::<OkBool>("/api/v1/crates/foo_fighters/follow", b"")
+    user.put::<OkBool>("/api/v1/crates/foo_fighters/follow", b"" as &[u8])
         .good();
-    user.put::<OkBool>("/api/v1/crates/bar_fighters/follow", b"")
+    user.put::<OkBool>("/api/v1/crates/bar_fighters/follow", b"" as &[u8])
         .good();
 
     let r: R = user.get("/api/v1/me/updates").good();

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -19,7 +19,7 @@ pub trait MockEmailHelper: RequestHelper {
             "kind": null
         }});
         let url = format!("/api/v1/users/{user_id}");
-        self.put(&url, body.to_string().as_bytes())
+        self.put(&url, body.to_string())
     }
 }
 

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -10,7 +10,7 @@ use secrecy::ExposeSecret;
 impl crate::util::MockCookieUser {
     fn confirm_email(&self, email_token: &str) -> OkBool {
         let url = format!("/api/v1/confirm/{email_token}");
-        self.put(&url, &[]).good()
+        self.put(&url, &[] as &[u8]).good()
     }
 }
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -140,7 +140,7 @@ pub trait RequestHelper {
     #[track_caller]
     fn put<T>(&self, path: &str, body: &[u8]) -> Response<T> {
         let mut request = self.request_builder(Method::PUT, path);
-        request.with_body(body);
+        *request.body_mut() = body.to_vec().into();
         self.run(request)
     }
 
@@ -155,7 +155,7 @@ pub trait RequestHelper {
     #[track_caller]
     fn delete_with_body<T>(&self, path: &str, body: &[u8]) -> Response<T> {
         let mut request = self.request_builder(Method::DELETE, path);
-        request.with_body(body);
+        *request.body_mut() = body.to_vec().into();
         self.run(request)
     }
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -138,9 +138,9 @@ pub trait RequestHelper {
 
     /// Issue a PUT request
     #[track_caller]
-    fn put<T>(&self, path: &str, body: &[u8]) -> Response<T> {
+    fn put<T>(&self, path: &str, body: impl Into<Bytes>) -> Response<T> {
         let mut request = self.request_builder(Method::PUT, path);
-        *request.body_mut() = body.to_vec().into();
+        *request.body_mut() = body.into();
         self.run(request)
     }
 
@@ -153,9 +153,9 @@ pub trait RequestHelper {
 
     /// Issue a DELETE request with a body... yes we do it, for crate owner removal
     #[track_caller]
-    fn delete_with_body<T>(&self, path: &str, body: &[u8]) -> Response<T> {
+    fn delete_with_body<T>(&self, path: &str, body: impl Into<Bytes>) -> Response<T> {
         let mut request = self.request_builder(Method::DELETE, path);
-        *request.body_mut() = body.to_vec().into();
+        *request.body_mut() = body.into();
         self.run(request)
     }
 
@@ -174,7 +174,7 @@ pub trait RequestHelper {
     /// Background jobs will publish to the git index and sync to the HTTP index.
     #[track_caller]
     fn publish_crate(&self, publish_builder: PublishBuilder) -> Response<GoodCrate> {
-        let response = self.put("/api/v1/crates/new", &publish_builder.body());
+        let response = self.put("/api/v1/crates/new", publish_builder.body());
         self.app().run_pending_background_jobs();
         response
     }
@@ -341,7 +341,7 @@ impl MockTokenUser {
     pub fn add_named_owners(&self, krate_name: &str, owners: &[&str]) -> Response<OkBool> {
         let url = format!("/api/v1/crates/{krate_name}/owners");
         let body = json!({ "owners": owners }).to_string();
-        self.put(&url, body.as_bytes())
+        self.put(&url, body)
     }
 
     /// Add a single owner to the specified crate.
@@ -353,7 +353,7 @@ impl MockTokenUser {
     pub fn remove_named_owners(&self, krate_name: &str, owners: &[&str]) -> Response<OkBool> {
         let url = format!("/api/v1/crates/{krate_name}/owners");
         let body = json!({ "owners": owners }).to_string();
-        self.delete_with_body(&url, body.as_bytes())
+        self.delete_with_body(&url, body)
     }
 
     /// Remove a single owner to the specified crate.

--- a/src/tests/util/mock_request.rs
+++ b/src/tests/util/mock_request.rs
@@ -4,16 +4,10 @@ use http::{header::IntoHeaderName, HeaderValue, Request};
 pub type MockRequest = Request<Bytes>;
 
 pub trait MockRequestExt {
-    fn with_body(&mut self, bytes: &[u8]);
-
     fn header<K: IntoHeaderName>(&mut self, name: K, value: &str);
 }
 
 impl MockRequestExt for MockRequest {
-    fn with_body(&mut self, bytes: &[u8]) {
-        *self.body_mut() = bytes.to_vec().into();
-    }
-
     fn header<K>(&mut self, name: K, value: &str)
     where
         K: IntoHeaderName,
@@ -51,7 +45,7 @@ mod tests {
     #[test]
     fn request_body_test() {
         let mut req = mock_request(Method::POST, "/articles");
-        req.with_body(b"Hello world");
+        *req.body_mut() = Bytes::from_static(b"Hello world");
 
         assert_eq!(req.method(), Method::POST);
         assert_eq!(req.uri(), "/articles");

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -13,7 +13,7 @@ fn index_smoke_test() {
     // Add a new crate
 
     let body = PublishBuilder::new("serde", "1.0.0").body();
-    let response = token.put::<()>("/api/v1/crates/new", &body);
+    let response = token.put::<()>("/api/v1/crates/new", body);
     assert_eq!(response.status(), StatusCode::OK);
 
     // Check that the git index is updated asynchronously


### PR DESCRIPTION
This PR avoids a couple of unnecessary `Vec<u8>` cloning in our test suite. Instead of passing a reference of `Vec<u8>` into the functions which is then immediately turned into a `Vec<u8>` again, we can use `impl Into<Bytes>` to avoid the unnecessary cloning.