### PR TITLE
worker/swirl/runner: Use public APIs for tests

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -41,19 +41,26 @@ pub fn run(command: Command) -> Result<()> {
 
             if count > 0 {
                 println!("Did not enqueue update_downloads, existing job already in progress");
-                Ok(())
             } else {
-                Ok(jobs::UpdateDownloads.enqueue(conn)?)
+                jobs::UpdateDownloads.enqueue(conn)?;
             }
         }
         Command::DumpDb {
             database_url,
             target_name,
-        } => Ok(jobs::DumpDb::new(database_url.expose_secret(), target_name).enqueue(conn)?),
-        Command::DailyDbMaintenance => Ok(jobs::DailyDbMaintenance.enqueue(conn)?),
-        Command::SquashIndex => Ok(jobs::SquashIndex.enqueue(conn)?),
-        Command::NormalizeIndex { dry_run } => {
-            Ok(jobs::NormalizeIndex::new(dry_run).enqueue(conn)?)
+        } => {
+            jobs::DumpDb::new(database_url.expose_secret(), target_name).enqueue(conn)?;
         }
-    }
+        Command::DailyDbMaintenance => {
+            jobs::DailyDbMaintenance.enqueue(conn)?;
+        }
+        Command::SquashIndex => {
+            jobs::SquashIndex.enqueue(conn)?;
+        }
+        Command::NormalizeIndex { dry_run } => {
+            jobs::NormalizeIndex::new(dry_run).enqueue(conn)?;
+        }
+    };
+
+    Ok(())
 }

--- a/src/worker/swirl/runner.rs
+++ b/src/worker/swirl/runner.rs
@@ -301,12 +301,7 @@ mod tests {
     use diesel::r2d2;
     use diesel::r2d2::ConnectionManager;
     use std::panic::AssertUnwindSafe;
-    use std::sync::mpsc::{sync_channel, SyncSender};
     use std::sync::{Arc, Barrier};
-
-    fn dummy_sender<T>() -> SyncSender<T> {
-        sync_channel(1).0
-    }
 
     fn job_exists(id: i64, conn: &mut PgConnection) -> bool {
         background_jobs::table
@@ -520,20 +515,5 @@ mod tests {
         Runner::new(connection_pool, context)
             .num_workers(2)
             .job_start_timeout(Duration::from_secs(10))
-    }
-
-    fn create_dummy_job(runner: &Runner<()>) -> storage::BackgroundJob {
-        diesel::insert_into(background_jobs::table)
-            .values((
-                background_jobs::job_type.eq("Foo"),
-                background_jobs::data.eq(serde_json::json!(null)),
-            ))
-            .returning((
-                background_jobs::id,
-                background_jobs::job_type,
-                background_jobs::data,
-            ))
-            .get_result(&mut *runner.connection().unwrap())
-            .unwrap()
     }
 }


### PR DESCRIPTION
The tests of the `Runner` were using the private `get_single_job()` fn in somewhat convoluted ways. This PR refactors the `Runner` tests to use custom job structs instead and only rely on public APIs. This should allow us to refactor the internal workings of the `Runner` in the future without having to modify these tests.