### PR TITLE
controllers/version/yank: Include version number in admin action logs

### DIFF
--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -72,7 +72,10 @@ fn modify_yank(
     if Handle::current().block_on(user.rights(state, &owners))? < Rights::Publish {
         if user.is_admin {
             let action = if yanked { "yanking" } else { "unyanking" };
-            warn!("Admin {} is {action} crate {}", user.gh_login, krate.name);
+            warn!(
+                "Admin {} is {action} {}@{}",
+                user.gh_login, krate.name, version.num
+            );
         } else {
             return Err(cargo_err("must already be an owner to yank or unyank"));
         }


### PR DESCRIPTION
> Admin Turbo87 is yanking crate crossbeam

The current logging is a bit misleading since users can only yank versions, but not complete crates. This PR fixes the issue.

Also, don't worry, the log line came from the staging environment. I didn't yank `crossbeam` on production 😉 