### PR TITLE
Fix IP-based request blocking for large page numbers

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -90,8 +90,7 @@ impl Server {
     ///   list will block *all* user-agents exceeding the offset. If not set or empty, no blocking
     ///   will occur.
     /// - `WEB_PAGE_OFFSET_CIDR_BLOCKLIST`: A comma separated list of CIDR blocks that will be used
-    ///   to block IP addresses given in the `X-Real-Ip` HTTP header, e.g. `192.168.1.0/24`.
-    ///   If not set or empty, no blocking will occur.
+    ///   to block IP addresses, e.g. `192.168.1.0/24`. If not set or empty, no blocking will occur.
     /// - `INSTANCE_METRICS_LOG_EVERY_SECONDS`: How frequently should instance metrics be logged.
     ///   If the environment variable is not present instance metrics are not logged.
     /// - `FORCE_UNCONDITIONAL_REDIRECTS`: Whether to force unconditional redirects in the download

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -226,7 +226,6 @@ fn req(method: Method, path: &str) -> MockRequest {
         .method(method)
         .uri(path)
         .header(header::USER_AGENT, "conduit-test")
-        .header("x-real-ip", "127.0.0.1")
         .body(Bytes::new())
         .unwrap()
 }


### PR DESCRIPTION
#7364 was a bit too eager to remove the `X-Real-Ip` header from nginx. As it turns out the header was/is still used in two places in our codebase, but the lowercase header value did not show up in my code search back then… 🙈 

Anyway, this PR fixes the IP-based request blocking use-case for large page numbers by using the `RealIp` request extension that was introduced in #7432.