### PR TITLE
tests/builders/publish: Simplify `create_publish_body()` fn by using `BytesMut` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "axum-extra",
  "base64 0.21.4",
  "bigdecimal",
+ "bytes",
  "cargo-manifest",
  "chrono",
  "claims",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }
 url = "=2.4.1"
 
 [dev-dependencies]
+bytes = "=1.5.0"
 cargo-manifest = "=0.11.1"
 crates_io_index = { path = "crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates_io_tarball", features = ["builder"] }


### PR DESCRIPTION
Hidden in that diff is also a small performance improvement by using `with_capacity()` and calculating the correct length upfront.