### PR TITLE
swirl/runner: Make `Runner` generic over `Context`

### DIFF
--- a/src/background_jobs.rs
+++ b/src/background_jobs.rs
@@ -30,8 +30,11 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + 'static {
     /// [Self::enqueue_with_priority] can be used to override the priority value.
     const PRIORITY: i16 = 0;
 
+    /// The application data provided to this job at runtime.
+    type Context: Clone + Send + 'static;
+
     /// Execute the task. This method should define its logic
-    fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError>;
+    fn run(&self, state: PerformState<'_>, env: &Self::Context) -> Result<(), PerformError>;
 
     fn enqueue(&self, conn: &mut PgConnection) -> Result<(), EnqueueError> {
         self.enqueue_with_priority(conn, Self::PRIORITY)

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -83,7 +83,7 @@ fn main() {
 
     let environment = Environment::new(repository, client, cloudfront, fastly, storage);
 
-    let environment = Arc::new(Some(environment));
+    let environment = Arc::new(environment);
 
     let build_runner = || {
         let connection_pool = r2d2::Pool::builder()

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -23,7 +23,7 @@ struct TestAppInner {
     app: Arc<App>,
     router: axum::Router,
     index: Option<UpstreamIndex>,
-    runner: Option<Runner>,
+    runner: Option<Runner<Arc<Environment>>>,
 
     primary_db_chaosproxy: Option<Arc<ChaosProxy>>,
     replica_db_chaosproxy: Option<Arc<ChaosProxy>>,
@@ -260,7 +260,7 @@ impl TestAppBuilder {
                 app.storage.clone(),
             );
 
-            let runner = Runner::new(app.primary_database.clone(), Arc::new(Some(environment)))
+            let runner = Runner::new(app.primary_database.clone(), Arc::new(environment))
                 .num_workers(1)
                 .job_start_timeout(Duration::from_secs(5))
                 .register_crates_io_job_types();

--- a/src/worker/daily_db_maintenance.rs
+++ b/src/worker/daily_db_maintenance.rs
@@ -1,12 +1,15 @@
 use crate::background_jobs::{BackgroundJob, Environment, PerformState};
 use crate::swirl::PerformError;
 use diesel::{sql_query, RunQueryDsl};
+use std::sync::Arc;
 
 #[derive(Serialize, Deserialize)]
 pub struct DailyDbMaintenanceJob;
 
 impl BackgroundJob for DailyDbMaintenanceJob {
     const JOB_NAME: &'static str = "daily_db_maintenance";
+
+    type Context = Arc<Environment>;
 
     /// Run daily database maintenance tasks
     ///
@@ -17,7 +20,7 @@ impl BackgroundJob for DailyDbMaintenanceJob {
     /// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
     /// archive daily download counts and drop historical data, we can drop this task and rely on
     /// auto-vacuum again.
-    fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
+    fn run(&self, state: PerformState<'_>, _env: &Self::Context) -> Result<(), PerformError> {
         let mut conn = state.fresh_connection()?;
 
         info!("Running VACUUM on version_downloads table");

--- a/src/worker/dump_db.rs
+++ b/src/worker/dump_db.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Context};
+use std::sync::Arc;
 use std::{
     fs::{self, File},
     path::{Path, PathBuf},
@@ -27,9 +28,11 @@ impl DumpDbJob {
 impl BackgroundJob for DumpDbJob {
     const JOB_NAME: &'static str = "dump_db";
 
+    type Context = Arc<Environment>;
+
     /// Create CSV dumps of the public information in the database, wrap them in a
     /// tarball and upload to S3.
-    fn run(&self, _state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
+    fn run(&self, _state: PerformState<'_>, env: &Self::Context) -> Result<(), PerformError> {
         let directory = DumpDirectory::create()?;
 
         info!(path = ?directory.export_dir, "Begin exporting database");

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -17,13 +17,15 @@ pub(crate) use git::{NormalizeIndexJob, SquashIndexJob, SyncToGitIndexJob, SyncT
 pub(crate) use readmes::RenderAndUploadReadmeJob;
 pub(crate) use update_downloads::UpdateDownloadsJob;
 
+use crate::background_jobs::Environment;
 use crate::swirl::Runner;
+use std::sync::Arc;
 
 pub trait RunnerExt {
     fn register_crates_io_job_types(self) -> Self;
 }
 
-impl RunnerExt for Runner {
+impl RunnerExt for Runner<Arc<Environment>> {
     fn register_crates_io_job_types(self) -> Self {
         self.register_job_type::<DailyDbMaintenanceJob>()
             .register_job_type::<DumpDbJob>()

--- a/src/worker/readmes.rs
+++ b/src/worker/readmes.rs
@@ -3,6 +3,7 @@
 use crate::swirl::PerformError;
 use anyhow::Context;
 use crates_io_markdown::text_to_html;
+use std::sync::Arc;
 
 use crate::background_jobs::{BackgroundJob, Environment, PerformState};
 use crate::models::Version;
@@ -38,8 +39,10 @@ impl BackgroundJob for RenderAndUploadReadmeJob {
     const JOB_NAME: &'static str = "render_and_upload_readme";
     const PRIORITY: i16 = 50;
 
+    type Context = Arc<Environment>;
+
     #[instrument(skip_all, fields(krate.name))]
-    fn run(&self, state: PerformState<'_>, env: &Environment) -> Result<(), PerformError> {
+    fn run(&self, state: PerformState<'_>, env: &Self::Context) -> Result<(), PerformError> {
         use crate::schema::*;
         use diesel::prelude::*;
 

--- a/src/worker/update_downloads.rs
+++ b/src/worker/update_downloads.rs
@@ -2,6 +2,7 @@ use crate::{
     models::VersionDownload,
     schema::{crates, metadata, version_downloads, versions},
 };
+use std::sync::Arc;
 
 use crate::background_jobs::{BackgroundJob, Environment, PerformState};
 use crate::swirl::PerformError;
@@ -13,7 +14,9 @@ pub struct UpdateDownloadsJob;
 impl BackgroundJob for UpdateDownloadsJob {
     const JOB_NAME: &'static str = "update_downloads";
 
-    fn run(&self, state: PerformState<'_>, _env: &Environment) -> Result<(), PerformError> {
+    type Context = Arc<Environment>;
+
+    fn run(&self, state: PerformState<'_>, _env: &Self::Context) -> Result<(), PerformError> {
         let mut conn = state.fresh_connection()?;
         update(&mut conn)?;
         Ok(())


### PR DESCRIPTION
Instead of assuming that the `Runner` will always work in combination with the `Environment` struct, we can make it generic now and let the job structs define what type of context they assume to get passed into them.

This, again, reduces the tight coupling between the `Runner` and our application-specific code (i.e. the `Environment` struct).

The design is roughly based on what https://github.com/rafaelcaricio/backie does :)