### PR TITLE
Adjust "version invalid / not found" errors to reply with "404 Not Found"

### DIFF
--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -8,6 +8,7 @@ use crate::db::PoolError;
 use crate::middleware::log_request::RequestLogExt;
 use crate::models::VersionDownload;
 use crate::schema::*;
+use crate::util::errors::version_not_found;
 use crate::views::EncodableVersionDownload;
 use chrono::{Duration, NaiveDate, Utc};
 use tracing::Instrument;
@@ -135,7 +136,7 @@ pub async fn downloads(
 ) -> AppResult<Json<Value>> {
     spawn_blocking(move || {
         if semver::Version::parse(&version).is_err() {
-            return Err(cargo_err(format_args!("invalid semver: {version}")));
+            return Err(version_not_found(&crate_name, &version));
         }
 
         let conn = &mut *app.db_read()?;

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -7,6 +7,7 @@
 use crate::controllers::frontend_prelude::*;
 
 use crate::models::VersionOwnerAction;
+use crate::util::errors::version_not_found;
 use crate::views::{EncodableDependency, EncodableVersion};
 
 use super::version_and_crate;
@@ -24,7 +25,7 @@ pub async fn dependencies(
 ) -> AppResult<Json<Value>> {
     spawn_blocking(move || {
         if semver::Version::parse(&version).is_err() {
-            return Err(cargo_err(format_args!("invalid semver: {version}")));
+            return Err(version_not_found(&crate_name, &version));
         }
 
         let conn = &mut state.db_read()?;
@@ -61,7 +62,7 @@ pub async fn show(
 ) -> AppResult<Json<Value>> {
     spawn_blocking(move || {
         if semver::Version::parse(&version).is_err() {
-            return Err(cargo_err(format_args!("invalid semver: {version}")));
+            return Err(version_not_found(&crate_name, &version));
         }
 
         let conn = &mut state.db_read()?;

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -8,6 +8,7 @@ use crate::models::Rights;
 use crate::models::{insert_version_owner_action, VersionAction};
 use crate::rate_limiter::LimitedAction;
 use crate::schema::versions;
+use crate::util::errors::version_not_found;
 use crate::worker::jobs;
 use tokio::runtime::Handle;
 
@@ -49,7 +50,7 @@ fn modify_yank(
     // lifetime issues with `req`.
 
     if semver::Version::parse(version).is_err() {
-        return Err(cargo_err(format_args!("invalid semver: {version}")));
+        return Err(version_not_found(crate_name, version));
     }
 
     let conn = &mut *state.db_write()?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -15,7 +15,7 @@ use crate::models::{
     CrateOwner, CrateOwnerInvitation, Dependency, NewCrateOwnerInvitationOutcome, Owner, OwnerKind,
     ReverseDependency, User, Version,
 };
-use crate::util::errors::{cargo_err, AppResult};
+use crate::util::errors::{version_not_found, AppResult};
 
 use crate::models::helpers::with_count::*;
 use crate::schema::*;
@@ -191,12 +191,7 @@ impl Crate {
             .filter(versions::num.eq(version))
             .first(conn)
             .optional()?
-            .ok_or_else(|| {
-                cargo_err(format_args!(
-                    "crate `{}` does not have a version `{}`",
-                    self.name, version
-                ))
-            })
+            .ok_or_else(|| version_not_found(&self.name, version))
     }
 
     // Validates the name is a valid crate name.

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -27,7 +27,7 @@ fn dependencies() {
     assert_eq!(deps.dependencies[0].crate_id, "bar_deps");
 
     let response = anon.get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies");
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
         response.into_json(),
         json!({ "errors": [{ "detail": "crate `foo_deps` does not have a version `1.0.2`" }] })

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -84,9 +84,8 @@ pub fn service_unavailable() -> BoxedAppError {
 }
 
 pub fn version_not_found(krate: &str, version: &str) -> BoxedAppError {
-    cargo_err(format_args!(
-        "crate `{krate}` does not have a version `{version}`"
-    ))
+    let detail = format!("crate `{krate}` does not have a version `{version}`");
+    custom(StatusCode::NOT_FOUND, detail)
 }
 
 // =============================================================================

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -83,6 +83,12 @@ pub fn service_unavailable() -> BoxedAppError {
     custom(StatusCode::SERVICE_UNAVAILABLE, "Service unavailable")
 }
 
+pub fn version_not_found(krate: &str, version: &str) -> BoxedAppError {
+    cargo_err(format_args!(
+        "crate `{krate}` does not have a version `{version}`"
+    ))
+}
+
 // =============================================================================
 // AppError trait
 


### PR DESCRIPTION
We don't need to use `cargo_err()` (aka. "200 OK") responses in these error cases anymore since the cargo compat middleware will ensure that we reply with a compatible status code for cargo-relevant endpoints.

This PR extracts a new `version_not_found()` fn and then adjusts its implementation to respond with "404 Not Found" instead.