### PR TITLE
util/errors: Remove unused `From<...> for BoxedAppError` impls

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -219,12 +219,6 @@ impl From<DieselError> for BoxedAppError {
     }
 }
 
-impl From<http::Error> for BoxedAppError {
-    fn from(err: http::Error) -> BoxedAppError {
-        Box::new(err)
-    }
-}
-
 impl From<EmailError> for BoxedAppError {
     fn from(error: EmailError) -> Self {
         match error {

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -193,12 +193,6 @@ impl<E: Error + Send + 'static> AppError for E {
     }
 }
 
-impl From<base64::DecodeError> for BoxedAppError {
-    fn from(err: base64::DecodeError) -> BoxedAppError {
-        Box::new(err)
-    }
-}
-
 impl From<diesel::ConnectionError> for BoxedAppError {
     fn from(err: diesel::ConnectionError) -> BoxedAppError {
         Box::new(err)


### PR DESCRIPTION
These two don't appear to be needed anymore since they have been replaced by explicit error handling.