### PR TITLE
worker: Improve job failure error logging

### DIFF
--- a/crates_io_worker/src/worker.rs
+++ b/crates_io_worker/src/worker.rs
@@ -39,7 +39,8 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
                     sleep(self.poll_interval).await;
                 }
                 Err(error) => {
-                    error!(%error, "Failed to run job");
+                    let error = format!("{error:#}");
+                    error!(error, "Failed to run job");
                     sleep(self.poll_interval).await;
                 }
             }
@@ -94,7 +95,8 @@ impl<Context: Clone + Send + Sync + 'static> Worker<Context> {
                         storage::delete_successful_job(conn, job_id)?
                     }
                     Err(error) => {
-                        warn!(%error, "Failed to run job");
+                        let error = format!("{error:#}");
+                        warn!(error, "Failed to run job");
                         storage::update_failed_job(conn, job_id);
                     }
                 }


### PR DESCRIPTION
[`anyhow` by default only returns the top-most error](https://github.com/dtolnay/anyhow/issues/111) when formatted via `Display`. The alternate formatting (`:#`) instructs it to return the full error chain instead. Unfortunately [`tracing` does not support alternate formatting yet](https://github.com/tokio-rs/tracing/issues/1311), so we have to call `format!()` manually.