### PR TITLE
models/email: Remove unused `AsChangeset` impl from `Email` struct

### DIFF
--- a/src/models/email.rs
+++ b/src/models/email.rs
@@ -3,7 +3,7 @@ use chrono::NaiveDateTime;
 use crate::models::User;
 use crate::schema::emails;
 
-#[derive(Debug, Queryable, AsChangeset, Identifiable, Associations)]
+#[derive(Debug, Queryable, Identifiable, Associations)]
 #[diesel(belongs_to(User))]
 pub struct Email {
     pub id: i32,


### PR DESCRIPTION
This does not appear to be used for anything... 🤷‍♂️ 