### PR TITLE
typosquat/test_util: Remove `conn` field from `Faker` struct

### DIFF
--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -168,23 +168,23 @@ mod tests {
 
     #[test]
     fn top_crates() -> Result<(), Error> {
-        let mut faker = Faker::new(pg_connection());
+        let mut conn = pg_connection();
+
+        let mut faker = Faker::new();
 
         // Set up two users.
-        let user_a = faker.user("a")?;
-        let user_b = faker.user("b")?;
+        let user_a = faker.user(&mut conn, "a")?;
+        let user_b = faker.user(&mut conn, "b")?;
 
         // Set up three crates with various ownership schemes.
-        let _top_a = faker.crate_and_version("a", "Hello", &user_a, 2)?;
-        let top_b = faker.crate_and_version("b", "Yes, this is dog", &user_b, 1)?;
-        let not_top_c = faker.crate_and_version("c", "Unpopular", &user_a, 0)?;
+        let _top_a = faker.crate_and_version(&mut conn, "a", "Hello", &user_a, 2)?;
+        let top_b = faker.crate_and_version(&mut conn, "b", "Yes, this is dog", &user_b, 1)?;
+        let not_top_c = faker.crate_and_version(&mut conn, "c", "Unpopular", &user_a, 0)?;
 
         // Let's set up a team that owns both b and c, but not a.
-        let not_the_a_team = faker.team("org", "team")?;
-        faker.add_crate_to_team(&user_b, &top_b.0, &not_the_a_team)?;
-        faker.add_crate_to_team(&user_b, &not_top_c.0, &not_the_a_team)?;
-
-        let mut conn = faker.into_conn();
+        let not_the_a_team = faker.team(&mut conn, "org", "team")?;
+        faker.add_crate_to_team(&mut conn, &user_b, &top_b.0, &not_the_a_team)?;
+        faker.add_crate_to_team(&mut conn, &user_b, &not_top_c.0, &not_the_a_team)?;
 
         let top_crates = TopCrates::new(&mut conn, 2)?;
 


### PR DESCRIPTION
Using `PgConnection` prevents us from using a pooled connection (i.e. what `TestDatabase::connect()` returns). An alternative would be to store the mutable reference to the connection in the `Faker` struct, but then we have to deal with explicit lifetimes, and the `borrow_conn()` and `into_conn()` fns would still cause a bit of weirdness.

This PR adjusts the `Faker` API to roughly match the rest of the codebase by accepting an explicit `&mut PgConnection` argument everywhere instead.