### PR TITLE
publish: Read `features` metadata from embedded `Cargo.toml` file

### DIFF
--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"!bar\", expected a valid feature name at line 1 column 65"
+      "detail": "\"!bar\" is an invalid feature name"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"~foo\", expected a valid feature name containing only letters, numbers, '-', '+', or '_' at line 1 column 57"
+      "detail": "\"~foo\" is an invalid feature name (feature names must contain only letters, numbers, '-', '+', or '_')"
     }
   ]
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -2,7 +2,6 @@
 //! and manages the serialising and deserializing of this information
 //! to and from structs. The serializing is only utilised in
 //! integration tests.
-use std::collections::BTreeMap;
 
 use diesel::pg::Pg;
 use diesel::serialize::{self, Output, ToSql};
@@ -19,7 +18,6 @@ pub struct PublishMetadata {
     pub name: EncodableCrateName,
     pub vers: EncodableCrateVersion,
     pub deps: Vec<EncodableCrateDependency>,
-    pub features: BTreeMap<EncodableFeatureName, Vec<EncodableFeature>>,
     pub readme: Option<String>,
     pub readme_file: Option<String>,
 }
@@ -80,23 +78,6 @@ impl<'de> Deserialize<'de> for EncodableDependencyName {
             Err(de::Error::invalid_value(value, &expected.as_ref()))
         } else {
             Ok(EncodableDependencyName(s))
-        }
-    }
-}
-
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Clone, Debug, Deref)]
-pub struct EncodableFeatureName(pub String);
-
-impl<'de> Deserialize<'de> for EncodableFeatureName {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(d)?;
-        if !Crate::valid_feature_name(&s) {
-            let value = de::Unexpected::Str(&s);
-            let expected = "a valid feature name containing only letters, \
-                            numbers, '-', '+', or '_'";
-            Err(de::Error::invalid_value(value, &expected))
-        } else {
-            Ok(EncodableFeatureName(s))
         }
     }
 }


### PR DESCRIPTION
... instead of the metadata JSON blob


see also:

- https://github.com/rust-lang/crates.io/pull/7194
- https://github.com/rust-lang/crates.io/pull/7201
- https://github.com/rust-lang/crates.io/pull/7204
- https://github.com/rust-lang/crates.io/pull/7209
- https://github.com/rust-lang/crates.io/pull/7214