### PR TITLE
Move `process_cdn_log` background job to a dedicated worker queue

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -109,6 +109,7 @@ fn main() -> anyhow::Result<()> {
 
     let runner = Runner::new(runtime.handle(), connection_pool, environment.clone())
         .configure_default_queue(|queue| queue.num_workers(5))
+        .configure_queue("downloads", |queue| queue.num_workers(1))
         .configure_queue("repository", |queue| queue.num_workers(1))
         .register_crates_io_job_types()
         .start();

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -42,6 +42,7 @@ impl ProcessCdnLog {
 
 impl BackgroundJob for ProcessCdnLog {
     const JOB_NAME: &'static str = "process_cdn_log";
+    const QUEUE: &'static str = "downloads";
 
     type Context = Arc<Environment>;
 


### PR DESCRIPTION
Running multiple instances of `save_to_version_downloads()` in parallel appears to be causing issues and job retries. This change moves the corresponding background job to a dedicated worker queue with only a single worker. This should prevent these jobs from running in parallel, similar to how we don't run any jobs in parallel that touch the git index repository.