### PR TITLE
Migrate request and body timeouts from nginx to axum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ threadpool = "=1.8.1"
 tokio = { version = "=1.33.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.8.2"
 tower = "=0.4.13"
-tower-http = { version = "=0.4.4", features = ["fs", "catch-panic"] }
+tower-http = { version = "=0.4.4", features = ["fs", "catch-panic", "timeout"] }
 tracing = "=0.1.40"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }
 url = "=2.4.1"

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -164,7 +164,6 @@ http {
 	default_type application/octet-stream;
 	sendfile on;
 
-	client_body_timeout 30;
 	client_max_body_size 50m;
 
 	upstream app_server {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -18,8 +18,10 @@ use axum::middleware::{from_fn, from_fn_with_state};
 use axum::Router;
 use axum_extra::either::Either;
 use axum_extra::middleware::option_layer;
+use std::time::Duration;
 use tower::layer::util::Identity;
 use tower_http::catch_panic::CatchPanicLayer;
+use tower_http::timeout::TimeoutLayer;
 
 use crate::app::AppState;
 use crate::Env;
@@ -36,6 +38,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router) -> Router {
     }
 
     let middleware = tower::ServiceBuilder::new()
+        .layer(TimeoutLayer::new(Duration::from_secs(30)))
         .layer(sentry_tower::NewSentryLayer::new_from_top())
         .layer(sentry_tower::SentryHttpLayer::with_transaction())
         .layer(from_fn(log_request::log_requests))

--- a/src/router.rs
+++ b/src/router.rs
@@ -3,6 +3,8 @@ use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::Router;
 use http::{Method, StatusCode};
+use hyper::Body;
+use tower_http::timeout::TimeoutBody;
 
 use crate::app::AppState;
 use crate::controllers::*;
@@ -11,7 +13,7 @@ use crate::Env;
 
 const MAX_PUBLISH_CONTENT_LENGTH: usize = 128 * 1024 * 1024; // 128 MB
 
-pub fn build_axum_router(state: AppState) -> Router {
+pub fn build_axum_router(state: AppState) -> Router<(), TimeoutBody<Body>> {
     let mut router = Router::new()
         // Route used by both `cargo search` and the frontend
         .route("/api/v1/crates", get(krate::search::search))


### PR DESCRIPTION
We've been using the [`client_body_timeout 30` nginx option](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_timeout) to ensure timeouts between request body read operations that can be caused by maliciously slow clients.

https://docs.rs/tower-http/latest/tower_http/timeout/struct.RequestBodyTimeoutLayer.html serves a similar purpose, and while we're at it, I've also added corresponding request and response body timeouts (see http://nginx.org/en/docs/http/ngx_http_core_module.html#send_timeout). This should cover all of the timeouts that nginx and the Heroku router have provided us so far.