### PR TITLE
Fix IP-based request blocking

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -64,6 +64,10 @@ pub fn apply_axum_middleware(state: AppState, router: Router<(), TimeoutBody<Bod
         ))
         .layer(from_fn_with_state(
             state.clone(),
+            block_traffic::block_by_ip,
+        ))
+        .layer(from_fn_with_state(
+            state.clone(),
             block_traffic::block_by_header,
         ))
         .layer(from_fn_with_state(

--- a/src/tests/snapshots/all__server__block_traffic_via_ip.snap
+++ b/src/tests/snapshots/all__server__block_traffic_via_ip.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/server.rs
+expression: resp.into_text()
+---
+We are unable to process your request at this time. This usually means that you are in violation of our crawler policy (https://crates.io/policies#crawlers). Please open an issue at https://github.com/rust-lang/crates.io or email help@crates.io and provide the request id 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -411,6 +411,7 @@ fn simple_config() -> config::Server {
         rate_limiter: Default::default(),
         new_version_rate_limit: Some(10),
         blocked_traffic: Default::default(),
+        blocked_ips: Default::default(),
         max_allowed_page_offset: 200,
         page_offset_ua_blocklist: vec![],
         page_offset_cidr_blocklist: vec![],


### PR DESCRIPTION
As https://github.com/rust-lang/crates.io/pull/7434 explains, IP-based request blocking is currently broken. This PR fixes the blocking based on the `BLOCKED_IPS` environment variable that we use on production.