### PR TITLE
worker/worker: Convert `run()` fns to async

### DIFF
--- a/crates_io_worker/src/job_registry.rs
+++ b/crates_io_worker/src/job_registry.rs
@@ -20,7 +20,7 @@ impl<Context> Default for JobRegistry<Context> {
     }
 }
 
-impl<Context: Clone + Send + 'static> JobRegistry<Context> {
+impl<Context: Clone + Send + Sync + 'static> JobRegistry<Context> {
     pub fn register<J: BackgroundJob<Context = Context>>(&mut self) {
         self.entries
             .insert(J::JOB_NAME.to_string(), Arc::new(runnable::<J>));

--- a/crates_io_worker/src/runner.rs
+++ b/crates_io_worker/src/runner.rs
@@ -27,7 +27,7 @@ pub struct Runner<Context> {
     shutdown_when_queue_empty: bool,
 }
 
-impl<Context: Clone + Send + 'static> Runner<Context> {
+impl<Context: Clone + Send + Sync + 'static> Runner<Context> {
     pub fn new(rt_handle: &Handle, connection_pool: ConnectionPool, context: Context) -> Self {
         Self {
             rt_handle: rt_handle.clone(),

--- a/crates_io_worker/src/runner.rs
+++ b/crates_io_worker/src/runner.rs
@@ -7,6 +7,7 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PoolError, PooledConnection};
 use futures_util::future::join_all;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
@@ -81,7 +82,7 @@ impl<Context: Clone + Send + 'static> Runner<Context> {
                 let worker = Worker {
                     connection_pool: self.connection_pool.clone(),
                     context: self.context.clone(),
-                    job_registry: queue.job_registry.clone(),
+                    job_registry: Arc::new(queue.job_registry.clone()),
                     shutdown_when_queue_empty: self.shutdown_when_queue_empty,
                     poll_interval: queue.poll_interval,
                 };

--- a/crates_io_worker/src/util.rs
+++ b/crates_io_worker/src/util.rs
@@ -28,7 +28,7 @@ where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<R, E>>,
 {
-    let hub = Hub::current();
+    let hub = Hub::new_from_top(Hub::current());
     let _scope_guard = hub.push_scope();
 
     let tx_ctx = sentry_core::TransactionContext::new(transaction_name, "swirl.perform");

--- a/crates_io_worker/src/util.rs
+++ b/crates_io_worker/src/util.rs
@@ -3,6 +3,22 @@ use sentry_core::Hub;
 use std::any::Any;
 use std::future::Future;
 use std::panic::PanicInfo;
+use tokio::task::JoinError;
+
+pub async fn spawn_blocking<F, R, E>(f: F) -> Result<R, E>
+where
+    F: FnOnce() -> Result<R, E> + Send + 'static,
+    R: Send + 'static,
+    E: Send + From<JoinError> + 'static,
+{
+    let hub = Hub::current();
+    tokio::task::spawn_blocking(move || Hub::run(hub, f))
+        .await
+        // Convert `JoinError` to `E`
+        .map_err(Into::into)
+        // Flatten `Result<Result<_, E>, E>` to `Result<_, E>`
+        .and_then(std::convert::identity)
+}
 
 pub async fn with_sentry_transaction<F, R, E, Fut>(
     transaction_name: &str,

--- a/crates_io_worker/src/worker.rs
+++ b/crates_io_worker/src/worker.rs
@@ -7,6 +7,7 @@ use diesel::prelude::*;
 use futures_util::FutureExt;
 use sentry_core::{Hub, SentryFutureExt};
 use std::panic::AssertUnwindSafe;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
 use tracing::{debug, error, info_span, warn};
@@ -14,7 +15,7 @@ use tracing::{debug, error, info_span, warn};
 pub struct Worker<Context> {
     pub(crate) connection_pool: ConnectionPool,
     pub(crate) context: Context,
-    pub(crate) job_registry: JobRegistry<Context>,
+    pub(crate) job_registry: Arc<JobRegistry<Context>>,
     pub(crate) shutdown_when_queue_empty: bool,
     pub(crate) poll_interval: Duration,
 }

--- a/crates_io_worker/src/worker.rs
+++ b/crates_io_worker/src/worker.rs
@@ -20,7 +20,7 @@ pub struct Worker<Context> {
     pub(crate) poll_interval: Duration,
 }
 
-impl<Context: Clone + Send + 'static> Worker<Context> {
+impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
     /// Run background jobs forever, or until the queue is empty if `shutdown_when_queue_empty` is set.
     pub fn run(&self) {
         loop {

--- a/crates_io_worker/src/worker.rs
+++ b/crates_io_worker/src/worker.rs
@@ -1,7 +1,7 @@
 use crate::job_registry::JobRegistry;
 use crate::runner::ConnectionPool;
 use crate::storage;
-use crate::util::{try_to_extract_panic_info, with_sentry_transaction};
+use crate::util::{spawn_blocking, try_to_extract_panic_info, with_sentry_transaction};
 use anyhow::anyhow;
 use diesel::prelude::*;
 use futures_util::FutureExt;
@@ -10,6 +10,7 @@ use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime::Handle;
+use tokio::time::sleep;
 use tracing::{debug, error, info_span, warn};
 
 pub struct Worker<Context> {
@@ -22,9 +23,9 @@ pub struct Worker<Context> {
 
 impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
     /// Run background jobs forever, or until the queue is empty if `shutdown_when_queue_empty` is set.
-    pub fn run(&self) {
+    pub async fn run(&self) {
         loop {
-            match self.run_next_job() {
+            match self.run_next_job().await {
                 Ok(Some(_)) => {}
                 Ok(None) if self.shutdown_when_queue_empty => {
                     debug!("No pending background worker jobs found. Shutting down the worker…");
@@ -35,11 +36,11 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
                         "No pending background worker jobs found. Polling again in {:?}…",
                         self.poll_interval
                     );
-                    std::thread::sleep(self.poll_interval);
+                    sleep(self.poll_interval).await;
                 }
                 Err(error) => {
                     error!(%error, "Failed to run job");
-                    std::thread::sleep(self.poll_interval);
+                    sleep(self.poll_interval).await;
                 }
             }
         }
@@ -51,53 +52,56 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
     /// - `Ok(Some(job_id))` if a job was run
     /// - `Ok(None)` if no jobs were waiting
     /// - `Err(...)` if there was an error retrieving the job
-    fn run_next_job(&self) -> anyhow::Result<Option<i64>> {
-        let job_types = &self.job_registry.job_types();
+    async fn run_next_job(&self) -> anyhow::Result<Option<i64>> {
+        let context = self.context.clone();
+        let job_registry = self.job_registry.clone();
+        let pool = self.connection_pool.clone();
 
-        let conn = &mut *self.connection_pool.get()?;
+        spawn_blocking(move || {
+            let job_types = job_registry.job_types();
+            let conn = &mut *pool.get()?;
+            conn.transaction(|conn| {
+                debug!("Looking for next background worker job…");
+                let Some(job) = storage::find_next_unlocked_job(conn, &job_types).optional()?
+                else {
+                    return Ok(None);
+                };
 
-        conn.transaction(|conn| {
-            debug!("Looking for next background worker job…");
-            let Some(job) = storage::find_next_unlocked_job(conn, job_types).optional()? else {
-                return Ok(None);
-            };
+                let span = info_span!("job", job.id = %job.id, job.typ = %job.job_type);
+                let _enter = span.enter();
 
-            let span = info_span!("job", job.id = %job.id, job.typ = %job.job_type);
-            let _enter = span.enter();
+                let job_id = job.id;
+                debug!("Running job…");
 
-            let job_id = job.id;
-            debug!("Running job…");
+                let future = with_sentry_transaction(&job.job_type, || async {
+                    let run_task_fn = job_registry
+                        .get(&job.job_type)
+                        .ok_or_else(|| anyhow!("Unknown job type {}", job.job_type))?;
 
-            let context = self.context.clone();
+                    AssertUnwindSafe(run_task_fn(context, job.data))
+                        .catch_unwind()
+                        .await
+                        .map_err(|e| try_to_extract_panic_info(&e))
+                        // TODO: Replace with flatten() once that stabilizes
+                        .and_then(std::convert::identity)
+                });
 
-            let future = with_sentry_transaction(&job.job_type, || async {
-                let run_task_fn = self
-                    .job_registry
-                    .get(&job.job_type)
-                    .ok_or_else(|| anyhow!("Unknown job type {}", job.job_type))?;
+                let result = Handle::current().block_on(future.bind_hub(Hub::current()));
 
-                AssertUnwindSafe(run_task_fn(context, job.data))
-                    .catch_unwind()
-                    .await
-                    .map_err(|e| try_to_extract_panic_info(&e))
-                    // TODO: Replace with flatten() once that stabilizes
-                    .and_then(std::convert::identity)
-            });
-
-            let result = Handle::current().block_on(future.bind_hub(Hub::current()));
-
-            match result {
-                Ok(_) => {
-                    debug!("Deleting successful job…");
-                    storage::delete_successful_job(conn, job_id)?
+                match result {
+                    Ok(_) => {
+                        debug!("Deleting successful job…");
+                        storage::delete_successful_job(conn, job_id)?
+                    }
+                    Err(error) => {
+                        warn!(%error, "Failed to run job");
+                        storage::update_failed_job(conn, job_id);
+                    }
                 }
-                Err(error) => {
-                    warn!(%error, "Failed to run job");
-                    storage::update_failed_job(conn, job_id);
-                }
-            }
 
-            Ok(Some(job_id))
+                Ok(Some(job_id))
+            })
         })
+        .await
     }
 }

--- a/crates_io_worker/tests/runner.rs
+++ b/crates_io_worker/tests/runner.rs
@@ -211,7 +211,7 @@ async fn panicking_in_jobs_updates_retry_counter() {
     assert_eq!(tries, 1);
 }
 
-fn runner<Context: Clone + Send + 'static>(
+fn runner<Context: Clone + Send + Sync + 'static>(
     database_url: &str,
     context: Context,
 ) -> Runner<Context> {


### PR DESCRIPTION
This PR converts the main `Worker::run()` fn to async/await, and wraps most of the `run_next_job()` fn content in a `spawn_blocking()` call.

This should get us one step closer to using an async database connection pool.