### PR TITLE
Make membership of the workspace more explicit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 default-run = "server"
 
 [workspace]
-members = ["crates_io_smoke_test"]
+members = ["crates_io_*"]
 
 [profile.release]
 opt-level = 2


### PR DESCRIPTION
Path dependencies are automatically members of the workspace and don't have to be added explicitly. This PR tries to make it more explicit to reduce the confusion.