### PR TITLE
db/sql_types/semver: Remove `SerializedTriple` struct

### DIFF
--- a/src/db/sql_types/semver.rs
+++ b/src/db/sql_types/semver.rs
@@ -4,7 +4,6 @@ use diesel::{
     pg::Pg,
     sql_types::{Numeric, Record},
 };
-use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::schema::sql_types::SemverTriple;
@@ -46,29 +45,6 @@ impl FromSql<SemverTriple, Pg> for Triple {
                 value: teeny,
             })?,
         })
-    }
-}
-
-// `Triple` is used in `models::Version`, which requires it to implement `Serialize` and
-// `Deserialize`. Deriving those traits would result in this being serialised as a map, which feels
-// wasteful, since the field names are basically just noise. We'll serialise as a tuple instead.
-
-#[derive(Deserialize, Serialize)]
-struct SerializedTriple(u64, u64, u64);
-
-impl From<&Triple> for SerializedTriple {
-    fn from(value: &Triple) -> Self {
-        Self(value.major, value.minor, value.teeny)
-    }
-}
-
-impl From<SerializedTriple> for Triple {
-    fn from(value: SerializedTriple) -> Self {
-        Self {
-            major: value.0,
-            minor: value.1,
-            teeny: value.2,
-        }
     }
 }
 

--- a/src/db/sql_types/semver.rs
+++ b/src/db/sql_types/semver.rs
@@ -4,7 +4,7 @@ use diesel::{
     pg::Pg,
     sql_types::{Numeric, Record},
 };
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::schema::sql_types::SemverTriple;
@@ -69,24 +69,6 @@ impl From<SerializedTriple> for Triple {
             minor: value.1,
             teeny: value.2,
         }
-    }
-}
-
-impl<'de> Deserialize<'de> for Triple {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        Ok(SerializedTriple::deserialize(deserializer)?.into())
-    }
-}
-
-impl Serialize for Triple {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        SerializedTriple::from(self).serialize(serializer)
     }
 }
 

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -11,7 +11,7 @@ use crate::schema::*;
 use crate::sql::split_part;
 
 // Queryable has a custom implementation below
-#[derive(Clone, Identifiable, Associations, Debug, Queryable, Deserialize, Serialize)]
+#[derive(Clone, Identifiable, Associations, Debug, Queryable)]
 #[diesel(belongs_to(Crate))]
 pub struct Version {
     pub id: i32,


### PR DESCRIPTION
This struct was introduced to simplify the (de)serialization of the `Triple` struct from the database, because the `models::Version` struct implements the `De/Serialize` traits. As it turns out, these traits from the `models::Version` struct are not actually used anywhere though.

This PR removes the unused trait impls and then removes the now obsolete `SerializedTriple` struct.