### PR TITLE
Heroku: Update `nginx` buildpack to v1.10

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,4 @@
 https://github.com/DataDog/heroku-buildpack-datadog.git#8d0b795
 https://github.com/unfold/heroku-buildpack-pnpm#b8dcee8
-https://github.com/heroku/heroku-buildpack-nginx#760407b
+https://github.com/heroku/heroku-buildpack-nginx#37a84b640e419fac6e58b77433d87194f7496c03
 https://github.com/Turbo87/heroku-buildpack-rust#30429b2


### PR DESCRIPTION
see https://github.com/heroku/heroku-buildpack-nginx/releases/tag/v1.10