### PR TITLE
background_jobs: Move `enqueue()` fn into `BackgroundJob` trait

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -1,4 +1,4 @@
-use crate::background_jobs::Job;
+use crate::background_jobs::{BackgroundJob, Job};
 use crate::db;
 use crate::schema::background_jobs;
 use anyhow::Result;

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -196,36 +196,6 @@ impl Job {
 
         Ok(())
     }
-
-    pub fn daily_db_maintenance() -> DailyDbMaintenanceJob {
-        DailyDbMaintenanceJob
-    }
-
-    pub fn dump_db(database_url: String, target_name: String) -> DumpDbJob {
-        DumpDbJob::new(database_url, target_name)
-    }
-
-    pub fn normalize_index(dry_run: bool) -> NormalizeIndexJob {
-        NormalizeIndexJob::new(dry_run)
-    }
-
-    pub fn render_and_upload_readme(
-        version_id: i32,
-        text: String,
-        readme_path: String,
-        base_url: Option<String>,
-        pkg_path_in_vcs: Option<String>,
-    ) -> RenderAndUploadReadmeJob {
-        RenderAndUploadReadmeJob::new(version_id, text, readme_path, base_url, pkg_path_in_vcs)
-    }
-
-    pub fn squash_index() -> SquashIndexJob {
-        SquashIndexJob
-    }
-
-    pub fn update_downloads() -> UpdateDownloadsJob {
-        UpdateDownloadsJob
-    }
 }
 
 pub struct Environment {

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -68,18 +68,6 @@ macro_rules! jobs {
         }
 
         impl $name {
-            fn as_type_str(&self) -> &'static str {
-                match self {
-                    $(Self::$variant(_) => $content::JOB_NAME,)+
-                }
-            }
-
-            fn to_value(&self) -> serde_json::Result<serde_json::Value> {
-                match self {
-                    $(Self::$variant(job) => serde_json::to_value(job),)+
-                }
-            }
-
             pub fn from_value(job_type: &str, value: serde_json::Value) -> Result<Self, PerformError> {
                 Ok(match job_type {
                     $($content::JOB_NAME => Self::$variant(serde_json::from_value(value)?),)+

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -2,6 +2,7 @@
 
 use crate::auth::AuthCheck;
 use crate::background_jobs::{BackgroundJob, Job, PRIORITY_RENDER_README};
+use crate::worker::RenderAndUploadReadmeJob;
 use axum::body::Bytes;
 use cargo_manifest::{Dependency, DepsSet, TargetDepsSet};
 use crates_io_tarball::{process_tarball, TarballError};
@@ -368,7 +369,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
 
             if let Some(readme) = metadata.readme {
                 if !readme.is_empty() {
-                    Job::render_and_upload_readme(
+                    RenderAndUploadReadmeJob::new(
                         version.id,
                         readme,
                         metadata

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -1,7 +1,7 @@
 //! Functionality related to publishing a new crate or version of a crate.
 
 use crate::auth::AuthCheck;
-use crate::background_jobs::{Job, PRIORITY_RENDER_README};
+use crate::background_jobs::{BackgroundJob, Job, PRIORITY_RENDER_README};
 use axum::body::Bytes;
 use cargo_manifest::{Dependency, DepsSet, TargetDepsSet};
 use crates_io_tarball::{process_tarball, TarballError};


### PR DESCRIPTION
Now that all job structs implement the `BackgroundJob` trait there is no need for us anymore to go through the `Job` enum when enqueueing new background jobs. This PR moves the `enqueue()` fns into the `BackgroundJob` trait and inlines some of the now obsolete constructor functions.