### PR TITLE
publish: Avoid N+1 query in `add_dependencies()`

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -4,10 +4,12 @@ use crate::auth::AuthCheck;
 use crate::background_jobs::{Job, PRIORITY_RENDER_README};
 use axum::body::Bytes;
 use crates_io_tarball::{process_tarball, TarballError};
+use diesel::connection::DefaultLoadingMode;
 use diesel::dsl::{exists, select};
 use hex::ToHex;
 use hyper::body::Buf;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use tokio::runtime::Handle;
 use url::Url;
 
@@ -436,6 +438,12 @@ pub fn add_dependencies(
     use self::dependencies::dsl::*;
     use diesel::insert_into;
 
+    let crate_ids = crates::table
+        .select((crates::name, crates::id))
+        .filter(crates::name.eq_any(deps.iter().map(|d| &d.name.0)))
+        .load_iter::<(String, i32), DefaultLoadingMode>(conn)?
+        .collect::<QueryResult<HashMap<_, _>>>()?;
+
     let new_dependencies = deps
         .iter()
         .map(|dep| {
@@ -446,9 +454,9 @@ pub fn add_dependencies(
             }
 
             // Match only identical names to ensure the index always references the original crate name
-            let krate:Crate = Crate::by_exact_name(&dep.name)
-                .first(conn)
-                .map_err(|_| cargo_err(&format_args!("no known crate named `{}`", &*dep.name)))?;
+            let Some(&krate_id) = crate_ids.get(&dep.name.0) else {
+                return Err(cargo_err(&format_args!("no known crate named `{}`", &*dep.name)));
+            };
 
             if let Ok(version_req) = semver::VersionReq::parse(&dep.version_req.0) {
                  if version_req == semver::VersionReq::STAR {
@@ -461,7 +469,7 @@ pub fn add_dependencies(
 
             Ok((
                 version_id.eq(target_version_id),
-                crate_id.eq(krate.id),
+                crate_id.eq(krate_id),
                 req.eq(dep.version_req.to_string()),
                 dep.kind.map(|k| kind.eq(k as i32)),
                 optional.eq(dep.optional),


### PR DESCRIPTION
Before this change we were sending out a query for each added dependency, just to look up the corresponding `id` and check if the dependency exists on crates.io. With longer lists of dependencies this behavior is quite wasteful and commonly referred to as an N+1 query.

After this change we send out a single query with all dependency names, save the resulting `name, id` tuples to an in-memory `HashMap` and then use that map inside the loop to check if the corresponding crate exists.