### PR TITLE
publish: Move dependency validation to `validate_dependency()` fn

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -443,6 +443,14 @@ pub fn validate_dependencies(deps: &[EncodableCrateDependency]) -> AppResult<()>
             )));
         }
 
+        for feature in &dep.features {
+            if !Crate::valid_feature(feature) {
+                return Err(cargo_err(&format_args!(
+                    "\"{feature}\" is an invalid feature name",
+                )));
+            }
+        }
+
         if let Some(registry) = &dep.registry {
             if !registry.is_empty() {
                 return Err(cargo_err(&format_args!("Dependency `{}` is hosted on another registry. Cross-registry dependencies are not permitted on crates.io.", dep.name)));

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -284,8 +284,11 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 VersionAction::Publish,
             )?;
 
+            for dep in &metadata.deps {
+                validate_dependency(dep)?;
+            }
+
             // Link this new version to all dependencies
-            validate_dependencies(&metadata.deps)?;
             add_dependencies(conn, &metadata.deps, version.id)?;
 
             // Update all keywords for this crate
@@ -429,15 +432,6 @@ fn missing_metadata_error_message(missing: &[&str]) -> String {
          how to upload metadata",
         missing.join(", ")
     )
-}
-
-#[instrument(skip_all)]
-pub fn validate_dependencies(deps: &[EncodableCrateDependency]) -> AppResult<()> {
-    for dep in deps {
-        validate_dependency(dep)?;
-    }
-
-    Ok(())
 }
 
 pub fn validate_dependency(dep: &EncodableCrateDependency) -> AppResult<()> {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -472,6 +472,17 @@ pub fn validate_dependencies(deps: &[EncodableCrateDependency]) -> AppResult<()>
             }
             _ => {}
         }
+
+        if let Some(toml_name) = &dep.explicit_name_in_toml {
+            if !Crate::valid_dependency_name(toml_name) {
+                return Err(cargo_err(&format_args!(
+                    "\"{toml_name}\" is an invalid dependency name (dependency \
+                    names must start with a letter or underscore, contain only \
+                    letters, numbers, hyphens, or underscores and have at most \
+                    {MAX_NAME_LENGTH} characters)"
+                )));
+            }
+        }
     }
 
     Ok(())

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -457,13 +457,20 @@ pub fn validate_dependencies(deps: &[EncodableCrateDependency]) -> AppResult<()>
             }
         }
 
-        if let Ok(version_req) = semver::VersionReq::parse(&dep.version_req.0) {
-            if version_req == semver::VersionReq::STAR {
+        match semver::VersionReq::parse(&dep.version_req) {
+            Err(_) => {
+                return Err(cargo_err(&format_args!(
+                    "\"{}\" is an invalid version requirement",
+                    dep.version_req
+                )));
+            }
+            Ok(req) if req == semver::VersionReq::STAR => {
                 return Err(cargo_err(&format_args!("wildcard (`*`) dependency constraints are not allowed \
                     on crates.io. Crate with this problem: `{}` See https://doc.rust-lang.org/cargo/faq.html#can-\
                     libraries-use--as-a-version-for-their-dependencies for more \
                     information", dep.name)));
             }
+            _ => {}
         }
     }
 

--- a/src/tests/builders/dependency.rs
+++ b/src/tests/builders/dependency.rs
@@ -6,7 +6,7 @@ pub struct DependencyBuilder {
     name: String,
     features: Vec<String>,
     registry: Option<String>,
-    version_req: u::EncodableCrateVersionReq,
+    version_req: String,
 }
 
 impl DependencyBuilder {
@@ -17,7 +17,7 @@ impl DependencyBuilder {
             name: name.to_string(),
             features: vec![],
             registry: None,
-            version_req: u::EncodableCrateVersionReq("> 0".to_string()),
+            version_req: "> 0".to_string(),
         }
     }
 
@@ -40,7 +40,7 @@ impl DependencyBuilder {
     /// Panics if the `version_req` string specified isn't a valid `semver::VersionReq`.
     #[track_caller]
     pub fn version_req(mut self, version_req: &str) -> Self {
-        self.version_req = u::EncodableCrateVersionReq(version_req.to_string());
+        self.version_req = version_req.to_string();
         self
     }
 

--- a/src/tests/builders/dependency.rs
+++ b/src/tests/builders/dependency.rs
@@ -60,7 +60,7 @@ impl DependencyBuilder {
             .collect();
 
         u::EncodableCrateDependency {
-            name: u::EncodableCrateName(self.name),
+            name: self.name,
             optional: false,
             default_features: true,
             features,

--- a/src/tests/builders/dependency.rs
+++ b/src/tests/builders/dependency.rs
@@ -2,7 +2,7 @@ use crates_io::views::krate_publish as u;
 
 /// A builder for constructing a dependency of another crate.
 pub struct DependencyBuilder {
-    explicit_name_in_toml: Option<u::EncodableDependencyName>,
+    explicit_name_in_toml: Option<String>,
     name: String,
     features: Vec<String>,
     registry: Option<String>,
@@ -23,7 +23,7 @@ impl DependencyBuilder {
 
     /// Rename this dependency.
     pub fn rename(mut self, new_name: &str) -> Self {
-        self.explicit_name_in_toml = Some(u::EncodableDependencyName(new_name.to_string()));
+        self.explicit_name_in_toml = Some(new_name.to_string());
         self
     }
 

--- a/src/tests/builders/dependency.rs
+++ b/src/tests/builders/dependency.rs
@@ -1,5 +1,4 @@
 use crates_io::views::krate_publish as u;
-use crates_io::views::krate_publish::EncodableFeature;
 
 /// A builder for constructing a dependency of another crate.
 pub struct DependencyBuilder {
@@ -53,17 +52,11 @@ impl DependencyBuilder {
     /// Consume this builder to create a `u::CrateDependency`. If the dependent crate doesn't
     /// already exist, publishing a crate with this dependency will fail.
     pub fn build(self) -> u::EncodableCrateDependency {
-        let features = self
-            .features
-            .into_iter()
-            .map(|d| EncodableFeature(d))
-            .collect();
-
         u::EncodableCrateDependency {
             name: self.name,
             optional: false,
             default_features: true,
-            features,
+            features: self.features,
             version_req: self.version_req,
             target: None,
             kind: None,

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -236,17 +236,10 @@ fn convert_dependency(
         ),
     };
 
-    let features = encoded
-        .features
-        .iter()
-        .map(|f| f.to_string())
-        .collect::<Vec<_>>()
-        .none_or_filled();
-
     let dependency = DependencyDetail {
         version: Some(encoded.version_req.to_string()),
         registry: encoded.registry.clone(),
-        features,
+        features: encoded.features.clone().none_or_filled(),
         optional: match encoded.optional {
             true => Some(true),
             false => None,

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -4,6 +4,18 @@ use http::StatusCode;
 use insta::assert_json_snapshot;
 
 #[test]
+fn invalid_dependency_name() {
+    let (app, _, _, token) = TestApp::full().with_token();
+
+    let response = token.publish_crate(
+        PublishBuilder::new("foo", "1.0.0").dependency(DependencyBuilder::new("🦀")),
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.into_json());
+    assert!(app.stored_files().is_empty());
+}
+
+#[test]
 fn new_with_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
 

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -223,3 +223,16 @@ fn new_krate_sorts_deps() {
     let crates = app.crates_from_index_head("two-deps");
     assert_json_snapshot!(crates);
 }
+
+#[test]
+fn invalid_feature_name() {
+    let (app, _, _, token) = TestApp::full().with_token();
+
+    let response = token.publish_crate(
+        PublishBuilder::new("foo", "1.0.0")
+            .dependency(DependencyBuilder::new("bar").add_feature("🍺")),
+    );
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.into_json());
+    assert!(app.stored_files().is_empty());
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"🦀\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 92"
+      "detail": "\"🦀\" is an invalid dependency name (dependency names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"🦀\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 92"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"💩\", expected a valid dependency name to start with a letter or underscore, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 197"
+      "detail": "\"💩\" is an invalid dependency name (dependency names must start with a letter or underscore, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_feature_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_feature_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"🍺\", expected a valid feature name at line 1 column 111"
+      "detail": "\"🍺\" is an invalid feature name"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_feature_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_feature_name.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid upload request: invalid value: string \"🍺\", expected a valid feature name at line 1 column 111"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_with_broken_dependency_requirement.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_with_broken_dependency_requirement.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"broken\", expected a valid version req at line 1 column 136"
+      "detail": "\"broken\" is an invalid version requirement"
     }
   ]
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -28,7 +28,7 @@ pub struct EncodableCrateDependency {
     pub version_req: String,
     pub target: Option<String>,
     pub kind: Option<DependencyKind>,
-    pub explicit_name_in_toml: Option<EncodableDependencyName>,
+    pub explicit_name_in_toml: Option<String>,
     pub registry: Option<String>,
 }
 
@@ -47,25 +47,6 @@ impl<'de> Deserialize<'de> for EncodableCrateName {
             Err(de::Error::invalid_value(value, &expected.as_ref()))
         } else {
             Ok(EncodableCrateName(s))
-        }
-    }
-}
-
-#[derive(Serialize, Clone, Debug, Deref)]
-pub struct EncodableDependencyName(pub String);
-
-impl<'de> Deserialize<'de> for EncodableDependencyName {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableDependencyName, D::Error> {
-        let s = String::deserialize(d)?;
-        if !Crate::valid_dependency_name(&s) {
-            let value = de::Unexpected::Str(&s);
-            let expected = format!(
-                "a valid dependency name to start with a letter or underscore, contain only letters, \
-                 numbers, hyphens, or underscores and have at most {MAX_NAME_LENGTH} characters"
-            );
-            Err(de::Error::invalid_value(value, &expected.as_ref()))
-        } else {
-            Ok(EncodableDependencyName(s))
         }
     }
 }

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -26,7 +26,7 @@ pub struct PublishMetadata {
 pub struct EncodableCrateDependency {
     pub optional: bool,
     pub default_features: bool,
-    pub name: EncodableCrateName,
+    pub name: String,
     pub features: Vec<EncodableFeature>,
     pub version_req: EncodableCrateVersionReq,
     pub target: Option<String>,

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -25,7 +25,7 @@ pub struct EncodableCrateDependency {
     pub default_features: bool,
     pub name: String,
     pub features: Vec<String>,
-    pub version_req: EncodableCrateVersionReq,
+    pub version_req: String,
     pub target: Option<String>,
     pub kind: Option<DependencyKind>,
     pub explicit_name_in_toml: Option<EncodableDependencyName>,
@@ -81,23 +81,6 @@ impl<'de> Deserialize<'de> for EncodableCrateVersion {
             Err(..) => {
                 let value = de::Unexpected::Str(&s);
                 let expected = "a valid semver";
-                Err(de::Error::invalid_value(value, &expected))
-            }
-        }
-    }
-}
-
-#[derive(Serialize, Clone, Debug, Deref)]
-pub struct EncodableCrateVersionReq(pub String);
-
-impl<'de> Deserialize<'de> for EncodableCrateVersionReq {
-    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<EncodableCrateVersionReq, D::Error> {
-        let s = String::deserialize(d)?;
-        match semver::VersionReq::parse(&s) {
-            Ok(_) => Ok(EncodableCrateVersionReq(s)),
-            Err(..) => {
-                let value = de::Unexpected::Str(&s);
-                let expected = "a valid version req";
                 Err(de::Error::invalid_value(value, &expected))
             }
         }


### PR DESCRIPTION
This moves the dependency validations from the `serde` Deserializers to a new `validate_dependencies()` fn. This is in preparation for moving this code away from using the JSON metadata and reading the dependencies from the embedded `Cargo.toml` file instead.