### PR TITLE
Add better error message for invalid crate names

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -52,7 +52,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
     let metadata: PublishMetadata = serde_json::from_slice(&json_bytes)
         .map_err(|e| cargo_err(format_args!("invalid upload request: {e}")))?;
 
-    Crate::validate_crate_name(&metadata.name).map_err(cargo_err)?;
+    Crate::validate_crate_name("crate", &metadata.name).map_err(cargo_err)?;
 
     let version = match semver::Version::parse(&metadata.vers) {
         Ok(parsed) => parsed,
@@ -586,7 +586,7 @@ fn convert_dependency(
 }
 
 pub fn validate_dependency(dep: &EncodableCrateDependency) -> AppResult<()> {
-    Crate::validate_crate_name(&dep.name).map_err(cargo_err)?;
+    Crate::validate_crate_name("dependency", &dep.name).map_err(cargo_err)?;
 
     for feature in &dep.features {
         Crate::validate_feature(feature).map_err(cargo_err)?;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -53,7 +53,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
     let metadata: PublishMetadata = serde_json::from_slice(&json_bytes)
         .map_err(|e| cargo_err(format_args!("invalid upload request: {e}")))?;
 
-    if !Crate::valid_name(&metadata.name) {
+    if !Crate::validate_crate_name(&metadata.name) {
         return Err(cargo_err(format_args!(
             "\"{}\" is an invalid crate name (crate names must start with a \
             letter, contain only letters, numbers, hyphens, or underscores and \
@@ -594,7 +594,7 @@ fn convert_dependency(
 }
 
 pub fn validate_dependency(dep: &EncodableCrateDependency) -> AppResult<()> {
-    if !Crate::valid_name(&dep.name) {
+    if !Crate::validate_crate_name(&dep.name) {
         return Err(cargo_err(format_args!(
             "\"{}\" is an invalid dependency name (dependency names must \
             start with a letter, contain only letters, numbers, hyphens, \

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -16,7 +16,6 @@ use tokio::runtime::Handle;
 use url::Url;
 
 use crate::controllers::cargo_prelude::*;
-use crate::models::krate::MAX_NAME_LENGTH;
 use crate::models::{
     insert_version_owner_action, Category, Crate, DependencyKind, Keyword, NewCrate, NewVersion,
     Rights, VersionAction,
@@ -53,14 +52,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
     let metadata: PublishMetadata = serde_json::from_slice(&json_bytes)
         .map_err(|e| cargo_err(format_args!("invalid upload request: {e}")))?;
 
-    if !Crate::validate_crate_name(&metadata.name) {
-        return Err(cargo_err(format_args!(
-            "\"{}\" is an invalid crate name (crate names must start with a \
-            letter, contain only letters, numbers, hyphens, or underscores and \
-            have at most {MAX_NAME_LENGTH} characters)",
-            metadata.name
-        )));
-    }
+    Crate::validate_crate_name(&metadata.name).map_err(cargo_err)?;
 
     let version = match semver::Version::parse(&metadata.vers) {
         Ok(parsed) => parsed,
@@ -594,14 +586,7 @@ fn convert_dependency(
 }
 
 pub fn validate_dependency(dep: &EncodableCrateDependency) -> AppResult<()> {
-    if !Crate::validate_crate_name(&dep.name) {
-        return Err(cargo_err(format_args!(
-            "\"{}\" is an invalid dependency name (dependency names must \
-            start with a letter, contain only letters, numbers, hyphens, \
-            or underscores and have at most {MAX_NAME_LENGTH} characters)",
-            dep.name
-        )));
-    }
+    Crate::validate_crate_name(&dep.name).map_err(cargo_err)?;
 
     for feature in &dep.features {
         Crate::validate_feature(feature).map_err(cargo_err)?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -192,11 +192,11 @@ impl Crate {
             })
     }
 
-    pub fn valid_name(name: &str) -> bool {
+    pub fn validate_crate_name(name: &str) -> bool {
         if name.chars().count() > MAX_NAME_LENGTH {
             return false;
         }
-        Crate::valid_create_ident(name)
+        Crate::validate_create_ident(name)
     }
 
     // Checks that the name is a valid crate name.
@@ -204,7 +204,7 @@ impl Crate {
     // 2. The first character must be an ASCII character.
     // 3. The remaining characters must be ASCII alphanumerics or `-` or `_`.
     // Note: This differs from `valid_dependency_name`, which allows `_` as the first character.
-    fn valid_create_ident(name: &str) -> bool {
+    fn validate_create_ident(name: &str) -> bool {
         if name.is_empty() {
             return false;
         }
@@ -585,17 +585,17 @@ mod tests {
     use crate::models::Crate;
 
     #[test]
-    fn valid_name() {
-        assert!(Crate::valid_name("foo"));
-        assert!(!Crate::valid_name("京"));
-        assert!(!Crate::valid_name(""));
-        assert!(!Crate::valid_name("💝"));
-        assert!(Crate::valid_name("foo_underscore"));
-        assert!(Crate::valid_name("foo-dash"));
-        assert!(!Crate::valid_name("foo+plus"));
+    fn validate_crate_name() {
+        assert!(Crate::validate_crate_name("foo"));
+        assert!(!Crate::validate_crate_name("京"));
+        assert!(!Crate::validate_crate_name(""));
+        assert!(!Crate::validate_crate_name("💝"));
+        assert!(Crate::validate_crate_name("foo_underscore"));
+        assert!(Crate::validate_crate_name("foo-dash"));
+        assert!(!Crate::validate_crate_name("foo+plus"));
         // Starting with an underscore is an invalid crate name.
-        assert!(!Crate::valid_name("_foo"));
-        assert!(!Crate::valid_name("-foo"));
+        assert!(!Crate::validate_crate_name("_foo"));
+        assert!(!Crate::validate_crate_name("-foo"));
     }
 
     #[test]

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -609,7 +609,7 @@ mod tests {
 
     #[test]
     fn validate_crate_name() {
-        use super::InvalidCrateName;
+        use super::{InvalidCrateName, MAX_NAME_LENGTH};
 
         assert_ok!(Crate::validate_crate_name("foo"));
         assert_err_eq!(
@@ -627,6 +627,7 @@ mod tests {
             Crate::validate_crate_name("foo+plus"),
             InvalidCrateName::Char('+', "foo+plus".into())
         );
+        // Crate names cannot start with an underscore on crates.io.
         assert_err_eq!(
             Crate::validate_crate_name("_foo"),
             InvalidCrateName::Start('_', "_foo".into())
@@ -634,6 +635,14 @@ mod tests {
         assert_err_eq!(
             Crate::validate_crate_name("-foo"),
             InvalidCrateName::Start('-', "-foo".into())
+        );
+        assert_err_eq!(
+            Crate::validate_crate_name("123"),
+            InvalidCrateName::StartWithDigit("123".into())
+        );
+        assert_err_eq!(
+            Crate::validate_crate_name("o".repeat(MAX_NAME_LENGTH + 1).as_str()),
+            InvalidCrateName::TooLong("o".repeat(MAX_NAME_LENGTH + 1).as_str().into())
         );
     }
 

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -108,7 +108,7 @@ impl CrateScope {
         }
 
         let name_without_wildcard = pattern.strip_suffix('*').unwrap_or(pattern);
-        Crate::validate_crate_name(name_without_wildcard).is_ok()
+        Crate::validate_crate_name("crate", name_without_wildcard).is_ok()
     }
 
     pub fn matches(&self, crate_name: &str) -> bool {

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -108,7 +108,7 @@ impl CrateScope {
         }
 
         let name_without_wildcard = pattern.strip_suffix('*').unwrap_or(pattern);
-        Crate::valid_name(name_without_wildcard)
+        Crate::validate_crate_name(name_without_wildcard)
     }
 
     pub fn matches(&self, crate_name: &str) -> bool {

--- a/src/models/token/scopes.rs
+++ b/src/models/token/scopes.rs
@@ -108,7 +108,7 @@ impl CrateScope {
         }
 
         let name_without_wildcard = pattern.strip_suffix('*').unwrap_or(pattern);
-        Crate::validate_crate_name(name_without_wildcard)
+        Crate::validate_crate_name(name_without_wildcard).is_ok()
     }
 
     pub fn matches(&self, crate_name: &str) -> bool {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "invalid character `🦀` in crate name: `🦀`, the first character must be an ASCII character"
+      "detail": "invalid character `🦀` in dependency name: `🦀`, the first character must be an ASCII character"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__invalid_dependency_name.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"🦀\" is an invalid dependency name (dependency names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `🦀` in crate name: `🦀`, the first character must be an ASCII character"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-2.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"foo bar\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character ` ` in crate name: `foo bar`, characters must be an ASCII alphanumeric characters, `-`, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-3.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "the crate name `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` is too long (max 64 characters)"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-4.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"snow☃\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `☃` in crate name: `snow☃`, characters must be an ASCII alphanumeric characters, `-`, or `_`"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names-5.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"áccênts\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "invalid character `á` in crate name: `áccênts`, the first character must be an ASCII character"
     }
   ]
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__invalid_names.snap
@@ -5,7 +5,7 @@ expression: response.into_json()
 {
   "errors": [
     {
-      "detail": "\"\" is an invalid crate name (crate names must start with a letter, contain only letters, numbers, hyphens, or underscores and have at most 64 characters)"
+      "detail": "crate name cannot be empty"
     }
   ]
 }


### PR DESCRIPTION
Split from https://github.com/rust-lang/crates.io/pull/7379

The summary:

| category                    | Cargo                                                                                                   | crates.io before change                                                                                      | crates.io after change                                                                                 |
| --------------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| Crate name                  | 1. cannot start with a number<br/>2. can only start with most letters or `_`<br/>3. can only contain numbers, `-`, `_`, or most letters. | 1. must start with alphabetic<br/>2. can only contain numbers, letters, `-`, `_`                         | 1. must start with alphabetic<br/>2. can only contain numbers, letters, `-`, `_` **(Nothing changes)**                |
