### PR TITLE
Use `async fn` and return-position `impl Trait` from std library for background jobs

### DIFF
--- a/crates_io_worker/src/job_registry.rs
+++ b/crates_io_worker/src/job_registry.rs
@@ -47,7 +47,6 @@ fn runnable<J: BackgroundJob>(ctx: J::Context, payload: serde_json::Value) -> Ru
 mod tests {
     use super::*;
     use crate::BackgroundJob;
-    use async_trait::async_trait;
     use serde::{Deserialize, Serialize};
 
     #[test]
@@ -55,7 +54,6 @@ mod tests {
         #[derive(Serialize, Deserialize)]
         struct TestJob;
 
-        #[async_trait]
         impl BackgroundJob for TestJob {
             const JOB_NAME: &'static str = "test";
             type Context = ();

--- a/crates_io_worker/tests/runner.rs
+++ b/crates_io_worker/tests/runner.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use crates_io_test_db::TestDatabase;
 use crates_io_worker::schema::background_jobs;
 use crates_io_worker::{BackgroundJob, Runner};
@@ -42,7 +41,6 @@ async fn jobs_are_locked_when_fetched() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
 
-    #[async_trait]
     impl BackgroundJob for TestJob {
         const JOB_NAME: &'static str = "test";
         type Context = TestContext;
@@ -86,7 +84,6 @@ async fn jobs_are_deleted_when_successfully_run() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
 
-    #[async_trait]
     impl BackgroundJob for TestJob {
         const JOB_NAME: &'static str = "test";
         type Context = ();
@@ -128,7 +125,6 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
 
-    #[async_trait]
     impl BackgroundJob for TestJob {
         const JOB_NAME: &'static str = "test";
         type Context = TestContext;
@@ -181,7 +177,6 @@ async fn panicking_in_jobs_updates_retry_counter() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
 
-    #[async_trait]
     impl BackgroundJob for TestJob {
         const JOB_NAME: &'static str = "test";
         type Context = ();

--- a/src/worker/jobs/daily_db_maintenance.rs
+++ b/src/worker/jobs/daily_db_maintenance.rs
@@ -1,6 +1,5 @@
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
-use async_trait::async_trait;
 use crates_io_worker::BackgroundJob;
 use diesel::{sql_query, RunQueryDsl};
 use std::sync::Arc;
@@ -8,7 +7,6 @@ use std::sync::Arc;
 #[derive(Serialize, Deserialize)]
 pub struct DailyDbMaintenance;
 
-#[async_trait]
 impl BackgroundJob for DailyDbMaintenance {
     const JOB_NAME: &'static str = "daily_db_maintenance";
 

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -3,7 +3,6 @@ use crate::storage::Storage;
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use anyhow::{anyhow, Context};
-use async_trait::async_trait;
 use crates_io_worker::BackgroundJob;
 use std::fs::{self, File};
 use std::path::{Path, PathBuf};
@@ -24,7 +23,6 @@ impl DumpDb {
     }
 }
 
-#[async_trait]
 impl BackgroundJob for DumpDb {
     const JOB_NAME: &'static str = "dump_db";
 

--- a/src/worker/jobs/git.rs
+++ b/src/worker/jobs/git.rs
@@ -2,7 +2,6 @@ use crate::models;
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use anyhow::Context;
-use async_trait::async_trait;
 use chrono::Utc;
 use crates_io_env_vars::var_parsed;
 use crates_io_index::{Crate, Repository};
@@ -27,7 +26,6 @@ impl SyncToGitIndex {
     }
 }
 
-#[async_trait]
 impl BackgroundJob for SyncToGitIndex {
     const JOB_NAME: &'static str = "sync_to_git_index";
     const PRIORITY: i16 = 100;
@@ -92,7 +90,6 @@ impl SyncToSparseIndex {
     }
 }
 
-#[async_trait]
 impl BackgroundJob for SyncToSparseIndex {
     const JOB_NAME: &'static str = "sync_to_sparse_index";
     const PRIORITY: i16 = 100;
@@ -165,7 +162,6 @@ pub fn get_index_data(name: &str, conn: &mut PgConnection) -> anyhow::Result<Opt
 #[derive(Serialize, Deserialize)]
 pub struct SquashIndex;
 
-#[async_trait]
 impl BackgroundJob for SquashIndex {
     const JOB_NAME: &'static str = "squash_index";
     const QUEUE: &'static str = "repository";
@@ -232,7 +228,6 @@ impl NormalizeIndex {
     }
 }
 
-#[async_trait]
 impl BackgroundJob for NormalizeIndex {
     const JOB_NAME: &'static str = "normalize_index";
     const QUEUE: &'static str = "repository";

--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -3,7 +3,6 @@
 use crate::models::Version;
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
-use async_trait::async_trait;
 use crates_io_markdown::text_to_html;
 use crates_io_worker::BackgroundJob;
 use std::sync::Arc;
@@ -36,7 +35,6 @@ impl RenderAndUploadReadme {
     }
 }
 
-#[async_trait]
 impl BackgroundJob for RenderAndUploadReadme {
     const JOB_NAME: &'static str = "render_and_upload_readme";
     const PRIORITY: i16 = 50;

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use std::sync::Arc;
 
 use crates_io_worker::BackgroundJob;
@@ -26,7 +25,6 @@ impl CheckTyposquat {
     }
 }
 
-#[async_trait]
 impl BackgroundJob for CheckTyposquat {
     const JOB_NAME: &'static str = "check_typosquat";
 

--- a/src/worker/jobs/update_downloads.rs
+++ b/src/worker/jobs/update_downloads.rs
@@ -2,7 +2,6 @@ use crate::models::VersionDownload;
 use crate::schema::{crates, metadata, version_downloads, versions};
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
-use async_trait::async_trait;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use std::sync::Arc;
@@ -10,7 +9,6 @@ use std::sync::Arc;
 #[derive(Serialize, Deserialize)]
 pub struct UpdateDownloads;
 
-#[async_trait]
 impl BackgroundJob for UpdateDownloads {
     const JOB_NAME: &'static str = "update_downloads";
 


### PR DESCRIPTION
Follow up https://github.com/rust-lang/crates.io/pull/7601

Because the async trait is already stabled in the std library, I think we probably can switch to using it. Then probably we can get rid of one depends.