### PR TITLE
publish: Use `homepage`, `documentation` and `repository` fields from embedded `Cargo.toml` file

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -142,8 +142,6 @@ impl PublishBuilder {
             vers: u::EncodableCrateVersion(self.version.clone()),
             features: self.features.clone(),
             deps: self.deps.clone(),
-            homepage: None,
-            documentation: self.doc_url.clone(),
             readme: self.readme,
             readme_file: None,
             keywords: u::EncodableKeywordList(
@@ -160,7 +158,6 @@ impl PublishBuilder {
                     .map(u::EncodableCategory)
                     .collect(),
             ),
-            repository: None,
             links: None,
         };
 

--- a/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 191"
+      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 154"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-2.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"?@?%\", expected a valid keyword specifier at line 1 column 150"
+      "detail": "invalid upload request: invalid value: string \"?@?%\", expected a valid keyword specifier at line 1 column 113"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-3.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid keyword specifier at line 1 column 155"
+      "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid keyword specifier at line 1 column 118"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 29, expected a keyword with less than 20 characters at line 1 column 175"
+      "detail": "invalid upload request: invalid length 29, expected a keyword with less than 20 characters at line 1 column 138"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 175"
+      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 138"
     }
   ]
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -18,15 +18,12 @@ pub struct PublishMetadata {
     pub vers: EncodableCrateVersion,
     pub deps: Vec<EncodableCrateDependency>,
     pub features: BTreeMap<EncodableFeatureName, Vec<EncodableFeature>>,
-    pub homepage: Option<String>,
-    pub documentation: Option<String>,
     pub readme: Option<String>,
     pub readme_file: Option<String>,
     #[serde(default)]
     pub keywords: EncodableKeywordList,
     #[serde(default)]
     pub categories: EncodableCategoryList,
-    pub repository: Option<String>,
     #[serde(default)]
     pub links: Option<String>,
 }


### PR DESCRIPTION
This PR is similar to #7194, but this time for the `homepage`, `documentation` and `repository` fields.