### PR TITLE
googletest: Extract `is_success()` and `is_redirection()` matchers for `StatusCode`

### DIFF
--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -1,13 +1,16 @@
 use crate::builders::CrateBuilder;
+use crate::util::matchers::is_redirection;
 use crate::util::ChaosProxy;
 use anyhow::{Context, Error};
 use crates_io::models::{NewUser, User};
 use crates_io_test_db::TestDatabase;
 use diesel::prelude::*;
+use googletest::prelude::*;
 use reqwest::blocking::{Client, Response};
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Child, Command, Stdio};
+use std::result::Result;
 use std::sync::{mpsc::Sender, Arc};
 use std::time::Duration;
 use url::Url;
@@ -25,7 +28,7 @@ fn normal_startup() {
     let resp = running_server
         .get("api/v1/crates/FOO/1.0.0/download")
         .unwrap();
-    assert!(resp.status().is_redirection());
+    assert_that!(resp.status(), is_redirection());
     assert!(resp
         .headers()
         .get("location")
@@ -52,7 +55,7 @@ fn startup_without_database() {
     let resp = running_server
         .get("api/v1/crates/FOO/1.0.0/download")
         .unwrap();
-    assert!(resp.status().is_redirection());
+    assert_that!(resp.status(), is_redirection());
     assert!(resp
         .headers()
         .get("location")

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -43,6 +43,7 @@ use tower::ServiceExt;
 mod chaosproxy;
 mod github;
 pub mod insta;
+pub mod matchers;
 mod mock_request;
 mod response;
 mod test_app;

--- a/src/tests/util/matchers.rs
+++ b/src/tests/util/matchers.rs
@@ -1,0 +1,44 @@
+use googletest::matcher::{Matcher, MatcherResult};
+use http::StatusCode;
+
+pub fn is_success() -> SuccessMatcher {
+    SuccessMatcher
+}
+
+pub struct SuccessMatcher;
+
+impl Matcher for SuccessMatcher {
+    type ActualT = StatusCode;
+
+    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+        actual.is_success().into()
+    }
+
+    fn describe(&self, matcher_result: MatcherResult) -> String {
+        match matcher_result {
+            MatcherResult::Match => "is a success status code (200-299)".into(),
+            MatcherResult::NoMatch => "isn't a success status code (200-299)".into(),
+        }
+    }
+}
+
+pub fn is_redirection() -> RedirectionMatcher {
+    RedirectionMatcher
+}
+
+pub struct RedirectionMatcher;
+
+impl Matcher for RedirectionMatcher {
+    type ActualT = StatusCode;
+
+    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
+        actual.is_redirection().into()
+    }
+
+    fn describe(&self, matcher_result: MatcherResult) -> String {
+        match matcher_result {
+            MatcherResult::Match => "is a redirection status code (300-399)".into(),
+            MatcherResult::NoMatch => "isn't a redirection status code (300-399)".into(),
+        }
+    }
+}

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -1,3 +1,5 @@
+use crate::util::matchers::is_success;
+use googletest::prelude::*;
 use serde_json::Value;
 use std::marker::PhantomData;
 use std::ops::Deref;
@@ -19,9 +21,7 @@ where
     /// Assert that the response is good and deserialize the message
     #[track_caller]
     pub fn good(self) -> T {
-        if !self.status().is_success() {
-            panic!("bad response: {:?}", self.status());
-        }
+        assert_that!(self.status(), is_success());
         json(self.response)
     }
 }


### PR DESCRIPTION
Before:

```
assertion failed: resp.status().is_redirection()
```

After:

```
Value of: resp.status()
Expected: is a redirection status code (300-399)
Actual: 200,
  which isn't a redirection status code (300-399)
  at src/tests/server_binary.rs:29:5
```