### PR TITLE
models: Use `QueryResult` instead of `AppResult` where possible

### DIFF
--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -436,7 +436,7 @@ impl Crate {
         &self,
         conn: &mut PgConnection,
         options: PaginationOptions,
-    ) -> AppResult<(Vec<ReverseDependency>, i64)> {
+    ) -> QueryResult<(Vec<ReverseDependency>, i64)> {
         use diesel::sql_query;
         use diesel::sql_types::{BigInt, Integer};
 

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -34,7 +34,11 @@ pub struct ApiToken {
 
 impl ApiToken {
     /// Generates a new named API token for a user
-    pub fn insert(conn: &mut PgConnection, user_id: i32, name: &str) -> AppResult<CreatedApiToken> {
+    pub fn insert(
+        conn: &mut PgConnection,
+        user_id: i32,
+        name: &str,
+    ) -> QueryResult<CreatedApiToken> {
         Self::insert_with_scopes(conn, user_id, name, None, None, None)
     }
 
@@ -45,7 +49,7 @@ impl ApiToken {
         crate_scopes: Option<Vec<CrateScope>>,
         endpoint_scopes: Option<Vec<EndpointScope>>,
         expired_at: Option<NaiveDateTime>,
-    ) -> AppResult<CreatedApiToken> {
+    ) -> QueryResult<CreatedApiToken> {
         let token = PlainToken::generate();
 
         let model: ApiToken = diesel::insert_into(api_tokens::table)


### PR DESCRIPTION
`AppResult` is something from the HTTP/API layer and the `models` modules shouldn't know anything about that. This PR reduces the coupling a little bit by replacing `AppResult` with `QueryResult` where possible.