### PR TITLE
Add `crate_not_found()` fn

### DIFF
--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -6,9 +6,15 @@ use diesel::associations::Identifiable;
 use crate::controllers::frontend_prelude::*;
 use crate::models::{Crate, Follow};
 use crate::schema::*;
+use crate::util::errors::crate_not_found;
 
 fn follow_target(crate_name: &str, conn: &mut PgConnection, user_id: i32) -> AppResult<Follow> {
-    let crate_id = Crate::by_name(crate_name).select(crates::id).first(conn)?;
+    let crate_id = Crate::by_name(crate_name)
+        .select(crates::id)
+        .first(conn)
+        .optional()?
+        .ok_or_else(|| crate_not_found(crate_name))?;
+
     Ok(Follow { user_id, crate_id })
 }
 

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -329,7 +329,12 @@ pub async fn readme(
 pub async fn versions(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     spawn_blocking(move || {
         let conn = &mut *state.db_read()?;
-        let krate: Crate = Crate::by_name(&crate_name).first(conn)?;
+
+        let krate: Crate = Crate::by_name(&crate_name)
+            .first(conn)
+            .optional()?
+            .ok_or_else(|| crate_not_found(&crate_name))?;
+
         let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
             .all_versions()
             .left_outer_join(users::table)

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -369,7 +369,12 @@ pub async fn reverse_dependencies(
     spawn_blocking(move || {
         let pagination_options = PaginationOptions::builder().gather(&req)?;
         let conn = &mut *app.db_read()?;
-        let krate: Crate = Crate::by_name(&name).first(conn)?;
+
+        let krate: Crate = Crate::by_name(&name)
+            .first(conn)
+            .optional()?
+            .ok_or_else(|| crate_not_found(&name))?;
+
         let (rev_deps, total) = krate.reverse_dependencies(conn, pagination_options)?;
         let rev_deps: Vec<_> = rev_deps
             .into_iter()

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -6,13 +6,18 @@ pub mod yank;
 use super::prelude::*;
 
 use crate::models::{Crate, Version};
+use crate::util::errors::crate_not_found;
 
 fn version_and_crate(
     conn: &mut PgConnection,
     crate_name: &str,
     semver: &str,
 ) -> AppResult<(Version, Crate)> {
-    let krate: Crate = Crate::by_name(crate_name).first(conn)?;
+    let krate: Crate = Crate::by_name(crate_name)
+        .first(conn)
+        .optional()?
+        .ok_or_else(|| crate_not_found(crate_name))?;
+
     let version = krate.find_version(conn, semver)?;
 
     Ok((version, krate))

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -84,15 +84,15 @@ fn test_unknown_crate() {
 
     let response = user.get::<()>("/api/v1/crates/unknown-crate/following");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
 
     let response = user.put::<()>("/api/v1/crates/unknown-crate/follow", b"" as &[u8]);
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
 
     let response = user.delete::<()>("/api/v1/crates/unknown-crate/follow");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
 }
 
 #[test]

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -581,26 +581,26 @@ fn test_unknown_crate() {
 
     let response = user.get::<()>("/api/v1/crates/unknown/owners");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 
     let response = user.get::<()>("/api/v1/crates/unknown/owner_team");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 
     let response = user.get::<()>("/api/v1/crates/unknown/owner_user");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 
     let body = json!({ "owners": ["bar"] });
     let body = serde_json::to_vec(&body).unwrap();
 
     let response = user.put::<()>("/api/v1/crates/unknown/owners", body.clone());
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 
     let response = user.delete_with_body::<()>("/api/v1/crates/unknown/owners", body);
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 }
 
 #[test]

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -111,7 +111,7 @@ fn test_crate_downloads() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_display_snapshot!(
         response.text(),
-        @r###"{"errors":[{"detail":"Not Found"}]}"###
+        @r###"{"errors":[{"detail":"crate `bar` does not exist"}]}"###
     );
 
     // check non-canonical crate name

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -150,7 +150,7 @@ fn test_version_downloads() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_display_snapshot!(
         response.text(),
-        @r###"{"errors":[{"detail":"Not Found"}]}"###
+        @r###"{"errors":[{"detail":"crate `bar` does not exist"}]}"###
     );
 
     // check non-canonical crate name

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -81,7 +81,7 @@ fn test_missing() {
 
     let response = anon.get::<()>("/api/v1/crates/missing");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `missing` does not exist"}]}"###);
 }
 
 #[test]

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -216,5 +216,5 @@ fn test_unknown_crate() {
 
     let response = anon.get::<()>("/api/v1/crates/unknown/reverse_dependencies");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 }

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -26,6 +26,13 @@ fn dependencies() {
         .good();
     assert_eq!(deps.dependencies[0].crate_id, "bar_deps");
 
+    let response = anon.get::<()>("/api/v1/crates/missing-crate/1.0.0/dependencies");
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        response.json(),
+        json!({ "errors": [{ "detail": "crate `missing-crate` does not exist" }] })
+    );
+
     let response = anon.get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -39,5 +39,5 @@ fn test_unknown_crate() {
 
     let response = anon.get::<()>("/api/v1/crates/unknown/versions");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Not Found"}]}"###);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 }

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -83,6 +83,11 @@ pub fn service_unavailable() -> BoxedAppError {
     custom(StatusCode::SERVICE_UNAVAILABLE, "Service unavailable")
 }
 
+pub fn crate_not_found(krate: &str) -> BoxedAppError {
+    let detail = format!("crate `{krate}` does not exist");
+    custom(StatusCode::NOT_FOUND, detail)
+}
+
 pub fn version_not_found(krate: &str, version: &str) -> BoxedAppError {
     let detail = format!("crate `{krate}` does not have a version `{version}`");
     custom(StatusCode::NOT_FOUND, detail)


### PR DESCRIPTION
This PR adds a `crate_not_found()` function, similar to the existing `version_not_found()` function. This function will return a "404 Not Found" error with a proper "crate `...` does not exist" message. Previously, we were relying on `diesel::result::Error::NotFound` errors being automatically converted to generic 404 errors, but with this change we get actionable error messages.

Related:

- #7851