### PR TITLE
controllers/helpers/pagination: Return `400 Bad Request` for invalid seek parameters

### DIFF
--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -248,7 +248,7 @@ pub(crate) struct RawSeekPayload(String);
 
 impl RawSeekPayload {
     pub(crate) fn decode<D: for<'a> Deserialize<'a>>(&self) -> AppResult<D> {
-        decode_seek(&self.0)
+        decode_seek(&self.0).map_err(|_| bad_request("invalid seek parameter"))
     }
 }
 
@@ -294,7 +294,7 @@ pub(crate) fn encode_seek<S: Serialize>(params: S) -> AppResult<String> {
 }
 
 /// Decode a list of params previously encoded with [`encode_seek`].
-pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> AppResult<D> {
+pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> anyhow::Result<D> {
     let decoded = serde_json::from_slice(&general_purpose::URL_SAFE_NO_PAD.decode(seek)?)?;
     Ok(decoded)
 }

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -6,6 +6,7 @@ use crates_io::schema::crates;
 use diesel::{dsl::*, prelude::*, update};
 use googletest::prelude::*;
 use http::StatusCode;
+use insta::assert_json_snapshot;
 
 #[test]
 fn index() {
@@ -791,6 +792,15 @@ fn test_pages_work_even_with_seek_based_pagination() {
     // Calling with page=2 will revert to offset-based pagination
     let second = anon.search("page=2&per_page=1");
     assert!(second.meta.next_page.unwrap().contains("page=3"));
+}
+
+#[test]
+fn invalid_seek_parameter() {
+    let (_app, anon, _cookie) = TestApp::init().with_user();
+
+    let response = anon.get::<()>("/api/v1/crates?seek=broken");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.into_json());
 }
 
 #[test]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_seek_parameter.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_seek_parameter.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/list.rs
+expression: response.into_json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid seek parameter"
+    }
+  ]
+}


### PR DESCRIPTION
well... it's still `200 OK` due to the cargo rewrite middleware, but it would be 400 if that wasn't there...

previously this was converted to an internal server error, but since it's not the server's fault if faulty data is passed in this would have been wrong.