### PR TITLE
Add a '+' to the MSRV on the crate page

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -21,7 +21,7 @@
       <div local-class="msrv" data-test-msrv>
         {{svg-jar "rust"}}
         <span>
-          v{{@version.msrv}}
+          v{{@version.msrv}}+
           <EmberTooltip @text="Minimum Supported Rust Version" />
         </span>
       </div>


### PR DESCRIPTION
The MSRV indicates not a specific version requirement, but a "this version or later" requirement (hence the 'minimum supported' in 'minimum supported rust version').
This PR adds a '+' to the end of the version display to indicate this.

Spawned off of https://github.com/badges/shields/pull/9871#discussion_r1443839958