### PR TITLE
publish: Move crate name and version validation to publish controller

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -134,8 +134,8 @@ impl PublishBuilder {
 
     pub fn build(self) -> (String, Vec<u8>) {
         let metadata = u::PublishMetadata {
-            name: u::EncodableCrateName(self.krate_name.clone()),
-            vers: u::EncodableCrateVersion(self.version.clone()),
+            name: self.krate_name.clone(),
+            vers: self.version.to_string(),
             deps: self.deps.clone(),
             readme: self.readme,
             readme_file: None,

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"foo bar\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
+      "detail": "\"foo bar\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 75"
+      "detail": "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"snow☃\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 17"
+      "detail": "\"snow☃\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"áccênts\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 19"
+      "detail": "\"áccênts\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"\", expected a valid crate name to start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters at line 1 column 10"
+      "detail": "\"\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_version.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_version.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid upload request: invalid value: string \"broken\", expected a valid semver at line 1 column 29"
+      "detail": "\"broken\" is an invalid semver version"
     }
   ]
 }


### PR DESCRIPTION
This is roughly similar to #7234, to have everything in one place instead of scattered across the codebase.