### PR TITLE
Ember Data: Fix `toArray()` deprecation warnings in the test suite code

### DIFF
--- a/tests/components/version-list-row-test.js
+++ b/tests/components/version-list-row-test.js
@@ -18,7 +18,7 @@ module('Component | VersionList::Row', function (hooks) {
 
     let store = this.owner.lookup('service:store');
     let crateRecord = await store.findRecord('crate', crate.name);
-    let versions = (await crateRecord.versions).toArray();
+    let versions = (await crateRecord.versions).slice();
     this.firstVersion = versions[0];
     this.secondVersion = versions[1];
 
@@ -38,7 +38,7 @@ module('Component | VersionList::Row', function (hooks) {
 
     let store = this.owner.lookup('service:store');
     let crateRecord = await store.findRecord('crate', crate.name);
-    this.version = (await crateRecord.versions).toArray()[0];
+    this.version = (await crateRecord.versions).slice()[0];
 
     await render(hbs`<VersionList::Row @version={{this.version}} />`);
     assert.dom('[data-test-release-track]').hasText('?');
@@ -71,7 +71,7 @@ module('Component | VersionList::Row', function (hooks) {
 
     let store = this.owner.lookup('service:store');
     let crateRecord = await store.findRecord('crate', crate.name);
-    let versions = (await crateRecord.versions).toArray();
+    let versions = (await crateRecord.versions).slice();
     this.firstVersion = versions[0];
     this.secondVersion = versions[1];
     this.thirdVersion = versions[2];

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -21,7 +21,7 @@ module('Model | Version', function (hooks) {
     server.create('version', { crate, created_at: '2010-06-16T21:30:45Z' });
 
     let crateRecord = await store.findRecord('crate', crate.name);
-    let versions = (await crateRecord.versions).toArray();
+    let versions = (await crateRecord.versions).slice();
 
     this.clock.setSystemTime(new Date('2010-06-16T21:40:45Z'));
     assert.true(versions[0].isNew);
@@ -59,7 +59,7 @@ module('Model | Version', function (hooks) {
       server.create('version', { crate, num });
 
       let crateRecord = await store.findRecord('crate', crate.name);
-      let versions = (await crateRecord.versions).toArray();
+      let versions = (await crateRecord.versions).slice();
       return versions[0];
     }
 
@@ -151,7 +151,7 @@ module('Model | Version', function (hooks) {
       }
 
       let crateRecord = await this.store.findRecord('crate', crate.name);
-      let versions = (await crateRecord.versions).toArray();
+      let versions = (await crateRecord.versions).slice();
 
       assert.deepEqual(
         versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
@@ -182,7 +182,7 @@ module('Model | Version', function (hooks) {
       this.server.create('version', { crate, num: '0.4.2', yanked: true });
 
       let crateRecord = await this.store.findRecord('crate', crate.name);
-      let versions = (await crateRecord.versions).toArray();
+      let versions = (await crateRecord.versions).slice();
 
       assert.deepEqual(
         versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
@@ -203,7 +203,7 @@ module('Model | Version', function (hooks) {
       server.create('version', { crate, features });
 
       let crateRecord = await store.findRecord('crate', crate.name);
-      let versions = (await crateRecord.versions).toArray();
+      let versions = (await crateRecord.versions).slice();
       return versions[0];
     }
 
@@ -284,7 +284,7 @@ module('Model | Version', function (hooks) {
 
     let crateRecord = await this.store.findRecord('crate', crate.name);
     assert.ok(crateRecord);
-    let versions = (await crateRecord.versions).toArray();
+    let versions = (await crateRecord.versions).slice();
     assert.strictEqual(versions.length, 1);
     let version = versions[0];
     assert.ok(version.published_by);


### PR DESCRIPTION
There are unfortunately still plenty of deprecation warnings left in the production code since Ember Data decided to completely throw away their previous philosophy and make async relationships significantly harder to work with... 😩 