### PR TITLE
Only upgrade deps once a week

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,7 @@
 {
+    schedule: [
+        'before 5am on Monday',
+    ],
     "extends": [
         "config:base",
         ":pinAllExceptPeerDependencies",


### PR DESCRIPTION
We have too many robot pull requests. Sometimes we will bump the same package a couple of times in a short period of time. So I guess maybe we can batch it. Only update the dep once a week. This would help us to save some CI and review resources.

@Turbo87 What do you think? Feel free to close the PR if you think it doesn't matter 🤣 