### PR TITLE
worker/jobs/downloads/queue: Delete messages *after* processing them

### DIFF
--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -86,6 +86,9 @@ async fn run(
                 continue;
             };
 
+            process_message(message, connection_pool).await?;
+            debug!("Processed message: {message_id}");
+
             debug!("Deleting message {message_id} from the CDN log queue…");
             queue
                 .delete_message(receipt_handle)
@@ -93,9 +96,6 @@ async fn run(
                 .with_context(|| {
                     format!("Failed to delete message {message_id} from the CDN log queue")
                 })?;
-
-            process_message(message, connection_pool).await?;
-            debug!("Processed message: {message_id}");
         }
     }
 


### PR DESCRIPTION
Previously, if enqueuing the job failed, the message would have been deleted already and the log file would never be processed. With this new implementation if enqueuing the job fails, the message will not get deleted from the queue. The downside of this is that if deletion fails for some reason, we might enqueue the job multiple times. This could already happen though if the code is running concurrently and we will need to introduce a deduplication mechanism anyway.