### PR TITLE
tests/server_binary: Assert on exact HTTP response status codes

### DIFF
--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -1,5 +1,4 @@
 use crate::builders::CrateBuilder;
-use crate::util::matchers::is_redirection;
 use crate::util::ChaosProxy;
 use anyhow::{Context, Error};
 use crates_io::models::{NewUser, User};
@@ -7,6 +6,7 @@ use crates_io_test_db::TestDatabase;
 use diesel::prelude::*;
 use googletest::prelude::*;
 use reqwest::blocking::{Client, Response};
+use reqwest::StatusCode;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Read};
 use std::process::{Child, Command, Stdio};
@@ -28,7 +28,7 @@ fn normal_startup() {
     let resp = running_server
         .get("api/v1/crates/FOO/1.0.0/download")
         .unwrap();
-    assert_that!(resp.status(), is_redirection());
+    assert_eq!(resp.status(), StatusCode::FOUND);
 
     let location = assert_some!(resp.headers().get("location"));
     let location = assert_ok!(location.to_str());
@@ -52,7 +52,7 @@ fn startup_without_database() {
     let resp = running_server
         .get("api/v1/crates/FOO/1.0.0/download")
         .unwrap();
-    assert_that!(resp.status(), is_redirection());
+    assert_eq!(resp.status(), StatusCode::FOUND);
 
     let location = assert_some!(resp.headers().get("location"));
     let location = assert_ok!(location.to_str());

--- a/src/tests/util/matchers.rs
+++ b/src/tests/util/matchers.rs
@@ -21,24 +21,3 @@ impl Matcher for SuccessMatcher {
         }
     }
 }
-
-pub fn is_redirection() -> RedirectionMatcher {
-    RedirectionMatcher
-}
-
-pub struct RedirectionMatcher;
-
-impl Matcher for RedirectionMatcher {
-    type ActualT = StatusCode;
-
-    fn matches(&self, actual: &Self::ActualT) -> MatcherResult {
-        actual.is_redirection().into()
-    }
-
-    fn describe(&self, matcher_result: MatcherResult) -> String {
-        match matcher_result {
-            MatcherResult::Match => "is a redirection status code (300-399)".into(),
-            MatcherResult::NoMatch => "isn't a redirection status code (300-399)".into(),
-        }
-    }
-}


### PR DESCRIPTION
We know the exact status code that we expect, so we might as well use `assert_eq!()` instead of the custom matcher implementation.