### PR TITLE
github: Use async `reqwest` client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ p256 = "=0.13.2"
 parking_lot = "=0.12.1"
 prometheus = { version = "=0.13.3", default-features = false }
 rand = "=0.8.5"
-reqwest = { version = "=0.11.22", features = ["blocking", "gzip", "json"] }
+reqwest = { version = "=0.11.22", features = ["gzip", "json"] }
 retry = "=2.0.0"
 scheduled-thread-pool = "=0.2.7"
 secrecy = "=0.8.0"

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,7 +16,7 @@ use axum::extract::{FromRef, FromRequestParts, State};
 use diesel::r2d2;
 use moka::future::{Cache, CacheBuilder};
 use oauth2::basic::BasicClient;
-use reqwest::blocking::Client;
+use reqwest::Client;
 use scheduled_thread_pool::ScheduledThreadPool;
 
 /// The `App` struct holds the main components of the application like

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -10,7 +10,7 @@ use std::{sync::Arc, time::Duration};
 use axum::ServiceExt;
 use futures_util::future::FutureExt;
 use prometheus::Encoder;
-use reqwest::blocking::Client;
+use reqwest::Client;
 use std::io::{self, Write};
 use std::net::SocketAddr;
 use tokio::signal::unix::{signal, SignalKind};

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -14,6 +14,7 @@ use chrono::{Duration, Utc};
 use diesel::{pg::Pg, sql_types::Bool};
 use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
+use tokio::runtime::Handle;
 
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
 pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
@@ -106,7 +107,7 @@ fn prepare_list(
                 // Only allow crate owners to query pending invitations for their crate.
                 let krate: Crate = Crate::by_name(&crate_name).first(conn)?;
                 let owners = krate.owners(conn)?;
-                if user.rights(state, &owners)? != Rights::Full {
+                if Handle::current().block_on(user.rights(state, &owners))? != Rights::Full {
                     return Err(forbidden());
                 }
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -6,6 +6,7 @@ use crate::models::token::EndpointScope;
 use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::views::EncodableOwner;
 use axum::body::Bytes;
+use tokio::runtime::Handle;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
 pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
@@ -113,7 +114,7 @@ fn modify_owners(
         let krate: Crate = Crate::by_name(crate_name).first(conn)?;
         let owners = krate.owners(conn)?;
 
-        match user.rights(app, &owners)? {
+        match Handle::current().block_on(user.rights(app, &owners))? {
             Rights::Full => {}
             // Yes!
             Rights::Publish => {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -295,7 +295,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             };
 
             let owners = krate.owners(conn)?;
-            if user.rights(&app, &owners)? < Rights::Publish {
+            if Handle::current().block_on(user.rights(&app, &owners))? < Rights::Publish {
                 return Err(cargo_err(MISSING_RIGHTS_ERROR_MESSAGE));
             }
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -2,6 +2,7 @@ use crate::controllers::frontend_prelude::*;
 
 use oauth2::reqwest::http_client;
 use oauth2::{AuthorizationCode, Scope, TokenResponse};
+use tokio::runtime::Handle;
 
 use crate::email::Emails;
 use crate::github::GithubUser;
@@ -100,7 +101,7 @@ pub async fn authorize(
         let token = token.access_token();
 
         // Fetch the user info from GitHub using the access token we just got and create a user record
-        let ghuser = app.github.current_user(token)?;
+        let ghuser = Handle::current().block_on(app.github.current_user(token))?;
         let user =
             save_user_to_database(&ghuser, token.secret(), &app.emails, &mut *app.db_write()?)?;
 

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -9,6 +9,7 @@ use crate::models::{insert_version_owner_action, VersionAction};
 use crate::rate_limiter::LimitedAction;
 use crate::schema::versions;
 use crate::worker::jobs;
+use tokio::runtime::Handle;
 
 /// Handles the `DELETE /crates/:crate_id/:version/yank` route.
 /// This does not delete a crate version, it makes the crate
@@ -67,7 +68,7 @@ fn modify_yank(
     let user = auth.user();
     let owners = krate.owners(conn)?;
 
-    if user.rights(state, &owners)? < Rights::Publish {
+    if Handle::current().block_on(user.rights(state, &owners))? < Rights::Publish {
         return Err(cargo_err("must already be an owner to yank or unyank"));
     }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -140,7 +140,7 @@ impl User {
     /// `Publish` as well, but this is a non-obvious invariant so we don't bother.
     /// Sweet free optimization if teams are proving burdensome to check.
     /// More than one team isn't really expected, though.
-    pub fn rights(&self, app: &App, owners: &[Owner]) -> AppResult<Rights> {
+    pub async fn rights(&self, app: &App, owners: &[Owner]) -> AppResult<Rights> {
         let mut best = Rights::None;
         for owner in owners {
             match *owner {
@@ -150,7 +150,7 @@ impl User {
                     }
                 }
                 Owner::Team(ref team) => {
-                    if team.contains_user(app, self)? {
+                    if team.contains_user(app, self).await? {
                         best = Rights::Publish;
                     }
                 }

--- a/src/tests/util/github.rs
+++ b/src/tests/util/github.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use crates_io::controllers::github::secret_scanning::GitHubPublicKey;
 use crates_io::github::{
     GitHubClient, GitHubOrgMembership, GitHubOrganization, GitHubTeam, GitHubTeamMembership,
@@ -64,8 +65,9 @@ impl MockGitHubClient {
     }
 }
 
+#[async_trait]
 impl GitHubClient for MockGitHubClient {
-    fn current_user(&self, _auth: &AccessToken) -> AppResult<GithubUser> {
+    async fn current_user(&self, _auth: &AccessToken) -> AppResult<GithubUser> {
         let user = &self.data.users[0];
         Ok(GithubUser {
             id: user.id,
@@ -76,7 +78,11 @@ impl GitHubClient for MockGitHubClient {
         })
     }
 
-    fn org_by_name(&self, org_name: &str, _auth: &AccessToken) -> AppResult<GitHubOrganization> {
+    async fn org_by_name(
+        &self,
+        org_name: &str,
+        _auth: &AccessToken,
+    ) -> AppResult<GitHubOrganization> {
         let org = self
             .data
             .orgs
@@ -89,7 +95,7 @@ impl GitHubClient for MockGitHubClient {
         })
     }
 
-    fn team_by_name(
+    async fn team_by_name(
         &self,
         org_name: &str,
         team_name: &str,
@@ -108,11 +114,11 @@ impl GitHubClient for MockGitHubClient {
         Ok(GitHubTeam {
             id: team.id,
             name: Some(team.name.into()),
-            organization: self.org_by_name(org_name, auth)?,
+            organization: self.org_by_name(org_name, auth).await?,
         })
     }
 
-    fn team_membership(
+    async fn team_membership(
         &self,
         org_id: i32,
         team_id: i32,
@@ -138,7 +144,7 @@ impl GitHubClient for MockGitHubClient {
         }
     }
 
-    fn org_membership(
+    async fn org_membership(
         &self,
         org_id: i32,
         username: &str,
@@ -169,7 +175,11 @@ impl GitHubClient for MockGitHubClient {
         }
     }
 
-    fn public_keys(&self, _username: &str, _password: &str) -> AppResult<Vec<GitHubPublicKey>> {
+    async fn public_keys(
+        &self,
+        _username: &str,
+        _password: &str,
+    ) -> AppResult<Vec<GitHubPublicKey>> {
         Ok(self.data.public_keys.iter().map(Into::into).collect())
     }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -16,7 +16,7 @@ use crates_io_test_db::TestDatabase;
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
-use reqwest::{blocking::Client, Proxy};
+use reqwest::{Client, Proxy};
 use std::collections::HashSet;
 use std::{rc::Rc, sync::Arc, time::Duration};
 


### PR DESCRIPTION
This is roughly similar to #7475 and converts our `GitHubClient` implementations to use async functions and an async `reqwest` client instead.

This unfortunately requires us to sprinkle a few `Handle::current().block_on(...)` calls across the codebase due to the usage of these functions within `conduit_compat()` (aka. `spawn_blocking()`) calls. I've tested this out on our staging environment and it looked like everything still works as intended. If anyone knows a reason why we should us `block_on()` like that please do let me know! 😅 