### PR TITLE
publish: Remove unnecessary integer cast

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -463,7 +463,7 @@ pub fn add_dependencies(
                 version_id.eq(target_version_id),
                 crate_id.eq(krate.id),
                 req.eq(dep.version_req.to_string()),
-                dep.kind.map(|k| kind.eq(k as i32)),
+                dep.kind.map(|k| kind.eq(k)),
                 optional.eq(dep.optional),
                 default_features.eq(dep.default_features),
                 features.eq(&dep.features),


### PR DESCRIPTION
The `DependencyKind` enum implements `ToSql`, so we don't have to explicitly cast this to an integer (anymore).