### PR TITLE
Fix markdown styling for regular `pre` tags

### DIFF
--- a/app/components/rendered-html.module.css
+++ b/app/components/rendered-html.module.css
@@ -15,14 +15,20 @@
     }
 
     pre {
-        code {
-            display: block;
-            overflow-x: auto;
-            padding: var(--space-s);
-            background-color: #f6f8fa;
-            font-size: 85%;
-            border-radius: var(--space-3xs);
-        }
+        display: block;
+        overflow-x: auto;
+        padding: var(--space-xs);
+        background-color: #f6f8fa;
+        font-size: 85%;
+        border-radius: var(--space-3xs);
+    }
+
+    :global(.hljs) {
+        color: unset;
+        background: unset;
+        display: unset;
+        overflow-x: unset;
+        padding: 0;
     }
 
     p, li {


### PR DESCRIPTION
Fixes https://github.com/rust-lang/crates.io/issues/7351

Before:

![Bildschirmfoto 2023-10-24 um 12 12 43](https://github.com/rust-lang/crates.io/assets/141300/c1b77c07-13b0-4500-9a7c-2e4903e2cb85)

After:

![Bildschirmfoto 2023-10-24 um 12 12 33](https://github.com/rust-lang/crates.io/assets/141300/b5af4434-8e0e-42b0-93fd-7d86bf12832d)
