### PR TITLE
Use custom crates.io buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,4 +1,3 @@
 https://github.com/DataDog/heroku-buildpack-datadog.git#8d0b795
-https://github.com/unfold/heroku-buildpack-pnpm#b8dcee8
 https://github.com/heroku/heroku-buildpack-nginx#37a84b640e419fac6e58b77433d87194f7496c03
-https://github.com/Turbo87/heroku-buildpack-rust#30429b2
+https://github.com/Turbo87/heroku-buildpack-crates-io#7bc6b2637282e11206b42e9e5feddec058d527a2


### PR DESCRIPTION
Using this custom buildpack brings our slug size down from 303 MB to 169 MB. It also appears to solve a Rust build caching issue with the generic Rust buildpack that we had been using so far.

The main source of slug size savings is the removal of the `node_modules` folder after the build, and that the Node.js binary is not included in the slug, since it is only needed at build-time.

see https://github.com/Turbo87/heroku-buildpack-crates-io/blob/main/bin/compile