### PR TITLE
worker: Enable missing `tokio` feature

### DIFF
--- a/crates_io_worker/Cargo.toml
+++ b/crates_io_worker/Cargo.toml
@@ -16,7 +16,7 @@ sentry-core = { version = "=0.31.8", features = ["client"] }
 serde = { version = "=1.0.193", features = ["derive"] }
 serde_json = "=1.0.108"
 thiserror = "=1.0.50"
-tokio = { version = "=1.35.0", features = ["rt"]}
+tokio = { version = "=1.35.0", features = ["rt", "time"]}
 tracing = "=0.1.40"
 
 [dev-dependencies]


### PR DESCRIPTION
This fixes the following issue:

```
$ cargo test --package crates_io_worker

error[E0432]: unresolved import `tokio::time`
  --> crates_io_worker/src/worker.rs:13:12
   |
13 | use tokio::time::sleep;
   |            ^^^^ could not find `time` in `tokio`
```