### PR TITLE
worker/environment: Replace six-argument constructor with builder pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,7 @@ dependencies = [
  "crates_io_test_db",
  "crossbeam-channel",
  "dashmap",
+ "derive_builder",
  "derive_deref",
  "dialoguer",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ clap = { version = "=4.4.8", features = ["derive", "env", "unicode", "wrap_help"
 cookie = { version = "=0.17.0", features = ["secure"] }
 crossbeam-channel = "=0.5.8"
 dashmap = { version = "=5.5.3", features = ["raw-api"] }
+derive_builder = "=0.12.0"
 derive_deref = "=1.1.1"
 dialoguer = "=0.11.0"
 diesel = { version = "=2.1.4", features = ["postgres", "serde_json", "chrono", "r2d2", "numeric"] }

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -81,14 +81,14 @@ fn main() -> anyhow::Result<()> {
 
     let connection_pool = DieselPool::new_background_worker(connection_pool);
 
-    let environment = Environment::new(
-        repository_config,
-        cloudfront,
-        fastly,
-        storage,
-        connection_pool.clone(),
-        emails,
-    );
+    let environment = Environment::builder()
+        .repository_config(repository_config)
+        .cloudfront(cloudfront)
+        .fastly(fastly)
+        .storage(storage)
+        .connection_pool(connection_pool.clone())
+        .emails(emails)
+        .build()?;
 
     let environment = Arc::new(environment);
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -263,14 +263,13 @@ impl TestAppBuilder {
                 index_location: index.url(),
                 credentials: Credentials::Missing,
             };
-            let environment = Environment::new(
-                repository_config,
-                None,
-                None,
-                app.storage.clone(),
-                app.primary_database.clone(),
-                app.emails.clone(),
-            );
+            let environment = Environment::builder()
+                .repository_config(repository_config)
+                .storage(app.storage.clone())
+                .connection_pool(app.primary_database.clone())
+                .emails(app.emails.clone())
+                .build()
+                .unwrap();
 
             let runner = Runner::new(app.primary_database.clone(), Arc::new(environment))
                 .num_workers(1)

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -5,44 +5,35 @@ use crate::storage::Storage;
 use crate::typosquat;
 use crate::Emails;
 use crates_io_index::{Repository, RepositoryConfig};
+use derive_builder::Builder;
 use diesel::PgConnection;
 use parking_lot::{Mutex, MutexGuard};
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
+#[derive(Builder)]
+#[builder(pattern = "owned")]
 pub struct Environment {
     repository_config: RepositoryConfig,
+    #[builder(default, setter(skip))]
     repository: Mutex<Option<Repository>>,
+    #[builder(default)]
     cloudfront: Option<CloudFront>,
+    #[builder(default)]
     fastly: Option<Fastly>,
     pub storage: Arc<Storage>,
     pub connection_pool: DieselPool,
     pub emails: Emails,
 
     /// A lazily initialised cache of the most popular crates ready to use in typosquatting checks.
+    #[builder(default, setter(skip))]
     typosquat_cache: OnceLock<Result<typosquat::Cache, typosquat::CacheError>>,
 }
 
 impl Environment {
-    pub fn new(
-        repository_config: RepositoryConfig,
-        cloudfront: Option<CloudFront>,
-        fastly: Option<Fastly>,
-        storage: Arc<Storage>,
-        connection_pool: DieselPool,
-        emails: Emails,
-    ) -> Self {
-        Self {
-            repository_config,
-            repository: Mutex::new(None),
-            cloudfront,
-            fastly,
-            storage,
-            connection_pool,
-            emails,
-            typosquat_cache: OnceLock::default(),
-        }
+    pub fn builder() -> EnvironmentBuilder {
+        EnvironmentBuilder::default()
     }
 
     #[instrument(skip_all)]


### PR DESCRIPTION
Having six argument that you have to specify in the right order was becoming a bit ridiculous and makes it hard to extend this struct in the future. This PR takes advantage of the `derive_builder` crate, which automatically generates an `EnvironmentBuilder` struct for us, making `Environment` construction a lot more straight-forward.