### PR TITLE
components/download-graph: Fix `beginAtZero` behavior

### DIFF
--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -39,7 +39,7 @@ export default class DownloadGraph extends Component {
             time: { tooltipFormat: 'MMM d', unit: 'day' },
             ticks: { maxTicksLimit: 13 },
           },
-          y: { stacked: true, ticks: { min: 0, precision: 0 } },
+          y: { beginAtZero: true, stacked: true, ticks: { precision: 0 } },
         },
         interaction: {
           mode: 'index',


### PR DESCRIPTION
It looks like the corresponding option has been moved at some point (https://www.chartjs.org/docs/latest/migration/v3-migration.html#specific-changes) and we didn't notice that it wasn't quite working as intended anymore...

Resolves #8118 