### PR TITLE
tests/builders/publish: Decrease `krate_name` visibility

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -14,7 +14,7 @@ pub struct PublishBuilder {
     desc: Option<String>,
     doc_url: Option<String>,
     keywords: Vec<String>,
-    pub krate_name: String,
+    krate_name: String,
     license: Option<String>,
     license_file: Option<String>,
     readme: Option<String>,


### PR DESCRIPTION
This field is not accessed outside of the module (anymore?), so there is really no need for this to be public.