### PR TITLE
Unify `assert_eq!()` argument order

### DIFF
--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -342,7 +342,7 @@ mod tests {
         let pagination = PaginationOptions::builder()
             .gather(&mock("per_page=5"))
             .unwrap();
-        assert_eq!(5, pagination.per_page);
+        assert_eq!(pagination.per_page, 5);
     }
 
     #[test]
@@ -359,7 +359,7 @@ mod tests {
             .unwrap();
 
         if let Page::Seek(raw) = pagination.page {
-            assert_eq!(98, raw.decode::<i32>().unwrap());
+            assert_ok_eq!(raw.decode::<i32>(), 98);
         } else {
             panic!(
                 "did not parse a seek page, parsed {:?} instead",
@@ -394,14 +394,14 @@ mod tests {
     #[test]
     fn test_seek_encode_and_decode() {
         // Encoding produces the results we expect
-        assert_eq!("OTg", encode_seek(98).unwrap());
-        assert_eq!("WyJmb28iLDQyXQ", encode_seek(("foo", 42)).unwrap());
+        assert_ok_eq!(encode_seek(98), "OTg");
+        assert_ok_eq!(encode_seek(("foo", 42)), "WyJmb28iLDQyXQ");
 
         // Encoded values can be then decoded.
-        assert_eq!(98, decode_seek::<i32>(&encode_seek(98).unwrap()).unwrap(),);
-        assert_eq!(
+        assert_ok_eq!(decode_seek::<i32>(&encode_seek(98).unwrap()), 98);
+        assert_ok_eq!(
+            decode_seek::<(String, i32)>(&encode_seek(("foo", 42)).unwrap()),
             ("foo".into(), 42),
-            decode_seek::<(String, i32)>(&encode_seek(("foo", 42)).unwrap()).unwrap(),
         );
     }
 
@@ -418,6 +418,6 @@ mod tests {
         assert_eq!(error.to_string(), message);
 
         let response = error.response();
-        assert_eq!(StatusCode::BAD_REQUEST, response.status());
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -267,7 +267,7 @@ mod tests {
         for _ in 0..5 {
             counter.increment(v2);
         }
-        assert_eq!(15, counter.pending_count.load(Ordering::SeqCst));
+        assert_eq!(counter.pending_count.load(Ordering::SeqCst), 15);
 
         // Persist everything to the database
         let stats = counter
@@ -314,7 +314,7 @@ mod tests {
         for _ in 0..5 {
             counter.increment(v2);
         }
-        assert_eq!(15, counter.pending_count.load(Ordering::SeqCst));
+        assert_eq!(counter.pending_count.load(Ordering::SeqCst), 15);
 
         // Persist one shard at the time and ensure the stats returned for each shard are expected.
         let mut pending = 15;

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -539,8 +539,8 @@ mod tests {
         let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
         let other_bucket = rate.take_token(other_user_id, LimitedAction::PublishNew, now, conn)?;
 
-        assert_eq!(20, bucket.tokens);
-        assert_eq!(10, other_bucket.tokens);
+        assert_eq!(bucket.tokens, 20);
+        assert_eq!(other_bucket.tokens, 10);
         Ok(())
     }
 
@@ -570,8 +570,8 @@ mod tests {
         let bucket = rate.take_token(user_id, LimitedAction::PublishNew, now, conn)?;
         let other_bucket = rate.take_token(other_user_id, LimitedAction::PublishNew, now, conn)?;
 
-        assert_eq!(20, bucket.tokens);
-        assert_eq!(10, other_bucket.tokens);
+        assert_eq!(bucket.tokens, 20);
+        assert_eq!(other_bucket.tokens, 10);
 
         // Manually expire the rate limit
         diesel::update(publish_rate_overrides::table)
@@ -585,8 +585,8 @@ mod tests {
         // The number of tokens of user_id is 10 and not 9 because when the new burst limit is
         // lower than the amount of available tokens, the number of available tokens is reset to
         // the new burst limit.
-        assert_eq!(10, bucket.tokens);
-        assert_eq!(9, other_bucket.tokens);
+        assert_eq!(bucket.tokens, 10);
+        assert_eq!(other_bucket.tokens, 9);
 
         Ok(())
     }

--- a/src/swirl/runner.rs
+++ b/src/swirl/runner.rs
@@ -335,7 +335,7 @@ mod tests {
         let remaining_jobs = background_jobs
             .count()
             .get_result(&mut *runner.connection().unwrap());
-        assert_eq!(Ok(0), remaining_jobs);
+        assert_eq!(remaining_jobs, Ok(0));
     }
 
     #[test]
@@ -369,7 +369,7 @@ mod tests {
             .for_update()
             .load::<i64>(conn)
             .unwrap();
-        assert_eq!(0, available_jobs.len());
+        assert_eq!(available_jobs.len(), 0);
 
         // Sanity check to make sure the job actually is there
         let total_jobs_including_failed = background_jobs
@@ -377,7 +377,7 @@ mod tests {
             .for_update()
             .load::<i64>(conn)
             .unwrap();
-        assert_eq!(1, total_jobs_including_failed.len());
+        assert_eq!(total_jobs_including_failed.len(), 1);
 
         runner.wait_for_jobs().unwrap();
     }
@@ -397,7 +397,7 @@ mod tests {
             .for_update()
             .first::<i32>(&mut *runner.connection().unwrap())
             .unwrap();
-        assert_eq!(1, tries);
+        assert_eq!(tries, 1);
     }
 
     // Since these tests deal with behavior concerning multiple connections

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -17,7 +17,7 @@ fn test_non_blocked_download_route() {
     });
 
     let status = anon.get::<()>("/api/v1/crates/foo/1.0.0/download").status();
-    assert_eq!(StatusCode::FOUND, status);
+    assert_eq!(status, StatusCode::FOUND);
 }
 
 #[test]
@@ -38,5 +38,5 @@ fn test_blocked_download_route() {
     });
 
     let status = anon.get::<()>("/api/v1/crates/foo/1.0.0/download").status();
-    assert_eq!(StatusCode::SERVICE_UNAVAILABLE, status);
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -22,7 +22,7 @@ fn github_secret_alert_revokes_token() {
     let (app, anon, user, token) = TestApp::init().with_token();
 
     // Ensure no emails were sent up to this point
-    assert_eq!(0, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Ensure that the token currently exists in the database
     app.db(|conn| {
@@ -75,7 +75,7 @@ fn github_secret_alert_revokes_token() {
     });
 
     // Ensure exactly one email was sent
-    assert_eq!(1, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn github_secret_alert_for_revoked_token() {
     let (app, anon, user, token) = TestApp::init().with_token();
 
     // Ensure no emails were sent up to this point
-    assert_eq!(0, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Ensure that the token currently exists in the database
     app.db(|conn| {
@@ -139,7 +139,7 @@ fn github_secret_alert_for_revoked_token() {
     });
 
     // Ensure still no emails were sent
-    assert_eq!(0, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 }
 
 #[test]
@@ -147,7 +147,7 @@ fn github_secret_alert_for_unknown_token() {
     let (app, anon, user, token) = TestApp::init().with_token();
 
     // Ensure no emails were sent up to this point
-    assert_eq!(0, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Ensure that the token currently exists in the database
     app.db(|conn| {
@@ -187,7 +187,7 @@ fn github_secret_alert_for_unknown_token() {
     });
 
     // Ensure still no emails were sent
-    assert_eq!(0, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 }
 
 #[test]

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -423,7 +423,7 @@ fn invite_already_invited_user() {
     app.db(|conn| CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(conn));
 
     // Ensure no emails were sent up to this point
-    assert_eq!(0, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Invite the user the first time
     let response = owner.add_named_owner("crate_name", "invited_user");
@@ -437,7 +437,7 @@ fn invite_already_invited_user() {
     );
 
     // Check one email was sent, this will be the ownership invite email
-    assert_eq!(1, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
 
     // Then invite the user a second time, the message should point out the user is already invited
     let response = owner.add_named_owner("crate_name", "invited_user");
@@ -451,7 +451,7 @@ fn invite_already_invited_user() {
     );
 
     // Check that no new email is sent after the second invitation
-    assert_eq!(1, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
 }
 
 #[test]
@@ -462,7 +462,7 @@ fn invite_with_existing_expired_invite() {
         app.db(|conn| CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(conn));
 
     // Ensure no emails were sent up to this point
-    assert_eq!(0, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Invite the user the first time
     let response = owner.add_named_owner("crate_name", "invited_user");
@@ -476,7 +476,7 @@ fn invite_with_existing_expired_invite() {
     );
 
     // Check one email was sent, this will be the ownership invite email
-    assert_eq!(1, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
 
     // Simulate the previous invite expiring
     expire_invitation(&app, krate.id);
@@ -493,7 +493,7 @@ fn invite_with_existing_expired_invite() {
     );
 
     // Check that the email for the second invite was sent
-    assert_eq!(2, app.as_inner().emails.mails_in_memory().unwrap().len());
+    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 2);
 }
 
 /// Testing the crate ownership between two crates and one team.
@@ -770,8 +770,9 @@ fn test_accept_expired_invitation() {
 
     // New owner tries to accept the invitation but it fails
     let resp = invited_user.try_accept_ownership_invitation::<()>(&krate.name, krate.id);
-    assert_eq!(StatusCode::GONE, resp.status());
+    assert_eq!(resp.status(), StatusCode::GONE);
     assert_eq!(
+        resp.into_json(),
         json!({
             "errors": [
                 {
@@ -779,8 +780,7 @@ fn test_accept_expired_invitation() {
                                Please reach out to an owner of the crate to request a new invitation.",
                 }
             ]
-        }),
-        resp.into_json()
+        })
     );
 
     // Invited user is NOT listed as an owner, so the crate still only has one owner
@@ -827,8 +827,9 @@ fn test_accept_expired_invitation_by_mail() {
 
     // Try to accept the invitation, and ensure it fails.
     let resp = anon.try_accept_ownership_invitation_by_token::<()>(&invite_token);
-    assert_eq!(StatusCode::GONE, resp.status());
+    assert_eq!(resp.status(), StatusCode::GONE);
     assert_eq!(
+        resp.into_json(),
         json!({
             "errors": [
                 {
@@ -836,8 +837,7 @@ fn test_accept_expired_invitation_by_mail() {
                                Please reach out to an owner of the crate to request a new invitation.",
                 }
             ]
-        }),
-        resp.into_json()
+        })
     );
 
     // Invited user is NOT listed as an owner, so the crate still only has one owner

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -54,7 +54,7 @@ fn can_download_crate_in_read_only_mode() {
 
         let dl_count: Result<Option<i64>, _> =
             version_downloads.select(sum(downloads)).get_result(conn);
-        assert_eq!(Ok(None), dl_count);
+        assert_ok_eq!(dl_count, None);
     })
 }
 

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -751,17 +751,17 @@ fn seek_based_pagination() {
         );
 
         if let Some(new_url) = resp.meta.next_page {
-            assert_eq!(1, resp.crates.len());
+            assert_eq!(resp.crates.len(), 1);
             url = Some(new_url);
         } else {
             assert!(resp.crates.is_empty());
         }
 
-        assert_eq!(None, resp.meta.prev_page);
-        assert_eq!(3, resp.meta.total);
+        assert_eq!(resp.meta.prev_page, None);
+        assert_eq!(resp.meta.total, 3);
     }
 
-    assert_eq!(4, calls);
+    assert_eq!(calls, 4);
     assert_eq!(
         vec![
             "pagination_links_1",

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -59,8 +59,8 @@ fn show() {
         versions[0].dl_path
     );
     let keywords = json.keywords.as_ref().unwrap();
-    assert_eq!(1, keywords.len());
-    assert_eq!("kw1", keywords[0].id);
+    assert_eq!(keywords.len(), 1);
+    assert_eq!(keywords[0].id, "kw1");
 
     assert_eq!(versions[1].num, "0.5.1");
     assert_eq!(versions[2].num, "0.5.0");

--- a/src/tests/routes/metrics.rs
+++ b/src/tests/routes/metrics.rs
@@ -9,13 +9,13 @@ fn metrics_endpoint_works() {
         .empty();
 
     let resp = request_metrics(&anon, "service", Some("foobar"));
-    assert_eq!(StatusCode::OK, resp.status());
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let resp = request_metrics(&anon, "instance", Some("foobar"));
-    assert_eq!(StatusCode::OK, resp.status());
+    assert_eq!(resp.status(), StatusCode::OK);
 
     let resp = request_metrics(&anon, "missing", Some("foobar"));
-    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 #[test]
@@ -27,24 +27,24 @@ fn metrics_endpoint_wrong_auth() {
     // Wrong secret
 
     let resp = request_metrics(&anon, "service", Some("foobar"));
-    assert_eq!(StatusCode::FORBIDDEN, resp.status());
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     let resp = request_metrics(&anon, "instance", Some("foobar"));
-    assert_eq!(StatusCode::FORBIDDEN, resp.status());
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     let resp = request_metrics(&anon, "missing", Some("foobar"));
-    assert_eq!(StatusCode::FORBIDDEN, resp.status());
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     // No secret
 
     let resp = request_metrics(&anon, "service", None);
-    assert_eq!(StatusCode::FORBIDDEN, resp.status());
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     let resp = request_metrics(&anon, "instance", None);
-    assert_eq!(StatusCode::FORBIDDEN, resp.status());
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     let resp = request_metrics(&anon, "missing", None);
-    assert_eq!(StatusCode::FORBIDDEN, resp.status());
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 #[test]
@@ -56,24 +56,24 @@ fn metrics_endpoint_auth_disabled() {
     // Wrong secret
 
     let resp = request_metrics(&anon, "service", Some("foobar"));
-    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     let resp = request_metrics(&anon, "instance", Some("foobar"));
-    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     let resp = request_metrics(&anon, "missing", Some("foobar"));
-    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     // No secret
 
     let resp = request_metrics(&anon, "service", None);
-    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     let resp = request_metrics(&anon, "instance", None);
-    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     let resp = request_metrics(&anon, "missing", None);
-    assert_eq!(StatusCode::NOT_FOUND, resp.status());
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
 fn request_metrics(anon: &MockAnonymousUser, kind: &str, token: Option<&str>) -> Response<()> {

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -13,11 +13,11 @@ fn show() {
     app.db_new_user("Bar");
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").good();
-    assert_eq!("foo", json.user.login);
+    assert_eq!(json.user.login, "foo");
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/bAr").good();
-    assert_eq!("Bar", json.user.login);
-    assert_eq!(Some("https://github.com/Bar".into()), json.user.url);
+    assert_eq!(json.user.login, "Bar");
+    assert_eq!(json.user.url, Some("https://github.com/Bar".into()));
 }
 
 #[test]

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -34,8 +34,8 @@ fn updating_existing_user_doesnt_change_api_token() {
         assert_ok!(User::find_by_api_token(conn, token.expose_secret()))
     });
 
-    assert_eq!("bar", user.gh_login);
-    assert_eq!("bar_token", user.gh_access_token);
+    assert_eq!(user.gh_login, "bar");
+    assert_eq!(user.gh_access_token, "bar_token");
 }
 
 /// Given a GitHub user, check that if the user logs in,

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -86,13 +86,13 @@ impl Response<()> {
     /// Assert that the status code is 404
     #[track_caller]
     pub fn assert_not_found(&self) {
-        assert_eq!(StatusCode::NOT_FOUND, self.status());
+        assert_eq!(self.status(), StatusCode::NOT_FOUND);
     }
 
     /// Assert that the status code is 403
     #[track_caller]
     pub fn assert_forbidden(&self) {
-        assert_eq!(StatusCode::FORBIDDEN, self.status());
+        assert_eq!(self.status(), StatusCode::FORBIDDEN);
     }
 }
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -73,11 +73,11 @@ impl<T> Response<T> {
             detail: String,
         }
 
-        assert_eq!(StatusCode::TOO_MANY_REQUESTS, self.status());
+        assert_eq!(self.status(), StatusCode::TOO_MANY_REQUESTS);
 
         let expected_message_start = format!("{}. Please try again after ", action.error_message());
         let error: ErrorResponse = json(self.response);
-        assert_eq!(1, error.errors.len());
+        assert_eq!(error.errors.len(), 1);
         assert!(error.errors[0].detail.starts_with(&expected_message_start));
     }
 }

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -142,18 +142,18 @@ mod test {
             .find(version.id)
             .select(versions::downloads)
             .first(conn);
-        assert_eq!(Ok(1), version_downloads);
+        assert_eq!(version_downloads, Ok(1));
         let crate_downloads = crates::table
             .find(krate.id)
             .select(crates::downloads)
             .first(conn);
-        assert_eq!(Ok(1), crate_downloads);
+        assert_eq!(crate_downloads, Ok(1));
         super::update(conn).unwrap();
         let version_downloads = versions::table
             .find(version.id)
             .select(versions::downloads)
             .first(conn);
-        assert_eq!(Ok(1), version_downloads);
+        assert_eq!(version_downloads, Ok(1));
     }
 
     #[test]
@@ -178,7 +178,7 @@ mod test {
             .filter(version_downloads::version_id.eq(version.id))
             .select(version_downloads::processed)
             .first(conn);
-        assert_eq!(Ok(true), processed);
+        assert_eq!(processed, Ok(true));
     }
 
     #[test]
@@ -202,7 +202,7 @@ mod test {
             .filter(version_downloads::version_id.eq(version.id))
             .select(version_downloads::processed)
             .first(conn);
-        assert_eq!(Ok(false), processed);
+        assert_eq!(processed, Ok(false));
     }
 
     #[test]
@@ -293,7 +293,7 @@ mod test {
         let crates_changed = crates::table
             .select(crates::updated_at.ne(now - 2.days()))
             .get_result(conn);
-        assert_eq!(Ok(false), versions_changed);
-        assert_eq!(Ok(false), crates_changed);
+        assert_eq!(versions_changed, Ok(false));
+        assert_eq!(crates_changed, Ok(false));
     }
 }


### PR DESCRIPTION
The majority of assertions in this project use `actual, expected` ordering. This changes the ones with `expected, actual` ordering to use the other one.

This makes it more consistent when trying to understand what `left` and `right` mean in the test suite output.

The `claims` assertion library that we use also assumes `actual, expected` ordering.