### PR TITLE
background_jobs: Simplify `Environment` struct

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -317,7 +317,7 @@ pub struct RenderAndUploadReadmeJob {
 }
 
 pub struct Environment {
-    index: Arc<Mutex<Repository>>,
+    index: Mutex<Repository>,
     http_client: AssertUnwindSafe<Client>,
     cloudfront: Option<CloudFront>,
     fastly: Option<Fastly>,
@@ -333,7 +333,7 @@ impl Environment {
         storage: Arc<Storage>,
     ) -> Self {
         Self {
-            index: Arc::new(Mutex::new(index)),
+            index: Mutex::new(index),
             http_client: AssertUnwindSafe(http_client),
             cloudfront,
             fastly,

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -332,24 +332,8 @@ impl Environment {
         fastly: Option<Fastly>,
         storage: Arc<Storage>,
     ) -> Self {
-        Self::new_shared(
-            Arc::new(Mutex::new(index)),
-            http_client,
-            cloudfront,
-            fastly,
-            storage,
-        )
-    }
-
-    pub fn new_shared(
-        index: Arc<Mutex<Repository>>,
-        http_client: Client,
-        cloudfront: Option<CloudFront>,
-        fastly: Option<Fastly>,
-        storage: Arc<Storage>,
-    ) -> Self {
         Self {
-            index,
+            index: Arc::new(Mutex::new(index)),
             http_client: AssertUnwindSafe(http_client),
             cloudfront,
             fastly,

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -22,7 +22,7 @@ use crates_io::{background_jobs::*, db, env_optional, ssh};
 use crates_io_index::{Repository, RepositoryConfig};
 use reqwest::blocking::Client;
 use secrecy::ExposeSecret;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
@@ -63,9 +63,7 @@ fn main() {
 
     let clone_start = Instant::now();
     let repository_config = RepositoryConfig::from_environment();
-    let repository = Arc::new(Mutex::new(
-        Repository::open(&repository_config).expect("Failed to clone index"),
-    ));
+    let repository = Repository::open(&repository_config).expect("Failed to clone index");
 
     let clone_duration = clone_start.elapsed();
     info!(duration = ?clone_duration, "Index cloned");
@@ -79,7 +77,7 @@ fn main() {
         .build()
         .expect("Couldn't build client");
 
-    let environment = Environment::new_shared(repository, client, cloudfront, fastly, storage);
+    let environment = Environment::new(repository, client, cloudfront, fastly, storage);
 
     let environment = Arc::new(Some(environment));
 


### PR DESCRIPTION
Looks like we don't need the `Arc` since the environment itself is already inside an `Arc` :)