### PR TITLE
env_vars: Add basic test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,7 +1000,9 @@ name = "crates_io_env_vars"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "claims",
  "dotenvy",
+ "once_cell",
 ]
 
 [[package]]

--- a/crates_io_env_vars/Cargo.toml
+++ b/crates_io_env_vars/Cargo.toml
@@ -10,3 +10,7 @@ workspace = true
 [dependencies]
 anyhow = "=1.0.76"
 dotenvy = "=0.15.7"
+
+[dev-dependencies]
+claims = "=0.7.1"
+once_cell = "1.19.0"


### PR DESCRIPTION
Previously this code wasn't really tested properly. This PR adds a basic test suite for the four helper functions defined in the `crates_io_env_vars` package.