### PR TITLE
background_jobs: Add `PRIORITY` constant to `BackgroundJob` trait

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -1,7 +1,7 @@
 //! Functionality related to publishing a new crate or version of a crate.
 
 use crate::auth::AuthCheck;
-use crate::background_jobs::{BackgroundJob, Job, PRIORITY_RENDER_README};
+use crate::background_jobs::{BackgroundJob, Job};
 use crate::worker::RenderAndUploadReadmeJob;
 use axum::body::Bytes;
 use cargo_manifest::{Dependency, DepsSet, TargetDepsSet};
@@ -378,7 +378,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                         repository,
                         pkg_path_in_vcs,
                     )
-                    .enqueue_with_priority(conn, PRIORITY_RENDER_README)?;
+                    .enqueue(conn)?;
                 }
             }
 

--- a/src/worker/git.rs
+++ b/src/worker/git.rs
@@ -24,6 +24,7 @@ impl SyncToGitIndexJob {
 
 impl BackgroundJob for SyncToGitIndexJob {
     const JOB_NAME: &'static str = "sync_to_git_index";
+    const PRIORITY: i16 = 100;
 
     /// Regenerates or removes an index file for a single crate
     #[instrument(skip_all, fields(krate.name = ? self.krate))]
@@ -79,6 +80,7 @@ impl SyncToSparseIndexJob {
 
 impl BackgroundJob for SyncToSparseIndexJob {
     const JOB_NAME: &'static str = "sync_to_sparse_index";
+    const PRIORITY: i16 = 100;
 
     /// Regenerates or removes an index file for a single crate
     #[instrument(skip_all, fields(krate.name = ?self.krate))]

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -36,6 +36,7 @@ impl RenderAndUploadReadmeJob {
 
 impl BackgroundJob for RenderAndUploadReadmeJob {
     const JOB_NAME: &'static str = "render_and_upload_readme";
+    const PRIORITY: i16 = 50;
 
     #[instrument(skip_all, fields(krate.name))]
     fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {


### PR DESCRIPTION
This means we can call `enqueue()` on a job struct and it will automatically use the correct default priority. `enqueue_with_priority()` can still be used to override the default priority value.