### PR TITLE
controllers: Remove unused import

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -22,7 +22,7 @@ mod prelude {
     use crate::controllers::util::RequestPartsExt;
     pub use crate::middleware::app::RequestApp;
     pub use crate::tasks::spawn_blocking;
-    pub use crate::util::errors::{cargo_err, AppError, AppResult, BoxedAppError};
+    pub use crate::util::errors::{cargo_err, AppResult, BoxedAppError};
     pub use crate::util::BytesRequest;
     use indexmap::IndexMap;
 


### PR DESCRIPTION
This should hopefully fix the failing CI jobs. I suppose this happened due to a merge "conflict" between some of the latest PRs 😅 