### PR TITLE
renovate: Use `github-tags` datasource for Rust updates

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,8 +12,6 @@ env:
   CARGO_TARPAULIN_VERSION: 0.27.1
   # renovate: datasource=crate depName=diesel_cli versioning=semver
   DIESEL_CLI_VERSION: 2.1.1
-  # renovate: datasource=github-releases depName=rust lookupName=rust-lang/rust
-  RUST_VERSION: 1.73.0
 
 jobs:
   coverage:
@@ -45,7 +43,6 @@ jobs:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       # Set up Rust
-      - run: rustup default ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2.7.0
 
       # Set up database

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -1,4 +1,4 @@
-# renovate: datasource=github-releases depName=rust lookupName=rust-lang/rust
+# renovate: datasource=github-tags depName=rust lookupName=rust-lang/rust
 ARG RUST_VERSION=1.73.0
 
 FROM rust:$RUST_VERSION


### PR DESCRIPTION
GitHub releases are sometimes a bit delayed and need manual work from the release team for patch releases. GitHub tags appear to be more reliable, so let's use those instead.

This should avoid https://github.com/rust-lang/crates.io/pull/7241 and https://github.com/rust-lang/crates.io/pull/7242 being two separate PRs instead of a single one.