### PR TITLE
Extract `Email` trait

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -6,7 +6,6 @@ use crate::controllers::frontend_prelude::*;
 use crate::controllers::helpers::*;
 
 use crate::controllers::helpers::pagination::{Paginated, PaginationOptions};
-use crate::email::UserConfirmEmail;
 use crate::models::{
     CrateOwner, Email, Follow, NewEmail, OwnerKind, User, Version, VersionOwnerAction,
 };
@@ -296,4 +295,29 @@ pub async fn update_email_notifications(app: AppState, req: BytesRequest) -> App
         ok_true()
     })
     .await
+}
+
+pub struct UserConfirmEmail<'a> {
+    pub user_name: &'a str,
+    pub domain: &'a str,
+    pub token: &'a str,
+}
+
+impl crate::email::Email for UserConfirmEmail<'_> {
+    const SUBJECT: &'static str = "Please confirm your email address";
+
+    fn body(&self) -> String {
+        // Create a URL with token string as path to send to user
+        // If user clicks on path, look email/user up in database,
+        // make sure tokens match
+
+        format!(
+            "Hello {user_name}! Welcome to crates.io. Please click the
+link below to verify your email address. Thank you!\n
+https://{domain}/confirm/{token}",
+            user_name = self.user_name,
+            domain = self.domain,
+            token = self.token,
+        )
+    }
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -66,41 +66,6 @@ or go to https://{domain}/me/pending-invites to manage all of your crate ownersh
 }
 
 #[derive(Debug, Clone)]
-pub struct PossibleTyposquatEmail<'a> {
-    pub domain: &'a str,
-    pub crate_name: &'a str,
-    pub squats: &'a [typomania::checks::Squat],
-}
-
-impl Email for PossibleTyposquatEmail<'_> {
-    const SUBJECT: &'static str = "Possible typosquatting in new crate";
-
-    fn body(&self) -> String {
-        let squats = self
-            .squats
-            .iter()
-            .map(|squat| {
-                let domain = self.domain;
-                let crate_name = squat.package();
-                format!("- {squat} (https://{domain}/crates/{crate_name})\n")
-            })
-            .collect::<Vec<_>>()
-            .join("");
-
-        format!(
-            "New crate {crate_name} may be typosquatting one or more other crates.\n
-Visit https://{domain}/crates/{crate_name} to see the offending crate.\n
-\n
-Specific squat checks that triggered:\n
-\n
-{squats}",
-            domain = self.domain,
-            crate_name = self.crate_name,
-        )
-    }
-}
-
-#[derive(Debug, Clone)]
 pub struct Emails {
     backend: EmailBackend,
     pub domain: String,

--- a/src/email.rs
+++ b/src/email.rs
@@ -100,22 +100,6 @@ impl Emails {
         }
     }
 
-    /// Attempts to send a confirmation email.
-    pub fn send_user_confirm(
-        &self,
-        recipient: &str,
-        user_name: &str,
-        token: &str,
-    ) -> Result<(), EmailError> {
-        let email = UserConfirmEmail {
-            user_name,
-            domain: &self.domain,
-            token,
-        };
-
-        self.send(recipient, email)
-    }
-
     /// This is supposed to be used only during tests, to retrieve the messages stored in the
     /// "memory" backend. It's not cfg'd away because our integration tests need to access this.
     pub fn mails_in_memory(&self) -> Option<Vec<(Envelope, String)>> {

--- a/src/email.rs
+++ b/src/email.rs
@@ -139,24 +139,6 @@ impl Emails {
         self.send(recipient, email)
     }
 
-    /// Attempts to send an ownership invitation.
-    pub fn send_owner_invite(
-        &self,
-        recipient: &str,
-        user_name: &str,
-        crate_name: &str,
-        token: &str,
-    ) -> Result<(), EmailError> {
-        let email = OwnerInviteEmail {
-            user_name,
-            domain: &self.domain,
-            crate_name,
-            token,
-        };
-
-        self.send(recipient, email)
-    }
-
     /// This is supposed to be used only during tests, to retrieve the messages stored in the
     /// "memory" backend. It's not cfg'd away because our integration tests need to access this.
     pub fn mails_in_memory(&self) -> Option<Vec<(Envelope, String)>> {

--- a/src/email.rs
+++ b/src/email.rs
@@ -241,26 +241,6 @@ impl Emails {
         self.send(recipient, email)
     }
 
-    /// Attempts to send an API token exposure notification email
-    pub fn send_token_exposed_notification(
-        &self,
-        recipient: &str,
-        url: &str,
-        reporter: &str,
-        source: &str,
-        token_name: &str,
-    ) -> Result<(), EmailError> {
-        let email = TokenExposedEmail {
-            domain: &self.domain,
-            reporter,
-            source,
-            token_name,
-            url,
-        };
-
-        self.send(recipient, email)
-    }
-
     /// This is supposed to be used only during tests, to retrieve the messages stored in the
     /// "memory" backend. It's not cfg'd away because our integration tests need to access this.
     pub fn mails_in_memory(&self) -> Option<Vec<(Envelope, String)>> {

--- a/src/email.rs
+++ b/src/email.rs
@@ -17,31 +17,6 @@ pub trait Email {
     fn body(&self) -> String;
 }
 
-pub struct UserConfirmEmail<'a> {
-    pub user_name: &'a str,
-    pub domain: &'a str,
-    pub token: &'a str,
-}
-
-impl Email for UserConfirmEmail<'_> {
-    const SUBJECT: &'static str = "Please confirm your email address";
-
-    fn body(&self) -> String {
-        // Create a URL with token string as path to send to user
-        // If user clicks on path, look email/user up in database,
-        // make sure tokens match
-
-        format!(
-            "Hello {user_name}! Welcome to crates.io. Please click the
-link below to verify your email address. Thank you!\n
-https://{domain}/confirm/{token}",
-            user_name = self.user_name,
-            domain = self.domain,
-            token = self.token,
-        )
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Emails {
     backend: EmailBackend,

--- a/src/email.rs
+++ b/src/email.rs
@@ -65,6 +65,7 @@ or go to https://{domain}/me/pending-invites to manage all of your crate ownersh
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PossibleTyposquatEmail<'a> {
     pub domain: &'a str,
     pub crate_name: &'a str,
@@ -102,7 +103,7 @@ Specific squat checks that triggered:\n
 #[derive(Debug, Clone)]
 pub struct Emails {
     backend: EmailBackend,
-    domain: String,
+    pub domain: String,
     from: Mailbox,
 }
 
@@ -186,22 +187,6 @@ impl Emails {
             domain: &self.domain,
             crate_name,
             token,
-        };
-
-        self.send(recipient, email)
-    }
-
-    /// Attempts to send a notification that a new crate may be typosquatting another crate.
-    pub fn send_possible_typosquat_notification(
-        &self,
-        recipient: &str,
-        crate_name: &str,
-        squats: &[typomania::checks::Squat],
-    ) -> Result<(), EmailError> {
-        let email = PossibleTyposquatEmail {
-            domain: &self.domain,
-            crate_name,
-            squats,
         };
 
         self.send(recipient, email)

--- a/src/email.rs
+++ b/src/email.rs
@@ -42,29 +42,6 @@ https://{domain}/confirm/{token}",
     }
 }
 
-pub struct OwnerInviteEmail<'a> {
-    pub user_name: &'a str,
-    pub domain: &'a str,
-    pub crate_name: &'a str,
-    pub token: &'a str,
-}
-
-impl Email for OwnerInviteEmail<'_> {
-    const SUBJECT: &'static str = "Crate ownership invitation";
-
-    fn body(&self) -> String {
-        format!(
-            "{user_name} has invited you to become an owner of the crate {crate_name}!\n
-Visit https://{domain}/accept-invite/{token} to accept this invitation,
-or go to https://{domain}/me/pending-invites to manage all of your crate ownership invitations.",
-            user_name = self.user_name,
-            domain = self.domain,
-            crate_name = self.crate_name,
-            token = self.token,
-        )
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Emails {
     backend: EmailBackend,

--- a/src/email.rs
+++ b/src/email.rs
@@ -99,40 +99,6 @@ Specific squat checks that triggered:\n
     }
 }
 
-pub struct TokenExposedEmail<'a> {
-    pub domain: &'a str,
-    pub reporter: &'a str,
-    pub source: &'a str,
-    pub token_name: &'a str,
-    pub url: &'a str,
-}
-
-impl Email for TokenExposedEmail<'_> {
-    const SUBJECT: &'static str = "Exposed API token found";
-
-    fn body(&self) -> String {
-        let mut body = format!(
-            "{reporter} has notified us that your crates.io API token {token_name}\n
-has been exposed publicly. We have revoked this token as a precaution.\n
-Please review your account at https://{domain} to confirm that no\n
-unexpected changes have been made to your settings or crates.\n
-\n
-Source type: {source}\n",
-            domain = self.domain,
-            reporter = self.reporter,
-            source = self.source,
-            token_name = self.token_name,
-        );
-        if self.url.is_empty() {
-            body.push_str("\nWe were not informed of the URL where the token was found.\n");
-        } else {
-            body.push_str(&format!("\nURL where the token was found: {}\n", self.url));
-        }
-
-        body
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Emails {
     backend: EmailBackend,

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -8,7 +8,7 @@ use diesel::sql_types::{Bool, Text};
 
 use crate::app::App;
 use crate::controllers::helpers::pagination::*;
-use crate::email::OwnerInviteEmail;
+use crate::email::Email;
 use crate::models::version::TopVersions;
 use crate::models::{
     CrateOwner, CrateOwnerInvitation, Dependency, NewCrateOwnerInvitationOutcome, Owner, OwnerKind,
@@ -536,6 +536,29 @@ impl Crate {
                 Ok(krate)
             })
             .collect()
+    }
+}
+
+struct OwnerInviteEmail<'a> {
+    user_name: &'a str,
+    domain: &'a str,
+    crate_name: &'a str,
+    token: &'a str,
+}
+
+impl Email for OwnerInviteEmail<'_> {
+    const SUBJECT: &'static str = "Crate ownership invitation";
+
+    fn body(&self) -> String {
+        format!(
+            "{user_name} has invited you to become an owner of the crate {crate_name}!\n
+Visit https://{domain}/accept-invite/{token} to accept this invitation,
+or go to https://{domain}/me/pending-invites to manage all of your crate ownership invitations.",
+            user_name = self.user_name,
+            domain = self.domain,
+            crate_name = self.crate_name,
+            token = self.token,
+        )
     }
 }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use std::borrow::Cow;
 
 use crate::app::App;
-use crate::email::Emails;
+use crate::email::{Emails, UserConfirmEmail};
 use crate::util::errors::AppResult;
 
 use crate::models::{ApiToken, Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};
@@ -100,7 +100,12 @@ impl<'a> NewUser<'a> {
 
                 if let Some(token) = token {
                     // Swallows any error. Some users might insert an invalid email address here.
-                    let _ = emails.send_user_confirm(user_email, &user.gh_login, &token);
+                    let email = UserConfirmEmail {
+                        user_name: &user.gh_login,
+                        domain: &emails.domain,
+                        token: &token,
+                    };
+                    let _ = emails.send(user_email, email);
                 }
             }
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -3,7 +3,8 @@ use diesel::prelude::*;
 use std::borrow::Cow;
 
 use crate::app::App;
-use crate::email::{Emails, UserConfirmEmail};
+use crate::controllers::user::me::UserConfirmEmail;
+use crate::email::Emails;
 use crate::util::errors::AppResult;
 
 use crate::models::{ApiToken, Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -5,7 +5,7 @@ use crates_io_worker::BackgroundJob;
 use diesel::PgConnection;
 use typomania::Package;
 
-use crate::email::PossibleTyposquatEmail;
+use crate::email::Email;
 use crate::tasks::spawn_blocking;
 use crate::{
     typosquat::{Cache, Crate},
@@ -80,6 +80,41 @@ fn check(
     }
 
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct PossibleTyposquatEmail<'a> {
+    domain: &'a str,
+    crate_name: &'a str,
+    squats: &'a [typomania::checks::Squat],
+}
+
+impl Email for PossibleTyposquatEmail<'_> {
+    const SUBJECT: &'static str = "Possible typosquatting in new crate";
+
+    fn body(&self) -> String {
+        let squats = self
+            .squats
+            .iter()
+            .map(|squat| {
+                let domain = self.domain;
+                let crate_name = squat.package();
+                format!("- {squat} (https://{domain}/crates/{crate_name})\n")
+            })
+            .collect::<Vec<_>>()
+            .join("");
+
+        format!(
+            "New crate {crate_name} may be typosquatting one or more other crates.\n
+Visit https://{domain}/crates/{crate_name} to see the offending crate.\n
+\n
+Specific squat checks that triggered:\n
+\n
+{squats}",
+            domain = self.domain,
+            crate_name = self.crate_name,
+        )
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously we implemented new email variants by adding another method to the `Emails` struct, which then internally called `self.send(...)`.

This PR explores a different implementation where each email variant is represented by its own struct, holding the values that it needs to generate the email body. Each of the structs implements a new `Email` trait, which has a `const SUBJECT` and `fn body()` on it.

This allows us to move the email generation code closer to where the emails are sent and should scale better with an increasing number of email variants. It also makes the email sending code in the `email` module a bit more generic and less coupled to the application logic.