### PR TITLE
middleware/block_traffic: Combine middleware functions

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -62,18 +62,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router<(), TimeoutBody<Bod
             state.clone(),
             require_user_agent::require_user_agent,
         ))
-        .layer(from_fn_with_state(
-            state.clone(),
-            block_traffic::block_by_ip,
-        ))
-        .layer(from_fn_with_state(
-            state.clone(),
-            block_traffic::block_by_header,
-        ))
-        .layer(from_fn_with_state(
-            state.clone(),
-            block_traffic::block_routes,
-        ))
+        .layer(from_fn_with_state(state.clone(), block_traffic::middleware))
         .layer(from_fn_with_state(
             state.clone(),
             common_headers::add_common_headers,


### PR DESCRIPTION
Before this commit the compile time of the `crates_io` package on my machine was around 50 seconds. After this commit it dropped down to 5 seconds. I'm not entirely sure what the root cause of this is, but `git bisect` suggested that the addition of the `block_by_ip` middleware layer (d1fc384) was at least partially responsible. It looks like the more middleware layers we add, the longer the app takes to compile. It might also be caused by the `from_fn_with_state()` fn usage, which this commit reduces a bit... tl;dr don't know, but it's faster now 🤷‍♂️