### PR TITLE
worker/swirl/runner: Spawn worker threads on tokio runtime

### DIFF
--- a/src/cloudfront.rs
+++ b/src/cloudfront.rs
@@ -6,7 +6,7 @@ use aws_sdk_cloudfront::{Client, Config};
 use retry::delay::{jitter, Exponential};
 use retry::OperationResult;
 use std::time::Duration;
-use tokio::runtime::Runtime;
+use tokio::runtime::Handle;
 
 pub struct CloudFront {
     client: Client,
@@ -39,7 +39,7 @@ impl CloudFront {
     ///
     /// `path` is the path to the file to invalidate, such as `config.json`, or `re/ge/regex`
     #[instrument(skip(self, rt))]
-    pub fn invalidate(&self, path: &str, rt: &Runtime) -> anyhow::Result<()> {
+    pub fn invalidate(&self, path: &str, rt: &Handle) -> anyhow::Result<()> {
         let path = if path.starts_with('/') {
             path.to_string()
         } else {

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -52,7 +52,7 @@ impl BackgroundJob for DumpDb {
 
         info!("Invalidating CDN caches");
         if let Some(cloudfront) = env.cloudfront() {
-            if let Err(error) = cloudfront.invalidate(&self.target_name, &rt) {
+            if let Err(error) = cloudfront.invalidate(&self.target_name, rt.handle()) {
                 warn!("failed to invalidate CloudFront cache: {}", error);
             }
         }

--- a/src/worker/jobs/git.rs
+++ b/src/worker/jobs/git.rs
@@ -110,7 +110,7 @@ impl BackgroundJob for SyncToSparseIndex {
 
             info!(%path, "Invalidating index file on CloudFront");
             cloudfront
-                .invalidate(&path, &rt)
+                .invalidate(&path, rt.handle())
                 .context("Failed to invalidate CloudFront")?;
         }
 


### PR DESCRIPTION
Do I know what I'm doing? Barely...

Does it work? Apparently!? 😅 

This PR essentially replaces the `std::thread::spawn()` call in the `start()` fn with `tokio::task::spawn_blocking()`. This means that all jobs are now executed within the context of a tokio runtime, which allows us to get rid of the per-job runtime creation that was happening in some of the jobs. This will hopefully also allow us to make the `run()` fn of the `BackgroundJob` trait async in the future.