### PR TITLE
background_jobs: Adjust `perform()` to work on `&self`

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -257,7 +257,7 @@ impl Job {
                 worker::perform_dump_db(env, &args.database_url, &args.target_name)
             }
             Job::SquashIndex => worker::perform_index_squash(env),
-            Job::NormalizeIndex(args) => worker::perform_normalize_index(env, args),
+            Job::NormalizeIndex(args) => worker::perform_normalize_index(env, &args),
             Job::RenderAndUploadReadme(args) => worker::perform_render_and_upload_readme(
                 conn,
                 env,

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -253,7 +253,9 @@ impl Job {
             Job::DailyDbMaintenance => {
                 worker::perform_daily_db_maintenance(&mut *fresh_connection(pool)?)
             }
-            Job::DumpDb(args) => worker::perform_dump_db(env, args.database_url, args.target_name),
+            Job::DumpDb(args) => {
+                worker::perform_dump_db(env, &args.database_url, &args.target_name)
+            }
             Job::SquashIndex => worker::perform_index_squash(env),
             Job::NormalizeIndex(args) => worker::perform_normalize_index(env, args),
             Job::RenderAndUploadReadme(args) => worker::perform_render_and_upload_readme(

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -241,7 +241,7 @@ impl Job {
     }
 
     pub(super) fn perform(
-        self,
+        &self,
         env: &Option<Environment>,
         state: PerformState<'_>,
     ) -> Result<(), PerformError> {
@@ -257,7 +257,7 @@ impl Job {
                 worker::perform_dump_db(env, &args.database_url, &args.target_name)
             }
             Job::SquashIndex => worker::perform_index_squash(env),
-            Job::NormalizeIndex(args) => worker::perform_normalize_index(env, &args),
+            Job::NormalizeIndex(args) => worker::perform_normalize_index(env, args),
             Job::RenderAndUploadReadme(args) => worker::perform_render_and_upload_readme(
                 conn,
                 env,

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -13,13 +13,13 @@ use crate::swirl::PerformError;
 /// tarball and upload to S3.
 pub fn perform_dump_db(
     env: &Environment,
-    database_url: String,
-    target_name: String,
+    database_url: &str,
+    target_name: &str,
 ) -> Result<(), PerformError> {
     let directory = DumpDirectory::create()?;
 
     info!(path = ?directory.export_dir, "Begin exporting database");
-    directory.populate(&database_url)?;
+    directory.populate(database_url)?;
 
     info!(path = ?directory.export_dir, "Creating tarball");
     let tarball = DumpTarball::create(&directory.export_dir)?;
@@ -33,11 +33,11 @@ pub fn perform_dump_db(
 
     let storage = Storage::from_environment();
 
-    rt.block_on(storage.upload_db_dump(&target_name, &tarball.tarball_path))?;
+    rt.block_on(storage.upload_db_dump(target_name, &tarball.tarball_path))?;
     info!("Database dump tarball uploaded");
 
     info!("Invalidating CDN caches");
-    invalidate_caches(env, &target_name);
+    invalidate_caches(env, target_name);
 
     Ok(())
 }

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -160,7 +160,7 @@ pub fn perform_index_squash(env: &Environment) -> Result<(), PerformError> {
 
 pub fn perform_normalize_index(
     env: &Environment,
-    args: NormalizeIndexJob,
+    args: &NormalizeIndexJob,
 ) -> Result<(), PerformError> {
     info!("Normalizing the index");
 


### PR DESCRIPTION
There is no need to unnecessarily consume the `Job` instance in the `perform()` call...