### PR TITLE
Reduce panic usage in admin commands

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -37,8 +37,7 @@ pub fn run(command: Command) -> Result<()> {
             let count: i64 = background_jobs::table
                 .filter(background_jobs::job_type.eq("update_downloads"))
                 .count()
-                .get_result(conn)
-                .unwrap();
+                .get_result(conn)?;
 
             if count > 0 {
                 println!("Did not enqueue update_downloads, existing job already in progress");

--- a/src/admin/migrate.rs
+++ b/src/admin/migrate.rs
@@ -1,4 +1,4 @@
-use anyhow::Error;
+use anyhow::{anyhow, Error};
 use diesel_migrations::{
     embed_migrations, EmbeddedMigrations, HarnessWithOutput, MigrationHarness,
 };
@@ -43,7 +43,7 @@ pub fn run(_opts: Opts) -> Result<(), Error> {
     let mut harness = HarnessWithOutput::new(conn, &mut stdout);
     harness
         .run_pending_migrations(MIGRATIONS)
-        .expect("failed to run migrations");
+        .map_err(|err| anyhow!("Failed to run migrations: {err}"))?;
 
     info!("Synchronizing crate categories");
     crate::boot::categories::sync_with_connection(CATEGORIES_TOML, conn)?;

--- a/src/admin/migrate.rs
+++ b/src/admin/migrate.rs
@@ -46,7 +46,7 @@ pub fn run(_opts: Opts) -> Result<(), Error> {
         .expect("failed to run migrations");
 
     info!("Synchronizing crate categories");
-    crate::boot::categories::sync_with_connection(CATEGORIES_TOML, conn).unwrap();
+    crate::boot::categories::sync_with_connection(CATEGORIES_TOML, conn)?;
 
     Ok(())
 }

--- a/src/admin/populate.rs
+++ b/src/admin/populate.rs
@@ -13,9 +13,10 @@ pub struct Opts {
     version_ids: Vec<i32>,
 }
 
-pub fn run(opts: Opts) {
-    let mut conn = db::oneoff_connection().unwrap();
-    conn.transaction(|conn| update(opts, conn)).unwrap();
+pub fn run(opts: Opts) -> anyhow::Result<()> {
+    let mut conn = db::oneoff_connection()?;
+    conn.transaction(|conn| update(opts, conn))?;
+    Ok(())
 }
 
 fn update(opts: Opts, conn: &mut PgConnection) -> QueryResult<()> {

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -42,7 +42,7 @@ pub struct Opts {
 
 pub fn run(opts: Opts) -> anyhow::Result<()> {
     let storage = Arc::new(Storage::from_environment());
-    let conn = &mut db::oneoff_connection().unwrap();
+    let conn = &mut db::oneoff_connection()?;
 
     let start_time = Utc::now();
 
@@ -116,8 +116,7 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
                     let rt = tokio::runtime::Builder::new_current_thread()
                         .enable_all()
                         .build()
-                        .context("Failed to initialize tokio runtime")
-                        .unwrap();
+                        .context("Failed to initialize tokio runtime")?;
 
                     rt.block_on(storage.upload_readme(&krate_name, &version.num, readme.into()))
                         .context("Failed to upload rendered README file to S3")?;
@@ -161,7 +160,7 @@ fn get_readme(
     if !response.status().is_success() {
         return Err(anyhow!(
             "Failed to get a 200 response: {}",
-            response.text().unwrap()
+            response.text()?
         ));
     }
 

--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -48,7 +48,7 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
 
     let older_than = if let Some(ref time) = opts.older_than {
         NaiveDateTime::parse_from_str(time, "%Y-%m-%d %H:%M:%S")
-            .expect("Could not parse --older-than argument as a time")
+            .context("Could not parse --older-than argument as a time")?
     } else {
         start_time.naive_utc()
     };
@@ -72,7 +72,7 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
         query = query.filter(crates::name.eq(crate_name));
     }
 
-    let version_ids: Vec<i32> = query.load(conn).expect("error loading version ids");
+    let version_ids: Vec<i32> = query.load(conn).context("error loading version ids")?;
 
     let total_versions = version_ids.len();
     println!("Rendering {total_versions} versions");
@@ -100,7 +100,7 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
             .filter(versions::id.eq_any(version_ids_chunk))
             .select((versions::all_columns, crates::name))
             .load(conn)
-            .expect("error loading versions");
+            .context("error loading versions")?;
 
         let mut tasks = Vec::with_capacity(page_size);
         for (version, krate_name) in versions {

--- a/src/admin/upload_index.rs
+++ b/src/admin/upload_index.rs
@@ -1,6 +1,6 @@
 use crate::admin::dialoguer;
 use crate::storage::Storage;
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use crates_io_index::{Repository, RepositoryConfig};
 use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
 
@@ -32,14 +32,24 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .context("Failed to initialize tokio runtime")
-        .unwrap();
+        .context("Failed to initialize tokio runtime")?;
 
     let pb = ProgressBar::new(files.len() as u64);
-    pb.set_style(ProgressStyle::with_template("{bar:60} ({pos}/{len}, ETA {eta})").unwrap());
+    pb.set_style(ProgressStyle::with_template(
+        "{bar:60} ({pos}/{len}, ETA {eta})",
+    )?);
 
     for file in files.iter().progress_with(pb.clone()) {
-        let crate_name = file.file_name().unwrap().to_str().unwrap();
+        let file_name = file.file_name().ok_or_else(|| {
+            let file = file.display();
+            anyhow!("Failed to get file name from path: {file}")
+        })?;
+
+        let crate_name = file_name.to_str().ok_or_else(|| {
+            let file_name = file_name.to_string_lossy();
+            anyhow!("Failed to convert file name to utf8: {file_name}",)
+        })?;
+
         let path = repo.index_file(crate_name);
         if !path.exists() {
             pb.suspend(|| println!("skipping file `{crate_name}`"));

--- a/src/admin/verify_token.rs
+++ b/src/admin/verify_token.rs
@@ -1,4 +1,5 @@
-use crate::{db, models::User, util::errors::AppResult};
+use crate::{db, models::User};
+use anyhow::anyhow;
 
 #[derive(clap::Parser, Debug)]
 #[command(
@@ -12,9 +13,9 @@ pub struct Opts {
     api_token: String,
 }
 
-pub fn run(opts: Opts) -> AppResult<()> {
+pub fn run(opts: Opts) -> anyhow::Result<()> {
     let conn = &mut db::oneoff_connection()?;
-    let user = User::find_by_api_token(conn, &opts.api_token)?;
+    let user = User::find_by_api_token(conn, &opts.api_token).map_err(|err| anyhow!("{err}"))?;
     println!("The token belongs to user {}", user.gh_login);
     Ok(())
 }

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -48,7 +48,7 @@ fn main() -> anyhow::Result<()> {
         Command::VerifyToken(opts) => verify_token::run(opts)?,
         Command::Migrate(opts) => migrate::run(opts)?,
         Command::UploadIndex(opts) => upload_index::run(opts)?,
-        Command::YankVersion(opts) => yank_version::run(opts),
+        Command::YankVersion(opts) => yank_version::run(opts)?,
         Command::GitImport(opts) => git_import::run(opts)?,
         Command::EnqueueJob(command) => enqueue_job::run(command)?,
     }

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -41,7 +41,7 @@ fn main() -> anyhow::Result<()> {
     match command {
         Command::DeleteCrate(opts) => delete_crate::run(opts)?,
         Command::DeleteVersion(opts) => delete_version::run(opts)?,
-        Command::Populate(opts) => populate::run(opts),
+        Command::Populate(opts) => populate::run(opts)?,
         Command::RenderReadmes(opts) => render_readmes::run(opts)?,
         Command::TestPagerduty(opts) => test_pagerduty::run(opts)?,
         Command::TransferCrates(opts) => transfer_crates::run(opts),

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -40,7 +40,7 @@ fn main() -> anyhow::Result<()> {
 
     match command {
         Command::DeleteCrate(opts) => delete_crate::run(opts)?,
-        Command::DeleteVersion(opts) => delete_version::run(opts),
+        Command::DeleteVersion(opts) => delete_version::run(opts)?,
         Command::Populate(opts) => populate::run(opts),
         Command::RenderReadmes(opts) => render_readmes::run(opts)?,
         Command::TestPagerduty(opts) => test_pagerduty::run(opts)?,

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -39,7 +39,7 @@ fn main() -> anyhow::Result<()> {
     span.record("command", tracing::field::debug(&command));
 
     match command {
-        Command::DeleteCrate(opts) => delete_crate::run(opts),
+        Command::DeleteCrate(opts) => delete_crate::run(opts)?,
         Command::DeleteVersion(opts) => delete_version::run(opts),
         Command::Populate(opts) => populate::run(opts),
         Command::RenderReadmes(opts) => render_readmes::run(opts)?,

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -39,19 +39,17 @@ fn main() -> anyhow::Result<()> {
     span.record("command", tracing::field::debug(&command));
 
     match command {
-        Command::DeleteCrate(opts) => delete_crate::run(opts)?,
-        Command::DeleteVersion(opts) => delete_version::run(opts)?,
-        Command::Populate(opts) => populate::run(opts)?,
-        Command::RenderReadmes(opts) => render_readmes::run(opts)?,
-        Command::TestPagerduty(opts) => test_pagerduty::run(opts)?,
-        Command::TransferCrates(opts) => transfer_crates::run(opts)?,
-        Command::VerifyToken(opts) => verify_token::run(opts)?,
-        Command::Migrate(opts) => migrate::run(opts)?,
-        Command::UploadIndex(opts) => upload_index::run(opts)?,
-        Command::YankVersion(opts) => yank_version::run(opts)?,
-        Command::GitImport(opts) => git_import::run(opts)?,
-        Command::EnqueueJob(command) => enqueue_job::run(command)?,
+        Command::DeleteCrate(opts) => delete_crate::run(opts),
+        Command::DeleteVersion(opts) => delete_version::run(opts),
+        Command::Populate(opts) => populate::run(opts),
+        Command::RenderReadmes(opts) => render_readmes::run(opts),
+        Command::TestPagerduty(opts) => test_pagerduty::run(opts),
+        Command::TransferCrates(opts) => transfer_crates::run(opts),
+        Command::VerifyToken(opts) => verify_token::run(opts),
+        Command::Migrate(opts) => migrate::run(opts),
+        Command::UploadIndex(opts) => upload_index::run(opts),
+        Command::YankVersion(opts) => yank_version::run(opts),
+        Command::GitImport(opts) => git_import::run(opts),
+        Command::EnqueueJob(command) => enqueue_job::run(command),
     }
-
-    Ok(())
 }

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -45,7 +45,7 @@ fn main() -> anyhow::Result<()> {
         Command::RenderReadmes(opts) => render_readmes::run(opts)?,
         Command::TestPagerduty(opts) => test_pagerduty::run(opts)?,
         Command::TransferCrates(opts) => transfer_crates::run(opts)?,
-        Command::VerifyToken(opts) => verify_token::run(opts).unwrap(),
+        Command::VerifyToken(opts) => verify_token::run(opts)?,
         Command::Migrate(opts) => migrate::run(opts)?,
         Command::UploadIndex(opts) => upload_index::run(opts)?,
         Command::YankVersion(opts) => yank_version::run(opts),

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -44,7 +44,7 @@ fn main() -> anyhow::Result<()> {
         Command::Populate(opts) => populate::run(opts)?,
         Command::RenderReadmes(opts) => render_readmes::run(opts)?,
         Command::TestPagerduty(opts) => test_pagerduty::run(opts)?,
-        Command::TransferCrates(opts) => transfer_crates::run(opts),
+        Command::TransferCrates(opts) => transfer_crates::run(opts)?,
         Command::VerifyToken(opts) => verify_token::run(opts).unwrap(),
         Command::Migrate(opts) => migrate::run(opts)?,
         Command::UploadIndex(opts) => upload_index::run(opts)?,


### PR DESCRIPTION
Instead of using `unwrap()` or `expect()` everywhere in the admin command code we can use the `?` operator to bubble error up to the `main()` fn which then displays the errors appropriately.