### PR TITLE
tests: Increase default upload size limits

### DIFF
--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -96,7 +96,12 @@ fn tarball_bigger_than_max_upload_size() {
 
 #[test]
 fn new_krate_gzip_bomb() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full()
+        .with_config(|config| {
+            config.max_upload_size = 3000;
+            config.max_unpack_size = 2000;
+        })
+        .with_token();
 
     let len = 512 * 1024;
     let mut body = Vec::new();
@@ -116,7 +121,12 @@ fn new_krate_gzip_bomb() {
 
 #[test]
 fn new_krate_too_big() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full()
+        .with_config(|config| {
+            config.max_upload_size = 3000;
+            config.max_unpack_size = 2000;
+        })
+        .with_user();
 
     let builder = PublishBuilder::new("foo_big", "1.0.0")
         .add_file("foo_big-1.0.0/big", &[b'a'; 2000] as &[_]);

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -390,8 +390,8 @@ fn simple_config() -> config::Server {
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: ClientId::new(dotenvy::var("GH_CLIENT_ID").unwrap_or_default()),
         gh_client_secret: ClientSecret::new(dotenvy::var("GH_CLIENT_SECRET").unwrap_or_default()),
-        max_upload_size: 3000,
-        max_unpack_size: 2000,
+        max_upload_size: 128 * 1024, // 128 kB should be enough for most testing purposes
+        max_unpack_size: 128 * 1024, // 128 kB should be enough for most testing purposes
         rate_limiter: Default::default(),
         new_version_rate_limit: Some(10),
         blocked_traffic: Default::default(),


### PR DESCRIPTION
A tarball with three empty files and a valid manifest shouldn't immediately hit those limits, so let's increase them a little bit...