### PR TITLE
cloudfront: Use official AWS SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,12 +219,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "aws-sigv4"
-version = "0.56.1"
+name = "aws-credential-types"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b28f4910bb956b7ab320b62e98096402354eca976c587d1eeccd523d9bac03"
+checksum = "80009846d61a0a4f9070d789cf0e64db284cba6984fae3871050d044e6569cd2"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e65730b741a5f6422fd338bf6f76b7956b090affeaa045e78fca8c4186e0fd5"
 dependencies = [
  "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2414b96071ae840b97c0cc1d44b248d5607d648593cdf474f3fb5465572898"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "fastrand",
+ "http",
+ "percent-encoding",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-cloudfront"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8aa0317541fdcacacd4e4958d513b7a1fc7a1ec306fde36c1adb1d77dc901d"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3347c738e0a8449020877d319cda56da74d6e8aba9fff210720fac66cae3c7f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "bytes",
  "form_urlencoded",
  "hex",
  "hmac",
@@ -238,18 +313,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-http"
-version = "0.56.1"
+name = "aws-smithy-async"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cdcf365d8eee60686885f750a34c190e513677db58bbc466c44c588abf4199"
+checksum = "b4b65a284265d3eec6cc9f1daef2d0cc3b78684b712cb6c7f1d0f665456b7604"
 dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715aeb61fb743848d5d398ce6fb1259f5eba5e13dceec5d5064cada1a181d38d"
+dependencies = [
+ "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http",
  "http-body",
- "hyper",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -258,17 +344,98 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "0.56.1"
+name = "aws-smithy-json"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90dbc8da2f6be461fa3c1906b20af8f79d14968fe47f2b7d29d086f62a51728"
+checksum = "de21d368dcd5cab17033406ea6e7351b091164b208381de837510bd7558c0f30"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4395310662d10f1847324af5fe43e621922cba03b1aa6d26c21096e18a4e79"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e27594c06f5b36e97d18ef26ed693f1d4c7167b9bbb544b3a9bb653f9f7035"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d36f1723ed61e82094498e7283510fe21484b73c215c33874c81a84411b5bdc"
 dependencies = [
  "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
  "itoa",
  "num-integer",
+ "pin-project-lite",
+ "pin-utils",
  "ryu",
  "serde",
  "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68225c8d3e3e6c565a3cf764aa82440837ef15c33d1dd7205e15715444e4b4ad"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc27aac60f715bab25f5d758ba5651b80aae791c48e9871ffe298683f00a2b"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -729,7 +896,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "aws-sigv4",
+ "aws-credential-types",
+ "aws-sdk-cloudfront",
  "axum",
  "axum-extra",
  "base64 0.21.5",
@@ -1749,7 +1917,9 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
 ]
@@ -3011,6 +3181,18 @@ dependencies = [
  "ring 0.17.5",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4494,6 +4676,12 @@ checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ slow-tests = []
 [dependencies]
 anyhow = "=1.0.75"
 async-trait = "=0.1.74"
-aws-sigv4 = "=0.56.1"
+aws-credential-types = { version = "=0.57.1", features = ["hardcoded-credentials"] }
+aws-sdk-cloudfront = "=0.35.0"
 axum = { version = "=0.6.20", features = ["headers", "macros", "matched-path"] }
 axum-extra = { version = "=0.8.0", features = ["cookie-signed"] }
 base64 = "=0.21.5"

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -51,7 +51,17 @@ impl BackgroundJob for DumpDb {
         info!("Database dump tarball uploaded");
 
         info!("Invalidating CDN caches");
-        invalidate_caches(env, &self.target_name);
+        if let Some(cloudfront) = env.cloudfront() {
+            if let Err(error) = cloudfront.invalidate(env.http_client(), &self.target_name) {
+                warn!("failed to invalidate CloudFront cache: {}", error);
+            }
+        }
+
+        if let Some(fastly) = env.fastly() {
+            if let Err(error) = fastly.invalidate(env.http_client(), &self.target_name) {
+                warn!("failed to invalidate Fastly cache: {}", error);
+            }
+        }
 
         Ok(())
     }
@@ -265,20 +275,6 @@ impl DumpTarball {
 impl Drop for DumpTarball {
     fn drop(&mut self) {
         std::fs::remove_file(&self.tarball_path).unwrap();
-    }
-}
-
-fn invalidate_caches(env: &Environment, target_name: &str) {
-    if let Some(cloudfront) = env.cloudfront() {
-        if let Err(error) = cloudfront.invalidate(env.http_client(), target_name) {
-            warn!("failed to invalidate CloudFront cache: {}", error);
-        }
-    }
-
-    if let Some(fastly) = env.fastly() {
-        if let Err(error) = fastly.invalidate(env.http_client(), target_name) {
-            warn!("failed to invalidate Fastly cache: {}", error);
-        }
     }
 }
 

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -52,7 +52,7 @@ impl BackgroundJob for DumpDb {
 
         info!("Invalidating CDN caches");
         if let Some(cloudfront) = env.cloudfront() {
-            if let Err(error) = cloudfront.invalidate(env.http_client(), &self.target_name) {
+            if let Err(error) = cloudfront.invalidate(&self.target_name, &rt) {
                 warn!("failed to invalidate CloudFront cache: {}", error);
             }
         }

--- a/src/worker/jobs/git.rs
+++ b/src/worker/jobs/git.rs
@@ -109,7 +109,7 @@ impl BackgroundJob for SyncToSparseIndex {
 
             info!(%path, "Invalidating index file on CloudFront");
             cloudfront
-                .invalidate(env.http_client(), &path)
+                .invalidate(&path, &rt)
                 .context("Failed to invalidate CloudFront")?;
         }
 


### PR DESCRIPTION
As #7439 is causing quite some issues, I thought it would probably be easiest to use the high(ish...)-level CloudFront SDK from AWS instead. Turns out their API isn't particularly easy to use either, but I've somehow made it work.

I've just tested this on our staging server, and everything appears to work as intended.