### PR TITLE
Re-introducing improve crates endpoint performance (#7941)

### DIFF
--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -350,6 +350,8 @@ where
         out.push_sql(") t LIMIT ");
         out.push_bind_param::<BigInt, _>(&self.options.per_page)?;
         if let Some(offset) = self.options.offset() {
+            // Injection safety: `offset()` returns `Option<i64>`, so this interpolation is constrained to known
+            // valid values and this is not vulnerable to user injection attacks.
             out.push_sql(format!(" OFFSET {offset}").as_str());
         }
         Ok(())

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -146,6 +146,18 @@ pub(crate) trait Paginate: Sized {
             options,
         }
     }
+
+    fn pages_pagination_with_count_query<C>(
+        self,
+        options: PaginationOptions,
+        count_query: C,
+    ) -> PaginatedQueryWithCountSubq<Self, C> {
+        PaginatedQueryWithCountSubq {
+            query: self,
+            count_query,
+            options,
+        }
+    }
 }
 
 impl<T> Paginate for T {}
@@ -301,6 +313,61 @@ pub(crate) fn encode_seek<S: Serialize>(params: S) -> AppResult<String> {
 pub(crate) fn decode_seek<D: for<'a> Deserialize<'a>>(seek: &str) -> anyhow::Result<D> {
     let decoded = serde_json::from_slice(&general_purpose::URL_SAFE_NO_PAD.decode(seek)?)?;
     Ok(decoded)
+}
+
+#[derive(Debug)]
+pub(crate) struct PaginatedQueryWithCountSubq<T, C> {
+    query: T,
+    count_query: C,
+    options: PaginationOptions,
+}
+
+impl<T, C> QueryId for PaginatedQueryWithCountSubq<T, C> {
+    const HAS_STATIC_QUERY_ID: bool = false;
+    type QueryId = ();
+}
+
+impl<
+        T: Query,
+        C: Query + QueryDsl + diesel::query_dsl::methods::SelectDsl<diesel::dsl::CountStar>,
+    > Query for PaginatedQueryWithCountSubq<T, C>
+{
+    type SqlType = (T::SqlType, BigInt);
+}
+
+impl<T, C, DB> RunQueryDsl<DB> for PaginatedQueryWithCountSubq<T, C> {}
+
+impl<T, C> QueryFragment<Pg> for PaginatedQueryWithCountSubq<T, C>
+where
+    T: QueryFragment<Pg>,
+    C: QueryFragment<Pg>,
+{
+    fn walk_ast<'b>(&'b self, mut out: AstPass<'_, 'b, Pg>) -> QueryResult<()> {
+        out.push_sql("SELECT *, (");
+        self.count_query.walk_ast(out.reborrow())?;
+        out.push_sql(") FROM (");
+        self.query.walk_ast(out.reborrow())?;
+        out.push_sql(") t LIMIT ");
+        out.push_bind_param::<BigInt, _>(&self.options.per_page)?;
+        if let Some(offset) = self.options.offset() {
+            out.push_sql(format!(" OFFSET {offset}").as_str());
+        }
+        Ok(())
+    }
+}
+
+impl<T, C> PaginatedQueryWithCountSubq<T, C> {
+    pub(crate) fn load<'a, U>(self, conn: &mut PgConnection) -> QueryResult<Paginated<U>>
+    where
+        Self: LoadQuery<'a, PgConnection, WithCount<U>>,
+    {
+        let options = self.options.clone();
+        let records_and_total = self.internal_load(conn)?.collect::<QueryResult<_>>()?;
+        Ok(Paginated {
+            records_and_total,
+            options,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -186,7 +186,10 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
 
             (total, next_page, None, results, conn)
         } else {
-            let query = query.pages_pagination(pagination);
+            let query = query.pages_pagination_with_count_query(
+                pagination,
+                filter_params.make_query(&req, conn)?.count(),
+            );
             let data: Paginated<(Crate, bool, Option<i64>)> =
                 info_span!("db.query", message = "SELECT ..., COUNT(*) FROM crates")
                     .in_scope(|| query.load(conn))?;

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -68,21 +68,53 @@ fn index_queries() {
     // Query containing a space
     assert_eq!(anon.search("q=foo%20kw3").meta.total, 1);
 
-    assert_eq!(anon.search_by_user_id(user.id).crates.len(), 4);
-    assert_eq!(anon.search_by_user_id(0).crates.len(), 0);
+    let json = anon.search_by_user_id(user.id);
+    assert_eq!(json.crates.len(), 4);
+    assert_eq!(json.meta.total, 4);
 
-    assert_eq!(anon.search("letter=F").crates.len(), 2);
-    assert_eq!(anon.search("letter=B").crates.len(), 1);
-    assert_eq!(anon.search("letter=b").crates.len(), 1);
-    assert_eq!(anon.search("letter=c").crates.len(), 0);
+    let json = anon.search_by_user_id(0);
+    assert_eq!(json.crates.len(), 0);
+    assert_eq!(json.meta.total, 0);
 
-    assert_eq!(anon.search("keyword=kw1").crates.len(), 3);
-    assert_eq!(anon.search("keyword=KW1").crates.len(), 3);
-    assert_eq!(anon.search("keyword=kw2").crates.len(), 0);
-    assert_eq!(anon.search("all_keywords=kw1%20kw3").crates.len(), 1);
+    let json = anon.search("letter=F");
+    assert_eq!(json.crates.len(), 2);
+    assert_eq!(json.meta.total, 2);
 
-    assert_eq!(anon.search("q=foo&keyword=kw1").crates.len(), 1);
-    assert_eq!(anon.search("q=foo2&keyword=kw1").crates.len(), 0);
+    let json = anon.search("letter=B");
+    assert_eq!(json.crates.len(), 1);
+    assert_eq!(json.meta.total, 1);
+
+    let json = anon.search("letter=b");
+    assert_eq!(json.crates.len(), 1);
+    assert_eq!(json.meta.total, 1);
+
+    let json = anon.search("letter=c");
+    assert_eq!(json.crates.len(), 0);
+    assert_eq!(json.meta.total, 0);
+
+    let json = anon.search("keyword=kw1");
+    assert_eq!(json.crates.len(), 3);
+    assert_eq!(json.meta.total, 3);
+
+    let json = anon.search("keyword=KW1");
+    assert_eq!(json.crates.len(), 3);
+    assert_eq!(json.meta.total, 3);
+
+    let json = anon.search("keyword=kw2");
+    assert_eq!(json.crates.len(), 0);
+    assert_eq!(json.meta.total, 0);
+
+    let json = anon.search("all_keywords=kw1%20kw3");
+    assert_eq!(json.crates.len(), 1);
+    assert_eq!(json.meta.total, 1);
+
+    let json = anon.search("q=foo&keyword=kw1");
+    assert_eq!(json.crates.len(), 1);
+    assert_eq!(json.meta.total, 1);
+
+    let json = anon.search("q=foo2&keyword=kw1");
+    assert_eq!(json.crates.len(), 0);
+    assert_eq!(json.meta.total, 0);
 
     app.db(|conn| {
         new_category("Category 1", "cat1", "Category 1 crates")
@@ -727,6 +759,10 @@ fn pagination_links_included_if_applicable() {
         Some("?letter=p&page=2&per_page=1".to_string()),
         page3.meta.prev_page
     );
+    assert!([page1.meta.total, page2.meta.total, page3.meta.total]
+        .iter()
+        .all(|w| *w == 3));
+    assert_eq!(page4.meta.total, 0);
 }
 
 #[test]
@@ -791,10 +827,12 @@ fn test_pages_work_even_with_seek_based_pagination() {
     // The next_page returned by the request is seek-based
     let first = anon.search("per_page=1");
     assert!(first.meta.next_page.unwrap().contains("seek="));
+    assert_eq!(first.meta.total, 3);
 
     // Calling with page=2 will revert to offset-based pagination
     let second = anon.search("page=2&per_page=1");
     assert!(second.meta.next_page.unwrap().contains("page=3"));
+    assert_eq!(second.meta.total, 3);
 }
 
 #[test]
@@ -844,6 +882,7 @@ fn crates_by_user_id() {
 
     let response = user.search_by_user_id(id);
     assert_eq!(response.crates.len(), 1);
+    assert_eq!(response.meta.total, 1);
 }
 
 #[test]
@@ -858,4 +897,5 @@ fn crates_by_user_id_not_including_deleted_owners() {
 
     let response = anon.search_by_user_id(user.id);
     assert_eq!(response.crates.len(), 0);
+    assert_eq!(response.meta.total, 0);
 }


### PR DESCRIPTION
This PR re-introduce #7941 and resolves #8052 by reverting the use of the `to_tsquery_with_search_config` for `TsQuery` part back to the original code.