### PR TITLE
typosquat: check for prefixes being manipulated like suffixes

### DIFF
--- a/src/typosquat/cache.rs
+++ b/src/typosquat/cache.rs
@@ -7,7 +7,7 @@ use typomania::{
     Harness,
 };
 
-use super::{checks::Suffixes, config, database::TopCrates};
+use super::{checks::Affixes, config, database::TopCrates};
 
 static NOTIFICATION_EMAILS_ENV: &str = "TYPOSQUAT_NOTIFICATION_EMAILS";
 
@@ -72,9 +72,9 @@ impl Cache {
                     .with_check(Typos::new(config::TYPOS.iter().map(|(c, typos)| {
                         (*c, typos.iter().map(|ss| ss.to_string()).collect())
                     })))
-                    .with_check(Suffixes::new(
-                        config::SUFFIX_SEPARATORS.iter(),
+                    .with_check(Affixes::new(
                         config::SUFFIXES.iter(),
+                        config::SUFFIX_SEPARATORS.iter(),
                     ))
                     .build(top),
             ),

--- a/src/typosquat/config.rs
+++ b/src/typosquat/config.rs
@@ -9,7 +9,7 @@ pub(super) static CRATE_NAME_ALPHABET: &str =
 pub(super) static SUFFIX_SEPARATORS: &[&str] = &["-", "_"];
 
 /// Commonly used suffixes when building crate names.
-pub(super) static SUFFIXES: &[&str] = &["api", "cli", "core", "lib", "rs", "rust", "sys"];
+pub(super) static SUFFIXES: &[&str] = &["api", "cargo", "cli", "core", "lib", "rs", "rust", "sys"];
 
 /// The number of crates to consider in the "top crates" corpus.
 pub(super) static TOP_CRATES: i64 = 3000;


### PR DESCRIPTION
In #7571, we added checks for crate names that added or removed suffixes from popular crates. This has turned out to be a useful check! (Spoiler alert for the blog post I'm publishing next week.)

@Turbo87 pointed out that this can also apply to prefixes, especially `cargo-`. This generalises the suffix check to also check prefixes, and adjusts the typomania configuration to add `cargo` to the list of interesting affixes. For now, the same set of affixes will be used for both, but depending on what we see, a future tweak would be to separate the prefix and suffix lists. Let's see how that pans out.

In terms of implementation, I briefly toyed with making this generic over the prefix/suffix combination to remove the copy/paste code, then was reminded by rust-analyzer that `std::str::pattern::Pattern` isn't stable. I'd rather duplicate 20 lines than deal with that, so here we are.