### PR TITLE
worker/swirl/runner: Simplify `AssertUnwindSafe` usage

### DIFF
--- a/src/cloudfront.rs
+++ b/src/cloudfront.rs
@@ -5,12 +5,11 @@ use aws_sdk_cloudfront::types::{InvalidationBatch, Paths};
 use aws_sdk_cloudfront::{Client, Config};
 use retry::delay::{jitter, Exponential};
 use retry::OperationResult;
-use std::panic::AssertUnwindSafe;
 use std::time::Duration;
 use tokio::runtime::Runtime;
 
 pub struct CloudFront {
-    client: AssertUnwindSafe<Client>,
+    client: Client,
     distribution_id: String,
 }
 
@@ -27,7 +26,7 @@ impl CloudFront {
             .credentials_provider(credentials)
             .build();
 
-        let client = AssertUnwindSafe(Client::from_conf(config));
+        let client = Client::from_conf(config);
 
         Some(Self {
             client,

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -4,15 +4,14 @@ use crate::storage::Storage;
 use crate::worker::swirl::PerformError;
 use crates_io_index::Repository;
 use reqwest::blocking::Client;
-use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 
 pub struct Environment {
     index: Mutex<Repository>,
-    http_client: AssertUnwindSafe<Client>,
+    http_client: Client,
     cloudfront: Option<CloudFront>,
     fastly: Option<Fastly>,
-    pub storage: AssertUnwindSafe<Arc<Storage>>,
+    pub storage: Arc<Storage>,
 }
 
 impl Environment {
@@ -25,10 +24,10 @@ impl Environment {
     ) -> Self {
         Self {
             index: Mutex::new(index),
-            http_client: AssertUnwindSafe(http_client),
+            http_client,
             cloudfront,
             fastly,
-            storage: AssertUnwindSafe(storage),
+            storage,
         }
     }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/40628, https://github.com/rust-lang/rust/issues/65717 and https://github.com/rust-lang/rfcs/pull/3260 all show that unwind safety isn't particularly ergonomic to use and implement, and ultimately leads to people slapping `AssertUnwindSafe` everywhere until the compiler stops complaining.

This situation has led to built-in test framework using `catch_unwind(AssertUnwindSafe(...))` (see https://github.com/rust-lang/rust/blob/1.73.0/library/test/src/lib.rs#L649) and libraries like tower-http doing the same (see https://docs.rs/tower-http/0.4.4/src/tower_http/catch_panic.rs.html#198).

As people have mentioned in the threads above, trying to implement this correctly is akin to fighting windmills at the moment. Since the above cases demonstrated that `catch_unwind(AssertUnwindSafe(...))` is currently the easiest way to deal with this situation, this commit does the same and refactors our background job runner code accordingly.