### PR TITLE
Improve `/api/v1/crates/:crate_id/reverse_dependencies` tests

### DIFF
--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -2,6 +2,8 @@ use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
 use crate::CrateMeta;
 use crates_io::views::{EncodableDependency, EncodableVersion};
+use http::StatusCode;
+use insta::assert_display_snapshot;
 
 #[derive(Deserialize)]
 struct RevDeps {
@@ -214,4 +216,13 @@ fn reverse_dependencies_query_supports_u64_version_number_parts() {
     assert_eq!(deps.versions.len(), 1);
     assert_eq!(deps.versions[0].krate, "c2");
     assert_eq!(deps.versions[0].num, large_but_valid_version_number);
+}
+
+#[test]
+fn test_unknown_crate() {
+    let (_, anon) = TestApp::init().empty();
+
+    let response = anon.get::<()>("/api/v1/crates/unknown/reverse_dependencies");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
 }

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [
+    {
+      "crate_id": "c1",
+      "default_features": false,
+      "downloads": 0,
+      "features": [],
+      "id": 1,
+      "kind": "normal",
+      "optional": false,
+      "req": ">= 0",
+      "target": null,
+      "version_id": 3
+    }
+  ],
+  "meta": {
+    "total": 1
+  },
+  "versions": [
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "c3",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/c3/1.0.0/download",
+      "downloads": 0,
+      "features": {},
+      "id": 3,
+      "license": null,
+      "links": {
+        "authors": "/api/v1/crates/c3/1.0.0/authors",
+        "dependencies": "/api/v1/crates/c3/1.0.0/dependencies",
+        "version_downloads": "/api/v1/crates/c3/1.0.0/downloads"
+      },
+      "num": "1.0.0",
+      "published_by": {
+        "avatar": null,
+        "id": 1,
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/c3/1.0.0/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [],
+  "meta": {
+    "total": 0
+  },
+  "versions": []
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [
+    {
+      "crate_id": "c1",
+      "default_features": false,
+      "downloads": 0,
+      "features": [],
+      "id": 2,
+      "kind": "normal",
+      "optional": false,
+      "req": ">= 0",
+      "target": null,
+      "version_id": 3
+    }
+  ],
+  "meta": {
+    "total": 1
+  },
+  "versions": [
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "c2",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/c2/1.1.0/download",
+      "downloads": 0,
+      "features": {},
+      "id": 3,
+      "license": null,
+      "links": {
+        "authors": "/api/v1/crates/c2/1.1.0/authors",
+        "dependencies": "/api/v1/crates/c2/1.1.0/dependencies",
+        "version_downloads": "/api/v1/crates/c2/1.1.0/downloads"
+      },
+      "num": "1.1.0",
+      "published_by": {
+        "avatar": null,
+        "id": 1,
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/c2/1.1.0/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
@@ -1,0 +1,89 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [
+    {
+      "crate_id": "c1",
+      "default_features": false,
+      "downloads": 0,
+      "features": [],
+      "id": 1,
+      "kind": "normal",
+      "optional": false,
+      "req": ">= 0",
+      "target": null,
+      "version_id": 2
+    },
+    {
+      "crate_id": "c1",
+      "default_features": false,
+      "downloads": 0,
+      "features": [],
+      "id": 2,
+      "kind": "normal",
+      "optional": false,
+      "req": ">= 0",
+      "target": null,
+      "version_id": 3
+    }
+  ],
+  "meta": {
+    "total": 2
+  },
+  "versions": [
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "c3",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/c3/3.0.0/download",
+      "downloads": 0,
+      "features": {},
+      "id": 3,
+      "license": null,
+      "links": {
+        "authors": "/api/v1/crates/c3/3.0.0/authors",
+        "dependencies": "/api/v1/crates/c3/3.0.0/dependencies",
+        "version_downloads": "/api/v1/crates/c3/3.0.0/downloads"
+      },
+      "num": "3.0.0",
+      "published_by": {
+        "avatar": null,
+        "id": 1,
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/c3/3.0.0/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    },
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "c2",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/c2/2.0.0/download",
+      "downloads": 0,
+      "features": {},
+      "id": 2,
+      "license": null,
+      "links": {
+        "authors": "/api/v1/crates/c2/2.0.0/authors",
+        "dependencies": "/api/v1/crates/c2/2.0.0/dependencies",
+        "version_downloads": "/api/v1/crates/c2/2.0.0/downloads"
+      },
+      "num": "2.0.0",
+      "published_by": null,
+      "readme_path": "/api/v1/crates/c2/2.0.0/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [
+    {
+      "crate_id": "c1",
+      "default_features": false,
+      "downloads": 0,
+      "features": [],
+      "id": 1,
+      "kind": "normal",
+      "optional": false,
+      "req": ">= 0",
+      "target": null,
+      "version_id": 2
+    }
+  ],
+  "meta": {
+    "total": 1
+  },
+  "versions": [
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "c2",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/c2/1.0.18446744073709551615/download",
+      "downloads": 0,
+      "features": {},
+      "id": 2,
+      "license": null,
+      "links": {
+        "authors": "/api/v1/crates/c2/1.0.18446744073709551615/authors",
+        "dependencies": "/api/v1/crates/c2/1.0.18446744073709551615/dependencies",
+        "version_downloads": "/api/v1/crates/c2/1.0.18446744073709551615/downloads"
+      },
+      "num": "1.0.18446744073709551615",
+      "published_by": {
+        "avatar": null,
+        "id": 1,
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/c2/1.0.18446744073709551615/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_depended_but_new_doesnt.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_depended_but_new_doesnt.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [],
+  "meta": {
+    "total": 0
+  },
+  "versions": []
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [
+    {
+      "crate_id": "c1",
+      "default_features": false,
+      "downloads": 0,
+      "features": [],
+      "id": 1,
+      "kind": "normal",
+      "optional": false,
+      "req": ">= 0",
+      "target": null,
+      "version_id": 3
+    }
+  ],
+  "meta": {
+    "total": 1
+  },
+  "versions": [
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "c2",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/c2/2.0.0/download",
+      "downloads": 0,
+      "features": {},
+      "id": 3,
+      "license": null,
+      "links": {
+        "authors": "/api/v1/crates/c2/2.0.0/authors",
+        "dependencies": "/api/v1/crates/c2/2.0.0/dependencies",
+        "version_downloads": "/api/v1/crates/c2/2.0.0/downloads"
+      },
+      "num": "2.0.0",
+      "published_by": {
+        "avatar": null,
+        "id": 1,
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/c2/2.0.0/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [],
+  "meta": {
+    "total": 0
+  },
+  "versions": []
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
@@ -1,0 +1,54 @@
+---
+source: src/tests/routes/crates/reverse_dependencies.rs
+expression: response.json()
+---
+{
+  "dependencies": [
+    {
+      "crate_id": "c1",
+      "default_features": false,
+      "downloads": 0,
+      "features": [],
+      "id": 1,
+      "kind": "normal",
+      "optional": false,
+      "req": ">= 0",
+      "target": null,
+      "version_id": 3
+    }
+  ],
+  "meta": {
+    "total": 1
+  },
+  "versions": [
+    {
+      "audit_actions": [],
+      "checksum": "                                                                ",
+      "crate": "c2",
+      "crate_size": 0,
+      "created_at": "[datetime]",
+      "dl_path": "/api/v1/crates/c2/2.0.0/download",
+      "downloads": 0,
+      "features": {},
+      "id": 3,
+      "license": null,
+      "links": {
+        "authors": "/api/v1/crates/c2/2.0.0/authors",
+        "dependencies": "/api/v1/crates/c2/2.0.0/dependencies",
+        "version_downloads": "/api/v1/crates/c2/2.0.0/downloads"
+      },
+      "num": "2.0.0",
+      "published_by": {
+        "avatar": null,
+        "id": 1,
+        "login": "foo",
+        "name": null,
+        "url": "https://github.com/foo"
+      },
+      "readme_path": "/api/v1/crates/c2/2.0.0/readme",
+      "rust_version": null,
+      "updated_at": "[datetime]",
+      "yanked": false
+    }
+  ]
+}


### PR DESCRIPTION
This PR …

- adds a dedicated "unknown crate" test case
- converts the existing tests to use snapshot testing to assert on as much of the API as possible
