### PR TITLE
renovate: Disable `digest` updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -61,5 +61,9 @@
             matchPackagePatterns: ["^diesel$", "^diesel_"],
             groupName: "diesel packages",
         },
+        {
+            "matchUpdateTypes": ["digest"],
+            "enabled": false,
+        },
     ],
 }


### PR DESCRIPTION
Unless they correspond to an actual version update we don't want these to be updated...