### PR TITLE
CI: Update `PERCY_TOKEN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,7 @@ jobs:
 
       # Percy secrets are included here to enable Percy's GitHub integration
       # on community-submitted PRs
-      PERCY_TOKEN: 0d8707a02b19aebbec79bb0bf302b8d2fa95edb33169cfe41b084289596670b1
-      PERCY_PROJECT: crates-io/crates.io
+      PERCY_TOKEN: web_0a783d8086b6f996809f3e751d032dd6d156782082bcd1423b9b860113c75054
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
This is a weird situation... we used to be part of the BrowserStack open-source program, but cancelled it back then because we were not using it. Then Percy got bought by BrowserStack, and when the free tier of Percy was exceeded we asked the Rust Foundation to pay for more credits. Which they did. And now BrowserStack (the "new" owner of Percy) wants to ramp up the cost by 4x. While we could apparently just go back to the BrowserStack open-source program, which is free and has unlimited Percy credits?!?

Anyway, I've applied us for the open-source program again and this PR is updating our `PERCY_TOKEN`. According to the docs the `PERCY_PROJECT` isn't needed anymore, but we'll see if that's true or not... :D