### PR TITLE
tests/utils/ajax: Adjust error message assertion for new Chrome release

### DIFF
--- a/tests/utils/ajax-test.js
+++ b/tests/utils/ajax-test.js
@@ -106,8 +106,10 @@ module('ajax()', function (hooks) {
       let expectedCauseMessages = [
         // Chrome < 104
         'Unexpected token f in JSON at position 2',
-        // Chrome >= 104
+        // Chrome 104 – 117
         "Expected property name or '}' in JSON at position 2",
+        // Chrome >= 117
+        "Expected property name or '}' in JSON at position 2 (line 1 column 3)",
       ];
 
       let { cause } = error;


### PR DESCRIPTION
The Chrome browser version on GitHub Actions apparently got bumped lately, which was causing issues with our test suite. One of our tests is asserting against a specific network error message and that message was updated to include more information than before. This PR fixes the issue by making the test compatible with the new Chrome version.

