### PR TITLE
background_jobs: Simplify `enqueue_sync_to_index()` trait bounds

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -112,7 +112,7 @@ impl Job {
     /// and the background worker queue locking only work when using multiple
     /// connections.
     #[instrument(name = "swirl.enqueue", skip_all, fields(message = "sync_to_index", krate = %krate))]
-    pub fn enqueue_sync_to_index<T: ToString + Display>(
+    pub fn enqueue_sync_to_index<T: Display>(
         krate: T,
         conn: &mut PgConnection,
     ) -> Result<(), EnqueueError> {


### PR DESCRIPTION
The `ToString` trait is automatically implemented for anything implementing `Display`, so we don't need to explicitly specify it.