### PR TITLE
publish: Use `links` field from embedded `Cargo.toml` file

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -162,7 +162,6 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         conn.transaction(|conn| {
             let name = metadata.name;
             let vers = &*metadata.vers;
-            let links = metadata.links;
             let features = metadata
                 .features
                 .into_iter()
@@ -238,7 +237,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 content_length as i32,
                 user.id,
                 hex_cksum,
-                links,
+                package.links,
                 rust_version,
             )?
             .save(conn, &verified_email_address)?;

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -158,7 +158,6 @@ impl PublishBuilder {
                     .map(u::EncodableCategory)
                     .collect(),
             ),
-            links: None,
         };
 
         let mut tarball_builder = TarballBuilder::new();

--- a/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 154"
+      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 155"
     }
   ]
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -24,8 +24,6 @@ pub struct PublishMetadata {
     pub keywords: EncodableKeywordList,
     #[serde(default)]
     pub categories: EncodableCategoryList,
-    #[serde(default)]
-    pub links: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Hash, Serialize, Clone, Debug, Deref)]


### PR DESCRIPTION
This PR is similar to https://github.com/rust-lang/crates.io/pull/7194, but this time for the `links` field