### PR TITLE
tests/util/response: Replace `reqwest::blocking::Response` with `hyper::Response`

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -103,14 +103,14 @@ pub trait RequestHelper {
         let router = router.layer(MockConnectInfo(mocket_addr));
 
         let axum_response = rt
-            .block_on(router.oneshot(request.map(hyper::Body::from)))
+            .block_on(router.oneshot(request.map(axum::body::Body::from)))
             .unwrap();
 
         let (parts, body) = axum_response.into_parts();
         let bytes = rt.block_on(hyper::body::to_bytes(body)).unwrap();
-        let hyper_response = hyper::Response::from_parts(parts, bytes);
+        let bytes_response = axum::response::Response::from_parts(parts, bytes);
 
-        Response::new(hyper_response)
+        Response::new(bytes_response)
     }
 
     /// Create a get request

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -106,13 +106,11 @@ pub trait RequestHelper {
             .block_on(router.oneshot(request.map(hyper::Body::from)))
             .unwrap();
 
-        // axum responses can't be converted directly to reqwest responses,
-        // so we have to convert it to a hyper response first.
         let (parts, body) = axum_response.into_parts();
         let bytes = rt.block_on(hyper::body::to_bytes(body)).unwrap();
         let hyper_response = hyper::Response::from_parts(parts, bytes);
 
-        Response::new(hyper_response.into())
+        Response::new(hyper_response)
     }
 
     /// Create a get request

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -2,7 +2,6 @@ use crate::util::matchers::is_success;
 use googletest::prelude::*;
 use serde_json::Value;
 use std::marker::PhantomData;
-use std::ops::Deref;
 
 use crates_io::rate_limiter::LimitedAction;
 use http::{header, StatusCode};
@@ -44,6 +43,10 @@ impl<T> Response<T> {
     #[track_caller]
     pub fn into_text(self) -> String {
         assert_ok!(self.response.text())
+    }
+
+    pub fn status(&self) -> StatusCode {
+        self.response.status()
     }
 
     #[track_caller]
@@ -89,14 +92,6 @@ impl Response<()> {
     #[track_caller]
     pub fn assert_forbidden(&self) {
         assert_eq!(self.status(), StatusCode::FORBIDDEN);
-    }
-}
-
-impl<T> Deref for Response<T> {
-    type Target = reqwest::blocking::Response;
-
-    fn deref(&self) -> &Self::Target {
-        &self.response
     }
 }
 


### PR DESCRIPTION
This should make our migration to axum 0.7 and hyper 1.x a little easier since our version of `reqwest` is currently not compatible with hyper 1.x.