### PR TITLE
util/errors: Extract `CustomApiError` struct

### DIFF
--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,5 +1,5 @@
 use crate::controllers::frontend_prelude::*;
-use crate::util::errors::{forbidden, not_found, MetricsDisabled};
+use crate::util::errors::{custom, forbidden, not_found};
 use prometheus::TextEncoder;
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
@@ -17,7 +17,8 @@ pub async fn prometheus(app: AppState, Path(kind): Path<String>, req: Parts) -> 
     } else {
         // To avoid accidentally leaking metrics if the environment variable is not set, prevent
         // access to any metrics endpoint if the authorization token is not configured.
-        return Err(Box::new(MetricsDisabled));
+        let detail = "Metrics are disabled on this crates.io instance";
+        return Err(custom(StatusCode::NOT_FOUND, detail));
     }
 
     let metrics = spawn_blocking(move || match kind.as_str() {

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -1,7 +1,7 @@
 use crate::app::AppState;
 use crate::middleware::log_request::RequestLogExt;
 use crate::middleware::real_ip::RealIp;
-use crate::util::errors::RouteBlocked;
+use crate::util::errors::custom;
 use axum::extract::{Extension, MatchedPath, Request};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
@@ -87,7 +87,9 @@ fn rejection_response_from(state: &AppState, headers: &HeaderMap) -> Response {
 pub fn block_routes(matched_path: Option<&MatchedPath>, state: &AppState) -> Result<(), Response> {
     if let Some(matched_path) = matched_path {
         if state.config.blocked_routes.contains(matched_path.as_str()) {
-            return Err(RouteBlocked.into_response());
+            let body = "This route is temporarily blocked. See https://status.crates.io.";
+            let error = custom(StatusCode::SERVICE_UNAVAILABLE, body);
+            return Err(error.into_response());
         }
     }
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -59,10 +59,12 @@ pub fn bad_request<S: ToString>(error: S) -> BoxedAppError {
 }
 
 pub fn account_locked(reason: &str, until: Option<NaiveDateTime>) -> BoxedAppError {
-    Box::new(json::AccountLocked {
-        reason: reason.to_string(),
-        until,
-    })
+    let detail = until
+        .map(|until| until.format("%Y-%m-%d at %H:%M:%S UTC"))
+        .map(|until| format!("This account is locked until {until}. Reason: {reason}"))
+        .unwrap_or_else(|| format!("This account is indefinitely locked. Reason: {reason}"));
+
+    custom(StatusCode::FORBIDDEN, detail)
 }
 
 pub fn forbidden() -> BoxedAppError {

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -33,8 +33,7 @@ use crate::email::EmailError;
 use crates_io_github::GitHubError;
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{
-    custom, InsecurelyGeneratedTokenRevoked, MetricsDisabled, OwnershipInvitationExpired,
-    ReadOnlyMode, TooManyRequests,
+    custom, InsecurelyGeneratedTokenRevoked, MetricsDisabled, ReadOnlyMode, TooManyRequests,
 };
 
 pub type BoxedAppError = Box<dyn AppError>;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -34,7 +34,7 @@ use crates_io_github::GitHubError;
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{
     custom, InsecurelyGeneratedTokenRevoked, MetricsDisabled, OwnershipInvitationExpired,
-    ReadOnlyMode, RouteBlocked, TooManyRequests,
+    ReadOnlyMode, TooManyRequests,
 };
 
 pub type BoxedAppError = Box<dyn AppError>;

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -32,9 +32,7 @@ mod json;
 use crate::email::EmailError;
 use crates_io_github::GitHubError;
 pub use json::TOKEN_FORMAT_ERROR;
-pub(crate) use json::{
-    custom, InsecurelyGeneratedTokenRevoked, MetricsDisabled, ReadOnlyMode, TooManyRequests,
-};
+pub(crate) use json::{custom, InsecurelyGeneratedTokenRevoked, ReadOnlyMode, TooManyRequests};
 
 pub type BoxedAppError = Box<dyn AppError>;
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -33,8 +33,8 @@ use crate::email::EmailError;
 use crates_io_github::GitHubError;
 pub use json::TOKEN_FORMAT_ERROR;
 pub(crate) use json::{
-    InsecurelyGeneratedTokenRevoked, MetricsDisabled, OwnershipInvitationExpired, ReadOnlyMode,
-    RouteBlocked, TooManyRequests,
+    custom, InsecurelyGeneratedTokenRevoked, MetricsDisabled, OwnershipInvitationExpired,
+    ReadOnlyMode, RouteBlocked, TooManyRequests,
 };
 
 pub type BoxedAppError = Box<dyn AppError>;
@@ -45,7 +45,7 @@ pub type BoxedAppError = Box<dyn AppError>;
 /// endpoints, use helpers like `bad_request` or `server_error` which set a
 /// correct status code.
 pub fn cargo_err<S: ToString>(error: S) -> BoxedAppError {
-    Box::new(json::Ok(error.to_string()))
+    custom(StatusCode::OK, error.to_string())
 }
 
 // The following are intended to be used for errors being sent back to the Ember
@@ -55,7 +55,7 @@ pub fn cargo_err<S: ToString>(error: S) -> BoxedAppError {
 
 /// Return an error with status 400 and the provided description as JSON
 pub fn bad_request<S: ToString>(error: S) -> BoxedAppError {
-    Box::new(json::BadRequest(error.to_string()))
+    custom(StatusCode::BAD_REQUEST, error.to_string())
 }
 
 pub fn account_locked(reason: &str, until: Option<NaiveDateTime>) -> BoxedAppError {
@@ -66,21 +66,22 @@ pub fn account_locked(reason: &str, until: Option<NaiveDateTime>) -> BoxedAppErr
 }
 
 pub fn forbidden() -> BoxedAppError {
-    Box::new(json::Forbidden)
+    let detail = "must be logged in to perform that action";
+    custom(StatusCode::FORBIDDEN, detail)
 }
 
 pub fn not_found() -> BoxedAppError {
-    Box::new(json::NotFound)
+    custom(StatusCode::NOT_FOUND, "Not Found")
 }
 
 /// Returns an error with status 500 and the provided description as JSON
 pub fn server_error<S: ToString>(error: S) -> BoxedAppError {
-    Box::new(json::ServerError(error.to_string()))
+    custom(StatusCode::INTERNAL_SERVER_ERROR, error.to_string())
 }
 
 /// Returns an error with status 503 and the provided description as JSON
 pub fn service_unavailable() -> BoxedAppError {
-    Box::new(json::ServiceUnavailable)
+    custom(StatusCode::SERVICE_UNAVAILABLE, "Service unavailable")
 }
 
 // =============================================================================

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -133,18 +133,3 @@ impl fmt::Display for InsecurelyGeneratedTokenRevoked {
         Result::Ok(())
     }
 }
-
-#[derive(Debug)]
-pub(crate) struct MetricsDisabled;
-
-impl AppError for MetricsDisabled {
-    fn response(&self) -> Response {
-        json_error(&self.to_string(), StatusCode::NOT_FOUND)
-    }
-}
-
-impl fmt::Display for MetricsDisabled {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("Metrics are disabled on this crates.io instance")
-    }
-}

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -201,25 +201,3 @@ impl fmt::Display for MetricsDisabled {
         f.write_str("Metrics are disabled on this crates.io instance")
     }
 }
-
-#[derive(Debug)]
-pub(crate) struct RouteBlocked;
-
-impl AppError for RouteBlocked {
-    fn response(&self) -> Response {
-        json_error(&self.to_string(), StatusCode::SERVICE_UNAVAILABLE)
-    }
-}
-
-impl fmt::Display for RouteBlocked {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("This route is temporarily blocked. See https://status.crates.io.")
-    }
-}
-
-impl IntoResponse for RouteBlocked {
-    fn into_response(self) -> Response {
-        let body = Json(json!({ "errors": [{ "detail": self.to_string() }] }));
-        (StatusCode::SERVICE_UNAVAILABLE, body).into_response()
-    }
-}

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -135,28 +135,6 @@ impl fmt::Display for InsecurelyGeneratedTokenRevoked {
 }
 
 #[derive(Debug)]
-pub(crate) struct OwnershipInvitationExpired {
-    pub(crate) crate_name: String,
-}
-
-impl AppError for OwnershipInvitationExpired {
-    fn response(&self) -> Response {
-        json_error(&self.to_string(), StatusCode::GONE)
-    }
-}
-
-impl fmt::Display for OwnershipInvitationExpired {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "The invitation to become an owner of the {} crate expired. \
-             Please reach out to an owner of the crate to request a new invitation.",
-            self.crate_name
-        )
-    }
-}
-
-#[derive(Debug)]
 pub(crate) struct MetricsDisabled;
 
 impl AppError for MetricsDisabled {

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -135,37 +135,6 @@ impl fmt::Display for InsecurelyGeneratedTokenRevoked {
 }
 
 #[derive(Debug)]
-pub(super) struct AccountLocked {
-    pub(super) reason: String,
-    pub(super) until: Option<NaiveDateTime>,
-}
-
-impl AppError for AccountLocked {
-    fn response(&self) -> Response {
-        json_error(&self.to_string(), StatusCode::FORBIDDEN)
-    }
-}
-
-impl fmt::Display for AccountLocked {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(until) = self.until {
-            let until = until.format("%Y-%m-%d at %H:%M:%S UTC");
-            write!(
-                f,
-                "This account is locked until {}. Reason: {}",
-                until, self.reason
-            )
-        } else {
-            write!(
-                f,
-                "This account is indefinitely locked. Reason: {}",
-                self.reason
-            )
-        }
-    }
-}
-
-#[derive(Debug)]
 pub(crate) struct OwnershipInvitationExpired {
     pub(crate) crate_name: String,
 }


### PR DESCRIPTION
Instead of having a dedicated `struct` per HTTP status code (and then some more), we can use a single struct and save the status code inside the struct, next to the error message. This allows us to throw away a significant chunk of verbose code while the API behaves exactly the same as before. Admittedly this removes the ability for `e.is::<NotFound>()` checks, but we were not and probably shouldn't be using those anyway.

Note that a few structs were not converted to using this "generic" struct yet:
- `InsecurelyGeneratedTokenRevoked` because it is used in an `e.is::<_>()` check
- `ReadOnlyMode` because it is used in an `e.is::<_>()` check
- `TooManyRequests` because it is setting a custom header, which `CustomApiError` does not currently allow