### PR TITLE
Refactor and rename `block_traffic()` middleware fn into `block_by_header()`

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -64,7 +64,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router<(), TimeoutBody<Bod
         ))
         .layer(from_fn_with_state(
             state.clone(),
-            block_traffic::block_traffic,
+            block_traffic::block_by_header,
         ))
         .layer(from_fn_with_state(
             state.clone(),

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -44,11 +44,10 @@ pub async fn block_by_header<B>(
             let body = format!(
                 "We are unable to process your request at this time. \
                  This usually means that you are in violation of our crawler \
-                 policy (https://{}/policies#crawlers). \
+                 policy (https://{domain_name}/policies#crawlers). \
                  Please open an issue at https://github.com/rust-lang/crates.io \
                  or email help@crates.io \
-                 and provide the request id {}",
-                domain_name, request_id
+                 and provide the request id {request_id}"
             );
 
             return (StatusCode::FORBIDDEN, body).into_response();

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -16,7 +16,7 @@ use axum::middleware::Next;
 use axum::response::IntoResponse;
 use http::StatusCode;
 
-pub async fn block_traffic<B>(
+pub async fn block_by_header<B>(
     state: AppState,
     req: http::Request<B>,
     next: Next<B>,

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -21,7 +21,7 @@ pub async fn block_by_header<B>(
     req: http::Request<B>,
     next: Next<B>,
 ) -> axum::response::Response {
-    let domain_name = state.config.domain_name.clone();
+    let domain_name = &state.config.domain_name;
     let blocked_traffic = &state.config.blocked_traffic;
 
     for (header_name, blocked_values) in blocked_traffic {

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -33,6 +33,14 @@ pub async fn block_by_header<B>(
         if has_blocked_value {
             let cause = format!("blocked due to contents of header {header_name}");
             req.request_log().add("cause", cause);
+
+            // Heroku should always set this header
+            let request_id = req
+                .headers()
+                .get("x-request-id")
+                .map(|val| val.to_str().unwrap_or_default())
+                .unwrap_or_default();
+
             let body = format!(
                 "We are unable to process your request at this time. \
                  This usually means that you are in violation of our crawler \
@@ -40,12 +48,7 @@ pub async fn block_by_header<B>(
                  Please open an issue at https://github.com/rust-lang/crates.io \
                  or email help@crates.io \
                  and provide the request id {}",
-                domain_name,
-                // Heroku should always set this header
-                req.headers()
-                    .get("x-request-id")
-                    .map(|val| val.to_str().unwrap_or_default())
-                    .unwrap_or_default()
+                domain_name, request_id
             );
 
             return (StatusCode::FORBIDDEN, body).into_response();


### PR DESCRIPTION
Now that we no longer use the `X-Real-Ip` header from nginx, the `block_traffic()` (now aka. `block_by_header()`) doesn't work anymore for IP-based request blocking, so we need a dedicated implementation for that. This PR prepares the module for the implementation of a `block_by_ip()` middleware by extracting a reusable `rejection_response_from()` fn and renaming the `block_traffic()` fn to something more meaningful.