### PR TITLE
email: Merge `TransportError` variants

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -112,15 +112,21 @@ impl Emails {
 
         match &self.backend {
             EmailBackend::Smtp(transport) => {
-                transport.send(&email)?;
+                transport
+                    .send(&email)
+                    .map_err(|error| EmailError::TransportError(error.into()))?;
                 info!(?message_id, ?subject, "Email sent");
             }
             EmailBackend::FileSystem(transport) => {
-                let id = transport.send(&email)?;
+                let id = transport
+                    .send(&email)
+                    .map_err(|error| EmailError::TransportError(error.into()))?;
                 info!(%id, ?subject, "Email sent");
             }
             EmailBackend::Memory(transport) => {
-                transport.send(&email)?;
+                transport
+                    .send(&email)
+                    .map_err(|error| EmailError::TransportError(error.into()))?;
             }
         }
 
@@ -135,11 +141,7 @@ pub enum EmailError {
     #[error(transparent)]
     MessageBuilderError(#[from] lettre::error::Error),
     #[error(transparent)]
-    SmtpTransportError(#[from] lettre::transport::smtp::Error),
-    #[error(transparent)]
-    FileTransportError(#[from] lettre::transport::file::Error),
-    #[error(transparent)]
-    StubTransportError(#[from] lettre::transport::stub::Error),
+    TransportError(anyhow::Error),
 }
 
 #[derive(Clone)]

--- a/src/email.rs
+++ b/src/email.rs
@@ -110,27 +110,7 @@ impl Emails {
             .header(ContentType::TEXT_PLAIN)
             .body(body)?;
 
-        match &self.backend {
-            EmailBackend::Smtp(transport) => {
-                transport
-                    .send(&email)
-                    .map_err(|error| EmailError::TransportError(error.into()))?;
-                info!(?message_id, ?subject, "Email sent");
-            }
-            EmailBackend::FileSystem(transport) => {
-                let id = transport
-                    .send(&email)
-                    .map_err(|error| EmailError::TransportError(error.into()))?;
-                info!(%id, ?subject, "Email sent");
-            }
-            EmailBackend::Memory(transport) => {
-                transport
-                    .send(&email)
-                    .map_err(|error| EmailError::TransportError(error.into()))?;
-            }
-        }
-
-        Ok(())
+        self.backend.send(email).map_err(EmailError::TransportError)
     }
 }
 
@@ -152,6 +132,18 @@ enum EmailBackend {
     FileSystem(Arc<FileTransport>),
     /// Backend used during tests, will keep messages in memory to allow tests to retrieve them.
     Memory(StubTransport),
+}
+
+impl EmailBackend {
+    fn send(&self, message: Message) -> anyhow::Result<()> {
+        match self {
+            EmailBackend::Smtp(transport) => transport.send(&message).map(|_| ())?,
+            EmailBackend::FileSystem(transport) => transport.send(&message).map(|_| ())?,
+            EmailBackend::Memory(transport) => transport.send(&message).map(|_| ())?,
+        }
+
+        Ok(())
+    }
 }
 
 // Custom Debug implementation to avoid showing the SMTP password.

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -230,15 +230,7 @@ impl From<EmailError> for BoxedAppError {
         match error {
             EmailError::AddressError(error) => Box::new(error),
             EmailError::MessageBuilderError(error) => Box::new(error),
-            EmailError::SmtpTransportError(error) => {
-                error!(?error, "Failed to send email");
-                server_error("Failed to send the email")
-            }
-            EmailError::FileTransportError(error) => {
-                error!(?error, "Failed to send email");
-                server_error("Email file could not be generated")
-            }
-            EmailError::StubTransportError(error) => {
+            EmailError::TransportError(error) => {
                 error!(?error, "Failed to send email");
                 server_error("Failed to send the email")
             }


### PR DESCRIPTION
Unfortunately `lettre` uses different error types for all the transports, but that doesn't mean we need to follow that example. This PR merges the three variants into one using `anyhow::Error`, since we don't really care about the specifics of the errors anyway.

The tracing logs are temporarily removed but will be restored in a follow-up PR :)