### PR TITLE
downloads: Avoid `spawn_blocking()` and database query if `cdn_log_counting_enabled` is set

### DIFF
--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -22,97 +22,95 @@ pub async fn download(
 ) -> AppResult<Response> {
     let wants_json = req.wants_json();
 
-    let cache_key = (crate_name.to_string(), version.to_string());
+    if !app.config.cdn_log_counting_enabled {
+        let cache_key = (crate_name.to_string(), version.to_string());
 
-    let cache_result = app
-        .version_id_cacher
-        .get(&cache_key)
-        .instrument(info_span!("cache.read", ?cache_key))
-        .await;
+        let cache_result = app
+            .version_id_cacher
+            .get(&cache_key)
+            .instrument(info_span!("cache.read", ?cache_key))
+            .await;
 
-    if let Some(version_id) = cache_result {
-        app.instance_metrics.version_id_cache_hits.inc();
+        if let Some(version_id) = cache_result {
+            app.instance_metrics.version_id_cache_hits.inc();
 
-        if !app.config.cdn_log_counting_enabled {
             // The increment does not happen instantly, but it's deferred to be executed in a batch
             // along with other downloads. See crate::downloads_counter for the implementation.
             app.downloads_counter.increment(version_id);
-        }
-    } else {
-        app.instance_metrics.version_id_cache_misses.inc();
+        } else {
+            app.instance_metrics.version_id_cache_misses.inc();
 
-        let version_id = spawn_blocking::<_, _, BoxedAppError>({
-            let app = app.clone();
-            let crate_name = crate_name.clone();
-            let version = version.clone();
+            let version_id = spawn_blocking::<_, _, BoxedAppError>({
+                let app = app.clone();
+                let crate_name = crate_name.clone();
+                let version = version.clone();
 
-            move || {
-                // When no database connection is ready unconditional redirects will be performed. This could
-                // happen if the pool is not healthy or if an operator manually configured the application to
-                // always perform unconditional redirects (for example as part of the mitigations for an
-                // outage). See the comments below for a description of what unconditional redirects do.
-                let conn = if app.config.force_unconditional_redirects {
-                    None
-                } else {
-                    match app.db_read_prefer_primary() {
-                        Ok(conn) => Some(conn),
-                        Err(PoolError::UnhealthyPool) => None,
-                        Err(err) => return Err(err.into()),
-                    }
-                };
+                move || {
+                    // When no database connection is ready unconditional redirects will be performed. This could
+                    // happen if the pool is not healthy or if an operator manually configured the application to
+                    // always perform unconditional redirects (for example as part of the mitigations for an
+                    // outage). See the comments below for a description of what unconditional redirects do.
+                    let conn = if app.config.force_unconditional_redirects {
+                        None
+                    } else {
+                        match app.db_read_prefer_primary() {
+                            Ok(conn) => Some(conn),
+                            Err(PoolError::UnhealthyPool) => None,
+                            Err(err) => return Err(err.into()),
+                        }
+                    };
 
-                if let Some(mut conn) = conn {
-                    // Returns the crate name as stored in the database, or an error if we could
-                    // not load the version ID from the database.
-                    let metric = &app.instance_metrics.downloads_select_query_execution_time;
-                    let version_id = metric.observe_closure_duration(|| {
-                        get_version_id(&crate_name, &version, &mut conn)
-                    })?;
+                    if let Some(mut conn) = conn {
+                        // Returns the crate name as stored in the database, or an error if we could
+                        // not load the version ID from the database.
+                        let metric = &app.instance_metrics.downloads_select_query_execution_time;
+                        let version_id = metric.observe_closure_duration(|| {
+                            get_version_id(&crate_name, &version, &mut conn)
+                        })?;
 
-                    if !app.config.cdn_log_counting_enabled {
                         // The increment does not happen instantly, but it's deferred to be executed in a batch
                         // along with other downloads. See crate::downloads_counter for the implementation.
                         app.downloads_counter.increment(version_id);
+
+                        Ok(Some(version_id))
+                    } else {
+                        // The download endpoint is the most critical route in the whole crates.io application,
+                        // as it's relied upon by users and automations to download crates. Keeping it working
+                        // is the most important thing for us.
+                        //
+                        // The endpoint relies on the database to fetch the canonical crate name (with the
+                        // right capitalization and hyphenation), but that's only needed to serve clients who
+                        // don't call the endpoint with the crate's canonical name.
+                        //
+                        // Thankfully Cargo always uses the right name when calling the endpoint, and we can
+                        // keep it working during a full database outage by unconditionally redirecting without
+                        // checking whether the crate exists or the right name is used. Non-Cargo clients might
+                        // get a 404 response instead of a 500, but that's worth it.
+                        //
+                        // Without a working database we also can't count downloads, but that's also less
+                        // critical than keeping Cargo downloads operational.
+
+                        app.instance_metrics
+                            .downloads_unconditional_redirects_total
+                            .inc();
+
+                        req.request_log().add("unconditional_redirect", "true");
+
+                        Ok(None)
                     }
-
-                    Ok(Some(version_id))
-                } else {
-                    // The download endpoint is the most critical route in the whole crates.io application,
-                    // as it's relied upon by users and automations to download crates. Keeping it working
-                    // is the most important thing for us.
-                    //
-                    // The endpoint relies on the database to fetch the canonical crate name (with the
-                    // right capitalization and hyphenation), but that's only needed to serve clients who
-                    // don't call the endpoint with the crate's canonical name.
-                    //
-                    // Thankfully Cargo always uses the right name when calling the endpoint, and we can
-                    // keep it working during a full database outage by unconditionally redirecting without
-                    // checking whether the crate exists or the right name is used. Non-Cargo clients might
-                    // get a 404 response instead of a 500, but that's worth it.
-                    //
-                    // Without a working database we also can't count downloads, but that's also less
-                    // critical than keeping Cargo downloads operational.
-
-                    app.instance_metrics
-                        .downloads_unconditional_redirects_total
-                        .inc();
-
-                    req.request_log().add("unconditional_redirect", "true");
-
-                    Ok(None)
                 }
-            }
-        })
-        .await?;
+            })
+            .await?;
 
-        if let Some(version_id) = version_id {
-            let span = info_span!("cache.write", ?cache_key);
-            app.version_id_cacher
-                .insert(cache_key, version_id)
-                .instrument(span)
-                .await;
-        }
-    };
+            if let Some(version_id) = version_id {
+                let span = info_span!("cache.write", ?cache_key);
+                app.version_id_cacher
+                    .insert(cache_key, version_id)
+                    .instrument(span)
+                    .await;
+            }
+        };
+    }
 
     let redirect_url = app.storage.crate_location(&crate_name, &version);
     if wants_json {


### PR DESCRIPTION
Previously, we were just not calling `downloads_counter.increment()` if the feature flag is enabled. This commit changes the code to not perform the `version_id` database query, not get a database connection from the pool, and not get a blocking thread from tokio via `spawn_blocking()`. This should speed up the download endpoint, and make it resilient against database issues.

Best reviewed in ignore-whitespace mode 😉 