### PR TITLE
Extract `licenses` module

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -17,9 +17,9 @@ use crate::models::{
     VersionAction,
 };
 
+use crate::licenses::validate_license_expr;
 use crate::middleware::log_request::RequestLogExt;
 use crate::models::token::EndpointScope;
-use crate::models::version::validate_license_expr;
 use crate::rate_limiter::LimitedAction;
 use crate::schema::*;
 use crate::sql::canon_crate_name;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod worker;
 
 pub mod auth;
 pub mod controllers;
+mod licenses;
 pub mod models;
 mod router;
 pub mod sentry;

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -1,0 +1,34 @@
+use crate::util::errors::{cargo_err, AppResult};
+
+const PARSE_MODE: spdx::ParseMode = spdx::ParseMode {
+    allow_lower_case_operators: false,
+    allow_slash_as_or_operator: true,
+    allow_imprecise_license_names: false,
+    allow_postfix_plus_on_gpl: true,
+};
+
+pub fn validate_license_expr(s: &str) -> AppResult<()> {
+    spdx::Expression::parse_mode(s, PARSE_MODE).map_err(|_| {
+        cargo_err("unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers")
+    })?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_license_expr;
+
+    #[test]
+    fn licenses() {
+        assert_ok!(validate_license_expr("MIT"));
+        assert_ok!(validate_license_expr("MIT OR Apache-2.0"));
+        assert_ok!(validate_license_expr("MIT/Apache-2.0"));
+        assert_ok!(validate_license_expr("MIT AND Apache-2.0"));
+        assert_ok!(validate_license_expr("MIT OR (Apache-2.0 AND MIT)"));
+        assert_ok!(validate_license_expr("GPL-3.0+"));
+
+        let error = assert_err!(validate_license_expr("apache 2.0")).to_string();
+        assert!(error.starts_with("unknown or invalid license expression; see http"));
+    }
+}

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -1,4 +1,4 @@
-use crate::util::errors::{cargo_err, AppResult};
+use spdx::{Expression, ParseError};
 
 const PARSE_MODE: spdx::ParseMode = spdx::ParseMode {
     allow_lower_case_operators: false,
@@ -7,28 +7,23 @@ const PARSE_MODE: spdx::ParseMode = spdx::ParseMode {
     allow_postfix_plus_on_gpl: true,
 };
 
-pub fn validate_license_expr(s: &str) -> AppResult<()> {
-    spdx::Expression::parse_mode(s, PARSE_MODE).map_err(|_| {
-        cargo_err("unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers")
-    })?;
-
-    Ok(())
+pub fn parse_license_expr(s: &str) -> Result<Expression, ParseError> {
+    Expression::parse_mode(s, PARSE_MODE)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::validate_license_expr;
+    use super::parse_license_expr;
 
     #[test]
     fn licenses() {
-        assert_ok!(validate_license_expr("MIT"));
-        assert_ok!(validate_license_expr("MIT OR Apache-2.0"));
-        assert_ok!(validate_license_expr("MIT/Apache-2.0"));
-        assert_ok!(validate_license_expr("MIT AND Apache-2.0"));
-        assert_ok!(validate_license_expr("MIT OR (Apache-2.0 AND MIT)"));
-        assert_ok!(validate_license_expr("GPL-3.0+"));
+        assert_ok!(parse_license_expr("MIT"));
+        assert_ok!(parse_license_expr("MIT OR Apache-2.0"));
+        assert_ok!(parse_license_expr("MIT/Apache-2.0"));
+        assert_ok!(parse_license_expr("MIT AND Apache-2.0"));
+        assert_ok!(parse_license_expr("MIT OR (Apache-2.0 AND MIT)"));
+        assert_ok!(parse_license_expr("GPL-3.0+"));
 
-        let error = assert_err!(validate_license_expr("apache 2.0")).to_string();
-        assert!(error.starts_with("unknown or invalid license expression; see http"));
+        assert_err!(parse_license_expr("apache 2.0"));
     }
 }

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -192,21 +192,6 @@ impl NewVersion {
     }
 }
 
-pub fn validate_license_expr(s: &str) -> AppResult<()> {
-    pub const PARSE_MODE: spdx::ParseMode = spdx::ParseMode {
-        allow_lower_case_operators: false,
-        allow_slash_as_or_operator: true,
-        allow_imprecise_license_names: false,
-        allow_postfix_plus_on_gpl: true,
-    };
-
-    spdx::Expression::parse_mode(s, PARSE_MODE).map_err(|_| {
-        cargo_err("unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers")
-    })?;
-
-    Ok(())
-}
-
 fn strip_build_metadata(version: &str) -> &str {
     version
         .split_once('+')
@@ -216,7 +201,7 @@ fn strip_build_metadata(version: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{validate_license_expr, TopVersions};
+    use super::TopVersions;
     use chrono::NaiveDateTime;
 
     #[track_caller]
@@ -285,19 +270,5 @@ mod tests {
                 newest: Some(version("1.0.4")),
             }
         );
-    }
-
-    #[test]
-    fn licenses() {
-        assert_ok!(validate_license_expr("MIT"));
-        assert_ok!(validate_license_expr("MIT OR Apache-2.0"));
-        assert_ok!(validate_license_expr("MIT/Apache-2.0"));
-        assert_ok!(validate_license_expr("MIT AND Apache-2.0"));
-        assert_ok!(validate_license_expr("MIT OR (Apache-2.0 AND MIT)"));
-        assert_ok!(validate_license_expr("GPL-3.0+"));
-
-        let error = assert_err!(validate_license_expr("apache 2.0"));
-        let error = format!("{error}");
-        assert!(error.starts_with("unknown or invalid license expression; see http"));
     }
 }


### PR DESCRIPTION
This PR moves the license expression parsing code out of `models::version` into a dedicated module. In the second commit the API is slightly simplified and the conversion from regular error to app-specific error wrapper is moved into the route handler that calls the fn.