### PR TITLE
bin/background-worker: Simplify restart behavior

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -99,16 +99,9 @@ fn main() -> anyhow::Result<()> {
 
     info!("Runner booted, running jobs");
 
-    let mut failure_count = 0;
-
     loop {
-        if let Err(e) = runner.run_all_pending_jobs() {
-            failure_count += 1;
-            if failure_count < 5 {
-                warn!(?failure_count, err = ?e, "Error running jobs -- retrying");
-            } else {
-                panic!("Failed to begin running jobs 5 times. Restarting the process");
-            }
+        if let Err(err) = runner.run_all_pending_jobs() {
+            warn!(%err, "Failed to run background jobs");
         }
         sleep(Duration::from_secs(1));
     }


### PR DESCRIPTION
All instances of our code hitting the `panic!()` on production so far have been because of a read-only database during database maintenance events (see Sentry).

The r2d2 connection pool can easily recover from these kinds of issues, so a restart of the dyno or re-initialization of the connection pool seems unnecessary.

This is emphasized by the fact that the startup time of the background worker in production is currently multiple minutes due to the index repository cloning. It seems bad to restart the background worker after just five unsuccessful connection attempts when it then takes multiple minutes again until the next attempt.