### PR TITLE
middleware: Add `tracing` instrumentation

### DIFF
--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -6,6 +6,7 @@ use crate::app::AppState;
 use crate::controllers::util::RequestPartsExt;
 
 /// `axum` middleware that injects the `AppState` instance into the `Request` extensions.
+#[instrument(skip_all)]
 pub async fn add_app_state_extension<B>(
     app_state: AppState,
     mut request: Request<B>,

--- a/src/middleware/balance_capacity.rs
+++ b/src/middleware/balance_capacity.rs
@@ -40,6 +40,7 @@ async fn handle_high_load<B>(
     }
 }
 
+#[instrument(skip_all)]
 pub async fn balance_capacity<B>(
     app_state: AppState,
     request: Request<B>,

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -16,6 +16,7 @@ use axum::middleware::Next;
 use axum::response::IntoResponse;
 use http::StatusCode;
 
+#[instrument(skip_all)]
 pub async fn block_traffic<B>(
     state: AppState,
     req: http::Request<B>,
@@ -57,6 +58,7 @@ pub async fn block_traffic<B>(
 
 /// Allow blocking individual routes by their pattern through the `BLOCKED_ROUTES`
 /// environment variable.
+#[instrument(skip_all)]
 pub async fn block_routes<B>(
     matched_path: Option<MatchedPath>,
     state: AppState,

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -13,6 +13,7 @@ use http::{header, Request, StatusCode};
 use tower::ServiceExt;
 use tower_http::services::ServeFile;
 
+#[instrument(skip_all)]
 pub async fn serve_html<B: Send + 'static>(request: Request<B>, next: Next<B>) -> Response {
     let path = &request.uri().path();
 

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -112,6 +112,7 @@ impl Display for Metadata<'_> {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn log_requests<B>(
     request_metadata: RequestMetadata,
     mut req: Request<B>,

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -50,6 +50,7 @@ impl Deref for SessionExtension {
     }
 }
 
+#[instrument(skip_all)]
 pub async fn attach_session<B>(
     jar: SignedCookieJar,
     mut req: Request<B>,

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -8,10 +8,12 @@ use std::path::Path;
 use tower::ServiceExt;
 use tower_http::services::ServeDir;
 
+#[instrument(skip_all)]
 pub async fn serve_local_uploads<B>(request: Request<B>, next: Next<B>) -> Response {
     serve("local_uploads", request, next).await
 }
 
+#[instrument(skip_all)]
 pub async fn serve_dist<B>(request: Request<B>, next: Next<B>) -> Response {
     serve("dist", request, next).await
 }

--- a/src/middleware/update_metrics.rs
+++ b/src/middleware/update_metrics.rs
@@ -7,6 +7,7 @@ use http::Request;
 use prometheus::IntGauge;
 use std::time::Instant;
 
+#[instrument(skip_all)]
 pub async fn update_metrics<B>(
     state: AppState,
     matched_path: Option<MatchedPath>,


### PR DESCRIPTION
The goal of this is to give us more datapoints to identify what middlewares might affect the performance of the system.