### PR TITLE
views/krate_publish: Remove unused `PartialEq` impl

### DIFF
--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -54,15 +54,6 @@ impl<'de> Deserialize<'de> for EncodableCrateName {
     }
 }
 
-impl<T: ?Sized> PartialEq<T> for EncodableCrateName
-where
-    String: PartialEq<T>,
-{
-    fn eq(&self, rhs: &T) -> bool {
-        self.0 == *rhs
-    }
-}
-
 #[derive(Serialize, Clone, Debug, Deref)]
 pub struct EncodableDependencyName(pub String);
 


### PR DESCRIPTION
This may have been used in the past but is apparently not needed anymore.