### PR TITLE
tests/test_app: Split `with_database()` into `without_test_database_pool()`, `with_chaos_proxy()` and `with_replica()`

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -51,7 +51,7 @@ pub(crate) use fresh_schema::FreshSchema;
 use mock_request::MockRequest;
 pub use mock_request::MockRequestExt;
 pub use response::Response;
-pub use test_app::{TestApp, TestDatabase};
+pub use test_app::TestApp;
 
 /// This function can be used to create a `Cookie` header for mock requests that
 /// include cookie-based authentication.


### PR DESCRIPTION
This decouples the chaos-proxy usage from the usage of the test-database-pool and makes the use of a database replica connection a bit easier to configure. This also prepares for some upcoming changes related to the `FreshSchema` struct.