### PR TITLE
tests/util: Use `oneshot()` for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -962,7 +962,6 @@ dependencies = [
  "toml 0.8.8",
  "tower",
  "tower-http",
- "tower-service",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,6 @@ claims = "=0.7.1"
 hyper-tls = "=0.5.0"
 insta = { version = "=1.34.0", features = ["json", "redactions"] }
 tokio = "=1.33.0"
-tower-service = "=0.3.2"
 
 [build-dependencies]
 diesel = { version = "=2.1.3", features = ["postgres"] }


### PR DESCRIPTION
This appears to be the recommended way of testing axum applications (see https://github.com/tokio-rs/axum/blob/axum-v0.6.20/examples/testing/src/main.rs#L77), and it allows us to drop the explicit `tower-service` dependency.