### PR TITLE
controllers/krate/owners: Use `Json` extractor to parse request body

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -16,7 +16,7 @@ mod prelude {
     pub use diesel::prelude::*;
     pub use serde_json::Value;
 
-    pub use http::{header, request::Parts, Request, StatusCode};
+    pub use http::{header, request::Parts, StatusCode};
 
     pub use crate::app::AppState;
     use crate::controllers::util::RequestPartsExt;

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -306,7 +306,7 @@ pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> anyhow::Res
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::{Method, StatusCode};
+    use http::{Method, Request, StatusCode};
 
     #[test]
     fn no_pagination_param() {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -438,32 +438,32 @@ fn test_owner_change_with_invalid_json() {
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
     let response = user.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid json request"}]}"###);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
 
     let response = user.delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes());
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid json request"}]}"###);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
 
-    // `users` is not an array
-    let input = r#"{"owners": ["foo", "bar"], "users": "baz"}"#;
+    // `owners` is not an array
+    let input = r#"{"owners": "foo"}"#;
     let response = user.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid json request"}]}"###);
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
 
     let response = user.delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes());
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid json request"}]}"###);
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
 
     // missing `owners` and/or `users` fields
     let input = r#"{}"#;
     let response = user.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid json request"}]}"###);
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
 
     let response = user.delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes());
-    assert_eq!(response.status(), StatusCode::OK);
-    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid json request"}]}"###);
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
 }
 
 #[test]


### PR DESCRIPTION
This will allow us to eventually get rid of our custom `BytesRequest` extractor and it also gives users more helpful error messages.