### PR TITLE
github: Extract `GitHubError` enum

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -31,8 +31,8 @@ mod json;
 
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{
-    InsecurelyGeneratedTokenRevoked, MetricsDisabled, NotFound, OwnershipInvitationExpired,
-    ReadOnlyMode, RouteBlocked, TooManyRequests,
+    InsecurelyGeneratedTokenRevoked, MetricsDisabled, OwnershipInvitationExpired, ReadOnlyMode,
+    RouteBlocked, TooManyRequests,
 };
 
 pub type BoxedAppError = Box<dyn AppError>;


### PR DESCRIPTION
This reduces the need for `e.is::<NotFound>()` checks and makes the code a little less coupled to our HTTP layer and its error responses.