### PR TITLE
Migrate gzip compression from nginx to `tower-http::compression`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "ammonia"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,11 +175,14 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f658e2baef915ba0f26f1f7c42bfb8e12f532a01f449a090ded75ae7a07e9ba2"
 dependencies = [
+ "brotli",
  "flate2",
  "futures-core",
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -412,6 +430,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503a0bcf59056a66c55d8eefd05e9c0f00f9c9cdddbb6bd499623ce49100da43"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -3838,6 +3877,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
 dependencies = [
+ "async-compression",
  "bitflags 2.4.1",
  "bytes",
  "futures-core",
@@ -4433,3 +4473,31 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zstd"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.9+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ threadpool = "=1.8.1"
 tokio = { version = "=1.33.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.8.2"
 tower = "=0.4.13"
-tower-http = { version = "=0.4.4", features = ["fs", "catch-panic", "timeout"] }
+tower-http = { version = "=0.4.4", features = ["fs", "catch-panic", "timeout", "compression-full"] }
 tracing = "=0.1.40"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }
 url = "=2.4.1"

--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -158,17 +158,6 @@ http {
 	set_real_ip_from 223.71.71.96/27;
 	set_real_ip_from 223.71.71.128/25;
 
-    # Enable gzip compression of responses
-	gzip on;
-	# Set the gzip compression level to 2 (range: 1-9, nginx default: 1)
-	gzip_comp_level 2;
-	# Enable gzip compression for all proxied requests
-	gzip_proxied any;
-	# Set the minimum length of a response that will be gzipped. The length is determined only from the “Content-Length” response header field.
-	gzip_min_length 512;
-	# Enable gzip for responses with the specified MIME types in addition to “text/html”. Responses with the “text/html” type are always compressed.
-	gzip_types text/plain text/css application/json application/javascript application/x-javascript text/javascript text/xml application/xml application/rss+xml application/atom+xml application/rdf+xml image/svg+xml;
-
     # Disable emitting nginx version on error pages and in the “Server” response header field
 	server_tokens off;
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -22,6 +22,7 @@ use hyper::Body;
 use std::time::Duration;
 use tower::layer::util::Identity;
 use tower_http::catch_panic::CatchPanicLayer;
+use tower_http::compression::{CompressionLayer, CompressionLevel};
 use tower_http::timeout::{RequestBodyTimeoutLayer, TimeoutBody, TimeoutLayer};
 
 use crate::app::AppState;
@@ -39,6 +40,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router<(), TimeoutBody<Bod
     }
 
     let middleware = tower::ServiceBuilder::new()
+        .layer(CompressionLayer::new().quality(CompressionLevel::Fastest))
         .layer(RequestBodyTimeoutLayer::new(Duration::from_secs(30)))
         .layer(TimeoutLayer::new(Duration::from_secs(30)))
         .layer(sentry_tower::NewSentryLayer::new_from_top())


### PR DESCRIPTION
see https://docs.rs/tower-http/latest/tower_http/compression/index.html

This is using slightly different settings than with nginx, but most of them seem reasonable:

- nginx defaults to 20 bytes, we explicitly set it to 512 bytes for undocumented reasons, tower-http defaults to 32 bytes. using the defaults here appears to be fine on first glance. if we see problems with this we can still change this to use the old 512 bytes setting.
- nginx uses a MIME type allow list list, while tower-http uses a deny list, which includes by default all images except for SVGs. since we don't use any exotic MIME types (crate files come from S3 directly) this should be fine.
- nginx only supports gzip compression, tower-http enables brotli, deflate, gzip and zstd 🎉 
- tower-http uses the "default compression level set by the compression algorithm" by default, but since we're in a server setting we would like to respond as quick as possible. for static assets we can consider pre-compressing them on disk, but that is out of scope for this pull request (see #7332).

Note that I've successfully tested this out on our staging environment at https://staging-crates-io.herokuapp.com/. Interestingly, brotli compression worked for https://staging-crates-io.herokuapp.com/, but not when accessed via https://staging.crates.io/. My assumption is that brotli compression is currently disabled on CloudFront for some reason and it is re-encoding the responses with gzip. I will talk to the infra team about this next week, but I don't consider it a blocking concern.