### PR TITLE
Fix error handling for optional SQL results

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -213,7 +213,8 @@ pub async fn regenerate_token_and_send(
             let email: Email = update(Email::belonging_to(user))
                 .set(emails::token.eq(sql("DEFAULT")))
                 .get_result(conn)
-                .map_err(|_| bad_request("Email could not be found"))?;
+                .optional()?
+                .ok_or_else(|| bad_request("Email could not be found"))?;
 
             state
                 .emails

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -188,7 +188,8 @@ impl Crate {
         self.all_versions()
             .filter(versions::num.eq(version))
             .first(conn)
-            .map_err(|_| {
+            .optional()?
+            .ok_or_else(|| {
                 cargo_err(format_args!(
                     "crate `{}` does not have a version `{}`",
                     self.name, version

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -76,8 +76,9 @@ impl Owner {
                 .filter(users::gh_id.ne(-1))
                 .order(users::gh_id.desc())
                 .first(conn)
+                .optional()?
                 .map(Owner::User)
-                .map_err(|_| cargo_err(format_args!("could not find user with login `{name}`")))
+                .ok_or_else(|| cargo_err(format_args!("could not find user with login `{name}`")))
         }
     }
 

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -92,16 +92,18 @@ impl Owner {
             teams::table
                 .filter(lower(teams::login).eq(&name.to_lowercase()))
                 .first(conn)
+                .optional()?
                 .map(Owner::Team)
-                .map_err(|_| cargo_err(format_args!("could not find team with login `{name}`")))
+                .ok_or_else(|| cargo_err(format_args!("could not find team with login `{name}`")))
         } else {
             users::table
                 .filter(lower(users::gh_login).eq(name.to_lowercase()))
                 .filter(users::gh_id.ne(-1))
                 .order(users::gh_id.desc())
                 .first(conn)
+                .optional()?
                 .map(Owner::User)
-                .map_err(|_| cargo_err(format_args!("could not find user with login `{name}`")))
+                .ok_or_else(|| cargo_err(format_args!("could not find user with login `{name}`")))
         }
     }
 


### PR DESCRIPTION
When `diesel` returns an error it doesn't always mean that the resource couldn't be found, it could also be any other kind of error. A couple of places in the codebase were unconditionally transforming `diesel` errors into "could not find ..." errors though. This PR fixes the issue by using `.optional()?.ok_or_else(|| ...)` instead of `.map_err(|_| ...)`.