### PR TITLE
tests/PublishBuilder: Generate correct manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "axum-extra",
  "base64 0.21.4",
  "bigdecimal",
+ "cargo-manifest",
  "chrono",
  "claims",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }
 url = "=2.4.1"
 
 [dev-dependencies]
+cargo-manifest = "=0.11.1"
 crates_io_index = { path = "crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates_io_tarball", features = ["builder"] }
 claims = "=0.7.1"

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -1,3 +1,4 @@
+use cargo_manifest::MaybeInherited;
 use crates_io::views::krate_publish as u;
 use hyper::body::Bytes;
 use std::collections::BTreeMap;
@@ -140,9 +141,9 @@ impl PublishBuilder {
             vers: u::EncodableCrateVersion(self.version.clone()),
             features: self.features,
             deps: self.deps,
-            description: self.desc,
+            description: self.desc.clone(),
             homepage: None,
-            documentation: self.doc_url,
+            documentation: self.doc_url.clone(),
             readme: self.readme,
             readme_file: None,
             keywords: u::EncodableKeywordList(
@@ -154,8 +155,8 @@ impl PublishBuilder {
                     .map(u::EncodableCategory)
                     .collect(),
             ),
-            license: self.license,
-            license_file: self.license_file,
+            license: self.license.clone(),
+            license_file: self.license_file.clone(),
             repository: None,
             links: None,
         };
@@ -165,10 +166,14 @@ impl PublishBuilder {
         match self.manifest {
             Manifest::None => {}
             Manifest::Generated => {
-                let package = cargo_manifest::Package::<()>::new(
+                let mut package = cargo_manifest::Package::<()>::new(
                     self.krate_name.clone(),
                     self.version.to_string(),
                 );
+                package.description = self.desc.map(MaybeInherited::Local);
+                package.documentation = self.doc_url.map(MaybeInherited::Local);
+                package.license = self.license.map(MaybeInherited::Local);
+                package.license_file = self.license_file.map(MaybeInherited::Local);
 
                 let manifest = cargo_manifest::Manifest {
                     package: Some(package),

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -147,10 +147,15 @@ impl PublishBuilder {
             readme: self.readme,
             readme_file: None,
             keywords: u::EncodableKeywordList(
-                self.keywords.into_iter().map(u::EncodableKeyword).collect(),
+                self.keywords
+                    .clone()
+                    .into_iter()
+                    .map(u::EncodableKeyword)
+                    .collect(),
             ),
             categories: u::EncodableCategoryList(
                 self.categories
+                    .clone()
                     .into_iter()
                     .map(u::EncodableCategory)
                     .collect(),
@@ -170,8 +175,10 @@ impl PublishBuilder {
                     self.krate_name.clone(),
                     self.version.to_string(),
                 );
+                package.categories = self.categories.none_or_filled().map(MaybeInherited::Local);
                 package.description = self.desc.map(MaybeInherited::Local);
                 package.documentation = self.doc_url.map(MaybeInherited::Local);
+                package.keywords = self.keywords.none_or_filled().map(MaybeInherited::Local);
                 package.license = self.license.map(MaybeInherited::Local);
                 package.license_file = self.license_file.map(MaybeInherited::Local);
 
@@ -223,5 +230,19 @@ impl PublishBuilder {
         body.extend(tarball);
 
         body
+    }
+}
+
+trait NoneOrFilled {
+    fn none_or_filled(self) -> Option<Self>;
+}
+
+impl<T> NoneOrFilled for Vec<T> {
+    fn none_or_filled(self) -> Option<Self> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self)
+        }
     }
 }

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -165,11 +165,17 @@ impl PublishBuilder {
         match self.manifest {
             Manifest::None => {}
             Manifest::Generated => {
-                let manifest = format!(
-                    "[package]\nname = \"{name}\"\nversion = \"{version}\"\n",
-                    name = self.krate_name,
-                    version = self.version
+                let package = cargo_manifest::Package::<()>::new(
+                    self.krate_name.clone(),
+                    self.version.to_string(),
                 );
+
+                let manifest = cargo_manifest::Manifest {
+                    package: Some(package),
+                    ..Default::default()
+                };
+
+                let manifest = toml::to_string(&manifest).unwrap();
 
                 tarball_builder = tarball_builder.add_raw_manifest(manifest.as_bytes());
             }

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -22,7 +22,7 @@ fn new_krate() {
     assert!(crates[0].deps.is_empty());
     assert_eq!(
         crates[0].cksum,
-        "8a8d84b87f379d5e32566b14df153c0ab0e1ea87dae79a00b891bb41f93dbbf6"
+        "270bbe1624abd766746bf9938b791fadd88e7e0135339510837e11b45e167350"
     );
 
     let expected_files = vec!["crates/foo_new/foo_new-1.0.0.crate", "index/fo/o_/foo_new"];

--- a/src/tests/krate/publish/inheritance.rs
+++ b/src/tests/krate/publish/inheritance.rs
@@ -1,17 +1,15 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
-use crates_io_tarball::TarballBuilder;
 use http::StatusCode;
 
 #[test]
 fn workspace_inheritance() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let tarball = TarballBuilder::new("foo", "1.0.0")
-        .add_raw_manifest(b"[package]\nname = \"foo\"\nversion.workspace = true\n")
-        .build();
-
-    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").tarball(tarball));
+    let response = token.publish_crate(
+        PublishBuilder::new("foo", "1.0.0")
+            .custom_manifest("[package]\nname = \"foo\"\nversion.workspace = true\n"),
+    );
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
@@ -23,13 +21,9 @@ fn workspace_inheritance() {
 fn workspace_inheritance_with_dep() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let tarball = TarballBuilder::new("foo", "1.0.0")
-        .add_raw_manifest(
-            b"[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nserde.workspace = true\n",
-        )
-        .build();
-
-    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").tarball(tarball));
+    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+        "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nserde.workspace = true\n",
+    ));
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -124,14 +124,8 @@ fn version_size() {
     user.publish_crate(crate_to_publish).good();
 
     // Add a file to version 2 so that it's a different size than version 1
-    let files = [
-        (
-            "foo_version_size-2.0.0/Cargo.toml",
-            b"[package]\nname = \"foo_version_size\"\nversion = \"2.0.0\"\n" as &[_],
-        ),
-        ("foo_version_size-2.0.0/big", &[b'a'; 1] as &[_]),
-    ];
-    let crate_to_publish = PublishBuilder::new("foo_version_size", "2.0.0").files(&files);
+    let crate_to_publish = PublishBuilder::new("foo_version_size", "2.0.0")
+        .add_file("foo_version_size-2.0.0/big", "a");
     user.publish_crate(crate_to_publish).good();
 
     let crate_json = user.show_crate("foo_version_size");

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -137,7 +137,7 @@ fn version_size() {
         .iter()
         .find(|v| v.num == "1.0.0")
         .expect("Could not find v1.0.0");
-    assert_eq!(version1.crate_size, Some(134));
+    assert_eq!(version1.crate_size, Some(158));
 
     let version2 = crate_json
         .versions
@@ -146,7 +146,7 @@ fn version_size() {
         .iter()
         .find(|v| v.num == "2.0.0")
         .expect("Could not find v2.0.0");
-    assert_eq!(version2.crate_size, Some(159));
+    assert_eq!(version2.crate_size, Some(184));
 }
 
 #[test]

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -34,13 +34,13 @@ pub struct EncodableCrateUpload {
     pub links: Option<String>,
 }
 
-#[derive(PartialEq, Eq, Hash, Serialize, Debug, Deref)]
+#[derive(PartialEq, Eq, Hash, Serialize, Clone, Debug, Deref)]
 pub struct EncodableCrateName(pub String);
-#[derive(Serialize, Debug, Deref)]
+#[derive(Serialize, Clone, Debug, Deref)]
 pub struct EncodableDependencyName(pub String);
 #[derive(Serialize, Debug, Deref)]
 pub struct EncodableCrateVersion(pub semver::Version);
-#[derive(Serialize, Debug, Deref)]
+#[derive(Serialize, Clone, Debug, Deref)]
 pub struct EncodableCrateVersionReq(pub String);
 #[derive(Serialize, Debug, Deref, Default)]
 pub struct EncodableKeywordList(pub Vec<EncodableKeyword>);
@@ -55,7 +55,7 @@ pub struct EncodableFeature(pub String);
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Clone, Debug, Deref)]
 pub struct EncodableFeatureName(pub String);
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct EncodableCrateDependency {
     pub optional: bool,
     pub default_features: bool,

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -50,9 +50,9 @@ pub struct EncodableKeyword(pub String);
 pub struct EncodableCategoryList(pub Vec<EncodableCategory>);
 #[derive(Serialize, Deserialize, Debug, Deref)]
 pub struct EncodableCategory(pub String);
-#[derive(Serialize, Debug, Deref)]
+#[derive(Serialize, Clone, Debug, Deref)]
 pub struct EncodableFeature(pub String);
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Debug, Deref)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Clone, Debug, Deref)]
 pub struct EncodableFeatureName(pub String);
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Up until now our `PublishBuilder` only generated a very basic manifest with `name` and `version` fields by default, even if e.g. dependencies or features were added to the builder. This led to inconsistencies between the JSON metadata and the content of the `Cargo.toml` file in the generated tarball.

This PR fixes the issue by moving the manifest and tarball generation into the `build()` method and extending it to generate the necessary data in the `Cargo.toml` file using `cargo_manifest`.

Note that the `tarball()` and `files()` methods of the `PublishBuilder` had to be replaced for this to work properly. `tarball()` is replaced by direct usage of `PublishBuilder::create_publish_body()`. `files()` is replaced by `add_file()`. Additionally `custom_manifest()` and `no_manifest()` have been added to be able to influence the manifest generation for certain test cases.

This PR is a prerequisite for reading more data from the `Cargo.toml` file during publishes instead of the metadata JSON blob.