### PR TITLE
background_jobs: Extract `BackgroundJob` trait

### DIFF
--- a/src/worker/daily_db_maintenance.rs
+++ b/src/worker/daily_db_maintenance.rs
@@ -1,12 +1,12 @@
-use crate::background_jobs::{Environment, PerformState};
+use crate::background_jobs::{BackgroundJob, Environment, PerformState};
 use crate::swirl::PerformError;
 use diesel::{sql_query, RunQueryDsl};
 
 #[derive(Serialize, Deserialize)]
 pub struct DailyDbMaintenanceJob;
 
-impl DailyDbMaintenanceJob {
-    pub const JOB_NAME: &'static str = "daily_db_maintenance";
+impl BackgroundJob for DailyDbMaintenanceJob {
+    const JOB_NAME: &'static str = "daily_db_maintenance";
 
     /// Run daily database maintenance tasks
     ///
@@ -17,7 +17,7 @@ impl DailyDbMaintenanceJob {
     /// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
     /// archive daily download counts and drop historical data, we can drop this task and rely on
     /// auto-vacuum again.
-    pub fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
+    fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
         let mut conn = state.fresh_connection()?;
 
         info!("Running VACUUM on version_downloads table");

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use self::configuration::VisibilityConfig;
-use crate::background_jobs::{Environment, PerformState};
+use crate::background_jobs::{BackgroundJob, Environment, PerformState};
 use crate::storage::Storage;
 use crate::swirl::PerformError;
 
@@ -15,12 +15,12 @@ pub struct DumpDbJob {
     pub(crate) target_name: String,
 }
 
-impl DumpDbJob {
-    pub const JOB_NAME: &'static str = "dump_db";
+impl BackgroundJob for DumpDbJob {
+    const JOB_NAME: &'static str = "dump_db";
 
     /// Create CSV dumps of the public information in the database, wrap them in a
     /// tarball and upload to S3.
-    pub fn run(&self, _state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
+    fn run(&self, _state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
         let directory = DumpDirectory::create()?;
 
         info!(path = ?directory.export_dir, "Begin exporting database");

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -4,7 +4,7 @@ use crate::swirl::PerformError;
 use anyhow::Context;
 use crates_io_markdown::text_to_html;
 
-use crate::background_jobs::{Environment, PerformState};
+use crate::background_jobs::{BackgroundJob, Environment, PerformState};
 use crate::models::Version;
 
 #[derive(Serialize, Deserialize)]
@@ -16,11 +16,11 @@ pub struct RenderAndUploadReadmeJob {
     pub(crate) pkg_path_in_vcs: Option<String>,
 }
 
-impl RenderAndUploadReadmeJob {
-    pub const JOB_NAME: &'static str = "render_and_upload_readme";
+impl BackgroundJob for RenderAndUploadReadmeJob {
+    const JOB_NAME: &'static str = "render_and_upload_readme";
 
     #[instrument(skip_all, fields(krate.name))]
-    pub fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
+    fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
         use crate::schema::*;
         use diesel::prelude::*;
 

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -3,17 +3,17 @@ use crate::{
     schema::{crates, metadata, version_downloads, versions},
 };
 
-use crate::background_jobs::{Environment, PerformState};
+use crate::background_jobs::{BackgroundJob, Environment, PerformState};
 use crate::swirl::PerformError;
 use diesel::prelude::*;
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateDownloadsJob;
 
-impl UpdateDownloadsJob {
-    pub const JOB_NAME: &'static str = "update_downloads";
+impl BackgroundJob for UpdateDownloadsJob {
+    const JOB_NAME: &'static str = "update_downloads";
 
-    pub fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
+    fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
         let mut conn = state.fresh_connection()?;
         update(&mut conn)?;
         Ok(())


### PR DESCRIPTION
As promised in #7406, this PR extracts a `BackgroundJob` trait. The trait itself it not really used in itself anywhere yet, but it ensures that all job structs conform to the same API and can't be incompatible with the `jobs!` macro.