### PR TITLE
util/errors: Simplify error function arguments

### DIFF
--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -85,20 +85,20 @@ async fn verify_github_signature(
         .get("GITHUB-PUBLIC-KEY-IDENTIFIER")
         .ok_or_else(|| bad_request("missing HTTP header: GITHUB-PUBLIC-KEY-IDENTIFIER"))?
         .to_str()
-        .map_err(|e| bad_request(&format!("failed to decode HTTP header: {e:?}")))?;
+        .map_err(|e| bad_request(format!("failed to decode HTTP header: {e:?}")))?;
 
     let sig = headers
         .get("GITHUB-PUBLIC-KEY-SIGNATURE")
         .ok_or_else(|| bad_request("missing HTTP header: GITHUB-PUBLIC-KEY-SIGNATURE"))?;
     let sig = general_purpose::STANDARD
         .decode(sig)
-        .map_err(|e| bad_request(&format!("failed to decode signature as base64: {e:?}")))?;
+        .map_err(|e| bad_request(format!("failed to decode signature as base64: {e:?}")))?;
     let sig = p256::ecdsa::Signature::from_der(&sig)
-        .map_err(|e| bad_request(&format!("failed to parse signature from ASN.1 DER: {e:?}")))?;
+        .map_err(|e| bad_request(format!("failed to parse signature from ASN.1 DER: {e:?}")))?;
 
     let public_keys = get_public_keys(state)
         .await
-        .map_err(|e| bad_request(&format!("failed to fetch GitHub public keys: {e:?}")))?;
+        .map_err(|e| bad_request(format!("failed to fetch GitHub public keys: {e:?}")))?;
 
     let key = public_keys
         .iter()
@@ -118,7 +118,7 @@ async fn verify_github_signature(
 
     VerifyingKey::from(public_key)
         .verify(json, &sig)
-        .map_err(|e| bad_request(&format!("invalid signature: {e:?}")))?;
+        .map_err(|e| bad_request(format!("invalid signature: {e:?}")))?;
 
     debug!(
         key_id = %key.key_identifier,
@@ -224,10 +224,10 @@ pub async fn verify(
 ) -> AppResult<Json<Vec<GitHubSecretAlertFeedback>>> {
     verify_github_signature(&headers, &state, &body)
         .await
-        .map_err(|e| bad_request(&format!("failed to verify request signature: {e:?}")))?;
+        .map_err(|e| bad_request(format!("failed to verify request signature: {e:?}")))?;
 
     let alerts: Vec<GitHubSecretAlert> = json::from_slice(&body)
-        .map_err(|e| bad_request(&format!("invalid secret alert request: {e:?}")))?;
+        .map_err(|e| bad_request(format!("invalid secret alert request: {e:?}")))?;
 
     conduit_compat(move || {
         let feedback = alerts

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -85,9 +85,9 @@ impl PaginationOptionsBuilder {
 
         let page = if let Some(s) = page_param {
             if self.enable_pages {
-                let numeric_page = s.parse().map_err(|e| bad_request(&e))?;
+                let numeric_page = s.parse().map_err(bad_request)?;
                 if numeric_page < 1 {
-                    return Err(bad_request(&format_args!(
+                    return Err(bad_request(format_args!(
                         "page indexing starts from 1, page {numeric_page} is invalid",
                     )));
                 }
@@ -123,10 +123,10 @@ impl PaginationOptionsBuilder {
 
         let per_page = params
             .get("per_page")
-            .map(|s| s.parse().map_err(|e| bad_request(&e)))
+            .map(|s| s.parse().map_err(bad_request))
             .unwrap_or(Ok(DEFAULT_PER_PAGE))?;
         if per_page > MAX_PER_PAGE {
-            return Err(bad_request(&format_args!(
+            return Err(bad_request(format_args!(
                 "cannot request more than {MAX_PER_PAGE} items",
             )));
         }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -133,7 +133,7 @@ fn modify_owners(
                 let login_test =
                     |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
                 if owners.iter().any(login_test) {
-                    return Err(cargo_err(&format_args!("`{login}` is already an owner")));
+                    return Err(cargo_err(format_args!("`{login}` is already an owner")));
                 }
                 let msg = krate.owner_add(app, conn, user, login)?;
                 msgs.push(msg);

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -84,7 +84,7 @@ pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
         }
 
         let new: NewApiTokenRequest = json::from_slice(req.body())
-            .map_err(|e| bad_request(&format!("invalid new token request: {e:?}")))?;
+            .map_err(|e| bad_request(format!("invalid new token request: {e:?}")))?;
 
         let name = &new.api_token.name;
         if name.is_empty() {

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -184,7 +184,7 @@ pub async fn downloads(
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         if semver::Version::parse(&version).is_err() {
-            return Err(cargo_err(&format_args!("invalid semver: {version}")));
+            return Err(cargo_err(format_args!("invalid semver: {version}")));
         }
 
         let conn = &mut *app.db_read()?;

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -24,7 +24,7 @@ pub async fn dependencies(
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         if semver::Version::parse(&version).is_err() {
-            return Err(cargo_err(&format_args!("invalid semver: {version}")));
+            return Err(cargo_err(format_args!("invalid semver: {version}")));
         }
 
         let conn = &mut state.db_read()?;
@@ -61,7 +61,7 @@ pub async fn show(
 ) -> AppResult<Json<Value>> {
     conduit_compat(move || {
         if semver::Version::parse(&version).is_err() {
-            return Err(cargo_err(&format_args!("invalid semver: {version}")));
+            return Err(cargo_err(format_args!("invalid semver: {version}")));
         }
 
         let conn = &mut state.db_read()?;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -49,7 +49,7 @@ fn modify_yank(
     // lifetime issues with `req`.
 
     if semver::Version::parse(version).is_err() {
-        return Err(cargo_err(&format_args!("invalid semver: {version}")));
+        return Err(cargo_err(format_args!("invalid semver: {version}")));
     }
 
     let conn = &mut *state.db_write()?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -185,7 +185,7 @@ impl Crate {
             .filter(versions::num.eq(version))
             .first(conn)
             .map_err(|_| {
-                cargo_err(&format_args!(
+                cargo_err(format_args!(
                     "crate `{}` does not have a version `{}`",
                     self.name, version
                 ))

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -77,7 +77,7 @@ impl Owner {
                 .order(users::gh_id.desc())
                 .first(conn)
                 .map(Owner::User)
-                .map_err(|_| cargo_err(&format_args!("could not find user with login `{name}`")))
+                .map_err(|_| cargo_err(format_args!("could not find user with login `{name}`")))
         }
     }
 
@@ -93,7 +93,7 @@ impl Owner {
                 .filter(lower(teams::login).eq(&name.to_lowercase()))
                 .first(conn)
                 .map(Owner::Team)
-                .map_err(|_| cargo_err(&format_args!("could not find team with login `{name}`")))
+                .map_err(|_| cargo_err(format_args!("could not find team with login `{name}`")))
         } else {
             users::table
                 .filter(lower(users::gh_login).eq(name.to_lowercase()))
@@ -101,7 +101,7 @@ impl Owner {
                 .order(users::gh_id.desc())
                 .first(conn)
                 .map(Owner::User)
-                .map_err(|_| cargo_err(&format_args!("could not find user with login `{name}`")))
+                .map_err(|_| cargo_err(format_args!("could not find user with login `{name}`")))
         }
     }
 

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -131,7 +131,7 @@ impl Team {
         }
 
         if let Some(c) = org_name.chars().find(|c| !is_allowed_char(*c)) {
-            return Err(cargo_err(&format_args!(
+            return Err(cargo_err(format_args!(
                 "organization cannot contain special \
                  characters like {c}"
             )));
@@ -141,7 +141,7 @@ impl Team {
         let team = Handle::current()
             .block_on(app.github.team_by_name(org_name, team_name, &token))
             .map_err(|_| {
-                cargo_err(&format_args!(
+                cargo_err(format_args!(
                     "could not find the github team {org_name}/{team_name}"
                 ))
             })?;

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -168,7 +168,7 @@ impl NewVersion {
                 .filter(split_part(versions::num, "+", 1).eq(num_no_build));
 
             if select(exists(already_uploaded)).get_result(conn)? {
-                return Err(cargo_err(&format_args!(
+                return Err(cargo_err(format_args!(
                     "crate version `{}` is already uploaded",
                     num_no_build
                 )));

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -77,7 +77,7 @@ pub fn server_error<S: ToString>(error: S) -> BoxedAppError {
 }
 
 /// Returns an error with status 503 and the provided description as JSON
-pub fn service_unavailable<S: ToString + ?Sized>(error: &S) -> BoxedAppError {
+pub fn service_unavailable<S: ToString>(error: S) -> BoxedAppError {
     Box::new(json::ServiceUnavailable(error.to_string()))
 }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -52,7 +52,7 @@ pub fn cargo_err<S: ToString>(error: S) -> BoxedAppError {
 // non-200 response codes for its stores to work properly.
 
 /// Return an error with status 400 and the provided description as JSON
-pub fn bad_request<S: ToString + ?Sized>(error: &S) -> BoxedAppError {
+pub fn bad_request<S: ToString>(error: S) -> BoxedAppError {
     Box::new(json::BadRequest(error.to_string()))
 }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -72,7 +72,7 @@ pub fn not_found() -> BoxedAppError {
 }
 
 /// Returns an error with status 500 and the provided description as JSON
-pub fn server_error<S: ToString + ?Sized>(error: &S) -> BoxedAppError {
+pub fn server_error<S: ToString>(error: S) -> BoxedAppError {
     Box::new(json::ServerError(error.to_string()))
 }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -42,7 +42,7 @@ pub type BoxedAppError = Box<dyn AppError>;
 /// This is for backwards compatibility with cargo endpoints.  For all other
 /// endpoints, use helpers like `bad_request` or `server_error` which set a
 /// correct status code.
-pub fn cargo_err<S: ToString + ?Sized>(error: &S) -> BoxedAppError {
+pub fn cargo_err<S: ToString>(error: S) -> BoxedAppError {
     Box::new(json::Ok(error.to_string()))
 }
 


### PR DESCRIPTION
There is no need for us to accept `impl &ToString` if we can accept `impl ToString` directly. This allow us to make calling these functions a little more straight-forward :)