### PR TITLE
tests/read_only_mode: Use real `read_only_mode` setting

### DIFF
--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -6,42 +6,49 @@ use http::StatusCode;
 
 #[test]
 fn can_hit_read_only_endpoints_in_read_only_mode() {
-    let (app, anon) = TestApp::init().empty();
-    app.db(set_read_only).unwrap();
+    let (_app, anon) = TestApp::init()
+        .without_test_database_pool()
+        .with_config(|config| {
+            config.db.primary.read_only_mode = true;
+        })
+        .empty();
+
     let response = anon.get::<()>("/api/v1/crates");
     assert_eq!(response.status(), StatusCode::OK);
 }
 
 #[test]
 fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init()
+        .without_test_database_pool()
+        .with_config(|config| {
+            config.db.primary.read_only_mode = true;
+        })
+        .with_token();
+
     app.db(|conn| {
         CrateBuilder::new("foo_yank_read_only", user.as_model().id)
             .version("1.0.0")
             .expect_build(conn);
-        set_read_only(conn).unwrap();
     });
 
     let response = token.delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank");
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-
-    // Restore the transaction so `TestApp::drop` can still access the transaction
-    app.db(|conn| {
-        diesel::sql_query("ROLLBACK TO test_post_readonly")
-            .execute(conn)
-            .unwrap();
-    });
 }
 
 #[test]
 fn can_download_crate_in_read_only_mode() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init()
+        .without_test_database_pool()
+        .with_config(|config| {
+            config.db.primary.read_only_mode = true;
+        })
+        .with_user();
 
     app.db(|conn| {
         CrateBuilder::new("foo_download_read_only", user.as_model().id)
             .version("1.0.0")
             .expect_build(conn);
-        set_read_only(conn).unwrap();
     });
 
     let response = anon.get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download");
@@ -57,10 +64,4 @@ fn can_download_crate_in_read_only_mode() {
             .get_result(conn);
         assert_ok_eq!(dl_count, None);
     })
-}
-
-fn set_read_only(conn: &mut PgConnection) -> QueryResult<()> {
-    diesel::sql_query("SET TRANSACTION READ ONLY").execute(conn)?;
-    diesel::sql_query("SAVEPOINT test_post_readonly").execute(conn)?;
-    Ok(())
 }


### PR DESCRIPTION
Previously these tests were using `SET TRANSACTION READ ONLY` to enter a read-only state, while in production the `read_only_mode` database connection pool option is used. This PR refactors the tests to use dedicated databases for these tests and a production-like database connection pool with the `read_only_mode` option set.

This requires the `TestApp::db()` method to not use the same database pool as the app itself, because that would be set to read-only mode. Thus this PR also refactors that method to use a dedicated connection pool it the test is using a `TestDatabase`.