### PR TITLE
Fix `User-Agent` header requirement error responses

### DIFF
--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -33,7 +33,7 @@ pub struct RequestMetadata {
     uri: Uri,
     original_path: Option<Extension<OriginalPath>>,
     real_ip: Extension<RealIp>,
-    user_agent: TypedHeader<UserAgent>,
+    user_agent: Option<TypedHeader<UserAgent>>,
     request_id: Option<TypedHeader<XRequestId>>,
     ci_service: Option<CiService>,
 }
@@ -87,7 +87,9 @@ impl Display for Metadata<'_> {
             line.add_field("status", self.status.as_str())?;
         }
 
-        line.add_quoted_field("user_agent", self.request.user_agent.as_str())?;
+        let user_agent = self.request.user_agent.as_ref();
+        let user_agent = user_agent.map(|ua| ua.as_str()).unwrap_or_default();
+        line.add_quoted_field("user_agent", user_agent)?;
 
         if self.request.original_path.is_some() {
             line.add_quoted_field("normalized_path", &self.request.uri)?;


### PR DESCRIPTION
The middleware that is responsible for rejecting requests without a `User-Agent` header runs after the middleware that logs requests. The request logging middleware however was expecting a `TypedHeader<UserAgent>`, which meant that requests without such a header were unconditionally rejected, even for download requests.

Our test suite for this functionality was setting an empty header, which unfortunately behaved differently than not having such a header at all.

Related:

- 44aeb47b56037890f49c05464a973b8447f7c0ff implemented the corresponding tests (April 2019)
- 88bd12977523bf68f62d622447c2b9cbbc2f8987 changed the logging middleware to rely on `TypedHeader<UserAgent>` (Dec 2022)