### PR TITLE
controllers/github/secret_scanning: Replace `Result<_, BoxedAppError>` with `QueryResult<_>`

### DIFF
--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -180,10 +180,13 @@ fn send_notification_email(
         return Err(anyhow!("No address found"));
     };
 
-    state
-        .emails
-        .send_token_exposed_notification(&email, &alert.url, "GitHub", &alert.source, &token.name)
-        .map_err(|error| anyhow!("{error}"))?;
+    state.emails.send_token_exposed_notification(
+        &email,
+        &alert.url,
+        "GitHub",
+        &alert.source,
+        &token.name,
+    )?;
 
     Ok(())
 }

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -127,7 +127,7 @@ fn alert_revoke_token(
     state: &AppState,
     alert: &GitHubSecretAlert,
     conn: &mut PgConnection,
-) -> Result<GitHubSecretAlertFeedbackLabel, BoxedAppError> {
+) -> QueryResult<GitHubSecretAlertFeedbackLabel> {
     let hashed_token = HashedToken::hash(&alert.token);
 
     // Not using `ApiToken::find_by_api_token()` in order to preserve `last_used_at`
@@ -228,7 +228,7 @@ pub async fn verify(
                     label,
                 })
             })
-            .collect::<Result<_, BoxedAppError>>()?;
+            .collect::<QueryResult<_>>()?;
 
         Ok(Json(feedback))
     })


### PR DESCRIPTION
There is no need to use `BoxedAppError` if the only error returned from a function is a `diesel` error.