### PR TITLE
Improve crate following test suite

### DIFF
--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -55,16 +55,27 @@ fn test_following() {
         CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(conn);
     });
 
+    // Check that initially we are not following the crate yet.
     assert_is_following(CRATE_NAME, false, &user);
-    follow(CRATE_NAME, &user);
+
+    // Follow the crate and check that we are now following it.
     follow(CRATE_NAME, &user);
     assert_is_following(CRATE_NAME, true, &user);
     assert_that!(user.search("following=1").crates, len(eq(1)));
 
-    unfollow(CRATE_NAME, &user);
+    // Follow the crate again and check that we are still following it
+    // (aka. the request is idempotent).
+    follow(CRATE_NAME, &user);
+    assert_is_following(CRATE_NAME, true, &user);
+
+    // Unfollow the crate and check that we are not following it anymore.
     unfollow(CRATE_NAME, &user);
     assert_is_following(CRATE_NAME, false, &user);
     assert_that!(user.search("following=1").crates, empty());
+
+    // Unfollow the crate again and check that this call is also idempotent.
+    unfollow(CRATE_NAME, &user);
+    assert_is_following(CRATE_NAME, false, &user);
 }
 
 #[test]

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -79,6 +79,23 @@ fn test_following() {
 }
 
 #[test]
+fn test_unknown_crate() {
+    let (_, _, user) = TestApp::init().with_user();
+
+    let response = user.get::<()>("/api/v1/crates/unknown-crate/following");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+
+    let response = user.put::<()>("/api/v1/crates/unknown-crate/follow", b"" as &[u8]);
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+
+    let response = user.delete::<()>("/api/v1/crates/unknown-crate/follow");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+}
+
+#[test]
 fn test_api_token_auth() {
     const CRATE_TO_FOLLOW: &str = "some_crate_to_follow";
     const CRATE_NOT_TO_FOLLOW: &str = "another_crate";

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -46,7 +46,7 @@ fn test_unauthenticated_requests() {
 }
 
 #[test]
-fn following() {
+fn test_following() {
     const CRATE_NAME: &str = "foo_following";
 
     let (app, _, user) = TestApp::init().with_user();
@@ -68,7 +68,7 @@ fn following() {
 }
 
 #[test]
-fn getting_followed_crates_allows_api_token_auth() {
+fn test_api_token_auth() {
     const CRATE_TO_FOLLOW: &str = "some_crate_to_follow";
     const CRATE_NOT_TO_FOLLOW: &str = "another_crate";
 

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -23,44 +23,45 @@ fn unfollow(crate_name: &str, user: &impl RequestHelper) {
 
 #[test]
 fn following() {
+    const CRATE_NAME: &str = "foo_following";
+
     // TODO: Test anon requests as well?
     let (app, _, user) = TestApp::init().with_user();
 
-    let crate_name = "foo_following";
     app.db(|conn| {
-        CrateBuilder::new(crate_name, user.as_model().id).expect_build(conn);
+        CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(conn);
     });
 
-    assert_is_following(crate_name, false, &user);
-    follow(crate_name, &user);
-    follow(crate_name, &user);
-    assert_is_following(crate_name, true, &user);
+    assert_is_following(CRATE_NAME, false, &user);
+    follow(CRATE_NAME, &user);
+    follow(CRATE_NAME, &user);
+    assert_is_following(CRATE_NAME, true, &user);
     assert_that!(user.search("following=1").crates, len(eq(1)));
 
-    unfollow(crate_name, &user);
-    unfollow(crate_name, &user);
-    assert_is_following(crate_name, false, &user);
+    unfollow(CRATE_NAME, &user);
+    unfollow(CRATE_NAME, &user);
+    assert_is_following(CRATE_NAME, false, &user);
     assert_that!(user.search("following=1").crates, empty());
 }
 
 #[test]
 fn getting_followed_crates_allows_api_token_auth() {
+    const CRATE_TO_FOLLOW: &str = "some_crate_to_follow";
+    const CRATE_NOT_TO_FOLLOW: &str = "another_crate";
+
     let (app, _, user, token) = TestApp::init().with_token();
     let api_token = token.as_model();
 
-    let crate_to_follow = "some_crate_to_follow";
-    let crate_not_followed = "another_crate";
-
     app.db(|conn| {
-        CrateBuilder::new(crate_to_follow, api_token.user_id).expect_build(conn);
-        CrateBuilder::new(crate_not_followed, api_token.user_id).expect_build(conn);
+        CrateBuilder::new(CRATE_TO_FOLLOW, api_token.user_id).expect_build(conn);
+        CrateBuilder::new(CRATE_NOT_TO_FOLLOW, api_token.user_id).expect_build(conn);
     });
 
-    follow(crate_to_follow, &token);
+    follow(CRATE_TO_FOLLOW, &token);
 
     // Token auth on GET for get following status is disallowed
-    assert_is_following(crate_to_follow, true, &user);
-    assert_is_following(crate_not_followed, false, &user);
+    assert_is_following(CRATE_TO_FOLLOW, true, &user);
+    assert_is_following(CRATE_NOT_TO_FOLLOW, false, &user);
 
     let json = token.search("following=1");
     assert_that!(json.crates, len(eq(1)));


### PR DESCRIPTION
Some branches of our route handlers were not tested at all. This PR slightly improves the situation by implementing tests for the unauthenticated case and the "unknown crate" case. It also improves the existing tests with a couple of comments and additional assertions.