### PR TITLE
publish: Read dependencies metadata from embedded `Cargo.toml` file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ axum = { version = "=0.6.20", features = ["headers", "macros", "matched-path"] }
 axum-extra = { version = "=0.8.0", features = ["cookie-signed"] }
 base64 = "=0.21.4"
 bigdecimal = "=0.4.1"
+cargo-manifest = "=0.12.0"
 crates_io_index = { path = "crates_io_index" }
 crates_io_markdown = { path = "crates_io_markdown" }
 crates_io_tarball = { path = "crates_io_tarball" }
@@ -98,7 +99,6 @@ url = "=2.4.1"
 
 [dev-dependencies]
 bytes = "=1.5.0"
-cargo-manifest = "=0.12.0"
 crates_io_index = { path = "crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates_io_tarball", features = ["builder"] }
 claims = "=0.7.1"

--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -136,7 +136,6 @@ impl PublishBuilder {
         let metadata = u::PublishMetadata {
             name: self.krate_name.clone(),
             vers: self.version.to_string(),
-            deps: self.deps.clone(),
             readme: self.readme,
             readme_file: None,
         };

--- a/src/views/krate_publish.rs
+++ b/src/views/krate_publish.rs
@@ -11,12 +11,11 @@ use crate::models::DependencyKind;
 pub struct PublishMetadata {
     pub name: String,
     pub vers: String,
-    pub deps: Vec<EncodableCrateDependency>,
     pub readme: Option<String>,
     pub readme_file: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Debug)]
 pub struct EncodableCrateDependency {
     pub optional: bool,
     pub default_features: bool,


### PR DESCRIPTION
... instead of the metadata JSON blob


see also:

- https://github.com/rust-lang/crates.io/pull/7194
- https://github.com/rust-lang/crates.io/pull/7201
- https://github.com/rust-lang/crates.io/pull/7204
- https://github.com/rust-lang/crates.io/pull/7209
- https://github.com/rust-lang/crates.io/pull/7214
- https://github.com/rust-lang/crates.io/pull/7215