### PR TITLE
config/server: Change `downloads_persist_interval` type to `Duration`

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -109,9 +109,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn downloads_counter_thread(app: Arc<App>) {
-    let interval = Duration::from_millis(
-        (app.config.downloads_persist_interval_ms / app.downloads_counter.shards_count()) as u64,
-    );
+    let interval =
+        app.config.downloads_persist_interval / app.downloads_counter.shards_count() as u32;
 
     std::thread::spawn(move || loop {
         std::thread::sleep(interval);

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -44,7 +44,7 @@ pub struct Server {
     pub excluded_crate_names: Vec<String>,
     pub domain_name: String,
     pub allowed_origins: AllowedOrigins,
-    pub downloads_persist_interval_ms: usize,
+    pub downloads_persist_interval: Duration,
     pub ownership_invitations_expiration_days: u64,
     pub metrics_authorization_token: Option<String>,
     pub use_test_database_pool: bool,
@@ -205,13 +205,14 @@ impl Default for Server {
             excluded_crate_names,
             domain_name: domain_name(),
             allowed_origins,
-            downloads_persist_interval_ms: dotenvy::var("DOWNLOADS_PERSIST_INTERVAL_MS")
+            downloads_persist_interval: dotenvy::var("DOWNLOADS_PERSIST_INTERVAL_MS")
                 .map(|interval| {
                     interval
                         .parse()
+                        .map(Duration::from_millis)
                         .expect("invalid DOWNLOADS_PERSIST_INTERVAL_MS")
                 })
-                .unwrap_or(60_000), // 1 minute
+                .unwrap_or(Duration::from_secs(60)),
             ownership_invitations_expiration_days: 30,
             metrics_authorization_token: dotenvy::var("METRICS_AUTHORIZATION_TOKEN").ok(),
             use_test_database_pool: false,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -402,7 +402,7 @@ fn simple_config() -> config::Server {
         excluded_crate_names: vec![],
         domain_name: "crates.io".into(),
         allowed_origins: Default::default(),
-        downloads_persist_interval_ms: 1000,
+        downloads_persist_interval: Duration::from_secs(1),
         ownership_invitations_expiration_days: 30,
         metrics_authorization_token: None,
         use_test_database_pool: true,


### PR DESCRIPTION
There is a `Duration` type in the std lib, so we might as well use it instead of having `_ms` suffixed variables that are converted to `Duration` on demand :D