### PR TITLE
codecov: Use `informational` mode for now

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true


### PR DESCRIPTION
We're still gathering information on how useful the coverage tracking actually is, so let's not fail CI yet for potentially flaky numbers.