### PR TITLE
Extract `real_ip` middleware

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -6,6 +6,7 @@ mod debug;
 mod ember_html;
 pub mod log_request;
 pub mod normalize_path;
+pub mod real_ip;
 mod require_user_agent;
 pub mod session;
 mod static_or_continue;
@@ -44,6 +45,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router<(), TimeoutBody<Bod
         .layer(TimeoutLayer::new(Duration::from_secs(30)))
         .layer(sentry_tower::NewSentryLayer::new_from_top())
         .layer(sentry_tower::SentryHttpLayer::with_transaction())
+        .layer(from_fn(self::real_ip::middleware))
         .layer(from_fn(log_request::log_requests))
         .layer(CatchPanicLayer::new())
         .layer(from_fn_with_state(

--- a/src/middleware/real_ip.rs
+++ b/src/middleware/real_ip.rs
@@ -1,0 +1,22 @@
+use crate::real_ip::process_xff_headers;
+use axum::extract::ConnectInfo;
+use axum::middleware::Next;
+use axum::response::IntoResponse;
+use http::Request;
+use std::net::{IpAddr, SocketAddr};
+
+#[derive(Copy, Clone, Debug, Deref)]
+pub struct RealIp(IpAddr);
+
+pub async fn middleware<B>(
+    ConnectInfo(socket_addr): ConnectInfo<SocketAddr>,
+    mut req: Request<B>,
+    next: Next<B>,
+) -> impl IntoResponse {
+    let xff_ip = process_xff_headers(req.headers());
+    let real_ip = xff_ip.unwrap_or_else(|| socket_addr.ip());
+
+    req.extensions_mut().insert(RealIp(real_ip));
+
+    next.run(req).await
+}


### PR DESCRIPTION
By having the middleware add a `RealIp` request extension we can reuse the result of this operation further down the middleware and request processing stack.