### PR TITLE
models/crate_owner_invitation: Remove unused `Eq` impls from `CrateOwnerInvitation` struct

### DIFF
--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -13,7 +13,7 @@ pub enum NewCrateOwnerInvitationOutcome {
 }
 
 /// The model representing a row in the `crate_owner_invitations` database table.
-#[derive(Clone, Debug, PartialEq, Eq, Identifiable, Queryable)]
+#[derive(Clone, Debug, Identifiable, Queryable)]
 #[diesel(primary_key(invited_user_id, crate_id))]
 pub struct CrateOwnerInvitation {
     pub invited_user_id: i32,


### PR DESCRIPTION
These appear to be unused and prevent us from using `SecretString` inside the struct