### PR TITLE
Fix `reqwest` imports

### DIFF
--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Context};
-use http::HeaderValue;
+use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::Client;
 use secrecy::{ExposeSecret, SecretString};
 
@@ -62,7 +62,7 @@ impl Fastly {
         let mut api_token = HeaderValue::try_from(api_token)?;
         api_token.set_sensitive(true);
 
-        let mut headers = reqwest::header::HeaderMap::new();
+        let mut headers = HeaderMap::new();
         headers.append("Fastly-Key", api_token);
 
         debug!("sending invalidation request to Fastly");

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,6 @@
 use anyhow::Context;
 use crates_io_env_vars::required_var;
 use futures_util::{StreamExt, TryStreamExt};
-use http::header::CACHE_CONTROL;
-use http::{HeaderMap, HeaderValue};
 use hyper::body::Bytes;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::local::LocalFileSystem;
@@ -10,6 +8,8 @@ use object_store::memory::InMemory;
 use object_store::path::Path;
 use object_store::prefix::PrefixStore;
 use object_store::{ClientOptions, ObjectStore, Result};
+use reqwest::header::CACHE_CONTROL;
+use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
 use std::fs;
 use std::path::PathBuf;


### PR DESCRIPTION
In the current situation `reqwest` reexports the header code from the `http` crate. However once we update `hyper` to 1.x we will have two copies of the `http` crate, with differing major versions. This leads to conflicts between the header code that `reqwest` expects and the `http` crate used by `crates_io`. By importing the header code from `reqwest` we can ensure that we use the correct `http` crate version that `reqwest` expects.