### PR TITLE
Replace remaining `TEST_DATABASE_URL` usage with `TestDatabase`

### DIFF
--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -154,12 +154,12 @@ pub async fn logout(session: SessionExtension) -> Json<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::pg_connection_no_transaction;
+    use crate::test_util::test_db_connection;
 
     #[test]
     fn gh_user_with_invalid_email_doesnt_fail() {
         let emails = Emails::new_in_memory();
-        let conn = &mut pg_connection_no_transaction();
+        let (_test_db, conn) = &mut test_db_connection();
         let gh_user = GithubUser {
             email: Some("String.Format(\"{0}.{1}@live.com\", FirstName, LastName)".into()),
             name: Some("My Name".into()),

--- a/src/downloads_counter.rs
+++ b/src/downloads_counter.rs
@@ -246,7 +246,7 @@ mod tests {
     use super::*;
     use crate::email::Emails;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User};
-    use crate::test_util::pg_connection;
+    use crate::test_util::test_db_connection;
     use diesel::PgConnection;
     use semver::Version;
     use std::collections::BTreeMap;
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn test_increment_and_persist_all() {
         let counter = DownloadsCounter::new();
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let mut state = State::new(conn);
 
         let v1 = state.new_version(conn);
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn test_increment_and_persist_shard() {
         let counter = DownloadsCounter::new();
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let mut state = State::new(conn);
 
         let v1 = state.new_version(conn);
@@ -386,7 +386,7 @@ mod tests {
         F: Fn(&DashMap<i32, AtomicUsize>, i32, i32) -> bool,
     {
         let counter = DownloadsCounter::new();
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let mut state = State::new(conn);
 
         let v1 = state.new_version(conn);

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -145,21 +145,12 @@ impl<'a> NewCategory<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::pg_connection_no_transaction;
-    use diesel::connection::SimpleConnection;
-
-    fn pg_connection() -> PgConnection {
-        let mut conn = pg_connection_no_transaction();
-        // These tests deadlock if run concurrently
-        conn.batch_execute("BEGIN; LOCK categories IN ACCESS EXCLUSIVE MODE")
-            .unwrap();
-        conn
-    }
+    use crate::test_util::test_db_connection;
 
     #[test]
     fn category_toplevel_excludes_subcategories() {
         use self::categories;
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         insert_into(categories::table)
             .values(&vec![
                 (
@@ -199,7 +190,7 @@ mod tests {
             )
         };
 
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         insert_into(categories::table)
             .values(&vec![
                 new_cat("Cat 1", "cat1", 0),
@@ -225,7 +216,7 @@ mod tests {
     #[test]
     fn category_toplevel_applies_limit_and_offset() {
         use self::categories;
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         insert_into(categories::table)
             .values(&vec![
                 (
@@ -269,7 +260,7 @@ mod tests {
             )
         };
 
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         insert_into(categories::table)
             .values(&vec![
                 new_cat("Cat 1", "cat1", 1),
@@ -307,7 +298,7 @@ mod tests {
             )
         };
 
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         insert_into(categories::table)
             .values(&vec![
                 new_cat("Cat 1", "cat1", 1),
@@ -349,7 +340,7 @@ mod tests {
             )
         };
 
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         insert_into(categories::table)
             .values(&vec![
                 new_cat("Cat 1", "cat1", 1),

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -89,11 +89,11 @@ impl Keyword {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::pg_connection;
+    use crate::test_util::test_db_connection;
 
     #[test]
     fn dont_associate_with_non_lowercased_keywords() {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         // The code should be preventing lowercased keywords from existing,
         // but if one happens to sneak in there, don't associate crates with it.
 

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -183,7 +183,7 @@ mod tests {
 
     #[test]
     fn default_rate_limits() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         // Set the defaults as if no env vars have been set in production
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn take_token_with_no_bucket_creates_new_one() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -298,7 +298,7 @@ mod tests {
 
     #[test]
     fn take_token_with_existing_bucket_modifies_existing_bucket() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn take_token_after_delay_refills() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -345,7 +345,7 @@ mod tests {
 
     #[test]
     fn refill_subsecond_rate() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         // Subsecond rates have floating point rounding issues, so use a known
         // timestamp that rounds fine
         let now =
@@ -373,7 +373,7 @@ mod tests {
 
     #[test]
     fn last_refill_always_advanced_by_multiple_of_rate() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn zero_tokens_returned_when_user_has_no_tokens_left() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn a_user_with_no_tokens_gets_a_token_after_exactly_rate() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn tokens_never_refill_past_burst() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn two_actions_dont_interfere_with_each_other() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let mut config = HashMap::new();
@@ -521,7 +521,7 @@ mod tests {
 
     #[test]
     fn override_is_used_instead_of_global_burst_if_present() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -551,7 +551,7 @@ mod tests {
 
     #[test]
     fn overrides_can_expire() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
         let rate = SampleRateLimiter {
@@ -598,7 +598,7 @@ mod tests {
 
     #[test]
     fn override_is_different_for_each_action() -> QueryResult<()> {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let now = now();
         let user_id = new_user(conn, "user")?;
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use crate::db::sql_types::semver::Triple;
     use crate::schema::sql_types::SemverTriple;
-    use crate::test_util::pg_connection;
+    use crate::test_util::test_db_connection;
     use diesel::prelude::*;
     use diesel::select;
 
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn to_semver_no_prerelease_works() {
-        let mut conn = pg_connection();
+        let (_test_db, mut conn) = test_db_connection();
 
         #[track_caller]
         fn test(conn: &mut PgConnection, text: &str, expected: Option<(u64, u64, u64)>) {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,15 +1,14 @@
 #![cfg(test)]
 
-use crates_io_env_vars::required_var;
+use crates_io_test_db::TestDatabase;
 use diesel::prelude::*;
+use diesel::r2d2::{ConnectionManager, PooledConnection};
 
-pub fn pg_connection_no_transaction() -> PgConnection {
-    let database_url = required_var("TEST_DATABASE_URL").unwrap();
-    PgConnection::establish(&database_url).unwrap()
-}
-
-pub fn pg_connection() -> PgConnection {
-    let mut conn = pg_connection_no_transaction();
-    conn.begin_test_transaction().unwrap();
-    conn
+pub fn test_db_connection() -> (
+    TestDatabase,
+    PooledConnection<ConnectionManager<PgConnection>>,
+) {
+    let test_db = TestDatabase::new();
+    let conn = test_db.connect();
+    (test_db, conn)
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -9,7 +9,6 @@ use crates_io::rate_limiter::{LimitedAction, RateLimiterConfig};
 use crates_io::storage::StorageConfig;
 use crates_io::worker::{Environment, RunnerExt};
 use crates_io::{App, Emails, Env};
-use crates_io_env_vars::required_var;
 use crates_io_index::testing::UpstreamIndex;
 use crates_io_index::{Credentials, RepositoryConfig};
 use crates_io_test_db::TestDatabase;
@@ -371,7 +370,10 @@ fn simple_config() -> config::Server {
 
     let db = DatabasePools {
         primary: DbPoolConfig {
-            url: required_var("TEST_DATABASE_URL").unwrap().into(),
+            // This value is supposed be overridden by the
+            // `TestAppBuilder::empty()` fn. If it's not, then
+            // something is broken.
+            url: String::from("invalid default url").into(),
             read_only_mode: false,
             pool_size: 5,
             min_idle: None,

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -168,23 +168,23 @@ mod tests {
 
     #[test]
     fn top_crates() -> Result<(), Error> {
-        let mut faker = Faker::new(pg_connection());
+        let mut conn = pg_connection();
+
+        let mut faker = Faker::new();
 
         // Set up two users.
-        let user_a = faker.user("a")?;
-        let user_b = faker.user("b")?;
+        let user_a = faker.user(&mut conn, "a")?;
+        let user_b = faker.user(&mut conn, "b")?;
 
         // Set up three crates with various ownership schemes.
-        let _top_a = faker.crate_and_version("a", "Hello", &user_a, 2)?;
-        let top_b = faker.crate_and_version("b", "Yes, this is dog", &user_b, 1)?;
-        let not_top_c = faker.crate_and_version("c", "Unpopular", &user_a, 0)?;
+        let _top_a = faker.crate_and_version(&mut conn, "a", "Hello", &user_a, 2)?;
+        let top_b = faker.crate_and_version(&mut conn, "b", "Yes, this is dog", &user_b, 1)?;
+        let not_top_c = faker.crate_and_version(&mut conn, "c", "Unpopular", &user_a, 0)?;
 
         // Let's set up a team that owns both b and c, but not a.
-        let not_the_a_team = faker.team("org", "team")?;
-        faker.add_crate_to_team(&user_b, &top_b.0, &not_the_a_team)?;
-        faker.add_crate_to_team(&user_b, &not_top_c.0, &not_the_a_team)?;
-
-        let mut conn = faker.into_conn();
+        let not_the_a_team = faker.team(&mut conn, "org", "team")?;
+        faker.add_crate_to_team(&mut conn, &user_b, &top_b.0, &not_the_a_team)?;
+        faker.add_crate_to_team(&mut conn, &user_b, &not_top_c.0, &not_the_a_team)?;
 
         let top_crates = TopCrates::new(&mut conn, 2)?;
 

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -161,14 +161,14 @@ impl From<crate::models::Owner> for Owner {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_util::pg_connection, typosquat::test_util::Faker};
+    use crate::{test_util::test_db_connection, typosquat::test_util::Faker};
     use thiserror::Error;
 
     use super::*;
 
     #[test]
     fn top_crates() -> Result<(), Error> {
-        let mut conn = pg_connection();
+        let (_test_db, mut conn) = test_db_connection();
 
         let mut faker = Faker::new();
 

--- a/src/worker/jobs/dump_db/gen_scripts.rs
+++ b/src/worker/jobs/dump_db/gen_scripts.rs
@@ -119,7 +119,7 @@ impl VisibilityConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::pg_connection;
+    use crate::test_util::test_db_connection;
     use diesel::prelude::*;
     use std::collections::HashSet;
     use std::iter::FromIterator;
@@ -128,7 +128,7 @@ mod tests {
     /// test database.
     #[test]
     fn check_visibility_config() {
-        let conn = &mut pg_connection();
+        let (_test_db, conn) = &mut test_db_connection();
         let db_columns = HashSet::<Column>::from_iter(get_db_columns(conn));
         let vis_columns = VisibilityConfig::get()
             .0

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -119,7 +119,7 @@ Specific squat checks that triggered:\n
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_util::pg_connection, typosquat::test_util::Faker};
+    use crate::{test_util::test_db_connection, typosquat::test_util::Faker};
     use lettre::Address;
 
     use super::*;
@@ -127,7 +127,7 @@ mod tests {
     #[test]
     fn integration() -> anyhow::Result<()> {
         let emails = Emails::new_in_memory();
-        let mut conn = pg_connection();
+        let (_test_db, mut conn) = test_db_connection();
         let mut faker = Faker::new();
 
         // Set up a user and a popular crate to match against.


### PR DESCRIPTION
`TEST_DATABASE_URL` is only supposed to be used as a database name prefix at this point, but not as a real, existing database. This PR adjusts the remaining usages to use the `TestDatabase` struct instead.

This PR is based on https://github.com/rust-lang/crates.io/pull/7827, since `Faker` needs to be made compatible with the pooled database connection that `TestDatabase::connect()` returns.