### PR TITLE
Use `db_write()` instead of the `primary_database` field

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -71,7 +71,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
     }
 
     conduit_compat(move || {
-        let conn = &mut *app.primary_database.get()?;
+        let conn = &mut *app.db_write()?;
 
         // this query should only be used for the endpoint scope calculation
         // since a race condition there would only cause `publish-new` instead of

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -65,12 +65,12 @@ impl DownloadsCounter {
     }
 
     pub fn persist_all_shards(&self, app: &App) -> Result<PersistStats, Error> {
-        let conn = &mut app.primary_database.get()?;
+        let conn = &mut app.db_write()?;
         self.persist_all_shards_with_conn(conn)
     }
 
     pub fn persist_next_shard(&self, app: &App) -> Result<PersistStats, Error> {
-        let conn = &mut app.primary_database.get()?;
+        let conn = &mut app.db_write()?;
         self.persist_next_shard_with_conn(conn)
     }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -169,6 +169,6 @@ fn recursive_get_of_db_conn_in_tests_will_panic() {
     let (app, _) = TestApp::init().empty();
     let app = app.as_inner();
 
-    let _conn1 = app.primary_database.get().unwrap();
-    let _conn2 = app.primary_database.get().unwrap();
+    let _conn1 = app.db_write().unwrap();
+    let _conn2 = app.db_write().unwrap();
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -50,7 +50,7 @@ impl Drop for TestAppInner {
 
         // Manually verify that all jobs have completed successfully
         // This will catch any tests that enqueued a job but forgot to initialize the runner
-        let conn = &mut *self.app.primary_database.get().unwrap();
+        let conn = &mut *self.app.db_write().unwrap();
         let job_count: i64 = background_jobs.count().get_result(conn).unwrap();
         assert_eq!(
             0, job_count,
@@ -95,7 +95,7 @@ impl TestApp {
     /// connection before making any API calls.  Once the closure returns, the connection is
     /// dropped, ensuring it is returned to the pool and available for any future API calls.
     pub fn db<T, F: FnOnce(&mut PgConnection) -> T>(&self, f: F) -> T {
-        let conn = &mut self.0.app.primary_database.get().unwrap();
+        let conn = &mut self.0.app.db_write().unwrap();
         f(conn)
     }
 


### PR DESCRIPTION
Less verbose, and with dedicated `tracing` instrumentation :)