### PR TITLE
Better error message for invalid dep names

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -622,7 +622,7 @@ pub fn validate_dependency(dep: &EncodableCrateDependency) -> AppResult<()> {
     }
 
     if let Some(toml_name) = &dep.explicit_name_in_toml {
-        Crate::valid_dependency_name(toml_name).map_err(|error| cargo_err(&error))?;
+        Crate::validate_dependency_name(toml_name).map_err(|error| cargo_err(&error))?;
     }
 
     Ok(())

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -16,7 +16,7 @@ use tokio::runtime::Handle;
 use url::Url;
 
 use crate::controllers::cargo_prelude::*;
-use crate::models::krate::{InvalidDependencyName, MAX_NAME_LENGTH};
+use crate::models::krate::MAX_NAME_LENGTH;
 use crate::models::{
     insert_version_owner_action, Category, Crate, DependencyKind, Keyword, NewCrate, NewVersion,
     Rights, VersionAction,
@@ -622,9 +622,7 @@ pub fn validate_dependency(dep: &EncodableCrateDependency) -> AppResult<()> {
     }
 
     if let Some(toml_name) = &dep.explicit_name_in_toml {
-        if !Crate::valid_dependency_name(toml_name) {
-            return Err(cargo_err(&InvalidDependencyName(toml_name.into())));
-        }
+        Crate::valid_dependency_name(toml_name).map_err(|error| cargo_err(&error))?;
     }
 
     Ok(())

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -622,7 +622,7 @@ mod tests {
     }
 
     #[test]
-    fn valid_feature_names() {
+    fn validate_feature_names() {
         use super::InvalidDependencyName;
         use super::InvalidFeature;
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -206,18 +206,18 @@ impl Crate {
                 .unwrap_or(false)
     }
 
-    pub fn valid_dependency_name(name: &str) -> Result<(), InvalidDependencyName> {
+    pub fn validate_dependency_name(name: &str) -> Result<(), InvalidDependencyName> {
         if name.chars().count() > MAX_NAME_LENGTH {
             return Err(InvalidDependencyName::TooLong(name.into()));
         }
-        Crate::valid_dependency_ident(name)
+        Crate::validate_dependency_ident(name)
     }
 
     // Checks that the name is a valid dependency name.
     // 1. The name must be non-empty.
     // 2. The first character must be an ASCII character or `_`.
     // 3. The remaining characters must be ASCII alphanumerics or `-` or `_`.
-    fn valid_dependency_ident(name: &str) -> Result<(), InvalidDependencyName> {
+    fn validate_dependency_ident(name: &str) -> Result<(), InvalidDependencyName> {
         if name.is_empty() {
             return Err(InvalidDependencyName::Empty);
         }
@@ -271,10 +271,10 @@ impl Crate {
     pub fn validate_feature(name: &str) -> Result<(), InvalidFeature> {
         if let Some((dep, dep_feat)) = name.split_once('/') {
             let dep = dep.strip_suffix('?').unwrap_or(dep);
-            Crate::valid_dependency_name(dep)?;
+            Crate::validate_dependency_name(dep)?;
             Crate::validate_feature_name(dep_feat)
         } else if let Some((_, dep)) = name.split_once("dep:") {
-            Crate::valid_dependency_name(dep)?;
+            Crate::validate_dependency_name(dep)?;
             return Ok(());
         } else {
             Crate::validate_feature_name(name)
@@ -587,36 +587,36 @@ mod tests {
     }
 
     #[test]
-    fn valid_dependency_name() {
+    fn validate_dependency_name() {
         use super::{InvalidDependencyName, MAX_NAME_LENGTH};
 
-        assert_ok!(Crate::valid_dependency_name("foo"));
+        assert_ok!(Crate::validate_dependency_name("foo"));
         assert_err_eq!(
-            Crate::valid_dependency_name("京"),
+            Crate::validate_dependency_name("京"),
             InvalidDependencyName::Start('京', "京".into())
         );
         assert_err_eq!(
-            Crate::valid_dependency_name(""),
+            Crate::validate_dependency_name(""),
             InvalidDependencyName::Empty
         );
         assert_err_eq!(
-            Crate::valid_dependency_name("💝"),
+            Crate::validate_dependency_name("💝"),
             InvalidDependencyName::Start('💝', "💝".into())
         );
-        assert_ok!(Crate::valid_dependency_name("foo_underscore"));
-        assert_ok!(Crate::valid_dependency_name("foo-dash"));
+        assert_ok!(Crate::validate_dependency_name("foo_underscore"));
+        assert_ok!(Crate::validate_dependency_name("foo-dash"));
         assert_err_eq!(
-            Crate::valid_dependency_name("foo+plus"),
+            Crate::validate_dependency_name("foo+plus"),
             InvalidDependencyName::Char('+', "foo+plus".into())
         );
         // Starting with an underscore is a valid dependency name.
-        assert_ok!(Crate::valid_dependency_name("_foo"));
+        assert_ok!(Crate::validate_dependency_name("_foo"));
         assert_err_eq!(
-            Crate::valid_dependency_name("-foo"),
+            Crate::validate_dependency_name("-foo"),
             InvalidDependencyName::Start('-', "-foo".into())
         );
         assert_err_eq!(
-            Crate::valid_dependency_name("o".repeat(MAX_NAME_LENGTH + 1).as_str()),
+            Crate::validate_dependency_name("o".repeat(MAX_NAME_LENGTH + 1).as_str()),
             InvalidDependencyName::TooLong("o".repeat(MAX_NAME_LENGTH + 1).as_str().into())
         );
     }

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -207,17 +207,37 @@ impl Crate {
     }
 
     pub fn valid_dependency_name(name: &str) -> bool {
-        let under_max_length = name.chars().take(MAX_NAME_LENGTH + 1).count() <= MAX_NAME_LENGTH;
-        Crate::valid_dependency_ident(name) && under_max_length
+        if name.chars().count() > MAX_NAME_LENGTH {
+            return false;
+        }
+        Crate::valid_dependency_ident(name)
     }
 
+    // Checks that the name is a valid dependency name.
+    // 1. The name must be non-empty.
+    // 2. The first character must be an ASCII character or `_`.
+    // 3. The remaining characters must be ASCII alphanumerics or `-` or `_`.
     fn valid_dependency_ident(name: &str) -> bool {
-        Self::valid_feature_prefix(name)
-            && name
-                .chars()
-                .next()
-                .map(|n| n.is_alphabetic() || n == '_')
-                .unwrap_or(false)
+        if name.is_empty() {
+            return false;
+        }
+        let mut chars = name.chars();
+        if let Some(ch) = chars.next() {
+            if ch.is_ascii_digit() {
+                return false;
+            }
+            if !(ch.is_ascii_alphabetic() || ch == '_') {
+                return false;
+            }
+        }
+
+        for ch in chars {
+            if !(ch.is_ascii_alphanumeric() || ch == '-' || ch == '_') {
+                return false;
+            }
+        }
+
+        true
     }
 
     /// Validates the THIS parts of `features = ["THIS", "and/THIS", "dep:THIS", "dep?/THIS"]`.

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__empty_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__empty_dependency_name.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "dependency name cannot be empty"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name_contains_unicode_chars.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name_contains_unicode_chars.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid character `🦀` in dependency name: `foo-🦀-bar`, characters must be an ASCII alphanumeric characters, `-`, or `_`"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name_starts_with_digit.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name_starts_with_digit.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "the name `1-foo` cannot be used as a dependency name, the name cannot start with a digit"
+    }
+  ]
+}

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_rename.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"💩\" is an invalid dependency name (dependency names must start with a letter or underscore, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `💩` in dependency name: `💩`, the first character must be an ASCII character, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_too_long_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_too_long_dependency_name.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "the dependency name `fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` is too long (max 64 characters)"
+    }
+  ]
+}


### PR DESCRIPTION
Split from https://github.com/rust-lang/crates.io/pull/7379/files

This PR only enhanced the error message for invalid dep names. Nothing changed for the validation rules.

| category                    | Cargo                                                                                                   | crates.io before change                                                                                      | crates.io after change                                                                                 |
| --------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| Dep name                    | 1. cannot start with a number<br/>2. can only start with most letters or `_`<br/>3. can only contain numbers, `-`, `_`, or most letters. | 1. first character must be ASCII alphabetic or `_`<br/>2. can only contain ASCII numbers, letters, `-`, `_`         | 1. can only start with ASCII letters or `_`<br/>2. can only contain numbers, `-`, `_`, or ASCII letters. <br/>  **(Nothing changes)**       |
