### PR TITLE
worker/swirl Rename `environment` to `context`

### DIFF
--- a/src/worker/swirl/background_job.rs
+++ b/src/worker/swirl/background_job.rs
@@ -20,7 +20,7 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + 'static {
     type Context: Clone + Send + 'static;
 
     /// Execute the task. This method should define its logic
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()>;
+    fn run(&self, ctx: &Self::Context) -> anyhow::Result<()>;
 
     fn enqueue(&self, conn: &mut PgConnection) -> Result<i64, EnqueueError> {
         self.enqueue_with_priority(conn, Self::PRIORITY)


### PR DESCRIPTION
Most types are already using the term `Context` and with this PR the struct fields and function arguments are also renamed to follow this convention.