### PR TITLE
models/krate: Fix unintentional `max_features` reset after publishing

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -89,8 +89,6 @@ type ByExactName<'a> = diesel::dsl::Filter<All, diesel::dsl::Eq<crates::name, &'
 #[diesel(
     table_name = crates,
     check_for_backend(diesel::pg::Pg),
-    // This is actually just to skip updating them
-    primary_key(name, max_upload_size),
     treat_none_as_null = true,
 )]
 pub struct NewCrate<'a> {
@@ -110,7 +108,13 @@ impl<'a> NewCrate<'a> {
 
         update(crates::table)
             .filter(canon_crate_name(crates::name).eq(canon_crate_name(self.name)))
-            .set(self)
+            .set((
+                crates::description.eq(self.description),
+                crates::homepage.eq(self.homepage),
+                crates::documentation.eq(self.documentation),
+                crates::readme.eq(self.readme),
+                crates::repository.eq(self.repository),
+            ))
             .returning(Crate::as_returning())
             .get_result(conn)
     }

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -147,6 +147,14 @@ fn too_many_features_with_custom_limit() {
         .feature("three", &[])
         .feature("four", &[]);
     token.publish_crate(publish_builder).good();
+
+    // see https://github.com/rust-lang/crates.io/issues/7632
+    let publish_builder = PublishBuilder::new("foo", "1.0.1")
+        .feature("one", &[])
+        .feature("two", &[])
+        .feature("three", &[])
+        .feature("four", &[]);
+    token.publish_crate(publish_builder).good();
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/crates.io/issues/7632