### PR TITLE
bin/server: Use `axum::serve(...).with_graceful_shutdown(...)`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,7 +958,6 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.1.0",
- "hyper-util",
  "indexmap",
  "indicatif",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ http = "=1.0.0"
 http-body = "=1.0.0"
 http-body-util = "=0.1.0"
 hyper = { version = "=1.1.0", features = ["client", "http1"] }
-hyper-util = { version = "=0.1.2", features = ["tokio", "server-auto", "http1"] }
 indexmap = { version = "=2.1.0", features = ["serde"] }
 indicatif = "=0.17.7"
 ipnetwork = "=0.20.0"


### PR DESCRIPTION
Now that https://github.com/tokio-rs/axum/pull/2398 is released we can simplify our server binary startup code quite a bit :)