### PR TITLE
Simplify `reqwest::Client` usage

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,13 +58,6 @@ pub struct App {
     /// Metrics related to this specific instance of the service
     pub instance_metrics: InstanceMetrics,
 
-    /// A configured client for outgoing HTTP requests
-    ///
-    /// In production this shares a single connection pool across requests.  In tests
-    /// this is either None (in which case any attempt to create an outgoing connection
-    /// will panic) or a `Client` configured with a per-test replay proxy.
-    pub(crate) http_client: Option<Client>,
-
     /// In-flight request counters for the `balance_capacity` middleware.
     pub balance_capacity: BalanceCapacityState,
 
@@ -172,26 +165,10 @@ impl App {
             storage: Arc::new(Storage::from_config(&config.storage)),
             service_metrics: ServiceMetrics::new().expect("could not initialize service metrics"),
             instance_metrics,
-            http_client,
             balance_capacity: Default::default(),
             rate_limiter: RateLimiter::new(config.rate_limiter.clone()),
             config,
         }
-    }
-
-    /// Returns a client for making HTTP requests to upload crate files.
-    ///
-    /// The client will go through a proxy if the application was configured via
-    /// `TestApp::with_proxy()`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the application was not initialized with a client.  This should only occur in
-    /// tests that were not properly initialized.
-    pub fn http_client(&self) -> &Client {
-        self.http_client
-            .as_ref()
-            .expect("No HTTP client is configured.  In tests, use `TestApp::with_proxy()`.")
     }
 
     /// A unique key to generate signed cookies

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -66,13 +66,14 @@ fn main() -> anyhow::Result<()> {
     let repository_config = RepositoryConfig::from_environment()?;
 
     let cloudfront = CloudFront::from_environment();
-    let fastly = Fastly::from_environment();
     let storage = Arc::new(Storage::from_config(&config.storage));
 
     let client = Client::builder()
         .timeout(Duration::from_secs(45))
         .build()
         .expect("Couldn't build client");
+
+    let fastly = Fastly::from_environment(client.clone());
 
     let connection_pool = r2d2::Pool::builder()
         .max_size(10)

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -73,7 +73,7 @@ fn main() -> anyhow::Result<()> {
         .build()
         .expect("Couldn't build client");
 
-    let fastly = Fastly::from_environment(client.clone());
+    let fastly = Fastly::from_environment(client);
 
     let connection_pool = r2d2::Pool::builder()
         .max_size(10)
@@ -84,7 +84,6 @@ fn main() -> anyhow::Result<()> {
 
     let environment = Environment::new(
         repository_config,
-        client,
         cloudfront,
         fastly,
         storage,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -254,7 +254,6 @@ impl TestAppBuilder {
             };
             let environment = Environment::new(
                 repository_config,
-                app.http_client().clone(),
                 None,
                 None,
                 app.storage.clone(),

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -3,7 +3,6 @@ use crate::db::DieselPool;
 use crate::fastly::Fastly;
 use crate::storage::Storage;
 use crates_io_index::{Repository, RepositoryConfig};
-use reqwest::blocking::Client;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
 use std::time::Instant;
@@ -11,7 +10,6 @@ use std::time::Instant;
 pub struct Environment {
     repository_config: RepositoryConfig,
     repository: Mutex<Option<Repository>>,
-    http_client: Client,
     cloudfront: Option<CloudFront>,
     fastly: Option<Fastly>,
     pub storage: Arc<Storage>,
@@ -21,7 +19,6 @@ pub struct Environment {
 impl Environment {
     pub fn new(
         repository_config: RepositoryConfig,
-        http_client: Client,
         cloudfront: Option<CloudFront>,
         fastly: Option<Fastly>,
         storage: Arc<Storage>,
@@ -30,7 +27,6 @@ impl Environment {
         Self {
             repository_config,
             repository: Mutex::new(None),
-            http_client,
             cloudfront,
             fastly,
             storage,
@@ -58,11 +54,6 @@ impl Environment {
         let repo_lock = RepositoryLock { repo };
         repo_lock.reset_head()?;
         Ok(repo_lock)
-    }
-
-    /// Returns a client for making HTTP requests to upload crate files.
-    pub(crate) fn http_client(&self) -> &Client {
-        &self.http_client
     }
 
     pub(crate) fn cloudfront(&self) -> Option<&CloudFront> {

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -58,7 +58,7 @@ impl BackgroundJob for DumpDb {
         }
 
         if let Some(fastly) = env.fastly() {
-            if let Err(error) = fastly.invalidate(env.http_client(), &self.target_name) {
+            if let Err(error) = fastly.invalidate(&self.target_name) {
                 warn!("failed to invalidate Fastly cache: {}", error);
             }
         }


### PR DESCRIPTION
The only parts of our codebase that are using the `reqwest` client are the GitHub and Fastly clients. The GitHub client is already taking ownership of a `Client` clone, and this PR refactors the Fastly client to do the same. This then allows us to remove the `http_client` fields from the `App` and `Environment` structs since they are not used by anything else anymore.