### PR TITLE
controllers/krate/owners: Simplify request body parsing

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -95,16 +95,13 @@ pub async fn remove_owners(
 fn parse_owners_request(req: &Request<Bytes>) -> AppResult<Vec<String>> {
     #[derive(Deserialize)]
     struct Request {
-        // identical, for back-compat (owners preferred)
-        users: Option<Vec<String>>,
-        owners: Option<Vec<String>>,
+        #[serde(alias = "users")]
+        owners: Vec<String>,
     }
     let request: Request =
         serde_json::from_slice(req.body()).map_err(|_| cargo_err("invalid json request"))?;
-    request
-        .owners
-        .or(request.users)
-        .ok_or_else(|| cargo_err("invalid json request"))
+
+    Ok(request.owners)
 }
 
 fn modify_owners(

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -85,6 +85,12 @@ pub async fn remove_owners(
     spawn_blocking(move || modify_owners(&app, &crate_name, &req, false)).await
 }
 
+#[derive(Deserialize)]
+struct ChangeOwnersRequest {
+    #[serde(alias = "users")]
+    owners: Vec<String>,
+}
+
 /// Parse the JSON request body of requests to modify the owners of a crate.
 ///
 /// The format is:
@@ -93,11 +99,6 @@ pub async fn remove_owners(
 /// {"owners": ["username", "github:org:team", ...]}
 /// ```
 fn parse_owners_request(req: &Request<Bytes>) -> AppResult<Vec<String>> {
-    #[derive(Deserialize)]
-    struct ChangeOwnersRequest {
-        #[serde(alias = "users")]
-        owners: Vec<String>,
-    }
     let request: ChangeOwnersRequest =
         serde_json::from_slice(req.body()).map_err(|_| cargo_err("invalid json request"))?;
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -94,11 +94,11 @@ pub async fn remove_owners(
 /// ```
 fn parse_owners_request(req: &Request<Bytes>) -> AppResult<Vec<String>> {
     #[derive(Deserialize)]
-    struct Request {
+    struct ChangeOwnersRequest {
         #[serde(alias = "users")]
         owners: Vec<String>,
     }
-    let request: Request =
+    let request: ChangeOwnersRequest =
         serde_json::from_slice(req.body()).map_err(|_| cargo_err("invalid json request"))?;
 
     Ok(request.owners)

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -418,6 +418,18 @@ fn owner_change_without_auth() {
 }
 
 #[test]
+fn test_owner_change_with_legacy_field() {
+    let (app, _, user1) = TestApp::full().with_user();
+    app.db(|conn| CrateBuilder::new("foo", user1.as_model().id).expect_build(conn));
+    app.db_new_user("user2");
+
+    let input = r#"{"users": ["user2"]}"#;
+    let response = user1.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_display_snapshot!(response.text(), @r###"{"msg":"user user2 has been invited to be an owner of crate foo","ok":true}"###);
+}
+
+#[test]
 fn invite_already_invited_user() {
     let (app, _, _, owner) = TestApp::init().with_token();
     app.db_new_user("invited_user");


### PR DESCRIPTION
This PR first adds a couple of tests for the `PUT/DELETE /crates/:crate_id/owners` endpoints. Afterwards it performs a few refactorings on the endpoint code to simplify the JSON request payload parsing code, without changing the behavior of the system.

Best reviewed commit-by-commit 😉 