### PR TITLE
tarball/builder: Remove `prefix` field and associated constructor arguments

### DIFF
--- a/crates_io_tarball/src/builder.rs
+++ b/crates_io_tarball/src/builder.rs
@@ -3,15 +3,14 @@ use flate2::Compression;
 use std::io::Read;
 
 pub struct TarballBuilder {
-    prefix: String,
     inner: tar::Builder<Vec<u8>>,
 }
 
 impl TarballBuilder {
-    pub fn new(name: &str, version: &str) -> Self {
-        let prefix = format!("{name}-{version}");
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
         let inner = tar::Builder::new(vec![]);
-        Self { prefix, inner }
+        Self { inner }
     }
 
     pub fn add_file(mut self, path: &str, content: &[u8]) -> Self {

--- a/crates_io_tarball/src/builder.rs
+++ b/crates_io_tarball/src/builder.rs
@@ -14,11 +14,6 @@ impl TarballBuilder {
         Self { prefix, inner }
     }
 
-    pub fn add_raw_manifest(self, content: &[u8]) -> Self {
-        let path = format!("{}/Cargo.toml", self.prefix);
-        self.add_file(&path, content)
-    }
-
     pub fn add_file(mut self, path: &str, content: &[u8]) -> Self {
         let mut header = tar::Header::new_gnu();
         header.set_size(content.len() as u64);

--- a/crates_io_tarball/src/lib.rs
+++ b/crates_io_tarball/src/lib.rs
@@ -150,7 +150,10 @@ mod tests {
     #[test]
     fn process_tarball_test() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n")
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
+                b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n",
+            )
             .build();
 
         let limit = 512 * 1024 * 1024;
@@ -164,7 +167,10 @@ mod tests {
     #[test]
     fn process_tarball_test_incomplete_vcs_info() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n")
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
+                b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n",
+            )
             .add_file("foo-0.0.1/.cargo_vcs_info.json", br#"{"unknown": "field"}"#)
             .build();
 
@@ -178,7 +184,10 @@ mod tests {
     #[test]
     fn process_tarball_test_vcs_info() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n")
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
+                b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n",
+            )
             .add_file(
                 "foo-0.0.1/.cargo_vcs_info.json",
                 br#"{"path_in_vcs": "path/in/vcs"}"#,
@@ -195,7 +204,8 @@ mod tests {
     #[test]
     fn process_tarball_test_manifest() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
 [package]
 name = "foo"
@@ -219,7 +229,8 @@ repository = "https://github.com/foo/bar"
     #[test]
     fn process_tarball_test_manifest_with_project() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
                 [project]
                 name = "foo"
@@ -239,7 +250,8 @@ repository = "https://github.com/foo/bar"
     #[test]
     fn process_tarball_test_manifest_with_default_readme() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
                 [package]
                 name = "foo"
@@ -258,7 +270,8 @@ repository = "https://github.com/foo/bar"
     #[test]
     fn process_tarball_test_manifest_with_boolean_readme() {
         let tarball = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
                 [package]
                 name = "foo"

--- a/crates_io_tarball/src/lib.rs
+++ b/crates_io_tarball/src/lib.rs
@@ -149,7 +149,7 @@ mod tests {
 
     #[test]
     fn process_tarball_test() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n",
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn process_tarball_test_incomplete_vcs_info() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n",
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn process_tarball_test_vcs_info() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n",
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn process_tarball_test_manifest() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -228,7 +228,7 @@ repository = "https://github.com/foo/bar"
 
     #[test]
     fn process_tarball_test_manifest_with_project() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -249,7 +249,7 @@ repository = "https://github.com/foo/bar"
 
     #[test]
     fn process_tarball_test_manifest_with_default_readme() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -269,7 +269,7 @@ repository = "https://github.com/foo/bar"
 
     #[test]
     fn process_tarball_test_manifest_with_boolean_readme() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -290,7 +290,7 @@ repository = "https://github.com/foo/bar"
 
     #[test]
     fn process_tarball_test_lowercase_manifest() {
-        let tarball = TarballBuilder::new("foo", "0.0.1")
+        let tarball = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/cargo.toml",
                 br#"
@@ -312,7 +312,7 @@ repository = "https://github.com/foo/bar"
     #[test]
     fn process_tarball_test_incorrect_manifest_casing() {
         for file in ["CARGO.TOML", "Cargo.Toml"] {
-            let tarball = TarballBuilder::new("foo", "0.0.1")
+            let tarball = TarballBuilder::new()
                 .add_file(
                     &format!("foo-0.0.1/{file}"),
                     br#"
@@ -344,7 +344,7 @@ repository = "https://github.com/foo/bar"
         ] {
             let tarball = files
                 .iter()
-                .fold(TarballBuilder::new("foo", "0.0.1"), |builder, file| {
+                .fold(TarballBuilder::new(), |builder, file| {
                     builder.add_file(
                         &format!("foo-0.0.1/{file}"),
                         br#"

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -245,7 +245,7 @@ pub mod tests {
 
     #[test]
     fn test_render_pkg_readme() {
-        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+        let serialized_archive = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -265,7 +265,7 @@ readme = "README.md"
 
     #[test]
     fn test_render_pkg_no_readme() {
-        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+        let serialized_archive = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -282,7 +282,7 @@ readme = "README.md"
 
     #[test]
     fn test_render_pkg_implicit_readme() {
-        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+        let serialized_archive = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -301,7 +301,7 @@ version = "0.0.1"
 
     #[test]
     fn test_render_pkg_readme_w_link() {
-        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+        let serialized_archive = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"
@@ -322,7 +322,7 @@ repository = "https://github.com/foo/foo"
 
     #[test]
     fn test_render_pkg_readme_not_at_root() {
-        let serialized_archive = TarballBuilder::new("foo", "0.0.1")
+        let serialized_archive = TarballBuilder::new()
             .add_file(
                 "foo-0.0.1/Cargo.toml",
                 br#"

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -246,7 +246,8 @@ pub mod tests {
     #[test]
     fn test_render_pkg_readme() {
         let serialized_archive = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
 [package]
 name = "foo"
@@ -265,7 +266,8 @@ readme = "README.md"
     #[test]
     fn test_render_pkg_no_readme() {
         let serialized_archive = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
 [package]
 "#,
@@ -281,7 +283,8 @@ readme = "README.md"
     #[test]
     fn test_render_pkg_implicit_readme() {
         let serialized_archive = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
 [package]
 name = "foo"
@@ -299,7 +302,8 @@ version = "0.0.1"
     #[test]
     fn test_render_pkg_readme_w_link() {
         let serialized_archive = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
 [package]
 name = "foo"
@@ -319,7 +323,8 @@ repository = "https://github.com/foo/foo"
     #[test]
     fn test_render_pkg_readme_not_at_root() {
         let serialized_archive = TarballBuilder::new("foo", "0.0.1")
-            .add_raw_manifest(
+            .add_file(
+                "foo-0.0.1/Cargo.toml",
                 br#"
 [package]
 name = "foo"

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -167,7 +167,7 @@ impl PublishBuilder {
             links: None,
         };
 
-        let mut tarball_builder = TarballBuilder::new(&self.krate_name, &self.version.to_string());
+        let mut tarball_builder = TarballBuilder::new();
 
         match self.manifest {
             Manifest::None => {}

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -207,10 +207,14 @@ impl PublishBuilder {
 
                 let manifest = toml::to_string(&manifest).unwrap();
 
-                tarball_builder = tarball_builder.add_raw_manifest(manifest.as_bytes());
+                let content = manifest.as_bytes();
+
+                let path = format!("{}-{}/Cargo.toml", self.krate_name, self.version);
+                tarball_builder = tarball_builder.add_file(&path, content);
             }
             Manifest::Custom(bytes) => {
-                tarball_builder = tarball_builder.add_raw_manifest(&bytes);
+                let path = format!("{}-{}/Cargo.toml", self.krate_name, self.version);
+                tarball_builder = tarball_builder.add_file(&path, &bytes);
             }
         }
 

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -18,7 +18,7 @@ fn tarball_between_default_axum_limit_and_max_upload_size() {
         .with_token();
 
     let tarball = {
-        let mut builder = TarballBuilder::new("foo", "1.1.0");
+        let mut builder = TarballBuilder::new();
 
         let data = b"[package]\nname = \"foo\"\nversion = \"1.1.0\"\n" as &[_];
 
@@ -68,7 +68,7 @@ fn tarball_bigger_than_max_upload_size() {
         // `data` is bigger than `max_upload_size`
         let data = &[b'a'; 6 * 1024 * 1024] as &[_];
 
-        let mut builder = TarballBuilder::new("foo", "1.1.0");
+        let mut builder = TarballBuilder::new();
 
         let mut header = tar::Header::new_gnu();
         assert_ok!(header.set_path("foo-1.1.0/Cargo.toml"));

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -27,7 +27,7 @@ fn new_krate_tarball_with_hard_links() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let tarball = {
-        let mut builder = TarballBuilder::new("foo", "1.1.0");
+        let mut builder = TarballBuilder::new();
 
         let mut header = tar::Header::new_gnu();
         assert_ok!(header.set_path("foo-1.1.0/bar"));


### PR DESCRIPTION
This was a cute idea, but not really worth it in the end...