### PR TITLE
Extract `crates_io_env_vars` package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,6 +740,7 @@ dependencies = [
  "claims",
  "clap",
  "cookie",
+ "crates_io_env_vars",
  "crates_io_index",
  "crates_io_markdown",
  "crates_io_tarball",
@@ -797,6 +798,14 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "crates_io_env_vars"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "dotenvy",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,9 +883,9 @@ dependencies = [
 name = "crates_io_test_db"
 version = "0.0.0"
 dependencies = [
+ "crates_io_env_vars",
  "diesel",
  "diesel_migrations",
- "dotenvy",
  "once_cell",
  "rand",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.5",
  "claims",
+ "crates_io_env_vars",
  "dotenvy",
  "git2",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ axum-extra = { version = "=0.8.0", features = ["cookie-signed"] }
 base64 = "=0.21.5"
 bigdecimal = "=0.4.2"
 cargo-manifest = "=0.12.1"
+crates_io_env_vars = { path = "crates_io_env_vars" }
 crates_io_index = { path = "crates_io_index" }
 crates_io_markdown = { path = "crates_io_markdown" }
 crates_io_tarball = { path = "crates_io_tarball" }

--- a/crates_io_env_vars/Cargo.toml
+++ b/crates_io_env_vars/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "crates_io_env_vars"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[dependencies]
+anyhow = "=1.0.75"
+dotenvy = "=0.15.7"

--- a/crates_io_env_vars/src/lib.rs
+++ b/crates_io_env_vars/src/lib.rs
@@ -1,0 +1,83 @@
+use anyhow::{anyhow, Context};
+use std::error::Error;
+use std::str::FromStr;
+
+/// Reads an environment variable for the current process.
+///
+/// Compared to [std::env::var] there are a couple of differences:
+///
+/// - [var] uses [dotenvy] which loads the `.env` file from the current or
+///   parent directories before returning the value.
+///
+/// - [var] returns `Ok(None)` (instead of `Err`) if an environment variable
+///   wasn't set.
+#[track_caller]
+pub fn var(key: &str) -> anyhow::Result<Option<String>> {
+    match dotenvy::var(key) {
+        Ok(content) => Ok(Some(content)),
+        Err(dotenvy::Error::EnvVar(std::env::VarError::NotPresent)) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// Reads an environment variable for the current process, and fails if it was
+/// not found.
+///
+/// Compared to [std::env::var] there are a couple of differences:
+///
+/// - [var] uses [dotenvy] which loads the `.env` file from the current or
+///   parent directories before returning the value.
+#[track_caller]
+pub fn required_var(key: &str) -> anyhow::Result<String> {
+    required(var(key), key)
+}
+
+/// Reads an environment variable for the current process, and parses it if
+/// it is set.
+///
+/// Compared to [std::env::var] there are a couple of differences:
+///
+/// - [var] uses [dotenvy] which loads the `.env` file from the current or
+///   parent directories before returning the value.
+///
+/// - [var] returns `Ok(None)` (instead of `Err`) if an environment variable
+///   wasn't set.
+#[track_caller]
+pub fn var_parsed<R>(key: &str) -> anyhow::Result<Option<R>>
+where
+    R: FromStr,
+    R::Err: Error + Send + Sync + 'static,
+{
+    match var(key) {
+        Ok(Some(content)) => {
+            Ok(Some(content.parse().with_context(|| {
+                format!("Failed to parse {key} environment variable")
+            })?))
+        }
+        Ok(None) => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+/// Reads an environment variable for the current process, and parses it if
+/// it is set or fails otherwise.
+///
+/// Compared to [std::env::var] there are a couple of differences:
+///
+/// - [var] uses [dotenvy] which loads the `.env` file from the current or
+///   parent directories before returning the value.
+#[track_caller]
+pub fn required_var_parsed<R>(key: &str) -> anyhow::Result<R>
+where
+    R: FromStr,
+    R::Err: Error + Send + Sync + 'static,
+{
+    required(var_parsed(key), key)
+}
+
+fn required<T>(res: anyhow::Result<Option<T>>, key: &str) -> anyhow::Result<T> {
+    match res {
+        Ok(opt) => opt.ok_or_else(|| anyhow!("Failed to find required {key} environment variable")),
+        Err(error) => Err(error),
+    }
+}

--- a/crates_io_index/Cargo.toml
+++ b/crates_io_index/Cargo.toml
@@ -15,6 +15,7 @@ testing = []
 [dependencies]
 anyhow = "=1.0.75"
 base64 = "=0.21.5"
+crates_io_env_vars = { path = "../crates_io_env_vars" }
 dotenvy = "=0.15.7"
 git2 = "=0.18.1"
 secrecy = "=0.8.0"

--- a/crates_io_test_db/Cargo.toml
+++ b/crates_io_test_db/Cargo.toml
@@ -5,9 +5,9 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
+crates_io_env_vars = { path = "../crates_io_env_vars" }
 diesel = { version = "=2.1.3", features = ["postgres", "r2d2"] }
 diesel_migrations = { version = "=2.1.0", features = ["postgres"] }
-dotenvy = "=0.15.7"
 once_cell = "=1.18.0"
 rand = "=0.8.5"
 tracing = "=0.1.40"

--- a/crates_io_test_db/src/lib.rs
+++ b/crates_io_test_db/src/lib.rs
@@ -1,3 +1,4 @@
+use crates_io_env_vars::required_var_parsed;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::sql_query;
@@ -23,8 +24,7 @@ impl TemplateDatabase {
 
     #[instrument]
     fn new() -> Self {
-        let base_url = env("TEST_DATABASE_URL");
-        let base_url = Url::parse(&base_url).expect("failed to parse TEST_DATABASE_URL");
+        let base_url: Url = required_var_parsed("TEST_DATABASE_URL").unwrap();
 
         let prefix = base_url.path().strip_prefix('/');
         let prefix = prefix.expect("failed to parse database name").to_string();
@@ -131,16 +131,6 @@ impl Drop for TestDatabase {
 
         let mut conn = TemplateDatabase::instance().get_connection();
         drop_database(&self.name, &mut conn).expect("failed to drop test database");
-    }
-}
-
-/// Return the environment variable only if it has been defined
-#[track_caller]
-fn env(var: &str) -> String {
-    match dotenvy::var(var) {
-        Ok(ref s) if s.is_empty() => panic!("environment variable `{var}` must not be empty"),
-        Ok(s) => s,
-        _ => panic!("environment variable `{var}` must be defined and valid unicode"),
     }
 }
 

--- a/src/admin/on_call.rs
+++ b/src/admin/on_call.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Result};
+use crates_io_env_vars::required_var;
 use reqwest::{blocking::Client, header, StatusCode as Status};
 
 #[derive(serde::Serialize, Debug)]
@@ -25,8 +26,8 @@ impl Event {
     /// If the variant is `Trigger`, this will page whoever is on call
     /// (potentially waking them up at 3 AM).
     pub fn send(self) -> Result<()> {
-        let api_token = dotenvy::var("PAGERDUTY_API_TOKEN")?;
-        let service_key = dotenvy::var("PAGERDUTY_INTEGRATION_KEY")?;
+        let api_token = required_var("PAGERDUTY_API_TOKEN")?;
+        let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?;
 
         let response = Client::new()
             .post("https://events.pagerduty.com/generic/2010-04-15/create_event.json")

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -23,7 +23,7 @@ use crates_io::storage::Storage;
 use crates_io::worker::swirl::Runner;
 use crates_io::worker::{Environment, RunnerExt};
 use crates_io::{db, ssh};
-use crates_io_env_vars::var_parsed;
+use crates_io_env_vars::{var, var_parsed};
 use crates_io_index::{Repository, RepositoryConfig};
 use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
@@ -61,7 +61,7 @@ fn main() -> anyhow::Result<()> {
 
     info!("Cloning index");
 
-    if dotenvy::var("HEROKU").is_ok() {
+    if var("HEROKU")?.is_some() {
         ssh::write_known_hosts_file().unwrap();
     }
 

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -22,7 +22,8 @@ use crates_io::fastly::Fastly;
 use crates_io::storage::Storage;
 use crates_io::worker::swirl::Runner;
 use crates_io::worker::{Environment, RunnerExt};
-use crates_io::{db, env_optional, ssh};
+use crates_io::{db, ssh};
+use crates_io_env_vars::var_parsed;
 use crates_io_index::{Repository, RepositoryConfig};
 use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
@@ -56,7 +57,7 @@ fn main() -> anyhow::Result<()> {
 
     let db_url = db::connection_url(&config.db, config.db.primary.url.expose_secret());
 
-    let job_start_timeout = env_optional("BACKGROUND_JOB_TIMEOUT").unwrap_or(30);
+    let job_start_timeout = var_parsed("BACKGROUND_JOB_TIMEOUT")?.unwrap_or(30);
 
     info!("Cloning index");
 

--- a/src/config/balance_capacity.rs
+++ b/src/config/balance_capacity.rs
@@ -1,4 +1,4 @@
-use crate::env_optional;
+use crates_io_env_vars::var_parsed;
 use std::env;
 
 pub struct BalanceCapacityConfig {
@@ -13,11 +13,11 @@ impl BalanceCapacityConfig {
     pub fn from_environment() -> anyhow::Result<Self> {
         Ok(Self {
             report_only: env::var("WEB_CAPACITY_REPORT_ONLY").is_ok(),
-            log_total_at_count: env_optional("WEB_CAPACITY_LOG_TOTAL_AT_COUNT").unwrap_or(50),
+            log_total_at_count: var_parsed("WEB_CAPACITY_LOG_TOTAL_AT_COUNT")?.unwrap_or(50),
             // The following are a percentage of `db_capacity`
-            log_at_percentage: env_optional("WEB_CAPACITY_LOG_PCT").unwrap_or(50),
-            throttle_at_percentage: env_optional("WEB_CAPACITY_THROTTLE_PCT").unwrap_or(70),
-            dl_only_at_percentage: env_optional("WEB_CAPACITY_DL_ONLY_PCT").unwrap_or(80),
+            log_at_percentage: var_parsed("WEB_CAPACITY_LOG_PCT")?.unwrap_or(50),
+            throttle_at_percentage: var_parsed("WEB_CAPACITY_THROTTLE_PCT")?.unwrap_or(70),
+            dl_only_at_percentage: var_parsed("WEB_CAPACITY_DL_ONLY_PCT")?.unwrap_or(80),
         })
     }
 }

--- a/src/config/base.rs
+++ b/src/config/base.rs
@@ -3,6 +3,7 @@
 //! - `HEROKU`: Is this instance of crates_io:: currently running on Heroku.
 
 use crate::Env;
+use crates_io_env_vars::var;
 
 pub struct Base {
     pub env: Env,
@@ -10,8 +11,8 @@ pub struct Base {
 
 impl Base {
     pub fn from_environment() -> anyhow::Result<Self> {
-        let env = match dotenvy::var("HEROKU") {
-            Ok(_) => Env::Production,
+        let env = match var("HEROKU")? {
+            Some(_) => Env::Production,
             _ => Env::Development,
         };
 

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -12,7 +12,8 @@
 //! - `DB_TCP_TIMEOUT_MS`: TCP timeout in milliseconds. See the doc comment for more details.
 
 use crate::config::Base;
-use crate::{env, Env};
+use crate::Env;
+use crates_io_env_vars::required_var;
 use secrecy::SecretString;
 use std::time::Duration;
 
@@ -64,7 +65,7 @@ impl DatabasePools {
     ///
     /// This function panics if `DB_OFFLINE=leader` but `READ_ONLY_REPLICA_URL` is unset.
     pub fn full_from_environment(base: &Base) -> anyhow::Result<Self> {
-        let leader_url = env("DATABASE_URL").into();
+        let leader_url = required_var("DATABASE_URL")?.into();
         let follower_url = dotenvy::var("READ_ONLY_REPLICA_URL").map(Into::into).ok();
         let read_only_mode = dotenvy::var("READ_ONLY_MODE").is_ok();
 

--- a/src/config/sentry.rs
+++ b/src/config/sentry.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use crates_io_env_vars::var_parsed;
+use crates_io_env_vars::{required_var, var, var_parsed};
 use sentry::types::Dsn;
 use sentry::IntoDsn;
 
@@ -12,15 +12,14 @@ pub struct SentryConfig {
 
 impl SentryConfig {
     pub fn from_environment() -> anyhow::Result<Self> {
-        let dsn = dotenvy::var("SENTRY_DSN_API")
-            .ok()
+        let dsn = var("SENTRY_DSN_API")?
             .into_dsn()
             .context("SENTRY_DSN_API is not a valid Sentry DSN value")?;
 
         let environment = match dsn {
             None => None,
             Some(_) => Some(
-                dotenvy::var("SENTRY_ENV_API")
+                required_var("SENTRY_ENV_API")
                     .context("SENTRY_ENV_API must be set when using SENTRY_DSN_API")?,
             ),
         };
@@ -28,7 +27,7 @@ impl SentryConfig {
         Ok(Self {
             dsn,
             environment,
-            release: dotenvy::var("HEROKU_SLUG_COMMIT").ok(),
+            release: var("HEROKU_SLUG_COMMIT")?,
             traces_sample_rate: var_parsed("SENTRY_TRACES_SAMPLE_RATE")?.unwrap_or(0.0),
         })
     }

--- a/src/config/sentry.rs
+++ b/src/config/sentry.rs
@@ -1,5 +1,5 @@
-use crate::env_optional;
 use anyhow::Context;
+use crates_io_env_vars::var_parsed;
 use sentry::types::Dsn;
 use sentry::IntoDsn;
 
@@ -29,7 +29,7 @@ impl SentryConfig {
             dsn,
             environment,
             release: dotenvy::var("HEROKU_SLUG_COMMIT").ok(),
-            traces_sample_rate: env_optional("SENTRY_TRACES_SAMPLE_RATE").unwrap_or(0.0),
+            traces_sample_rate: var_parsed("SENTRY_TRACES_SAMPLE_RATE")?.unwrap_or(0.0),
         })
     }
 }

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -3,13 +3,13 @@ use ipnetwork::IpNetwork;
 use oauth2::{ClientId, ClientSecret};
 
 use crate::rate_limiter::{LimitedAction, RateLimiterConfig};
-use crate::{env, Env};
+use crate::Env;
 
 use super::base::Base;
 use super::database_pools::DatabasePools;
 use crate::config::balance_capacity::BalanceCapacityConfig;
 use crate::storage::StorageConfig;
-use crates_io_env_vars::{var, var_parsed};
+use crates_io_env_vars::{required_var, var, var_parsed};
 use http::HeaderValue;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -190,9 +190,9 @@ impl Server {
             ip,
             port,
             max_blocking_threads,
-            session_key: cookie::Key::derive_from(env("SESSION_KEY").as_bytes()),
-            gh_client_id: ClientId::new(env("GH_CLIENT_ID")),
-            gh_client_secret: ClientSecret::new(env("GH_CLIENT_SECRET")),
+            session_key: cookie::Key::derive_from(required_var("SESSION_KEY")?.as_bytes()),
+            gh_client_id: ClientId::new(required_var("GH_CLIENT_ID")?),
+            gh_client_secret: ClientSecret::new(required_var("GH_CLIENT_SECRET")?),
             max_upload_size: 10 * 1024 * 1024, // 10 MB default file upload size limit
             max_unpack_size: 512 * 1024 * 1024, // 512 MB max when decompressed
             max_features: DEFAULT_MAX_FEATURES,
@@ -300,7 +300,7 @@ pub struct AllowedOrigins(Vec<String>);
 
 impl AllowedOrigins {
     pub fn from_default_env() -> anyhow::Result<Self> {
-        let allowed_origins = env("WEB_ALLOWED_ORIGINS")
+        let allowed_origins = required_var("WEB_ALLOWED_ORIGINS")?
             .split(',')
             .map(ToString::to_string)
             .collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,13 +24,11 @@ extern crate serde_json;
 extern crate tracing;
 
 pub use crate::{app::App, email::Emails};
-use std::error::Error;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::app::AppState;
 use crate::router::build_axum_router;
-use crates_io_env_vars::{required_var, var_parsed};
+use crates_io_env_vars::required_var;
 use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
@@ -101,22 +99,4 @@ pub fn build_handler(app: Arc<App>) -> axum::Router {
 #[track_caller]
 pub fn env(s: &str) -> String {
     required_var(s).unwrap()
-}
-
-/// Parse an optional environment variable
-///
-/// Ensures that we've initialized the dotenvy crate in order to read environment variables
-/// from a *.env* file if present. A variable that is set to invalid unicode will be handled
-/// as if it was unset.
-///
-/// # Panics
-///
-/// Panics if the environment variable is set but cannot be parsed as the requested type.
-#[track_caller]
-pub fn env_optional<R>(s: &str) -> Option<R>
-where
-    R: FromStr,
-    R::Err: Error + Send + Sync + 'static,
-{
-    var_parsed(s).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,6 @@ use std::sync::Arc;
 
 use crate::app::AppState;
 use crate::router::build_axum_router;
-use crates_io_env_vars::required_var;
 use tikv_jemallocator::Jemalloc;
 
 #[global_allocator]
@@ -85,18 +84,4 @@ pub fn build_handler(app: Arc<App>) -> axum::Router {
 
     let axum_router = build_axum_router(state.clone());
     middleware::apply_axum_middleware(state, axum_router)
-}
-
-/// Convenience function requiring that an environment variable is set.
-///
-/// Ensures that we've initialized the dotenvy crate in order to read environment variables
-/// from a *.env* file if present. Don't use this for optionally set environment variables.
-///
-/// # Panics
-///
-/// Panics if the environment variable with the name passed in as an argument is not defined
-/// in the current environment.
-#[track_caller]
-pub fn env(s: &str) -> String {
-    required_var(s).unwrap()
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,5 @@
-use crate::env;
 use anyhow::Context;
+use crates_io_env_vars::required_var;
 use futures_util::{StreamExt, TryStreamExt};
 use http::header::CACHE_CONTROL;
 use http::{HeaderMap, HeaderValue};
@@ -65,11 +65,11 @@ impl StorageConfig {
             let region = dotenvy::var("S3_REGION").ok();
             let cdn_prefix = dotenvy::var("S3_CDN").ok();
 
-            let index_bucket = env("S3_INDEX_BUCKET");
+            let index_bucket = required_var("S3_INDEX_BUCKET").unwrap();
             let index_region = dotenvy::var("S3_INDEX_REGION").ok();
 
-            let access_key = env("AWS_ACCESS_KEY");
-            let secret_key: SecretString = env("AWS_SECRET_KEY").into();
+            let access_key = required_var("AWS_ACCESS_KEY").unwrap();
+            let secret_key: SecretString = required_var("AWS_SECRET_KEY").unwrap().into();
 
             let default = S3Config {
                 bucket,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
+use crates_io_env_vars::required_var;
 use diesel::prelude::*;
 
 pub fn pg_connection_no_transaction() -> PgConnection {
-    let database_url =
-        dotenvy::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set to run tests");
+    let database_url = required_var("TEST_DATABASE_URL").unwrap();
     PgConnection::establish(&database_url).unwrap()
 }
 

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -1,5 +1,6 @@
 use crates_io::schema::categories;
 
+use crates_io_env_vars::required_var;
 use diesel::*;
 
 const ALGORITHMS: &str = r#"
@@ -38,8 +39,7 @@ description = "Another category ho hum"
 "#;
 
 fn pg_connection() -> PgConnection {
-    let database_url =
-        dotenvy::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set to run tests");
+    let database_url = required_var("TEST_DATABASE_URL").unwrap();
     let mut conn = PgConnection::establish(&database_url).unwrap();
     conn.begin_test_transaction().unwrap();
     conn

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -8,7 +8,8 @@ use crates_io::rate_limiter::{LimitedAction, RateLimiterConfig};
 use crates_io::storage::StorageConfig;
 use crates_io::worker::swirl::Runner;
 use crates_io::worker::{Environment, RunnerExt};
-use crates_io::{env, App, Emails, Env};
+use crates_io::{App, Emails, Env};
+use crates_io_env_vars::required_var;
 use crates_io_index::testing::UpstreamIndex;
 use crates_io_index::{Credentials, Repository as WorkerRepository, RepositoryConfig};
 use crates_io_test_db::TestDatabase;
@@ -372,7 +373,7 @@ fn simple_config() -> config::Server {
 
     let db = DatabasePools {
         primary: DbPoolConfig {
-            url: env("TEST_DATABASE_URL").into(),
+            url: required_var("TEST_DATABASE_URL").unwrap().into(),
             read_only_mode: false,
             pool_size: 1,
             min_idle: None,


### PR DESCRIPTION
The `env()` and `env_optional()` functions in the main package were a good start, but they often were doing too much or too little. This PR introduces four replacement functions: `var()`, `required_var()`, `var_parsed()`, and `required_var_parsed()`. 

The main difference between these and the former functions is that they return `Result` instead of panicking. This allows us to bubble up errors instead of instantly quitting the application.