### PR TITLE
worker/jobs/downloads/queue: Skip `spawn_blocking()` call if there are no jobs to enqueue

### DIFF
--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -124,6 +124,9 @@ async fn process_message(message: &Message, connection_pool: &DieselPool) -> any
     }
 
     let jobs = jobs_from_message(message);
+    if jobs.is_empty() {
+        return Ok(());
+    }
 
     let pool = connection_pool.clone();
     spawn_blocking({


### PR DESCRIPTION
The `jobs_from_message()` can return an empty `Vec` if all of the records are skipped, e.g. if the paths are ignored. In that case we shouldn't call the `spawn_blocking()` fn to avoid the unnecessary thread "creation". In addition to that the `enqueue_jobs()` fn inside would also acquire a database connection to then use it to enqueue zero new background jobs, which is even more wasteful.