### PR TITLE
util/errors: Simplify `ServiceUnavailable` struct

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -77,8 +77,8 @@ pub fn server_error<S: ToString>(error: S) -> BoxedAppError {
 }
 
 /// Returns an error with status 503 and the provided description as JSON
-pub fn service_unavailable<S: ToString>(error: S) -> BoxedAppError {
-    Box::new(json::ServiceUnavailable(error.to_string()))
+pub fn service_unavailable() -> BoxedAppError {
+    Box::new(json::ServiceUnavailable)
 }
 
 // =============================================================================
@@ -238,7 +238,7 @@ impl From<lettre::address::AddressError> for BoxedAppError {
 impl From<PoolError> for BoxedAppError {
     fn from(err: PoolError) -> BoxedAppError {
         match err {
-            PoolError::UnhealthyPool => service_unavailable("Service unavailable"),
+            PoolError::UnhealthyPool => service_unavailable(),
             _ => Box::new(err),
         }
     }

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -72,7 +72,7 @@ pub(super) struct BadRequest(pub(super) String);
 #[derive(Debug)]
 pub(super) struct ServerError(pub(super) String);
 #[derive(Debug)]
-pub(crate) struct ServiceUnavailable(pub(super) String);
+pub(crate) struct ServiceUnavailable;
 #[derive(Debug)]
 pub(crate) struct TooManyRequests {
     pub action: LimitedAction,
@@ -117,13 +117,13 @@ impl fmt::Display for ServerError {
 
 impl AppError for ServiceUnavailable {
     fn response(&self) -> Response {
-        json_error(&self.0, StatusCode::SERVICE_UNAVAILABLE)
+        json_error("Service unavailable", StatusCode::SERVICE_UNAVAILABLE)
     }
 }
 
 impl fmt::Display for ServiceUnavailable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+        "Service unavailable".fmt(f)
     }
 }
 


### PR DESCRIPTION
If we only ever put `"Service unavailable"` in it we might as well simplify the code :D