### PR TITLE
email: Add `domain` field

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,5 +8,4 @@ pub use self::balance_capacity::BalanceCapacityConfig;
 pub use self::base::Base;
 pub use self::database_pools::{DatabasePools, DbPoolConfig};
 pub use self::sentry::SentryConfig;
-pub(crate) use self::server::domain_name;
 pub use self::server::Server;

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -202,7 +202,7 @@ impl Server {
             page_offset_ua_blocklist,
             page_offset_cidr_blocklist,
             excluded_crate_names,
-            domain_name: domain_name(),
+            domain_name: dotenvy::var("DOMAIN_NAME").unwrap_or_else(|_| "crates.io".into()),
             allowed_origins,
             downloads_persist_interval: var_parsed("DOWNLOADS_PERSIST_INTERVAL_MS")?
                 .map(Duration::from_millis)
@@ -234,10 +234,6 @@ impl Server {
     pub fn env(&self) -> Env {
         self.base.env
     }
-}
-
-pub(crate) fn domain_name() -> String {
-    dotenvy::var("DOMAIN_NAME").unwrap_or_else(|_| "crates.io".into())
 }
 
 /// Parses a CIDR block string to a valid `IpNetwork` struct.


### PR DESCRIPTION
Instead of calling `dotenvy::var("DOMAIN_NAME")` over and over we can read the value from the server config struct and save it inside the `Emails` instance 🎉 