### PR TITLE
tests/routes/crates/downloads: Split `test_downloads()` into `test_crate/version_downloads()`

### DIFF
--- a/src/tests/routes/crates/snapshots/all__routes__crates__downloads__crate_downloads.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__downloads__crate_downloads.snap
@@ -3,10 +3,18 @@ source: src/tests/routes/crates/downloads.rs
 expression: json
 ---
 {
+  "meta": {
+    "extra_downloads": []
+  },
   "version_downloads": [
     {
       "date": "[date]",
       "downloads": 1,
+      "version": 2
+    },
+    {
+      "date": "[date]",
+      "downloads": 3,
       "version": 1
     }
   ]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__downloads__version_downloads.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__downloads__version_downloads.snap
@@ -1,0 +1,13 @@
+---
+source: src/tests/routes/crates/downloads.rs
+expression: json
+---
+{
+  "version_downloads": [
+    {
+      "date": "[date]",
+      "downloads": 3,
+      "version": 1
+    }
+  ]
+}


### PR DESCRIPTION
The `/api/v1/crates/:crate_id/downloads` was previously only implicitly tested. This PR adds an explicit test function for it.