### PR TITLE
worker: Extract job structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,6 @@ dependencies = [
  "once_cell",
  "p256",
  "parking_lot",
- "paste",
  "prometheus",
  "rand",
  "reqwest",
@@ -2463,12 +2462,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pem-rfc7468"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,6 @@ object_store = { version = "=0.7.1", features = ["aws"] }
 once_cell = "=1.18.0"
 p256 = "=0.13.2"
 parking_lot = "=0.12.1"
-paste = "=1.0.14"
 prometheus = { version = "=0.13.3", default-features = false }
 rand = "=0.8.5"
 reqwest = { version = "=0.11.22", features = ["blocking", "gzip", "json"] }

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -269,7 +269,7 @@ impl Job {
             }
             Job::DumpDb(job) => worker::perform_dump_db(job, env),
             Job::SquashIndex => worker::perform_index_squash(env),
-            Job::NormalizeIndex(args) => worker::perform_normalize_index(env, args),
+            Job::NormalizeIndex(job) => job.run(env),
             Job::RenderAndUploadReadme(job) => {
                 worker::perform_render_and_upload_readme(job, state.conn, env)
             }

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -267,7 +267,7 @@ impl Job {
             Job::DailyDbMaintenance => {
                 worker::perform_daily_db_maintenance(&mut *state.fresh_connection()?)
             }
-            Job::DumpDb(job) => worker::perform_dump_db(job, env),
+            Job::DumpDb(job) => job.run(env),
             Job::SquashIndex => worker::perform_index_squash(env),
             Job::NormalizeIndex(job) => job.run(env),
             Job::RenderAndUploadReadme(job) => job.run(state.conn, env),

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -270,9 +270,7 @@ impl Job {
             Job::DumpDb(job) => worker::perform_dump_db(job, env),
             Job::SquashIndex => worker::perform_index_squash(env),
             Job::NormalizeIndex(job) => job.run(env),
-            Job::RenderAndUploadReadme(job) => {
-                worker::perform_render_and_upload_readme(job, state.conn, env)
-            }
+            Job::RenderAndUploadReadme(job) => job.run(state.conn, env),
             Job::SyncToGitIndex(args) => worker::sync_to_git_index(env, state.conn, &args.krate),
             Job::SyncToSparseIndex(args) => {
                 worker::sync_to_sparse_index(env, state.conn, &args.krate)

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -271,10 +271,8 @@ impl Job {
             Job::SquashIndex => worker::perform_index_squash(env),
             Job::NormalizeIndex(job) => job.run(env),
             Job::RenderAndUploadReadme(job) => job.run(state.conn, env),
-            Job::SyncToGitIndex(args) => worker::sync_to_git_index(env, state.conn, &args.krate),
-            Job::SyncToSparseIndex(args) => {
-                worker::sync_to_sparse_index(env, state.conn, &args.krate)
-            }
+            Job::SyncToGitIndex(job) => job.run_git_sync(env, state.conn),
+            Job::SyncToSparseIndex(job) => job.run_sparse_sync(env, state.conn),
             Job::UpdateDownloads => {
                 worker::perform_update_downloads(&mut *state.fresh_connection()?)
             }

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -56,6 +56,18 @@ macro_rules! jobs {
                     })
                 }
 
+                pub(super) fn perform(
+                    &self,
+                    env: &Option<Environment>,
+                    state: PerformState<'_>,
+                ) -> Result<(), PerformError> {
+                    let env = env
+                        .as_ref()
+                        .expect("Application should configure a background runner environment");
+                    match self {
+                        $(Self::$variant(job) => job.run(state, env),)+
+                    }
+                }
             }
         }
     }
@@ -237,26 +249,6 @@ impl Job {
             ))
             .execute(conn)?;
         Ok(())
-    }
-
-    pub(super) fn perform(
-        &self,
-        env: &Option<Environment>,
-        state: PerformState<'_>,
-    ) -> Result<(), PerformError> {
-        let env = env
-            .as_ref()
-            .expect("Application should configure a background runner environment");
-        match self {
-            Job::DailyDbMaintenance(job) => job.run(state, env),
-            Job::DumpDb(job) => job.run(state, env),
-            Job::SquashIndex(job) => job.run(state, env),
-            Job::NormalizeIndex(job) => job.run(state, env),
-            Job::RenderAndUploadReadme(job) => job.run(state, env),
-            Job::SyncToGitIndex(job) => job.run(state, env),
-            Job::SyncToSparseIndex(job) => job.run(state, env),
-            Job::UpdateDownloads(job) => job.run(state, env),
-        }
     }
 }
 

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -16,6 +16,7 @@ use crate::swirl::PerformError;
 use crate::worker;
 use crate::worker::cloudfront::CloudFront;
 use crate::worker::fastly::Fastly;
+use crate::worker::{DumpDbJob, NormalizeIndexJob, RenderAndUploadReadmeJob, SyncToIndexJob};
 use crates_io_index::Repository;
 
 pub const PRIORITY_DEFAULT: i16 = 0;
@@ -281,31 +282,6 @@ impl Job {
             }
         }
     }
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct DumpDbJob {
-    pub(super) database_url: String,
-    pub(super) target_name: String,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct SyncToIndexJob {
-    pub(super) krate: String,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct NormalizeIndexJob {
-    pub dry_run: bool,
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct RenderAndUploadReadmeJob {
-    pub(super) version_id: i32,
-    pub(super) text: String,
-    pub(super) readme_path: String,
-    pub(super) base_url: Option<String>,
-    pub(super) pkg_path_in_vcs: Option<String>,
 }
 
 pub struct Environment {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -16,7 +16,9 @@ use crate::swirl::PerformError;
 use crate::worker;
 use crate::worker::cloudfront::CloudFront;
 use crate::worker::fastly::Fastly;
-use crate::worker::{DumpDbJob, NormalizeIndexJob, RenderAndUploadReadmeJob, SyncToIndexJob};
+use crate::worker::{
+    DumpDbJob, NormalizeIndexJob, RenderAndUploadReadmeJob, SyncToGitIndexJob, SyncToSparseIndexJob,
+};
 use crates_io_index::Repository;
 
 pub const PRIORITY_DEFAULT: i16 = 0;
@@ -84,8 +86,8 @@ jobs! {
         NormalizeIndex(NormalizeIndexJob),
         RenderAndUploadReadme(RenderAndUploadReadmeJob),
         SquashIndex,
-        SyncToGitIndex(SyncToIndexJob),
-        SyncToSparseIndex(SyncToIndexJob),
+        SyncToGitIndex(SyncToGitIndexJob),
+        SyncToSparseIndex(SyncToSparseIndexJob),
         UpdateDownloads,
     }
 }
@@ -219,13 +221,13 @@ impl Job {
     }
 
     pub fn sync_to_git_index<T: ToString>(krate: T) -> Self {
-        Self::SyncToGitIndex(SyncToIndexJob {
+        Self::SyncToGitIndex(SyncToGitIndexJob {
             krate: krate.to_string(),
         })
     }
 
     pub fn sync_to_sparse_index<T: ToString>(krate: T) -> Self {
-        Self::SyncToSparseIndex(SyncToIndexJob {
+        Self::SyncToSparseIndex(SyncToSparseIndexJob {
             krate: krate.to_string(),
         })
     }
@@ -269,8 +271,8 @@ impl Job {
             Job::SquashIndex => worker::perform_index_squash(state, env),
             Job::NormalizeIndex(job) => job.run(state, env),
             Job::RenderAndUploadReadme(job) => job.run(state, env),
-            Job::SyncToGitIndex(job) => job.run_git_sync(state, env),
-            Job::SyncToSparseIndex(job) => job.run_sparse_sync(state, env),
+            Job::SyncToGitIndex(job) => job.run(state, env),
+            Job::SyncToSparseIndex(job) => job.run(state, env),
             Job::UpdateDownloads => worker::perform_update_downloads(state, env),
         }
     }

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -39,19 +39,19 @@ macro_rules! jobs {
             impl $name {
                 fn as_type_str(&self) -> &'static str {
                     match self {
-                        $(Self:: $variant ([<_ $content:snake:lower>]) => stringify!([<$variant:snake:lower>]),)+
+                        $(Self::$variant(_) => $content::JOB_NAME,)+
                     }
                 }
 
                 fn to_value(&self) -> serde_json::Result<serde_json::Value> {
                     match self {
-                        $(Self:: $variant ([<$content:snake:lower>]) => serde_json::to_value([<$content:snake:lower>]),)+
+                        $(Self::$variant(job) => serde_json::to_value(job),)+
                     }
                 }
 
                 pub fn from_value(job_type: &str, value: serde_json::Value) -> Result<Self, PerformError> {
                     Ok(match job_type {
-                        $(stringify!([<$variant:snake:lower>]) => Self::$variant(serde_json::from_value(value)?),)+
+                        $($content::JOB_NAME => Self::$variant(serde_json::from_value(value)?),)+
                         job_type => Err(PerformError::from(format!("Unknown job type {job_type}")))?,
                     })
                 }

--- a/src/worker/daily_db_maintenance.rs
+++ b/src/worker/daily_db_maintenance.rs
@@ -6,6 +6,8 @@ use diesel::{sql_query, RunQueryDsl};
 pub struct DailyDbMaintenanceJob;
 
 impl DailyDbMaintenanceJob {
+    pub const JOB_NAME: &'static str = "daily_db_maintenance";
+
     /// Run daily database maintenance tasks
     ///
     /// By default PostgreSQL will run an auto-vacuum when 20% of the tuples in a table are dead.

--- a/src/worker/daily_db_maintenance.rs
+++ b/src/worker/daily_db_maintenance.rs
@@ -2,23 +2,25 @@ use crate::background_jobs::{Environment, PerformState};
 use crate::swirl::PerformError;
 use diesel::{sql_query, RunQueryDsl};
 
-/// Run daily database maintenance tasks
-///
-/// By default PostgreSQL will run an auto-vacuum when 20% of the tuples in a table are dead.
-/// Because the `version_downloads` table includes years of historical data, we can accumulate
-/// a *lot* of garbage before an auto-vacuum is run.
-///
-/// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
-/// archive daily download counts and drop historical data, we can drop this task and rely on
-/// auto-vacuum again.
-pub(crate) fn perform_daily_db_maintenance(
-    state: PerformState<'_>,
-    _env: &Environment,
-) -> Result<(), PerformError> {
-    let mut conn = state.fresh_connection()?;
+#[derive(Serialize, Deserialize)]
+pub struct DailyDbMaintenanceJob;
 
-    info!("Running VACUUM on version_downloads table");
-    sql_query("VACUUM version_downloads;").execute(&mut conn)?;
-    info!("Finished running VACUUM on version_downloads table");
-    Ok(())
+impl DailyDbMaintenanceJob {
+    /// Run daily database maintenance tasks
+    ///
+    /// By default PostgreSQL will run an auto-vacuum when 20% of the tuples in a table are dead.
+    /// Because the `version_downloads` table includes years of historical data, we can accumulate
+    /// a *lot* of garbage before an auto-vacuum is run.
+    ///
+    /// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
+    /// archive daily download counts and drop historical data, we can drop this task and rely on
+    /// auto-vacuum again.
+    pub fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
+        let mut conn = state.fresh_connection()?;
+
+        info!("Running VACUUM on version_downloads table");
+        sql_query("VACUUM version_downloads;").execute(&mut conn)?;
+        info!("Finished running VACUUM on version_downloads table");
+        Ok(())
+    }
 }

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -16,6 +16,8 @@ pub struct DumpDbJob {
 }
 
 impl DumpDbJob {
+    pub const JOB_NAME: &'static str = "dump_db";
+
     /// Create CSV dumps of the public information in the database, wrap them in a
     /// tarball and upload to S3.
     pub fn run(&self, _state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -5,9 +5,15 @@ use std::{
 };
 
 use self::configuration::VisibilityConfig;
-use crate::background_jobs::{DumpDbJob, Environment};
+use crate::background_jobs::Environment;
 use crate::storage::Storage;
 use crate::swirl::PerformError;
+
+#[derive(Serialize, Deserialize)]
+pub struct DumpDbJob {
+    pub(crate) database_url: String,
+    pub(crate) target_name: String,
+}
 
 /// Create CSV dumps of the public information in the database, wrap them in a
 /// tarball and upload to S3.

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use self::configuration::VisibilityConfig;
-use crate::background_jobs::Environment;
+use crate::background_jobs::{Environment, PerformState};
 use crate::storage::Storage;
 use crate::swirl::PerformError;
 
@@ -18,7 +18,7 @@ pub struct DumpDbJob {
 impl DumpDbJob {
     /// Create CSV dumps of the public information in the database, wrap them in a
     /// tarball and upload to S3.
-    pub fn run(&self, env: &Environment) -> Result<(), PerformError> {
+    pub fn run(&self, _state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
         let directory = DumpDirectory::create()?;
 
         info!(path = ?directory.export_dir, "Begin exporting database");

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -11,18 +11,14 @@ use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::process::Command;
 
 #[derive(Serialize, Deserialize)]
-pub struct SyncToIndexJob {
+pub struct SyncToGitIndexJob {
     pub(crate) krate: String,
 }
 
-impl SyncToIndexJob {
+impl SyncToGitIndexJob {
     /// Regenerates or removes an index file for a single crate
-    #[instrument(skip_all, fields(krate.name = ?self.krate))]
-    pub fn run_git_sync(
-        &self,
-        state: PerformState<'_>,
-        env: &Environment,
-    ) -> Result<(), PerformError> {
+    #[instrument(skip_all, fields(krate.name = ? self.krate))]
+    pub fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
         info!("Syncing to git index");
 
         let new = get_index_data(&self.krate, state.conn).context("Failed to get index data")?;
@@ -58,14 +54,17 @@ impl SyncToIndexJob {
 
         Ok(())
     }
+}
 
+#[derive(Serialize, Deserialize)]
+pub struct SyncToSparseIndexJob {
+    pub(crate) krate: String,
+}
+
+impl SyncToSparseIndexJob {
     /// Regenerates or removes an index file for a single crate
     #[instrument(skip_all, fields(krate.name = ?self.krate))]
-    pub fn run_sparse_sync(
-        &self,
-        state: PerformState<'_>,
-        env: &Environment,
-    ) -> Result<(), PerformError> {
+    pub fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
         info!("Syncing to sparse index");
 
         let content =

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -1,4 +1,4 @@
-use crate::background_jobs::{Environment, NormalizeIndexJob};
+use crate::background_jobs::Environment;
 use crate::models;
 use crate::swirl::PerformError;
 use anyhow::Context;
@@ -9,6 +9,11 @@ use sentry::Level;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::process::Command;
+
+#[derive(Serialize, Deserialize)]
+pub struct SyncToIndexJob {
+    pub(crate) krate: String,
+}
 
 /// Regenerates or removes an index file for a single crate
 #[instrument(skip_all, fields(krate.name = ?krate))]
@@ -156,6 +161,11 @@ pub fn perform_index_squash(env: &Environment) -> Result<(), PerformError> {
     info!("The index has been successfully squashed.");
 
     Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct NormalizeIndexJob {
+    pub dry_run: bool,
 }
 
 pub fn perform_normalize_index(

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -16,6 +16,8 @@ pub struct SyncToGitIndexJob {
 }
 
 impl SyncToGitIndexJob {
+    pub const JOB_NAME: &'static str = "sync_to_git_index";
+
     /// Regenerates or removes an index file for a single crate
     #[instrument(skip_all, fields(krate.name = ? self.krate))]
     pub fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
@@ -62,6 +64,8 @@ pub struct SyncToSparseIndexJob {
 }
 
 impl SyncToSparseIndexJob {
+    pub const JOB_NAME: &'static str = "sync_to_sparse_index";
+
     /// Regenerates or removes an index file for a single crate
     #[instrument(skip_all, fields(krate.name = ?self.krate))]
     pub fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
@@ -132,6 +136,8 @@ pub fn get_index_data(name: &str, conn: &mut PgConnection) -> anyhow::Result<Opt
 pub struct SquashIndexJob;
 
 impl SquashIndexJob {
+    pub const JOB_NAME: &'static str = "squash_index";
+
     /// Collapse the index into a single commit, archiving the current history in a snapshot branch.
     #[instrument(skip_all)]
     pub fn run(&self, _state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
@@ -176,6 +182,8 @@ pub struct NormalizeIndexJob {
 }
 
 impl NormalizeIndexJob {
+    pub const JOB_NAME: &'static str = "normalize_index";
+
     pub fn run(&self, _state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
         info!("Normalizing the index");
 

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -14,8 +14,8 @@ mod update_downloads;
 pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
 pub(crate) use dump_db::{perform_dump_db, DumpDbJob};
 pub(crate) use git::{
-    perform_index_squash, perform_normalize_index, sync_to_git_index, sync_to_sparse_index,
-    NormalizeIndexJob, SyncToIndexJob,
+    perform_index_squash, sync_to_git_index, sync_to_sparse_index, NormalizeIndexJob,
+    SyncToIndexJob,
 };
 pub(crate) use readmes::{perform_render_and_upload_readme, RenderAndUploadReadmeJob};
 pub(crate) use update_downloads::perform_update_downloads;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -12,9 +12,10 @@ mod readmes;
 mod update_downloads;
 
 pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
-pub(crate) use dump_db::perform_dump_db;
+pub(crate) use dump_db::{perform_dump_db, DumpDbJob};
 pub(crate) use git::{
     perform_index_squash, perform_normalize_index, sync_to_git_index, sync_to_sparse_index,
+    NormalizeIndexJob, SyncToIndexJob,
 };
-pub(crate) use readmes::perform_render_and_upload_readme;
+pub(crate) use readmes::{perform_render_and_upload_readme, RenderAndUploadReadmeJob};
 pub(crate) use update_downloads::perform_update_downloads;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -11,10 +11,8 @@ mod git;
 mod readmes;
 mod update_downloads;
 
-pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
+pub(crate) use daily_db_maintenance::DailyDbMaintenanceJob;
 pub(crate) use dump_db::DumpDbJob;
-pub(crate) use git::{
-    perform_index_squash, NormalizeIndexJob, SyncToGitIndexJob, SyncToSparseIndexJob,
-};
+pub(crate) use git::{NormalizeIndexJob, SquashIndexJob, SyncToGitIndexJob, SyncToSparseIndexJob};
 pub(crate) use readmes::RenderAndUploadReadmeJob;
-pub(crate) use update_downloads::perform_update_downloads;
+pub(crate) use update_downloads::UpdateDownloadsJob;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -13,6 +13,8 @@ mod update_downloads;
 
 pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
 pub(crate) use dump_db::DumpDbJob;
-pub(crate) use git::{perform_index_squash, NormalizeIndexJob, SyncToIndexJob};
+pub(crate) use git::{
+    perform_index_squash, NormalizeIndexJob, SyncToGitIndexJob, SyncToSparseIndexJob,
+};
 pub(crate) use readmes::RenderAndUploadReadmeJob;
 pub(crate) use update_downloads::perform_update_downloads;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -12,7 +12,7 @@ mod readmes;
 mod update_downloads;
 
 pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
-pub(crate) use dump_db::{perform_dump_db, DumpDbJob};
+pub(crate) use dump_db::DumpDbJob;
 pub(crate) use git::{
     perform_index_squash, sync_to_git_index, sync_to_sparse_index, NormalizeIndexJob,
     SyncToIndexJob,

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -17,5 +17,5 @@ pub(crate) use git::{
     perform_index_squash, sync_to_git_index, sync_to_sparse_index, NormalizeIndexJob,
     SyncToIndexJob,
 };
-pub(crate) use readmes::{perform_render_and_upload_readme, RenderAndUploadReadmeJob};
+pub(crate) use readmes::RenderAndUploadReadmeJob;
 pub(crate) use update_downloads::perform_update_downloads;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -13,9 +13,6 @@ mod update_downloads;
 
 pub(crate) use daily_db_maintenance::perform_daily_db_maintenance;
 pub(crate) use dump_db::DumpDbJob;
-pub(crate) use git::{
-    perform_index_squash, sync_to_git_index, sync_to_sparse_index, NormalizeIndexJob,
-    SyncToIndexJob,
-};
+pub(crate) use git::{perform_index_squash, NormalizeIndexJob, SyncToIndexJob};
 pub(crate) use readmes::RenderAndUploadReadmeJob;
 pub(crate) use update_downloads::perform_update_downloads;

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -17,6 +17,8 @@ pub struct RenderAndUploadReadmeJob {
 }
 
 impl RenderAndUploadReadmeJob {
+    pub const JOB_NAME: &'static str = "render_and_upload_readme";
+
     #[instrument(skip_all, fields(krate.name))]
     pub fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
         use crate::schema::*;

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -17,47 +17,45 @@ pub struct RenderAndUploadReadmeJob {
     pub(crate) pkg_path_in_vcs: Option<String>,
 }
 
-#[instrument(skip_all, fields(krate.name))]
-pub fn perform_render_and_upload_readme(
-    job: &RenderAndUploadReadmeJob,
-    conn: &mut PgConnection,
-    env: &Environment,
-) -> Result<(), PerformError> {
-    use crate::schema::*;
-    use diesel::prelude::*;
+impl RenderAndUploadReadmeJob {
+    #[instrument(skip_all, fields(krate.name))]
+    pub fn run(&self, conn: &mut PgConnection, env: &Environment) -> Result<(), PerformError> {
+        use crate::schema::*;
+        use diesel::prelude::*;
 
-    info!(version_id = ?job.version_id, "Rendering README");
+        info!(version_id = ?self.version_id, "Rendering README");
 
-    let rendered = text_to_html(
-        &job.text,
-        &job.readme_path,
-        job.base_url.as_deref(),
-        job.pkg_path_in_vcs.as_ref(),
-    );
-    if rendered.is_empty() {
-        return Ok(());
+        let rendered = text_to_html(
+            &self.text,
+            &self.readme_path,
+            self.base_url.as_deref(),
+            self.pkg_path_in_vcs.as_ref(),
+        );
+        if rendered.is_empty() {
+            return Ok(());
+        }
+
+        conn.transaction(|conn| {
+            Version::record_readme_rendering(self.version_id, conn)?;
+            let (crate_name, vers): (String, String) = versions::table
+                .find(self.version_id)
+                .inner_join(crates::table)
+                .select((crates::name, versions::num))
+                .first(conn)?;
+
+            tracing::Span::current().record("krate.name", tracing::field::display(&crate_name));
+
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("Failed to initialize tokio runtime")
+                .unwrap();
+
+            let bytes = rendered.into();
+            let future = env.storage.upload_readme(&crate_name, &vers, bytes);
+            rt.block_on(future)?;
+
+            Ok(())
+        })
     }
-
-    conn.transaction(|conn| {
-        Version::record_readme_rendering(job.version_id, conn)?;
-        let (crate_name, vers): (String, String) = versions::table
-            .find(job.version_id)
-            .inner_join(crates::table)
-            .select((crates::name, versions::num))
-            .first(conn)?;
-
-        tracing::Span::current().record("krate.name", tracing::field::display(&crate_name));
-
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("Failed to initialize tokio runtime")
-            .unwrap();
-
-        let bytes = rendered.into();
-        let future = env.storage.upload_readme(&crate_name, &vers, bytes);
-        rt.block_on(future)?;
-
-        Ok(())
-    })
 }

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -5,8 +5,17 @@ use anyhow::Context;
 use crates_io_markdown::text_to_html;
 use diesel::PgConnection;
 
-use crate::background_jobs::{Environment, RenderAndUploadReadmeJob};
+use crate::background_jobs::Environment;
 use crate::models::Version;
+
+#[derive(Serialize, Deserialize)]
+pub struct RenderAndUploadReadmeJob {
+    pub(crate) version_id: i32,
+    pub(crate) text: String,
+    pub(crate) readme_path: String,
+    pub(crate) base_url: Option<String>,
+    pub(crate) pkg_path_in_vcs: Option<String>,
+}
 
 #[instrument(skip_all, fields(krate.name))]
 pub fn perform_render_and_upload_readme(

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -7,13 +7,15 @@ use crate::background_jobs::{Environment, PerformState};
 use crate::swirl::PerformError;
 use diesel::prelude::*;
 
-pub fn perform_update_downloads(
-    state: PerformState<'_>,
-    _env: &Environment,
-) -> Result<(), PerformError> {
-    let mut conn = state.fresh_connection()?;
-    update(&mut conn)?;
-    Ok(())
+#[derive(Serialize, Deserialize)]
+pub struct UpdateDownloadsJob;
+
+impl UpdateDownloadsJob {
+    pub fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
+        let mut conn = state.fresh_connection()?;
+        update(&mut conn)?;
+        Ok(())
+    }
 }
 
 fn update(conn: &mut PgConnection) -> QueryResult<()> {

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -11,6 +11,8 @@ use diesel::prelude::*;
 pub struct UpdateDownloadsJob;
 
 impl UpdateDownloadsJob {
+    pub const JOB_NAME: &'static str = "update_downloads";
+
     pub fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
         let mut conn = state.fresh_connection()?;
         update(&mut conn)?;

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -3,11 +3,16 @@ use crate::{
     schema::{crates, metadata, version_downloads, versions},
 };
 
+use crate::background_jobs::{Environment, PerformState};
 use crate::swirl::PerformError;
 use diesel::prelude::*;
 
-pub fn perform_update_downloads(conn: &mut PgConnection) -> Result<(), PerformError> {
-    update(conn)?;
+pub fn perform_update_downloads(
+    state: PerformState<'_>,
+    _env: &Environment,
+) -> Result<(), PerformError> {
+    let mut conn = state.fresh_connection()?;
+    update(&mut conn)?;
     Ok(())
 }
 


### PR DESCRIPTION
Buckle up, this is a big one!

I recommend reviewing this commit-by-commit and with the "Hide whitespace" option turned on, to ignore whitespace-only indentation changes.

The goal of this PR is to unify how our background job structs look like. After this PR they all have an associated `JOB_NAME` constant and a `run()` fn, all with the same arguments. This allows us to generate the `perform()` fn with the existing `jobs!` macro.

And if you now think "this looks a lot like it should be trait definition" then you are totally right. Extracting a corresponding trait and making the runner generic over the registered jobs will come in a follow-up PR :)

As a side-effect the move to the `JOB_NAME` constant allows us to get rid of the `paste` dependency again and significantly simplify the `jobs!` macro.