### PR TITLE
swirl/runner: Add `register_job_type()` fn

### DIFF
--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -1,4 +1,4 @@
-use crate::background_jobs::Job;
+use crate::background_jobs::enqueue_sync_to_index;
 use crate::storage::Storage;
 use crate::{admin::dialoguer, db, schema::crates};
 use anyhow::Context;
@@ -71,7 +71,7 @@ pub fn run(opts: Opts) {
         };
 
         info!(%name, "Enqueuing index sync jobs");
-        if let Err(error) = Job::enqueue_sync_to_index(name, conn) {
+        if let Err(error) = enqueue_sync_to_index(name, conn) {
             warn!(%name, ?error, "Failed to enqueue index sync jobs");
         }
 

--- a/src/admin/delete_version.rs
+++ b/src/admin/delete_version.rs
@@ -1,4 +1,4 @@
-use crate::background_jobs::Job;
+use crate::background_jobs::enqueue_sync_to_index;
 use crate::schema::crates;
 use crate::storage::Storage;
 use crate::{admin::dialoguer, db, schema::versions};
@@ -74,7 +74,7 @@ pub fn run(opts: Opts) {
     }
 
     info!(%crate_name, "Enqueuing index sync jobs");
-    if let Err(error) = Job::enqueue_sync_to_index(crate_name, conn) {
+    if let Err(error) = enqueue_sync_to_index(crate_name, conn) {
         warn!(%crate_name, ?error, "Failed to enqueue index sync jobs");
     }
 

--- a/src/admin/yank_version.rs
+++ b/src/admin/yank_version.rs
@@ -5,7 +5,7 @@ use crate::{
     schema::versions,
 };
 
-use crate::background_jobs::Job;
+use crate::background_jobs::enqueue_sync_to_index;
 use diesel::prelude::*;
 
 #[derive(clap::Parser, Debug)]
@@ -65,5 +65,5 @@ fn yank(opts: Opts, conn: &mut PgConnection) {
         .execute(conn)
         .unwrap();
 
-    Job::enqueue_sync_to_index(&krate.name, conn).unwrap();
+    enqueue_sync_to_index(&krate.name, conn).unwrap();
 }

--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -136,77 +136,75 @@ impl PerformState<'_> {
     }
 }
 
-impl Job {
-    /// Enqueue both index sync jobs (git and sparse) for a crate, unless they
-    /// already exist in the background job queue.
-    ///
-    /// Note that there are currently no explicit tests for this functionality,
-    /// since our test suite only allows us to use a single database connection
-    /// and the background worker queue locking only work when using multiple
-    /// connections.
-    #[instrument(name = "swirl.enqueue", skip_all, fields(message = "sync_to_index", krate = %krate))]
-    pub fn enqueue_sync_to_index<T: Display>(
-        krate: T,
-        conn: &mut PgConnection,
-    ) -> Result<(), EnqueueError> {
-        // Returns jobs with matching `job_type`, `data` and `priority`,
-        // skipping ones that are already locked by the background worker.
-        let find_similar_jobs_query =
-            |job_type: &'static str, data: serde_json::Value, priority: i16| {
-                background_jobs::table
-                    .select(background_jobs::id)
-                    .filter(background_jobs::job_type.eq(job_type))
-                    .filter(background_jobs::data.eq(data))
-                    .filter(background_jobs::priority.eq(priority))
-                    .for_update()
-                    .skip_locked()
-            };
+/// Enqueue both index sync jobs (git and sparse) for a crate, unless they
+/// already exist in the background job queue.
+///
+/// Note that there are currently no explicit tests for this functionality,
+/// since our test suite only allows us to use a single database connection
+/// and the background worker queue locking only work when using multiple
+/// connections.
+#[instrument(name = "swirl.enqueue", skip_all, fields(message = "sync_to_index", krate = %krate))]
+pub fn enqueue_sync_to_index<T: Display>(
+    krate: T,
+    conn: &mut PgConnection,
+) -> Result<(), EnqueueError> {
+    // Returns jobs with matching `job_type`, `data` and `priority`,
+    // skipping ones that are already locked by the background worker.
+    let find_similar_jobs_query =
+        |job_type: &'static str, data: serde_json::Value, priority: i16| {
+            background_jobs::table
+                .select(background_jobs::id)
+                .filter(background_jobs::job_type.eq(job_type))
+                .filter(background_jobs::data.eq(data))
+                .filter(background_jobs::priority.eq(priority))
+                .for_update()
+                .skip_locked()
+        };
 
-        // Returns one `job_type, data, priority` row with values from the
-        // passed-in `job`, unless a similar row already exists.
-        let deduplicated_select_query =
-            |job_type: &'static str, data: serde_json::Value, priority: i16| {
-                diesel::select((
-                    job_type.into_sql::<Text>(),
-                    data.clone().into_sql::<Jsonb>(),
-                    priority.into_sql::<Int2>(),
-                ))
-                .filter(not(exists(find_similar_jobs_query(
-                    job_type, data, priority,
-                ))))
-            };
-
-        let to_git = deduplicated_select_query(
-            SyncToGitIndexJob::JOB_NAME,
-            serde_json::to_value(SyncToGitIndexJob::new(krate.to_string()))?,
-            SyncToGitIndexJob::PRIORITY,
-        );
-
-        let to_sparse = deduplicated_select_query(
-            SyncToSparseIndexJob::JOB_NAME,
-            serde_json::to_value(SyncToSparseIndexJob::new(krate.to_string()))?,
-            SyncToSparseIndexJob::PRIORITY,
-        );
-
-        // Insert index update background jobs, but only if they do not
-        // already exist.
-        let added_jobs_count = diesel::insert_into(background_jobs::table)
-            .values(to_git.union_all(to_sparse))
-            .into_columns((
-                background_jobs::job_type,
-                background_jobs::data,
-                background_jobs::priority,
+    // Returns one `job_type, data, priority` row with values from the
+    // passed-in `job`, unless a similar row already exists.
+    let deduplicated_select_query =
+        |job_type: &'static str, data: serde_json::Value, priority: i16| {
+            diesel::select((
+                job_type.into_sql::<Text>(),
+                data.clone().into_sql::<Jsonb>(),
+                priority.into_sql::<Int2>(),
             ))
-            .execute(conn)?;
+            .filter(not(exists(find_similar_jobs_query(
+                job_type, data, priority,
+            ))))
+        };
 
-        // Print a log event if we skipped inserting a job due to deduplication.
-        if added_jobs_count != 2 {
-            let skipped_jobs_count = 2 - added_jobs_count;
-            info!(%skipped_jobs_count, "Skipped adding duplicate jobs to the background worker queue");
-        }
+    let to_git = deduplicated_select_query(
+        SyncToGitIndexJob::JOB_NAME,
+        serde_json::to_value(SyncToGitIndexJob::new(krate.to_string()))?,
+        SyncToGitIndexJob::PRIORITY,
+    );
 
-        Ok(())
+    let to_sparse = deduplicated_select_query(
+        SyncToSparseIndexJob::JOB_NAME,
+        serde_json::to_value(SyncToSparseIndexJob::new(krate.to_string()))?,
+        SyncToSparseIndexJob::PRIORITY,
+    );
+
+    // Insert index update background jobs, but only if they do not
+    // already exist.
+    let added_jobs_count = diesel::insert_into(background_jobs::table)
+        .values(to_git.union_all(to_sparse))
+        .into_columns((
+            background_jobs::job_type,
+            background_jobs::data,
+            background_jobs::priority,
+        ))
+        .execute(conn)?;
+
+    // Print a log event if we skipped inserting a job due to deduplication.
+    if added_jobs_count != 2 {
+        let skipped_jobs_count = 2 - added_jobs_count;
+        info!(%skipped_jobs_count, "Skipped adding duplicate jobs to the background worker queue");
     }
+
+    Ok(())
 }
 
 pub struct Environment {

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -31,6 +31,7 @@ use std::time::{Duration, Instant};
 
 use crates_io::swirl::Runner;
 use crates_io::worker::fastly::Fastly;
+use crates_io::worker::RunnerExt;
 
 fn main() {
     let _sentry = crates_io::sentry::init();
@@ -95,6 +96,7 @@ fn main() {
         Runner::new(connection_pool, environment.clone())
             .num_workers(5)
             .job_start_timeout(Duration::from_secs(job_start_timeout))
+            .register_crates_io_job_types()
     };
 
     let mut runner = build_runner();

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -1,7 +1,7 @@
 //! Functionality related to publishing a new crate or version of a crate.
 
 use crate::auth::AuthCheck;
-use crate::background_jobs::{BackgroundJob, Job};
+use crate::background_jobs::{enqueue_sync_to_index, BackgroundJob};
 use crate::worker::RenderAndUploadReadmeJob;
 use axum::body::Bytes;
 use cargo_manifest::{Dependency, DepsSet, TargetDepsSet};
@@ -391,7 +391,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 ))
                 .map_err(|e| internal(format!("failed to upload crate: {e}")))?;
 
-            Job::enqueue_sync_to_index(&krate.name, conn)?;
+            enqueue_sync_to_index(&krate.name, conn)?;
 
             // The `other` field on `PublishWarnings` was introduced to handle a temporary warning
             // that is no longer needed. As such, crates.io currently does not return any `other`

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -1,7 +1,7 @@
 //! Endpoints for yanking and unyanking specific versions of crates
 
 use crate::auth::AuthCheck;
-use crate::background_jobs::Job;
+use crate::background_jobs::enqueue_sync_to_index;
 
 use super::version_and_crate;
 use crate::controllers::cargo_prelude::*;
@@ -89,7 +89,7 @@ fn modify_yank(
 
     insert_version_owner_action(conn, version.id, user.id, api_token_id, action)?;
 
-    Job::enqueue_sync_to_index(&krate.name, conn)?;
+    enqueue_sync_to_index(&krate.name, conn)?;
 
     ok_true()
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -12,6 +12,7 @@ use anyhow::Context;
 use crates_io::models::token::{CrateScope, EndpointScope};
 use crates_io::rate_limiter::{LimitedAction, RateLimiterConfig};
 use crates_io::swirl::Runner;
+use crates_io::worker::RunnerExt;
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
@@ -259,7 +260,8 @@ impl TestAppBuilder {
 
             let runner = Runner::new(app.primary_database.clone(), Arc::new(Some(environment)))
                 .num_workers(1)
-                .job_start_timeout(Duration::from_secs(5));
+                .job_start_timeout(Duration::from_secs(5))
+                .register_crates_io_job_types();
 
             Some(runner)
         } else {

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -1,6 +1,6 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
-use crates_io::background_jobs::Job;
+use crates_io::background_jobs::enqueue_sync_to_index;
 use crates_io::models::Crate;
 use diesel::prelude::*;
 use http::StatusCode;
@@ -51,7 +51,7 @@ fn index_smoke_test() {
         let krate: Crate = assert_ok!(Crate::by_name("serde").first(conn));
         assert_ok!(diesel::delete(crates::table.find(krate.id)).execute(conn));
 
-        assert_ok!(Job::enqueue_sync_to_index("serde", conn));
+        assert_ok!(enqueue_sync_to_index("serde", conn));
     });
 
     app.run_pending_background_jobs();

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -16,3 +16,22 @@ pub(crate) use dump_db::DumpDbJob;
 pub(crate) use git::{NormalizeIndexJob, SquashIndexJob, SyncToGitIndexJob, SyncToSparseIndexJob};
 pub(crate) use readmes::RenderAndUploadReadmeJob;
 pub(crate) use update_downloads::UpdateDownloadsJob;
+
+use crate::swirl::Runner;
+
+pub trait RunnerExt {
+    fn register_crates_io_job_types(self) -> Self;
+}
+
+impl RunnerExt for Runner {
+    fn register_crates_io_job_types(self) -> Self {
+        self.register_job_type::<DailyDbMaintenanceJob>()
+            .register_job_type::<DumpDbJob>()
+            .register_job_type::<NormalizeIndexJob>()
+            .register_job_type::<RenderAndUploadReadmeJob>()
+            .register_job_type::<SquashIndexJob>()
+            .register_job_type::<SyncToGitIndexJob>()
+            .register_job_type::<SyncToSparseIndexJob>()
+            .register_job_type::<UpdateDownloadsJob>()
+    }
+}


### PR DESCRIPTION
This new API decouples the `Runner` from the `Job` enum and makes it possible to configure the runner with different sets of job types, for example for testing purposes.

This allows us to completely get rid of the `Job` enum and similarly the custom `jobs!` macro.

The registration of the crates.io-specific job types is implemented in a `register_crates_io_job_types()` fn in the `RunnerExt` extension trait, to keep it decoupled from the background runner implementation in the `swirl` module.