### PR TITLE
Remove `reject_non_canonical_downloads` feature flag

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -50,7 +50,6 @@ pub struct Server {
     pub metrics_authorization_token: Option<String>,
     pub instance_metrics_log_every_seconds: Option<u64>,
     pub force_unconditional_redirects: bool,
-    pub reject_non_canonical_downloads: bool,
     pub blocked_routes: HashSet<String>,
     pub version_id_cache_size: u64,
     pub version_id_cache_ttl: Duration,
@@ -211,7 +210,6 @@ impl Server {
             metrics_authorization_token: var("METRICS_AUTHORIZATION_TOKEN")?,
             instance_metrics_log_every_seconds: var_parsed("INSTANCE_METRICS_LOG_EVERY_SECONDS")?,
             force_unconditional_redirects: var("FORCE_UNCONDITIONAL_REDIRECTS")?.is_some(),
-            reject_non_canonical_downloads: var("REJECT_NON_CANONICAL_DOWNLOADS")?.is_some(),
             blocked_routes: var("BLOCKED_ROUTES")?
                 .map(|routes| routes.split(',').map(|s| s.into()).collect())
                 .unwrap_or_default(),

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -87,12 +87,10 @@ pub async fn download(
                         .inc();
                     req.request_log().add("bot", "dl");
 
-                    if app.config.reject_non_canonical_downloads {
-                        return Err(Box::new(NonCanonicalDownload {
-                            requested_name: crate_name,
-                            canonical_name: canonical_crate_name,
-                        }));
-                    }
+                    return Err(Box::new(NonCanonicalDownload {
+                        requested_name: crate_name,
+                        canonical_name: canonical_crate_name,
+                    }));
                 } else {
                     // The version_id is only cached if the provided crate name was canonical.
                     // Non-canonical requests fallback to the "slow" path with a DB query, but

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -17,29 +17,8 @@ fn download_nonexistent_version_of_existing_crate_404s() {
 }
 
 #[test]
-fn download_noncanonical_crate_name() {
-    let (app, anon, user) = TestApp::init()
-        .with_config(|config| config.reject_non_canonical_downloads = false)
-        .with_user();
-    let user = user.as_model();
-
-    app.db(|conn| {
-        CrateBuilder::new("foo_download", user.id)
-            .version(VersionBuilder::new("1.0.0"))
-            .expect_build(conn);
-    });
-
-    // Request download for "foo-download" with a dash instead of an underscore,
-    // and assert that the correct download link is returned.
-    anon.get::<()>("/api/v1/crates/foo-download/1.0.0/download")
-        .assert_redirect_ends_with("/crates/foo_download/foo_download-1.0.0.crate");
-}
-
-#[test]
 fn rejected_non_canonical_download() {
-    let (app, anon, user) = TestApp::init()
-        .with_config(|config| config.reject_non_canonical_downloads = true)
-        .with_user();
+    let (app, anon, user) = TestApp::init().with_user();
 
     app.db(|conn| {
         let user = user.as_model();

--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -26,7 +26,7 @@ fn normal_startup() {
 
     // Ensure the application correctly responds to download requests
     let resp = running_server
-        .get("api/v1/crates/FOO/1.0.0/download")
+        .get("api/v1/crates/foo/1.0.0/download")
         .unwrap();
     assert_eq!(resp.status(), StatusCode::FOUND);
 

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -9,10 +9,7 @@ const DB_HEALTHY_TIMEOUT: Duration = Duration::from_millis(2000);
 
 #[test]
 fn download_crate_with_broken_networking_primary_database() {
-    let (app, anon, _, owner) = TestApp::init()
-        .with_config(|config| config.reject_non_canonical_downloads = false)
-        .with_chaos_proxy()
-        .with_token();
+    let (app, anon, _, owner) = TestApp::init().with_chaos_proxy().with_token();
 
     app.db(|conn| {
         CrateBuilder::new("crate_name", owner.as_model().user_id)
@@ -49,7 +46,7 @@ fn assert_checked_redirects(anon: &MockAnonymousUser) {
         .assert_redirect_ends_with("/crate_name/crate_name-1.0.0.crate");
 
     anon.get::<()>("/api/v1/crates/Crate-Name/1.0.0/download")
-        .assert_redirect_ends_with("/crate_name/crate_name-1.0.0.crate");
+        .assert_not_found();
 
     anon.get::<()>("/api/v1/crates/crate_name/2.0.0/download")
         .assert_not_found();

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -422,7 +422,6 @@ fn simple_config() -> config::Server {
         metrics_authorization_token: None,
         instance_metrics_log_every_seconds: None,
         force_unconditional_redirects: false,
-        reject_non_canonical_downloads: true,
         blocked_routes: HashSet::new(),
         version_id_cache_size: 10000,
         version_id_cache_ttl: Duration::from_secs(5 * 60),


### PR DESCRIPTION
We've had this enabled for about a month now so its time to remove the feature flag.