### PR TITLE
Use `SecretString` for `token` fields

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -1,4 +1,5 @@
 use crate::auth::AuthCheck;
+use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
 
 use crate::controllers::frontend_prelude::*;
@@ -144,13 +145,14 @@ pub async fn update_user(
                 email: user_email,
             };
 
-            let token: String = insert_into(emails::table)
+            let token = insert_into(emails::table)
                 .values(&new_email)
                 .on_conflict(user_id)
                 .do_update()
                 .set(&new_email)
                 .returning(emails::token)
                 .get_result(conn)
+                .map(SecretString::new)
                 .map_err(|_| server_error("Error in creating token"))?;
 
             // This swallows any errors that occur while attempting to send the email. Some users have
@@ -160,7 +162,7 @@ pub async fn update_user(
             let email = UserConfirmEmail {
                 user_name: &user.gh_login,
                 domain: &state.emails.domain,
-                token: &token,
+                token,
             };
 
             let _ = state.emails.send(user_email, email);
@@ -223,7 +225,7 @@ pub async fn regenerate_token_and_send(
             let email1 = UserConfirmEmail {
                 user_name: &user.gh_login,
                 domain: &state.emails.domain,
-                token: &email.token,
+                token: SecretString::from(email.token),
             };
 
             state.emails.send(&email.email, email1).map_err(Into::into)
@@ -300,7 +302,7 @@ pub async fn update_email_notifications(app: AppState, req: BytesRequest) -> App
 pub struct UserConfirmEmail<'a> {
     pub user_name: &'a str,
     pub domain: &'a str,
-    pub token: &'a str,
+    pub token: SecretString,
 }
 
 impl crate::email::Email for UserConfirmEmail<'_> {
@@ -317,7 +319,7 @@ link below to verify your email address. Thank you!\n
 https://{domain}/confirm/{token}",
             user_name = self.user_name,
             domain = self.domain,
-            token = self.token,
+            token = self.token.expose_secret(),
         )
     }
 }

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -225,7 +225,7 @@ pub async fn regenerate_token_and_send(
             let email1 = UserConfirmEmail {
                 user_name: &user.gh_login,
                 domain: &state.emails.domain,
-                token: SecretString::from(email.token),
+                token: email.token,
             };
 
             state.emails.send(&email.email, email1).map_err(Into::into)

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -21,7 +21,8 @@ pub struct CrateOwnerInvitation {
     pub invited_by_user_id: i32,
     pub crate_id: i32,
     pub created_at: NaiveDateTime,
-    pub token: String,
+    #[diesel(deserialize_as = String)]
+    pub token: SecretString,
     pub token_created_at: Option<NaiveDateTime>,
 }
 
@@ -76,7 +77,7 @@ impl CrateOwnerInvitation {
 
         Ok(match res {
             Some(record) => NewCrateOwnerInvitationOutcome::InviteCreated {
-                plaintext_token: SecretString::from(record.token),
+                plaintext_token: record.token,
             },
             None => NewCrateOwnerInvitationOutcome::AlreadyExists,
         })

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -1,5 +1,6 @@
 use chrono::{NaiveDateTime, Utc};
 use diesel::prelude::*;
+use secrecy::SecretString;
 
 use crate::config;
 use crate::models::{CrateOwner, OwnerKind};
@@ -9,7 +10,7 @@ use crate::util::errors::{AppResult, OwnershipInvitationExpired};
 #[derive(Debug)]
 pub enum NewCrateOwnerInvitationOutcome {
     AlreadyExists,
-    InviteCreated { plaintext_token: String },
+    InviteCreated { plaintext_token: SecretString },
 }
 
 /// The model representing a row in the `crate_owner_invitations` database table.
@@ -75,7 +76,7 @@ impl CrateOwnerInvitation {
 
         Ok(match res {
             Some(record) => NewCrateOwnerInvitationOutcome::InviteCreated {
-                plaintext_token: record.token,
+                plaintext_token: SecretString::from(record.token),
             },
             None => NewCrateOwnerInvitationOutcome::AlreadyExists,
         })

--- a/src/models/email.rs
+++ b/src/models/email.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+use secrecy::SecretString;
 
 use crate::models::User;
 use crate::schema::emails;
@@ -10,7 +11,8 @@ pub struct Email {
     pub user_id: i32,
     pub email: String,
     pub verified: bool,
-    pub token: String,
+    #[diesel(deserialize_as = String, serialize_as = String)]
+    pub token: SecretString,
     pub token_generated_at: Option<NaiveDateTime>,
 }
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -383,7 +383,7 @@ impl Crate {
                                 user_name: &req_user.gh_login,
                                 domain: &app.emails.domain,
                                 crate_name: &self.name,
-                                token: SecretString::from(plaintext_token),
+                                token: plaintext_token,
                             };
 
                             let _ = app.emails.send(&recipient, email);

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -5,6 +5,7 @@ use diesel::associations::Identifiable;
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::sql_types::{Bool, Text};
+use secrecy::{ExposeSecret, SecretString};
 
 use crate::app::App;
 use crate::controllers::helpers::pagination::*;
@@ -382,7 +383,7 @@ impl Crate {
                                 user_name: &req_user.gh_login,
                                 domain: &app.emails.domain,
                                 crate_name: &self.name,
-                                token: &plaintext_token,
+                                token: SecretString::from(plaintext_token),
                             };
 
                             let _ = app.emails.send(&recipient, email);
@@ -543,7 +544,7 @@ struct OwnerInviteEmail<'a> {
     user_name: &'a str,
     domain: &'a str,
     crate_name: &'a str,
-    token: &'a str,
+    token: SecretString,
 }
 
 impl Email for OwnerInviteEmail<'_> {
@@ -557,7 +558,7 @@ or go to https://{domain}/me/pending-invites to manage all of your crate ownersh
             user_name = self.user_name,
             domain = self.domain,
             crate_name = self.crate_name,
-            token = self.token,
+            token = self.token.expose_secret(),
         )
     }
 }


### PR DESCRIPTION
I wanted to add `Debug` impls for all of the structs that implement the new `Email` trait, but then I saw that some of them contain sensitive information. This PR replaces those fields with `secrecy::SecretString` types to ensure that the `Debug` representation is not unintentionally leaking sensitive information.