### PR TITLE
Change "Just Updated" links to point to the corresponding crate version

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -116,7 +116,7 @@
           {{#each this.model.just_updated as |crate index|}}
             <li>
               <FrontPageList::Item
-                @link={{link "crate" crate.id}}
+                @link={{link "crate.version" crate.id crate.newest_version}}
                 @title={{crate.name}}
                 @subtitle="v{{crate.newest_version}}"
                 data-test-crate-link={{index}}

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -20,7 +20,7 @@ module('Acceptance | crate page', function (hooks) {
     await visit('/');
     await click('[data-test-just-updated] [data-test-crate-link="0"]');
 
-    assert.strictEqual(currentURL(), '/crates/nanomsg');
+    assert.strictEqual(currentURL(), '/crates/nanomsg/0.6.1');
     assert.strictEqual(getPageTitle(), 'nanomsg - crates.io: Rust Package Registry');
 
     assert.dom('[data-test-heading] [data-test-crate-name]').hasText('nanomsg');
@@ -124,7 +124,7 @@ module('Acceptance | crate page', function (hooks) {
 
     await visit('/');
     await click('[data-test-just-updated] [data-test-crate-link="0"]');
-    assert.strictEqual(currentURL(), '/crates/nanomsg');
+    assert.strictEqual(currentURL(), '/crates/nanomsg/0.6.0');
     assert.dom('[data-test-404-page]').exists();
     assert.dom('[data-test-title]').hasText('nanomsg: Failed to load version data');
     assert.dom('[data-test-go-back]').doesNotExist();

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -39,7 +39,7 @@ module('Acceptance | front page', function (hooks) {
     assert.dom('[data-test-most-downloaded] [data-test-crate-link="0"]').hasAttribute('href', '/crates/serde');
 
     assert.dom('[data-test-just-updated] [data-test-crate-link="0"]').hasText('nanomsg v0.6.1');
-    assert.dom('[data-test-just-updated] [data-test-crate-link="0"]').hasAttribute('href', '/crates/nanomsg');
+    assert.dom('[data-test-just-updated] [data-test-crate-link="0"]').hasAttribute('href', '/crates/nanomsg/0.6.1');
 
     await percySnapshot(assert);
     await a11yAudit(axeConfig);


### PR DESCRIPTION
I noticed that when a crate publishes a pre-release version the links in the "Just Updated" section of our front page would point to the crate page, which defaults to the latest stable version. In other words: the shown version is unrelated to the just published pre-release version.

This PR changes the links to point to the corresponding version instead, fixing this confusing behavior.