### PR TITLE
worker: Move `block_on()` call further outside

### DIFF
--- a/crates_io_worker/Cargo.toml
+++ b/crates_io_worker/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "=1.0.75"
 async-trait = "=0.1.74"
 diesel = { version = "=2.1.4", features = ["postgres", "r2d2", "serde_json"] }
 futures-util = "=0.3.29"
-sentry-core = "=0.31.8"
+sentry-core = { version = "=0.31.8", features = ["client"] }
 serde = { version = "=1.0.193", features = ["derive"] }
 serde_json = "=1.0.108"
 thiserror = "=1.0.50"

--- a/crates_io_worker/src/background_job.rs
+++ b/crates_io_worker/src/background_job.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use tracing::instrument;
 
 #[async_trait]
-pub trait BackgroundJob: Serialize + DeserializeOwned + 'static {
+pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
     /// Unique name of the task.
     ///
     /// This MUST be unique for the whole application.


### PR DESCRIPTION
This PR converts more of our worker code to async/await by moving the `block_on()` call further to the outside. Each new layer inside is converted to async/await accordingly.