### PR TITLE
Disable non-canonical downloads if `REJECT_NON_CANONICAL_DOWNLOADS` env var is set

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -50,6 +50,7 @@ pub struct Server {
     pub metrics_authorization_token: Option<String>,
     pub instance_metrics_log_every_seconds: Option<u64>,
     pub force_unconditional_redirects: bool,
+    pub reject_non_canonical_downloads: bool,
     pub blocked_routes: HashSet<String>,
     pub version_id_cache_size: u64,
     pub version_id_cache_ttl: Duration,
@@ -210,6 +211,7 @@ impl Server {
             metrics_authorization_token: var("METRICS_AUTHORIZATION_TOKEN")?,
             instance_metrics_log_every_seconds: var_parsed("INSTANCE_METRICS_LOG_EVERY_SECONDS")?,
             force_unconditional_redirects: var("FORCE_UNCONDITIONAL_REDIRECTS")?.is_some(),
+            reject_non_canonical_downloads: var("REJECT_NON_CANONICAL_DOWNLOADS")?.is_some(),
             blocked_routes: var("BLOCKED_ROUTES")?
                 .map(|routes| routes.split(',').map(|s| s.into()).collect())
                 .unwrap_or_default(),

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -40,7 +40,9 @@ pub fn assert_dl_count(
 
 #[test]
 fn download() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init()
+        .with_config(|config| config.reject_non_canonical_downloads = false)
+        .with_user();
     let user = user.as_model();
 
     app.db(|conn| {

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__download__rejected_non_canonical_download.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__download__rejected_non_canonical_download.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/crates/versions/download.rs
+expression: response.into_text()
+---
+Your request is for a version of the `foo-download` crate, but that crate is actually named `foo_download`. Support for "non-canonical" downloads has been deprecated and disabled. See https://blog.rust-lang.org/2023/10/27/crates-io-non-canonical-downloads.html for more detail.

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -9,7 +9,11 @@ const DB_HEALTHY_TIMEOUT: Duration = Duration::from_millis(2000);
 
 #[test]
 fn download_crate_with_broken_networking_primary_database() {
-    let (app, anon, _, owner) = TestApp::init().with_chaos_proxy().with_token();
+    let (app, anon, _, owner) = TestApp::init()
+        .with_config(|config| config.reject_non_canonical_downloads = false)
+        .with_chaos_proxy()
+        .with_token();
+
     app.db(|conn| {
         CrateBuilder::new("crate_name", owner.as_model().user_id)
             .version("1.0.0")

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -432,6 +432,7 @@ fn simple_config() -> config::Server {
         metrics_authorization_token: None,
         instance_metrics_log_every_seconds: None,
         force_unconditional_redirects: false,
+        reject_non_canonical_downloads: true,
         blocked_routes: HashSet::new(),
         version_id_cache_size: 10000,
         version_id_cache_ttl: Duration::from_secs(5 * 60),


### PR DESCRIPTION
see https://blog.rust-lang.org/2023/10/27/crates-io-non-canonical-downloads.html

This PR implements a feature flag that can be used to disable support for non-canonical downloads in our backend API. As the blog post mentions, next Monday we plan to disable support for them and roughly a month later we will remove the supporting code paths and the custom error message.