### PR TITLE
crate-header: correctly pluralise the number of crate versions

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -54,7 +54,7 @@
   </nav.Tab>
 
   <nav.Tab @link={{link "crate.versions" @crate}} data-test-versions-tab>
-    {{@crate.versions.length}} Versions
+    {{pluralize @crate.versions.length "Version"}}
   </nav.Tab>
 
   <nav.Tab


### PR DESCRIPTION
Obviously I'm focusing on the important things today.