### PR TITLE
Use `googletest` crate for assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "flate2",
  "futures-channel",
  "futures-util",
+ "googletest",
  "hex",
  "http",
  "http-body",
@@ -1724,6 +1725,28 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "googletest"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09213705c85aa0e4b4fff44a3a826a556979a34a266df6bcda703a49c69fb61e"
+dependencies = [
+ "googletest_macro",
+ "num-traits",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
+name = "googletest_macro"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005e4cb962c56efd249bdeeb4ac232b11e1c45a2e49793bba2b2982dcc3f2e9d"
+dependencies = [
+ "quote",
+ "syn 2.0.39",
+]
 
 [[package]]
 name = "group"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ crates_io_index = { path = "crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates_io_tarball", features = ["builder"] }
 crates_io_test_db = { path = "crates_io_test_db" }
 claims = "=0.7.1"
+googletest = "=0.10.0"
 hyper-tls = "=0.5.0"
 insta = { version = "=1.34.0", features = ["json", "redactions"] }
 tokio = "=1.34.0"


### PR DESCRIPTION
This allows us:

- to write tests with non-fatal assertions (e.g. when unit testing a function multiple times in the same test with different inputs)
- see better failure output including the expression that was tested and a diff between the actual and expected value
- reduce the confusion of what side of `assert_eq!()` is the actual and expected value
- implement custom matchers to improve assertion expressiveness (e.g. for `assert_that!(response.status(), is_success())` it will show the actual status code instead of a boolean value)

see https://github.com/google/googletest-rust
