### PR TITLE
Revert "Update Rust crate anyhow to v1.0.77"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.77"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
 
 [[package]]
 name = "async-compression"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default = ["slow-tests"]
 slow-tests = []
 
 [dependencies]
-anyhow = "=1.0.77"
+anyhow = "=1.0.76"
 async-trait = "=0.1.75"
 aws-credential-types = { version = "=1.1.1", features = ["hardcoded-credentials"] }
 aws-ip-ranges = "=0.40.0"

--- a/crates_io_env_vars/Cargo.toml
+++ b/crates_io_env_vars/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-anyhow = "=1.0.77"
+anyhow = "=1.0.76"
 dotenvy = "=0.15.7"

--- a/crates_io_github/Cargo.toml
+++ b/crates_io_github/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-anyhow = "=1.0.77"
+anyhow = "=1.0.76"
 async-trait = "=0.1.75"
 oauth2 = { version = "=4.4.2", default-features = false }
 reqwest = { version = "=0.11.23", features = ["json"] }

--- a/crates_io_index/Cargo.toml
+++ b/crates_io_index/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 testing = []
 
 [dependencies]
-anyhow = "=1.0.77"
+anyhow = "=1.0.76"
 base64 = "=0.21.5"
 crates_io_env_vars = { path = "../crates_io_env_vars" }
 dotenvy = "=0.15.7"

--- a/crates_io_smoke_test/Cargo.toml
+++ b/crates_io_smoke_test/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-anyhow = "=1.0.77"
+anyhow = "=1.0.76"
 bytes = "=1.5.0"
 clap = { version = "=4.4.11", features = ["derive", "env", "unicode", "wrap_help"] }
 crates_io_index = { path = "../crates_io_index" }

--- a/crates_io_tarball/Cargo.toml
+++ b/crates_io_tarball/Cargo.toml
@@ -23,7 +23,7 @@ toml = "=0.8.8"
 tracing = "=0.1.40"
 
 [dev-dependencies]
-anyhow = "=1.0.77"
+anyhow = "=1.0.76"
 claims = "=0.7.1"
 clap = { version = "=4.4.11", features = ["derive", "unicode", "wrap_help"] }
 indicatif = { version = "=0.17.7", features = ["rayon"] }

--- a/crates_io_worker/Cargo.toml
+++ b/crates_io_worker/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 workspace = true
 
 [dependencies]
-anyhow = "=1.0.77"
+anyhow = "=1.0.76"
 async-trait = "=0.1.75"
 diesel = { version = "=2.1.4", features = ["postgres", "r2d2", "serde_json"] }
 futures-util = "=0.3.30"


### PR DESCRIPTION
This reverts commit 1b9fba41e7b1070214bbfc3f64d28ca42db24549.

Related:
- https://github.com/dtolnay/thiserror/issues/270
- https://github.com/rust-lang/crates.io/pull/7819