### PR TITLE
Further speed-up reverse depdencies query

### DIFF
--- a/src/models/krate_reverse_dependencies.sql
+++ b/src/models/krate_reverse_dependencies.sql
@@ -1,36 +1,40 @@
--- Apply pagination to the whole thing
-SELECT *, COUNT(*) OVER () as total FROM (
-    -- Multple dependencies can exist, make it distinct
-    SELECT DISTINCT ON (crate_downloads, crate_name)
-    dependencies.*,
-    crates.downloads AS crate_downloads,
-    crates.name AS crate_name
-    FROM dependencies
-    -- We only want the crates whose *max* version is dependent, so we join on a
-    -- subselect that includes the versions with their ordinal position
-    INNER JOIN (
-        SELECT DISTINCT ON (crate_id)
-           *
-        FROM versions
-        WHERE NOT yanked
-        ORDER BY
-            crate_id,
-            semver_no_prerelease DESC NULLS LAST,
-            id DESC
-    ) versions
-      ON versions.id = dependencies.version_id
-    INNER JOIN crates
-      ON crates.id = versions.crate_id
-    WHERE dependencies.crate_id = $1
-    -- this ORDER BY is redundant with the outer one but benefits
-    -- the `DISTINCT ON`
+SELECT
+    dependencies.*, crate_downloads, crate_name, total
+FROM (
+    -- Apply pagination to the crates
+    SELECT *, COUNT(*) OVER () as total FROM (
+        SELECT
+            crates.downloads AS crate_downloads,
+            crates.name AS crate_name,
+            versions.id AS version_id
+        FROM
+        -- We only want the crates whose *max* version is dependent, so we join on a
+        -- subselect that includes the versions with their ordinal position
+        (
+            SELECT DISTINCT ON (crate_id)
+               crate_id, semver_no_prerelease, id
+            FROM versions
+            WHERE NOT yanked
+            ORDER BY
+                crate_id,
+                semver_no_prerelease DESC NULLS LAST,
+                id DESC
+        ) versions
+        INNER JOIN crates
+          ON crates.id = versions.crate_id
+        WHERE versions.id IN (SELECT version_id FROM dependencies WHERE crate_id = $1)
+    ) c
     ORDER BY
         crate_downloads DESC,
-        crate_name ASC,
-        dependencies.id ASC
-) t
-ORDER BY
-    crate_downloads DESC,
-    crate_name ASC
+        crate_name ASC
+) crates
+-- Multiple dependencies can exist, we only want first one
+CROSS JOIN LATERAL (
+    SELECT dependencies.*
+    FROM dependencies
+    WHERE dependencies.crate_id = $1 AND dependencies.version_id = crates.version_id
+    ORDER BY id ASC
+    LIMIT 1
+) dependencies
 OFFSET $2
 LIMIT $3


### PR DESCRIPTION
This pr optimizes the query by pinpointing relevant crates and efficiently retrieving dependencies.

<details>
<summary>Strategies</summary>
1. Identifying relevant crates:

```sql
SELECT
    crates.downloads AS crate_downloads,
    crates.name AS crate_name,
    versions.id AS version_id
FROM
-- We only want the crates whose *max* version is dependent, so we join on a
-- subselect that includes the versions with their ordinal position
(
    SELECT DISTINCT ON (crate_id)
       crate_id, semver_no_prerelease, id
    FROM versions
    WHERE NOT yanked
    ORDER BY
        crate_id,
        semver_no_prerelease DESC NULLS LAST,
        id DESC
) versions
INNER JOIN crates
  ON crates.id = versions.crate_id
WHERE versions.id IN (SELECT version_id FROM dependencies WHERE crate_id = $1)
```

The uniqueness of crates eliminates the need for deduplication.

2. Efficiently Retrieving Dependencies:

```sql
-- Multiple dependencies can exist, we only want first one
CROSS JOIN LATERAL (
    SELECT dependencies.*
    FROM dependencies
    WHERE dependencies.crate_id = $1 AND dependencies.version_id = crates.version_id
    ORDER BY id ASC
    LIMIT 1
) dependencies
```

A lateral join effectively addresses top-N scenario and also make good use of index.

</details>

---


The following are `EXPLAIN ANALYZE` outputs for current query and proposed query:
All queries run locally on my m1 MBP with pg13 installed from nixpkgs.

## Current query [visualization](https://explain.dalibo.com/plan/fab694987342gda9) 
Execution time: `645ms`

<details>
<summary>EXPLAIN ANALYZE output</summary>

```log
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=293098.54..293098.84 rows=10 width=105) (actual time=635.818..635.823 rows=10 loops=1)
   Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name, (count(*) OVER (?))
   Buffers: shared hit=7534 read=95936, temp read=4516 written=4815
   ->  WindowAgg  (cost=293098.54..295583.11 rows=82819 width=105) (actual time=635.817..635.821 rows=10 loops=1)
         Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name, count(*) OVER (?)
         Buffers: shared hit=7534 read=95936, temp read=4516 written=4815
         ->  Unique  (cost=293098.54..293719.68 rows=82819 width=97) (actual time=622.537..630.480 rows=32800 loops=1)
               Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name
               Buffers: shared hit=7534 read=95936, temp read=4456 written=4464
               ->  Sort  (cost=293098.54..293305.59 rows=82819 width=97) (actual time=622.537..626.307 rows=33643 loops=1)
                     Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name
                     Sort Key: crates.downloads DESC, crates.name, dependencies.id
                     Sort Method: external merge  Disk: 2880kB
                     Buffers: shared hit=7534 read=95936, temp read=4456 written=4464
                     ->  Merge Join  (cost=278754.60..281800.69 rows=82819 width=97) (actual time=561.991..606.185 rows=33643 loops=1)
                           Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name
                           Merge Cond: (dependencies.version_id = versions.id)
                           Buffers: shared hit=7531 read=95936, temp read=4096 written=4103
                           ->  Sort  (cost=215024.12..215926.02 rows=360761 width=81) (actual time=382.065..400.212 rows=351740 loops=1)
                                 Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name
                                 Sort Key: dependencies.version_id
                                 Sort Method: external merge  Disk: 24072kB
                                 Buffers: shared read=85740, temp read=3009 written=3022
                                 ->  Bitmap Heap Scan on public.dependencies  (cost=4212.33..164459.15 rows=360761 width=81) (actual time=15.965..320.151 rows=351740 loops=1)
                                       Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name
                                       Recheck Cond: (dependencies.crate_id = 463)
                                       Rows Removed by Index Recheck: 3164762
                                       Heap Blocks: exact=52427 lossy=33035
                                       Buffers: shared read=85740
                                       ->  Bitmap Index Scan on index_dependencies_crate_id  (cost=0.00..4122.14 rows=360761 width=0) (actual time=11.123..11.124 rows=351740 loops=1)
                                             Index Cond: (dependencies.crate_id = 463)
                                             Buffers: shared read=278
                           ->  Sort  (cost=63730.48..63835.99 rows=42202 width=20) (actual time=179.867..186.577 rows=128556 loops=1)
                                 Output: versions.id, crates.downloads, crates.name
                                 Sort Key: versions.id
                                 Sort Method: external sort  Disk: 4320kB
                                 Buffers: shared hit=7531 read=10196, temp read=1083 written=1081
                                 ->  Merge Join  (cost=0.84..60488.31 rows=42202 width=20) (actual time=0.114..145.647 rows=127713 loops=1)
                                       Output: versions.id, crates.downloads, crates.name
                                       Inner Unique: true
                                       Merge Cond: (versions.crate_id = crates.id)
                                       Buffers: shared hit=7531 read=10196
                                       ->  Unique  (cost=0.42..53811.11 rows=42202 width=298) (actual time=0.076..121.378 rows=127713 loops=1)
                                             Output: versions.id, versions.crate_id, NULL::character varying, NULL::timestamp without time zone, NULL::timestamp without time zone, NULL::integer, NULL::jsonb, NULL::boolean, NULL::character varying, NULL::integer, NULL::integer, NULL::character(64), NULL::character varying, NULL::character varying, versions.semver_no_prerelease
                                             Buffers: shared hit=7531 read=9347
                                             ->  Index Only Scan using index_versions_crate_id_semver_no_prerelease_id on public.versions  (cost=0.42..51488.44 rows=929068 width=298) (actual time=0.075..87.806 rows=931303 loops=1)
                                                   Output: versions.id, versions.crate_id, NULL::character varying, NULL::timestamp without time zone, NULL::timestamp without time zone, NULL::integer, NULL::jsonb, NULL::boolean, NULL::character varying, NULL::integer, NULL::integer, NULL::character(64), NULL::character varying, NULL::character varying, versions.semver_no_prerelease
                                                   Heap Fetches: 0
                                                   Buffers: shared hit=7531 read=9347
                                       ->  Index Only Scan using index_crates_id_downloads_name on public.crates  (cost=0.42..5395.76 rows=132756 width=20) (actual time=0.032..8.042 rows=132756 loops=1)
                                             Output: crates.id, crates.downloads, crates.name
                                             Heap Fetches: 0
                                             Buffers: shared read=849
 Planning:
   Buffers: shared hit=393 read=68
 Planning Time: 0.968 ms
 Execution Time: 644.884 ms
(57 rows)
```
</details>


## Current query - cost flag [visualization](https://explain.dalibo.com/plan/19h0048e8fb9gc2c)

Execution time: `429ms`

<details>
We could hint planner to generate better plan by tuning with cost flag
<summary>EXPLAIN ANALYZE output</summary>

```log
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=147871.75..147872.05 rows=10 width=105) (actual time=425.078..425.082 rows=10 loops=1)
   Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name, (count(*) OVER (?))
   Buffers: shared hit=61152 read=98691, temp read=1507 written=1793
   ->  WindowAgg  (cost=147871.75..150356.32 rows=82819 width=105) (actual time=425.077..425.081 rows=10 loops=1)
         Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name, count(*) OVER (?)
         Buffers: shared hit=61152 read=98691, temp read=1507 written=1793
         ->  Unique  (cost=147871.75..148492.90 rows=82819 width=97) (actual time=412.945..420.319 rows=32800 loops=1)
               Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name
               Buffers: shared hit=61152 read=98691, temp read=1447 written=1442
               ->  Sort  (cost=147871.75..148078.80 rows=82819 width=97) (actual time=412.945..416.168 rows=33643 loops=1)
                     Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name
                     Sort Key: crates.downloads DESC, crates.name, dependencies.id
                     Sort Method: external merge  Disk: 2880kB
                     Buffers: shared hit=61152 read=98691, temp read=1447 written=1442
                     ->  Merge Join  (cost=34037.82..138451.65 rows=82819 width=97) (actual time=184.441..396.257 rows=33643 loops=1)
                           Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name, crates.downloads, crates.name
                           Merge Cond: (dependencies.version_id = versions.id)
                           Buffers: shared hit=61149 read=98691, temp read=1087 written=1081
                           ->  Index Scan using dependencies_crate_id_version_id_idx on public.dependencies  (cost=0.43..102270.08 rows=360761 width=81) (actual time=0.013..184.655 rows=351740 loops=1)
                                 Output: dependencies.id, dependencies.version_id, dependencies.crate_id, dependencies.req, dependencies.optional, dependencies.default_features, dependencies.features, dependencies.target, dependencies.kind, dependencies.explicit_name
                                 Index Cond: (dependencies.crate_id = 463)
                                 Buffers: shared hit=53615 read=88498
                           ->  Sort  (cost=34037.38..34142.89 rows=42202 width=20) (actual time=184.270..191.434 rows=128556 loops=1)
                                 Output: versions.id, crates.downloads, crates.name
                                 Sort Key: versions.id
                                 Sort Method: external sort  Disk: 4320kB
                                 Buffers: shared hit=7534 read=10193, temp read=1083 written=1081
                                 ->  Merge Join  (cost=0.84..30795.21 rows=42202 width=20) (actual time=0.056..149.950 rows=127713 loops=1)
                                       Output: versions.id, crates.downloads, crates.name
                                       Inner Unique: true
                                       Merge Cond: (versions.crate_id = crates.id)
                                       Buffers: shared hit=7534 read=10193
                                       ->  Unique  (cost=0.42..26585.92 rows=42202 width=298) (actual time=0.029..125.290 rows=127713 loops=1)
                                             Output: versions.id, versions.crate_id, NULL::character varying, NULL::timestamp without time zone, NULL::timestamp without time zone, NULL::integer, NULL::jsonb, NULL::boolean, NULL::character varying, NULL::integer, NULL::integer, NULL::character(64), NULL::character varying, NULL::character varying, versions.semver_no_prerelease
                                             Buffers: shared hit=7532 read=9346
                                             ->  Index Only Scan using index_versions_crate_id_semver_no_prerelease_id on public.versions  (cost=0.42..24263.24 rows=929068 width=298) (actual time=0.029..91.823 rows=931303 loops=1)
                                                   Output: versions.id, versions.crate_id, NULL::character varying, NULL::timestamp without time zone, NULL::timestamp without time zone, NULL::integer, NULL::jsonb, NULL::boolean, NULL::character varying, NULL::integer, NULL::integer, NULL::character(64), NULL::character varying, NULL::character varying, versions.semver_no_prerelease
                                                   Heap Fetches: 0
                                                   Buffers: shared hit=7532 read=9346
                                       ->  Index Only Scan using index_crates_id_downloads_name on public.crates  (cost=0.42..2927.86 rows=132756 width=20) (actual time=0.025..8.320 rows=132756 loops=1)
                                             Output: crates.id, crates.downloads, crates.name
                                             Heap Fetches: 0
                                             Buffers: shared hit=2 read=847
 Planning:
   Buffers: shared hit=393 read=68
 Planning Time: 0.969 ms
 Execution Time: 428.610 ms
(47 rows)
```
</details>



## Proposed query [visualization](https://explain.dalibo.com/plan/27ggade31gheb594)

Execution time: `186ms`
<details>
<summary>EXPLAIN ANALYZE output</summary>

```log
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=80081.02..80204.71 rows=10 width=105) (actual time=185.540..185.568 rows=10 loops=1)
   Output: dependencies_1.id, dependencies_1.version_id, dependencies_1.crate_id, dependencies_1.req, dependencies_1.optional, dependencies_1.default_features, dependencies_1.features, dependencies_1.target, dependencies_1.kind, dependencies_1.explicit_name, crates.downloads, crates.name, (count(*) OVER (?))
   Buffers: shared hit=20820, temp read=478 written=480
   ->  Nested Loop  (cost=80081.02..341085.94 rows=21101 width=105) (actual time=185.540..185.567 rows=10 loops=1)
         Output: dependencies_1.id, dependencies_1.version_id, dependencies_1.crate_id, dependencies_1.req, dependencies_1.optional, dependencies_1.default_features, dependencies_1.features, dependencies_1.target, dependencies_1.kind, dependencies_1.explicit_name, crates.downloads, crates.name, (count(*) OVER (?))
         Buffers: shared hit=20820, temp read=478 written=480
         ->  Sort  (cost=80068.68..80121.44 rows=21101 width=28) (actual time=185.518..185.520 rows=10 loops=1)
               Output: crates.downloads, crates.name, versions.id, (count(*) OVER (?))
               Sort Key: crates.downloads DESC, crates.name
               Sort Method: quicksort  Memory: 3526kB
               Buffers: shared hit=20780, temp read=478 written=480
               ->  WindowAgg  (cost=63730.92..78553.10 rows=21101 width=28) (actual time=176.364..178.669 rows=32800 loops=1)
                     Output: crates.downloads, crates.name, versions.id, count(*) OVER (?)
                     Buffers: shared hit=20777, temp read=478 written=480
                     ->  Merge Semi Join  (cost=63730.92..78289.34 rows=21101 width=20) (actual time=135.532..172.997 rows=32800 loops=1)
                           Output: crates.downloads, crates.name, versions.id
                           Merge Cond: (versions.id = dependencies.version_id)
                           Buffers: shared hit=20777, temp read=478 written=480
                           ->  Sort  (cost=63730.48..63835.99 rows=42202 width=20) (actual time=135.415..142.370 rows=127713 loops=1)
                                 Output: versions.id, crates.downloads, crates.name
                                 Sort Key: versions.id
                                 Sort Method: external merge  Disk: 3824kB
                                 Buffers: shared hit=17727, temp read=478 written=480
                                 ->  Merge Join  (cost=0.84..60488.31 rows=42202 width=20) (actual time=0.053..111.112 rows=127713 loops=1)
                                       Output: versions.id, crates.downloads, crates.name
                                       Inner Unique: true
                                       Merge Cond: (versions.crate_id = crates.id)
                                       Buffers: shared hit=17727
                                       ->  Unique  (cost=0.42..53811.11 rows=42202 width=41) (actual time=0.028..86.199 rows=127713 loops=1)
                                             Output: versions.crate_id, versions.semver_no_prerelease, versions.id
                                             Buffers: shared hit=16878
                                             ->  Index Only Scan using index_versions_crate_id_semver_no_prerelease_id on public.versions  (cost=0.42..51488.44 rows=929068 width=41) (actual time=0.028..55.706 rows=931303 loops=1)
                                                   Output: versions.crate_id, versions.semver_no_prerelease, versions.id
                                                   Heap Fetches: 0
                                                   Buffers: shared hit=16878
                                       ->  Index Only Scan using index_crates_id_downloads_name on public.crates  (cost=0.42..5395.76 rows=132756 width=20) (actual time=0.023..7.348 rows=132756 loops=1)
                                             Output: crates.id, crates.downloads, crates.name
                                             Heap Fetches: 0
                                             Buffers: shared hit=849
                           ->  Index Only Scan using dependencies_crate_id_version_id_idx on public.dependencies  (cost=0.43..12617.75 rows=360761 width=4) (actual time=0.060..15.847 rows=351740 loops=1)
                                 Output: dependencies.crate_id, dependencies.version_id
                                 Index Cond: (dependencies.crate_id = 463)
                                 Heap Fetches: 0
                                 Buffers: shared hit=3050
         ->  Limit  (cost=12.33..12.34 rows=1 width=81) (actual time=0.004..0.004 rows=1 loops=10)
               Output: dependencies_1.id, dependencies_1.version_id, dependencies_1.crate_id, dependencies_1.req, dependencies_1.optional, dependencies_1.default_features, dependencies_1.features, dependencies_1.target, dependencies_1.kind, dependencies_1.explicit_name
               Buffers: shared hit=40
               ->  Sort  (cost=12.33..12.34 rows=2 width=81) (actual time=0.004..0.004 rows=1 loops=10)
                     Output: dependencies_1.id, dependencies_1.version_id, dependencies_1.crate_id, dependencies_1.req, dependencies_1.optional, dependencies_1.default_features, dependencies_1.features, dependencies_1.target, dependencies_1.kind, dependencies_1.explicit_name
                     Sort Key: dependencies_1.id
                     Sort Method: quicksort  Memory: 25kB
                     Buffers: shared hit=40
                     ->  Index Scan using dependencies_crate_id_version_id_idx on public.dependencies dependencies_1  (cost=0.43..12.32 rows=2 width=81) (actual time=0.003..0.003 rows=1 loops=10)
                           Output: dependencies_1.id, dependencies_1.version_id, dependencies_1.crate_id, dependencies_1.req, dependencies_1.optional, dependencies_1.default_features, dependencies_1.features, dependencies_1.target, dependencies_1.kind, dependencies_1.explicit_name
                           Index Cond: ((dependencies_1.crate_id = 463) AND (dependencies_1.version_id = versions.id))
                           Buffers: shared hit=40
 Planning:
   Buffers: shared hit=452
 Planning Time: 0.801 ms
 Execution Time: 186.362 ms
(60 rows)
```
</details>