### PR TITLE
Respond with "413 Payload too large" when max upload size is exceeded

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -27,7 +27,7 @@ use crate::models::token::EndpointScope;
 use crate::rate_limiter::LimitedAction;
 use crate::schema::*;
 use crate::sql::canon_crate_name;
-use crate::util::errors::{cargo_err, internal, AppResult};
+use crate::util::errors::{cargo_err, custom, internal, AppResult};
 use crate::util::Maximums;
 use crate::views::{
     EncodableCrate, EncodableCrateDependency, GoodCrate, PublishMetadata, PublishWarnings,
@@ -120,7 +120,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         );
 
         if content_length > maximums.max_upload_size {
-            return Err(cargo_err(format_args!(
+            return Err(custom(StatusCode::PAYLOAD_TOO_LARGE, format!(
                 "max upload size is: {}",
                 maximums.max_upload_size
             )));

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -84,7 +84,7 @@ fn tarball_bigger_than_max_upload_size() {
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
     let response = token.publish_crate(body);
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     assert_json_snapshot!(response.json());
     assert_that!(app.stored_files(), empty());
 }

--- a/src/util/bytes_request.rs
+++ b/src/util/bytes_request.rs
@@ -39,7 +39,7 @@ where
         let collected = body.collect().await.map_err(|err| {
             let box_error = err.into_inner();
             match box_error.downcast::<LengthLimitError>() {
-                Ok(_) => StatusCode::BAD_REQUEST.into_response(),
+                Ok(_) => StatusCode::PAYLOAD_TOO_LARGE.into_response(),
                 Err(err) => server_error_response(&*err),
             }
         })?;
@@ -91,7 +91,7 @@ mod tests {
         let request = Request::get("/").body(body).unwrap();
         let response = app().oneshot(request).await.unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
 
         let body = vec![0; BODY_SIZE_LIMIT];
         let body = axum::body::Body::from(body);


### PR DESCRIPTION
This PR changes our `BytesRequest` implementation to respond with a "413 Payload too large" status code if the maximum request body size is exceeded. It also adjusts our publish endpoint to return the same status code if the per-crate size limit is exceeded.

Related:

- https://github.com/rust-lang/crates.io/issues/7881