### PR TITLE
tests/github_secret_scanning: Use snapshot assertions

### DIFF
--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_revoked_token.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_revoked_token.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: response.into_json()
+---
+[
+  {
+    "label": "true_positive",
+    "token_raw": "some_token",
+    "token_type": "some_type"
+  }
+]

--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_unknown_token.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_unknown_token.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: response.into_json()
+---
+[
+  {
+    "label": "false_positive",
+    "token_raw": "some_token",
+    "token_type": "some_type"
+  }
+]

--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: response.into_json()
+---
+[
+  {
+    "label": "true_positive",
+    "token_raw": "some_token",
+    "token_type": "some_type"
+  }
+]


### PR DESCRIPTION
This ensures that `GitHubSecretAlertFeedbackLabel` serializes correctly, and that the response does not contain any unexpected other fields.