### PR TITLE
EncodableCrateUpload: Rename struct to `PublishMetadata`

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -137,7 +137,7 @@ impl PublishBuilder {
     }
 
     pub fn build(self) -> (String, Vec<u8>) {
-        let new_crate = u::EncodableCrateUpload {
+        let metadata = u::PublishMetadata {
             name: u::EncodableCrateName(self.krate_name.clone()),
             vers: u::EncodableCrateVersion(self.version.clone()),
             features: self.features.clone(),
@@ -223,7 +223,7 @@ impl PublishBuilder {
         }
 
         let tarball = tarball_builder.build();
-        (serde_json::to_string(&new_crate).unwrap(), tarball)
+        (serde_json::to_string(&metadata).unwrap(), tarball)
     }
 
     /// Consume this builder to make the Put request body

--- a/src/views.rs
+++ b/src/views.rs
@@ -11,7 +11,7 @@ use crate::models::{
 use crate::util::rfc3339;
 
 pub mod krate_publish;
-pub use self::krate_publish::{EncodableCrateDependency, EncodableCrateUpload};
+pub use self::krate_publish::{EncodableCrateDependency, PublishMetadata};
 
 /// Hosts in this list are known to not be hosting documentation,
 /// and are possibly of malicious intent e.g. ad tracking networks, etc.

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -13,7 +13,7 @@ use crate::models::DependencyKind;
 use crate::models::Keyword as CrateKeyword;
 
 #[derive(Deserialize, Serialize, Debug)]
-pub struct EncodableCrateUpload {
+pub struct PublishMetadata {
     pub name: EncodableCrateName,
     pub vers: EncodableCrateVersion,
     pub deps: Vec<EncodableCrateDependency>,


### PR DESCRIPTION
... and the corresponding variables to `metadata`.

It feels to me like this is a more straight-forward and easier to understand name compared to `EncodableCrateUpload` and `new_crate`, especially because we also have a `NewCrate` struct that was not at all related to the `new_crate` variable 😅 
