### PR TITLE
worker: Clone index repository in the background

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -78,6 +78,15 @@ fn main() -> anyhow::Result<()> {
 
     let environment = Arc::new(environment);
 
+    std::thread::spawn({
+        let environment = environment.clone();
+        move || {
+            if let Err(err) = environment.lock_index() {
+                warn!(%err, "Failed to clone index");
+            };
+        }
+    });
+
     let connection_pool = r2d2::Pool::builder()
         .max_size(10)
         .min_idle(Some(0))

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -11,7 +11,7 @@ use crates_io::worker::{Environment, RunnerExt};
 use crates_io::{App, Emails, Env};
 use crates_io_env_vars::required_var;
 use crates_io_index::testing::UpstreamIndex;
-use crates_io_index::{Credentials, Repository as WorkerRepository, RepositoryConfig};
+use crates_io_index::{Credentials, RepositoryConfig};
 use crates_io_test_db::TestDatabase;
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
@@ -252,9 +252,8 @@ impl TestAppBuilder {
                 index_location: UpstreamIndex::url(),
                 credentials: Credentials::Missing,
             };
-            let index = WorkerRepository::open(&repository_config).expect("Could not clone index");
             let environment = Environment::new(
-                index,
+                repository_config,
                 app.http_client().clone(),
                 None,
                 None,


### PR DESCRIPTION
We are currently delaying the execution of **any** tasks until the index repository is cloned. This was useful while we were mostly running tasks that needed the repository anyway, but with the introduction of the sparse index, this is no longer the case.

This PR adjusts the code to lazily clone the index when requested, but then also fire off a background thread to start that operation once the background worker has started.

This should allow us to process sparse index updates while the git repository is still being cloned.

Note that due to the way the background worker is implemented this is still not entirely true. While the repository is being cloned a `Mutex` is being held. At some point all five background worker threads might be handling `sync_to_git_index` jobs with all of them waiting to lock that mutex. At this point no other jobs can run anymore since the workers are busy. This can be solved in the future by having multiple queues, with a dedicated queue for jobs that involve the git repository.