### PR TITLE
Remove `AppError::chain()` method

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -67,17 +67,20 @@ impl AuthCheck {
             if !self.allow_token {
                 let error_message =
                     "API Token authentication was explicitly disallowed for this API";
-                return Err(internal(error_message).chain(forbidden()));
+                request.request_log().add("cause", error_message);
+                return Err(forbidden());
             }
 
             if !self.endpoint_scope_matches(token.endpoint_scopes.as_ref()) {
                 let error_message = "Endpoint scope mismatch";
-                return Err(internal(error_message).chain(forbidden()));
+                request.request_log().add("cause", error_message);
+                return Err(forbidden());
             }
 
             if !self.crate_scope_matches(token.crate_scopes.as_ref()) {
                 let error_message = "Crate scope mismatch";
-                return Err(internal(error_message).chain(forbidden()));
+                request.request_log().add("cause", error_message);
+                return Err(forbidden());
             }
         }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -204,7 +204,10 @@ fn authenticate_via_token<T: RequestPartsExt>(
         if e.is::<InsecurelyGeneratedTokenRevoked>() {
             e
         } else {
-            e.chain(internal("invalid token")).chain(forbidden())
+            let cause = format!("invalid token caused by {e}");
+            req.request_log().add("cause", cause);
+
+            forbidden()
         }
     })?;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -5,7 +5,7 @@ use crate::middleware::session::RequestSession;
 use crate::models::token::{CrateScope, EndpointScope};
 use crate::models::{ApiToken, User};
 use crate::util::errors::{
-    account_locked, forbidden, internal, AppError, AppResult, InsecurelyGeneratedTokenRevoked,
+    account_locked, forbidden, internal, AppResult, InsecurelyGeneratedTokenRevoked,
 };
 use chrono::Utc;
 use diesel::PgConnection;
@@ -241,7 +241,10 @@ fn authenticate<T: RequestPartsExt>(req: &T, conn: &mut PgConnection) -> AppResu
     }
 
     // Unable to authenticate the user
-    return Err(internal("no cookie session or auth header found").chain(forbidden()));
+    let cause = "no cookie session or auth header found";
+    req.request_log().add("cause", cause);
+
+    return Err(forbidden());
 }
 
 fn ensure_not_locked(user: &User) -> AppResult<()> {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -174,8 +174,10 @@ fn authenticate_via_cookie<T: RequestPartsExt>(
         return Ok(None);
     };
 
-    let user = User::find(conn, id)
-        .map_err(|err| err.chain(internal("user_id from cookie not found in database")))?;
+    let user = User::find(conn, id).map_err(|err| {
+        req.request_log().add("cause", err);
+        internal("user_id from cookie not found in database")
+    })?;
 
     ensure_not_locked(&user)?;
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -211,8 +211,10 @@ fn authenticate_via_token<T: RequestPartsExt>(
         }
     })?;
 
-    let user = User::find(conn, token.user_id)
-        .map_err(|err| err.chain(internal("user_id from token not found in database")))?;
+    let user = User::find(conn, token.user_id).map_err(|err| {
+        req.request_log().add("cause", err);
+        internal("user_id from token not found in database")
+    })?;
 
     ensure_not_locked(&user)?;
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -670,9 +670,9 @@ pub fn add_dependencies(
 impl From<TarballError> for BoxedAppError {
     fn from(error: TarballError) -> Self {
         match error {
-            TarballError::Malformed(err) => err.chain(cargo_err(
+            TarballError::Malformed(_err) => cargo_err(
                 "uploaded tarball is malformed or too large when decompressed",
-            )),
+            ),
             TarballError::InvalidPath(path) => cargo_err(format!("invalid path found: {path}")),
             TarballError::UnexpectedSymlink(path) => {
                 cargo_err(format!("unexpected symlink or hard link found: {path}"))

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,5 +1,6 @@
 use super::prelude::*;
-use crate::util::errors::{forbidden, internal, AppError, AppResult};
+use crate::middleware::log_request::RequestLogExt;
+use crate::util::errors::{forbidden, AppResult};
 use http::request::Parts;
 use http::{Extensions, HeaderMap, HeaderValue, Method, Request, Uri, Version};
 
@@ -20,7 +21,9 @@ pub fn verify_origin<T: RequestPartsExt>(req: &T) -> AppResult<()> {
     if let Some(bad_origin) = bad_origin {
         let error_message =
             format!("only same-origin requests can be authenticated. got {bad_origin:?}");
-        return Err(internal(&error_message).chain(forbidden()));
+
+        req.request_log().add("cause", error_message);
+        return Err(forbidden());
     }
     Ok(())
 }

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -106,17 +106,6 @@ pub trait AppError: Send + fmt::Display + fmt::Debug + 'static {
     fn get_type_id(&self) -> TypeId {
         TypeId::of::<Self>()
     }
-
-    fn chain<E>(self, error: E) -> BoxedAppError
-    where
-        Self: Sized,
-        E: AppError,
-    {
-        Box::new(ChainedError {
-            error,
-            cause: Box::new(self),
-        })
-    }
 }
 
 impl dyn AppError {
@@ -154,31 +143,6 @@ impl IntoResponse for BoxedAppError {
 }
 
 pub type AppResult<T> = Result<T, BoxedAppError>;
-
-// =============================================================================
-// Chaining errors
-
-#[derive(Debug)]
-struct ChainedError<E> {
-    error: E,
-    cause: BoxedAppError,
-}
-
-impl<E: AppError> AppError for ChainedError<E> {
-    fn response(&self) -> axum::response::Response {
-        self.error.response()
-    }
-
-    fn cause(&self) -> Option<&dyn AppError> {
-        Some(&*self.cause)
-    }
-}
-
-impl<E: AppError> fmt::Display for ChainedError<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} caused by {}", self.error, self.cause)
-    }
-}
 
 // =============================================================================
 // Error impls
@@ -353,8 +317,6 @@ fn server_error_response(error: String) -> axum::response::Response {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::middleware::log_request::CauseField;
-    use axum::response::IntoResponse;
     use diesel::result::Error as DieselError;
     use http::StatusCode;
 
@@ -376,19 +338,6 @@ mod tests {
         // cargo_err errors are returned as 200 so that cargo displays this nicely on the command line
         assert_eq!(cargo_err("").response().status(), StatusCode::OK);
 
-        // Inner errors are captured for logging when wrapped by a user facing error
-        let response = "-1"
-            .parse::<u8>()
-            .map_err(|err| err.chain(internal("middle error")))
-            .map_err(|err| err.chain(bad_request("outer user facing error")))
-            .unwrap_err()
-            .into_response();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        assert_eq!(
-            response.extensions().get::<CauseField>().unwrap().0,
-            "middle error caused by invalid digit found in string"
-        );
-
         // All other error types are converted to internal server errors
         assert_eq!(
             internal("").response().status(),
@@ -405,63 +354,6 @@ mod tests {
                 .response()
                 .status(),
             StatusCode::INTERNAL_SERVER_ERROR
-        );
-    }
-
-    #[test]
-    fn chain_error_internal() {
-        assert_eq!(
-            Err::<(), _>(internal("inner"))
-                .map_err(|err| err.chain(internal("middle")))
-                .map_err(|err| err.chain(internal("outer")))
-                .unwrap_err()
-                .to_string(),
-            "outer caused by middle caused by inner"
-        );
-        assert_eq!(
-            Err::<(), _>(internal("inner"))
-                .map_err(|err| err.chain(internal("outer")))
-                .unwrap_err()
-                .to_string(),
-            "outer caused by inner"
-        );
-
-        // Don't do this, the user will see a generic 500 error instead of the intended message
-        assert_eq!(
-            Err::<(), _>(cargo_err("inner"))
-                .map_err(|err| err.chain(internal("outer")))
-                .unwrap_err()
-                .to_string(),
-            "outer caused by inner"
-        );
-        assert_eq!(
-            Err::<(), _>(forbidden())
-                .map_err(|err| err.chain(internal("outer")))
-                .unwrap_err()
-                .to_string(),
-            "outer caused by must be logged in to perform that action"
-        );
-    }
-
-    #[test]
-    fn chain_error_user_facing() {
-        // Do this rarely, the user will only see the outer error
-        assert_eq!(
-            Err::<(), _>(cargo_err("inner"))
-                .map_err(|err| err.chain(cargo_err("outer")))
-                .unwrap_err()
-                .to_string(),
-            "outer caused by inner" // never logged
-        );
-
-        // The outer error is sent as a response to the client.
-        // The inner error never bubbles up to the logging middleware
-        assert_eq!(
-            Err::<(), _>(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
-                .map_err(|err| err.chain(cargo_err("outer")))
-                .unwrap_err()
-                .to_string(),
-            "outer caused by permission denied" // never logged
         );
     }
 }

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -255,28 +255,6 @@ impl AppError for InternalAppError {
     }
 }
 
-#[derive(Debug)]
-struct InternalAppErrorStatic {
-    description: &'static str,
-}
-
-impl fmt::Display for InternalAppErrorStatic {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.description)?;
-        Ok(())
-    }
-}
-
-impl AppError for InternalAppErrorStatic {
-    fn response(&self) -> axum::response::Response {
-        error!(error = %self.description, "Internal Server Error");
-
-        sentry::capture_message(self.description, sentry::Level::Error);
-
-        server_error_response(self.description.to_string())
-    }
-}
-
 pub fn internal<S: ToString>(error: S) -> BoxedAppError {
     Box::new(InternalAppError {
         description: error.to_string(),


### PR DESCRIPTION
Chained errors were used in our codebase to print a `cause` field in the log output. `internal(error_message).chain(forbidden())` for example would print `cause=<error_message>` and use `forbidden()` as the HTTP response.

Unfortunately our `AppError` struct is incompatible with `std::error::Error` and its `source()` fn though, which makes our error chaining less useful.

This PR removes/replaces our custom error chaining to make it easier in the future to build one based on `std::error::Error` instead.