### PR TITLE
worker: Extract `...Job::new()` fns

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -195,13 +195,10 @@ impl Job {
         base_url: Option<String>,
         pkg_path_in_vcs: Option<String>,
     ) -> Self {
-        Self::RenderAndUploadReadme(RenderAndUploadReadmeJob {
-            version_id,
-            text,
-            readme_path,
-            base_url,
-            pkg_path_in_vcs,
-        })
+        let job =
+            RenderAndUploadReadmeJob::new(version_id, text, readme_path, base_url, pkg_path_in_vcs);
+
+        Self::RenderAndUploadReadme(job)
     }
 
     pub fn squash_index() -> Self {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -212,10 +212,8 @@ impl Job {
         Self::SyncToGitIndex(SyncToGitIndexJob::new(krate))
     }
 
-    pub fn sync_to_sparse_index<T: ToString>(krate: T) -> Self {
-        Self::SyncToSparseIndex(SyncToSparseIndexJob {
-            krate: krate.to_string(),
-        })
+    pub fn sync_to_sparse_index(krate: impl Into<String>) -> Self {
+        Self::SyncToSparseIndex(SyncToSparseIndexJob::new(krate))
     }
 
     pub fn update_downloads() -> Self {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -185,7 +185,7 @@ impl Job {
     }
 
     pub fn normalize_index(dry_run: bool) -> Self {
-        Self::NormalizeIndex(NormalizeIndexJob { dry_run })
+        Self::NormalizeIndex(NormalizeIndexJob::new(dry_run))
     }
 
     pub fn render_and_upload_readme(

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -181,10 +181,7 @@ impl Job {
     }
 
     pub fn dump_db(database_url: String, target_name: String) -> Self {
-        Self::DumpDb(DumpDbJob {
-            database_url,
-            target_name,
-        })
+        Self::DumpDb(DumpDbJob::new(database_url, target_name))
     }
 
     pub fn normalize_index(dry_run: bool) -> Self {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -208,10 +208,8 @@ impl Job {
         Self::SquashIndex(SquashIndexJob)
     }
 
-    pub fn sync_to_git_index<T: ToString>(krate: T) -> Self {
-        Self::SyncToGitIndex(SyncToGitIndexJob {
-            krate: krate.to_string(),
-        })
+    pub fn sync_to_git_index(krate: impl Into<String>) -> Self {
+        Self::SyncToGitIndex(SyncToGitIndexJob::new(krate))
     }
 
     pub fn sync_to_sparse_index<T: ToString>(krate: T) -> Self {

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -11,8 +11,17 @@ use crate::swirl::PerformError;
 
 #[derive(Serialize, Deserialize)]
 pub struct DumpDbJob {
-    pub(crate) database_url: String,
-    pub(crate) target_name: String,
+    database_url: String,
+    target_name: String,
+}
+
+impl DumpDbJob {
+    pub fn new(database_url: impl Into<String>, target_name: impl Into<String>) -> Self {
+        Self {
+            database_url: database_url.into(),
+            target_name: target_name.into(),
+        }
+    }
 }
 
 impl DumpDbJob {

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -192,7 +192,13 @@ impl SquashIndexJob {
 
 #[derive(Serialize, Deserialize)]
 pub struct NormalizeIndexJob {
-    pub dry_run: bool,
+    dry_run: bool,
+}
+
+impl NormalizeIndexJob {
+    pub fn new(dry_run: bool) -> Self {
+        Self { dry_run }
+    }
 }
 
 impl NormalizeIndexJob {

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -12,7 +12,14 @@ use std::process::Command;
 
 #[derive(Serialize, Deserialize)]
 pub struct SyncToGitIndexJob {
-    pub(crate) krate: String,
+    krate: String,
+}
+
+impl SyncToGitIndexJob {
+    pub fn new(krate: impl Into<String>) -> Self {
+        let krate = krate.into();
+        Self { krate }
+    }
 }
 
 impl SyncToGitIndexJob {

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -67,7 +67,14 @@ impl SyncToGitIndexJob {
 
 #[derive(Serialize, Deserialize)]
 pub struct SyncToSparseIndexJob {
-    pub(crate) krate: String,
+    krate: String,
+}
+
+impl SyncToSparseIndexJob {
+    pub fn new(krate: impl Into<String>) -> Self {
+        let krate = krate.into();
+        Self { krate }
+    }
 }
 
 impl SyncToSparseIndexJob {

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -9,11 +9,29 @@ use crate::models::Version;
 
 #[derive(Serialize, Deserialize)]
 pub struct RenderAndUploadReadmeJob {
-    pub(crate) version_id: i32,
-    pub(crate) text: String,
-    pub(crate) readme_path: String,
-    pub(crate) base_url: Option<String>,
-    pub(crate) pkg_path_in_vcs: Option<String>,
+    version_id: i32,
+    text: String,
+    readme_path: String,
+    base_url: Option<String>,
+    pkg_path_in_vcs: Option<String>,
+}
+
+impl RenderAndUploadReadmeJob {
+    pub fn new(
+        version_id: i32,
+        text: String,
+        readme_path: String,
+        base_url: Option<String>,
+        pkg_path_in_vcs: Option<String>,
+    ) -> Self {
+        Self {
+            version_id,
+            text,
+            readme_path,
+            base_url,
+            pkg_path_in_vcs,
+        }
+    }
 }
 
 impl RenderAndUploadReadmeJob {


### PR DESCRIPTION
This PR extracts `new()` constructor functions for all of our background job structs, except for the unit structs, for which they seem somewhat unuseful.

While this is slightly more verbose on the implementation side, it also allows us to reduce the visibility level of the struct fields, since they only need to be read and written in the same module now.