### PR TITLE
controllers/krate/publish: Remove unnecessary string allocations

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -45,8 +45,8 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         .map_err(|e| cargo_err(&format_args!("invalid upload request: {e}")))?;
 
     let request_log = req.request_log();
-    request_log.add("crate_name", metadata.name.to_string());
-    request_log.add("crate_version", metadata.vers.to_string());
+    request_log.add("crate_name", &*metadata.name);
+    request_log.add("crate_version", &*metadata.vers);
 
     // Make sure required fields are provided
     fn empty(s: Option<&String>) -> bool {


### PR DESCRIPTION
There are already two `.to_string()` calls happening within the `request_log.add()` function, so there is no need for us to allocate memory a third time if we can just pass in a `&str` :)