### PR TITLE
Ensure `200 OK` status codes for cargo endpoints

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,10 +1,10 @@
 pub mod app;
 mod balance_capacity;
 mod block_traffic;
+mod cargo_compat;
 mod common_headers;
 mod debug;
 mod ember_html;
-mod errors;
 pub mod log_request;
 pub mod normalize_path;
 pub mod real_ip;
@@ -26,7 +26,6 @@ use tower_http::compression::{CompressionLayer, CompressionLevel};
 use tower_http::timeout::{RequestBodyTimeoutLayer, TimeoutLayer};
 
 use crate::app::AppState;
-use crate::middleware::errors::ensure_json_errors;
 use crate::Env;
 
 pub fn apply_axum_middleware(state: AppState, router: Router<()>) -> Router {
@@ -64,7 +63,7 @@ pub fn apply_axum_middleware(state: AppState, router: Router<()>) -> Router {
         }));
 
     let middlewares_2 = tower::ServiceBuilder::new()
-        .layer(from_fn(ensure_json_errors))
+        .layer(from_fn(cargo_compat::middleware))
         .layer(from_fn_with_state(state.clone(), session::attach_session))
         .layer(from_fn_with_state(
             state.clone(),

--- a/src/middleware/cargo_compat.rs
+++ b/src/middleware/cargo_compat.rs
@@ -1,19 +1,55 @@
-use axum::extract::Request;
+use axum::extract::{MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use axum::Json;
-use http::{header, StatusCode};
+use axum::{Extension, Json};
+use http::{header, Method, StatusCode};
 
-/// Convert plain text errors into JSON errors.
-pub async fn middleware(req: Request, next: Next) -> Response {
+/// Convert plain text errors into JSON errors and adjust status codes.
+pub async fn middleware(
+    matched_path: Option<Extension<MatchedPath>>,
+    req: Request,
+    next: Next,
+) -> Response {
     let is_api_request = req.uri().path().starts_with("/api/");
+    let is_cargo_endpoint = matched_path
+        .map(|m| is_cargo_endpoint(req.method(), m.as_str()))
+        .unwrap_or(false);
 
     let mut res = next.run(req).await;
     if is_api_request {
         res = ensure_json_errors(res).await;
     }
+    if is_cargo_endpoint {
+        // cargo until 1.34.0 expected crates.io to always return 200 OK for
+        // all requests, even if they failed. If a different status code was
+        // returned, cargo would show the raw JSON response to the user, instead
+        // of a friendly error message.
+        //
+        // With cargo 1.34.0 this issue got resolved (see https://github.com/rust-lang/cargo/pull/6771),
+        // for successful requests still only "200 OK" was expected and no other
+        // 2xx status code. This will change with cargo 1.76.0 (see https://github.com/rust-lang/cargo/pull/13158),
+        // but for backwards compatibility we still return "200 OK" for now for
+        // all endpoints that are relevant for cargo.
+        *res.status_mut() = StatusCode::OK;
+    }
 
     res
+}
+
+fn is_cargo_endpoint(method: &Method, path: &str) -> bool {
+    const CARGO_ENDPOINTS: &[(Method, &str)] = &[
+        (Method::PUT, "/api/v1/crates/new"),
+        (Method::DELETE, "/api/v1/crates/:crate_id/:version/yank"),
+        (Method::PUT, "/api/v1/crates/:crate_id/:version/unyank"),
+        (Method::GET, "/api/v1/crates/:crate_id/owners"),
+        (Method::PUT, "/api/v1/crates/:crate_id/owners"),
+        (Method::DELETE, "/api/v1/crates/:crate_id/owners"),
+        (Method::GET, "/api/v1/crates"),
+    ];
+
+    CARGO_ENDPOINTS
+        .iter()
+        .any(|(m, p)| m == method && p == &path)
 }
 
 /// Convert plain text errors into JSON errors.
@@ -60,7 +96,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::middleware::from_fn;
-    use axum::routing::get;
+    use axum::routing::{get, put};
     use axum::Router;
     use bytes::Bytes;
     use http::response::Parts;
@@ -80,11 +116,27 @@ mod tests {
             .route("/teapot", teapot)
             .route("/api/500", internal.clone())
             .route("/500", internal)
+            .route("/api/v1/crates/new", put(|| async { StatusCode::CREATED }))
+            .route(
+                "/api/v1/crates/:crate_id/owners",
+                get(|| async { StatusCode::INTERNAL_SERVER_ERROR }),
+            )
             .layer(from_fn(middleware))
     }
 
     async fn request(path: &str) -> anyhow::Result<(Parts, Bytes)> {
-        let request = Request::get(path).body(Body::empty())?;
+        request_inner(Method::GET, path).await
+    }
+
+    async fn put_request(path: &str) -> anyhow::Result<(Parts, Bytes)> {
+        request_inner(Method::PUT, path).await
+    }
+
+    async fn request_inner(method: Method, path: &str) -> anyhow::Result<(Parts, Bytes)> {
+        let request = Request::builder()
+            .method(method)
+            .uri(path)
+            .body(Body::empty())?;
         let response = build_app().oneshot(request).await?;
         let (parts, body) = response.into_parts();
         let bytes = axum::body::to_bytes(body, usize::MAX).await?;
@@ -154,5 +206,14 @@ mod tests {
         }
         "###);
         assert_debug_snapshot!(bytes, @r###"b"Internal Server Error""###);
+    }
+
+    #[tokio::test]
+    async fn test_cargo_endpoint_status() {
+        let (parts, _bytes) = put_request("/api/v1/crates/new").await.unwrap();
+        assert_eq!(parts.status, StatusCode::OK);
+
+        let (parts, _bytes) = request("/api/v1/crates/foo/owners").await.unwrap();
+        assert_eq!(parts.status, StatusCode::OK);
     }
 }

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -13,7 +13,7 @@ fn new_wrong_token() {
     // Try to publish without a token
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
     let response = anon.publish_crate(crate_to_publish);
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -29,7 +29,7 @@ fn new_wrong_token() {
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
     let response = token.publish_crate(crate_to_publish);
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -366,7 +366,7 @@ fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, body);
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -388,7 +388,7 @@ fn owner_change_via_publish_token() {
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, body);
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -409,7 +409,7 @@ fn owner_change_without_auth() {
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
     let response = anon.put::<()>(&url, body);
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -21,7 +21,7 @@ fn pagination_blocks_ip_from_cidr_block_list() {
     });
 
     let response = anon.get_with_query::<()>("/api/v1/crates", "page=2&per_page=1");
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "requested page offset is too large" }] })

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -3,6 +3,7 @@ use crate::{RequestHelper, TestApp};
 
 use diesel::prelude::*;
 use http::StatusCode;
+use insta::assert_json_snapshot;
 
 #[test]
 fn can_hit_read_only_endpoints_in_read_only_mode() {
@@ -31,7 +32,8 @@ fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
     });
 
     let response = token.delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank");
-    assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.into_json());
 }
 
 #[test]

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -806,7 +806,7 @@ fn pagination_parameters_only_accept_integers() {
 
     let response =
         anon.get_with_query::<()>("/api/v1/crates", "page=1&per_page=100%22%EF%BC%8Cexception");
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "invalid digit found in string" }] })
@@ -814,7 +814,7 @@ fn pagination_parameters_only_accept_integers() {
 
     let response =
         anon.get_with_query::<()>("/api/v1/crates", "page=100%22%EF%BC%8Cexception&per_page=1");
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "invalid digit found in string" }] })

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -115,14 +115,14 @@ mod auth {
         let (_, client, _) = prepare();
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -182,14 +182,14 @@ mod auth {
             client.db_new_scoped_token("test-token", None, None, Some(expired_at.naive_utc()));
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -222,14 +222,14 @@ mod auth {
         );
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -286,14 +286,14 @@ mod auth {
         );
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
@@ -311,14 +311,14 @@ mod auth {
         );
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
-        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(
             response.into_json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -11,14 +11,16 @@ fn user_agent_is_required() {
 
     let req = Request::get("/api/v1/crates").body("").unwrap();
     let resp = anon.run::<()>(req);
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_json_snapshot!(resp.into_json());
 
     let req = Request::get("/api/v1/crates")
         .header(header::USER_AGENT, "")
         .body("")
         .unwrap();
     let resp = anon.run::<()>(req);
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_json_snapshot!(resp.into_json());
 }
 
 #[test]
@@ -99,6 +101,6 @@ fn block_traffic_via_ip() {
         .empty();
 
     let resp = anon.get::<()>("/api/v1/crates");
-    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    assert_eq!(resp.status(), StatusCode::OK);
     assert_json_snapshot!(resp.into_json());
 }

--- a/src/tests/snapshots/all__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
+++ b/src/tests/snapshots/all__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/read_only_mode.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "crates.io is currently in read-only mode for maintenance. Please try again later."
+    }
+  ]
+}

--- a/src/tests/snapshots/all__server__user_agent_is_required-2.snap
+++ b/src/tests/snapshots/all__server__user_agent_is_required-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/server.rs
+expression: resp.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "We require that all requests include a `User-Agent` header.  To allow us to determine the impact your bot has on our service, we ask that your user agent actually identify your bot, and not just report the HTTP client library you're using.  Including contact information will also reduce the chance that we will need to take action against your bot.\n\nBad:\n  User-Agent: reqwest/0.9.1\n\nBetter:\n  User-Agent: my_crawler\n\nBest:\n  User-Agent: my_crawler (my_crawler.com/info)\n  User-Agent: my_crawler (help@my_crawler.com)\n\nIf you believe you've received this message in error, please email help@crates.io and include the request id .\n"
+    }
+  ]
+}

--- a/src/tests/snapshots/all__server__user_agent_is_required.snap
+++ b/src/tests/snapshots/all__server__user_agent_is_required.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/server.rs
+expression: resp.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "We require that all requests include a `User-Agent` header.  To allow us to determine the impact your bot has on our service, we ask that your user agent actually identify your bot, and not just report the HTTP client library you're using.  Including contact information will also reduce the chance that we will need to take action against your bot.\n\nBad:\n  User-Agent: reqwest/0.9.1\n\nBetter:\n  User-Agent: my_crawler\n\nBest:\n  User-Agent: my_crawler (my_crawler.com/info)\n  User-Agent: my_crawler (help@my_crawler.com)\n\nIf you believe you've received this message in error, please email help@crates.io and include the request id .\n"
+    }
+  ]
+}

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -75,7 +75,7 @@ impl<T> Response<T> {
             detail: String,
         }
 
-        assert_eq!(self.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(self.status(), StatusCode::OK);
 
         let expected_message_start = format!("{}. Please try again after ", action.error_message());
         let error: ErrorResponse = json(self.response);


### PR DESCRIPTION
cargo before 1.34.0 only showed raw JSON errors when a non-200 status code was returned. In crates.io we are using the `cargo_err()` fn in many places to ensure that the error that is returned uses the `200 OK` status code. As can be seen in the diff, we haven't been consistent in this though.

This PR introduces a middleware that overrides the HTTP status code to `200 OK` for all API endpoints that are relevant for cargo (see https://doc.rust-lang.org/cargo/reference/registry-web-api.html).

This will allow us to remove `cargo_err()` and use proper status codes internally. This is particularly useful for helper functions that are used by both cargo- and non-cargo endpoints. It also makes it easier to phase out the `200 OK` requirement since the middleware could easily be disabled by a feature flag in the future.