### PR TITLE
worker/swirl/runner: Use `TestDatabase` instead of locking test with `Mutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "crates_io_index",
  "crates_io_markdown",
  "crates_io_tarball",
+ "crates_io_test_db",
  "crossbeam-channel",
  "dashmap",
  "derive_deref",
@@ -866,6 +867,19 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+]
+
+[[package]]
+name = "crates_io_test_db"
+version = "0.0.0"
+dependencies = [
+ "diesel",
+ "diesel_migrations",
+ "dotenvy",
+ "once_cell",
+ "rand",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ url = "=2.4.1"
 bytes = "=1.5.0"
 crates_io_index = { path = "crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates_io_tarball", features = ["builder"] }
+crates_io_test_db = { path = "crates_io_test_db" }
 claims = "=0.7.1"
 hyper-tls = "=0.5.0"
 insta = { version = "=1.34.0", features = ["json", "redactions"] }

--- a/crates_io_test_db/Cargo.toml
+++ b/crates_io_test_db/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "crates_io_test_db"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[dependencies]
+diesel = { version = "=2.1.3", features = ["postgres", "r2d2"] }
+diesel_migrations = { version = "=2.1.0", features = ["postgres"] }
+dotenvy = "=0.15.7"
+once_cell = "=1.18.0"
+rand = "=0.8.5"
+tracing = "=0.1.40"
+url = "=2.4.1"

--- a/crates_io_test_db/src/lib.rs
+++ b/crates_io_test_db/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::env;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::sql_query;
@@ -132,6 +131,16 @@ impl Drop for TestDatabase {
 
         let mut conn = TemplateDatabase::instance().get_connection();
         drop_database(&self.name, &mut conn).expect("failed to drop test database");
+    }
+}
+
+/// Return the environment variable only if it has been defined
+#[track_caller]
+fn env(var: &str) -> String {
+    match dotenvy::var(var) {
+        Ok(ref s) if s.is_empty() => panic!("environment variable `{var}` must not be empty"),
+        Ok(s) => s,
+        _ => panic!("environment variable `{var}` must be defined and valid unicode"),
     }
 }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -97,16 +97,6 @@ pub struct OkBool {
     ok: bool,
 }
 
-// Return the environment variable only if it has been defined
-#[track_caller]
-fn env(var: &str) -> String {
-    match dotenvy::var(var) {
-        Ok(ref s) if s.is_empty() => panic!("environment variable `{var}` must not be empty"),
-        Ok(s) => s,
-        _ => panic!("environment variable `{var}` must be defined and valid unicode"),
-    }
-}
-
 static NEXT_GH_ID: AtomicUsize = AtomicUsize::new(0);
 
 fn new_user(login: &str) -> NewUser<'_> {

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -1,5 +1,5 @@
-use crate::util::TestDatabase;
 use crates_io::worker::jobs::dump_db;
+use crates_io_test_db::TestDatabase;
 
 #[test]
 fn dump_db_and_reimport_dump() {

--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -1,7 +1,8 @@
 use crate::builders::CrateBuilder;
-use crate::util::{ChaosProxy, TestDatabase};
+use crate::util::ChaosProxy;
 use anyhow::{Context, Error};
 use crates_io::models::{NewUser, User};
+use crates_io_test_db::TestDatabase;
 use diesel::prelude::*;
 use reqwest::blocking::{Client, Response};
 use std::collections::HashMap;

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -46,14 +46,12 @@ pub mod insta;
 mod mock_request;
 mod response;
 mod test_app;
-mod test_database;
 
 pub(crate) use chaosproxy::ChaosProxy;
 use mock_request::MockRequest;
 pub use mock_request::MockRequestExt;
 pub use response::Response;
 pub use test_app::TestApp;
-pub(crate) use test_database::TestDatabase;
 
 /// This function can be used to create a `Cookie` header for mock requests that
 /// include cookie-based authentication.

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -1,6 +1,6 @@
 use super::{MockAnonymousUser, MockCookieUser, MockTokenUser};
+use crate::util::chaosproxy::ChaosProxy;
 use crate::util::github::{MockGitHubClient, MOCK_GITHUB_DATA};
-use crate::util::{chaosproxy::ChaosProxy, test_database::TestDatabase};
 use anyhow::Context;
 use crates_io::config::{self, BalanceCapacityConfig, Base, DatabasePools, DbPoolConfig};
 use crates_io::models::token::{CrateScope, EndpointScope};
@@ -11,6 +11,7 @@ use crates_io::worker::{Environment, RunnerExt};
 use crates_io::{env, App, Emails, Env};
 use crates_io_index::testing::UpstreamIndex;
 use crates_io_index::{Credentials, Repository as WorkerRepository, RepositoryConfig};
+use crates_io_test_db::TestDatabase;
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};


### PR DESCRIPTION
Using the `TestDatabase` struct allows us to run the background job runner test suite in parallel. 

This PR also extracts a `crates_io_test_db` package, since the `TestDatabase` was only available to our integration test code so far. This allows us to use it also in unit tests within the main package.