### PR TITLE
markdown: Use insta inline snapshots for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,7 @@ dependencies = [
  "ammonia",
  "comrak",
  "htmlescape",
+ "insta",
  "url",
 ]
 

--- a/crates_io_markdown/Cargo.toml
+++ b/crates_io_markdown/Cargo.toml
@@ -14,3 +14,6 @@ ammonia = "=3.3.0"
 comrak = { version = "=0.19.0", default-features = false }
 htmlescape = "=0.3.1"
 url = "=2.4.1"
+
+[dev-dependencies]
+insta = "=1.34.0"

--- a/crates_io_markdown/lib.rs
+++ b/crates_io_markdown/lib.rs
@@ -364,40 +364,29 @@ mod tests {
 
     #[test]
     fn code_block_with_syntax_highlighting() {
-        let code_block = r#"```rust \
-                            println!("Hello World"); \
-                           ```"#;
+        let code_block = "```rust\nprintln!(\"Hello World\");\n```";
         assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
-        <pre><code class="language-rust">                            println!("Hello World"); \
-                                   ```
+        <pre><code class="language-rust">println!("Hello World");
         </code></pre>
         "###);
     }
 
     #[test]
     fn code_block_with_mermaid_highlighting() {
-        let code_block = r"```mermaid \
-                            graph LR \
-                            A --> C \
-                            C --> A \
-                           ```";
+        let code_block = "```mermaid\ngraph LR\nA --> C\nC --> A\n```";
         assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
-        <pre><code class="language-mermaid">                            graph LR \
-                                    A --&gt; C \
-                                    C --&gt; A \
-                                   ```
+        <pre><code class="language-mermaid">graph LR
+        A --&gt; C
+        C --&gt; A
         </code></pre>
         "###);
     }
 
     #[test]
     fn code_block_with_syntax_highlighting_even_if_annot_has_no_run() {
-        let code_block = r#"```rust  ,  no_run \
-                            println!("Hello World"); \
-                           ```"#;
+        let code_block = "```rust, no_run\nprintln!(\"Hello World\");\n```";
         assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
-        <pre><code class="language-rust">                            println!("Hello World"); \
-                                   ```
+        <pre><code class="language-rust">println!("Hello World");
         </code></pre>
         "###);
     }


### PR DESCRIPTION
see https://insta.rs/docs/snapshot-types/#inline-snapshots

The second commit in this PR also fixes a bug in our code block rendering tests which was discovered by the introduction of the snapshot tests. The combination of `r#"` strings and `\` led to us not actually using correct markdown syntax and the test only working by accident.