### PR TITLE
controllers/crates: default to sort by recent downloads

### DIFF
--- a/app/controllers/crates.js
+++ b/app/controllers/crates.js
@@ -9,7 +9,7 @@ export default class CratesController extends Controller {
   queryParams = ['page', 'per_page', 'sort'];
   @tracked page = '1';
   @tracked per_page = 50;
-  @tracked sort = 'alpha';
+  @tracked sort = 'recent-downloads';
 
   @reads('model.meta.total') totalItems;
   @pagination() pagination;

--- a/e2e/acceptance/crates.spec.ts
+++ b/e2e/acceptance/crates.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@/e2e/helper';
+import { expect, test } from '@/e2e/helper';
 
 test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
   // should match the default set in the crates controller
@@ -72,7 +72,7 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
 
     await page.goto('/crates');
 
-    await expect(page.locator('[data-test-crates-sort] [data-test-current-order]')).toHaveText('Alphabetical');
+    await expect(page.locator('[data-test-crates-sort] [data-test-current-order]')).toHaveText('Recent Downloads');
   });
 
   test('downloads appears for each crate on crate list', async ({ page, mirage }) => {
@@ -81,7 +81,7 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
     });
 
     await page.goto('/crates');
-    await expect(page.locator('[data-test-crate-row="0"] [data-test-downloads]')).toHaveText('All-Time: 497');
+    await expect(page.locator('[data-test-crate-row="0"] [data-test-downloads]')).toHaveText('All-Time: 21,573');
   });
 
   test('recent downloads appears for each crate on crate list', async ({ page, mirage }) => {
@@ -90,6 +90,6 @@ test.describe('Acceptance | crates page', { tag: '@acceptance' }, () => {
     });
 
     await page.goto('/crates');
-    await expect(page.locator('[data-test-crate-row="0"] [data-test-recent-downloads]')).toHaveText('Recent: 497');
+    await expect(page.locator('[data-test-crate-row="0"] [data-test-recent-downloads]')).toHaveText('Recent: 2,000');
   });
 });

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -44,6 +44,8 @@ export function list(schema, request) {
 
   if (request.queryParams.sort === 'alpha') {
     crates = crates.sort((a, b) => compareStrings(a.id.toLowerCase(), b.id.toLowerCase()));
+  } else if (request.queryParams.sort === 'recent-downloads') {
+    crates = crates.sort((a, b) => b.recent_downloads - a.recent_downloads);
   }
 
   return { ...this.serialize(crates.slice(start, end)), meta: { total: crates.length } };

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -66,25 +66,29 @@ module('Acceptance | crates page', function (hooks) {
     assert.dom('[data-test-crates-nav] [data-test-total-rows]').hasText(`${total}`);
   });
 
-  test('crates default sort is alphabetical', async function (assert) {
+  test('crates default sort is by recent downloads', async function (assert) {
     this.server.loadFixtures();
 
     await visit('/crates');
 
-    assert.dom('[data-test-crates-sort] [data-test-current-order]').hasText('Alphabetical');
+    assert.dom('[data-test-crates-sort] [data-test-current-order]').hasText('Recent Downloads');
   });
 
   test('downloads appears for each crate on crate list', async function (assert) {
     this.server.loadFixtures();
 
     await visit('/crates');
-    assert.dom('[data-test-crate-row="0"] [data-test-downloads]').hasText('All-Time: 497');
+
+    let formatted = Number(21_573).toLocaleString();
+    assert.dom('[data-test-crate-row="0"] [data-test-downloads]').hasText(`All-Time: ${formatted}`);
   });
 
   test('recent downloads appears for each crate on crate list', async function (assert) {
     this.server.loadFixtures();
 
     await visit('/crates');
-    assert.dom('[data-test-crate-row="0"] [data-test-recent-downloads]').hasText('Recent: 497');
+
+    let formatted = Number(2000).toLocaleString();
+    assert.dom('[data-test-crate-row="0"] [data-test-recent-downloads]').hasText(`Recent: ${formatted}`);
   });
 });


### PR DESCRIPTION
"Browse All Crates" is the most prominent link in the menu bar, displayed on all pages. Before this change, this link would present the user with (mostly) irrelevant crates, as it was sorted alphabetically: crates like `a`, `a-`, `a0`, etc.

With this change, the list is now sorted to present the most downloaded crates first.

`/keywords/:term` already defaults to that same order.