### PR TITLE
Adjust "crates.io" usage to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A volunteer will get back to you as soon as possible.
 
 ## Contributing
 
-Welcome! We love contributions! Crates.io is an [Ember](https://emberjs.com/)
+Welcome! We love contributions! crates.io is an [Ember](https://emberjs.com/)
 frontend with a Rust backend, and there are many tasks appropriate for a
 variety of skill levels.
 

--- a/crates_io_markdown/lib.rs
+++ b/crates_io_markdown/lib.rs
@@ -544,10 +544,10 @@ There can also be some text in between!
     #[test]
     fn absolute_links_dont_get_resolved() {
         let text =
-            "[![Crates.io](https://img.shields.io/crates/v/clap.svg)](https://crates.io/crates/clap)";
+            "[![crates.io](https://img.shields.io/crates/v/clap.svg)](https://crates.io/crates/clap)";
         let repository = "https://github.com/kbknapp/clap-rs/";
         assert_snapshot!(markdown_to_html(text, Some(repository), ""), @r###"
-        <p><a href="https://crates.io/crates/clap" rel="nofollow noopener noreferrer"><img src="https://img.shields.io/crates/v/clap.svg" alt="Crates.io"></a></p>
+        <p><a href="https://crates.io/crates/clap" rel="nofollow noopener noreferrer"><img src="https://img.shields.io/crates/v/clap.svg" alt="crates.io"></a></p>
         "###);
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# Architecture of Crates.io
+# Architecture of crates.io
 
 This document is an intro to the codebase in this repo. If you want to work on a bug or a feature,
 hopefully after reading this doc, you'll have a good idea of where to start looking for the code
@@ -65,7 +65,7 @@ These files have to do with the frontend:
 
 ## Deployment - Heroku
 
-Crates.io is deployed on [Heroku](https://heroku.com/).
+crates.io is deployed on [Heroku](https://heroku.com/).
 
 These files are Heroku-specific; if you're deploying the crates.io codebase on another platform,
 there's useful information in these files that you might need to translate to a different format

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Crates.io
+# Contributing to crates.io
 
 ## Attending the weekly team meetings
 
@@ -400,7 +400,7 @@ Subject: Please confirm your email address
 Content-Transfer-Encoding: 7bit
 Date: Thu, 24 Jun 2021 08:02:23 -0000
 
-Hello hi-rustin! Welcome to Crates.io. Please click the
+Hello hi-rustin! Welcome to crates.io. Please click the
 link below to verify your email address. Thank you!
 
 https://crates.io/confirm/RiphVyFo31wuKQhpyTw7RF2LIf

--- a/src/email.rs
+++ b/src/email.rs
@@ -61,7 +61,7 @@ impl Emails {
 
         let subject = "Please confirm your email address";
         let body = format!(
-            "Hello {}! Welcome to Crates.io. Please click the
+            "Hello {}! Welcome to crates.io. Please click the
 link below to verify your email address. Thank you!\n
 https://{}/confirm/{}",
             user_name,

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -51,7 +51,7 @@ impl fmt::Display for Forbidden {
 
 impl AppError for ReadOnlyMode {
     fn response(&self) -> Response {
-        let detail = "Crates.io is currently in read-only mode for maintenance. \
+        let detail = "crates.io is currently in read-only mode for maintenance. \
                       Please try again later.";
         json_error(detail, StatusCode::SERVICE_UNAVAILABLE)
     }


### PR DESCRIPTION
This change makes our usage of the "crates.io" name consistent across the project by using it in lowercase form everywhere, also at the start of a sentence.