### PR TITLE
controllers/token: Order by `id` instead of `created_at`

### DIFF
--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -56,7 +56,7 @@ pub async fn list(
                         .bind::<Interval, _>(params.expired_days_interval())
                         .sql(")"))),
             )
-            .order(api_tokens::created_at.desc())
+            .order(api_tokens::id.desc())
             .load(conn)?;
 
         Ok(Json(json!({ "api_tokens": tokens })))

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
@@ -5,15 +5,6 @@ expression: response.into_json()
 {
   "api_tokens": [
     {
-      "crate_scopes": null,
-      "created_at": "[datetime]",
-      "endpoint_scopes": null,
-      "expired_at": null,
-      "id": "[id]",
-      "last_used_at": "[datetime]",
-      "name": "bar"
-    },
-    {
       "crate_scopes": [
         "serde",
         "serde-*"
@@ -26,6 +17,15 @@ expression: response.into_json()
       "id": "[id]",
       "last_used_at": "[datetime]",
       "name": "baz"
+    },
+    {
+      "crate_scopes": null,
+      "created_at": "[datetime]",
+      "endpoint_scopes": null,
+      "expired_at": null,
+      "id": "[id]",
+      "last_used_at": "[datetime]",
+      "name": "bar"
     }
   ]
 }


### PR DESCRIPTION
In a real world scenario this should not make a huge difference, since `id` is a monotonically increasing counter, so the order should be the same as with `created_at`. We do have the unique `id` index though, which might be used by the database to speed up the query.

The main reason for this change is to ensure a stable sort order for our test suite. The `list_tokens()` test case has been a bit flaky lately (see https://github.com/rust-lang/crates.io/actions/runs/6305682314/job/17119535543?pr=7178) because the `created_at` column for all tokens is the same during a test, due to each test running within a Postgres transaction. The `id` however won't be the same, so we can achieve a stable sort order that way.