### PR TITLE
Simplify GitHub client assignment

### DIFF
--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -28,7 +28,7 @@ fn main() -> anyhow::Result<()> {
     let config = crates_io::config::Server::from_environment()?;
 
     let client = Client::new();
-    let github = RealGitHubClient::new(Some(client));
+    let github = RealGitHubClient::new(client);
     let github = Box::new(github);
 
     let app = Arc::new(App::new(config, github));

--- a/src/github.rs
+++ b/src/github.rs
@@ -44,11 +44,11 @@ pub trait GitHubClient: Send + Sync {
 
 #[derive(Debug)]
 pub struct RealGitHubClient {
-    client: Option<Client>,
+    client: Client,
 }
 
 impl RealGitHubClient {
-    pub fn new(client: Option<Client>) -> Self {
+    pub fn new(client: Client) -> Self {
         Self { client }
     }
 
@@ -60,7 +60,7 @@ impl RealGitHubClient {
         let url = format!("https://api.github.com{url}");
         info!("GITHUB HTTP: {url}");
 
-        self.client()
+        self.client
             .get(&url)
             .header(header::ACCEPT, "application/vnd.github.v3+json")
             .header(header::AUTHORIZATION, auth)
@@ -90,21 +90,6 @@ impl RealGitHubClient {
     {
         self._request(url, &format!("basic {username}:{password}"))
             .await
-    }
-
-    /// Returns a client for making HTTP requests to upload crate files.
-    ///
-    /// The client will go through a proxy if the application was configured via
-    /// `TestApp::with_proxy()`.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the application was not initialized with a client.  This should only occur in
-    /// tests that were not properly initialized.
-    fn client(&self) -> &Client {
-        self.client
-            .as_ref()
-            .expect("No HTTP client is configured.  In tests, use `TestApp::with_proxy()`.")
     }
 }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -16,7 +16,6 @@ use crates_io_test_db::TestDatabase;
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
-use reqwest::{Client, Proxy};
 use std::collections::HashSet;
 use std::{rc::Rc, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
@@ -453,16 +452,7 @@ fn simple_config() -> config::Server {
     }
 }
 
-fn build_app(config: config::Server, proxy: Option<String>) -> (Arc<App>, axum::Router) {
-    let _client = if let Some(proxy) = proxy {
-        let mut builder = Client::builder();
-        builder = builder
-            .proxy(Proxy::all(proxy).expect("Unable to configure proxy with the provided URL"));
-        Some(builder.build().expect("TLS backend cannot be initialized"))
-    } else {
-        None
-    };
-
+fn build_app(config: config::Server, _proxy: Option<String>) -> (Arc<App>, axum::Router) {
     // Use a custom mock for the GitHub client, allowing to define the GitHub users and
     // organizations without actually having to create GitHub accounts.
     let github = Box::new(MockGitHubClient::new(&MOCK_GITHUB_DATA));

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -77,21 +77,15 @@ impl TestApp {
 
         TestAppBuilder {
             config: simple_config(),
-            proxy: None,
             index: None,
             build_job_runner: false,
             use_chaos_proxy: false,
         }
     }
 
-    /// Initialize the app and a proxy that can record and playback outgoing HTTP requests
-    pub fn with_proxy() -> TestAppBuilder {
-        Self::init().with_proxy()
-    }
-
     /// Initialize a full application, with a proxy, index, and background worker
     pub fn full() -> TestAppBuilder {
-        Self::with_proxy().with_git_index().with_job_runner()
+        Self::init().with_git_index().with_job_runner()
     }
 
     /// Obtain the database connection and pass it to the closure
@@ -207,7 +201,6 @@ impl TestApp {
 
 pub struct TestAppBuilder {
     config: config::Server,
-    proxy: Option<String>,
     index: Option<UpstreamIndex>,
     build_job_runner: bool,
     use_chaos_proxy: bool,
@@ -254,7 +247,7 @@ impl TestAppBuilder {
             (primary_proxy, replica_proxy, Some(test_database))
         };
 
-        let (app, router) = build_app(self.config, self.proxy);
+        let (app, router) = build_app(self.config);
 
         let runner = if self.build_job_runner {
             let index = self
@@ -303,14 +296,6 @@ impl TestAppBuilder {
             app: test_app.clone(),
         };
         (test_app, anon)
-    }
-
-    /// Create a proxy for use with this app
-    pub fn with_proxy(mut self) -> Self {
-        // Use a dummy proxy address so that we do not accidentally perform real
-        // HTTP requests when running the test suite.
-        self.proxy = Some("http://127.0.0.1:0".into());
-        self
     }
 
     // Create a `TestApp` with a database including a default user
@@ -452,7 +437,7 @@ fn simple_config() -> config::Server {
     }
 }
 
-fn build_app(config: config::Server, _proxy: Option<String>) -> (Arc<App>, axum::Router) {
+fn build_app(config: config::Server) -> (Arc<App>, axum::Router) {
     // Use a custom mock for the GitHub client, allowing to define the GitHub users and
     // organizations without actually having to create GitHub accounts.
     let github = Box::new(MockGitHubClient::new(&MOCK_GITHUB_DATA));


### PR DESCRIPTION
Passing in a `GitHubClient` into `App::new()` instead of a raw `reqwest::Client` unlocked quite a bit of cleanup since the `Client` in test-mode wasn't actually used anywhere, thus making the whole `proxy` field unused too.