### PR TITLE
Fix `GET /api/v1/crates/new` requests

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -130,6 +130,11 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
     .await
 }
 
+/// Handles the `GET /crates/new` special case.
+pub async fn show_new(app: AppState, req: Parts) -> AppResult<Json<Value>> {
+    show(app, Path("new".to_string()), req).await
+}
+
 /// Handles the `GET /crates/:crate_id` route.
 pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     spawn_blocking(move || {

--- a/src/router.rs
+++ b/src/router.rs
@@ -18,7 +18,9 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         // Routes used by `cargo`
         .route(
             "/api/v1/crates/new",
-            put(krate::publish::publish).layer(DefaultBodyLimit::max(MAX_PUBLISH_CONTENT_LENGTH)),
+            put(krate::publish::publish)
+                .layer(DefaultBodyLimit::max(MAX_PUBLISH_CONTENT_LENGTH))
+                .get(krate::metadata::show_new),
         )
         .route(
             "/api/v1/crates/:crate_id/owners",

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -131,3 +131,16 @@ fn block_bad_documentation_url() {
     let json = anon.show_crate("foo_bad_doc_url");
     assert_eq!(json.krate.documentation, None);
 }
+
+#[test]
+fn test_new_name() {
+    let (app, anon, user) = TestApp::init().with_user();
+    app.db(|conn| CrateBuilder::new("new", user.as_model().id).expect_build(conn));
+
+    let response = anon.get::<()>("/api/v1/crates/new?include=");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.json(), {
+        ".crate.created_at" => "[datetime]",
+        ".crate.updated_at" => "[datetime]",
+    });
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__read__new_name.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__read__new_name.snap
@@ -1,0 +1,37 @@
+---
+source: src/tests/routes/crates/read.rs
+expression: response.json()
+---
+{
+  "categories": null,
+  "crate": {
+    "badges": null,
+    "categories": null,
+    "created_at": "[datetime]",
+    "description": null,
+    "documentation": null,
+    "downloads": 0,
+    "exact_match": false,
+    "homepage": null,
+    "id": "new",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/new/owner_team",
+      "owner_user": "/api/v1/crates/new/owner_user",
+      "owners": "/api/v1/crates/new/owners",
+      "reverse_dependencies": "/api/v1/crates/new/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/new/downloads",
+      "versions": "/api/v1/crates/new/versions"
+    },
+    "max_stable_version": null,
+    "max_version": "0.0.0",
+    "name": "new",
+    "newest_version": "0.0.0",
+    "recent_downloads": null,
+    "repository": null,
+    "updated_at": "[datetime]",
+    "versions": null
+  },
+  "keywords": null,
+  "versions": null
+}


### PR DESCRIPTION
Since `PUT /api/v1/crates/new` is used for publishing new crates/versions, `GET /api/v1/crates/new` was not being handled by the `GET /api/v1/crates/:crate_name` handler and returned "405 Method Not Allowed". This change special cases `GET /api/v1/crates/new` requests and forwards them to the `GET /api/v1/crates/:crate_name` request handler function.

Resolves https://github.com/rust-lang/crates.io/issues/7899