### PR TITLE
controllers/krate/downloads: Use stable sort order

### DIFF
--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -28,7 +28,10 @@ pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppRe
 
         let downloads = VersionDownload::belonging_to(latest_five)
             .filter(version_downloads::date.gt(date(now - 90.days())))
-            .order(version_downloads::date.asc())
+            .order((
+                version_downloads::date.asc(),
+                version_downloads::version_id.desc(),
+            ))
             .load(conn)?
             .into_iter()
             .map(VersionDownload::into)


### PR DESCRIPTION
`version_downloads::date` is not unique, which apparently makes our test suite flaky. This change fixes it by adding `version_downloads::version_id` as a secondary sort key. The combination of `date` and `version_id` should be unique, so the sort order should be stable now.