### PR TITLE
Migrate common headers from nginx to axum middleware

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,18 +1,11 @@
 <%
-def s3_host(env)
+def s3_cdn(env)
 	cdn = env['S3_CDN']
 	if cdn and !cdn.empty?
-		return cdn
+		return "https://#{cdn}"
 	end
 
-	region = env['S3_REGION']
-	bucket = env['S3_BUCKET']
-
-	if region and !region.empty?
-		region = "-#{region}"
-	end
-
-	return "#{bucket}.s3#{region}.amazonaws.com"
+	return ""
 end
 %>
 
@@ -219,7 +212,7 @@ http {
 		add_header X-Frame-Options "SAMEORIGIN";
 		add_header X-XSS-Protection "0";
 
-		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org https://<%= s3_host(ENV) %>; script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
+		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org <%= s3_cdn(ENV) %>; script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
 		add_header Access-Control-Allow-Origin "*" always;
 
 		add_header Strict-Transport-Security "max-age=31536000" always;

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -1,14 +1,3 @@
-<%
-def s3_cdn(env)
-	cdn = env['S3_CDN']
-	if cdn and !cdn.empty?
-		return "https://#{cdn}"
-	end
-
-	return ""
-end
-%>
-
 daemon off;
 #Heroku dynos have at least 4 cores.
 worker_processes <%= ENV['NGINX_WORKERS'] || 4 %>;
@@ -207,16 +196,6 @@ http {
 			root dist;
 			expires 1d;
 		}
-
-		add_header X-Content-Type-Options "nosniff";
-		add_header X-Frame-Options "SAMEORIGIN";
-		add_header X-XSS-Protection "0";
-
-		add_header Content-Security-Policy "default-src 'self'; connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org <%= s3_cdn(ENV) %>; script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; font-src https://code.cdn.mozilla.net; img-src *; object-src 'none'";
-		add_header Access-Control-Allow-Origin "*" always;
-
-		add_header Strict-Transport-Security "max-age=31536000" always;
-		add_header Vary 'Accept, Accept-Encoding, Cookie';
 
 		proxy_set_header Host $http_host;
 		proxy_set_header X-Real-Ip $remote_addr;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,7 @@
 pub mod app;
 mod balance_capacity;
 mod block_traffic;
+mod common_headers;
 mod debug;
 mod ember_html;
 pub mod log_request;
@@ -62,6 +63,10 @@ pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
         .layer(from_fn_with_state(
             state.clone(),
             block_traffic::block_routes,
+        ))
+        .layer(from_fn_with_state(
+            state.clone(),
+            common_headers::add_common_headers,
         ))
         .layer(conditional_layer(env == Env::Development, || {
             from_fn(static_or_continue::serve_local_uploads)

--- a/src/middleware/common_headers.rs
+++ b/src/middleware/common_headers.rs
@@ -21,24 +21,12 @@ pub async fn add_common_headers<B: Send + 'static>(
     headers.insert(header::STRICT_TRANSPORT_SECURITY, v("max-age=31536000"));
 
     if NGINX_SUCCESS_CODES.contains(&response.status().as_u16()) {
-        let cdn_prefix = state.config.storage.cdn_prefix.as_ref();
-        let cdn_domain = cdn_prefix.map(|cdn_prefix| format!("https://{cdn_prefix}"));
-        let cdn_domain = cdn_domain.unwrap_or_default();
-
-        let csp = format!(
-            "default-src 'self'; \
-            connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org {cdn_domain}; \
-            script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='; \
-            style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; \
-            font-src https://code.cdn.mozilla.net; \
-            img-src *; \
-            object-src 'none'"
-        );
-
         headers.insert(header::X_CONTENT_TYPE_OPTIONS, v("nosniff"));
         headers.insert(header::X_FRAME_OPTIONS, v("SAMEORIGIN"));
         headers.insert(header::X_XSS_PROTECTION, v("0"));
-        headers.insert(header::CONTENT_SECURITY_POLICY, csp.parse().unwrap());
+        if let Some(ref csp) = state.config.content_security_policy {
+            headers.insert(header::CONTENT_SECURITY_POLICY, csp.clone());
+        }
         headers.insert(header::VARY, v("Accept, Accept-Encoding, Cookie"));
     }
 

--- a/src/middleware/common_headers.rs
+++ b/src/middleware/common_headers.rs
@@ -1,0 +1,46 @@
+use crate::app::AppState;
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use http::{header, HeaderMap, HeaderValue, Request};
+
+// see http://nginx.org/en/docs/http/ngx_http_headers_module.html#add_header
+const NGINX_SUCCESS_CODES: [u16; 10] = [200, 201, 204, 206, 301, 203, 303, 304, 307, 308];
+
+#[instrument(skip_all)]
+pub async fn add_common_headers<B: Send + 'static>(
+    state: AppState,
+    request: Request<B>,
+    next: Next<B>,
+) -> impl IntoResponse {
+    let response = next.run(request).await;
+
+    let v = HeaderValue::from_static;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, v("*"));
+    headers.insert(header::STRICT_TRANSPORT_SECURITY, v("max-age=31536000"));
+
+    if NGINX_SUCCESS_CODES.contains(&response.status().as_u16()) {
+        let cdn_prefix = state.config.storage.cdn_prefix.as_ref();
+        let cdn_domain = cdn_prefix.map(|cdn_prefix| format!("https://{cdn_prefix}"));
+        let cdn_domain = cdn_domain.unwrap_or_default();
+
+        let csp = format!(
+            "default-src 'self'; \
+            connect-src 'self' *.ingest.sentry.io https://docs.rs https://play.rust-lang.org {cdn_domain}; \
+            script-src 'self' 'unsafe-eval' 'sha256-n1+BB7Ckjcal1Pr7QNBh/dKRTtBQsIytFodRiIosXdE='; \
+            style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; \
+            font-src https://code.cdn.mozilla.net; \
+            img-src *; \
+            object-src 'none'"
+        );
+
+        headers.insert(header::X_CONTENT_TYPE_OPTIONS, v("nosniff"));
+        headers.insert(header::X_FRAME_OPTIONS, v("SAMEORIGIN"));
+        headers.insert(header::X_XSS_PROTECTION, v("0"));
+        headers.insert(header::CONTENT_SECURITY_POLICY, csp.parse().unwrap());
+        headers.insert(header::VARY, v("Accept, Accept-Encoding, Cookie"));
+    }
+
+    (headers, response)
+}

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -417,6 +417,7 @@ fn simple_config() -> config::Server {
         // The frontend code is not needed for the backend tests.
         serve_dist: false,
         serve_html: false,
+        content_security_policy: None,
     }
 }
 


### PR DESCRIPTION
We eventually would like to get rid of the `nginx` wrapper that we use on Heroku and rely completely on our axum server. This PR is one more step in that direction. It migrates most of the `add_header` calls from the nginx configuration to a custom axum middleware.

Note that the first commit simplifies the `s3_host()` fn a little bit to make the migration easier. The commit message explains the reasoning behind the simplification.