### PR TITLE
Use `instanceof NotFoundError` for 404 checks

### DIFF
--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -12,7 +13,7 @@ export default class CrateRoute extends Route {
     try {
       return await this.store.findRecord('crate', crateName);
     } catch (error) {
-      if (error.errors?.some(e => e.detail === 'Not Found')) {
+      if (error instanceof NotFoundError) {
         let title = `${crateName}: Crate not found`;
         this.router.replaceWith('catch-all', { transition, error, title });
       } else {

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -23,7 +24,7 @@ export default class TeamRoute extends Route {
 
       return { crates, team };
     } catch (error) {
-      if (error.errors?.some(e => e.detail === 'Not Found')) {
+      if (error instanceof NotFoundError) {
         this.notifications.error(`Team '${params.team_id}' does not exist`);
         return this.router.replaceWith('index');
       }

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -1,3 +1,4 @@
+import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
@@ -22,7 +23,7 @@ export default class UserRoute extends Route {
 
       return { crates, user };
     } catch (error) {
-      if (error.errors?.some(e => e.detail === 'Not Found')) {
+      if (error instanceof NotFoundError) {
         this.notifications.error(`User '${params.user_id}' does not exist`);
         return this.router.replaceWith('index');
       }


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/pull/7873 and https://github.com/rust-lang/crates.io/pull/7851 changed the error messages of 404 errors, but forgot to adjust our frontend code, which relied on these specific error messages to display a more useful error to the users. This PR fixes the issue by relying on the HTTP status code now, instead of checking the error message string.