### PR TITLE
controllers/github/secret_scanning: Replace `unwrap()` usage with `is_some_and()`

### DIFF
--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -48,9 +48,10 @@ struct GitHubPublicKeyCache {
 
 /// Check if cache of public keys is populated and not expired
 fn is_cache_valid(timestamp: Option<chrono::DateTime<chrono::Utc>>) -> bool {
-    timestamp.is_some()
-        && chrono::Utc::now()
-            < timestamp.unwrap() + chrono::Duration::seconds(PUBLIC_KEY_CACHE_LIFETIME_SECONDS)
+    timestamp.is_some_and(|timestamp| {
+        chrono::Utc::now()
+            < timestamp + chrono::Duration::seconds(PUBLIC_KEY_CACHE_LIFETIME_SECONDS)
+    })
 }
 
 // Fetches list of public keys from GitHub API


### PR DESCRIPTION
Less `unwrap()`, more better! 🦺 