### PR TITLE
Extract `crates_io_github` package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,6 +966,7 @@ dependencies = [
  "clap",
  "cookie",
  "crates_io_env_vars",
+ "crates_io_github",
  "crates_io_index",
  "crates_io_markdown",
  "crates_io_tarball",
@@ -1035,6 +1036,19 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "dotenvy",
+]
+
+[[package]]
+name = "crates_io_github"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "oauth2",
+ "reqwest",
+ "serde",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ base64 = "=0.21.5"
 bigdecimal = "=0.4.2"
 cargo-manifest = "=0.12.1"
 crates_io_env_vars = { path = "crates_io_env_vars" }
+crates_io_github = { path = "crates_io_github" }
 crates_io_index = { path = "crates_io_index" }
 crates_io_markdown = { path = "crates_io_markdown" }
 crates_io_tarball = { path = "crates_io_tarball" }

--- a/crates_io_github/Cargo.toml
+++ b/crates_io_github/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "crates_io_github"
+version = "0.0.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "=1.0.75"
+async-trait = "=0.1.74"
+oauth2 = { version = "=4.4.2", default-features = false }
+reqwest = { version = "=0.11.22", features = ["json"] }
+serde = { version = "=1.0.193", features = ["derive"] }
+thiserror = "=1.0.50"
+tracing = "=0.1.40"
+
+[dev-dependencies]

--- a/crates_io_github/src/lib.rs
+++ b/crates_io_github/src/lib.rs
@@ -1,5 +1,8 @@
 //! This module implements functionality for interacting with GitHub.
 
+#[macro_use]
+extern crate tracing;
+
 use oauth2::AccessToken;
 use reqwest::{self, header};
 
@@ -9,6 +12,7 @@ use std::str;
 
 use async_trait::async_trait;
 use reqwest::Client;
+use serde::Deserialize;
 
 type Result<T> = std::result::Result<T, GitHubError>;
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,11 +8,11 @@ use std::sync::Arc;
 
 use crate::downloads_counter::DownloadsCounter;
 use crate::email::Emails;
-use crate::github::GitHubClient;
 use crate::metrics::{InstanceMetrics, ServiceMetrics};
 use crate::rate_limiter::RateLimiter;
 use crate::storage::Storage;
 use axum::extract::{FromRef, FromRequestParts, State};
+use crates_io_github::GitHubClient;
 use diesel::r2d2;
 use moka::future::{Cache, CacheBuilder};
 use oauth2::basic::BasicClient;

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -7,7 +7,7 @@ use std::{sync::Arc, time::Duration};
 
 use axum::extract::Request;
 use axum::ServiceExt;
-use crates_io::github::RealGitHubClient;
+use crates_io_github::RealGitHubClient;
 use hyper::body::Incoming;
 use hyper_util::rt::TokioIo;
 use prometheus::Encoder;

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -1,12 +1,12 @@
 use crate::app::AppState;
 use crate::controllers::frontend_prelude::*;
-use crate::github::GitHubPublicKey;
 use crate::models::{ApiToken, User};
 use crate::schema::api_tokens;
 use crate::util::token::HashedToken;
 use anyhow::{anyhow, Context};
 use axum::body::Bytes;
 use base64::{engine::general_purpose, Engine};
+use crates_io_github::GitHubPublicKey;
 use http::HeaderMap;
 use once_cell::sync::Lazy;
 use p256::ecdsa::signature::Verifier;

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -1,5 +1,6 @@
 use crate::app::AppState;
 use crate::controllers::frontend_prelude::*;
+use crate::github::GitHubPublicKey;
 use crate::models::{ApiToken, User};
 use crate::schema::api_tokens;
 use crate::util::token::HashedToken;
@@ -27,18 +28,6 @@ static PUBLIC_KEY_CACHE: Lazy<Mutex<GitHubPublicKeyCache>> = Lazy::new(|| {
     };
     Mutex::new(cache)
 });
-
-#[derive(Debug, Deserialize, Clone, Eq, Hash, PartialEq)]
-pub struct GitHubPublicKey {
-    pub key_identifier: String,
-    pub key: String,
-    pub is_current: bool,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct GitHubPublicKeyList {
-    pub public_keys: Vec<GitHubPublicKey>,
-}
 
 #[derive(Debug, Clone)]
 struct GitHubPublicKeyCache {

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -6,12 +6,12 @@ use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
 use tokio::runtime::Handle;
 
 use crate::email::Emails;
-use crate::github::GithubUser;
 use crate::middleware::session::SessionExtension;
 use crate::models::{NewUser, User};
 use crate::schema::users;
 use crate::util::errors::ReadOnlyMode;
 use crate::views::EncodableMe;
+use crates_io_github::GithubUser;
 
 /// Handles the `GET /api/private/session/begin` route.
 ///

--- a/src/github.rs
+++ b/src/github.rs
@@ -7,7 +7,6 @@ use serde::de::DeserializeOwned;
 
 use std::str;
 
-use crate::controllers::github::secret_scanning::{GitHubPublicKey, GitHubPublicKeyList};
 use crate::util::errors::{cargo_err, internal, not_found, BoxedAppError};
 use async_trait::async_trait;
 use reqwest::Client;
@@ -218,6 +217,18 @@ pub struct GitHubTeamMembership {
 pub struct GitHubOrgMembership {
     pub state: String,
     pub role: String,
+}
+
+#[derive(Debug, Deserialize, Clone, Eq, Hash, PartialEq)]
+pub struct GitHubPublicKey {
+    pub key_identifier: String,
+    pub key: String,
+    pub is_current: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubPublicKeyList {
+    pub public_keys: Vec<GitHubPublicKey>,
 }
 
 pub fn team_url(login: &str) -> String {

--- a/src/github.rs
+++ b/src/github.rs
@@ -7,7 +7,6 @@ use serde::de::DeserializeOwned;
 
 use std::str;
 
-use crate::util::errors::{cargo_err, internal, not_found, BoxedAppError};
 use async_trait::async_trait;
 use reqwest::Client;
 
@@ -165,23 +164,6 @@ impl From<reqwest::Error> for GitHubError {
             Some(Status::UNAUTHORIZED) | Some(Status::FORBIDDEN) => Self::Permission(error.into()),
             Some(Status::NOT_FOUND) => Self::NotFound(error.into()),
             _ => Self::Other(error.into()),
-        }
-    }
-}
-
-impl From<GitHubError> for BoxedAppError {
-    fn from(error: GitHubError) -> Self {
-        match error {
-            GitHubError::Permission(_) => cargo_err(
-                "It looks like you don't have permission \
-                     to query a necessary property from GitHub \
-                     to complete this request. \
-                     You may need to re-authenticate on \
-                     crates.io to grant permission to read \
-                     GitHub org memberships.",
-            ),
-            GitHubError::NotFound(_) => not_found(),
-            _ => internal(format!("didn't get a 200 result from github: {error}")),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ mod downloads_counter;
 pub mod email;
 pub mod external_urls;
 pub mod fastly;
-pub mod github;
 pub mod headers;
 mod licenses;
 pub mod metrics;

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use crate::app::App;
 use crate::util::errors::{cargo_err, AppResult};
 
-use crate::github::GitHubError;
+use crates_io_github::GitHubError;
 use oauth2::AccessToken;
 use tokio::runtime::Handle;
 

--- a/src/tests/util/github.rs
+++ b/src/tests/util/github.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
-use crates_io::github::{
+use crates_io_github::{
     GitHubClient, GitHubError, GitHubOrgMembership, GitHubOrganization, GitHubPublicKey,
     GitHubTeam, GitHubTeamMembership, GithubUser,
 };

--- a/src/tests/util/github.rs
+++ b/src/tests/util/github.rs
@@ -1,9 +1,8 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
-use crates_io::controllers::github::secret_scanning::GitHubPublicKey;
 use crates_io::github::{
-    GitHubClient, GitHubError, GitHubOrgMembership, GitHubOrganization, GitHubTeam,
-    GitHubTeamMembership, GithubUser,
+    GitHubClient, GitHubError, GitHubOrgMembership, GitHubOrganization, GitHubPublicKey,
+    GitHubTeam, GitHubTeamMembership, GithubUser,
 };
 use oauth2::AccessToken;
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -29,6 +29,7 @@ use crate::middleware::log_request::{CauseField, ErrorField};
 
 mod json;
 
+use crate::github::GitHubError;
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{
     InsecurelyGeneratedTokenRevoked, MetricsDisabled, OwnershipInvitationExpired, ReadOnlyMode,
@@ -277,6 +278,23 @@ impl From<crates_io_worker::EnqueueError> for BoxedAppError {
 impl From<JoinError> for BoxedAppError {
     fn from(err: JoinError) -> BoxedAppError {
         Box::new(err)
+    }
+}
+
+impl From<GitHubError> for BoxedAppError {
+    fn from(error: GitHubError) -> Self {
+        match error {
+            GitHubError::Permission(_) => cargo_err(
+                "It looks like you don't have permission \
+                     to query a necessary property from GitHub \
+                     to complete this request. \
+                     You may need to re-authenticate on \
+                     crates.io to grant permission to read \
+                     GitHub org memberships.",
+            ),
+            GitHubError::NotFound(_) => not_found(),
+            _ => internal(format!("didn't get a 200 result from github: {error}")),
+        }
     }
 }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -29,7 +29,7 @@ use crate::middleware::log_request::{CauseField, ErrorField};
 
 mod json;
 
-use crate::github::GitHubError;
+use crates_io_github::GitHubError;
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{
     InsecurelyGeneratedTokenRevoked, MetricsDisabled, OwnershipInvitationExpired, ReadOnlyMode,

--- a/src/views.rs
+++ b/src/views.rs
@@ -2,13 +2,13 @@ use chrono::NaiveDateTime;
 use secrecy::ExposeSecret;
 
 use crate::external_urls::remove_blocked_urls;
-use crate::github;
 use crate::models::{
     ApiToken, Category, Crate, CrateOwnerInvitation, CreatedApiToken, Dependency, DependencyKind,
     Keyword, Owner, ReverseDependency, Team, TopVersions, User, Version, VersionDownload,
     VersionOwnerAction,
 };
 use crate::util::rfc3339;
+use crates_io_github as github;
 
 pub mod krate_publish;
 pub use self::krate_publish::{EncodableCrateDependency, PublishMetadata};


### PR DESCRIPTION
This PR extracts our top-level `github` module into a dedicated workspace package. This makes it easier to enforce the decoupling between the GitHub client code and our HTTP API layer.