### PR TITLE
worker/jobs/downloads/queue: Improve `message_id` logging

### DIFF
--- a/src/sqs.rs
+++ b/src/sqs.rs
@@ -71,6 +71,17 @@ impl SqsQueue for SqsQueueImpl {
     }
 }
 
+#[async_trait]
+impl<T: SqsQueue + Send + Sync + ?Sized> SqsQueue for Box<T> {
+    async fn receive_messages(&self, max_messages: i32) -> anyhow::Result<ReceiveMessageOutput> {
+        (**self).receive_messages(max_messages).await
+    }
+
+    async fn delete_message(&self, receipt_handle: &str) -> anyhow::Result<()> {
+        (**self).delete_message(receipt_handle).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Instead of passing the `message_id` reference everywhere we can refactor the code a bit to add the message ID to a `tracing` span, which automatically adds it to all log messages within the scope of the span.