### PR TITLE
fastly: Use async `reqwest` client

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -27,7 +27,7 @@ use crates_io_env_vars::{var, var_parsed};
 use crates_io_index::RepositoryConfig;
 use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
-use reqwest::blocking::Client;
+use reqwest::Client;
 use secrecy::ExposeSecret;
 use std::sync::Arc;
 use std::thread::sleep;

--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -49,13 +49,13 @@ impl Fastly {
 
         for domain in domains.iter() {
             let url = format!("https://api.fastly.com/purge/{}/{}", domain, path);
-            self.purge_url(&self.client, &url).await?;
+            self.purge_url(&url).await?;
         }
 
         Ok(())
     }
 
-    async fn purge_url(&self, client: &Client, url: &str) -> anyhow::Result<()> {
+    async fn purge_url(&self, url: &str) -> anyhow::Result<()> {
         trace!(?url);
 
         let api_token = self.api_token.expose_secret();
@@ -66,7 +66,8 @@ impl Fastly {
         headers.append("Fastly-Key", api_token);
 
         debug!("sending invalidation request to Fastly");
-        let response = client
+        let response = self
+            .client
             .post(url)
             .headers(headers)
             .send()

--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context};
 use http::HeaderValue;
-use reqwest::blocking::Client;
+use reqwest::Client;
 use secrecy::{ExposeSecret, SecretString};
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl Fastly {
     /// More information on Fastly's APIs for cache invalidations can be found here:
     /// <https://developer.fastly.com/reference/api/purging/>
     #[instrument(skip(self))]
-    pub fn invalidate(&self, path: &str) -> anyhow::Result<()> {
+    pub async fn invalidate(&self, path: &str) -> anyhow::Result<()> {
         if path.contains('*') {
             return Err(anyhow!(
                 "wildcard invalidations are not supported for Fastly"
@@ -49,13 +49,13 @@ impl Fastly {
 
         for domain in domains.iter() {
             let url = format!("https://api.fastly.com/purge/{}/{}", domain, path);
-            self.purge_url(&self.client, &url)?;
+            self.purge_url(&self.client, &url).await?;
         }
 
         Ok(())
     }
 
-    fn purge_url(&self, client: &Client, url: &str) -> anyhow::Result<()> {
+    async fn purge_url(&self, client: &Client, url: &str) -> anyhow::Result<()> {
         trace!(?url);
 
         let api_token = self.api_token.expose_secret();
@@ -70,6 +70,7 @@ impl Fastly {
             .post(url)
             .headers(headers)
             .send()
+            .await
             .context("failed to send invalidation request to Fastly")?;
 
         let status = response.status();
@@ -81,7 +82,7 @@ impl Fastly {
             }
             Err(error) => {
                 let headers = response.headers().clone();
-                let body = response.text();
+                let body = response.text().await;
                 debug!(
                     ?status,
                     ?headers,

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -58,7 +58,7 @@ impl BackgroundJob for DumpDb {
         }
 
         if let Some(fastly) = env.fastly() {
-            if let Err(error) = fastly.invalidate(&self.target_name) {
+            if let Err(error) = rt.block_on(fastly.invalidate(&self.target_name)) {
                 warn!("failed to invalidate Fastly cache: {}", error);
             }
         }


### PR DESCRIPTION
This PR refactors our basic `Fastly` client to use async fns and an async `reqwest` HTTP client.

This will should us to eventually write async test cases. This is currently prevented by the `reqwest::blocking::Client` constructor panicking if executed from within an async context.

The background jobs are not async functions yet, but the `DumpDb` job which uses the Fastly client already has an async runtime to upload the database dump to S3 and invalidate CloudFront, so it is relatively straight-forward to integrate there.