### PR TITLE
Use the same feature and dep name validation rules from Cargo 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "tracing-subscriber",
+ "unicode-xid",
  "url",
 ]
 
@@ -4260,6 +4261,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unicode_categories"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ tower-http = { version = "=0.4.4", features = ["add-extension", "fs", "catch-pan
 tracing = "=0.1.40"
 tracing-subscriber = { version = "=0.3.17", features = ["env-filter"] }
 url = "=2.4.1"
+unicode-xid = "0.2.4"
 
 [dev-dependencies]
 bytes = "=1.5.0"

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -244,9 +244,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             }
 
             for value in values.iter() {
-                if !Crate::valid_feature(value) {
-                    return Err(cargo_err(&format!("\"{value}\" is an invalid feature name")));
-                }
+                Crate::valid_feature(value)?;
             }
         }
 
@@ -577,11 +575,7 @@ pub fn validate_dependency(dep: &EncodableCrateDependency) -> AppResult<()> {
     Crate::valid_name(&dep.name)?;
 
     for feature in &dep.features {
-        if !Crate::valid_feature(feature) {
-            return Err(cargo_err(&format_args!(
-                "\"{feature}\" is an invalid feature name",
-            )));
-        }
+        Crate::valid_feature(feature)?;
     }
 
     if let Some(registry) = &dep.registry {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -238,12 +238,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         }
 
         for (key, values) in features.iter() {
-            if !Crate::valid_feature_name(key) {
-                return Err(cargo_err(&format!(
-                    "\"{key}\" is an invalid feature name (feature names must contain only letters, numbers, '-', '+', or '_')"
-                )));
-            }
-
+            Crate::valid_feature_name(key)?;
             let num_features = values.len();
             if num_features > max_features {
                 return Err(cargo_err(&format!(

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -225,7 +225,7 @@ impl Crate {
         !name.is_empty()
             && name
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+')
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.')
     }
 
     /// Validates the prefix in front of the slash: `features = ["THIS/feature"]`.
@@ -531,5 +531,7 @@ mod tests {
         assert!(!Crate::valid_feature("dep:foo?/bar"));
         assert!(!Crate::valid_feature("foo/?bar"));
         assert!(!Crate::valid_feature("foo?bar"));
+        assert!(Crate::valid_feature("bar.web"));
+        assert!(Crate::valid_feature("foo/bar.web"));
     }
 }

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -288,15 +288,15 @@ impl Crate {
         Ok(())
     }
 
-    /// Validates a whole feature string, `features = ["THIS", "ALL/THIS"]`.
-    pub fn valid_feature(name: &str) -> bool {
+    /// Validates a whole feature string, `features = ["THIS", "and/THIS", "dep:THIS", "dep?/THIS"]`.
+    pub fn valid_feature(name: &str) -> AppResult<()> {
         match name.split_once('/') {
             Some((dep, dep_feat)) => {
                 let dep = dep.strip_suffix('?').unwrap_or(dep);
-                Crate::valid_dependency_name(dep).is_ok()
-                    && Crate::valid_feature_name(dep_feat).is_ok()
+                Crate::valid_dependency_name(dep)?;
+                Crate::valid_feature_name(dep_feat)
             }
-            None => Crate::valid_feature_name(name.strip_prefix("dep:").unwrap_or(name)).is_ok(),
+            None => Crate::valid_feature_name(name.strip_prefix("dep:").unwrap_or(name)),
         }
     }
 
@@ -567,25 +567,25 @@ mod tests {
 
     #[test]
     fn valid_feature_names() {
-        assert!(Crate::valid_feature("foo"));
-        assert!(Crate::valid_feature("1foo"));
-        assert!(Crate::valid_feature("_foo"));
-        assert!(Crate::valid_feature("_foo-_+.1"));
-        assert!(Crate::valid_feature("_foo-_+.1"));
-        assert!(!Crate::valid_feature(""));
-        assert!(!Crate::valid_feature("/"));
-        assert!(!Crate::valid_feature("%/%"));
-        assert!(Crate::valid_feature("a/a"));
-        assert!(Crate::valid_feature("32-column-tables"));
-        assert!(Crate::valid_feature("c++20"));
-        assert!(Crate::valid_feature("krate/c++20"));
-        assert!(!Crate::valid_feature("c++20/wow"));
-        assert!(Crate::valid_feature("foo?/bar"));
-        assert!(Crate::valid_feature("dep:foo"));
-        assert!(!Crate::valid_feature("dep:foo?/bar"));
-        assert!(!Crate::valid_feature("foo/?bar"));
-        assert!(!Crate::valid_feature("foo?bar"));
-        assert!(Crate::valid_feature("bar.web"));
-        assert!(Crate::valid_feature("foo/bar.web"));
+        assert!(Crate::valid_feature("foo").is_ok());
+        assert!(Crate::valid_feature("1foo").is_ok());
+        assert!(Crate::valid_feature("_foo").is_ok());
+        assert!(Crate::valid_feature("_foo-_+.1").is_ok());
+        assert!(Crate::valid_feature("_foo-_+.1").is_ok());
+        assert!(Crate::valid_feature("").is_err());
+        assert!(Crate::valid_feature("/").is_err());
+        assert!(Crate::valid_feature("%/%").is_err());
+        assert!(Crate::valid_feature("a/a").is_ok());
+        assert!(Crate::valid_feature("32-column-tables").is_ok());
+        assert!(Crate::valid_feature("c++20").is_ok());
+        assert!(Crate::valid_feature("krate/c++20").is_ok());
+        assert!(Crate::valid_feature("c++20/wow").is_err());
+        assert!(Crate::valid_feature("foo?/bar").is_ok());
+        assert!(Crate::valid_feature("dep:foo").is_ok());
+        assert!(Crate::valid_feature("dep:foo?/bar").is_err());
+        assert!(Crate::valid_feature("foo/?bar").is_err());
+        assert!(Crate::valid_feature("foo?bar").is_err());
+        assert!(Crate::valid_feature("bar.web").is_ok());
+        assert!(Crate::valid_feature("foo/bar.web").is_ok());
     }
 }

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -108,7 +108,7 @@ impl CrateScope {
         }
 
         let name_without_wildcard = pattern.strip_suffix('*').unwrap_or(pattern);
-        Crate::valid_name(name_without_wildcard)
+        Crate::valid_name(name_without_wildcard).is_ok()
     }
 
     pub fn matches(&self, crate_name: &str) -> bool {

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -25,6 +25,15 @@ fn features_version_2() {
 }
 
 #[test]
+fn feature_name_with_dot() {
+    let (app, _, _, token) = TestApp::full().with_token();
+    let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo.bar", &[]);
+    token.publish_crate(crate_to_publish).good();
+    let crates = app.crates_from_index_head("foo");
+    assert_json_snapshot!(crates);
+}
+
+#[test]
 fn invalid_feature_name() {
     let (app, _, _, token) = TestApp::full().with_token();
 

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid character `🦀` in crate name: `🦀`, the first character must be an ASCII character, or `_`"
+      "detail": "invalid character `🦀` in crate name: `🦀`, the first character must be an ASCII character"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"🦀\" is an invalid dependency name (dependency names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `🦀` in crate name: `🦀`, the first character must be an ASCII character, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"💩\" is an invalid dependency name (dependency names must start with a letter or underscore, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `💩` in dependency name: `💩`, the first character must be an ASCII character, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_feature_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_feature_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"🍺\" is an invalid feature name"
+      "detail": "invalid character `🍺` in feature `🍺`, the first character must be a Unicode XID start character or digit (most letters or `_` or `0` to `9`)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__feature_name_with_dot.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__feature_name_with_dot.snap
@@ -1,0 +1,16 @@
+---
+source: src/tests/krate/publish/features.rs
+expression: crates
+---
+[
+  {
+    "name": "foo",
+    "vers": "1.0.0",
+    "deps": [],
+    "cksum": "d0bfdbcd4905a15b3dc6db5ce23e206ac413b4d780053fd38e145a75197fb1e1",
+    "features": {
+      "foo.bar": []
+    },
+    "yanked": false
+  }
+]

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"!bar\" is an invalid feature name"
+      "detail": "invalid character `!` in feature `!bar`, the first character must be a Unicode XID start character or digit (most letters or `_` or `0` to `9`)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__invalid_feature_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"~foo\" is an invalid feature name (feature names must contain only letters, numbers, '-', '+', or '_')"
+      "detail": "invalid character `~` in feature `~foo`, the first character must be a Unicode XID start character or digit (most letters or `_` or `0` to `9`)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"foo bar\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character ` ` in crate name: `foo bar`, characters must be an ASCII alphanumeric characters, `-`, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "the name `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` is too long (max 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"snow☃\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `☃` in crate name: `snow☃`, characters must be an ASCII alphanumeric characters, `-`, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"áccênts\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `á` in crate name: `áccênts`, the first character must be an ASCII character, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid character `á` in crate name: `áccênts`, the first character must be an ASCII character, or `_`"
+      "detail": "invalid character `á` in crate name: `áccênts`, the first character must be an ASCII character"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "the crate name cannot be an empty"
     }
   ]
 }


### PR DESCRIPTION
close https://github.com/rust-lang/crates.io/issues/7250

- This PR allowed `.` in the feature name. I added some unit tests and integration tests for it.
- This PR also updated the feature, crate, and dep name validation rules from Cargo.

The summary:

| category                    | Cargo                                                                                                   | crates.io before change                                                                                      | crates.io after change                                                                                 |
| --------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| Crate name                  | 1. cannot start with a number<br/>2. can only start with most letters or `_`<br/>3. can only contain numbers, `-`, `_`, or most letters. | 1. must start with alphabetic<br/>2. can only contain numbers, letters, `-`, `_`                         | 1. must start with alphabetic<br/>2. can only contain numbers, letters, `-`, `_` **(Nothing changes)**                |
| Dep name                    | 1. cannot start with a number<br/>2. can only start with most letters or `_`<br/>3. can only contain numbers, `-`, `_`, or most letters. | 1. first character must be alphabetic or `_`<br/>2. can only contain numbers, letters, `-`, `_`         | 1. cannot start with a number<br/>2. can only start with ASCII letters or `_`<br/>3. can only contain numbers, `-`, `_`, or ASCII letters.  **(Nothing changes)**       |
| Normal feature name         | 1. can only start with most letters, `_`, or `0` to `9`<br/>2. can only contain numbers, `+`, `-`, `_`, `.`, or most letters | can only contain numbers, `+`, `-`, `_`, or most letters                                       | 1. can only start with most letters, `_`, or `0` to `9`<br/>2. can only contain numbers, `+`, `-`, `_`, `.`, or most letters  |
| Optional dep name   | same as dep name                                                                                        | can only contain numbers, `+`, `-`, `_`, or most letters                                       | same as dep name                                     |
| Optional dep feature name   | dep_name/feat_name<br/>1. so the first part is the same as the dep name<br/>2. the second part is the same as the normal feature name. | can only contain numbers, `+`, `-`, `_`, or most letters                                       | dep_name/feat_name<br/>1. so the first part is the same as the dep name<br/>2. the second part is the same as the normal feature name.                                   |