### PR TITLE
Update Open Graph Image URL to Absolute Path for Compatibility

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -23,7 +23,7 @@
 
     <meta name="google" content="notranslate" />
 
-    <meta property="og:image" content="/assets/og-image.png">
+    <meta property="og:image" content="https://crates.io/assets/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
   </head>
   <body>


### PR DESCRIPTION
Ref-: https://github.com/rust-lang/crates.io/pull/7789

Making the Open Graph image a full path URL (`/assets/og-image.png` to `https://crates.io/assets/og-image.png`). This change ensures that the Open Graph image works as expected, as Open Graph only supports absolute file paths.