### PR TITLE
tarball: Move `rust-version` validation into publish endpoint code

### DIFF
--- a/crates_io_tarball/src/manifest.rs
+++ b/crates_io_tarball/src/manifest.rs
@@ -48,11 +48,6 @@ pub fn validate_package(package: &Package) -> Result<(), Error> {
         ));
     }
 
-    // Check that the `rust-version` field has a valid value, if it exists.
-    if let Some(MaybeInherited::Local(ref rust_version)) = package.rust_version {
-        validate_rust_version(rust_version)?;
-    }
-
     Ok(())
 }
 
@@ -81,13 +76,5 @@ impl IsInherited for Dependency {
 impl IsInherited for DepsSet {
     fn is_inherited(&self) -> bool {
         self.iter().any(|(_key, dep)| dep.is_inherited())
-    }
-}
-
-pub fn validate_rust_version(value: &str) -> Result<(), Error> {
-    match semver::VersionReq::parse(value) {
-        // Exclude semver operators like `^` and pre-release identifiers
-        Ok(_) if value.chars().all(|c| c.is_ascii_digit() || c == '.') => Ok(()),
-        Ok(_) | Err(..) => Err(Error::Other("invalid `rust-version` value".to_string())),
     }
 }

--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -119,13 +119,13 @@ fn invalid_rust_version() {
 
     let response =
         token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
-            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\nrust-version = \"\"\n",
+            "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"\"\n",
         ));
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
 
     let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
-        "[package]\nname = \"foo\"\nversion = \"1.0.0\"\nrust-version = \"1.0.0-beta.2\"\n",
+        "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"1.0.0-beta.2\"\n",
     ));
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());


### PR DESCRIPTION
This ensures that all validation code lives in the same place instead of being scattered across the codebase :)