### PR TITLE
clippy: Warn about `todo!()` usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ unused = "warn"
 
 [workspace.lints.clippy]
 all = "warn"
+todo = "warn"
 
 [lints]
 workspace = true


### PR DESCRIPTION
Surprisingly, clippy does not warn about `todo!()` by default. This PR changes that to avoid us unintentionally pushing work-in-progress code to the `main` branch.