### PR TITLE
tests/utils/ajax: Add assertion description

### DIFF
--- a/tests/utils/ajax-test.js
+++ b/tests/utils/ajax-test.js
@@ -113,7 +113,7 @@ module('ajax()', function (hooks) {
       let { cause } = error;
       assert.notOk(cause instanceof HttpError);
       assert.strictEqual(cause.name, 'SyntaxError');
-      assert.ok(expectedCauseMessages.includes(cause.message));
+      assert.ok(expectedCauseMessages.includes(cause.message), `"${cause.message}" is an expected error message`);
       return true;
     });
   });


### PR DESCRIPTION
This should help when debugging why this assertion is not working correctly on CI or locally...

e.g. for some reason it currently fails on https://github.com/rust-lang/crates.io/pull/7149, but appears to work fine on this PR 🤷‍♂️ 