### PR TITLE
publish: Introduce dependency limit

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -24,6 +24,9 @@ const DEFAULT_VERSION_ID_CACHE_TTL: u64 = 5 * 60; // 5 minutes
 /// enable. This value can be overridden in the database on a per-crate basis.
 const DEFAULT_MAX_FEATURES: usize = 300;
 
+/// Maximum number of dependencies a crate can have.
+const DEFAULT_MAX_DEPENDENCIES: usize = 500;
+
 pub struct Server {
     pub base: Base,
     pub ip: IpAddr,
@@ -36,6 +39,7 @@ pub struct Server {
     pub gh_client_secret: ClientSecret,
     pub max_upload_size: u64,
     pub max_unpack_size: u64,
+    pub max_dependencies: usize,
     pub max_features: usize,
     pub rate_limiter: HashMap<LimitedAction, RateLimiterConfig>,
     pub new_version_rate_limit: Option<u32>,
@@ -177,6 +181,7 @@ impl Server {
             gh_client_secret: ClientSecret::new(required_var("GH_CLIENT_SECRET")?),
             max_upload_size: 10 * 1024 * 1024, // 10 MB default file upload size limit
             max_unpack_size: 512 * 1024 * 1024, // 512 MB max when decompressed
+            max_dependencies: DEFAULT_MAX_DEPENDENCIES,
             max_features: DEFAULT_MAX_FEATURES,
             rate_limiter,
             new_version_rate_limit: var_parsed("MAX_NEW_VERSIONS_DAILY")?,

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -264,6 +264,16 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             tarball_info.manifest.target.as_ref()
         );
 
+        let max_dependencies = app.config.max_dependencies;
+        if deps.len() > max_dependencies {
+            return Err(cargo_err(format!(
+                "crates.io only allows a maximum number of {max_dependencies} dependencies.\n\
+                \n\
+                If you have a use case that requires an increase of this limit, \
+                please send us an email to help@crates.io to discuss the details."
+            )));
+        }
+
         for dep in &deps {
             validate_dependency(dep)?;
         }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -257,6 +257,16 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             }
         }
 
+        let deps = convert_dependencies(
+            tarball_info.manifest.dependencies.as_ref(),
+            tarball_info.manifest.dev_dependencies.as_ref(),
+            tarball_info.manifest.build_dependencies.as_ref(),
+            tarball_info.manifest.target.as_ref()
+        );
+
+        for dep in &deps {
+            validate_dependency(dep)?;
+        }
 
         // Create a transaction on the database, if there are no errors,
         // commit the transactions to record a new or updated crate.
@@ -336,17 +346,6 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 api_token_id,
                 VersionAction::Publish,
             )?;
-
-            let deps = convert_dependencies(
-                tarball_info.manifest.dependencies.as_ref(),
-                tarball_info.manifest.dev_dependencies.as_ref(),
-                tarball_info.manifest.build_dependencies.as_ref(),
-                tarball_info.manifest.target.as_ref()
-            );
-
-            for dep in &deps {
-                validate_dependency(dep)?;
-            }
 
             // Link this new version to all dependencies
             add_dependencies(conn, &deps, version.id)?;

--- a/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__dep_limit-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__dependencies__dep_limit-2.snap
@@ -1,0 +1,39 @@
+---
+source: src/tests/krate/publish/dependencies.rs
+expression: response.json()
+---
+{
+  "crate": {
+    "badges": null,
+    "categories": null,
+    "created_at": "[datetime]",
+    "description": "description",
+    "documentation": null,
+    "downloads": 0,
+    "exact_match": false,
+    "homepage": null,
+    "id": "foo",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/foo/owner_team",
+      "owner_user": "/api/v1/crates/foo/owner_user",
+      "owners": "/api/v1/crates/foo/owners",
+      "reverse_dependencies": "/api/v1/crates/foo/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/foo/downloads",
+      "versions": "/api/v1/crates/foo/versions"
+    },
+    "max_stable_version": "1.0.0",
+    "max_version": "1.0.0",
+    "name": "foo",
+    "newest_version": "1.0.0",
+    "recent_downloads": null,
+    "repository": null,
+    "updated_at": "[datetime]",
+    "versions": null
+  },
+  "warnings": {
+    "invalid_badges": [],
+    "invalid_categories": [],
+    "other": []
+  }
+}

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -420,6 +420,7 @@ fn simple_config() -> config::Server {
         max_upload_size: 128 * 1024, // 128 kB should be enough for most testing purposes
         max_unpack_size: 128 * 1024, // 128 kB should be enough for most testing purposes
         max_features: 10,
+        max_dependencies: 10,
         rate_limiter: Default::default(),
         new_version_rate_limit: Some(10),
         blocked_traffic: Default::default(),


### PR DESCRIPTION
Allowing users to publish crates with an unlimited number of dependencies has the potential to cause various issues. The crate with the most dependencies currently has 256 dependencies, so a limit of 500 dependencies seems reasonable for now. If necessary, we can make this limit configurable with an environment variable in the future, or even per crate with another database column.

see https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/dependencies.20limit