### PR TITLE
util/response: Simplify `into_text/json()` fns

### DIFF
--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -31,7 +31,7 @@ fn account_locked_indefinitely() {
 
     let error_message = format!("This account is indefinitely locked. Reason: {LOCK_REASON}");
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": error_message }] })
     );
 }
@@ -49,7 +49,7 @@ fn account_locked_with_future_expiry() {
 
     let error_message = format!("This account is locked until {until}. Reason: {LOCK_REASON}");
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": error_message }] })
     );
 }

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -13,7 +13,7 @@ fn anonymous_user_unauthorized() {
     let response: Response<()> = anon.get(URL);
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(response.into_json().to_string().as_bytes(), MUST_LOGIN);
+    assert_eq!(response.json().to_string().as_bytes(), MUST_LOGIN);
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn token_auth_cannot_find_token() {
     let response: Response<()> = anon.run(request);
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(response.into_json().to_string().as_bytes(), MUST_LOGIN);
+    assert_eq!(response.json().to_string().as_bytes(), MUST_LOGIN);
 }
 
 // Ensure that an unexpected authentication error is available for logging.  The user would see

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -48,7 +48,7 @@ fn github_secret_alert_revokes_token() {
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
     let response = anon.run::<()>(request);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     // Ensure that the token was revoked
     app.db(|conn| {
@@ -103,7 +103,7 @@ fn github_secret_alert_for_revoked_token() {
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
     let response = anon.run::<()>(request);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     // Ensure that the token is still revoked
     app.db(|conn| {
@@ -146,7 +146,7 @@ fn github_secret_alert_for_unknown_token() {
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
     let response = anon.run::<()>(request);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     // Ensure that the token was not revoked
     app.db(|conn| {

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -6,19 +6,19 @@ use http::StatusCode;
 fn assert_is_following(crate_name: &str, expected: bool, user: &impl RequestHelper) {
     let response = user.get::<()>(&format!("/api/v1/crates/{crate_name}/following"));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(response.into_json(), json!({ "following": expected }));
+    assert_eq!(response.json(), json!({ "following": expected }));
 }
 
 fn follow(crate_name: &str, user: &impl RequestHelper) {
     let response = user.put::<()>(&format!("/api/v1/crates/{crate_name}/follow"), b"" as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(response.into_json(), json!({ "ok": true }));
+    assert_eq!(response.json(), json!({ "ok": true }));
 }
 
 fn unfollow(crate_name: &str, user: &impl RequestHelper) {
     let response = user.delete::<()>(&format!("/api/v1/crates/{crate_name}/follow"));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(response.into_json(), json!({ "ok": true }));
+    assert_eq!(response.json(), json!({ "ok": true }));
 }
 
 #[test]

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -15,7 +15,7 @@ fn new_wrong_token() {
     let response = anon.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
     );
 
@@ -31,7 +31,7 @@ fn new_wrong_token() {
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
     );
     assert_that!(app.stored_files(), empty());
@@ -52,7 +52,7 @@ fn new_krate_wrong_user() {
 
     let response = another_user.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -13,7 +13,7 @@ fn new_krate() {
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
     let response = user.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -40,7 +40,7 @@ fn new_krate_with_token() {
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -56,7 +56,7 @@ fn new_krate_weird_version() {
     let crate_to_publish = PublishBuilder::new("foo_weird", "0.0.0-pre");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -79,7 +79,7 @@ fn new_krate_twice() {
         PublishBuilder::new("foo_twice", "2.0.0").description("2.0.0 description");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -109,7 +109,7 @@ fn new_krate_duplicate_version() {
     let crate_to_publish = PublishBuilder::new("foo_dupe", "1.0.0");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/build_metadata.rs
+++ b/src/tests/krate/publish/build_metadata.rs
@@ -8,7 +8,7 @@ fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
 
     let response = token.publish_crate(PublishBuilder::new("foo", v1));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -16,7 +16,7 @@ fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
     let response = token.publish_crate(PublishBuilder::new("foo", v2));
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": expected_error }] })
     );
 }

--- a/src/tests/krate/publish/categories.rs
+++ b/src/tests/krate/publish/categories.rs
@@ -18,7 +18,7 @@ fn good_categories() {
     let crate_to_publish = PublishBuilder::new("foo_good_cat", "1.0.0").category("cat1");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -31,7 +31,7 @@ fn ignored_categories() {
     let crate_to_publish = PublishBuilder::new("foo_ignored_cat", "1.0.0").category("bar");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -51,6 +51,6 @@ fn too_many_categories() {
             .category("six"),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -12,7 +12,7 @@ fn invalid_dependency_name() {
         PublishBuilder::new("foo", "1.0.0").dependency(DependencyBuilder::new("🦀")),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -48,7 +48,7 @@ fn invalid_dependency_rename() {
             .dependency(DependencyBuilder::new("package-name").rename("💩")),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -66,7 +66,7 @@ fn invalid_dependency_name_starts_with_digit() {
             .dependency(DependencyBuilder::new("package-name").rename("1-foo")),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -84,7 +84,7 @@ fn invalid_dependency_name_contains_unicode_chars() {
             .dependency(DependencyBuilder::new("package-name").rename("foo-🦀-bar")),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -103,7 +103,7 @@ fn invalid_too_long_dependency_name() {
                 DependencyBuilder::new("package-name").rename("f".repeat(65).as_str()),
             ));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -120,7 +120,7 @@ fn empty_dependency_name() {
             .dependency(DependencyBuilder::new("package-name").rename("")),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -192,7 +192,7 @@ fn new_krate_with_broken_dependency_requirement() {
     let crate_to_publish = PublishBuilder::new("new_dep", "1.0.0").dependency(dependency);
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -211,7 +211,7 @@ fn reject_new_krate_with_non_exact_dependency() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -239,7 +239,7 @@ fn reject_new_crate_with_alternative_registry_dependency() {
         PublishBuilder::new("depends-on-alt-registry", "1.0.0").dependency(dependency);
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -258,7 +258,7 @@ fn new_krate_with_wildcard_dependency() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -273,7 +273,7 @@ fn new_krate_dependency_missing() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -309,6 +309,6 @@ fn invalid_feature_name() {
             .dependency(DependencyBuilder::new("bar").add_feature("🍺")),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/emails.rs
+++ b/src/tests/krate/publish/emails.rs
@@ -18,7 +18,7 @@ fn new_krate_without_any_email_fails() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -37,6 +37,6 @@ fn new_krate_with_unverified_email_fails() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -60,7 +60,7 @@ fn empty_feature_name() {
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("", &[]);
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert!(app.stored_files().is_empty());
 }
 
@@ -71,7 +71,7 @@ fn invalid_feature_name1() {
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("~foo", &[]);
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -82,7 +82,7 @@ fn invalid_feature_name2() {
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo", &["!bar"]);
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -92,7 +92,7 @@ fn invalid_feature_name_start_with_hyphen() {
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("-foo1.bar", &[]);
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert!(app.stored_files().is_empty());
 }
 
@@ -112,7 +112,7 @@ fn too_many_features() {
         .feature("five", &[]);
     let response = token.publish_crate(publish_builder);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -138,7 +138,7 @@ fn too_many_features_with_custom_limit() {
         .feature("five", &[]);
     let response = token.publish_crate(publish_builder);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
@@ -169,7 +169,7 @@ fn too_many_enabled_features() {
         .feature("default", &["one", "two", "three", "four", "five"]);
     let response = token.publish_crate(publish_builder);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -191,7 +191,7 @@ fn too_many_enabled_features_with_custom_limit() {
         .feature("default", &["one", "two", "three", "four", "five"]);
     let response = token.publish_crate(publish_builder);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 
     let publish_builder =

--- a/src/tests/krate/publish/inheritance.rs
+++ b/src/tests/krate/publish/inheritance.rs
@@ -12,7 +12,7 @@ fn workspace_inheritance() {
             .custom_manifest("[package]\nname = \"foo\"\nversion.workspace = true\n"),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -23,5 +23,5 @@ fn workspace_inheritance_with_dep() {
         "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nserde.workspace = true\n",
     ));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }

--- a/src/tests/krate/publish/keywords.rs
+++ b/src/tests/krate/publish/keywords.rs
@@ -13,7 +13,7 @@ fn good_keywords() {
         .keyword("1password");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -26,17 +26,17 @@ fn bad_keywords() {
         PublishBuilder::new("foo_bad_key", "1.0.0").keyword("super-long-keyword-name-oh-no");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key", "1.0.0").keyword("?@?%");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key", "1.0.0").keyword("áccênts");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -52,6 +52,6 @@ fn too_many_keywords() {
             .keyword("six"),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -20,14 +20,14 @@ fn boolean_readme() {
             readme = false"#,
     ));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
 
     let response = token.get::<()>("/api/v1/crates/foo/1.0.0");
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".version.id" => any_id_redaction(),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
@@ -43,7 +43,7 @@ fn missing_manifest() {
 
     let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").no_manifest());
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn manifest_casing() {
             .no_manifest(),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -79,7 +79,7 @@ fn multiple_manifests() {
             .no_manifest(),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn invalid_manifest() {
 
     let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(""));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -99,7 +99,7 @@ fn invalid_manifest_missing_name() {
         PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nversion = \"1.0.0\""),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -110,7 +110,7 @@ fn invalid_manifest_missing_version() {
         PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nname = \"foo\""),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -122,11 +122,11 @@ fn invalid_rust_version() {
             "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"\"\n",
         ));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
         "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"1.0.0-beta.2\"\n",
     ));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -47,7 +47,7 @@ fn tarball_between_default_axum_limit_and_max_upload_size() {
 
     let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -85,7 +85,7 @@ fn tarball_bigger_than_max_upload_size() {
 
     let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -106,7 +106,7 @@ fn new_krate_gzip_bomb() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }
@@ -125,7 +125,7 @@ fn new_krate_too_big() {
 
     let response = user.publish_crate(builder);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -10,7 +10,7 @@ fn new_krate_with_readme() {
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("hello world");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -30,7 +30,7 @@ fn new_krate_with_empty_readme() {
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
@@ -49,7 +49,7 @@ fn new_krate_with_readme_and_plus_version() {
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0+foo").readme("hello world");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -17,7 +17,7 @@ fn new_crate_similar_name() {
     let crate_to_publish = PublishBuilder::new("foo_similar", "1.1.0");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }
@@ -35,7 +35,7 @@ fn new_crate_similar_name_hyphen() {
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen", "1.1.0");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }
@@ -53,7 +53,7 @@ fn new_crate_similar_name_underscore() {
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore", "1.1.0");
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -16,7 +16,7 @@ fn new_krate_wrong_files() {
     let response = user.publish_crate(builder);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "invalid path found: bar-1.0.0/a" }] })
     );
 
@@ -46,7 +46,7 @@ fn new_krate_tarball_with_hard_links() {
 
     let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -56,7 +56,7 @@ fn empty_body() {
 
     let response = user.publish_crate(&[] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -66,7 +66,7 @@ fn json_len_truncated() {
 
     let response = token.publish_crate(&[0u8, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -76,7 +76,7 @@ fn json_bytes_truncated() {
 
     let response = token.publish_crate(&[100u8, 0, 0, 0, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -86,7 +86,7 @@ fn tarball_len_truncated() {
 
     let response = token.publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -96,6 +96,6 @@ fn tarball_bytes_truncated() {
 
     let response = token.publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8]);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -14,7 +14,7 @@ fn empty_json() {
 
     let response = token.publish_crate(body);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -26,7 +26,7 @@ fn invalid_names() {
         let crate_to_publish = PublishBuilder::new(name, "1.0.0");
         let response = token.publish_crate(crate_to_publish);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_json_snapshot!(response.into_json());
+        assert_json_snapshot!(response.json());
     };
 
     bad_name("");
@@ -54,7 +54,7 @@ fn invalid_version() {
     let body = PublishBuilder::create_publish_body(&new_json, &tarball);
 
     let response = token.publish_crate(body);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -68,13 +68,13 @@ fn license_and_description_required() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0").unset_description();
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0")
         .unset_license()
@@ -83,7 +83,7 @@ fn license_and_description_required() {
 
     let response = token.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }
@@ -95,7 +95,7 @@ fn invalid_license() {
     let response =
         token.publish_crate(PublishBuilder::new("foo", "1.0.0").license("MIT AND foobar"));
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }
 
@@ -107,7 +107,7 @@ fn invalid_urls() {
         PublishBuilder::new("foo", "1.0.0").documentation("javascript:alert('boom')"),
     );
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     assert_that!(app.stored_files(), empty());
 }

--- a/src/tests/middleware/head.rs
+++ b/src/tests/middleware/head.rs
@@ -8,7 +8,7 @@ fn head_method_works() {
     let req = anon.request_builder(Method::HEAD, "/api/v1/summary");
     let res = anon.run::<()>(req);
     assert_eq!(res.status(), StatusCode::OK);
-    assert_eq!(res.into_text(), "");
+    assert_eq!(res.text(), "");
 }
 
 #[test]
@@ -18,5 +18,5 @@ fn head_method_works_for_404() {
     let req = anon.request_builder(Method::HEAD, "/unknown");
     let res = anon.run::<()>(req);
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
-    assert_eq!(res.into_text(), "");
+    assert_eq!(res.text(), "");
 }

--- a/src/tests/not_found_error.rs
+++ b/src/tests/not_found_error.rs
@@ -8,7 +8,7 @@ fn visiting_unknown_route_returns_404() {
     let response = anon.get::<()>("/does-not-exist");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "Not Found" }] })
     );
 }
@@ -20,7 +20,7 @@ fn visiting_unknown_api_route_returns_404() {
     let response = anon.get::<()>("/api/v1/does-not-exist");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "Not Found" }] })
     );
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -184,7 +184,7 @@ fn owners_can_remove_self() {
     let response = token.remove_named_owner("owners_selfremove", username);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required." }] })
     );
 
@@ -194,7 +194,7 @@ fn owners_can_remove_self() {
     let response = token.remove_named_owner("owners_selfremove", username);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "msg": "owners successfully removed", "ok": true })
     );
 
@@ -202,7 +202,7 @@ fn owners_can_remove_self() {
     let response = token.remove_named_owner("owners_selfremove", username);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "only owners have permission to modify owners" }] })
     );
 }
@@ -223,7 +223,7 @@ fn modify_multiple_owners() {
     let response = token.remove_named_owners("owners_multiple", &[username, "user2", "user3"]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required." }] })
     );
     assert_eq!(app.db(|conn| krate.owners(conn).unwrap()).len(), 3);
@@ -232,7 +232,7 @@ fn modify_multiple_owners() {
     let response = token.remove_named_owners("owners_multiple", &["user2", "user3"]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "msg": "owners successfully removed", "ok": true })
     );
     assert_eq!(app.db(|conn| krate.owners(conn).unwrap()).len(), 1);
@@ -241,7 +241,7 @@ fn modify_multiple_owners() {
     let response = token.add_named_owners("owners_multiple", &["user2", username]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "`foo` is already an owner" }] })
     );
     assert_eq!(app.db(|conn| krate.owners(conn).unwrap()).len(), 1);
@@ -250,7 +250,7 @@ fn modify_multiple_owners() {
     let response = token.add_named_owners("owners_multiple", &["user2", "user3"]);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({
             "msg": "user user2 has been invited to be an owner of crate owners_multiple,user user3 has been invited to be an owner of crate owners_multiple",
             "ok": true,
@@ -279,7 +279,7 @@ fn owner_change_via_cookie() {
     let response = cookie.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
     );
 }
@@ -300,7 +300,7 @@ fn owner_change_via_token() {
     let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
     );
 }
@@ -322,7 +322,7 @@ fn owner_change_via_change_owner_token() {
     let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
     );
 }
@@ -345,7 +345,7 @@ fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "ok": true, "msg": "user user-2 has been invited to be an owner of crate foo_crate" })
     );
 }
@@ -368,7 +368,7 @@ fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
     );
 }
@@ -390,7 +390,7 @@ fn owner_change_via_publish_token() {
     let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
     );
 }
@@ -411,7 +411,7 @@ fn owner_change_without_auth() {
     let response = anon.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
     );
 }
@@ -429,7 +429,7 @@ fn invite_already_invited_user() {
     let response = owner.add_named_owner("crate_name", "invited_user");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({
             "msg": "user invited_user has been invited to be an owner of crate crate_name",
             "ok": true,
@@ -443,7 +443,7 @@ fn invite_already_invited_user() {
     let response = owner.add_named_owner("crate_name", "invited_user");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({
             "msg": "user invited_user already has a pending invitation to be an owner of crate crate_name",
             "ok": true,
@@ -468,7 +468,7 @@ fn invite_with_existing_expired_invite() {
     let response = owner.add_named_owner("crate_name", "invited_user");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({
             "msg": "user invited_user has been invited to be an owner of crate crate_name",
             "ok": true,
@@ -485,7 +485,7 @@ fn invite_with_existing_expired_invite() {
     let response = owner.add_named_owner("crate_name", "invited_user");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({
             "msg": "user invited_user has been invited to be an owner of crate crate_name",
             "ok": true,
@@ -770,7 +770,7 @@ fn test_accept_expired_invitation() {
     let resp = invited_user.try_accept_ownership_invitation::<()>(&krate.name, krate.id);
     assert_eq!(resp.status(), StatusCode::GONE);
     assert_eq!(
-        resp.into_json(),
+        resp.json(),
         json!({
             "errors": [
                 {
@@ -827,7 +827,7 @@ fn test_accept_expired_invitation_by_mail() {
     let resp = anon.try_accept_ownership_invitation_by_token::<()>(&invite_token);
     assert_eq!(resp.status(), StatusCode::GONE);
     assert_eq!(
-        resp.into_json(),
+        resp.json(),
         json!({
             "errors": [
                 {
@@ -1184,7 +1184,7 @@ fn invitation_list_with_no_filter() {
     let resp = owner.get::<()>("/api/private/crate_owner_invitations");
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        resp.into_json(),
+        resp.json(),
         json!({
             "errors": [{
                 "detail": "missing or invalid filter",

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -23,7 +23,7 @@ fn pagination_blocks_ip_from_cidr_block_list() {
     let response = anon.get_with_query::<()>("/api/v1/crates", "page=2&per_page=1");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "Page 2 is unavailable for performance reasons. Please take a look at https://crates.io/data-access for alternatives." }] })
     );
 }

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -33,7 +33,7 @@ fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
 
     let response = token.delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank");
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -800,7 +800,7 @@ fn invalid_seek_parameter() {
 
     let response = anon.get::<()>("/api/v1/crates?seek=broken");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]
@@ -818,7 +818,7 @@ fn pagination_parameters_only_accept_integers() {
         anon.get_with_query::<()>("/api/v1/crates", "page=1&per_page=100%22%EF%BC%8Cexception");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "invalid digit found in string" }] })
     );
 
@@ -826,7 +826,7 @@ fn pagination_parameters_only_accept_integers() {
         anon.get_with_query::<()>("/api/v1/crates", "page=100%22%EF%BC%8Cexception&per_page=1");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "invalid digit found in string" }] })
     );
 }

--- a/src/tests/routes/crates/new.rs
+++ b/src/tests/routes/crates/new.rs
@@ -14,7 +14,7 @@ fn daily_limit() {
     let crate_to_publish = PublishBuilder::new("foo_daily_limit", "1.0.0");
     let response = user.publish_crate(crate_to_publish);
     assert!(response.status().is_success());
-    let json = response.into_json();
+    let json = response.json();
     assert_eq!(
         json["errors"][0]["detail"],
         "You have published too many versions of this crate in the last 24 hours"

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -29,7 +29,7 @@ fn dependencies() {
     let response = anon.get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "crate `foo_deps` does not have a version `1.0.2`" }] })
     );
 }

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -42,7 +42,7 @@ fn yank_by_a_non_owner_fails() {
     let response = token.yank("foo_not", "1.0.0");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must already be an owner to yank or unyank" }] })
     );
 }
@@ -131,7 +131,7 @@ mod auth {
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -139,7 +139,7 @@ mod auth {
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -151,12 +151,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
@@ -167,12 +167,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
@@ -186,12 +186,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
@@ -206,7 +206,7 @@ mod auth {
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -214,7 +214,7 @@ mod auth {
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -228,12 +228,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
@@ -250,7 +250,7 @@ mod auth {
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -258,7 +258,7 @@ mod auth {
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -276,12 +276,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
@@ -298,12 +298,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
@@ -320,7 +320,7 @@ mod auth {
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -328,7 +328,7 @@ mod auth {
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -347,7 +347,7 @@ mod auth {
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -355,7 +355,7 @@ mod auth {
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_eq!(
-            response.into_json(),
+            response.json(),
             json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
         );
         assert!(!is_yanked(&app));
@@ -376,12 +376,12 @@ mod auth {
 
         let response = admin.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
         let response = admin.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 }

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -15,7 +15,7 @@ impl crate::util::MockCookieUser {
     fn update_email_notifications(&self, updates: Vec<EmailNotificationsUpdate>) {
         let response = self.put::<()>("/api/v1/me/email_notifications", json!(updates).to_string());
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
     }
 }
 

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -27,7 +27,7 @@ fn me() {
 
     let response = user.get::<()>("/api/v1/me");
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 
     app.db(|conn| {
         CrateBuilder::new("foo_my_packages", user.as_model().id).expect_build(conn);
@@ -35,7 +35,7 @@ fn me() {
 
     let response = user.get::<()>("/api/v1/me");
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json());
+    assert_json_snapshot!(response.json());
 }
 
 #[test]

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -23,7 +23,7 @@ fn me() {
 
     let response = anon.get::<()>("/api/v1/me");
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_display_snapshot!(response.into_text(), @r###"{"errors":[{"detail":"must be logged in to perform that action"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"must be logged in to perform that action"}]}"###);
 
     let response = user.get::<()>("/api/v1/me");
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -22,7 +22,7 @@ fn create_token_invalid_request() {
     let response = user.put::<()>("/api/v1/me/tokens", invalid);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "invalid new token request: Error(\"missing field `api_token`\", line: 1, column: 14)" }] })
     );
 }
@@ -34,7 +34,7 @@ fn create_token_no_name() {
     let response = user.put::<()>("/api/v1/me/tokens", empty_name);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "name must have a value" }] })
     );
 }
@@ -51,7 +51,7 @@ fn create_token_exceeded_tokens_per_user() {
     let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "maximum tokens per user is: 500" }] })
     );
 }
@@ -62,7 +62,7 @@ fn create_token_success() {
 
     let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR);
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",
@@ -112,7 +112,7 @@ fn cannot_create_token_with_token() {
     );
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "cannot use an API token to create a new API token" }] })
     );
 }
@@ -131,7 +131,7 @@ fn create_token_with_scopes() {
 
     let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",
@@ -174,7 +174,7 @@ fn create_token_with_null_scopes() {
 
     let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",
@@ -209,7 +209,7 @@ fn create_token_with_empty_crate_scope() {
     let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "invalid crate scope" }] })
     );
 }
@@ -229,7 +229,7 @@ fn create_token_with_invalid_endpoint_scope() {
     let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "invalid endpoint scope" }] })
     );
 }
@@ -249,7 +249,7 @@ fn create_token_with_expiry_date() {
 
     let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
         ".api_token.created_at" => "[datetime]",
         ".api_token.last_used_at" => "[datetime]",

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -39,7 +39,7 @@ fn revoke_current_token_without_auth() {
     let response = anon.delete::<()>("/api/v1/tokens/current");
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
     );
 }
@@ -62,7 +62,7 @@ fn revoke_current_token_with_cookie_user() {
     let response = user.delete::<()>("/api/v1/tokens/current");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "token not provided" }] })
     );
 

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -22,7 +22,7 @@ fn list_empty() {
     let (_, _, user) = TestApp::init().with_user();
     let response = user.get::<()>("/api/v1/me/tokens");
     assert_eq!(response.status(), StatusCode::OK);
-    let json = response.into_json();
+    let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
     assert_eq!(response_tokens.len(), 0);
 }
@@ -58,7 +58,7 @@ fn list_tokens() {
 
     let response = user.get::<()>("/api/v1/me/tokens");
     assert_eq!(response.status(), StatusCode::OK);
-    assert_json_snapshot!(response.into_json(), {
+    assert_json_snapshot!(response.json(), {
         ".api_tokens[].id" => insta::any_id_redaction(),
         ".api_tokens[].created_at" => "[datetime]",
         ".api_tokens[].last_used_at" => "[datetime]",
@@ -101,7 +101,7 @@ fn list_recently_expired_tokens() {
 
     let response = user.get::<()>("/api/v1/me/tokens?expired_days=30");
     assert_eq!(response.status(), StatusCode::OK);
-    let json = response.into_json();
+    let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
     assert_eq!(response_tokens.len(), 2);
     assert_response_tokens_contain_name(response_tokens, "bar");
@@ -109,7 +109,7 @@ fn list_recently_expired_tokens() {
 
     let response = user.get::<()>("/api/v1/me/tokens?expired_days=60");
     assert_eq!(response.status(), StatusCode::OK);
-    let json = response.into_json();
+    let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
     assert_eq!(response_tokens.len(), 3);
     assert_response_tokens_contain_name(response_tokens, "bar");
@@ -131,7 +131,7 @@ fn list_tokens_exclude_revoked() {
     // List tokens expecting them all to be there.
     let response = user.get::<()>("/api/v1/me/tokens");
     assert_eq!(response.status(), StatusCode::OK);
-    let json = response.into_json();
+    let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
     assert_eq!(response_tokens.len(), 2);
 
@@ -142,7 +142,7 @@ fn list_tokens_exclude_revoked() {
     // Check that we now have one less token being listed.
     let response = user.get::<()>("/api/v1/me/tokens");
     assert_eq!(response.status(), StatusCode::OK);
-    let json = response.into_json();
+    let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
     assert_eq!(response_tokens.len(), 1);
     assert_eq!(response_tokens[0]["name"], json!("baz"));

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -92,7 +92,7 @@ fn following() {
     let response = user.get_with_query::<()>("/api/v1/me/updates", "page=0");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "page indexing starts from 1, page 0 is invalid" }] })
     );
 }

--- a/src/tests/routes/session/authorize.rs
+++ b/src/tests/routes/session/authorize.rs
@@ -7,7 +7,7 @@ fn access_token_needs_data() {
     let response = anon.get::<()>("/api/private/session/authorize");
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "Failed to deserialize query string: missing field `code`" }] })
     );
 }

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -30,7 +30,7 @@ impl crate::util::MockCookieUser {
         let model = self.as_model();
         let response = self.update_email_more_control(model.id, Some(email));
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
     }
 }
 
@@ -51,14 +51,14 @@ fn test_empty_email_not_added() {
     let response = user.update_email_more_control(model.id, Some(""));
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "empty email rejected" }] })
     );
 
     let response = user.update_email_more_control(model.id, None);
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "empty email rejected" }] })
     );
 }
@@ -80,7 +80,7 @@ fn test_other_users_cannot_change_my_email() {
     );
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "current user does not match requested user" }] })
     );
 
@@ -90,7 +90,7 @@ fn test_other_users_cannot_change_my_email() {
     );
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
     );
 }

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -12,7 +12,7 @@ fn user_agent_is_required() {
     let req = Request::get("/api/v1/crates").body("").unwrap();
     let resp = anon.run::<()>(req);
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    assert_json_snapshot!(resp.into_json());
+    assert_json_snapshot!(resp.json());
 
     let req = Request::get("/api/v1/crates")
         .header(header::USER_AGENT, "")
@@ -20,7 +20,7 @@ fn user_agent_is_required() {
         .unwrap();
     let resp = anon.run::<()>(req);
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    assert_json_snapshot!(resp.into_json());
+    assert_json_snapshot!(resp.json());
 }
 
 #[test]
@@ -76,7 +76,7 @@ fn block_traffic_via_arbitrary_header_and_value() {
 
     let resp = anon.run::<()>(req);
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    assert_json_snapshot!(resp.into_json());
+    assert_json_snapshot!(resp.json());
 
     let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
         // A request with a header value we don't want to block is allowed, even though there might
@@ -102,5 +102,5 @@ fn block_traffic_via_ip() {
 
     let resp = anon.get::<()>("/api/v1/crates");
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    assert_json_snapshot!(resp.into_json());
+    assert_json_snapshot!(resp.json());
 }

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -31,7 +31,7 @@ fn not_github() {
     let response = token.add_named_owner("foo_not_github", "dropbox:foo:foo");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "unknown organization handler, only 'github:org:team' is supported" }] })
     );
 }
@@ -47,7 +47,7 @@ fn weird_name() {
     let response = token.add_named_owner("foo_weird_name", "github:foo/../bar:wut");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "organization cannot contain special characters like /" }] })
     );
 }
@@ -64,7 +64,7 @@ fn one_colon() {
     let response = token.add_named_owner("foo_one_colon", "github:foo");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "missing github team argument; format is github:org:team" }] })
     );
 }
@@ -81,7 +81,7 @@ fn add_nonexistent_team() {
         token.add_named_owner("foo_add_nonexistent", "github:test-org:this-does-not-exist");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "could not find the github team test-org/this-does-not-exist" }] })
     );
 }
@@ -192,7 +192,7 @@ fn add_team_as_non_member() {
     let response = token.add_named_owner("foo_team_non_member", "github:test-org:core");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "only members of a team or organization owners can add it as an owner" }] })
     );
 }
@@ -217,7 +217,7 @@ fn remove_team_as_named_owner() {
     let response = token_on_both_teams.remove_named_owner("foo_remove_team", username);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required." }] })
     );
 
@@ -230,7 +230,7 @@ fn remove_team_as_named_owner() {
     let response = user_on_one_team.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing." }] })
     );
 }
@@ -257,7 +257,7 @@ fn remove_team_as_team_owner() {
         token_on_one_team.remove_named_owner("foo_remove_team_owner", "github:test-org:all");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "team members don't have permission to modify owners" }] })
     );
 
@@ -267,7 +267,7 @@ fn remove_team_as_team_owner() {
         token_org_owner.remove_named_owner("foo_remove_team_owner", "github:test-org:all");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "only owners have permission to modify owners" }] })
     );
 }
@@ -316,7 +316,7 @@ fn publish_not_owned() {
     let response = user_on_one_team.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing." }] })
     );
 }
@@ -341,7 +341,7 @@ fn publish_org_owner_owned() {
     let response = user_org_owner.publish_crate(crate_to_publish);
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "this crate exists but you don't seem to be an owner. If you believe this is a mistake, perhaps you need to accept an invitation to be an owner before publishing." }] })
     );
 }
@@ -388,7 +388,7 @@ fn add_owners_as_org_owner() {
     let response = token_org_owner.add_named_owner("foo_add_owner", "arbitrary_username");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "only owners have permission to modify owners" }] })
     );
 }
@@ -413,7 +413,7 @@ fn add_owners_as_team_owner() {
     let response = token_on_one_team.add_named_owner("foo_add_owner", "arbitrary_username");
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": "team members don't have permission to modify owners" }] })
     );
 }

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -38,7 +38,7 @@ fn old_tokens_give_specific_error_message() {
     let response = anon.run::<()>(request);
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(
-        response.into_json(),
+        response.json(),
         json!({ "errors": [{ "detail": TOKEN_FORMAT_ERROR }] })
     );
 }

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -13,7 +13,7 @@ impl crate::util::MockCookieUser {
         let url = format!("/api/v1/confirm/{email_token}");
         let response = self.put::<()>(&url, &[] as &[u8]);
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.into_json(), json!({ "ok": true }));
+        assert_eq!(response.json(), json!({ "ok": true }));
     }
 }
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -23,7 +23,7 @@ where
     #[track_caller]
     pub fn good(self) -> T {
         assert_that!(self.status(), is_success());
-        json(self.response)
+        json(&self.response)
     }
 }
 
@@ -38,12 +38,12 @@ impl<T> Response<T> {
 
     /// Consume the response body and convert it to a JSON value
     #[track_caller]
-    pub fn into_json(self) -> Value {
-        json(self.response)
+    pub fn into_json(&self) -> Value {
+        json(&self.response)
     }
 
     #[track_caller]
-    pub fn into_text(self) -> String {
+    pub fn into_text(&self) -> String {
         let bytes = self.response.body();
         assert_ok!(from_utf8(bytes)).to_string()
     }
@@ -78,7 +78,7 @@ impl<T> Response<T> {
         assert_eq!(self.status(), StatusCode::TOO_MANY_REQUESTS);
 
         let expected_message_start = format!("{}. Please try again after ", action.error_message());
-        let error: ErrorResponse = json(self.response);
+        let error: ErrorResponse = json(&self.response);
         assert_that!(error.errors, len(eq(1)));
         assert_that!(error.errors[0].detail, starts_with(expected_message_start));
     }
@@ -98,7 +98,7 @@ impl Response<()> {
     }
 }
 
-fn json<T>(r: hyper::Response<Bytes>) -> T
+fn json<T>(r: &hyper::Response<Bytes>) -> T
 where
     for<'de> T: serde::Deserialize<'de>,
 {

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -38,7 +38,7 @@ impl<T> Response<T> {
 
     /// Consume the response body and convert it to a JSON value
     #[track_caller]
-    pub fn into_json(&self) -> Value {
+    pub fn json(&self) -> Value {
         json(&self.response)
     }
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -43,7 +43,7 @@ impl<T> Response<T> {
     }
 
     #[track_caller]
-    pub fn into_text(&self) -> String {
+    pub fn text(&self) -> String {
         let bytes = self.response.body();
         assert_ok!(from_utf8(bytes)).to_string()
     }


### PR DESCRIPTION
These two functions don't need to take ownership of `self` to work, and thus they shouldn't use the `into_` prefix either. 