### PR TITLE
tests/util/chaosproxy: Simplify `spawn()` call

### DIFF
--- a/src/tests/util/chaosproxy.rs
+++ b/src/tests/util/chaosproxy.rs
@@ -111,7 +111,7 @@ impl ChaosProxy {
             .into_split();
 
         let self_clone = self.clone();
-        self.runtime.spawn(async move {
+        tokio::spawn(async move {
             if let Err(err) = self_clone.proxy_data(client_read, backend_write).await {
                 eprintln!("ChaosProxy connection error: {err}");
             }


### PR DESCRIPTION
`tokio::spawn()` will automatically find the parent runtime, so there is no need to refer to it directly