### PR TITLE
codecov: Use `informational: true` for `patch` status too

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
     project:
       default:
         informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
This is similar to #7956, but for the `patch` commit status. The [documentation](https://docs.codecov.com/docs/commit-status#patch-status) is unclear whether this is actually supported, but some other projects on GitHub appear to be using it, so we might as well try 😅 