### PR TITLE
Switch to binary prefixes

### DIFF
--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -211,6 +211,7 @@
 
 .bytes {
     font-variant-numeric: tabular-nums;
+    text-transform: none;
 }
 
 .feature-list {

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -5,8 +5,8 @@ import prettyBytes from 'pretty-bytes';
 /**
  * See https://github.com/rust-lang/crates.io/discussions/7177
  * 
- * Here set {minimum,maximum}FractionDigits to 1 because
- * `cargo publish` uses this format
+ * Here we set fraction digits to 1 because `cargo publish`
+ * uses this format (see https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_package.rs#L168-L171)
 */
 export default helper(([bytes], options) => prettyBytes(bytes, {
     ...options,

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -6,7 +6,7 @@ import prettyBytes from 'pretty-bytes';
  * See https://github.com/rust-lang/crates.io/discussions/7177
  *
  * Here we set fraction digits to 1 because `cargo publish`
- * uses this format (see https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_package.rs#L168-L171)
+ * uses this format (see https://github.com/rust-lang/cargo/blob/0.73.1/src/cargo/ops/cargo_package.rs#L167-L170)
  */
 export default helper(([bytes], options) =>
   prettyBytes(bytes, {

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -4,15 +4,10 @@ import prettyBytes from 'pretty-bytes';
 
 /**
  * See https://github.com/rust-lang/crates.io/discussions/7177
- *
- * Here we set fraction digits to 1 because `cargo publish`
- * uses this format (see https://github.com/rust-lang/cargo/blob/0.73.1/src/cargo/ops/cargo_package.rs#L167-L170)
  */
 export default helper(([bytes], options) =>
   prettyBytes(bytes, {
     binary: true,
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
     ...options,
   }),
 );

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -9,8 +9,8 @@ import prettyBytes from 'pretty-bytes';
  * uses this format (see https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_package.rs#L168-L171)
 */
 export default helper(([bytes], options) => prettyBytes(bytes, {
-    ...options,
-    binary: true,
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
+  ...options,
+  binary: true,
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1,
 }));

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -4,13 +4,15 @@ import prettyBytes from 'pretty-bytes';
 
 /**
  * See https://github.com/rust-lang/crates.io/discussions/7177
- * 
+ *
  * Here we set fraction digits to 1 because `cargo publish`
  * uses this format (see https://github.com/rust-lang/cargo/blob/master/src/cargo/ops/cargo_package.rs#L168-L171)
-*/
-export default helper(([bytes], options) => prettyBytes(bytes, {
-  ...options,
-  binary: true,
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1,
-}));
+ */
+export default helper(([bytes], options) =>
+  prettyBytes(bytes, {
+    ...options,
+    binary: true,
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }),
+);

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -2,4 +2,15 @@ import { helper } from '@ember/component/helper';
 
 import prettyBytes from 'pretty-bytes';
 
-export default helper(([bytes], options) => prettyBytes(bytes, { ...options, binary: true}));
+/**
+ * See https://github.com/rust-lang/crates.io/discussions/7177
+ * 
+ * Here set {minimum,maximum}FractionDigits to 1 because
+ * `cargo publish` uses this format
+*/
+export default helper(([bytes], options) => prettyBytes(bytes, {
+    ...options,
+    binary: true,
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+}));

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -10,9 +10,9 @@ import prettyBytes from 'pretty-bytes';
  */
 export default helper(([bytes], options) =>
   prettyBytes(bytes, {
-    ...options,
     binary: true,
     minimumFractionDigits: 1,
     maximumFractionDigits: 1,
+    ...options,
   }),
 );

--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -2,4 +2,4 @@ import { helper } from '@ember/component/helper';
 
 import prettyBytes from 'pretty-bytes';
 
-export default helper(([bytes], options) => prettyBytes(bytes, options));
+export default helper(([bytes], options) => prettyBytes(bytes, { ...options, binary: true}));

--- a/tests/unit/helpers/pretty-bytes-test.js
+++ b/tests/unit/helpers/pretty-bytes-test.js
@@ -1,0 +1,26 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { hbs } from 'ember-cli-htmlbars';
+
+import { setupRenderingTest } from 'cargo/tests/helpers';
+
+module('Unit | Helper | pretty-bytes', function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("it displays as expected", async function (assert) {
+        this.owner.lookup('service:intl').locale = 'en';
+
+        await render(hbs`{{pretty-bytes 42}}`);
+        assert.dom().hasText('42.0 B');
+
+        await render(hbs`{{pretty-bytes 42000}}`);
+        assert.dom().hasText('41.0 KiB');
+
+        await render(hbs`{{pretty-bytes 42420}}`);
+        assert.dom().hasText('41.4 KiB');
+
+        await render(hbs`{{pretty-bytes 42424242}}`);
+        assert.dom().hasText('40.5 MiB');
+    })
+});

--- a/tests/unit/helpers/pretty-bytes-test.js
+++ b/tests/unit/helpers/pretty-bytes-test.js
@@ -22,5 +22,5 @@ module('Unit | Helper | pretty-bytes', function (hooks) {
 
     await render(hbs`{{pretty-bytes 42424242}}`);
     assert.dom().hasText('40.5 MiB');
-  })
+  });
 });

--- a/tests/unit/helpers/pretty-bytes-test.js
+++ b/tests/unit/helpers/pretty-bytes-test.js
@@ -6,21 +6,21 @@ import { hbs } from 'ember-cli-htmlbars';
 import { setupRenderingTest } from 'cargo/tests/helpers';
 
 module('Unit | Helper | pretty-bytes', function (hooks) {
-    setupRenderingTest(hooks);
+  setupRenderingTest(hooks);
 
-    test("it displays as expected", async function (assert) {
-        this.owner.lookup('service:intl').locale = 'en';
+  test("it displays as expected", async function (assert) {
+    this.owner.lookup('service:intl').locale = 'en';
 
-        await render(hbs`{{pretty-bytes 42}}`);
-        assert.dom().hasText('42.0 B');
+    await render(hbs`{{pretty-bytes 42}}`);
+    assert.dom().hasText('42.0 B');
 
-        await render(hbs`{{pretty-bytes 42000}}`);
-        assert.dom().hasText('41.0 KiB');
+    await render(hbs`{{pretty-bytes 42000}}`);
+    assert.dom().hasText('41.0 KiB');
 
-        await render(hbs`{{pretty-bytes 42420}}`);
-        assert.dom().hasText('41.4 KiB');
+    await render(hbs`{{pretty-bytes 42420}}`);
+    assert.dom().hasText('41.4 KiB');
 
-        await render(hbs`{{pretty-bytes 42424242}}`);
-        assert.dom().hasText('40.5 MiB');
-    })
+    await render(hbs`{{pretty-bytes 42424242}}`);
+    assert.dom().hasText('40.5 MiB');
+  })
 });

--- a/tests/unit/helpers/pretty-bytes-test.js
+++ b/tests/unit/helpers/pretty-bytes-test.js
@@ -12,15 +12,29 @@ module('Unit | Helper | pretty-bytes', function (hooks) {
     this.owner.lookup('service:intl').locale = 'en';
 
     await render(hbs`{{pretty-bytes 42}}`);
-    assert.dom().hasText('42.0 B');
+    assert.dom().hasText('42 B');
 
+    await render(hbs`{{pretty-bytes 1024}}`);
+    assert.dom().hasText('1 KiB');
+
+    // 4200 / 1024 = 4.101...
+    await render(hbs`{{pretty-bytes 4200}}`);
+    assert.dom().hasText('4.1 KiB');
+
+    // 4200 / 1024 = 4.142...
+    await render(hbs`{{pretty-bytes 4242}}`);
+    assert.dom().hasText('4.14 KiB');
+
+    // 42000 / 1024 = 41.0156...
     await render(hbs`{{pretty-bytes 42000}}`);
-    assert.dom().hasText('41.0 KiB');
+    assert.dom().hasText('41 KiB');
 
-    await render(hbs`{{pretty-bytes 42420}}`);
-    assert.dom().hasText('41.4 KiB');
+    // 42623 / 1024 = 41.625
+    await render(hbs`{{pretty-bytes 42624}}`);
+    assert.dom().hasText('41.6 KiB');
 
-    await render(hbs`{{pretty-bytes 42424242}}`);
-    assert.dom().hasText('40.5 MiB');
+    // 424242 / 1024 = 414.2988...
+    await render(hbs`{{pretty-bytes 424242}}`);
+    assert.dom().hasText('414 KiB');
   });
 });

--- a/tests/unit/helpers/pretty-bytes-test.js
+++ b/tests/unit/helpers/pretty-bytes-test.js
@@ -8,7 +8,7 @@ import { setupRenderingTest } from 'cargo/tests/helpers';
 module('Unit | Helper | pretty-bytes', function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it displays as expected", async function (assert) {
+  test('it displays as expected', async function (assert) {
     this.owner.lookup('service:intl').locale = 'en';
 
     await render(hbs`{{pretty-bytes 42}}`);


### PR DESCRIPTION
This is from
- https://github.com/rust-lang/crates.io/discussions/7177

and changes the unit of package size to use binary prefixes as shown in test cases in `tests/unit/helpers/pretty-bytes-test.js`.