### PR TITLE
Add basic support for seek-based pagination to versions endpoint

### DIFF
--- a/src/controllers/krate.rs
+++ b/src/controllers/krate.rs
@@ -4,3 +4,4 @@ pub mod metadata;
 pub mod owners;
 pub mod publish;
 pub mod search;
+pub mod versions;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -328,43 +328,6 @@ pub async fn readme(
     }
 }
 
-/// Handles the `GET /crates/:crate_id/versions` route.
-// FIXME: Not sure why this is necessary since /crates/:crate_id returns
-// this information already, but ember is definitely requesting it
-pub async fn versions(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
-        let conn = &mut *state.db_read()?;
-
-        let krate: Crate = Crate::by_name(&crate_name)
-            .first(conn)
-            .optional()?
-            .ok_or_else(|| crate_not_found(&crate_name))?;
-
-        let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
-            .all_versions()
-            .left_outer_join(users::table)
-            .select((versions::all_columns, users::all_columns.nullable()))
-            .load(conn)?;
-
-        versions_and_publishers
-            .sort_by_cached_key(|(version, _)| Reverse(semver::Version::parse(&version.num).ok()));
-
-        let versions = versions_and_publishers
-            .iter()
-            .map(|(v, _)| v)
-            .cloned()
-            .collect::<Vec<_>>();
-        let versions = versions_and_publishers
-            .into_iter()
-            .zip(VersionOwnerAction::for_versions(conn, &versions)?)
-            .map(|((v, pb), aas)| EncodableVersion::from(v, &crate_name, pb, aas))
-            .collect::<Vec<_>>();
-
-        Ok(Json(json!({ "versions": versions })))
-    })
-    .await
-}
-
 /// Handles the `GET /crates/:crate_id/reverse_dependencies` route.
 pub async fn reverse_dependencies(
     app: AppState,

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -2,7 +2,11 @@
 
 use std::cmp::Reverse;
 
+use diesel::connection::DefaultLoadingMode;
+use indexmap::IndexMap;
+
 use crate::controllers::frontend_prelude::*;
+use crate::controllers::helpers::pagination::{encode_seek, Page, PaginationOptions};
 
 use crate::models::{Crate, CrateVersions, User, Version, VersionOwnerAction};
 use crate::schema::{users, versions};
@@ -10,9 +14,11 @@ use crate::util::errors::crate_not_found;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /crates/:crate_id/versions` route.
-// FIXME: Not sure why this is necessary since /crates/:crate_id returns
-// this information already, but ember is definitely requesting it
-pub async fn versions(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
+pub async fn versions(
+    state: AppState,
+    Path(crate_name): Path<String>,
+    req: Parts,
+) -> AppResult<Json<Value>> {
     spawn_blocking(move || {
         let conn = &mut *state.db_read()?;
 
@@ -21,27 +27,256 @@ pub async fn versions(state: AppState, Path(crate_name): Path<String>) -> AppRes
             .optional()?
             .ok_or_else(|| crate_not_found(&crate_name))?;
 
-        let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
-            .all_versions()
-            .left_outer_join(users::table)
-            .select((versions::all_columns, users::all_columns.nullable()))
-            .load(conn)?;
+        let mut pagination = None;
+        let params = req.query();
+        // To keep backward compatibility, we paginate only if per_page is provided
+        if params.get("per_page").is_some() {
+            pagination = Some(
+                PaginationOptions::builder()
+                    .enable_seek(true)
+                    .enable_pages(false)
+                    .gather(&req)?,
+            );
+        }
 
-        versions_and_publishers
-            .sort_by_cached_key(|(version, _)| Reverse(semver::Version::parse(&version.num).ok()));
+        // Sort by semver by default
+        let versions_and_publishers = match params.get("sort").map(|s| s.to_lowercase()).as_deref()
+        {
+            Some("date") => list_by_date(&krate, pagination.as_ref(), &req, conn)?,
+            _ => list_by_semver(&krate, pagination.as_ref(), &req, conn)?,
+        };
 
         let versions = versions_and_publishers
+            .data
             .iter()
             .map(|(v, _)| v)
             .cloned()
             .collect::<Vec<_>>();
         let versions = versions_and_publishers
+            .data
             .into_iter()
             .zip(VersionOwnerAction::for_versions(conn, &versions)?)
             .map(|((v, pb), aas)| EncodableVersion::from(v, &crate_name, pb, aas))
             .collect::<Vec<_>>();
 
-        Ok(Json(json!({ "versions": versions })))
+        Ok(Json(match pagination {
+            Some(_) => json!({ "versions": versions, "meta": versions_and_publishers.meta }),
+            None => json!({ "versions": versions }),
+        }))
     })
     .await
+}
+
+/// Seek-based pagination of versions by date
+///
+/// # Panics
+///
+/// This function will panic if `option` is built with `enable_pages` set to true.
+fn list_by_date(
+    krate: &Crate,
+    options: Option<&PaginationOptions>,
+    req: &Parts,
+    conn: &mut PgConnection,
+) -> AppResult<PaginatedVersionsAndPublishers> {
+    use seek::*;
+
+    let mut query = krate
+        .all_versions()
+        .left_outer_join(users::table)
+        .select((versions::all_columns, users::all_columns.nullable()));
+
+    if let Some(options) = options {
+        assert!(
+            !matches!(&options.page, Page::Numeric(_)),
+            "?page= is not supported"
+        );
+        if let Some(SeekPayload::Date(Date(created_at, id))) = Seek::Date.after(&options.page)? {
+            query = query.filter(
+                versions::created_at
+                    .eq(created_at)
+                    .and(versions::id.lt(id))
+                    .or(versions::created_at.lt(created_at)),
+            )
+        }
+        query = query.limit(options.per_page);
+    }
+
+    query = query.order((versions::created_at.desc(), versions::id.desc()));
+
+    let data: Vec<(Version, Option<User>)> = query.load(conn)?;
+    let mut next_page = None;
+    if let Some(options) = options {
+        next_page = next_seek_params(&data, options, |last| Seek::Date.to_payload(last))?
+            .map(|p| req.query_with_params(p));
+    };
+
+    // Since the total count is retrieved through an additional query, to maintain consistency
+    // with other pagination methods, we only make a count query while data is not empty.
+    let total = if !data.is_empty() {
+        krate.all_versions().count().get_result(conn)?
+    } else {
+        0
+    };
+
+    Ok(PaginatedVersionsAndPublishers {
+        data,
+        meta: ResponseMeta { total, next_page },
+    })
+}
+
+/// Seek-based pagination of versions by semver
+///
+/// # Panics
+///
+/// This function will panic if `option` is built with `enable_pages` set to true.
+
+// Unfortunately, Heroku Postgres has no support for the semver PG extension.
+// Therefore, we need to perform both sorting and pagination manually on the server.
+fn list_by_semver(
+    krate: &Crate,
+    options: Option<&PaginationOptions>,
+    req: &Parts,
+    conn: &mut PgConnection,
+) -> AppResult<PaginatedVersionsAndPublishers> {
+    use seek::*;
+
+    let (data, total) = if let Some(options) = options {
+        // Since versions will only increase in the future and both sorting and pagination need to
+        // happen on the app server, implementing it with fetching only the data needed for sorting
+        // and pagination, then making another query for the data to respond with, would minimize
+        // payload and memory usage. This way, we can utilize the sorted map and enrich it later
+        // without sorting twice.
+        // Sorting by semver but opted for id as the seek key because num can be quite lengthy,
+        // while id values are significantly smaller.
+        let mut sorted_versions = IndexMap::new();
+        for result in krate
+            .all_versions()
+            .select((versions::id, versions::num))
+            .load_iter::<(i32, String), DefaultLoadingMode>(conn)?
+        {
+            let (id, num) = result?;
+            sorted_versions.insert(id, (num, None));
+        }
+        sorted_versions.sort_by_cached_key(|_, (num, _)| Reverse(semver::Version::parse(num).ok()));
+
+        assert!(
+            !matches!(&options.page, Page::Numeric(_)),
+            "?page= is not supported"
+        );
+        let mut idx = Some(0);
+        if let Some(SeekPayload::Semver(Semver(id))) = Seek::Semver.after(&options.page)? {
+            idx = sorted_versions
+                .get_index_of(&id)
+                .filter(|i| i + 1 < sorted_versions.len())
+                .map(|i| i + 1);
+        }
+        if let Some(start) = idx {
+            let end = (start + options.per_page as usize).min(sorted_versions.len());
+            let ids = sorted_versions[start..end].keys().collect::<Vec<_>>();
+            for result in krate
+                .all_versions()
+                .left_outer_join(users::table)
+                .select((versions::all_columns, users::all_columns.nullable()))
+                .filter(versions::id.eq_any(ids))
+                .load_iter::<(Version, Option<User>), DefaultLoadingMode>(conn)?
+            {
+                let row = result?;
+                sorted_versions.insert(row.0.id, (row.0.num.to_owned(), Some(row)));
+            }
+
+            let len = sorted_versions.len();
+            (
+                sorted_versions
+                    .into_values()
+                    .filter_map(|(_, v)| v)
+                    .collect(),
+                len,
+            )
+        } else {
+            (vec![], 0)
+        }
+    } else {
+        let mut data: Vec<(Version, Option<User>)> = krate
+            .all_versions()
+            .left_outer_join(users::table)
+            .select((versions::all_columns, users::all_columns.nullable()))
+            .load(conn)?;
+        data.sort_by_cached_key(|(version, _)| Reverse(semver::Version::parse(&version.num).ok()));
+        let total = data.len();
+        (data, total)
+    };
+
+    let mut next_page = None;
+    if let Some(options) = options {
+        next_page = next_seek_params(&data, options, |last| Seek::Semver.to_payload(last))?
+            .map(|p| req.query_with_params(p))
+    };
+
+    Ok(PaginatedVersionsAndPublishers {
+        data,
+        meta: ResponseMeta {
+            total: total as i64,
+            next_page,
+        },
+    })
+}
+
+mod seek {
+    use crate::controllers::helpers::pagination::seek;
+    use crate::models::{User, Version};
+    use chrono::naive::serde::ts_microseconds;
+
+    // We might consider refactoring this to use named fields, which would be clearer and more
+    // flexible. It's also worth noting that we currently encode seek compactly as a Vec, which
+    // doesn't include field names.
+    seek! {
+        pub enum Seek {
+            Semver(i32)
+            Date(#[serde(with="ts_microseconds")] chrono::NaiveDateTime, i32)
+        }
+    }
+
+    impl Seek {
+        pub(crate) fn to_payload(&self, record: &(Version, Option<User>)) -> SeekPayload {
+            match *self {
+                Seek::Semver => SeekPayload::Semver(Semver(record.0.id)),
+                Seek::Date => SeekPayload::Date(Date(record.0.created_at, record.0.id)),
+            }
+        }
+    }
+}
+
+fn next_seek_params<T, S, F>(
+    records: &[T],
+    options: &PaginationOptions,
+    f: F,
+) -> AppResult<Option<IndexMap<String, String>>>
+where
+    F: Fn(&T) -> S,
+    S: serde::Serialize,
+{
+    if matches!(options.page, Page::Numeric(_)) || records.len() < options.per_page as usize {
+        return Ok(None);
+    }
+
+    let mut opts = IndexMap::new();
+    match options.page {
+        Page::Unspecified | Page::Seek(_) => {
+            let seek = f(records.last().unwrap());
+            opts.insert("seek".into(), encode_seek(seek)?);
+        }
+        Page::Numeric(_) => unreachable!(),
+    };
+    Ok(Some(opts))
+}
+
+struct PaginatedVersionsAndPublishers {
+    data: Vec<(Version, Option<User>)>,
+    meta: ResponseMeta,
+}
+
+#[derive(Serialize)]
+struct ResponseMeta {
+    total: i64,
+    next_page: Option<String>,
 }

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -1,0 +1,47 @@
+//! Endpoint for versions of a crate
+
+use std::cmp::Reverse;
+
+use crate::controllers::frontend_prelude::*;
+
+use crate::models::{Crate, CrateVersions, User, Version, VersionOwnerAction};
+use crate::schema::{users, versions};
+use crate::util::errors::crate_not_found;
+use crate::views::EncodableVersion;
+
+/// Handles the `GET /crates/:crate_id/versions` route.
+// FIXME: Not sure why this is necessary since /crates/:crate_id returns
+// this information already, but ember is definitely requesting it
+pub async fn versions(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
+    spawn_blocking(move || {
+        let conn = &mut *state.db_read()?;
+
+        let krate: Crate = Crate::by_name(&crate_name)
+            .first(conn)
+            .optional()?
+            .ok_or_else(|| crate_not_found(&crate_name))?;
+
+        let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
+            .all_versions()
+            .left_outer_join(users::table)
+            .select((versions::all_columns, users::all_columns.nullable()))
+            .load(conn)?;
+
+        versions_and_publishers
+            .sort_by_cached_key(|(version, _)| Reverse(semver::Version::parse(&version.num).ok()));
+
+        let versions = versions_and_publishers
+            .iter()
+            .map(|(v, _)| v)
+            .cloned()
+            .collect::<Vec<_>>();
+        let versions = versions_and_publishers
+            .into_iter()
+            .zip(VersionOwnerAction::for_versions(conn, &versions)?)
+            .map(|((v, pb), aas)| EncodableVersion::from(v, &crate_name, pb, aas))
+            .collect::<Vec<_>>();
+
+        Ok(Json(json!({ "versions": versions })))
+    })
+    .await
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -68,7 +68,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         )
         .route(
             "/api/v1/crates/:crate_id/versions",
-            get(krate::metadata::versions),
+            get(krate::versions::versions),
         )
         .route(
             "/api/v1/crates/:crate_id/follow",

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -1,7 +1,9 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
 use crates_io::schema::versions;
+use crates_io::views::EncodableVersion;
 use diesel::{prelude::*, update};
+use googletest::prelude::*;
 use http::StatusCode;
 use insta::{assert_display_snapshot, assert_json_snapshot};
 
@@ -40,4 +42,221 @@ fn test_unknown_crate() {
     let response = anon.get::<()>("/api/v1/crates/unknown/versions");
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_display_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+}
+
+#[test]
+fn test_sorting() {
+    let (app, anon, user) = TestApp::init().with_user();
+    let user = user.as_model();
+    let versions = [
+        "1.0.0-alpha",
+        "2.0.0-alpha",
+        "1.0.0-beta",
+        "1.0.0-alpha.1",
+        "1.0.0-beta.2",
+        "1.0.0-alpha.beta",
+        "1.0.0-beta.11",
+        "1.0.0-rc.1",
+        "1.0.0",
+    ];
+    app.db(|conn| {
+        let mut builder = CrateBuilder::new("foo_versions", user.id);
+        for version in versions {
+            builder = builder.version(version);
+        }
+        builder.expect_build(conn);
+        // Make version 1.0.0-beta.2 and 1.0.0-alpha.beta mimic versions created at same time,
+        // but 1.0.0-alpha.beta owns larger id number
+        let versions_aliased = diesel::alias!(versions as versions_aliased);
+        let created_at_by_num = |num: &str| {
+            versions_aliased
+                .filter(versions_aliased.field(versions::num).eq(num.to_owned()))
+                .select(versions_aliased.field(versions::created_at))
+                .single_value()
+        };
+        update(versions::table)
+            .filter(versions::num.eq("1.0.0-beta.2"))
+            .set(versions::created_at.eq(created_at_by_num("1.0.0-alpha.beta").assume_not_null()))
+            .execute(conn)
+            .unwrap();
+
+        // An additional crate to guarantee the accuracy of the response dataset and its total
+        CrateBuilder::new("bar_versions", user.id)
+            .version("0.0.1")
+            .expect_build(conn);
+    });
+
+    // Sort by semver
+    let url = "/api/v1/crates/foo_versions/versions?sort=semver";
+    let json: AllVersions = anon.get(url).good();
+    let expects = [
+        "2.0.0-alpha",
+        "1.0.0",
+        "1.0.0-rc.1",
+        "1.0.0-beta.11",
+        "1.0.0-beta.2",
+        "1.0.0-beta",
+        "1.0.0-alpha.beta",
+        "1.0.0-alpha.1",
+        "1.0.0-alpha",
+    ];
+    for (num, expect) in nums(&json.versions).iter().zip(expects) {
+        assert_eq!(num, expect);
+    }
+    let (resp, calls) = page_with_seek(&anon, url);
+    for (json, expect) in resp.iter().zip(expects) {
+        assert_eq!(json.versions[0].num, expect);
+        assert_eq!(json.meta.total as usize, expects.len());
+    }
+    assert_eq!(calls as usize, expects.len() + 1);
+
+    // Sort by date
+    let url = "/api/v1/crates/foo_versions/versions?sort=date";
+    let json: AllVersions = anon.get(url).good();
+    let expects = versions.iter().cloned().rev().collect::<Vec<_>>();
+    for (num, expect) in nums(&json.versions).iter().zip(&expects) {
+        assert_eq!(num, *expect);
+    }
+    let (resp, calls) = page_with_seek(&anon, url);
+    for (json, expect) in resp.iter().zip(&expects) {
+        assert_eq!(json.versions[0].num, *expect);
+        assert_eq!(json.meta.total as usize, expects.len());
+    }
+    assert_eq!(calls as usize, expects.len() + 1);
+}
+
+#[test]
+fn test_seek_based_pagination_semver_sorting() {
+    let (app, anon, user) = TestApp::init().with_user();
+    let user = user.as_model();
+    app.db(|conn| {
+        CrateBuilder::new("foo_versions", user.id)
+            .version("0.5.1")
+            .version(VersionBuilder::new("1.0.0").rust_version("1.64"))
+            .version("0.5.0")
+            .expect_build(conn);
+        // Make version 1.0.0 mimic a version published before we started recording who published
+        // versions
+        let none: Option<i32> = None;
+        update(versions::table)
+            .filter(versions::num.eq("1.0.0"))
+            .set(versions::published_by.eq(none))
+            .execute(conn)
+            .unwrap();
+    });
+
+    let url = "/api/v1/crates/foo_versions/versions";
+    let expects = ["1.0.0", "0.5.1", "0.5.0"];
+
+    // per_page larger than the number of versions
+    let json: VersionList = anon.get_with_query(url, "per_page=10&sort=semver").good();
+    assert_eq!(nums(&json.versions), expects);
+    assert_eq!(json.meta.total as usize, expects.len());
+
+    let json: VersionList = anon.get_with_query(url, "per_page=1&sort=semver").good();
+    assert_eq!(nums(&json.versions), expects[0..1]);
+    assert_eq!(json.meta.total as usize, expects.len());
+
+    let seek = json
+        .meta
+        .next_page
+        .map(|s| s.split_once("seek=").unwrap().1.to_owned())
+        .map(|p| p.split_once('&').map(|t| t.0.to_owned()).unwrap_or(p))
+        .unwrap();
+
+    // per_page larger than the number of remain versions
+    let json: VersionList = anon
+        .get_with_query(url, &format!("per_page=5&sort=semver&seek={seek}"))
+        .good();
+    assert_eq!(nums(&json.versions), expects[1..]);
+    assert!(json.meta.next_page.is_none());
+    assert_eq!(json.meta.total as usize, expects.len());
+
+    // per_page euqal to the number of remain versions
+    let json: VersionList = anon
+        .get_with_query(url, &format!("per_page=2&sort=semver&seek={seek}"))
+        .good();
+    assert_eq!(nums(&json.versions), expects[1..]);
+    assert!(json.meta.next_page.is_some());
+    assert_eq!(json.meta.total as usize, expects.len());
+
+    // A decodable seek value, MTAwCg (100), but doesn't actaully exist
+    let json: VersionList = anon
+        .get_with_query(url, "per_page=10&sort=semver&seek=MTAwCg")
+        .good();
+    assert_eq!(json.versions.len(), 0);
+    assert!(json.meta.next_page.is_none());
+    assert_eq!(json.meta.total, 0);
+}
+
+#[test]
+fn invalid_seek_parameter() {
+    let (app, anon, user) = TestApp::init().with_user();
+    let user = user.as_model();
+    app.db(|conn| {
+        CrateBuilder::new("foo_versions", user.id).expect_build(conn);
+    });
+
+    let url = "/api/v1/crates/foo_versions/versions";
+    // Sort by semver
+    let response = anon.get_with_query::<()>(url, "per_page=1&sort=semver&seek=broken");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_json_snapshot!(response.json());
+
+    // Sort by date
+    let response = anon.get_with_query::<()>(url, "per_page=1&sort=date&seek=broken");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_json_snapshot!(response.json());
+
+    // borken seek but without per_page parameter should be ok
+    // since it's not consider as seek-based pagination
+    let response = anon.get_with_query::<()>(url, "seek=broken");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AllVersions {
+    pub versions: Vec<EncodableVersion>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct VersionList {
+    pub versions: Vec<EncodableVersion>,
+    pub meta: ResponseMeta,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ResponseMeta {
+    pub total: i64,
+    pub next_page: Option<String>,
+}
+
+fn nums(versions: &[EncodableVersion]) -> Vec<String> {
+    versions.iter().map(|v| v.num.to_owned()).collect()
+}
+
+fn page_with_seek<U: RequestHelper>(anon: &U, url: &str) -> (Vec<VersionList>, i32) {
+    let (url_without_query, query) = url.split_once('?').unwrap_or((url, ""));
+    let mut url = Some(format!("{url_without_query}?per_page=1&{query}"));
+    let mut results = Vec::new();
+    let mut calls = 0;
+    while let Some(current_url) = url.take() {
+        let resp: VersionList = anon.get(&current_url).good();
+        calls += 1;
+        if calls > 200 {
+            panic!("potential infinite loop detected!");
+        }
+
+        if let Some(ref new_url) = resp.meta.next_page {
+            assert!(new_url.contains("seek="));
+            assert_that!(resp.versions, len(eq(1)));
+            url = Some(format!("{url_without_query}{}", new_url));
+            assert_ne!(resp.meta.total, 0)
+        } else {
+            assert_that!(resp.versions, empty());
+            assert_eq!(resp.meta.total, 0)
+        }
+        results.push(resp);
+    }
+    (results, calls)
 }

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__invalid_seek_parameter-2.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__invalid_seek_parameter-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/versions/list.rs
+expression: response.json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid seek parameter"
+    }
+  ]
+}

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__invalid_seek_parameter.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__invalid_seek_parameter.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/versions/list.rs
+expression: response.json()
+---
+{
+  "errors": [
+    {
+      "detail": "invalid seek parameter"
+    }
+  ]
+}


### PR DESCRIPTION
This PR is an improved implementation of #5302.
Add seek-based pagination support to versions endpoint with following:
- move versions to its own file
- To keep backward compatibility, paginate versions only if `per_page` is provided.
- Support `sort` query parameter to choose either sorting by `date` or `semver` .

For date sorting, we can perform sorting and pagination directly in the database. However, Heroku Postgres doesn't support the semver PG extension, so sorting and pagination for semver needs to be done on the app server.

Resolves #5292 