### PR TITLE
Add blog post link to `max_features` error messages

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -231,9 +231,13 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         if num_features > max_features {
             return Err(cargo_err(format!(
                 "crates.io only allows a maximum number of {max_features} \
-                features, but your crate is declaring {num_features} features. \
-                If you have a valid use case needing more features, please \
-                send us an email to help@crates.io to discuss the details."
+                features, but your crate is declaring {num_features} features.\n\
+                \n\
+                Take a look at https://blog.rust-lang.org/2023/10/26/broken-badges-and-23k-keywords.html \
+                to understand why this restriction was introduced.\n\
+                \n\
+                If you have a use case that requires an increase of this limit, \
+                please send us an email to help@crates.io to discuss the details."
             )));
         }
 
@@ -246,9 +250,13 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                     "crates.io only allows a maximum number of {max_features} \
                     features or dependencies that another feature can enable, \
                     but the \"{key}\" feature of your crate is enabling \
-                    {num_features} features or dependencies. If you have a \
-                    valid use case needing to increase this limit, please send \
-                    us an email to help@crates.io to discuss the details."
+                    {num_features} features or dependencies.\n\
+                    \n\
+                    Take a look at https://blog.rust-lang.org/2023/10/26/broken-badges-and-23k-keywords.html \
+                    to understand why this restriction was introduced.\n\
+                    \n\
+                    If you have a use case that requires an increase of this limit, \
+                    please send us an email to help@crates.io to discuss the details."
                 )));
             }
 

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_enabled_features.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_enabled_features.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "crates.io only allows a maximum number of 3 features or dependencies that another feature can enable, but the \"default\" feature of your crate is enabling 5 features or dependencies. If you have a valid use case needing to increase this limit, please send us an email to help@crates.io to discuss the details."
+      "detail": "crates.io only allows a maximum number of 3 features or dependencies that another feature can enable, but the \"default\" feature of your crate is enabling 5 features or dependencies.\n\nTake a look at https://blog.rust-lang.org/2023/10/26/broken-badges-and-23k-keywords.html to understand why this restriction was introduced.\n\nIf you have a use case that requires an increase of this limit, please send us an email to help@crates.io to discuss the details."
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_enabled_features_with_custom_limit.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_enabled_features_with_custom_limit.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "crates.io only allows a maximum number of 4 features or dependencies that another feature can enable, but the \"default\" feature of your crate is enabling 5 features or dependencies. If you have a valid use case needing to increase this limit, please send us an email to help@crates.io to discuss the details."
+      "detail": "crates.io only allows a maximum number of 4 features or dependencies that another feature can enable, but the \"default\" feature of your crate is enabling 5 features or dependencies.\n\nTake a look at https://blog.rust-lang.org/2023/10/26/broken-badges-and-23k-keywords.html to understand why this restriction was introduced.\n\nIf you have a use case that requires an increase of this limit, please send us an email to help@crates.io to discuss the details."
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_features.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_features.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "crates.io only allows a maximum number of 3 features, but your crate is declaring 5 features. If you have a valid use case needing more features, please send us an email to help@crates.io to discuss the details."
+      "detail": "crates.io only allows a maximum number of 3 features, but your crate is declaring 5 features.\n\nTake a look at https://blog.rust-lang.org/2023/10/26/broken-badges-and-23k-keywords.html to understand why this restriction was introduced.\n\nIf you have a use case that requires an increase of this limit, please send us an email to help@crates.io to discuss the details."
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_features_with_custom_limit.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__features__too_many_features_with_custom_limit.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "crates.io only allows a maximum number of 4 features, but your crate is declaring 5 features. If you have a valid use case needing more features, please send us an email to help@crates.io to discuss the details."
+      "detail": "crates.io only allows a maximum number of 4 features, but your crate is declaring 5 features.\n\nTake a look at https://blog.rust-lang.org/2023/10/26/broken-badges-and-23k-keywords.html to understand why this restriction was introduced.\n\nIf you have a use case that requires an increase of this limit, please send us an email to help@crates.io to discuss the details."
     }
   ]
 }


### PR DESCRIPTION
Most people contacting us about the `max_features` restriction apparently did not see or read the blog post yet that explains the introduction of the limit. Adding the URL to the blog post should give people more context before they send that email to help@crates.io.