### PR TITLE
Implement writing CDN log counted downloads to the database

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -36,6 +36,13 @@ pub struct Server {
     pub max_blocking_threads: Option<usize>,
     pub db: DatabasePools,
     pub storage: StorageConfig,
+    /// If `true`, disables download counting on the download API endpoint, and
+    /// enables writing download counts from the CDN logs to the database.
+    ///
+    /// If `false`, downloads will be counted on the download API endpoint and
+    /// the download counts from the CDN logs will only be reported in the
+    /// logs.
+    pub cdn_log_counting_enabled: bool,
     pub cdn_log_storage: CdnLogStorageConfig,
     pub cdn_log_queue: CdnLogQueueConfig,
     pub session_key: cookie::Key,
@@ -176,6 +183,7 @@ impl Server {
         Ok(Server {
             db: DatabasePools::full_from_environment(&base)?,
             storage,
+            cdn_log_counting_enabled: var("CDN_LOG_COUNTING_ENABLED")?.is_some(),
             cdn_log_storage: CdnLogStorageConfig::from_env()?,
             cdn_log_queue: CdnLogQueueConfig::from_env()?,
             base,

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -33,9 +33,11 @@ pub async fn download(
     if let Some(version_id) = cache_result {
         app.instance_metrics.version_id_cache_hits.inc();
 
-        // The increment does not happen instantly, but it's deferred to be executed in a batch
-        // along with other downloads. See crate::downloads_counter for the implementation.
-        app.downloads_counter.increment(version_id);
+        if !app.config.cdn_log_counting_enabled {
+            // The increment does not happen instantly, but it's deferred to be executed in a batch
+            // along with other downloads. See crate::downloads_counter for the implementation.
+            app.downloads_counter.increment(version_id);
+        }
     } else {
         app.instance_metrics.version_id_cache_misses.inc();
 
@@ -67,9 +69,11 @@ pub async fn download(
                         get_version_id(&crate_name, &version, &mut conn)
                     })?;
 
-                    // The increment does not happen instantly, but it's deferred to be executed in a batch
-                    // along with other downloads. See crate::downloads_counter for the implementation.
-                    app.downloads_counter.increment(version_id);
+                    if !app.config.cdn_log_counting_enabled {
+                        // The increment does not happen instantly, but it's deferred to be executed in a batch
+                        // along with other downloads. See crate::downloads_counter for the implementation.
+                        app.downloads_counter.increment(version_id);
+                    }
 
                     Ok(Some(version_id))
                 } else {

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -425,6 +425,7 @@ fn simple_config() -> config::Server {
         max_blocking_threads: None,
         db,
         storage,
+        cdn_log_counting_enabled: false,
         cdn_log_queue: CdnLogQueueConfig::Mock,
         cdn_log_storage: CdnLogStorageConfig::memory(),
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -160,15 +160,7 @@ mod tests {
 
         let path = "cloudfront/static.crates.io/E35K556QRQDZXW.2024-01-16-16.d01d5f13.gz";
 
-        let store = Arc::new(InMemory::new());
-
-        // Add dummy data into the store
-        {
-            let bytes =
-                include_bytes!("../../../../crates_io_cdn_logs/test_data/cloudfront/basic.log.gz");
-
-            store.put(&path.into(), bytes[..].into()).await.unwrap();
-        }
+        let store = build_dummy_store().await;
 
         assert_ok!(run(path, store).await);
     }
@@ -192,5 +184,19 @@ mod tests {
     fn test_build_store_memory() {
         let config = CdnLogStorageConfig::memory();
         assert_ok!(build_store(&config, "us-west-1", "bucket"));
+    }
+
+    /// Builds a dummy object store with a log file in it.
+    async fn build_dummy_store() -> Arc<dyn ObjectStore> {
+        let store = InMemory::new();
+
+        // Add dummy data to the store
+        let path = CLOUDFRONT_PATH.into();
+        let bytes =
+            include_bytes!("../../../../crates_io_cdn_logs/test_data/cloudfront/basic.log.gz");
+
+        store.put(&path, bytes[..].into()).await.unwrap();
+
+        Arc::new(store)
     }
 }

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -1,13 +1,19 @@
 use crate::config::CdnLogStorageConfig;
+use crate::db::DieselPool;
+use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use anyhow::Context;
+use chrono::NaiveDate;
 use crates_io_cdn_logs::{count_downloads, Decompressor, DownloadsMap};
 use crates_io_worker::BackgroundJob;
+use diesel::prelude::*;
+use diesel::{PgConnection, QueryResult};
 use object_store::aws::AmazonS3Builder;
 use object_store::local::LocalFileSystem;
 use object_store::memory::InMemory;
 use object_store::path::Path;
 use object_store::ObjectStore;
+use semver::Version;
 use std::cmp::Reverse;
 use std::sync::Arc;
 use tokio::io::BufReader;
@@ -44,7 +50,9 @@ impl BackgroundJob for ProcessCdnLog {
         let store = build_store(&ctx.config.cdn_log_storage, &self.region, &self.bucket)
             .context("Failed to build object store")?;
 
-        run(&self.path, store).await
+        let db_pool = ctx.connection_pool.clone();
+        let writing_enabled = ctx.config.cdn_log_counting_enabled;
+        run(store, &self.path, db_pool, writing_enabled).await
     }
 }
 
@@ -88,22 +96,33 @@ fn build_store(
 /// it can be tested without having to construct a full [`Environment`]
 /// struct.
 #[instrument(skip_all, fields(cdn_log_store.path = %path))]
-async fn run(path: &str, store: Arc<dyn ObjectStore>) -> anyhow::Result<()> {
+async fn run(
+    store: Arc<dyn ObjectStore>,
+    path: &str,
+    db_pool: DieselPool,
+    writing_enabled: bool,
+) -> anyhow::Result<()> {
     let path = Path::parse(path).with_context(|| format!("Failed to parse path: {path:?}"))?;
 
     let downloads = load_and_count(&path, store).await?;
-
-    // TODO: for now this background job just prints out the results, but
-    // if `config.cdn_log_counting_enabled` is set it should insert them into
-    // the database instead.
-
     if downloads.is_empty() {
         info!("No downloads found in log file");
         return Ok(());
     }
 
     log_stats(&downloads);
-    log_top_downloads(downloads, 30);
+
+    if writing_enabled {
+        spawn_blocking(move || {
+            let mut conn = db_pool.get()?;
+            conn.transaction(|conn| save_downloads(downloads, conn))?;
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .await?;
+    } else {
+        log_top_downloads(downloads, 30);
+    }
 
     Ok(())
 }
@@ -150,19 +169,176 @@ fn log_top_downloads(downloads: DownloadsMap, num: usize) {
     info!("Top {num} downloads: {top_downloads:?}");
 }
 
+table! {
+    /// Diesel table definition for the temporary `temp_downloads` table that is
+    /// created by the [`create_temp_downloads_table`] function.
+    ///
+    /// The primary key does not actually exist, but specifying one is
+    /// required by Diesel.
+    temp_downloads (name, version, date) {
+        name -> Text,
+        version -> Text,
+        date -> Date,
+        downloads -> BigInt,
+    }
+}
+
+/// Helper struct for inserting downloads into the `temp_downloads` table.
+#[derive(Insertable)]
+#[diesel(table_name = temp_downloads)]
+struct NewDownload {
+    name: String,
+    version: String,
+    date: NaiveDate,
+    downloads: i64,
+}
+
+impl From<(String, Version, NaiveDate, u64)> for NewDownload {
+    fn from((name, version, date, downloads): (String, Version, NaiveDate, u64)) -> Self {
+        Self {
+            name,
+            version: version.to_string(),
+            date,
+            downloads: downloads as i64,
+        }
+    }
+}
+
+/// Saves the downloads from the given [`DownloadsMap`] to the database into
+/// the `version_downloads` table.
+///
+/// This function **should be run inside a transaction** to ensure that the
+/// temporary `temp_downloads` table is dropped after the inserts are
+/// completed!
+///
+/// The temporary table only exists on the current connection, but if a
+/// connection pool is used, the temporary table will not be dropped when
+/// the connection is returned to the pool.
+pub fn save_downloads(downloads: DownloadsMap, conn: &mut PgConnection) -> anyhow::Result<()> {
+    debug!("Creating temp_downloads table");
+    create_temp_downloads_table(conn).context("Failed to create temp_downloads table")?;
+
+    debug!("Saving counted downloads to temp_downloads table");
+    fill_temp_downloads_table(downloads, conn).context("Failed to fill temp_downloads table")?;
+
+    debug!("Saving temp_downloads to version_downloads table");
+    save_to_version_downloads(conn)
+        .context("Failed to save temp_downloads to version_downloads table")?;
+
+    Ok(())
+}
+
+/// Creates the temporary `temp_downloads` table that is used to store the
+/// counted downloads before they are inserted into the `version_downloads`
+/// table.
+///
+/// We can't insert directly into `version_downloads` table because we need to
+/// look up the `version_id` for each crate and version combination, and that
+/// requires a join with the `crates` and `versions` tables.
+#[instrument("db.query", skip_all, fields(message = "CREATE TEMPORARY TABLE ..."))]
+fn create_temp_downloads_table(conn: &mut PgConnection) -> QueryResult<usize> {
+    diesel::sql_query(
+        r#"
+            CREATE TEMPORARY TABLE temp_downloads (
+                name VARCHAR NOT NULL,
+                version VARCHAR NOT NULL,
+                date DATE NOT NULL,
+                downloads INTEGER NOT NULL
+            ) ON COMMIT DROP;
+        "#,
+    )
+    .execute(conn)
+}
+
+/// Fills the temporary `temp_downloads` table with the downloads from the
+/// given [`DownloadsMap`].
+#[instrument(
+    "db.query",
+    skip_all,
+    fields(message = "INSERT INTO temp_downloads ...")
+)]
+fn fill_temp_downloads_table(
+    downloads: DownloadsMap,
+    conn: &mut PgConnection,
+) -> QueryResult<usize> {
+    let map = downloads
+        .into_vec()
+        .into_iter()
+        .map(NewDownload::from)
+        .collect::<Vec<_>>();
+
+    diesel::insert_into(temp_downloads::table)
+        .values(map)
+        .execute(conn)
+}
+
+/// Saves the downloads from the temporary `temp_downloads` table to the
+/// `version_downloads` table.
+#[instrument(
+    "db.query",
+    skip_all,
+    fields(message = "INSERT INTO version_downloads ...")
+)]
+fn save_to_version_downloads(conn: &mut PgConnection) -> QueryResult<usize> {
+    diesel::sql_query(
+        r#"
+            INSERT INTO version_downloads (version_id, date, downloads)
+            SELECT versions.id, temp_downloads.date, temp_downloads.downloads FROM temp_downloads
+                INNER JOIN crates ON crates.name = temp_downloads.name
+                INNER JOIN versions ON versions.num = temp_downloads.version
+                       AND versions.crate_id = crates.id
+            ON CONFLICT (version_id, date) DO UPDATE SET downloads = version_downloads.downloads + EXCLUDED.downloads;
+        "#,
+    )
+        .execute(conn)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::schema::{crates, version_downloads, versions};
+    use crates_io_test_db::TestDatabase;
+    use diesel::r2d2::{ConnectionManager, Pool};
+    use insta::assert_debug_snapshot;
+
+    const CLOUDFRONT_PATH: &str =
+        "cloudfront/static.crates.io/E35K556QRQDZXW.2024-01-16-16.d01d5f13.gz";
 
     #[tokio::test]
     async fn test_process_cdn_log() {
         let _guard = crate::util::tracing::init_for_test();
 
-        let path = "cloudfront/static.crates.io/E35K556QRQDZXW.2024-01-16-16.d01d5f13.gz";
+        let test_database = TestDatabase::new();
+        let db_pool = build_connection_pool(test_database.url());
+        create_dummy_crates_and_versions(db_pool.clone()).await;
 
         let store = build_dummy_store().await;
 
-        assert_ok!(run(path, store).await);
+        let writing_enabled = true;
+        assert_ok!(run(store, CLOUDFRONT_PATH, db_pool.clone(), writing_enabled).await);
+        assert_debug_snapshot!(all_version_downloads(db_pool).await, @r###"
+        [
+            "bindgen | 0.65.1 | 1 | 0 | 2024-01-16 | false",
+            "quick-error | 1.2.3 | 2 | 0 | 2024-01-16 | false",
+            "quick-error | 1.2.3 | 1 | 0 | 2024-01-17 | false",
+            "tracing-core | 0.1.32 | 1 | 0 | 2024-01-16 | false",
+        ]
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_process_cdn_log_report_only() {
+        let _guard = crate::util::tracing::init_for_test();
+
+        let test_database = TestDatabase::new();
+        let db_pool = build_connection_pool(test_database.url());
+        create_dummy_crates_and_versions(db_pool.clone()).await;
+
+        let store = build_dummy_store().await;
+
+        let writing_enabled = false;
+        assert_ok!(run(store, CLOUDFRONT_PATH, db_pool.clone(), writing_enabled).await);
+        assert_debug_snapshot!(all_version_downloads(db_pool).await, @"[]");
     }
 
     #[test]
@@ -198,5 +374,83 @@ mod tests {
         store.put(&path, bytes[..].into()).await.unwrap();
 
         Arc::new(store)
+    }
+
+    /// Builds a connection pool to the test database.
+    fn build_connection_pool(url: &str) -> DieselPool {
+        let pool = Pool::builder().build(ConnectionManager::new(url)).unwrap();
+        DieselPool::new_background_worker(pool)
+    }
+
+    /// Inserts some dummy crates and versions into the database.
+    async fn create_dummy_crates_and_versions(db_pool: DieselPool) {
+        spawn_blocking(move || {
+            let mut conn = db_pool.get().unwrap();
+
+            create_crate_and_version("bindgen", "0.65.1", &mut conn);
+            create_crate_and_version("tracing-core", "0.1.32", &mut conn);
+            create_crate_and_version("quick-error", "1.2.3", &mut conn);
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+        .unwrap();
+    }
+
+    /// Inserts a dummy crate and version into the database.
+    fn create_crate_and_version(name: &str, version: &str, conn: &mut PgConnection) {
+        let crate_id: i32 = diesel::insert_into(crates::table)
+            .values(crates::name.eq(name))
+            .returning(crates::id)
+            .get_result(conn)
+            .unwrap();
+
+        diesel::insert_into(versions::table)
+            .values((
+                versions::crate_id.eq(crate_id),
+                versions::num.eq(version),
+                versions::checksum.eq("checksum"),
+            ))
+            .execute(conn)
+            .unwrap();
+    }
+
+    /// Queries all version downloads from the database and returns them as a
+    /// [`Vec`] of strings for use with [`assert_debug_snapshot!()`].
+    async fn all_version_downloads(db_pool: DieselPool) -> Vec<String> {
+        let downloads = spawn_blocking(move || {
+            let mut conn = db_pool.get().unwrap();
+            Ok::<_, anyhow::Error>(query_all_version_downloads(&mut conn))
+        })
+        .await
+        .unwrap();
+
+        downloads
+            .into_iter()
+            .map(|(name, version, downloads, counted, date, processed)| {
+                format!("{name} | {version} | {downloads} | {counted} | {date} | {processed}")
+            })
+            .collect()
+    }
+
+    /// Queries all version downloads from the database and returns them as a
+    /// [`Vec`] of tuples.
+    fn query_all_version_downloads(
+        conn: &mut PgConnection,
+    ) -> Vec<(String, String, i32, i32, NaiveDate, bool)> {
+        version_downloads::table
+            .inner_join(versions::table)
+            .inner_join(crates::table.on(versions::crate_id.eq(crates::id)))
+            .select((
+                crates::name,
+                versions::num,
+                version_downloads::downloads,
+                version_downloads::counted,
+                version_downloads::date,
+                version_downloads::processed,
+            ))
+            .order((crates::name, versions::num, version_downloads::date))
+            .load(conn)
+            .unwrap()
     }
 }

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -94,7 +94,8 @@ async fn run(path: &str, store: Arc<dyn ObjectStore>) -> anyhow::Result<()> {
     let downloads = load_and_count(&path, store).await?;
 
     // TODO: for now this background job just prints out the results, but
-    // eventually it should insert them into the database instead.
+    // if `config.cdn_log_counting_enabled` is set it should insert them into
+    // the database instead.
 
     if downloads.is_empty() {
         info!("No downloads found in log file");


### PR DESCRIPTION
This PR resolves the `TODO` comment in the `ProcessCdnLog` background job by implementing the database writing part of the job.

The writing behavior is enabled by a new `CDN_LOG_COUNTING_ENABLED` feature flag. If this flag is set, regular download counting on the download endpoint is disabled and the writing behavior of background job is enabled.

Writing the downloads to the database is a three step process. First, a new temporary database table will be created. Then we insert the content of the `DownloadMap` into this temporary table. Finally, we use the temporary table to insert data into the `version_downloads` table. This multi-step process is needed because we only have the name and version of the downloaded crate, but not the corresponding `version_id` and looking them up one-by-one would be quite slow. The third step uses a couple of joins to figure out the right `version_id` from the crate name and version columns from that temporary table instead.

Note the this does not implement the deduplication of log files yet. #8081 has been put into draft mode for now, since its implementation will be significantly easier to test once the database writing in this PR is implemented.