### PR TITLE
googletest: Use `starts/ends_with()` matchers

### DIFF
--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -29,13 +29,10 @@ fn normal_startup() {
         .get("api/v1/crates/FOO/1.0.0/download")
         .unwrap();
     assert_that!(resp.status(), is_redirection());
-    assert!(resp
-        .headers()
-        .get("location")
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .ends_with("/crates/foo/foo-1.0.0.crate"));
+
+    let location = assert_some!(resp.headers().get("location"));
+    let location = assert_ok!(location.to_str());
+    assert_that!(location, ends_with("/crates/foo/foo-1.0.0.crate"));
 }
 
 #[cfg(feature = "slow-tests")]
@@ -56,13 +53,10 @@ fn startup_without_database() {
         .get("api/v1/crates/FOO/1.0.0/download")
         .unwrap();
     assert_that!(resp.status(), is_redirection());
-    assert!(resp
-        .headers()
-        .get("location")
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .ends_with("/crates/FOO/FOO-1.0.0.crate"));
+
+    let location = assert_some!(resp.headers().get("location"));
+    let location = assert_ok!(location.to_str());
+    assert_that!(location, ends_with("/crates/FOO/FOO-1.0.0.crate"));
 }
 
 fn initialize_dummy_crate(conn: &mut PgConnection) {

--- a/src/tests/util/insta.rs
+++ b/src/tests/util/insta.rs
@@ -1,4 +1,5 @@
 pub use ::insta::*;
+use googletest::prelude::*;
 
 pub fn id_redaction(expected_id: i32) -> insta::internals::Redaction {
     insta::dynamic_redaction(move |value, _path| {
@@ -16,7 +17,7 @@ pub fn any_id_redaction() -> insta::internals::Redaction {
 
 pub fn api_token_redaction() -> insta::internals::Redaction {
     insta::dynamic_redaction(move |value, _path| {
-        assert!(assert_some!(value.as_str()).starts_with("cio"));
+        assert_that!(assert_some!(value.as_str()), starts_with("cio"));
         "[token]"
     })
 }

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -51,7 +51,7 @@ impl<T> Response<T> {
         let headers = self.response.headers();
         let location = assert_some!(headers.get(header::LOCATION));
         let location = assert_ok!(location.to_str());
-        assert!(location.ends_with(target));
+        assert_that!(location, ends_with(target));
         self
     }
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -74,7 +74,7 @@ impl<T> Response<T> {
         let expected_message_start = format!("{}. Please try again after ", action.error_message());
         let error: ErrorResponse = json(self.response);
         assert_eq!(error.errors.len(), 1);
-        assert!(error.errors[0].detail.starts_with(&expected_message_start));
+        assert_that!(error.errors[0].detail, starts_with(expected_message_start));
     }
 }
 

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -88,11 +88,12 @@ fn generate_secure_alphanumeric_string(len: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use googletest::prelude::*;
 
     #[test]
     fn test_generated_and_parse() {
         let token = PlainToken::generate();
-        assert!(token.expose_secret().starts_with(TOKEN_PREFIX));
+        assert_that!(token.expose_secret(), starts_with(TOKEN_PREFIX));
         assert_eq!(
             token.hashed().0.expose_secret(),
             Sha256::digest(token.expose_secret().as_bytes()).as_slice()


### PR DESCRIPTION
Before:

```
assertion failed: token.expose_secret().starts_with(TOKEN_PREFIX)
```

After:

```
Value of: token.expose_secret()
Expected: starts with prefix "cio"
Actual: "foodBDxOyQu1C7K64sFW4rEVm2BYUaqdnxQ",
  which does not start with "cio"
  at src/util/token.rs:96:9
```