### PR TITLE
VersionList::Row: Limit version number size

### DIFF
--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -107,6 +107,9 @@
 }
 
 .num-link {
+    max-width: 200px;
+    text-overflow: ellipsis;
+    overflow: hidden;
     color: var(--fg-color);
     font-weight: 500;
     font-variant-numeric: tabular-nums;


### PR DESCRIPTION
Before:

<img width="1032" alt="Bildschirmfoto 2023-11-28 um 08 49 50" src="https://github.com/rust-lang/crates.io/assets/141300/d2f3501d-343b-4593-918f-2cea0d1f8305">

After:

<img width="974" alt="Bildschirmfoto 2023-11-28 um 08 49 40" src="https://github.com/rust-lang/crates.io/assets/141300/604a75b2-23c6-463c-aa74-b827a61564b2">
