### PR TITLE
worker: Move database connection pool into the `Environment` struct

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -65,13 +65,6 @@ impl DieselPool {
         Self::BackgroundJobPool { pool }
     }
 
-    pub(crate) fn to_real_pool(&self) -> Option<ConnectionPool> {
-        match self {
-            Self::Pool { pool, .. } | Self::BackgroundJobPool { pool } => Some(pool.clone()),
-            _ => None,
-        }
-    }
-
     pub(crate) fn new_test(config: &config::DatabasePools, url: &SecretString) -> DieselPool {
         let mut conn = PgConnection::establish(&connection_url(config, url.expose_secret()))
             .expect("failed to establish connection");

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -258,6 +258,7 @@ impl TestAppBuilder {
                 None,
                 None,
                 app.storage.clone(),
+                app.primary_database.clone(),
             );
 
             let runner = Runner::new(app.primary_database.clone(), Arc::new(environment))

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -1,4 +1,5 @@
 use crate::cloudfront::CloudFront;
+use crate::db::DieselPool;
 use crate::fastly::Fastly;
 use crate::storage::Storage;
 use crate::worker::swirl::PerformError;
@@ -15,6 +16,7 @@ pub struct Environment {
     cloudfront: Option<CloudFront>,
     fastly: Option<Fastly>,
     pub storage: Arc<Storage>,
+    pub connection_pool: DieselPool,
 }
 
 impl Environment {
@@ -24,6 +26,7 @@ impl Environment {
         cloudfront: Option<CloudFront>,
         fastly: Option<Fastly>,
         storage: Arc<Storage>,
+        connection_pool: DieselPool,
     ) -> Self {
         Self {
             repository_config,
@@ -32,6 +35,7 @@ impl Environment {
             cloudfront,
             fastly,
             storage,
+            connection_pool,
         }
     }
 

--- a/src/worker/jobs/daily_db_maintenance.rs
+++ b/src/worker/jobs/daily_db_maintenance.rs
@@ -20,11 +20,11 @@ impl BackgroundJob for DailyDbMaintenance {
     /// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
     /// archive daily download counts and drop historical data, we can drop this task and rely on
     /// auto-vacuum again.
-    fn run(&self, state: PerformState<'_>, _env: &Self::Context) -> Result<(), PerformError> {
-        let mut conn = state.fresh_connection()?;
+    fn run(&self, _state: PerformState<'_>, env: &Self::Context) -> Result<(), PerformError> {
+        let mut conn = env.connection_pool.get()?;
 
         info!("Running VACUUM on version_downloads table");
-        sql_query("VACUUM version_downloads;").execute(&mut conn)?;
+        sql_query("VACUUM version_downloads;").execute(&mut *conn)?;
         info!("Finished running VACUUM on version_downloads table");
         Ok(())
     }

--- a/src/worker/jobs/update_downloads.rs
+++ b/src/worker/jobs/update_downloads.rs
@@ -13,8 +13,8 @@ impl BackgroundJob for UpdateDownloads {
 
     type Context = Arc<Environment>;
 
-    fn run(&self, state: PerformState<'_>, _env: &Self::Context) -> Result<(), PerformError> {
-        let mut conn = state.fresh_connection()?;
+    fn run(&self, _state: PerformState<'_>, env: &Self::Context) -> Result<(), PerformError> {
+        let mut conn = env.connection_pool.get()?;
         update(&mut conn)?;
         Ok(())
     }

--- a/src/worker/swirl/perform_state.rs
+++ b/src/worker/swirl/perform_state.rs
@@ -1,6 +1,3 @@
-use crate::db::ConnectionPool;
-use crate::worker::swirl::PerformError;
-use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::PgConnection;
 
 /// Database state that is passed to `Job::perform()`.
@@ -10,26 +7,4 @@ pub struct PerformState<'a> {
     /// Most jobs can reuse the existing connection, however it will already be within a
     /// transaction and is thus not appropriate in all cases.
     pub(crate) conn: &'a mut PgConnection,
-    /// A connection pool for obtaining a unique connection.
-    ///
-    /// This will be `None` within our standard test framework, as there everything is expected to
-    /// run within a single transaction.
-    pub(crate) pool: Option<ConnectionPool>,
-}
-
-impl PerformState<'_> {
-    /// A helper function for jobs needing a fresh connection (i.e. not already within a transaction).
-    ///
-    /// This will error when run from our main test framework, as there most work is expected to be
-    /// done within an existing transaction.
-    pub fn fresh_connection(
-        &self,
-    ) -> Result<PooledConnection<ConnectionManager<PgConnection>>, PerformError> {
-        match self.pool {
-            // In production a pool should be available. This can only be hit in tests, which don't
-            // provide the pool.
-            None => Err(String::from("Database pool was unavailable").into()),
-            Some(ref pool) => Ok(pool.get()?),
-        }
-    }
 }

--- a/src/worker/swirl/runner.rs
+++ b/src/worker/swirl/runner.rs
@@ -193,8 +193,7 @@ impl<Context: Clone + Send + 'static> Worker<Context> {
 
             let result = with_sentry_transaction(&job.job_type, || {
                 conn.transaction(|conn| {
-                    let pool = self.connection_pool.to_real_pool();
-                    let state = PerformState { conn, pool };
+                    let state = PerformState { conn };
                     catch_unwind(AssertUnwindSafe(|| {
                         let job_registry = self.job_registry.read();
                         let run_task_fn = job_registry.get(&job.job_type).ok_or_else(|| {


### PR DESCRIPTION
This roughly matches the situation on the API server side, where the database pool lives on the `App` struct alongside other parts of the system. The `PerformState` is now only used to share the existing database connection of the `Worker` with the jobs.