### PR TITLE
SQL: Fix metadata handling in to_semver_no_prerelease() function

### DIFF
--- a/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/down.sql
+++ b/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/down.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION to_semver_no_prerelease(text) RETURNS public.semver_triple IMMUTABLE PARALLEL SAFE AS $$
+  SELECT (
+    split_part($1, '.', 1)::numeric,
+    split_part($1, '.', 2)::numeric,
+    split_part(split_part($1, '+', 1), '.', 3)::numeric
+  )::public.semver_triple
+  WHERE strpos($1, '-') = 0
+  $$ LANGUAGE SQL;

--- a/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/up.sql
+++ b/migrations/2023-10-19-092709_fix_semver_no_prerelease_fn/up.sql
@@ -1,0 +1,8 @@
+CREATE OR REPLACE FUNCTION to_semver_no_prerelease(text) RETURNS public.semver_triple IMMUTABLE PARALLEL SAFE AS $$
+  SELECT (
+    split_part($1, '.', 1)::numeric,
+    split_part($1, '.', 2)::numeric,
+    split_part(split_part($1, '+', 1), '.', 3)::numeric
+  )::public.semver_triple
+  WHERE strpos(split_part($1, '+', 1), '-') = 0
+  $$ LANGUAGE SQL;

--- a/src/db/sql_types/semver.rs
+++ b/src/db/sql_types/semver.rs
@@ -13,7 +13,7 @@ use crate::schema::sql_types::SemverTriple;
 /// Note that this implements `FromSql` but not `ToSql` as this is only used in a generated column
 /// and therefore we should never have to insert a record that includes an instance of this.
 /// Implementing `ToSql` is trivial, but therefore unnecessary.
-#[derive(Debug, Clone, AsExpression)]
+#[derive(Debug, Clone, Eq, PartialEq, AsExpression)]
 #[diesel(sql_type = SemverTriple)]
 pub struct Triple {
     pub major: u64,

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -53,3 +53,39 @@ macro_rules! pg_enum {
 }
 
 pub(crate) use pg_enum;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::sql_types::semver::Triple;
+    use crate::schema::sql_types::SemverTriple;
+    use crate::test_util::pg_connection;
+    use diesel::prelude::*;
+    use diesel::select;
+
+    sql_function!(fn to_semver_no_prerelease(x: Text) -> Nullable<SemverTriple>);
+
+    #[test]
+    fn to_semver_no_prerelease_works() {
+        let mut conn = pg_connection();
+
+        #[track_caller]
+        fn test(conn: &mut PgConnection, text: &str, expected: Option<(u64, u64, u64)>) {
+            let query = select(to_semver_no_prerelease(text));
+            let result = query
+                .get_result::<Option<Triple>>(conn)
+                .unwrap()
+                .map(|triple| (triple.major, triple.minor, triple.teeny));
+
+            assert_eq!(result, expected);
+        }
+
+        test(&mut conn, "0.0.0", Some((0, 0, 0)));
+        test(&mut conn, "1.2.4", Some((1, 2, 4)));
+        test(&mut conn, "1.2.4+metadata", Some((1, 2, 4)));
+        test(&mut conn, "1.2.4-beta.3", None);
+        // TODO: see https://github.com/rust-lang/crates.io/issues/3882
+        test(&mut conn, "0.4.45+curl-7.78.0", None);
+        test(&mut conn, "0.1.4-preview+4.3.2", None);
+    }
+}

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -84,8 +84,8 @@ mod tests {
         test(&mut conn, "1.2.4", Some((1, 2, 4)));
         test(&mut conn, "1.2.4+metadata", Some((1, 2, 4)));
         test(&mut conn, "1.2.4-beta.3", None);
-        // TODO: see https://github.com/rust-lang/crates.io/issues/3882
-        test(&mut conn, "0.4.45+curl-7.78.0", None);
+        // see https://github.com/rust-lang/crates.io/issues/3882
+        test(&mut conn, "0.4.45+curl-7.78.0", Some((0, 4, 45)));
         test(&mut conn, "0.1.4-preview+4.3.2", None);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/3882

This PR is basically reviving https://github.com/rust-lang/crates.io/pull/3886, since we now have a generated and stored `semver_no_prerelease` column in the `versions` table, which should fix the performance concerns that led to #3886 being initially rejected.