### PR TITLE
Rearchitect `swirl::Runner` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -976,7 +976,6 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "threadpool",
  "tikv-jemallocator",
  "tokio",
  "toml 0.8.8",
@@ -3912,15 +3911,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,6 @@ spdx = "=0.10.2"
 tar = "=0.4.40"
 tempfile = "=3.8.1"
 thiserror = "=1.0.50"
-threadpool = "=1.8.1"
 tokio = { version = "=1.34.0", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros"]}
 toml = "=0.8.8"
 tower = "=0.4.13"

--- a/src/worker/swirl/errors.rs
+++ b/src/worker/swirl/errors.rs
@@ -1,6 +1,4 @@
-use crate::db::PoolError;
 use diesel::result::Error as DieselError;
-use std::sync::mpsc::RecvTimeoutError;
 
 /// An error occurred queueing the job
 #[derive(Debug, thiserror::Error)]
@@ -13,25 +11,4 @@ pub enum EnqueueError {
     /// An error occurred inserting the job into the database
     #[error(transparent)]
     DatabaseError(#[from] DieselError),
-}
-
-/// An error occurred while attempting to fetch jobs from the queue
-#[derive(Debug, thiserror::Error)]
-pub enum FetchError {
-    /// We could not acquire a database connection from the pool.
-    ///
-    /// Either the connection pool is too small, or new connections cannot be
-    /// established.
-    #[error("Timed out acquiring a database connection. Try increasing the connection pool size.")]
-    NoDatabaseConnection(#[source] PoolError),
-
-    /// Could not execute the query to load a job from the database.
-    #[error("An error occurred loading a job from the database.")]
-    FailedLoadingJob(#[source] DieselError),
-
-    /// No message was received from the worker thread.
-    ///
-    /// Either the thread pool is too small, or jobs have hung indefinitely
-    #[error("No message was received from the worker thread. Try increasing the thread pool size or timeout period.")]
-    NoMessageReceived(#[from] RecvTimeoutError),
 }


### PR DESCRIPTION
Instead of calling `run_all_pending_jobs()` in a loop, which then fills up the `threadpool` to its maximum capacity, we now call `start()`, which starts up `num_workers` background worker threads and then `wait_for_shutdown()` can be used to wait for the worker threads to finish. In normal operation these thread should not finish on their own. In testing mode, when `shutdown_when_queue_empty()` has been used, the worker threads will shutdown once they can't find any pending jobs in the queue anymore.

This change also removes the `Event` enum and the related channel code, since the new implementation does not require communication between the workers and the runner anymore.

Rearchitecting the runner like this should make it a bit easier to replace our usage of threads with tokio tasks in the future.

And sorry, I couldn't figure out how to make the diff easier to digest... 😞
