### PR TITLE
publish: Remove `dsl::*` import

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -433,7 +433,7 @@ fn missing_metadata_error_message(missing: &[&str]) -> String {
 pub fn add_dependencies(
     conn: &mut PgConnection,
     deps: &[EncodableCrateDependency],
-    target_version_id: i32,
+    version_id: i32,
 ) -> AppResult<()> {
     use diesel::insert_into;
 
@@ -467,7 +467,7 @@ pub fn add_dependencies(
             }
 
             Ok((
-                dependencies::version_id.eq(target_version_id),
+                dependencies::version_id.eq(version_id),
                 dependencies::crate_id.eq(krate_id),
                 dependencies::req.eq(dep.version_req.to_string()),
                 dep.kind.map(|k| dependencies::kind.eq(k)),

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -453,7 +453,7 @@ pub fn add_dependencies(
             }
 
             // Match only identical names to ensure the index always references the original crate name
-            let Some(&krate_id) = crate_ids.get(&dep.name.0) else {
+            let Some(&crate_id) = crate_ids.get(&dep.name.0) else {
                 return Err(cargo_err(&format_args!("no known crate named `{}`", &*dep.name)));
             };
 
@@ -468,7 +468,7 @@ pub fn add_dependencies(
 
             Ok((
                 dependencies::version_id.eq(version_id),
-                dependencies::crate_id.eq(krate_id),
+                dependencies::crate_id.eq(crate_id),
                 dependencies::req.eq(dep.version_req.to_string()),
                 dep.kind.map(|k| dependencies::kind.eq(k)),
                 dependencies::optional.eq(dep.optional),

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -435,7 +435,6 @@ pub fn add_dependencies(
     deps: &[EncodableCrateDependency],
     target_version_id: i32,
 ) -> AppResult<()> {
-    use self::dependencies::dsl::*;
     use diesel::insert_into;
 
     let crate_ids = crates::table
@@ -468,20 +467,20 @@ pub fn add_dependencies(
             }
 
             Ok((
-                version_id.eq(target_version_id),
-                crate_id.eq(krate_id),
-                req.eq(dep.version_req.to_string()),
-                dep.kind.map(|k| kind.eq(k)),
-                optional.eq(dep.optional),
-                default_features.eq(dep.default_features),
-                features.eq(&dep.features),
-                target.eq(dep.target.as_deref()),
-                explicit_name.eq(dep.explicit_name_in_toml.as_deref())
+                dependencies::version_id.eq(target_version_id),
+                dependencies::crate_id.eq(krate_id),
+                dependencies::req.eq(dep.version_req.to_string()),
+                dep.kind.map(|k| dependencies::kind.eq(k)),
+                dependencies::optional.eq(dep.optional),
+                dependencies::default_features.eq(dep.default_features),
+                dependencies::features.eq(&dep.features),
+                dependencies::target.eq(dep.target.as_deref()),
+                dependencies::explicit_name.eq(dep.explicit_name_in_toml.as_deref())
             ))
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    insert_into(dependencies)
+    insert_into(dependencies::table)
         .values(&new_dependencies)
         .execute(conn)?;
 


### PR DESCRIPTION
These imports always cause a lot of name clashes with local variables since they often match the SQL column names. By prefixing the column names with the table name we can easily avoid this confusing issue.