### PR TITLE
controllers/krate/publish: Respond with "429 Too Many Requests" when daily version limit is reached

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -303,7 +303,8 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             if let Some(daily_version_limit) = app.config.new_version_rate_limit {
                 let published_today = count_versions_published_today(krate.id, conn)?;
                 if published_today >= daily_version_limit as i64 {
-                    return Err(cargo_err(
+                    return Err(custom(
+                        StatusCode::TOO_MANY_REQUESTS,
                         "You have published too many versions of this crate in the last 24 hours",
                     ));
                 }

--- a/src/tests/routes/crates/new.rs
+++ b/src/tests/routes/crates/new.rs
@@ -1,5 +1,6 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
+use http::StatusCode;
 
 #[test]
 fn daily_limit() {
@@ -13,7 +14,7 @@ fn daily_limit() {
 
     let crate_to_publish = PublishBuilder::new("foo_daily_limit", "1.0.0");
     let response = user.publish_crate(crate_to_publish);
-    assert!(response.status().is_success());
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     let json = response.json();
     assert_eq!(
         json["errors"][0]["detail"],


### PR DESCRIPTION
Related:
- https://github.com/rust-lang/crates.io/issues/7881