### PR TITLE
team_repo: Query permission instead of team

### DIFF
--- a/src/team_repo.rs
+++ b/src/team_repo.rs
@@ -13,22 +13,19 @@ use reqwest::{Certificate, Client};
 #[automock]
 #[async_trait]
 pub trait TeamRepo {
-    async fn get_team(&self, name: &str) -> anyhow::Result<Team>;
+    async fn get_permission(&self, name: &str) -> anyhow::Result<Permission>;
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct Team {
-    pub name: String,
-    pub kind: String,
-    pub members: Vec<Member>,
+pub struct Permission {
+    pub people: Vec<Person>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct Member {
+pub struct Person {
     pub name: String,
     pub github: String,
     pub github_id: i32,
-    pub is_lead: bool,
 }
 
 pub struct TeamRepoImpl {
@@ -62,8 +59,8 @@ fn build_client() -> Client {
 
 #[async_trait]
 impl TeamRepo for TeamRepoImpl {
-    async fn get_team(&self, name: &str) -> anyhow::Result<Team> {
-        let url = format!("https://team-api.infra.rust-lang.org/v1/teams/{name}.json");
+    async fn get_permission(&self, name: &str) -> anyhow::Result<Permission> {
+        let url = format!("https://team-api.infra.rust-lang.org/v1/permissions/{name}.json");
         let response = self.client.get(url).send().await?.error_for_status()?;
         Ok(response.json().await?)
     }

--- a/src/worker/jobs/sync_admins.rs
+++ b/src/worker/jobs/sync_admins.rs
@@ -9,8 +9,8 @@ use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
-/// See <https://github.com/rust-lang/team/blob/master/teams/crates-io-admins.toml>.
-const TEAM_NAME: &str = "crates-io-admins";
+/// See <https://github.com/rust-lang/team/pull/1197>.
+const PERMISSION_NAME: &str = "crates_io_admin";
 
 #[derive(Serialize, Deserialize)]
 pub struct SyncAdmins;
@@ -23,7 +23,7 @@ impl BackgroundJob for SyncAdmins {
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
         info!("Syncing admins from rust-lang/team repo…");
 
-        let repo_admins = ctx.team_repo.get_team(TEAM_NAME).await?.members;
+        let repo_admins = ctx.team_repo.get_permission(PERMISSION_NAME).await?.people;
         let repo_admin_ids = repo_admins
             .iter()
             .map(|m| m.github_id)


### PR DESCRIPTION
Related:

- https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/team.20repo.20integration
- https://github.com/rust-lang/team/pull/1197
- https://github.com/rust-lang/team/pull/1290
- https://team-api.infra.rust-lang.org/v1/permissions/crates_io_admin.json