### PR TITLE
CI: Split build step from test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
       - run: cargo install diesel_cli --vers ${{ env.DIESEL_CLI_VERSION }} --no-default-features --features postgres --debug
       - run: diesel database setup --locked-schema
 
+      - run: cargo build --tests --workspace
       - run: cargo test --workspace
 
   frontend-lint:


### PR DESCRIPTION
This can give us a clearer understanding of how long both of these phases take to complete.