### PR TITLE
models/krate: Move URL and name validation out of `create_or_update()`

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -142,6 +142,10 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             };
 
             let license_file = metadata.license_file.as_deref();
+
+            persist.validate()?;
+            persist.ensure_name_not_reserved(conn)?;
+
             let krate = persist.create_or_update(conn, user.id)?;
 
             let owners = krate.owners(conn)?;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -352,9 +352,8 @@ fn is_reserved_name(name: &str, conn: &mut PgConnection) -> QueryResult<bool> {
 }
 
 fn validate_url(url: Option<&str>, field: &str) -> AppResult<()> {
-    let url = match url {
-        Some(s) => s,
-        None => return Ok(()),
+    let Some(url) = url else {
+        return Ok(());
     };
 
     // Manually check the string, as `Url::parse` may normalize relative URLs

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -105,9 +105,6 @@ impl<'a> NewCrate<'a> {
     pub fn create_or_update(self, conn: &mut PgConnection, uploader: i32) -> AppResult<Crate> {
         use diesel::update;
 
-        self.validate()?;
-        self.ensure_name_not_reserved(conn)?;
-
         conn.transaction(|conn| {
             // To avoid race conditions, we try to insert
             // first so we know whether to add an owner
@@ -124,7 +121,7 @@ impl<'a> NewCrate<'a> {
         })
     }
 
-    fn validate(&self) -> AppResult<()> {
+    pub fn validate(&self) -> AppResult<()> {
         fn validate_url(url: Option<&str>, field: &str) -> AppResult<()> {
             let url = match url {
                 Some(s) => s,
@@ -151,7 +148,7 @@ impl<'a> NewCrate<'a> {
         Ok(())
     }
 
-    fn ensure_name_not_reserved(&self, conn: &mut PgConnection) -> AppResult<()> {
+    pub fn ensure_name_not_reserved(&self, conn: &mut PgConnection) -> AppResult<()> {
         use crate::schema::reserved_crate_names::dsl::*;
         use diesel::dsl::exists;
         use diesel::select;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -148,22 +148,6 @@ impl<'a> NewCrate<'a> {
         Ok(())
     }
 
-    pub fn ensure_name_not_reserved(&self, conn: &mut PgConnection) -> AppResult<()> {
-        use crate::schema::reserved_crate_names::dsl::*;
-        use diesel::dsl::exists;
-        use diesel::select;
-
-        let reserved_name: bool = select(exists(
-            reserved_crate_names.filter(canon_crate_name(name).eq(canon_crate_name(self.name))),
-        ))
-        .get_result(conn)?;
-        if reserved_name {
-            Err(cargo_err("cannot upload a crate with a reserved name"))
-        } else {
-            Ok(())
-        }
-    }
-
     fn save_new_crate(&self, conn: &mut PgConnection, user_id: i32) -> QueryResult<Option<Crate>> {
         use crate::schema::crates::dsl::*;
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -5,7 +5,6 @@ use diesel::associations::Identifiable;
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::sql_types::{Bool, Text};
-use url::Url;
 
 use crate::app::App;
 use crate::controllers::helpers::pagination::*;
@@ -119,33 +118,6 @@ impl<'a> NewCrate<'a> {
                 .get_result(conn)
                 .map_err(Into::into)
         })
-    }
-
-    pub fn validate(&self) -> AppResult<()> {
-        fn validate_url(url: Option<&str>, field: &str) -> AppResult<()> {
-            let url = match url {
-                Some(s) => s,
-                None => return Ok(()),
-            };
-
-            // Manually check the string, as `Url::parse` may normalize relative URLs
-            // making it difficult to ensure that both slashes are present.
-            if !url.starts_with("http://") && !url.starts_with("https://") {
-                return Err(cargo_err(&format_args!(
-                    "URL for field `{field}` must begin with http:// or https:// (url: {url})"
-                )));
-            }
-
-            // Ensure the entire URL parses as well
-            Url::parse(url)
-                .map_err(|_| cargo_err(&format_args!("`{field}` is not a valid url: `{url}`")))?;
-            Ok(())
-        }
-
-        validate_url(self.homepage, "homepage")?;
-        validate_url(self.documentation, "documentation")?;
-        validate_url(self.repository, "repository")?;
-        Ok(())
     }
 
     fn save_new_crate(&self, conn: &mut PgConnection, user_id: i32) -> QueryResult<Option<Crate>> {
@@ -502,21 +474,7 @@ impl Crate {
 
 #[cfg(test)]
 mod tests {
-    use crate::models::{Crate, NewCrate};
-
-    #[test]
-    fn deny_relative_urls() {
-        let krate = NewCrate {
-            name: "name",
-            description: None,
-            homepage: Some("https:/example.com/home"),
-            documentation: None,
-            readme: None,
-            repository: None,
-            max_upload_size: None,
-        };
-        assert_err!(krate.validate());
-    }
+    use crate::models::Crate;
 
     #[test]
     fn valid_name() {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_urls.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_urls.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/validation.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "URL for field `documentation` must begin with http:// or https:// (url: javascript:alert('boom'))"
+    }
+  ]
+}

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -86,3 +86,16 @@ fn license_and_description_required() {
 
     assert!(app.stored_files().is_empty());
 }
+
+#[test]
+fn invalid_urls() {
+    let (app, _, _, token) = TestApp::full().with_token();
+
+    let response = token.publish_crate(
+        PublishBuilder::new("foo", "1.0.0").documentation("javascript:alert('boom')"),
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.into_json());
+
+    assert!(app.stored_files().is_empty());
+}


### PR DESCRIPTION
The reserved name and URL validations are somewhat unrelated to the `NewCrate` struct and are much more useful as independent validations, that can be run in combination with some of the other publish validations that we have (e.g. missing/empty metadata fields or the Cargo.toml content validation).

This PR extracts that functionality and moves it to the publish module instead.