### PR TITLE
cdn_logs: Instrument `count_downloads()` fn

### DIFF
--- a/crates_io_cdn_logs/examples/count_downloads.rs
+++ b/crates_io_cdn_logs/examples/count_downloads.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use clap::Parser;
 use crates_io_cdn_logs::{count_downloads, Decompressor};
 use std::path::PathBuf;
-use std::time::SystemTime;
 use tokio::fs::File;
 use tokio::io::BufReader;
 use tracing::level_filters::LevelFilter;
@@ -32,7 +31,6 @@ async fn main() -> anyhow::Result<()> {
         .and_then(|ext| ext.to_str())
         .unwrap_or_default();
 
-    let start = SystemTime::now();
     let downloads = match extension {
         "gz" | "zst" => {
             let decompressor = Decompressor::from_extension(reader, Some(extension))?;
@@ -41,7 +39,6 @@ async fn main() -> anyhow::Result<()> {
         }
         _ => count_downloads(reader).await?,
     };
-    let duration = start.elapsed()?;
     println!("{downloads:?}");
     println!();
 
@@ -52,7 +49,6 @@ async fn main() -> anyhow::Result<()> {
     println!("Number of crates: {num_crates}");
     println!("Number of needed inserts: {total_inserts}");
     println!("Total number of downloads: {total_downloads}");
-    println!("Time to parse: {duration:?}");
 
     Ok(())
 }

--- a/crates_io_cdn_logs/src/lib.rs
+++ b/crates_io_cdn_logs/src/lib.rs
@@ -10,7 +10,9 @@ pub use crate::compression::Decompressor;
 pub use crate::download_map::DownloadsMap;
 use std::io::Cursor;
 use tokio::io::{AsyncBufRead, AsyncReadExt};
+use tracing::instrument;
 
+#[instrument(skip_all)]
 pub async fn count_downloads<R>(mut reader: R) -> anyhow::Result<DownloadsMap>
 where
     R: AsyncBufRead + Unpin,

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -9,7 +9,6 @@ use object_store::memory::InMemory;
 use object_store::ObjectStore;
 use std::cmp::Reverse;
 use std::sync::Arc;
-use std::time::Instant;
 use tokio::io::BufReader;
 
 /// A background job that loads a CDN log file from an object store (aka. S3),
@@ -95,9 +94,7 @@ impl ProcessCdnLog {
         let decompressor = Decompressor::from_extension(reader, path.extension())?;
         let reader = BufReader::new(decompressor);
 
-        let parse_start = Instant::now();
         let downloads = count_downloads(reader).await?;
-        let parse_duration = parse_start.elapsed();
 
         // TODO: for now this background job just prints out the results, but
         // eventually it should insert them into the database instead.
@@ -115,7 +112,6 @@ impl ProcessCdnLog {
         info!("Number of crates: {num_crates}");
         info!("Number of needed inserts: {total_inserts}");
         info!("Total number of downloads: {total_downloads}");
-        info!("Time to parse: {parse_duration:?}");
 
         let mut downloads = downloads.into_vec();
         downloads.sort_by_key(|(_, _, _, downloads)| Reverse(*downloads));


### PR DESCRIPTION
... instead of manually timing the execution time

Admittedly, we don't see the parse time in the logs anymore like this, but we have the performance instrumentation data for background jobs on Sentry, so we still get the same information that way.