### PR TITLE
models/user: Simplify `NewUser::gh_access_token` type

### DIFF
--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,7 +1,6 @@
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use secrecy::SecretString;
-use std::borrow::Cow;
 
 use crate::app::App;
 use crate::controllers::user::me::UserConfirmEmail;
@@ -33,7 +32,7 @@ pub struct NewUser<'a> {
     pub gh_login: &'a str,
     pub name: Option<&'a str>,
     pub gh_avatar: Option<&'a str>,
-    pub gh_access_token: Cow<'a, str>,
+    pub gh_access_token: &'a str,
 }
 
 impl<'a> NewUser<'a> {
@@ -49,7 +48,7 @@ impl<'a> NewUser<'a> {
             gh_login,
             name,
             gh_avatar,
-            gh_access_token: Cow::Borrowed(gh_access_token),
+            gh_access_token,
         }
     }
 

--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -16,10 +16,7 @@ use crates_io::{
         EncodableOwner, EncodableVersion, GoodCrate,
     },
 };
-use std::{
-    borrow::Cow,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use diesel::prelude::*;
 
@@ -106,7 +103,7 @@ fn new_user(login: &str) -> NewUser<'_> {
         gh_login: login,
         name: None,
         gh_avatar: None,
-        gh_access_token: Cow::Borrowed("some random token"),
+        gh_access_token: "some random token",
     }
 }
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -846,7 +846,6 @@ fn test_accept_expired_invitation_by_mail() {
 #[test]
 fn inactive_users_dont_get_invitations() {
     use crates_io::models::NewUser;
-    use std::borrow::Cow;
 
     let (app, _, owner, owner_token) = TestApp::init().with_token();
     let owner = owner.as_model();
@@ -861,7 +860,7 @@ fn inactive_users_dont_get_invitations() {
             gh_login: invited_gh_login,
             name: None,
             gh_avatar: None,
-            gh_access_token: Cow::Borrowed("some random token"),
+            gh_access_token: "some random token",
         }
         .create_or_update(None, &app.as_inner().emails, conn)
         .unwrap();


### PR DESCRIPTION
No need for a `Cow` if we use `&str` everywhere 🤷‍♂️ 