### PR TITLE
publish: Use `description`, `license` and `license_file` fields from embedded `Cargo.toml` file

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -142,7 +142,6 @@ impl PublishBuilder {
             vers: u::EncodableCrateVersion(self.version.clone()),
             features: self.features.clone(),
             deps: self.deps.clone(),
-            description: self.desc.clone(),
             homepage: None,
             documentation: self.doc_url.clone(),
             readme: self.readme,
@@ -161,8 +160,6 @@ impl PublishBuilder {
                     .map(u::EncodableCategory)
                     .collect(),
             ),
-            license: self.license.clone(),
-            license_file: self.license_file.clone(),
             repository: None,
             links: None,
         };

--- a/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 219"
+      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 191"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-2.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"?@?%\", expected a valid keyword specifier at line 1 column 178"
+      "detail": "invalid upload request: invalid value: string \"?@?%\", expected a valid keyword specifier at line 1 column 150"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-3.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid keyword specifier at line 1 column 183"
+      "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid keyword specifier at line 1 column 155"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 29, expected a keyword with less than 20 characters at line 1 column 203"
+      "detail": "invalid upload request: invalid length 29, expected a keyword with less than 20 characters at line 1 column 175"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 203"
+      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 175"
     }
   ]
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -18,7 +18,6 @@ pub struct PublishMetadata {
     pub vers: EncodableCrateVersion,
     pub deps: Vec<EncodableCrateDependency>,
     pub features: BTreeMap<EncodableFeatureName, Vec<EncodableFeature>>,
-    pub description: Option<String>,
     pub homepage: Option<String>,
     pub documentation: Option<String>,
     pub readme: Option<String>,
@@ -27,8 +26,6 @@ pub struct PublishMetadata {
     pub keywords: EncodableKeywordList,
     #[serde(default)]
     pub categories: EncodableCategoryList,
-    pub license: Option<String>,
-    pub license_file: Option<String>,
     pub repository: Option<String>,
     #[serde(default)]
     pub links: Option<String>,


### PR DESCRIPTION
This PR changes our handling of the `description`, `license` and `license_file` fields so that they are read from the `Cargo.toml` file embedded in the crate tarball, instead of the metadata JSON blob.

This is another step forward towards avoiding issues like https://blog.vlt.sh/blog/the-massive-hole-in-the-npm-ecosystem in the Rust ecosystem. Note that, compared to e.g. npm, this is currently not exploitable due to the way cargo works, but it is still confusing to our users if the metadata does not match what is actually in the tarball.

This change required a small reordering of things in the publish endpoint. Specifically, the publish size limit is read from the database earlier than previously, which could potentially cause a race condition, but from what I can tell this race condition should not matter in practice (see commit message for details). Similarly, the tarball analysis step now happens before we run any `INSERT` queries on the database, since the tarball analysis result is now needed before we can insert anything. Thirdly, the description and license validation now happens after the tarball analysis for obvious reasons.