### PR TITLE
Simplify `EncodablePublicUser::url` field

### DIFF
--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -17,7 +17,7 @@ fn show() {
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/bAr").good();
     assert_eq!(json.user.login, "Bar");
-    assert_eq!(json.user.url, Some("https://github.com/Bar".into()));
+    assert_eq!(json.user.url, "https://github.com/Bar");
 }
 
 #[test]

--- a/src/views.rs
+++ b/src/views.rs
@@ -506,7 +506,7 @@ pub struct EncodablePublicUser {
     pub login: String,
     pub name: Option<String>,
     pub avatar: Option<String>,
-    pub url: Option<String>,
+    pub url: String,
 }
 
 /// Converts a `User` model into an `EncodablePublicUser` for JSON serialization.
@@ -525,7 +525,7 @@ impl From<User> for EncodablePublicUser {
             avatar: gh_avatar,
             login: gh_login,
             name,
-            url: Some(url),
+            url,
         }
     }
 }
@@ -740,7 +740,7 @@ mod tests {
                     login: String::new(),
                     name: None,
                     avatar: None,
-                    url: None,
+                    url: String::new(),
                 },
                 time: NaiveDate::from_ymd_opt(2017, 1, 6)
                     .unwrap()


### PR DESCRIPTION
We always assign a value to this field, so there is no need for us to use `Option` here.