### PR TITLE
worker/swirl/background_job: Pass owned `Context` to the `run()` fn

### DIFF
--- a/src/worker/jobs/daily_db_maintenance.rs
+++ b/src/worker/jobs/daily_db_maintenance.rs
@@ -20,7 +20,7 @@ impl BackgroundJob for DailyDbMaintenance {
     /// We only need to keep 90 days of entries in `version_downloads`. Once we have a mechanism to
     /// archive daily download counts and drop historical data, we can drop this task and rely on
     /// auto-vacuum again.
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         let mut conn = env.connection_pool.get()?;
 
         info!("Running VACUUM on version_downloads table");

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -30,7 +30,7 @@ impl BackgroundJob for DumpDb {
 
     /// Create CSV dumps of the public information in the database, wrap them in a
     /// tarball and upload to S3.
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         let directory = DumpDirectory::create()?;
 
         info!(path = ?directory.export_dir, "Begin exporting database");

--- a/src/worker/jobs/git.rs
+++ b/src/worker/jobs/git.rs
@@ -32,7 +32,7 @@ impl BackgroundJob for SyncToGitIndex {
 
     /// Regenerates or removes an index file for a single crate
     #[instrument(skip_all, fields(krate.name = ? self.krate))]
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to git index");
 
         let mut conn = env.connection_pool.get()?;
@@ -91,7 +91,7 @@ impl BackgroundJob for SyncToSparseIndex {
 
     /// Regenerates or removes an index file for a single crate
     #[instrument(skip_all, fields(krate.name = ?self.krate))]
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to sparse index");
 
         let mut conn = env.connection_pool.get()?;
@@ -161,7 +161,7 @@ impl BackgroundJob for SquashIndex {
 
     /// Collapse the index into a single commit, archiving the current history in a snapshot branch.
     #[instrument(skip_all)]
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Squashing the index into a single commit");
 
         let repo = env.lock_index()?;
@@ -213,7 +213,7 @@ impl BackgroundJob for NormalizeIndex {
 
     type Context = Arc<Environment>;
 
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Normalizing the index");
 
         let repo = env.lock_index()?;

--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -41,7 +41,7 @@ impl BackgroundJob for RenderAndUploadReadme {
     type Context = Arc<Environment>;
 
     #[instrument(skip_all, fields(krate.name))]
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         use crate::schema::*;
         use diesel::prelude::*;
 

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -28,7 +28,7 @@ impl BackgroundJob for CheckTyposquat {
     type Context = Arc<Environment>;
 
     #[instrument(skip(env), err)]
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         let mut conn = env.connection_pool.get()?;
         let cache = env.typosquat_cache(&mut conn)?;
         check(&env.emails, cache, &mut conn, &self.name)

--- a/src/worker/jobs/update_downloads.rs
+++ b/src/worker/jobs/update_downloads.rs
@@ -13,7 +13,7 @@ impl BackgroundJob for UpdateDownloads {
 
     type Context = Arc<Environment>;
 
-    fn run(&self, env: &Self::Context) -> anyhow::Result<()> {
+    fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         let mut conn = env.connection_pool.get()?;
         update(&mut conn)?;
         Ok(())

--- a/src/worker/swirl/background_job.rs
+++ b/src/worker/swirl/background_job.rs
@@ -20,7 +20,7 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + 'static {
     type Context: Clone + Send + 'static;
 
     /// Execute the task. This method should define its logic
-    fn run(&self, ctx: &Self::Context) -> anyhow::Result<()>;
+    fn run(&self, ctx: Self::Context) -> anyhow::Result<()>;
 
     fn enqueue(&self, conn: &mut PgConnection) -> Result<i64, EnqueueError> {
         self.enqueue_with_priority(conn, Self::PRIORITY)


### PR DESCRIPTION
References are tricky when dealing with async boundaries... Since our jobs use `Context = Arc<Environment>` the cloning should be relatively cheap and make the async/await conversion a bit easier.