### PR TITLE
controllers/crate/versions: Fix null error in `sortedVersions`

### DIFF
--- a/app/controllers/crate/versions.js
+++ b/app/controllers/crate/versions.js
@@ -14,7 +14,22 @@ export default class SearchController extends Controller {
     let versions = this.model.versions.toArray();
 
     return this.sort === 'semver'
-      ? versions.sort((a, b) => b.semver.compare(a.semver))
+      ? versions.sort(compareBySemver)
       : versions.sort((a, b) => b.created_at - a.created_at);
+  }
+}
+
+function compareBySemver(a, b) {
+  let aSemver = a.semver;
+  let bSemver = b.semver;
+
+  if (aSemver === bSemver) {
+    return b.created_at - a.created_at;
+  } else if (aSemver === null) {
+    return 1;
+  } else if (bSemver === null) {
+    return -1;
+  } else {
+    return bSemver.compare(aSemver);
   }
 }


### PR DESCRIPTION
If we fail to parse a version string then the `semver` property will be `null`, leading us running `null.compare(...)` which does not exist. This change extends the sorting function to handle this edge case.

see https://crates.io/crates/cursed-trying-to-break-cargo/versions?sort=semver