### PR TITLE
Make frontend build scripts work on Windows

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shell-emulator=true


### PR DESCRIPTION
This PR uses pnpm's [shell-emulator](https://pnpm.io/cli/run#shell-emulator) to execute scripts, so that syntax like `PROXY_BACKEND=https://crates.io` can run on Windows.

Resolves #7360