### PR TITLE
publish: Normalize dependency version requirements

### DIFF
--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -96,7 +96,7 @@ fn new_krate_with_dependency() {
 
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].crate_id, "foo-dep");
-    assert_eq!(dependencies[0].req, "1.0.0");
+    assert_eq!(dependencies[0].req, "^1.0.0");
 
     let crates = app.crates_from_index_head("new_dep");
     assert_json_snapshot!(crates);

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -97,6 +97,9 @@ fn new_krate_with_dependency() {
     assert_eq!(dependencies.len(), 1);
     assert_eq!(dependencies[0].crate_id, "foo-dep");
     assert_eq!(dependencies[0].req, "1.0.0");
+
+    let crates = app.crates_from_index_head("new_dep");
+    assert_json_snapshot!(crates);
 }
 
 #[test]

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_sorts_deps.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_sorts_deps.snap
@@ -9,7 +9,7 @@ expression: crates
     "deps": [
       {
         "name": "dep-a",
-        "req": "> 0",
+        "req": ">0",
         "features": [],
         "optional": false,
         "default_features": true,
@@ -18,7 +18,7 @@ expression: crates
       },
       {
         "name": "dep-b",
-        "req": "> 0",
+        "req": ">0",
         "features": [],
         "optional": false,
         "default_features": true,

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_with_dependency.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_with_dependency.snap
@@ -1,0 +1,24 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: crates
+---
+[
+  {
+    "name": "new_dep",
+    "vers": "1.0.0",
+    "deps": [
+      {
+        "name": "foo-dep",
+        "req": "1.0.0",
+        "features": [],
+        "optional": false,
+        "default_features": true,
+        "target": null,
+        "kind": "normal"
+      }
+    ],
+    "cksum": "b1ce14dbe59036a964369747770d2d64695039065384b1ab56f09a59525300a6",
+    "features": {},
+    "yanked": false
+  }
+]

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_with_dependency.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_krate_with_dependency.snap
@@ -9,7 +9,7 @@ expression: crates
     "deps": [
       {
         "name": "foo-dep",
-        "req": "1.0.0",
+        "req": "^1.0.0",
         "features": [],
         "optional": false,
         "default_features": true,

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_with_renamed_dependency.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_with_renamed_dependency.snap
@@ -9,7 +9,7 @@ expression: crates
     "deps": [
       {
         "name": "my-name",
-        "req": "> 0",
+        "req": ">0",
         "features": [],
         "optional": false,
         "default_features": true,

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_with_underscore_renamed_dependency.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__new_with_underscore_renamed_dependency.snap
@@ -9,7 +9,7 @@ expression: crates
     "deps": [
       {
         "name": "_my-name",
-        "req": "> 0",
+        "req": ">0",
         "features": [],
         "optional": false,
         "default_features": true,

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__features_version_2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__features_version_2.snap
@@ -9,7 +9,7 @@ expression: crates
     "deps": [
       {
         "name": "bar",
-        "req": "> 0",
+        "req": ">0",
         "features": [],
         "optional": false,
         "default_features": true,


### PR DESCRIPTION
When cargo reads a `Cargo.toml` file and sees a `foo = "1.0"` dependency declaration it saves the version requirement as a `semver::VersionReq`. If cargo then publishes the crate and transforms the dependency declaration to the publish metadata JSON blob it essentially uses `semver::VersionReq::to_string()` which normalizes the version requirement and transforms `1.0` into `^1.0`.

On the crates.io side we've been accepting these values from the metadata as-is and only using `VersionReq::parse()` to check if it is a valid version requirement, but there was no normalization performed.

Since we now read dependency declarations directly from the embedded `Cargo.toml` file ourselves (see https://github.com/rust-lang/crates.io/pull/7238) the normalization that cargo (unintentionally?) performed is now missing.

This PR brings back the normalization with a `VersionReq::parse()` and `to_string()` cycle.