### PR TITLE
tests: Use `tracing::subscriber::DefaultGuard` to set subscriber

### DIFF
--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -3,7 +3,7 @@ use crates_io_test_db::TestDatabase;
 
 #[test]
 fn dump_db_and_reimport_dump() {
-    crates_io::util::tracing::init_for_test();
+    let _guard = crates_io::util::tracing::init_for_test();
 
     let db_one = TestDatabase::new();
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -20,8 +20,12 @@ use oauth2::{ClientId, ClientSecret};
 use std::collections::HashSet;
 use std::{rc::Rc, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
+use tracing::subscriber::DefaultGuard;
 
 struct TestAppInner {
+    #[allow(dead_code)]
+    tracing_guard: DefaultGuard,
+
     pub runtime: Runtime,
 
     app: Arc<App>,
@@ -74,9 +78,10 @@ pub struct TestApp(Rc<TestAppInner>);
 impl TestApp {
     /// Initialize an application with an `Uploader` that panics
     pub fn init() -> TestAppBuilder {
-        crates_io::util::tracing::init_for_test();
+        let tracing_guard = crates_io::util::tracing::init_for_test();
 
         TestAppBuilder {
+            tracing_guard,
             config: simple_config(),
             index: None,
             build_job_runner: false,
@@ -202,6 +207,7 @@ impl TestApp {
 }
 
 pub struct TestAppBuilder {
+    tracing_guard: DefaultGuard,
     config: config::Server,
     index: Option<UpstreamIndex>,
     build_job_runner: bool,
@@ -286,6 +292,7 @@ impl TestAppBuilder {
         };
 
         let test_app_inner = TestAppInner {
+            tracing_guard: self.tracing_guard,
             runtime,
             app,
             test_database,

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,4 +1,5 @@
 use sentry::integrations::tracing::EventFilter;
+use tracing::subscriber::DefaultGuard;
 use tracing::Level;
 use tracing::Metadata;
 use tracing_subscriber::filter::LevelFilter;
@@ -46,15 +47,17 @@ pub fn event_filter(metadata: &Metadata<'_>) -> EventFilter {
 }
 
 /// Initializes the `tracing` logging framework for usage in tests.
-pub fn init_for_test() {
+pub fn init_for_test() -> DefaultGuard {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
 
-    let _ = tracing_subscriber::fmt()
+    let subscriber = tracing_subscriber::fmt()
         .compact()
         .with_env_filter(env_filter)
         .without_time()
         .with_test_writer()
-        .try_init();
+        .finish();
+
+    tracing::subscriber::set_default(subscriber)
 }


### PR DESCRIPTION
This avoids `try_init()` failing because a default subscriber is already registered globally. `set_default()` will register a temporary one only for the lifetime of the returned scope guard.