### PR TITLE
Reduce `OkBool` usage in tests

### DIFF
--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -1,8 +1,9 @@
 use crate::builders::CrateBuilder;
+use crate::new_user;
 use crate::util::{RequestHelper, TestApp};
-use crate::{new_user, OkBool};
 use crates_io::schema::crate_owners;
 use diesel::prelude::*;
+use http::StatusCode;
 
 #[derive(Serialize)]
 struct EmailNotificationsUpdate {
@@ -11,9 +12,10 @@ struct EmailNotificationsUpdate {
 }
 
 impl crate::util::MockCookieUser {
-    fn update_email_notifications(&self, updates: Vec<EmailNotificationsUpdate>) -> OkBool {
-        self.put("/api/v1/me/email_notifications", json!(updates).to_string())
-            .good()
+    fn update_email_notifications(&self, updates: Vec<EmailNotificationsUpdate>) {
+        let response = self.put::<()>("/api/v1/me/email_notifications", json!(updates).to_string());
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.into_json(), json!({ "ok": true }));
     }
 }
 

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -1,12 +1,11 @@
 use crate::util::{RequestHelper, Response, TestApp};
-use crate::OkBool;
 use http::StatusCode;
 
 pub trait MockEmailHelper: RequestHelper {
     // TODO: I don't like the name of this method or `update_email` on the `MockCookieUser` impl;
     // this is starting to look like a builder might help?
     // I want to explore alternative abstractions in any case.
-    fn update_email_more_control(&self, user_id: i32, email: Option<&str>) -> Response<OkBool> {
+    fn update_email_more_control(&self, user_id: i32, email: Option<&str>) -> Response<()> {
         // When updating your email in crates.io, the request goes to the user route with PUT.
         // Ember sends all the user attributes. We check to make sure the ID in the URL matches
         // the ID of the currently logged in user, then we ignore everything but the email address.
@@ -27,9 +26,11 @@ impl MockEmailHelper for crate::util::MockCookieUser {}
 impl MockEmailHelper for crate::util::MockAnonymousUser {}
 
 impl crate::util::MockCookieUser {
-    pub fn update_email(&self, email: &str) -> OkBool {
+    pub fn update_email(&self, email: &str) {
         let model = self.as_model();
-        self.update_email_more_control(model.id, Some(email)).good()
+        let response = self.update_email_more_control(model.id, Some(email));
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.into_json(), json!({ "ok": true }));
     }
 }
 

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,16 +1,19 @@
 use crate::{
     new_user,
     util::{MockCookieUser, RequestHelper},
-    OkBool, TestApp,
+    TestApp,
 };
 use crates_io::models::{Email, NewUser, User};
 use diesel::prelude::*;
+use http::StatusCode;
 use secrecy::ExposeSecret;
 
 impl crate::util::MockCookieUser {
-    fn confirm_email(&self, email_token: &str) -> OkBool {
+    fn confirm_email(&self, email_token: &str) {
         let url = format!("/api/v1/confirm/{email_token}");
-        self.put(&url, &[] as &[u8]).good()
+        let response = self.put::<()>(&url, &[] as &[u8]);
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.into_json(), json!({ "ok": true }));
     }
 }
 


### PR DESCRIPTION
Testing against `json!()` is easier and ensures that the response does not contain any other unexpected JSON fields.