### PR TITLE
Heroku: Remove Datadog buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,2 @@
-https://github.com/DataDog/heroku-buildpack-datadog.git#8d0b795
 https://github.com/heroku/heroku-buildpack-nginx#37a84b640e419fac6e58b77433d87194f7496c03
 https://github.com/Turbo87/heroku-buildpack-crates-io#7bc6b2637282e11206b42e9e5feddec058d527a2


### PR DESCRIPTION
According to the infra team, the buildpack is only needed for additional per-dyno metrics, and the log collection is independent from this. This buildpack however is responsible for a 90 MB increase of the slug size on Heroku. If we don't gain that much from having it, then we should remove it and improve our dyno boot times again :)

After this PR the slug size is down to 73 MB (from 303 MB earlier to day)