### PR TITLE
Render footnotes in crates' README.md

### DIFF
--- a/app/components/rendered-html.module.css
+++ b/app/components/rendered-html.module.css
@@ -65,4 +65,18 @@
             padding: var(--space-2xs) var(--space-s);
         }
     }
+
+    :global(section.footnotes) {
+        color: var(--main-color-light);
+        font-size: 80%;
+        border-top: 1px solid var(--gray-border);
+
+        a {
+            color: var(--main-color-light);
+
+            &:hover {
+                color: var(--main-color);
+            }
+        }
+    }
 }

--- a/crates_io_markdown/lib.rs
+++ b/crates_io_markdown/lib.rs
@@ -188,12 +188,7 @@ impl UrlRelativeEvaluate for SanitizeUrl {
     fn evaluate<'a>(&self, url: &'a str) -> Option<Cow<'a, str>> {
         if let Some(clean) = url.strip_prefix('#') {
             // Handle auto-generated footnote links
-            if clean
-                .strip_prefix("fn-")
-                .or_else(|| clean.strip_prefix("fnref-"))
-                .map(|num| num.parse::<u32>().is_ok())
-                .unwrap_or(false)
-            {
+            if clean.starts_with("fn-") || clean.starts_with("fnref-") {
                 return Some(Cow::Owned(format!("#user-content-{}", clean)));
             }
 
@@ -443,7 +438,7 @@ There can also be some text in between!
     Add as many paragraphs as you like."#;
 
         assert_snapshot!(markdown_to_html(text, None, ""), @r###"
-        <p>Here's a simple footnote,<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup> and here's a longer one.<sup><a href="#fn-bignote" id="user-content-fnref-bignote" rel="nofollow noopener noreferrer">2</a></sup></p>
+        <p>Here's a simple footnote,<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup> and here's a longer one.<sup><a href="#user-content-fn-bignote" id="user-content-fnref-bignote" rel="nofollow noopener noreferrer">2</a></sup></p>
         <p>There can also be some text in between!</p>
         <section>
         <ol>
@@ -454,7 +449,7 @@ There can also be some text in between!
         <p>Here's one with multiple paragraphs and code.</p>
         <p>Indent paragraphs to include them in the footnote.</p>
         <p><code>{ my code }</code></p>
-        <p>Add as many paragraphs as you like. <a href="#fnref-bignote" rel="nofollow noopener noreferrer">↩</a></p>
+        <p>Add as many paragraphs as you like. <a href="#user-content-fnref-bignote" rel="nofollow noopener noreferrer">↩</a></p>
         </li>
         </ol>
         </section>

--- a/crates_io_markdown/lib.rs
+++ b/crates_io_markdown/lib.rs
@@ -18,27 +18,30 @@ impl<'a> MarkdownRenderer<'a> {
     /// Per `text_to_html`, `base_url` is the base URL prepended to any
     /// relative links in the input document.  See that function for more detail.
     fn new(base_url: Option<&'a str>, base_dir: &'a str) -> MarkdownRenderer<'a> {
-        let allowed_classes = hashmap(&[(
-            "code",
-            hashset(&[
-                "language-bash",
-                "language-clike",
-                "language-glsl",
-                "language-go",
-                "language-ini",
-                "language-javascript",
-                "language-json",
-                "language-markup",
-                "language-mermaid",
-                "language-protobuf",
-                "language-ruby",
-                "language-rust",
-                "language-scss",
-                "language-sql",
-                "language-toml",
-                "language-yaml",
-            ]),
-        )]);
+        let allowed_classes = hashmap(&[
+            (
+                "code",
+                hashset(&[
+                    "language-bash",
+                    "language-clike",
+                    "language-glsl",
+                    "language-go",
+                    "language-ini",
+                    "language-javascript",
+                    "language-json",
+                    "language-markup",
+                    "language-mermaid",
+                    "language-protobuf",
+                    "language-ruby",
+                    "language-rust",
+                    "language-scss",
+                    "language-sql",
+                    "language-toml",
+                    "language-yaml",
+                ]),
+            ),
+            ("section", hashset(&["footnotes"])),
+        ]);
         let sanitize_url = UrlRelative::Custom(Box::new(SanitizeUrl::new(base_url, base_dir)));
 
         let mut html_sanitizer = Builder::default();
@@ -411,7 +414,7 @@ mod tests {
         let text = "Hello World![^1]\n\n[^1]: Hello Ferris, actually!";
         assert_snapshot!(markdown_to_html(text, None, ""), @r###"
         <p>Hello World!<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup></p>
-        <section>
+        <section class="footnotes">
         <ol>
         <li id="user-content-fn-1">
         <p>Hello Ferris, actually! <a href="#user-content-fnref-1" rel="nofollow noopener noreferrer">↩</a></p>
@@ -440,7 +443,7 @@ There can also be some text in between!
         assert_snapshot!(markdown_to_html(text, None, ""), @r###"
         <p>Here's a simple footnote,<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup> and here's a longer one.<sup><a href="#user-content-fn-bignote" id="user-content-fnref-bignote" rel="nofollow noopener noreferrer">2</a></sup></p>
         <p>There can also be some text in between!</p>
-        <section>
+        <section class="footnotes">
         <ol>
         <li id="user-content-fn-1">
         <p>This is the first footnote. <a href="#user-content-fnref-1" rel="nofollow noopener noreferrer">↩</a></p>

--- a/crates_io_markdown/lib.rs
+++ b/crates_io_markdown/lib.rs
@@ -427,6 +427,41 @@ mod tests {
     }
 
     #[test]
+    fn text_with_complex_footnotes() {
+        let text = r#"Here's a simple footnote,[^1] and here's a longer one.[^bignote]
+
+[^1]: This is the first footnote.
+
+There can also be some text in between!
+
+[^bignote]: Here's one with multiple paragraphs and code.
+
+    Indent paragraphs to include them in the footnote.
+
+    `{ my code }`
+
+    Add as many paragraphs as you like."#;
+
+        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        <p>Here's a simple footnote,<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup> and here's a longer one.<sup><a href="#fn-bignote" id="user-content-fnref-bignote" rel="nofollow noopener noreferrer">2</a></sup></p>
+        <p>There can also be some text in between!</p>
+        <section>
+        <ol>
+        <li id="user-content-fn-1">
+        <p>This is the first footnote. <a href="#user-content-fnref-1" rel="nofollow noopener noreferrer">↩</a></p>
+        </li>
+        <li id="user-content-fn-bignote">
+        <p>Here's one with multiple paragraphs and code.</p>
+        <p>Indent paragraphs to include them in the footnote.</p>
+        <p><code>{ my code }</code></p>
+        <p>Add as many paragraphs as you like. <a href="#fnref-bignote" rel="nofollow noopener noreferrer">↩</a></p>
+        </li>
+        </ol>
+        </section>
+        "###);
+    }
+
+    #[test]
     fn relative_links() {
         let absolute = "[hi](/hi)";
         let relative = "[there](there)";

--- a/tests/acceptance/readme-rendering-test.js
+++ b/tests/acceptance/readme-rendering-test.js
@@ -53,6 +53,9 @@ on StackOverflow</a>, the <a href="https://www.reddit.com/r/rust" rel="nofollow 
 weekly easy questions post, or the Rust <a href="https://users.rust-lang.org" rel="nofollow noopener noreferrer">Discourse forum</a>. It's
 acceptable to file a support issue in this repo but they tend not to get as many
 eyes as any of the above and may get closed without a response after some time.</p>
+
+<p>Hello World!<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup></p>
+
 <pre><code class="language-mermaid">
 graph TD;
     A-->B;
@@ -60,6 +63,14 @@ graph TD;
     B-->D;
     C-->D;
 </code></pre>
+
+<section class="footnotes">
+<ol>
+<li id="user-content-fn-1">
+<p>Hello Ferris, actually! <a href="#user-content-fnref-1" rel="nofollow noopener noreferrer">↩</a></p>
+</li>
+</ol>
+</section>
 `;
 
 module('Acceptance | README rendering', function (hooks) {


### PR DESCRIPTION
I realized that crates.io currently doesn't seem to render _Markdown Footnotes_ which are part of the GitHub Flavored Markdown spec. This is already supported on GitHub (obviously) and docs.rs renders them as well.

This conflicts a little bit with the HTML sanitiser, as it rewrites IDs but I did my best to match them properly in the URL sanitizer.
