### PR TITLE
fastly: Remove unnecessary `Clone` impl

### DIFF
--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -3,7 +3,7 @@ use http::HeaderValue;
 use reqwest::blocking::Client;
 use secrecy::{ExposeSecret, SecretString};
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Fastly {
     api_token: SecretString,
     static_domain_name: String,


### PR DESCRIPTION
We don't need to `clone()` this anywhere since the `Environment` struct is usually wrapped in an `Arc`, so we might as well remove the `Clone` impl.