### PR TITLE
worker/jobs/downloads/queue: Extract various functions

### DIFF
--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -111,11 +111,7 @@ async fn run(
                 continue;
             }
 
-            let jobs = message
-                .records
-                .into_iter()
-                .filter_map(job_from_record)
-                .collect::<Vec<_>>();
+            let jobs = jobs_from_message(message);
 
             let pool = connection_pool.clone();
             spawn_blocking({
@@ -129,6 +125,14 @@ async fn run(
     }
 
     Ok(())
+}
+
+fn jobs_from_message(message: super::message::Message) -> Vec<ProcessCdnLog> {
+    message
+        .records
+        .into_iter()
+        .filter_map(job_from_record)
+        .collect()
 }
 
 fn job_from_record(record: super::message::Record) -> Option<ProcessCdnLog> {


### PR DESCRIPTION
The previous implementation was basically a single big method on the `ProcessCdnLogQueue` struct. This PR changes the implementation to consist of multiple smaller functions, that make some of the logic a little easier to digest. Semantically, the code should still behave the same as before though.