### PR TITLE
swirl/runner: Extract `new()` fn

### DIFF
--- a/src/swirl/runner.rs
+++ b/src/swirl/runner.rs
@@ -46,12 +46,6 @@ impl Runner {
             .job_start_timeout(Duration::from_secs(job_start_timeout))
     }
 
-    pub fn test_runner(environment: Environment, connection_pool: DieselPool) -> Self {
-        Self::new(connection_pool, Arc::new(Some(environment)))
-            .num_workers(1)
-            .job_start_timeout(Duration::from_secs(5))
-    }
-
     pub fn new(connection_pool: DieselPool, environment: Arc<Option<Environment>>) -> Self {
         Self {
             connection_pool,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -258,10 +258,11 @@ impl TestAppBuilder {
                 app.storage.clone(),
             );
 
-            Some(Runner::test_runner(
-                environment,
-                app.primary_database.clone(),
-            ))
+            let runner = Runner::new(app.primary_database.clone(), Arc::new(Some(environment)))
+                .num_workers(1)
+                .job_start_timeout(Duration::from_secs(5));
+
+            Some(runner)
         } else {
             None
         };


### PR DESCRIPTION
Instead of having three special constructor functions for all the different cases, we can have a single `new()` function and a couple of builder-style methods to configure the `Runner` instance before using it.