### PR TITLE
publish: Read `categories` metadata from embedded `Cargo.toml` file

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -151,7 +151,6 @@ impl PublishBuilder {
                     .map(u::EncodableKeyword)
                     .collect(),
             ),
-            categories: u::EncodableCategoryList(self.categories.clone()),
         };
 
         let mut tarball_builder = TarballBuilder::new();

--- a/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__categories__too_many_categories.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 categories per crate at line 1 column 155"
+      "detail": "expected at most 5 categories per crate"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 138"
+      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 139"
     }
   ]
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -25,8 +25,6 @@ pub struct PublishMetadata {
     pub readme_file: Option<String>,
     #[serde(default)]
     pub keywords: EncodableKeywordList,
-    #[serde(default)]
-    pub categories: EncodableCategoryList,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -192,21 +190,6 @@ impl<'de> Deserialize<'de> for EncodableKeywordList {
             return Err(de::Error::invalid_length(inner.len(), &expected));
         }
         Ok(EncodableKeywordList(inner))
-    }
-}
-
-#[derive(Serialize, Debug, Deref, Default)]
-pub struct EncodableCategoryList(pub Vec<String>);
-
-impl<'de> Deserialize<'de> for EncodableCategoryList {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableCategoryList, D::Error> {
-        let inner = <Vec<String> as Deserialize<'de>>::deserialize(d)?;
-        if inner.len() > 5 {
-            let expected = "at most 5 categories per crate";
-            Err(de::Error::invalid_length(inner.len(), &expected))
-        } else {
-            Ok(EncodableCategoryList(inner))
-        }
     }
 }
 


### PR DESCRIPTION
... instead of the metadata JSON blob


see also:

- https://github.com/rust-lang/crates.io/pull/7194
- https://github.com/rust-lang/crates.io/pull/7201
- https://github.com/rust-lang/crates.io/pull/7204