### PR TITLE
Add CI system detection for requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "flate2",
  "futures-channel",
  "futures-util",
+ "github-meta",
  "googletest",
  "hex",
  "http",
@@ -1718,6 +1719,16 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "url",
+]
+
+[[package]]
+name = "github-meta"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0b46f370a709ba4324525925d7ad7d44765f82652cb3616c2634fee4752813"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ dotenvy = "=0.15.7"
 flate2 = "=1.0.28"
 futures-channel = { version = "=0.3.29", default-features = false }
 futures-util = "=0.3.29"
+github-meta = "=0.4.0"
 hex = "=0.4.3"
 http = "=0.2.10"
 http-body = "=0.4.5"

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -1,0 +1,60 @@
+use crate::middleware::real_ip::RealIp;
+use async_trait::async_trait;
+use axum::extract::FromRequestParts;
+use http::request::Parts;
+use ipnetwork::IpNetwork;
+use once_cell::sync::Lazy;
+use std::fmt::Display;
+use std::net::IpAddr;
+
+#[derive(Copy, Clone, Debug)]
+pub enum CiService {
+    GitHubActions,
+}
+
+impl Display for CiService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CiService::GitHubActions => write!(f, "GitHub Actions"),
+        }
+    }
+}
+
+#[async_trait]
+impl<S> FromRequestParts<S> for CiService {
+    type Rejection = ();
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let real_ip = parts.extensions.get::<RealIp>().ok_or(())?;
+
+        if is_github_actions_ip(real_ip) {
+            return Ok(CiService::GitHubActions);
+        }
+
+        Err(())
+    }
+}
+
+fn is_github_actions_ip(ip: &IpAddr) -> bool {
+    static GITHUB_ACTIONS_CIDRS: Lazy<Vec<IpNetwork>> = Lazy::new(|| {
+        github_meta::META
+            .actions
+            .iter()
+            .filter_map(|cidr| parse_cidr(cidr, "GitHub Actions"))
+            .collect()
+    });
+
+    GITHUB_ACTIONS_CIDRS
+        .iter()
+        .any(|trusted_proxy| trusted_proxy.contains(*ip))
+}
+
+fn parse_cidr(cidr: &str, service: &'static str) -> Option<IpNetwork> {
+    match cidr.parse() {
+        Ok(ip_network) => Some(ip_network),
+        Err(error) => {
+            warn!(%cidr, %error, "Failed to parse {service} CIDR");
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub mod admin;
 mod app;
 pub mod auth;
 pub mod boot;
+pub mod ci;
 pub mod cloudfront;
 pub mod config;
 pub mod controllers;

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -1,6 +1,7 @@
 //! Log all requests in a format similar to Heroku's router, but with additional
 //! information that we care about like User-Agent
 
+use crate::ci::CiService;
 use crate::controllers::util::RequestPartsExt;
 use crate::headers::XRequestId;
 use crate::middleware::normalize_path::OriginalPath;
@@ -32,6 +33,7 @@ pub struct RequestMetadata {
     real_ip: Extension<RealIp>,
     user_agent: TypedHeader<UserAgent>,
     request_id: Option<TypedHeader<XRequestId>>,
+    ci_service: Option<CiService>,
 }
 
 pub struct Metadata<'a> {
@@ -87,6 +89,10 @@ impl Display for Metadata<'_> {
 
         if self.request.original_path.is_some() {
             line.add_quoted_field("normalized_path", &self.request.uri)?;
+        }
+
+        if let Some(ci_service) = self.request.ci_service {
+            line.add_quoted_field("ci", ci_service)?;
         }
 
         let metadata = self.custom_metadata.lock();


### PR DESCRIPTION
Knowing if a request to our package registry came from a CI system or not can be useful in various ways. The immediate interest for us at the moment is telemetry, to be able to what percentage of downloads comes from known public CI systems.

This PR uses the public GitHub Actions CIDR list from https://github.com/Turbo87/github-meta and compares it to the value of the `RealIp` detection extension. If a match is found `ci="GitHub Actions"` is added to the logs.

This is currently focussed on GitHub Actions, but the design is flexible enough to add other CI providers as well.