### PR TITLE
Remove unused `hyper-tls` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,6 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
- "hyper-tls",
  "indexmap",
  "indicatif",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,5 @@ crates_io_tarball = { path = "crates_io_tarball", features = ["builder"] }
 crates_io_test_db = { path = "crates_io_test_db" }
 claims = "=0.7.1"
 googletest = "=0.10.0"
-hyper-tls = "=0.5.0"
 insta = { version = "=1.34.0", features = ["json", "redactions"] }
 tokio = "=1.34.0"


### PR DESCRIPTION
This is used internally by `reqwest`, but there appears to be no need for us to have this as an explicit dependency.