### PR TITLE
controllers/version/downloads: Return regular 404 error for non-canonical downloads

### DIFF
--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -87,10 +87,7 @@ pub async fn download(
                         .inc();
                     req.request_log().add("bot", "dl");
 
-                    return Err(Box::new(NonCanonicalDownload {
-                        requested_name: crate_name,
-                        canonical_name: canonical_crate_name,
-                    }));
+                    return Err(Box::new(NonCanonicalDownload));
                 } else {
                     // The version_id is only cached if the provided crate name was canonical.
                     // Non-canonical requests fallback to the "slow" path with a DB query, but
@@ -148,29 +145,17 @@ pub async fn download(
 }
 
 #[derive(Debug)]
-struct NonCanonicalDownload {
-    requested_name: String,
-    canonical_name: String,
-}
+struct NonCanonicalDownload;
 
 impl Display for NonCanonicalDownload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "Your request is for a version of the `{requested_name}` crate, \
-            but that crate is actually named `{canonical_name}`. Support for \
-            \"non-canonical\" downloads has been deprecated and disabled. See \
-            https://blog.rust-lang.org/2023/10/27/crates-io-non-canonical-downloads.html \
-            for more detail.",
-            requested_name = self.requested_name,
-            canonical_name = self.canonical_name,
-        )
+        write!(f, "Non-canonical crate downloads are no longer supported")
     }
 }
 
 impl AppError for NonCanonicalDownload {
     fn response(&self) -> Response {
-        (StatusCode::NOT_FOUND, self.to_string()).into_response()
+        StatusCode::NOT_FOUND.into_response()
     }
 }
 

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -1,7 +1,6 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
-use insta::assert_json_snapshot;
 
 #[test]
 fn download_nonexistent_version_of_existing_crate_404s() {
@@ -31,7 +30,6 @@ fn rejected_non_canonical_download() {
     // and assert that the correct download link is returned.
     let response = anon.get::<()>("/api/v1/crates/foo-download/1.0.0/download");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_json_snapshot!(response.into_json());
 }
 
 #[test]


### PR DESCRIPTION
see https://blog.rust-lang.org/2023/10/27/crates-io-non-canonical-downloads.html