### PR TITLE
models/krate: Split `create_or_update()` fn into `create()` and `update()`

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -157,11 +157,10 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             let krate = conn.transaction(|conn| {
                 // To avoid race conditions, we try to insert
                 // first so we know whether to add an owner
-                if let Some(krate) = persist.create(conn, user.id).optional()? {
-                    return Ok(krate);
+                match persist.create(conn, user.id).optional()? {
+                    Some(krate) => Ok(krate),
+                    None => persist.update(conn),
                 }
-
-                persist.update(conn)
             })?;
 
             let owners = krate.owners(conn)?;

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -439,7 +439,7 @@ mod tests {
                 name: "foo",
                 ..NewCrate::default()
             }
-            .create_or_update(conn, user.id)
+            .create(conn, user.id)
             .expect("failed to create crate");
 
             Self {

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -105,7 +105,7 @@ impl<'a> NewCrate<'a> {
         conn.transaction(|conn| {
             // To avoid race conditions, we try to insert
             // first so we know whether to add an owner
-            if let Some(krate) = conn.transaction(|conn| self.create(conn, uploader).optional())? {
+            if let Some(krate) = self.create(conn, uploader).optional()? {
                 return Ok(krate);
             }
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -105,7 +105,7 @@ impl<'a> NewCrate<'a> {
         conn.transaction(|conn| {
             // To avoid race conditions, we try to insert
             // first so we know whether to add an owner
-            if let Some(krate) = self.save_new_crate(conn, uploader)? {
+            if let Some(krate) = conn.transaction(|conn| self.create(conn, uploader).optional())? {
                 return Ok(krate);
             }
 
@@ -147,10 +147,6 @@ impl<'a> NewCrate<'a> {
 
             Ok(krate)
         })
-    }
-
-    fn save_new_crate(&self, conn: &mut PgConnection, user_id: i32) -> QueryResult<Option<Crate>> {
-        conn.transaction(|conn| self.create(conn, user_id).optional())
     }
 }
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -101,18 +101,6 @@ pub struct NewCrate<'a> {
 }
 
 impl<'a> NewCrate<'a> {
-    pub fn create_or_update(self, conn: &mut PgConnection, uploader: i32) -> AppResult<Crate> {
-        conn.transaction(|conn| {
-            // To avoid race conditions, we try to insert
-            // first so we know whether to add an owner
-            if let Some(krate) = self.create(conn, uploader).optional()? {
-                return Ok(krate);
-            }
-
-            Ok(self.update(conn)?)
-        })
-    }
-
     pub fn update(&self, conn: &mut PgConnection) -> QueryResult<Crate> {
         use diesel::update;
 

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -114,7 +114,7 @@ impl<'a> CrateBuilder<'a> {
     pub fn build(mut self, connection: &mut PgConnection) -> AppResult<Crate> {
         use diesel::{insert_into, select, update};
 
-        let mut krate = self.krate.create_or_update(connection, self.owner_id)?;
+        let mut krate = self.krate.create(connection, self.owner_id)?;
 
         // Since we are using `NewCrate`, we can't set all the
         // crate properties in a single DB call.

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -98,7 +98,7 @@ mod test {
             name: "foo",
             ..Default::default()
         }
-        .create_or_update(conn, user_id)
+        .create(conn, user_id)
         .unwrap();
         let version = NewVersion::new(
             krate.id,


### PR DESCRIPTION
This PR attempts to simplify the `NewCrate::create_or_update()` fn, by splitting up into two more straight-forward `create()` and `update()` fns. This allows us to explicitly use only `create()` in our test suite code, and a combination of both in the publish endpoint.