### PR TITLE
publish: Read `keywords` metadata from embedded `Cargo.toml` file

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -144,13 +144,6 @@ impl PublishBuilder {
             deps: self.deps.clone(),
             readme: self.readme,
             readme_file: None,
-            keywords: u::EncodableKeywordList(
-                self.keywords
-                    .clone()
-                    .into_iter()
-                    .map(u::EncodableKeyword)
-                    .collect(),
-            ),
         };
 
         let mut tarball_builder = TarballBuilder::new();

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-2.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"?@?%\", expected a valid keyword specifier at line 1 column 113"
+      "detail": "\"?@?%\" is an invalid keyword"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords-3.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid keyword specifier at line 1 column 118"
+      "detail": "\"áccênts\" is an invalid keyword"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__bad_keywords.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 29, expected a keyword with less than 20 characters at line 1 column 138"
+      "detail": "\"super-long-keyword-name-oh-no\" is an invalid keyword (keywords must have less than 20 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__too_many_keywords.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid length 6, expected at most 5 keywords per crate at line 1 column 139"
+      "detail": "expected at most 5 keywords per crate"
     }
   ]
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -13,7 +13,6 @@ use crate::models::krate::MAX_NAME_LENGTH;
 
 use crate::models::Crate;
 use crate::models::DependencyKind;
-use crate::models::Keyword as CrateKeyword;
 
 #[derive(Deserialize, Serialize, Debug)]
 pub struct PublishMetadata {
@@ -23,8 +22,6 @@ pub struct PublishMetadata {
     pub features: BTreeMap<EncodableFeatureName, Vec<EncodableFeature>>,
     pub readme: Option<String>,
     pub readme_file: Option<String>,
-    #[serde(default)]
-    pub keywords: EncodableKeywordList,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -83,25 +80,6 @@ impl<'de> Deserialize<'de> for EncodableDependencyName {
             Err(de::Error::invalid_value(value, &expected.as_ref()))
         } else {
             Ok(EncodableDependencyName(s))
-        }
-    }
-}
-
-#[derive(Serialize, Debug, Deref)]
-pub struct EncodableKeyword(pub String);
-
-impl<'de> Deserialize<'de> for EncodableKeyword {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableKeyword, D::Error> {
-        let s = String::deserialize(d)?;
-        if s.len() > 20 {
-            let expected = "a keyword with less than 20 characters";
-            Err(de::Error::invalid_length(s.len(), &expected))
-        } else if !CrateKeyword::valid_name(&s) {
-            let value = de::Unexpected::Str(&s);
-            let expected = "a valid keyword specifier";
-            Err(de::Error::invalid_value(value, &expected))
-        } else {
-            Ok(EncodableKeyword(s))
         }
     }
 }
@@ -176,20 +154,6 @@ impl<'de> Deserialize<'de> for EncodableCrateVersionReq {
                 Err(de::Error::invalid_value(value, &expected))
             }
         }
-    }
-}
-
-#[derive(Serialize, Debug, Deref, Default)]
-pub struct EncodableKeywordList(pub Vec<EncodableKeyword>);
-
-impl<'de> Deserialize<'de> for EncodableKeywordList {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableKeywordList, D::Error> {
-        let inner = <Vec<EncodableKeyword> as Deserialize<'de>>::deserialize(d)?;
-        if inner.len() > 5 {
-            let expected = "at most 5 keywords per crate";
-            return Err(de::Error::invalid_length(inner.len(), &expected));
-        }
-        Ok(EncodableKeywordList(inner))
     }
 }
 


### PR DESCRIPTION
... instead of the metadata JSON blob


see also:

- https://github.com/rust-lang/crates.io/pull/7194
- https://github.com/rust-lang/crates.io/pull/7201
- https://github.com/rust-lang/crates.io/pull/7204
- https://github.com/rust-lang/crates.io/pull/7209