### PR TITLE
nginx: Remove obsolete `ember-fetch` and `moment` paths from configuration

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -176,7 +176,7 @@ http {
 		server_name _;
 		keepalive_timeout 5;
 
-		location ~ ^/(assets|ember-fetch|moment)/ {
+		location ~ ^/assets/ {
 			add_header X-Content-Type-Options nosniff;
 			add_header Cache-Control public;
 			root dist;


### PR DESCRIPTION
We are no longer using these libraries so there is no need for these configuration options anymore :)