### PR TITLE
codecov: Set default branch to `main`

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  branch: main
+
 coverage:
   status:
     project:


### PR DESCRIPTION
codecov claims to "use the default branch from Git for your repository as the primary source", but it doesn't appear to do so in practice...