### PR TITLE
test_db: Use the force when dropping databases

### DIFF
--- a/crates_io_test_db/src/lib.rs
+++ b/crates_io_test_db/src/lib.rs
@@ -169,7 +169,7 @@ fn create_database_from_template(
 #[instrument(skip(conn))]
 fn drop_database(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
     debug!("Dropping database…");
-    sql_query(format!("DROP DATABASE {name}")).execute(conn)?;
+    sql_query(format!("DROP DATABASE {name} WITH (FORCE)")).execute(conn)?;
     Ok(())
 }
 


### PR DESCRIPTION
`WITH (FORCE)` causes existing connections to the database to be dropped. This should fix a small flakiness in our test suite where the database connection pool isn't fast enough in dropping its connections, while the `DROP DATABASE` command is already executed.