### PR TITLE
worker: Simplify `perform()` fn arguments

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -266,9 +266,7 @@ impl Job {
             Job::DailyDbMaintenance => {
                 worker::perform_daily_db_maintenance(&mut *state.fresh_connection()?)
             }
-            Job::DumpDb(args) => {
-                worker::perform_dump_db(env, &args.database_url, &args.target_name)
-            }
+            Job::DumpDb(job) => worker::perform_dump_db(job, env),
             Job::SquashIndex => worker::perform_index_squash(env),
             Job::NormalizeIndex(args) => worker::perform_normalize_index(env, args),
             Job::RenderAndUploadReadme(job) => {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -271,15 +271,9 @@ impl Job {
             }
             Job::SquashIndex => worker::perform_index_squash(env),
             Job::NormalizeIndex(args) => worker::perform_normalize_index(env, args),
-            Job::RenderAndUploadReadme(args) => worker::perform_render_and_upload_readme(
-                state.conn,
-                env,
-                args.version_id,
-                &args.text,
-                &args.readme_path,
-                args.base_url.as_deref(),
-                args.pkg_path_in_vcs.as_deref(),
-            ),
+            Job::RenderAndUploadReadme(job) => {
+                worker::perform_render_and_upload_readme(job, state.conn, env)
+            }
             Job::SyncToGitIndex(args) => worker::sync_to_git_index(env, state.conn, &args.krate),
             Job::SyncToSparseIndex(args) => {
                 worker::sync_to_sparse_index(env, state.conn, &args.krate)

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -5,21 +5,17 @@ use std::{
 };
 
 use self::configuration::VisibilityConfig;
-use crate::background_jobs::Environment;
+use crate::background_jobs::{DumpDbJob, Environment};
 use crate::storage::Storage;
 use crate::swirl::PerformError;
 
 /// Create CSV dumps of the public information in the database, wrap them in a
 /// tarball and upload to S3.
-pub fn perform_dump_db(
-    env: &Environment,
-    database_url: &str,
-    target_name: &str,
-) -> Result<(), PerformError> {
+pub fn perform_dump_db(job: &DumpDbJob, env: &Environment) -> Result<(), PerformError> {
     let directory = DumpDirectory::create()?;
 
     info!(path = ?directory.export_dir, "Begin exporting database");
-    directory.populate(database_url)?;
+    directory.populate(&job.database_url)?;
 
     info!(path = ?directory.export_dir, "Creating tarball");
     let tarball = DumpTarball::create(&directory.export_dir)?;
@@ -33,11 +29,11 @@ pub fn perform_dump_db(
 
     let storage = Storage::from_environment();
 
-    rt.block_on(storage.upload_db_dump(target_name, &tarball.tarball_path))?;
+    rt.block_on(storage.upload_db_dump(&job.target_name, &tarball.tarball_path))?;
     info!("Database dump tarball uploaded");
 
     info!("Invalidating CDN caches");
-    invalidate_caches(env, target_name);
+    invalidate_caches(env, &job.target_name);
 
     Ok(())
 }


### PR DESCRIPTION
Instead of using so many arguments in these functions it's easier to just pass in a reference to the corresponding job struct. This also allows us to eventually make this a method of the struct itself.