### PR TITLE
Format all markdown files with prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ categories will be synced from this file.
 
 Licensed under either of these:
 
- * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-   https://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or
-   https://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+  https://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  https://opensource.org/licenses/MIT)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,13 +10,13 @@ This is a work in progress. Pull requests and issues to improve this document ar
 
 Documentation about the codebase appears in these locations:
 
-* `LICENSE-APACHE` and `LICENSE-MIT` - the terms under which this codebase is licensed.
-* `README.md` - Important information we want to show on the github front page.
-* `docs/` - Long-form documentation.
+- `LICENSE-APACHE` and `LICENSE-MIT` - the terms under which this codebase is licensed.
+- `README.md` - Important information we want to show on the github front page.
+- `docs/` - Long-form documentation.
 
 ## Backend - Rust
 
-The backend of crates.io is written in Rust. Most of that code lives in the *src* directory. It
+The backend of crates.io is written in Rust. Most of that code lives in the _src_ directory. It
 serves a JSON API over HTTP, and the HTTP server interface is provided by the [axum][] crate and
 related crates. More information about the backend is in
 [`docs/BACKEND.md`](https://github.com/rust-lang/crates.io/blob/master/docs/BACKEND.md).
@@ -25,14 +25,14 @@ related crates. More information about the backend is in
 
 These files and directories have to do with the backend:
 
-* `build.rs` - Cargo build script
-* `Cargo.lock` - Locks dependencies to specific versions providing consistency across development
+- `build.rs` - Cargo build script
+- `Cargo.lock` - Locks dependencies to specific versions providing consistency across development
   and deployment
-* `Cargo.toml` - Defines the crate and its dependencies
-* `migrations/` - Diesel migrations applied to the database during development and deployment
-* `.rustfmt.toml` - Defines Rust coding style guidelines which are enforced by the CI environment
-* `src/` - The backend's source code
-* `target/` - Compiled output, including dependencies and final binary artifacts - (ignored in
+- `Cargo.toml` - Defines the crate and its dependencies
+- `migrations/` - Diesel migrations applied to the database during development and deployment
+- `.rustfmt.toml` - Defines Rust coding style guidelines which are enforced by the CI environment
+- `src/` - The backend's source code
+- `target/` - Compiled output, including dependencies and final binary artifacts - (ignored in
   `.gitignore`)
 
 The backend stores information in a Postgres database.
@@ -46,22 +46,22 @@ frontend is in [`docs/FRONTEND.md`](https://github.com/rust-lang/crates.io/blob/
 
 These files have to do with the frontend:
 
-* `app/` - The frontend's source code
-* `config/{environment,targets}.js` - Configuration of the frontend
-* `dist/` - Contains the distributable (optimized and self-contained) output of building the
+- `app/` - The frontend's source code
+- `config/{environment,targets}.js` - Configuration of the frontend
+- `dist/` - Contains the distributable (optimized and self-contained) output of building the
   frontend; served under the root `/` url - (ignored in `.gitignore`)
-* `.ember-cli` - Settings for the `ember` command line interface
-* `ember-cli-build.js` - Contains the build specification for Broccoli
-* `.eslintrc.js` - Defines Javascript coding style guidelines (enforced during CI???)
-* `mirage/` - A mock backend used during development and testing
-* `node_modules/` - npm dependencies - (ignored in `.gitignore`)
-* `package.json` - Defines the npm package and its dependencies
-* `package-lock.json` - Locks dependencies to specific versions providing consistency across
+- `.ember-cli` - Settings for the `ember` command line interface
+- `ember-cli-build.js` - Contains the build specification for Broccoli
+- `.eslintrc.js` - Defines Javascript coding style guidelines (enforced during CI???)
+- `mirage/` - A mock backend used during development and testing
+- `node_modules/` - npm dependencies - (ignored in `.gitignore`)
+- `package.json` - Defines the npm package and its dependencies
+- `package-lock.json` - Locks dependencies to specific versions providing consistency across
   development and deployment
-* `public/` - Static files that are merged into `dist/` during build
-* `testem.js` - Integration with Test'em Scripts
-* `tests/` - Frontend tests
-* `vendor/` - frontend dependencies not distributed by npm; not currently used
+- `public/` - Static files that are merged into `dist/` during build
+- `testem.js` - Integration with Test'em Scripts
+- `tests/` - Frontend tests
+- `vendor/` - frontend dependencies not distributed by npm; not currently used
 
 ## Deployment - Heroku
 
@@ -71,32 +71,32 @@ These files are Heroku-specific; if you're deploying the crates.io codebase on a
 there's useful information in these files that you might need to translate to a different format
 for another platform.
 
-* `.buildpacks` - A list of buildpacks used during deployment
-* `config/nginx.conf.erb` - Template used by the nginx buildpack
-* `.diesel_version` - Used by diesel buildpack to install a specific version of Diesel CLI during
+- `.buildpacks` - A list of buildpacks used during deployment
+- `config/nginx.conf.erb` - Template used by the nginx buildpack
+- `.diesel_version` - Used by diesel buildpack to install a specific version of Diesel CLI during
   deployment
-* `Procfile` - Contains process type declarations for Heroku
+- `Procfile` - Contains process type declarations for Heroku
 
 ## Development
 
 These files are mostly only relevant when running crates.io's code in development mode.
 
-* `.editorconfig` - Coding style definitions supported by some IDEs
-  * [EditorConfig for VS Code]
-  * [EditorConfig for JetBrains IDEs]
-  * More plugins are available at: https://editorconfig.org/#download
-* `.env` - Environment variables loaded by the backend - (ignored in `.gitignore`)
-* `.env.sample` - Example environment file checked into the repository
-* `.git/` - The git repository; not available in all deployments (e.g. Heroku)
-* `.gitignore` - Configures git to ignore certain files and folders
-* `local_uploads/` - Serves crates and readmes that are published to the
-local development environment
-* `script/init-local-index.sh` - Creates registry repositories used during development
-* `tmp/` - Temporary files created during development; when deployed on Heroku this is the only
+- `.editorconfig` - Coding style definitions supported by some IDEs
+  - [EditorConfig for VS Code]
+  - [EditorConfig for JetBrains IDEs]
+  - More plugins are available at: https://editorconfig.org/#download
+- `.env` - Environment variables loaded by the backend - (ignored in `.gitignore`)
+- `.env.sample` - Example environment file checked into the repository
+- `.git/` - The git repository; not available in all deployments (e.g. Heroku)
+- `.gitignore` - Configures git to ignore certain files and folders
+- `local_uploads/` - Serves crates and readmes that are published to the
+  local development environment
+- `script/init-local-index.sh` - Creates registry repositories used during development
+- `tmp/` - Temporary files created during development; when deployed on Heroku this is the only
   writable directory - (ignored in `.gitignore`)
-* `tmp/index-bare` - A bare git repository during development - (ignored in `.gitignore`)
-* `.github/workflows/*` - Configuration for continuous integration at [GitHub Actions]
-* `.watchmanconfig` - Use by Ember CLI to efficiently watch for file changes if you install watchman
+- `tmp/index-bare` - A bare git repository during development - (ignored in `.gitignore`)
+- `.github/workflows/*` - Configuration for continuous integration at [GitHub Actions]
+- `.watchmanconfig` - Use by Ember CLI to efficiently watch for file changes if you install watchman
 
 [GitHub Actions]: https://github.com/rust-lang/crates.io/actions
 [EditorConfig for VS Code]: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig

--- a/docs/BACKEND.md
+++ b/docs/BACKEND.md
@@ -2,7 +2,7 @@
 
 ## Server
 
-The code to actually run the server is in *src/bin/server.rs*. This is where most of the pieces of
+The code to actually run the server is in _src/bin/server.rs_. This is where most of the pieces of
 the system are instantiated and configured, and can be thought of as the "entry point" to crates.io.
 
 The server does the following things:
@@ -11,7 +11,7 @@ The server does the following things:
 2. Check out the index git repository, if it isn't already checked out
 3. Reads values from environment variables to configure a new instance of `crates_io::App`
 4. Adds middleware to the app by calling `crates_io::middleware`
-5. Syncs the categories defined in *src/categories.toml* with the categories in the database
+5. Syncs the categories defined in _src/categories.toml_ with the categories in the database
 6. Starts a [hyper] server that uses the `crates_io::App` instance
 7. Tells Nginx on Heroku that the application is ready to receive requests, if running on Heroku
 8. Blocks forever (or until the process is killed)
@@ -21,7 +21,7 @@ The server does the following things:
 ## Routes
 
 The API URLs that the server responds to (aka "routes") are defined in
-*src/router.rs*.
+_src/router.rs_.
 
 All of the `api_router` routes are mounted under the `/api/v1` path (see the
 lines that look like `router.get("/api/v1/*path", R(api_router.clone()));`).
@@ -43,7 +43,7 @@ succeed. The `C` struct's purpose is to reduce some boilerplate.
 
 ## Code having to do with running a web application
 
-These modules could *maybe* be refactored into another crate. Maybe not. But their primary purpose
+These modules could _maybe_ be refactored into another crate. Maybe not. But their primary purpose
 is supporting the running of crates.io's web application parts, and they don't have much to do with
 the crate registry purpose of the application.
 
@@ -142,16 +142,16 @@ In addition to setting `RECORD`, you will also need to set a number of other
 environment variables to handle any requests to S3. These are in `.env.sample`,
 but are also reproduced here for convenience:
 
-* `TEST_S3_BUCKET`: the S3 bucket used for package uploads.
-* `TEST_S3_REGION`: the S3 region used to package uploads. This may also be an
+- `TEST_S3_BUCKET`: the S3 bucket used for package uploads.
+- `TEST_S3_REGION`: the S3 region used to package uploads. This may also be an
   absolute URL (such as `http://127.0.0.1:19000`), in which that will be used as
   the endpoint. If this is an S3 region name, then it must be one that supports
   what [AWS documents as `s3-Region` host names][s3-region].
-* `TEST_S3_INDEX_BUCKET`: the S3 bucket used for sparse index uploads.
-* `TEST_S3_INDEX_REGION`: the S3 region used for sparse index uploads. This has
+- `TEST_S3_INDEX_BUCKET`: the S3 bucket used for sparse index uploads.
+- `TEST_S3_INDEX_REGION`: the S3 region used for sparse index uploads. This has
   the same semantics as `TEST_S3_REGION`.
-* `TEST_AWS_ACCESS_KEY`: the AWS access key used with S3.
-* `TEST_AWS_SECRET_KEY`: the AWS secret key used with S3.
+- `TEST_AWS_ACCESS_KEY`: the AWS access key used with S3.
+- `TEST_AWS_SECRET_KEY`: the AWS secret key used with S3.
 
 Note that, if the bucket and region environment variables are set, they _must_
 match the values used when `src/tests/http-data` was regenerated for existing

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -134,13 +134,13 @@ To build and serve the frontend assets, use the command `yarn start`. There
 are variations on this command that change which backend your frontend tries to
 talk to:
 
-| Command                                      | Backend | Use case |
-|----------------------------------------------|---------|----------|
-| `pnpm start:live`                            | https://crates.io | Testing UI changes with the full live site's data |
-| `pnpm start:staging`                         | https://staging-crates-io.herokuapp.com | Testing UI changes with a smaller set of realistic data |
-| `pnpm start`                                 | Static fixture test data in `mirage/fixtures` | Setting up particular situations, see note |
-| `pnpm start:local`                           | Backend server running locally | See the Working on the backend section for setup |
-| `PROXY_BACKEND=https://crates.io pnpm start` | Whatever is specified in the `PROXY_BACKEND` environment variable | If your use case is not covered here |
+| Command                                      | Backend                                                           | Use case                                                |
+| -------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
+| `pnpm start:live`                            | https://crates.io                                                 | Testing UI changes with the full live site's data       |
+| `pnpm start:staging`                         | https://staging-crates-io.herokuapp.com                           | Testing UI changes with a smaller set of realistic data |
+| `pnpm start`                                 | Static fixture test data in `mirage/fixtures`                     | Setting up particular situations, see note              |
+| `pnpm start:local`                           | Backend server running locally                                    | See the Working on the backend section for setup        |
+| `PROXY_BACKEND=https://crates.io pnpm start` | Whatever is specified in the `PROXY_BACKEND` environment variable | If your use case is not covered here                    |
 
 > Note: If you want to set up a particular situation, you can edit the fixture
 > data used for tests in `mirage/fixtures`. The fixture data does not currently
@@ -192,7 +192,7 @@ methods we'd recommend for each operating system:
   - Fedora: `sudo dnf install postgresql-server postgresql-contrib postgresql-devel pkgconfig`
 
   > If you're missing a package, when you try to `cargo install` or `cargo
-  > build` later, you'll get an error that looks like this:
+build` later, you'll get an error that looks like this:
   >
   >     ```
   >     error: linking with `cc` failed: exit code: 1
@@ -213,6 +213,7 @@ by typing `\q`) without any errors to connect to your running Postgres server.
 > Is the server running locally and accepting
 > connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
 > ```
+>
 > You may need to start the postgreql server on your system. On a Linux system,
 > you can start it with this command:
 >
@@ -222,7 +223,7 @@ by typing `\q`) without any errors to connect to your running Postgres server.
 
 > Depending on your system, its permissions, and how Postgres was installed, you
 > may need to use the `postgres` user for some operations (by using `sudo su -
-> postgres`). Generally, the problem is that by default the postgres server is
+postgres`). Generally, the problem is that by default the postgres server is
 > only set up to allow connections by the `postrges` user. You'll know if you're
 > in this situation because if you try to run `psql` as yourself, you'll get
 > this error:
@@ -292,7 +293,7 @@ This will install a binary named `diesel`, so you should be able to run `diesel
 --version` to confirm successful installation.
 
 > If you're on Linux and this fails with an error that looks like `error:
-> linking with `cc` failed: exit code: 1`, you're probably missing some
+linking with `cc` failed: exit code: 1`, you're probably missing some
 > Postgres related libraries. See the Postgres section above on how to fix this.
 
 #### Building and serving the backend
@@ -320,7 +321,6 @@ Try using `postgres://postgres@localhost/cargo_registry` first.
 > - Replace `[database_name]` with the name of the database you'd like to use.
 >   We're going to create a database named `cargo_registry` in the next
 >   section; change this if you'd like to name it something else.
-
 
 > If you receive an error that looks like:
 >
@@ -405,6 +405,7 @@ link below to verify your email address. Thank you!
 
 https://crates.io/confirm/RiphVyFo31wuKQhpyTw7RF2LIf
 ```
+
 When verifying the email, you need to change the prefix to your frontend host.
 For example, change the above link to `http://localhost:4200/confirm/RiphVyFo31wuKQhpyTw7RF2LIf`.
 
@@ -504,13 +505,13 @@ that `./script/init-local-index.sh` set up.
 Note that when you're running crates.io in development mode without the S3
 variables set (which is what we've done in these setup steps), the crate files
 will be stored in `local_uploads/crates` and served from there when a
-crate is downloaded.  If you try to install a crate from your local crates.io and
+crate is downloaded. If you try to install a crate from your local crates.io and
 `cargo` can't find the crate files, it is probably because this directory does not
 exist.
 
 ##### Downloading a crate from your local crates.io
 
-In *another* crate, you can use the crate you've published as a dependency by
+In _another_ crate, you can use the crate you've published as a dependency by
 telling `cargo` to replace crates.io with your local crates.io as a source.
 
 In this other crate's directory, create a `.cargo/config` file with this
@@ -555,7 +556,7 @@ For example, in order to specify a set of Github OAuth Client credentials, a
 `docker-compose.override.yml` file might look like this:
 
 ```yaml
-version: "3"
+version: '3'
 services:
   backend:
     environment:
@@ -570,9 +571,9 @@ for various configuration options.
 
 By default, the services will be exposed on their normal ports:
 
-* `5432` for Postgres
-* `8888` for the crates.io backend
-* `4200` for the crates.io frontend
+- `5432` for Postgres
+- `8888` for the crates.io backend
+- `4200` for the crates.io frontend
 
 These can be changed with the `docker-compose.override.yml` file.
 

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,7 +1,7 @@
 # Frontend Overview
 
 The frontend of crates.io is written in JavaScript using [Ember.js][]. Most of that code lives in
-the *src* directory. We endeavor to follow Ember conventions and best practices, but we're Rust
+the _src_ directory. We endeavor to follow Ember conventions and best practices, but we're Rust
 developers, so we don't always live up to this goal :)
 
 [Ember.js]: https://emberjs.com/

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint:deps": "ember dependency-lint",
     "lint:hbs": "ember-template-lint app",
     "lint:js": "eslint . --cache",
-    "prettier": "prettier --write package.json '**/*.js'",
+    "prettier": "prettier --write package.json '**/*.js' '**/*.md'",
     "start": "ember serve",
     "start:live": "PROXY_BACKEND=https://crates.io ember serve",
     "start:local": "PROXY_BACKEND=http://127.0.0.1:8888 ember serve",

--- a/src/worker/dump_db/readme_for_tarball.md
+++ b/src/worker/dump_db/readme_for_tarball.md
@@ -4,27 +4,27 @@ This is a dump of the public information in the crates.io database.
 
 ## Files
 
-* `data/` – the CSV files with the actual data.
-* `export.sql` – the `psql` script that was used to create this database dump. It is only included in the archive for reference.
-* `import.sql` – a `psql` script that can be used to restore the dump into a PostgreSQL database with the same schema as the `crates.io` database, destroying all current data.
-* `metadata.json` – some metadata of this dump.
-* `schema.sql` – a dump of the database schema to facilitate generating a new database from the data.
+- `data/` – the CSV files with the actual data.
+- `export.sql` – the `psql` script that was used to create this database dump. It is only included in the archive for reference.
+- `import.sql` – a `psql` script that can be used to restore the dump into a PostgreSQL database with the same schema as the `crates.io` database, destroying all current data.
+- `metadata.json` – some metadata of this dump.
+- `schema.sql` – a dump of the database schema to facilitate generating a new database from the data.
 
 ## Metadata Fields
 
-* `timestamp` – the UTC time the dump was started.
-* `crates_io_commit` – the git commit hash of the deployed version of crates.io that created this dump.
+- `timestamp` – the UTC time the dump was started.
+- `crates_io_commit` – the git commit hash of the deployed version of crates.io that created this dump.
 
 ## Restoring to a Local crates.io Database
 
-1. Create a new database.
+1.  Create a new database.
 
         createdb DATABASE_NAME
 
-2. Restore the database schema.
+2.  Restore the database schema.
 
         psql DATABASE_NAME < schema.sql
 
-3. Run the import script.
+3.  Run the import script.
 
         psql DATABASE_URL < import.sql


### PR DESCRIPTION
When I working on [this PR](https://github.com/rust-lang/crates.io/pull/7335), my vscode automatically changes the format of markdown files. So I think it would be better to use prettier to format all markdowns.