### PR TITLE
worker/jobs/downloads/process_log: Use realistic path for tests

### DIFF
--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -138,7 +138,7 @@ mod tests {
     async fn test_process_cdn_log() {
         let _guard = crate::util::tracing::init_for_test();
 
-        let path = "cloudfront/index.staging.crates.io/E35K556QRQDZXW.2024-01-16-16.d01d5f13.gz";
+        let path = "cloudfront/static.crates.io/E35K556QRQDZXW.2024-01-16-16.d01d5f13.gz";
 
         let job = ProcessCdnLog::new(
             "us-west-1".to_string(),


### PR DESCRIPTION
`index.staging.crates.io` is usually filtered out... :D