### PR TITLE
Revert "middleware: Add `tracing` instrumentation"

### DIFF
--- a/src/middleware/app.rs
+++ b/src/middleware/app.rs
@@ -6,7 +6,6 @@ use crate::app::AppState;
 use crate::controllers::util::RequestPartsExt;
 
 /// `axum` middleware that injects the `AppState` instance into the `Request` extensions.
-#[instrument(skip_all)]
 pub async fn add_app_state_extension<B>(
     app_state: AppState,
     mut request: Request<B>,

--- a/src/middleware/balance_capacity.rs
+++ b/src/middleware/balance_capacity.rs
@@ -40,7 +40,6 @@ async fn handle_high_load<B>(
     }
 }
 
-#[instrument(skip_all)]
 pub async fn balance_capacity<B>(
     app_state: AppState,
     request: Request<B>,

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -16,7 +16,6 @@ use axum::middleware::Next;
 use axum::response::IntoResponse;
 use http::StatusCode;
 
-#[instrument(skip_all)]
 pub async fn block_traffic<B>(
     state: AppState,
     req: http::Request<B>,
@@ -58,7 +57,6 @@ pub async fn block_traffic<B>(
 
 /// Allow blocking individual routes by their pattern through the `BLOCKED_ROUTES`
 /// environment variable.
-#[instrument(skip_all)]
 pub async fn block_routes<B>(
     matched_path: Option<MatchedPath>,
     state: AppState,

--- a/src/middleware/common_headers.rs
+++ b/src/middleware/common_headers.rs
@@ -11,7 +11,6 @@ const NGINX_SUCCESS_CODES: [u16; 10] = [200, 201, 204, 206, 301, 203, 303, 304, 
 const ONE_DAY: Duration = Duration::from_secs(24 * 60 * 60);
 const ONE_YEAR: Duration = Duration::from_secs(365 * 24 * 60 * 60);
 
-#[instrument(skip_all)]
 pub async fn add_common_headers<B: Send + 'static>(
     state: AppState,
     request: Request<B>,

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -13,7 +13,6 @@ use http::{header, Request, StatusCode};
 use tower::ServiceExt;
 use tower_http::services::ServeFile;
 
-#[instrument(skip_all)]
 pub async fn serve_html<B: Send + 'static>(request: Request<B>, next: Next<B>) -> Response {
     let path = &request.uri().path();
 

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -112,7 +112,6 @@ impl Display for Metadata<'_> {
     }
 }
 
-#[instrument(skip_all)]
 pub async fn log_requests<B>(
     request_metadata: RequestMetadata,
     mut req: Request<B>,

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -50,7 +50,6 @@ impl Deref for SessionExtension {
     }
 }
 
-#[instrument(skip_all)]
 pub async fn attach_session<B>(
     jar: SignedCookieJar,
     mut req: Request<B>,

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -8,12 +8,10 @@ use std::path::Path;
 use tower::ServiceExt;
 use tower_http::services::ServeDir;
 
-#[instrument(skip_all)]
 pub async fn serve_local_uploads<B>(request: Request<B>, next: Next<B>) -> Response {
     serve("local_uploads", request, next).await
 }
 
-#[instrument(skip_all)]
 pub async fn serve_dist<B>(request: Request<B>, next: Next<B>) -> Response {
     serve("dist", request, next).await
 }

--- a/src/middleware/update_metrics.rs
+++ b/src/middleware/update_metrics.rs
@@ -7,7 +7,6 @@ use http::Request;
 use prometheus::IntGauge;
 use std::time::Instant;
 
-#[instrument(skip_all)]
 pub async fn update_metrics<B>(
     state: AppState,
     matched_path: Option<MatchedPath>,


### PR DESCRIPTION
Reverts rust-lang/crates.io#7315

As somewhat expected, this was not particularly useful and caused more noise than anything else. Let's revert it and find other ways of getting to the information we're interested in...