### PR TITLE
Revert "Update dependency pnpm to v8.10.5"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
   # renovate: datasource=crate depName=diesel_cli versioning=semver
   DIESEL_CLI_VERSION: 2.1.1
   # renovate: datasource=npm depName=pnpm
-  PNPM_VERSION: 8.10.5
+  PNPM_VERSION: 8.10.4
 
 jobs:
   changed-files:

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -4,7 +4,7 @@ ARG NODE_VERSION=20.9.0
 FROM node:${NODE_VERSION}-alpine
 
 # renovate: datasource=npm depName=pnpm
-ARG PNPM_VERSION=8.10.5
+ARG PNPM_VERSION=8.10.4
 
 # Install `pnpm`
 RUN npm install --global pnpm@$PNPM_VERSION

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
   },
   "engines": {
     "node": "20.9.0",
-    "pnpm": "8.10.5"
+    "pnpm": "8.10.4"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Reverts rust-lang/crates.io#7535

```
=====> Detected Framework: crates.io
-----> jq v1.7 already installed
-----> Parsing pnpm version from `package.json` file
-----> Installing pnpm v8.10.5
curl: (22) The requested URL returned error: 401
pnpm version '8.10.5' could not be found
 !     Push rejected, failed to compile Multipack app.
 !     Push failed
```

It's not clear exactly why v8.10.5 is failing on Heroku, but it looks like the version is currently not available for download 🤷 