### PR TITLE
github: Use `Bearer` authorization scheme instead of `token`

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -79,7 +79,7 @@ impl RealGitHubClient {
     where
         T: DeserializeOwned,
     {
-        self._request(url, &format!("token {}", auth.secret()))
+        self._request(url, &format!("Bearer {}", auth.secret()))
             .await
     }
 


### PR DESCRIPTION
`Bearer` is the official standard scheme (see https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml), while `token` is a GitHub-specific variant. According to https://docs.github.com/de/rest/authentication/authenticating-to-the-rest-api?apiVersion=2022-11-28#about-authentication both are equivalent though.

This commit changes the authorization scheme to `Bearer` to make it easier to interact with regular HTTP tooling that does not support `token`.