### PR TITLE
worker: Extract 'JobRegistry` struct

### DIFF
--- a/crates_io_worker/src/job_registry.rs
+++ b/crates_io_worker/src/job_registry.rs
@@ -5,12 +5,31 @@ use tokio::runtime::Handle;
 
 type RunTaskFn<Context> = dyn Fn(Context, serde_json::Value) -> anyhow::Result<()> + Send + Sync;
 
-pub type JobRegistry<Context> = HashMap<String, Arc<RunTaskFn<Context>>>;
+#[derive(Clone)]
+pub struct JobRegistry<Context> {
+    entries: HashMap<String, Arc<RunTaskFn<Context>>>,
+}
 
-pub fn runnable<J: BackgroundJob>(
-    ctx: J::Context,
-    payload: serde_json::Value,
-) -> anyhow::Result<()> {
+impl<Context> Default for JobRegistry<Context> {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+}
+
+impl<Context: Clone + Send + 'static> JobRegistry<Context> {
+    pub fn register<J: BackgroundJob<Context = Context>>(&mut self) {
+        self.entries
+            .insert(J::JOB_NAME.to_string(), Arc::new(runnable::<J>));
+    }
+
+    pub fn get(&self, key: &str) -> Option<&Arc<RunTaskFn<Context>>> {
+        self.entries.get(key)
+    }
+}
+
+fn runnable<J: BackgroundJob>(ctx: J::Context, payload: serde_json::Value) -> anyhow::Result<()> {
     let job: J = serde_json::from_value(payload)?;
     Handle::current().block_on(job.run(ctx))
 }

--- a/crates_io_worker/src/runner.rs
+++ b/crates_io_worker/src/runner.rs
@@ -1,11 +1,10 @@
-use crate::job_registry::{runnable, JobRegistry};
+use crate::job_registry::JobRegistry;
 use crate::worker::Worker;
 use crate::{storage, BackgroundJob};
 use anyhow::anyhow;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PoolError, PooledConnection};
 use futures_util::future::join_all;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
@@ -54,9 +53,7 @@ impl<Context: Clone + Send + 'static> Runner<Context> {
 
     /// Register a new job type for this job runner.
     pub fn register_job_type<J: BackgroundJob<Context = Context>>(mut self) -> Self {
-        self.job_registry
-            .insert(J::JOB_NAME.to_string(), Arc::new(runnable::<J>));
-
+        self.job_registry.register::<J>();
         self
     }
 


### PR DESCRIPTION
This makes the raw `HashMap` a little easier to work with and allows us to restrict access to the `runnable()` fn to the `job_registry` module.