### PR TITLE
env: Remove obsolete `TEST` environment variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -79,17 +79,3 @@ export GH_CLIENT_SECRET=
 # Credentials for connecting to the Sentry error reporting service.
 # export SENTRY_DSN_API=
 export SENTRY_ENV_API=local
-
-# Credentials and bucket configuration used when running integration tests
-# against live S3 servers. These credentials aren't used when running the tests
-# normally: they are only used if new HTTP cassettes are being recorded into
-# `src/tests/http-data`. See `docs/BACKEND.md` for more information on how this
-# works.
-#
-# If you don't know if you need to set these environment variables, you don't.
-# export TEST_S3_BUCKET=crates-test
-# export TEST_S3_REGION=http://127.0.0.1:19000
-# export TEST_S3_INDEX_BUCKET=crates-index-test
-# export TEST_S3_INDEX_REGION=http://127.0.0.1:19000
-# export TEST_AWS_ACCESS_KEY=minio
-# export TEST_AWS_SECRET_KEY=miniominio


### PR DESCRIPTION
The HTTP recorder in our test suite is no longer a thing, so these environment variables are not used anymore.