### PR TITLE
tests/krate/publish: Add missing `description` and `license` fields to generated `Cargo.toml` files

### DIFF
--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -13,6 +13,8 @@ fn boolean_readme() {
         r#"[package]
             name = "foo"
             version = "1.0.0"
+            description = "description"
+            license = "MIT"
             rust-version = "1.69"
             readme = false"#,
     ));

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -20,7 +20,7 @@ fn tarball_between_default_axum_limit_and_max_upload_size() {
     let tarball = {
         let mut builder = TarballBuilder::new();
 
-        let data = b"[package]\nname = \"foo\"\nversion = \"1.1.0\"\n" as &[_];
+        let data = b"[package]\nname = \"foo\"\nversion = \"1.1.0\"\ndescription = \"description\"\nlicense = \"MIT\"\n" as &[_];
 
         let mut header = tar::Header::new_gnu();
         assert_ok!(header.set_path("foo-1.1.0/Cargo.toml"));


### PR DESCRIPTION
Without this the server is not supposed to accept any publish requests. Once we switch from reading the values from the metadata JSON blob to using the embedded `Cargo.toml` file, these tests would start to fail.