### PR TITLE
tracing: Disable colored log output on Heroku

### DIFF
--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,3 +1,4 @@
+use crates_io_env_vars::var;
 use sentry::integrations::tracing::EventFilter;
 use tracing::Level;
 use tracing::Metadata;
@@ -17,12 +18,15 @@ pub fn init() {
 }
 
 fn init_with_default_level(level: LevelFilter) {
+    let is_heroku = matches!(var("HEROKU"), Ok(Some(_)));
+
     let env_filter = EnvFilter::builder()
         .with_default_directive(level.into())
         .from_env_lossy();
 
     let log_layer = tracing_subscriber::fmt::layer()
         .compact()
+        .with_ansi(!is_heroku)
         .without_time()
         .with_filter(env_filter);
 


### PR DESCRIPTION
Having ANSI escape sequences sprinkled across the log lines helps the readability on Papertrail, but Datadog does not support them and displays them as their regular characters which makes the logs hard to read and parse. This commit disables the color support when run on Heroku to address that issue.

This might also cause a small decrease in our log volume due to the escape characters no longer counting against it.