### PR TITLE
app: Change `new()` fn to accept `Emails` argument

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -72,7 +72,7 @@ impl App {
     /// - GitHub OAuth
     /// - Database connection pools
     /// - A `git2::Repository` instance from the index repo checkout (that server.rs ensures exists)
-    pub fn new(config: config::Server, github: Box<dyn GitHubClient>) -> App {
+    pub fn new(config: config::Server, emails: Emails, github: Box<dyn GitHubClient>) -> App {
         use oauth2::{AuthUrl, TokenUrl};
 
         let instance_metrics =
@@ -152,7 +152,7 @@ impl App {
             github_oauth,
             version_id_cacher,
             downloads_counter: DownloadsCounter::new(),
-            emails: Emails::from_environment(&config),
+            emails,
             storage: Arc::new(Storage::from_config(&config.storage)),
             service_metrics: ServiceMetrics::new().expect("could not initialize service metrics"),
             instance_metrics,

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -2,7 +2,7 @@
 extern crate tracing;
 
 use crates_io::middleware::normalize_path::normalize_path;
-use crates_io::{metrics::LogEncoder, util::errors::AppResult, App};
+use crates_io::{metrics::LogEncoder, util::errors::AppResult, App, Emails};
 use std::{sync::Arc, time::Duration};
 
 use axum::ServiceExt;
@@ -27,11 +27,13 @@ fn main() -> anyhow::Result<()> {
 
     let config = crates_io::config::Server::from_environment()?;
 
+    let emails = Emails::from_environment(&config);
+
     let client = Client::new();
     let github = RealGitHubClient::new(client);
     let github = Box::new(github);
 
-    let app = Arc::new(App::new(config, github));
+    let app = Arc::new(App::new(config, emails, github));
 
     // Start the background thread periodically persisting download counts to the database.
     downloads_counter_thread(app.clone());

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -438,15 +438,15 @@ fn simple_config() -> config::Server {
 }
 
 fn build_app(config: config::Server) -> (Arc<App>, axum::Router) {
+    // Use the in-memory email backend for all tests, allowing tests to analyze the emails sent by
+    // the application. This will also prevent cluttering the filesystem.
+    let emails = Emails::new_in_memory();
+
     // Use a custom mock for the GitHub client, allowing to define the GitHub users and
     // organizations without actually having to create GitHub accounts.
     let github = Box::new(MockGitHubClient::new(&MOCK_GITHUB_DATA));
 
-    let mut app = App::new(config, github);
-
-    // Use the in-memory email backend for all tests, allowing tests to analyze the emails sent by
-    // the application. This will also prevent cluttering the filesystem.
-    app.emails = Emails::new_in_memory();
+    let app = App::new(config, emails, github);
 
     let app = Arc::new(app);
     let router = crates_io::build_handler(Arc::clone(&app));


### PR DESCRIPTION
This removes the need to mutate the `App` in testing mode after it has been constructed and the corresponding duplicate initialization of the `email` field.