### PR TITLE
worker: Fix `tracing` instrumentation across `spawn_blocking()` calls

### DIFF
--- a/crates_io_worker/src/util.rs
+++ b/crates_io_worker/src/util.rs
@@ -11,8 +11,9 @@ where
     R: Send + 'static,
     E: Send + From<JoinError> + 'static,
 {
+    let current_span = tracing::Span::current();
     let hub = Hub::current();
-    tokio::task::spawn_blocking(move || Hub::run(hub, f))
+    tokio::task::spawn_blocking(move || current_span.in_scope(|| Hub::run(hub, f)))
         .await
         // Convert `JoinError` to `E`
         .map_err(Into::into)


### PR DESCRIPTION
This is similar to #7878, but for the fn copy in the `crates_io_worker` package. Clearly it was a great idea to have multiple copies of this function... 😅 