### PR TITLE
Replace `dsl::*` imports

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -1,6 +1,6 @@
 use crate::background_jobs::Job;
 use crate::db;
-use crate::schema::background_jobs::dsl::*;
+use crate::schema::background_jobs;
 use anyhow::Result;
 use diesel::prelude::*;
 use secrecy::{ExposeSecret, SecretString};
@@ -33,8 +33,8 @@ pub fn run(command: Command) -> Result<()> {
 
     match command {
         Command::UpdateDownloads => {
-            let count: i64 = background_jobs
-                .filter(job_type.eq("update_downloads"))
+            let count: i64 = background_jobs::table
+                .filter(background_jobs::job_type.eq("update_downloads"))
                 .count()
                 .get_result(conn)
                 .unwrap();

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -76,7 +76,7 @@ fn categories_from_toml(
 }
 
 pub fn sync_with_connection(toml_str: &str, conn: &mut PgConnection) -> Result<()> {
-    use crate::schema::categories::dsl::*;
+    use crate::schema::categories;
     use diesel::pg::upsert::excluded;
 
     let toml: toml::value::Table =
@@ -87,27 +87,27 @@ pub fn sync_with_connection(toml_str: &str, conn: &mut PgConnection) -> Result<(
         .into_iter()
         .map(|c| {
             (
-                slug.eq(c.slug.to_lowercase()),
-                category.eq(c.name),
-                description.eq(c.description),
+                categories::slug.eq(c.slug.to_lowercase()),
+                categories::category.eq(c.name),
+                categories::description.eq(c.description),
             )
         })
         .collect::<Vec<_>>();
 
     conn.transaction(|conn| {
-        let slugs: Vec<String> = diesel::insert_into(categories)
+        let slugs: Vec<String> = diesel::insert_into(categories::table)
             .values(&to_insert)
-            .on_conflict(slug)
+            .on_conflict(categories::slug)
             .do_update()
             .set((
-                category.eq(excluded(category)),
-                description.eq(excluded(description)),
+                categories::category.eq(excluded(categories::category)),
+                categories::description.eq(excluded(categories::description)),
             ))
-            .returning(slug)
+            .returning(categories::slug)
             .get_results(conn)?;
 
-        diesel::delete(categories)
-            .filter(slug.ne_all(slugs))
+        diesel::delete(categories::table)
+            .filter(categories::slug.ne_all(slugs))
             .execute(conn)?;
         Ok(())
     })

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -22,12 +22,10 @@ use crate::views::{
 /// Handles the `GET /summary` route.
 pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
     conduit_compat(move || {
-        use crate::schema::crates::dsl::*;
-
         let config = &state.config;
 
         let conn = &mut *state.db_read()?;
-        let num_crates: i64 = crates.count().get_result(conn)?;
+        let num_crates: i64 = crates::table.count().get_result(conn)?;
         let num_downloads: i64 = metadata::table
             .select(metadata::total_downloads)
             .get_result(conn)?;
@@ -64,38 +62,39 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
             recent_crate_downloads::downloads.nullable(),
         );
 
-        let new_crates = crates
+        let new_crates = crates::table
             .left_join(recent_crate_downloads::table)
-            .order(created_at.desc())
+            .order(crates::created_at.desc())
             .select(selection)
             .limit(10)
             .load(conn)?;
-        let just_updated = crates
+        let just_updated = crates::table
             .left_join(recent_crate_downloads::table)
-            .filter(updated_at.ne(created_at))
-            .order(updated_at.desc())
+            .filter(crates::updated_at.ne(crates::created_at))
+            .order(crates::updated_at.desc())
             .select(selection)
             .limit(10)
             .load(conn)?;
 
-        let mut most_downloaded_query =
-            crates.left_join(recent_crate_downloads::table).into_boxed();
+        let mut most_downloaded_query = crates::table
+            .left_join(recent_crate_downloads::table)
+            .into_boxed();
         if !config.excluded_crate_names.is_empty() {
             most_downloaded_query =
-                most_downloaded_query.filter(name.ne_all(&config.excluded_crate_names));
+                most_downloaded_query.filter(crates::name.ne_all(&config.excluded_crate_names));
         }
         let most_downloaded = most_downloaded_query
-            .then_order_by(downloads.desc())
+            .then_order_by(crates::downloads.desc())
             .select(selection)
             .limit(10)
             .load(conn)?;
 
-        let mut most_recently_downloaded_query = crates
+        let mut most_recently_downloaded_query = crates::table
             .inner_join(recent_crate_downloads::table)
             .into_boxed();
         if !config.excluded_crate_names.is_empty() {
-            most_recently_downloaded_query =
-                most_recently_downloaded_query.filter(name.ne_all(&config.excluded_crate_names));
+            most_recently_downloaded_query = most_recently_downloaded_query
+                .filter(crates::name.ne_all(&config.excluded_crate_names));
         }
         let most_recently_downloaded = most_recently_downloaded_query
             .then_order_by(recent_crate_downloads::downloads.desc())

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -410,15 +410,14 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
     .await
 }
 
-/// Counts the number of versions for `krate_id` that were published within
+/// Counts the number of versions for `crate_id` that were published within
 /// the last 24 hours.
-fn count_versions_published_today(krate_id: i32, conn: &mut PgConnection) -> QueryResult<i64> {
-    use crate::schema::versions::dsl::*;
+fn count_versions_published_today(crate_id: i32, conn: &mut PgConnection) -> QueryResult<i64> {
     use diesel::dsl::{now, IntervalDsl};
 
-    versions
-        .filter(crate_id.eq(krate_id))
-        .filter(created_at.gt(now - 24.hours()))
+    versions::table
+        .filter(versions::crate_id.eq(crate_id))
+        .filter(versions::created_at.gt(now - 24.hours()))
         .count()
         .get_result(conn)
 }

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -58,8 +58,6 @@ pub async fn download(
             };
 
             if let Some(mut conn) = conn {
-                use self::versions::dsl::*;
-
                 // Returns the crate name as stored in the database, or an error if we could
                 // not load the version ID from the database.
                 let (version_id, canonical_crate_name) = app
@@ -68,11 +66,11 @@ pub async fn download(
                     .observe_closure_duration(|| {
                         info_span!("db.query", message = "SELECT ... FROM versions").in_scope(
                             || {
-                                versions
+                                versions::table
                                     .inner_join(crates::table)
-                                    .select((id, crates::name))
+                                    .select((versions::id, crates::name))
                                     .filter(Crate::with_name(&crate_name))
-                                    .filter(num.eq(&version))
+                                    .filter(versions::num.eq(&version))
                                     .first::<(i32, String)>(&mut *conn)
                             },
                         )

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -470,12 +470,12 @@ mod tests {
         }
 
         fn assert_downloads_count(&self, conn: &mut PgConnection, version: i32, expected: i64) {
-            use crate::schema::version_downloads::dsl::*;
+            use crate::schema::version_downloads;
             use diesel::dsl::*;
 
-            let actual: Option<i64> = version_downloads
-                .select(sum(downloads))
-                .filter(version_id.eq(version))
+            let actual: Option<i64> = version_downloads::table
+                .select(sum(version_downloads::downloads))
+                .filter(version_downloads::version_id.eq(version))
                 .first(conn)
                 .unwrap();
             assert_eq!(actual.unwrap_or(0), expected);

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -72,10 +72,8 @@ impl Category {
     }
 
     pub fn count_toplevel(conn: &mut PgConnection) -> QueryResult<i64> {
-        use self::categories::dsl::*;
-
-        categories
-            .filter(category.not_like("%::%"))
+        categories::table
+            .filter(categories::category.not_like("%::%"))
             .count()
             .get_result(conn)
     }
@@ -135,11 +133,9 @@ pub struct NewCategory<'a> {
 impl<'a> NewCategory<'a> {
     /// Inserts the category into the database, or updates an existing one.
     pub fn create_or_update(&self, conn: &mut PgConnection) -> QueryResult<Category> {
-        use crate::schema::categories::dsl::*;
-
-        insert_into(categories)
+        insert_into(categories::table)
             .values(self)
-            .on_conflict(slug)
+            .on_conflict(categories::slug)
             .do_update()
             .set(self)
             .get_result(conn)
@@ -162,13 +158,22 @@ mod tests {
 
     #[test]
     fn category_toplevel_excludes_subcategories() {
-        use self::categories::dsl::*;
+        use self::categories;
         let conn = &mut pg_connection();
-        insert_into(categories)
+        insert_into(categories::table)
             .values(&vec![
-                (category.eq("Cat 2"), slug.eq("cat2")),
-                (category.eq("Cat 1"), slug.eq("cat1")),
-                (category.eq("Cat 1::sub"), slug.eq("cat1::sub")),
+                (
+                    categories::category.eq("Cat 2"),
+                    categories::slug.eq("cat2"),
+                ),
+                (
+                    categories::category.eq("Cat 1"),
+                    categories::slug.eq("cat1"),
+                ),
+                (
+                    categories::category.eq("Cat 1::sub"),
+                    categories::slug.eq("cat1::sub"),
+                ),
             ])
             .execute(conn)
             .unwrap();
@@ -184,13 +189,25 @@ mod tests {
 
     #[test]
     fn category_toplevel_orders_by_crates_cnt_when_sort_given() {
-        use self::categories::dsl::*;
+        use self::categories;
         let conn = &mut pg_connection();
-        insert_into(categories)
+        insert_into(categories::table)
             .values(&vec![
-                (category.eq("Cat 1"), slug.eq("cat1"), crates_cnt.eq(0)),
-                (category.eq("Cat 2"), slug.eq("cat2"), crates_cnt.eq(2)),
-                (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(1)),
+                (
+                    categories::category.eq("Cat 1"),
+                    categories::slug.eq("cat1"),
+                    categories::crates_cnt.eq(0),
+                ),
+                (
+                    categories::category.eq("Cat 2"),
+                    categories::slug.eq("cat2"),
+                    categories::crates_cnt.eq(2),
+                ),
+                (
+                    categories::category.eq("Cat 3"),
+                    categories::slug.eq("cat3"),
+                    categories::crates_cnt.eq(1),
+                ),
             ])
             .execute(conn)
             .unwrap();
@@ -210,12 +227,18 @@ mod tests {
 
     #[test]
     fn category_toplevel_applies_limit_and_offset() {
-        use self::categories::dsl::*;
+        use self::categories;
         let conn = &mut pg_connection();
-        insert_into(categories)
+        insert_into(categories::table)
             .values(&vec![
-                (category.eq("Cat 1"), slug.eq("cat1")),
-                (category.eq("Cat 2"), slug.eq("cat2")),
+                (
+                    categories::category.eq("Cat 1"),
+                    categories::slug.eq("cat1"),
+                ),
+                (
+                    categories::category.eq("Cat 2"),
+                    categories::slug.eq("cat2"),
+                ),
             ])
             .execute(conn)
             .unwrap();
@@ -239,28 +262,40 @@ mod tests {
 
     #[test]
     fn category_toplevel_includes_subcategories_in_crate_cnt() {
-        use self::categories::dsl::*;
+        use self::categories;
         let conn = &mut pg_connection();
-        insert_into(categories)
+        insert_into(categories::table)
             .values(&vec![
-                (category.eq("Cat 1"), slug.eq("cat1"), crates_cnt.eq(1)),
                 (
-                    category.eq("Cat 1::sub"),
-                    slug.eq("cat1::sub"),
-                    crates_cnt.eq(2),
-                ),
-                (category.eq("Cat 2"), slug.eq("cat2"), crates_cnt.eq(3)),
-                (
-                    category.eq("Cat 2::Sub 1"),
-                    slug.eq("cat2::sub1"),
-                    crates_cnt.eq(4),
+                    categories::category.eq("Cat 1"),
+                    categories::slug.eq("cat1"),
+                    categories::crates_cnt.eq(1),
                 ),
                 (
-                    category.eq("Cat 2::Sub 2"),
-                    slug.eq("cat2::sub2"),
-                    crates_cnt.eq(5),
+                    categories::category.eq("Cat 1::sub"),
+                    categories::slug.eq("cat1::sub"),
+                    categories::crates_cnt.eq(2),
                 ),
-                (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(6)),
+                (
+                    categories::category.eq("Cat 2"),
+                    categories::slug.eq("cat2"),
+                    categories::crates_cnt.eq(3),
+                ),
+                (
+                    categories::category.eq("Cat 2::Sub 1"),
+                    categories::slug.eq("cat2::sub1"),
+                    categories::crates_cnt.eq(4),
+                ),
+                (
+                    categories::category.eq("Cat 2::Sub 2"),
+                    categories::slug.eq("cat2::sub2"),
+                    categories::crates_cnt.eq(5),
+                ),
+                (
+                    categories::category.eq("Cat 3"),
+                    categories::slug.eq("cat3"),
+                    categories::crates_cnt.eq(6),
+                ),
             ])
             .execute(conn)
             .unwrap();
@@ -280,28 +315,40 @@ mod tests {
 
     #[test]
     fn category_toplevel_applies_limit_and_offset_after_grouping() {
-        use self::categories::dsl::*;
+        use self::categories;
         let conn = &mut pg_connection();
-        insert_into(categories)
+        insert_into(categories::table)
             .values(&vec![
-                (category.eq("Cat 1"), slug.eq("cat1"), crates_cnt.eq(1)),
                 (
-                    category.eq("Cat 1::sub"),
-                    slug.eq("cat1::sub"),
-                    crates_cnt.eq(2),
-                ),
-                (category.eq("Cat 2"), slug.eq("cat2"), crates_cnt.eq(3)),
-                (
-                    category.eq("Cat 2::Sub 1"),
-                    slug.eq("cat2::sub1"),
-                    crates_cnt.eq(4),
+                    categories::category.eq("Cat 1"),
+                    categories::slug.eq("cat1"),
+                    categories::crates_cnt.eq(1),
                 ),
                 (
-                    category.eq("Cat 2::Sub 2"),
-                    slug.eq("cat2::sub2"),
-                    crates_cnt.eq(5),
+                    categories::category.eq("Cat 1::sub"),
+                    categories::slug.eq("cat1::sub"),
+                    categories::crates_cnt.eq(2),
                 ),
-                (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(6)),
+                (
+                    categories::category.eq("Cat 2"),
+                    categories::slug.eq("cat2"),
+                    categories::crates_cnt.eq(3),
+                ),
+                (
+                    categories::category.eq("Cat 2::Sub 1"),
+                    categories::slug.eq("cat2::sub1"),
+                    categories::crates_cnt.eq(4),
+                ),
+                (
+                    categories::category.eq("Cat 2::Sub 2"),
+                    categories::slug.eq("cat2::sub2"),
+                    categories::crates_cnt.eq(5),
+                ),
+                (
+                    categories::category.eq("Cat 3"),
+                    categories::slug.eq("cat3"),
+                    categories::crates_cnt.eq(6),
+                ),
             ])
             .execute(conn)
             .unwrap();
@@ -325,38 +372,50 @@ mod tests {
 
     #[test]
     fn category_parent_categories_includes_path_to_node_with_count() {
-        use self::categories::dsl::*;
+        use self::categories;
         let conn = &mut pg_connection();
-        insert_into(categories)
+        insert_into(categories::table)
             .values(&vec![
-                (category.eq("Cat 1"), slug.eq("cat1"), crates_cnt.eq(1)),
                 (
-                    category.eq("Cat 1::sub1"),
-                    slug.eq("cat1::sub1"),
-                    crates_cnt.eq(2),
+                    categories::category.eq("Cat 1"),
+                    categories::slug.eq("cat1"),
+                    categories::crates_cnt.eq(1),
                 ),
                 (
-                    category.eq("Cat 1::sub2"),
-                    slug.eq("cat1::sub2"),
-                    crates_cnt.eq(2),
+                    categories::category.eq("Cat 1::sub1"),
+                    categories::slug.eq("cat1::sub1"),
+                    categories::crates_cnt.eq(2),
                 ),
                 (
-                    category.eq("Cat 1::sub1::subsub1"),
-                    slug.eq("cat1::sub1::subsub1"),
-                    crates_cnt.eq(2),
-                ),
-                (category.eq("Cat 2"), slug.eq("cat2"), crates_cnt.eq(3)),
-                (
-                    category.eq("Cat 2::Sub 1"),
-                    slug.eq("cat2::sub1"),
-                    crates_cnt.eq(4),
+                    categories::category.eq("Cat 1::sub2"),
+                    categories::slug.eq("cat1::sub2"),
+                    categories::crates_cnt.eq(2),
                 ),
                 (
-                    category.eq("Cat 2::Sub 2"),
-                    slug.eq("cat2::sub2"),
-                    crates_cnt.eq(5),
+                    categories::category.eq("Cat 1::sub1::subsub1"),
+                    categories::slug.eq("cat1::sub1::subsub1"),
+                    categories::crates_cnt.eq(2),
                 ),
-                (category.eq("Cat 3"), slug.eq("cat3"), crates_cnt.eq(200)),
+                (
+                    categories::category.eq("Cat 2"),
+                    categories::slug.eq("cat2"),
+                    categories::crates_cnt.eq(3),
+                ),
+                (
+                    categories::category.eq("Cat 2::Sub 1"),
+                    categories::slug.eq("cat2::sub1"),
+                    categories::crates_cnt.eq(4),
+                ),
+                (
+                    categories::category.eq("Cat 2::Sub 2"),
+                    categories::slug.eq("cat2::sub2"),
+                    categories::crates_cnt.eq(5),
+                ),
+                (
+                    categories::category.eq("Cat 3"),
+                    categories::slug.eq("cat3"),
+                    categories::crates_cnt.eq(200),
+                ),
             ])
             .execute(conn)
             .unwrap();

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -116,10 +116,8 @@ impl<'a> NewCrate<'a> {
     }
 
     pub fn create(&self, conn: &mut PgConnection, user_id: i32) -> QueryResult<Crate> {
-        use crate::schema::crates::dsl::*;
-
         conn.transaction(|conn| {
-            let krate: Crate = diesel::insert_into(crates)
+            let krate: Crate = diesel::insert_into(crates::table)
                 .values(self)
                 .on_conflict_do_nothing()
                 .returning(Crate::as_returning())
@@ -253,10 +251,10 @@ impl Crate {
     /// Return both the newest (most recently updated) and
     /// highest version (in semver order) for the current crate.
     pub fn top_versions(&self, conn: &mut PgConnection) -> QueryResult<TopVersions> {
-        use crate::schema::versions::dsl::*;
-
         Ok(TopVersions::from_date_version_pairs(
-            self.versions().select((created_at, num)).load(conn)?,
+            self.versions()
+                .select((versions::created_at, versions::num))
+                .load(conn)?,
         ))
     }
 

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -31,11 +31,9 @@ impl CrateOwner {
     /// Returns a base crate owner query filtered by the owner kind argument. This query also
     /// filters out deleted records.
     pub fn by_owner_kind(kind: OwnerKind) -> BoxedQuery<'static> {
-        use self::crate_owners::dsl::*;
-
-        crate_owners
-            .filter(deleted.eq(false))
-            .filter(owner_kind.eq(kind))
+        crate_owners::table
+            .filter(crate_owners::deleted.eq(false))
+            .filter(crate_owners::owner_kind.eq(kind))
             .into_boxed()
     }
 }

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -57,12 +57,11 @@ impl<'a> NewTeam<'a> {
     }
 
     pub fn create_or_update(&self, conn: &mut PgConnection) -> QueryResult<Team> {
-        use crate::schema::teams::dsl::*;
         use diesel::insert_into;
 
-        insert_into(teams)
+        insert_into(teams::table)
             .values(self)
-            .on_conflict(github_id)
+            .on_conflict(teams::github_id)
             .do_update()
             .set(self)
             .get_result(conn)

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -57,14 +57,13 @@ impl<'a> NewUser<'a> {
         emails: &Emails,
         conn: &mut PgConnection,
     ) -> QueryResult<User> {
-        use crate::schema::users::dsl::*;
         use diesel::dsl::sql;
         use diesel::insert_into;
         use diesel::pg::upsert::excluded;
         use diesel::sql_types::Integer;
 
         conn.transaction(|conn| {
-            let user: User = insert_into(users)
+            let user: User = insert_into(users::table)
                 .values(self)
                 // We need the `WHERE gh_id > 0` condition here because `gh_id` set
                 // to `-1` indicates that we were unable to find a GitHub ID for
@@ -77,10 +76,10 @@ impl<'a> NewUser<'a> {
                 .on_conflict(sql::<Integer>("(gh_id) WHERE gh_id > 0"))
                 .do_update()
                 .set((
-                    gh_login.eq(excluded(gh_login)),
-                    name.eq(excluded(name)),
-                    gh_avatar.eq(excluded(gh_avatar)),
-                    gh_access_token.eq(excluded(gh_access_token)),
+                    users::gh_login.eq(excluded(users::gh_login)),
+                    users::name.eq(excluded(users::name)),
+                    users::gh_avatar.eq(excluded(users::gh_avatar)),
+                    users::gh_access_token.eq(excluded(users::gh_access_token)),
                 ))
                 .get_result(conn)?;
 

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -107,18 +107,14 @@ impl Version {
             .load(conn)
     }
 
-    pub fn record_readme_rendering(
-        version_id_: i32,
-        conn: &mut PgConnection,
-    ) -> QueryResult<usize> {
-        use crate::schema::readme_renderings::dsl::*;
+    pub fn record_readme_rendering(version_id: i32, conn: &mut PgConnection) -> QueryResult<usize> {
         use diesel::dsl::now;
 
-        diesel::insert_into(readme_renderings)
-            .values(version_id.eq(version_id_))
-            .on_conflict(version_id)
+        diesel::insert_into(readme_renderings::table)
+            .values(readme_renderings::version_id.eq(version_id))
+            .on_conflict(readme_renderings::version_id)
             .do_update()
-            .set(rendered_at.eq(now))
+            .set(readme_renderings::rendered_at.eq(now))
             .execute(conn)
     }
 
@@ -161,16 +157,15 @@ impl NewVersion {
     }
 
     pub fn save(&self, conn: &mut PgConnection, published_by_email: &str) -> AppResult<Version> {
-        use crate::schema::versions::dsl::*;
         use diesel::dsl::exists;
         use diesel::{insert_into, select};
 
         conn.transaction(|conn| {
             let num_no_build = strip_build_metadata(&self.num);
 
-            let already_uploaded = versions
-                .filter(crate_id.eq(self.crate_id))
-                .filter(split_part(num, "+", 1).eq(num_no_build));
+            let already_uploaded = versions::table
+                .filter(versions::crate_id.eq(self.crate_id))
+                .filter(split_part(versions::num, "+", 1).eq(num_no_build));
 
             if select(exists(already_uploaded)).get_result(conn)? {
                 return Err(cargo_err(&format_args!(
@@ -179,7 +174,7 @@ impl NewVersion {
                 )));
             }
 
-            let version: Version = insert_into(versions).values(self).get_result(conn)?;
+            let version: Version = insert_into(versions::table).values(self).get_result(conn)?;
 
             insert_into(versions_published_by::table)
                 .values((

--- a/src/swirl/storage.rs
+++ b/src/swirl/storage.rs
@@ -4,7 +4,7 @@ use diesel::prelude::*;
 use diesel::sql_types::{Bool, Integer, Interval};
 use diesel::{delete, update};
 
-use crate::schema::{self, background_jobs};
+use crate::schema::background_jobs;
 
 #[derive(Queryable, Identifiable, Debug, Clone)]
 pub(super) struct BackgroundJob {
@@ -15,22 +15,26 @@ pub(super) struct BackgroundJob {
 
 fn retriable() -> Box<dyn BoxableExpression<background_jobs::table, Pg, SqlType = Bool>> {
     use diesel::dsl::*;
-    use schema::background_jobs::dsl::*;
 
     sql_function!(fn power(x: Integer, y: Integer) -> Integer);
 
-    Box::new(last_retry.lt(now - 1.minute().into_sql::<Interval>() * power(2, retries)))
+    Box::new(
+        background_jobs::last_retry
+            .lt(now - 1.minute().into_sql::<Interval>() * power(2, background_jobs::retries)),
+    )
 }
 
 /// Finds the next job that is unlocked, and ready to be retried. If a row is
 /// found, it will be locked.
 pub(super) fn find_next_unlocked_job(conn: &mut PgConnection) -> QueryResult<BackgroundJob> {
-    use schema::background_jobs::dsl::*;
-
-    background_jobs
-        .select((id, job_type, data))
+    background_jobs::table
+        .select((
+            background_jobs::id,
+            background_jobs::job_type,
+            background_jobs::data,
+        ))
         .filter(retriable())
-        .order((priority.desc(), id))
+        .order((background_jobs::priority.desc(), background_jobs::id))
         .for_update()
         .skip_locked()
         .first::<BackgroundJob>(conn)
@@ -38,19 +42,15 @@ pub(super) fn find_next_unlocked_job(conn: &mut PgConnection) -> QueryResult<Bac
 
 /// The number of jobs that have failed at least once
 pub(super) fn failed_job_count(conn: &mut PgConnection) -> QueryResult<i64> {
-    use schema::background_jobs::dsl::*;
-
-    background_jobs
+    background_jobs::table
         .count()
-        .filter(retries.gt(0))
+        .filter(background_jobs::retries.gt(0))
         .get_result(conn)
 }
 
 /// Deletes a job that has successfully completed running
 pub(super) fn delete_successful_job(conn: &mut PgConnection, job_id: i64) -> QueryResult<()> {
-    use schema::background_jobs::dsl::*;
-
-    delete(background_jobs.find(job_id)).execute(conn)?;
+    delete(background_jobs::table.find(job_id)).execute(conn)?;
     Ok(())
 }
 
@@ -59,9 +59,10 @@ pub(super) fn delete_successful_job(conn: &mut PgConnection, job_id: i64) -> Que
 /// Ignores any database errors that may have occurred. If the DB has gone away,
 /// we assume that just trying again with a new connection will succeed.
 pub(super) fn update_failed_job(conn: &mut PgConnection, job_id: i64) {
-    use schema::background_jobs::dsl::*;
-
-    let _ = update(background_jobs.find(job_id))
-        .set((retries.eq(retries + 1), last_retry.eq(now)))
+    let _ = update(background_jobs::table.find(job_id))
+        .set((
+            background_jobs::retries.eq(background_jobs::retries + 1),
+            background_jobs::last_retry.eq(now),
+        ))
         .execute(conn);
 }

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -49,11 +49,12 @@ fn can_download_crate_in_read_only_mode() {
 
     // We're in read only mode so the download should not have been counted
     app.db(|conn| {
-        use crates_io::schema::version_downloads::dsl::*;
+        use crates_io::schema::version_downloads;
         use diesel::dsl::sum;
 
-        let dl_count: Result<Option<i64>, _> =
-            version_downloads.select(sum(downloads)).get_result(conn);
+        let dl_count: Result<Option<i64>, _> = version_downloads::table
+            .select(sum(version_downloads::downloads))
+            .get_result(conn);
         assert_ok_eq!(dl_count, None);
     })
 }

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -65,7 +65,7 @@ fn force_unconditional_redirect() {
 #[test]
 fn download_caches_version_id() {
     use super::super::downloads;
-    use crates_io::schema::crates::dsl::*;
+    use crates_io::schema::crates;
     use diesel::prelude::*;
 
     let (app, anon, user) = TestApp::init().with_user();
@@ -82,8 +82,8 @@ fn download_caches_version_id() {
 
     // Rename the crate, so that `foo_download` will not be found if its version_id was not cached
     app.db(|conn| {
-        diesel::update(crates.filter(name.eq("foo_download")))
-            .set(name.eq("other"))
+        diesel::update(crates::table.filter(crates::name.eq("foo_download")))
+            .set(crates::name.eq("other"))
             .execute(conn)
             .unwrap();
     });

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -95,7 +95,7 @@ fn add_renamed_team() {
     let owner_id = user.as_model().id;
 
     app.db(|conn| {
-        use crates_io::schema::teams::dsl::*;
+        use crates_io::schema::teams;
 
         CrateBuilder::new("foo_renamed_team", owner_id).expect_build(conn);
 
@@ -111,7 +111,7 @@ fn add_renamed_team() {
         .create_or_update(conn)
         .unwrap();
 
-        assert_eq!(teams.count().get_result::<i64>(conn).unwrap(), 1);
+        assert_eq!(teams::table.count().get_result::<i64>(conn).unwrap(), 1);
     });
 
     token

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -34,7 +34,7 @@ struct TestAppInner {
 
 impl Drop for TestAppInner {
     fn drop(&mut self) {
-        use crates_io::schema::background_jobs::dsl::*;
+        use crates_io::schema::background_jobs;
         use diesel::prelude::*;
 
         // Avoid a double-panic if the test is already failing
@@ -51,7 +51,7 @@ impl Drop for TestAppInner {
         // Manually verify that all jobs have completed successfully
         // This will catch any tests that enqueued a job but forgot to initialize the runner
         let conn = &mut *self.app.db_write().unwrap();
-        let job_count: i64 = background_jobs.count().get_result(conn).unwrap();
+        let job_count: i64 = background_jobs::table.count().get_result(conn).unwrap();
         assert_eq!(
             0, job_count,
             "Unprocessed or failed jobs remain in the queue"

--- a/src/worker/dump_db/gen_scripts.rs
+++ b/src/worker/dump_db/gen_scripts.rs
@@ -182,11 +182,11 @@ mod tests {
     }
 
     fn get_db_columns(conn: &mut PgConnection) -> Vec<Column> {
-        use information_schema::columns::dsl::*;
-        columns
-            .select((table_name, column_name))
-            .filter(table_schema.eq("public"))
-            .order_by((table_name, ordinal_position))
+        use information_schema::columns;
+        columns::table
+            .select((columns::table_name, columns::column_name))
+            .filter(columns::table_schema.eq("public"))
+            .order_by((columns::table_name, columns::ordinal_position))
             .load(conn)
             .unwrap()
     }

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -12,13 +12,12 @@ pub fn perform_update_downloads(conn: &mut PgConnection) -> Result<(), PerformEr
 }
 
 fn update(conn: &mut PgConnection) -> QueryResult<()> {
-    use self::version_downloads::dsl::*;
     use diesel::dsl::now;
     use diesel::select;
 
-    let rows = version_downloads
-        .filter(processed.eq(false))
-        .filter(downloads.ne(counted))
+    let rows = version_downloads::table
+        .filter(version_downloads::processed.eq(false))
+        .filter(version_downloads::downloads.ne(version_downloads::counted))
         .load(conn)?;
 
     info!(rows = rows.len(), "Updating versions");
@@ -27,11 +26,11 @@ fn update(conn: &mut PgConnection) -> QueryResult<()> {
 
     // Anything older than 24 hours ago will be frozen and will not be queried
     // against again.
-    diesel::update(version_downloads)
-        .set(processed.eq(true))
-        .filter(date.lt(diesel::dsl::date(now)))
-        .filter(downloads.eq(counted))
-        .filter(processed.eq(false))
+    diesel::update(version_downloads::table)
+        .set(version_downloads::processed.eq(true))
+        .filter(version_downloads::date.lt(diesel::dsl::date(now)))
+        .filter(version_downloads::downloads.eq(version_downloads::counted))
+        .filter(version_downloads::processed.eq(false))
         .execute(conn)?;
     info!("Finished freezing old version_downloads");
 


### PR DESCRIPTION
Using these kinds of wildcard imports makes it hard to use variable or argument names that match the names of the table columns. This leads to argument names like `token_` or `id_`. Using the table name prefix is a little more verbose, but also makes it much easier to see where the code is referring to a column vs. a regular variable.