### PR TITLE
email: Use `Transport` implementations in all backend variants

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -1,12 +1,14 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::config;
 use crate::Env;
+use lettre::address::Envelope;
 use lettre::message::header::ContentType;
 use lettre::message::Mailbox;
 use lettre::transport::file::FileTransport;
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};
 use lettre::transport::smtp::SmtpTransport;
+use lettre::transport::stub::StubTransport;
 use lettre::{Message, Transport};
 use rand::distributions::{Alphanumeric, DistString};
 
@@ -62,9 +64,7 @@ impl Emails {
     /// to later assert the mails were sent.
     pub fn new_in_memory() -> Self {
         Self {
-            backend: EmailBackend::Memory {
-                mails: Arc::new(Mutex::new(Vec::new())),
-            },
+            backend: EmailBackend::Memory(StubTransport::new_ok()),
             domain: "crates.io".into(),
             from: DEFAULT_FROM.parse().unwrap(),
         }
@@ -169,9 +169,9 @@ Source type: {source}\n",
 
     /// This is supposed to be used only during tests, to retrieve the messages stored in the
     /// "memory" backend. It's not cfg'd away because our integration tests need to access this.
-    pub fn mails_in_memory(&self) -> Option<Vec<StoredEmail>> {
-        if let EmailBackend::Memory { mails } = &self.backend {
-            Some(mails.lock().unwrap().clone())
+    pub fn mails_in_memory(&self) -> Option<Vec<(Envelope, String)>> {
+        if let EmailBackend::Memory(transport) = &self.backend {
+            Some(transport.messages())
         } else {
             None
         }
@@ -208,12 +208,8 @@ Source type: {source}\n",
                 let id = transport.send(&email)?;
                 info!(%id, ?subject, "Email sent");
             }
-            EmailBackend::Memory { mails } => {
-                mails.lock().unwrap().push(StoredEmail {
-                    to: recipient.into(),
-                    subject: subject.into(),
-                    body: body.into(),
-                });
+            EmailBackend::Memory(transport) => {
+                transport.send(&email)?;
             }
         }
 
@@ -231,6 +227,8 @@ pub enum EmailError {
     SmtpTransportError(#[from] lettre::transport::smtp::Error),
     #[error(transparent)]
     FileTransportError(#[from] lettre::transport::file::Error),
+    #[error(transparent)]
+    StubTransportError(#[from] lettre::transport::stub::Error),
 }
 
 #[derive(Clone)]
@@ -240,7 +238,7 @@ enum EmailBackend {
     /// Backend used locally during development, will store the emails in the provided directory.
     FileSystem(Arc<FileTransport>),
     /// Backend used during tests, will keep messages in memory to allow tests to retrieve them.
-    Memory { mails: Arc<Mutex<Vec<StoredEmail>>> },
+    Memory(StubTransport),
 }
 
 // Custom Debug implementation to avoid showing the SMTP password.
@@ -254,7 +252,7 @@ impl std::fmt::Debug for EmailBackend {
             EmailBackend::FileSystem(transport) => {
                 f.debug_tuple("FileSystem").field(transport).finish()?;
             }
-            EmailBackend::Memory { .. } => f.write_str("Memory")?,
+            EmailBackend::Memory(transport) => f.debug_tuple("Memory").field(transport).finish()?,
         }
         Ok(())
     }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -901,17 +901,18 @@ fn highest_gh_id_is_most_recent_account_we_know_of() {
 }
 
 fn extract_token_from_invite_email(emails: &Emails) -> String {
+    let emails = emails.mails_in_memory().unwrap();
+
     let message = emails
-        .mails_in_memory()
-        .unwrap()
         .into_iter()
-        .find(|m| m.subject.contains("invitation"))
+        .map(|(_envelope, message)| message)
+        .find(|m| m.contains("Subject: Crate ownership invitation"))
         .expect("missing email");
 
     // Simple (but kinda fragile) parser to extract the token.
     let before_token = "/accept-invite/";
     let after_token = " ";
-    let body = message.body.as_str();
+    let body = message.as_str();
     let before_pos = body.find(before_token).unwrap() + before_token.len();
     let after_pos = before_pos + body[before_pos..].find(after_token).unwrap();
     body[before_pos..after_pos].to_string()

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -238,6 +238,10 @@ impl From<EmailError> for BoxedAppError {
                 error!(?error, "Failed to send email");
                 server_error("Email file could not be generated")
             }
+            EmailError::StubTransportError(error) => {
+                error!(?error, "Failed to send email");
+                server_error("Failed to send the email")
+            }
         }
     }
 }

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -74,6 +74,7 @@ fn check(
 #[cfg(test)]
 mod tests {
     use crate::{test_util::pg_connection, typosquat::test_util::Faker};
+    use lettre::Address;
 
     use super::*;
 
@@ -116,7 +117,7 @@ mod tests {
         let sent_mail = emails.mails_in_memory().unwrap();
         assert!(!sent_mail.is_empty());
         let sent = sent_mail.into_iter().next().unwrap();
-        assert_eq!(&sent.to, "admin@example.com");
+        assert_eq!(&sent.0.to(), &["admin@example.com".parse::<Address>()?]);
 
         Ok(())
     }


### PR DESCRIPTION
Previously we were creating these `Transport` instances per email that we send, but that seems a bit unnecessary. Creating them once on server startup allows us to fail early for configuration issues.

Our in-memory implementation was also using a bit of custom code, when instead we could use the official `StubTransport` implementation, which achieves the same thing.