### PR TITLE
RequestHelper: Accept all `Into<Bytes>` in `publish_crate()` fn

### DIFF
--- a/src/tests/builders/publish.rs
+++ b/src/tests/builders/publish.rs
@@ -225,6 +225,12 @@ impl PublishBuilder {
     }
 }
 
+impl From<PublishBuilder> for Bytes {
+    fn from(builder: PublishBuilder) -> Self {
+        builder.body()
+    }
+}
+
 fn convert_dependency(
     encoded: &u::EncodableCrateDependency,
 ) -> (String, cargo_manifest::Dependency) {

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -44,14 +44,12 @@ fn tarball_between_default_axum_limit_and_max_upload_size() {
     let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
-    let response = token.put::<()>("/api/v1/crates/new", body);
+    let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
-
-    app.run_pending_background_jobs();
     assert_eq!(app.stored_files().len(), 2);
 }
 
@@ -84,11 +82,9 @@ fn tarball_bigger_than_max_upload_size() {
     let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
-    let response = token.put::<()>("/api/v1/crates/new", body);
+    let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
-
-    app.run_pending_background_jobs();
     assert!(app.stored_files().is_empty());
 }
 

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -43,11 +43,9 @@ fn new_krate_tarball_with_hard_links() {
     let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
-    let response = token.put::<()>("/api/v1/crates/new", body);
+    let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
-
-    app.run_pending_background_jobs();
     assert!(app.stored_files().is_empty());
 }
 
@@ -55,7 +53,7 @@ fn new_krate_tarball_with_hard_links() {
 fn empty() {
     let (app, _, user) = TestApp::full().with_user();
 
-    let response = user.put::<()>("/api/v1/crates/new", &[] as &[u8]);
+    let response = user.publish_crate(&[] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -65,7 +63,7 @@ fn empty() {
 fn json_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.put::<()>("/api/v1/crates/new", &[0u8, 0] as &[u8]);
+    let response = token.publish_crate(&[0u8, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -75,7 +73,7 @@ fn json_len_truncated() {
 fn json_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.put::<()>("/api/v1/crates/new", &[100u8, 0, 0, 0, 0] as &[u8]);
+    let response = token.publish_crate(&[100u8, 0, 0, 0, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -85,10 +83,7 @@ fn json_bytes_truncated() {
 fn tarball_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.put::<()>(
-        "/api/v1/crates/new",
-        &[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8],
-    );
+    let response = token.publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -98,10 +93,7 @@ fn tarball_len_truncated() {
 fn tarball_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.put::<()>(
-        "/api/v1/crates/new",
-        &[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8],
-    );
+    let response = token.publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -11,7 +11,7 @@ fn empty_json() {
     let (_json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
     let body = PublishBuilder::create_publish_body("{}", &tarball);
 
-    let response = token.put::<()>("/api/v1/crates/new", body);
+    let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
@@ -45,14 +45,14 @@ fn invalid_names() {
 
 #[test]
 fn invalid_version() {
-    let (app, _, _, token) = TestApp::init().with_token();
+    let (app, _, _, token) = TestApp::full().with_token();
 
     let (json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
     let new_json = json.replace(r#""vers":"1.0.0""#, r#""vers":"broken""#);
     assert_ne!(json, new_json);
     let body = PublishBuilder::create_publish_body(&new_json, &tarball);
 
-    let response = token.put::<()>("/api/v1/crates/new", body);
+    let response = token.publish_crate(body);
     assert_json_snapshot!(response.into_json());
     assert!(app.stored_files().is_empty());
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -20,8 +20,8 @@
 //! to the underlying database model value (`User` and `ApiToken` respectively).
 
 use crate::{
-    builders::PublishBuilder, CategoryListResponse, CategoryResponse, CrateList, CrateResponse,
-    GoodCrate, OkBool, OwnersResponse, VersionResponse,
+    CategoryListResponse, CategoryResponse, CrateList, CrateResponse, GoodCrate, OkBool,
+    OwnersResponse, VersionResponse,
 };
 use crates_io::middleware::session;
 use crates_io::models::{ApiToken, CreatedApiToken, User};
@@ -173,8 +173,8 @@ pub trait RequestHelper {
     ///
     /// Background jobs will publish to the git index and sync to the HTTP index.
     #[track_caller]
-    fn publish_crate(&self, publish_builder: PublishBuilder) -> Response<GoodCrate> {
-        let response = self.put("/api/v1/crates/new", publish_builder.body());
+    fn publish_crate(&self, body: impl Into<Bytes>) -> Response<GoodCrate> {
+        let response = self.put("/api/v1/crates/new", body);
         self.app().run_pending_background_jobs();
         response
     }


### PR DESCRIPTION
This allows us to use `publish_crate()` in more places, which ensures that `run_pending_background_jobs()` is run when asserting on `app.stored_files()`.