### PR TITLE
util/errors: Use "403 Forbidden" for GitHub permission errors

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -226,7 +226,8 @@ impl From<JoinError> for BoxedAppError {
 impl From<GitHubError> for BoxedAppError {
     fn from(error: GitHubError) -> Self {
         match error {
-            GitHubError::Permission(_) => cargo_err(
+            GitHubError::Permission(_) => custom(
+                StatusCode::FORBIDDEN,
                 "It looks like you don't have permission \
                      to query a necessary property from GitHub \
                      to complete this request. \


### PR DESCRIPTION
I guess it's debatable which status code exactly we should use here, but this should definitely not use "200 OK" 😅 