### PR TITLE
worker/jobs/downloads/update_metadata: Implement optional batch processing

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -45,6 +45,9 @@ pub struct Server {
     pub cdn_log_counting_enabled: bool,
     pub cdn_log_storage: CdnLogStorageConfig,
     pub cdn_log_queue: CdnLogQueueConfig,
+    /// If `true`, the `update_downloads` background job will use batch
+    /// processing with a static SQL query.
+    pub batch_update_downloads: bool,
     pub session_key: cookie::Key,
     pub gh_client_id: ClientId,
     pub gh_client_secret: ClientSecret,
@@ -191,6 +194,7 @@ impl Server {
             cdn_log_counting_enabled: var("CDN_LOG_COUNTING_ENABLED")?.is_some(),
             cdn_log_storage: CdnLogStorageConfig::from_env()?,
             cdn_log_queue: CdnLogQueueConfig::from_env()?,
+            batch_update_downloads: var("BATCH_UPDATE_DOWNLOADS")?.is_some(),
             base,
             ip,
             port,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -428,6 +428,7 @@ fn simple_config() -> config::Server {
         cdn_log_counting_enabled: false,
         cdn_log_queue: CdnLogQueueConfig::Mock,
         cdn_log_storage: CdnLogStorageConfig::memory(),
+        batch_update_downloads: true,
         session_key: cookie::Key::derive_from("test this has to be over 32 bytes long".as_bytes()),
         gh_client_id: ClientId::new(dotenvy::var("GH_CLIENT_ID").unwrap_or_default()),
         gh_client_secret: ClientSecret::new(dotenvy::var("GH_CLIENT_SECRET").unwrap_or_default()),

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -5,6 +5,7 @@ use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateDownloads;
@@ -17,24 +18,52 @@ impl BackgroundJob for UpdateDownloads {
     async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         spawn_blocking(move || {
             let mut conn = env.connection_pool.get()?;
-            update(&mut conn)?;
+            update(&mut conn, env.config.batch_update_downloads)?;
             Ok(())
         })
         .await
     }
 }
 
-fn update(conn: &mut PgConnection) -> QueryResult<()> {
+fn update(conn: &mut PgConnection, use_batch_update: bool) -> QueryResult<()> {
     use diesel::dsl::now;
     use diesel::select;
 
-    let rows = version_downloads::table
-        .filter(version_downloads::processed.eq(false))
-        .filter(version_downloads::downloads.ne(version_downloads::counted))
-        .load(conn)?;
+    if use_batch_update {
+        info!("Updating versions…");
 
-    info!(rows = rows.len(), "Updating versions");
-    collect(conn, &rows)?;
+        // After 45 minutes, we stop the batch updating process to avoid
+        // triggering the long-running job alert. 15 minutes later, the job
+        // will be started again by our cron service anyway.
+        const TIME_LIMIT: Duration = Duration::from_secs(45 * 60);
+
+        // We update the `downloads` columns in batches to a) avoid the
+        // back and forth between the application and the database and b) avoid
+        // holding locks on any of the involved tables for too long.
+        const BATCH_SIZE: i64 = 5_000;
+
+        let start_time = Instant::now();
+        loop {
+            let update_count = batch_update(BATCH_SIZE, conn)?;
+            info!("Updated {update_count} versions");
+            if update_count < BATCH_SIZE {
+                break;
+            }
+
+            if start_time.elapsed() > TIME_LIMIT {
+                info!("Time limit reached, stopping batch update");
+                break;
+            }
+        }
+    } else {
+        let rows = version_downloads::table
+            .filter(version_downloads::processed.eq(false))
+            .filter(version_downloads::downloads.ne(version_downloads::counted))
+            .load(conn)?;
+
+        info!(rows = rows.len(), "Updating versions");
+        collect(conn, &rows)?;
+    }
     info!("Finished updating versions");
 
     // Anything older than 24 hours ago will be frozen and will not be queried
@@ -52,6 +81,83 @@ fn update(conn: &mut PgConnection) -> QueryResult<()> {
     info!("Finished running refresh_recent_crate_downloads");
 
     Ok(())
+}
+
+fn batch_update(batch_size: i64, conn: &mut PgConnection) -> QueryResult<i64> {
+    table! {
+        /// Imaginary table to make Diesel happy when using the `sql_query` function.
+        sql_query_results (count) {
+            count -> BigInt,
+        }
+    }
+
+    /// A helper struct for the result of the query.
+    ///
+    /// The result of `sql_query` can not be a tuple, so we have to define a
+    /// proper struct for the result.
+    #[derive(QueryableByName)]
+    struct SqlQueryResult {
+        count: i64,
+    }
+
+    let query = format!(
+        r#"
+            WITH downloads_batch AS (
+                -- Select a batch of downloads (incl. `crate_id`) that have not been
+                -- counted yet.
+                SELECT crate_id, version_id, date, version_downloads.downloads - counted AS downloads
+                FROM version_downloads
+                INNER JOIN versions ON versions.id = version_id
+                WHERE NOT processed AND version_downloads.downloads != counted
+                LIMIT {batch_size}
+            ), version_downloads_batch AS (
+                -- Group the downloads by `version_id` and sum them up for the
+                -- `updated_versions` CTE.
+                SELECT version_id, SUM(downloads_batch.downloads) as downloads
+                FROM downloads_batch
+                GROUP BY version_id
+            ), updated_versions AS (
+                -- Update the `downloads` count for each version.
+                UPDATE versions
+                SET downloads = versions.downloads + version_downloads_batch.downloads
+                FROM version_downloads_batch
+                WHERE versions.id = version_downloads_batch.version_id
+            ), crate_downloads_batch AS (
+                -- Group the downloads by `crate_id` and sum them up for the
+                -- `updated_crates` CTE.
+                SELECT crate_id, SUM(downloads_batch.downloads) as downloads
+                FROM downloads_batch
+                GROUP BY crate_id
+            ), updated_crates AS (
+                -- Update the `downloads` count for each crate.
+                UPDATE crates
+                SET downloads = crates.downloads + crate_downloads_batch.downloads
+                FROM crate_downloads_batch
+                WHERE crates.id = crate_downloads_batch.crate_id
+            ), updated_metadata AS (
+                -- Update the `total_downloads` count in the `metadata` table.
+                UPDATE metadata
+                SET total_downloads = metadata.total_downloads + sum.downloads
+                FROM (
+                    SELECT COALESCE(SUM(downloads), 0) as downloads
+                    FROM downloads_batch
+                ) sum
+                WHERE sum.downloads > 0
+            ), updated_version_downloads AS (
+                -- Update the `counted` value for each version in the batch.
+                UPDATE version_downloads
+                SET counted = version_downloads.counted + downloads_batch.downloads
+                FROM downloads_batch
+                WHERE version_downloads.version_id = downloads_batch.version_id AND version_downloads.date = downloads_batch.date
+            )
+            -- Return the number of rows in the `downloads_batch` CTE to determine whether
+            -- there are more rows to process.
+            SELECT COUNT(*) AS count FROM downloads_batch
+        "#,
+    );
+
+    let result = diesel::sql_query(query).get_result::<SqlQueryResult>(conn)?;
+    Ok(result.count)
 }
 
 fn collect(conn: &mut PgConnection, rows: &[VersionDownload]) -> QueryResult<()> {
@@ -148,7 +254,7 @@ mod test {
             .execute(conn)
             .unwrap();
 
-        super::update(conn).unwrap();
+        super::update(conn, false).unwrap();
         let version_downloads = versions::table
             .find(version.id)
             .select(versions::downloads)
@@ -159,7 +265,7 @@ mod test {
             .select(crates::downloads)
             .first(conn);
         assert_eq!(crate_downloads, Ok(1));
-        super::update(conn).unwrap();
+        super::update(conn, false).unwrap();
         let version_downloads = versions::table
             .find(version.id)
             .select(versions::downloads)
@@ -184,7 +290,7 @@ mod test {
             ))
             .execute(conn)
             .unwrap();
-        super::update(conn).unwrap();
+        super::update(conn, false).unwrap();
         let processed = version_downloads::table
             .filter(version_downloads::version_id.eq(version.id))
             .select(version_downloads::processed)
@@ -208,7 +314,7 @@ mod test {
             ))
             .execute(conn)
             .unwrap();
-        super::update(conn).unwrap();
+        super::update(conn, false).unwrap();
         let processed = version_downloads::table
             .filter(version_downloads::version_id.eq(version.id))
             .select(version_downloads::processed)
@@ -255,7 +361,7 @@ mod test {
             .filter(crates::id.eq(krate.id))
             .first(conn)
             .unwrap();
-        super::update(conn).unwrap();
+        super::update(conn, false).unwrap();
         let version2: Version = versions::table.find(version.id).first(conn).unwrap();
         assert_eq!(version2.downloads, 2);
         assert_eq!(version2.updated_at, version_before.updated_at);
@@ -265,7 +371,7 @@ mod test {
             .unwrap();
         assert_eq!(krate2.downloads, 2);
         assert_eq!(krate2.updated_at, krate_before.updated_at);
-        super::update(conn).unwrap();
+        super::update(conn, false).unwrap();
         let version3: Version = versions::table.find(version.id).first(conn).unwrap();
         assert_eq!(version3.downloads, 2);
     }
@@ -304,7 +410,234 @@ mod test {
             .execute(conn)
             .unwrap();
 
-        super::update(conn).unwrap();
+        super::update(conn, false).unwrap();
+        let versions_changed = versions::table
+            .select(versions::updated_at.ne(now - 2.days()))
+            .get_result(conn);
+        let crates_changed = crates::table
+            .select(crates::updated_at.ne(now - 2.days()))
+            .get_result(conn);
+        assert_eq!(versions_changed, Ok(false));
+        assert_eq!(crates_changed, Ok(false));
+    }
+}
+
+/// This is a copy of the `test` module above, but using
+/// `use_batch_update: true` in the `update` calls.
+#[cfg(test)]
+mod batch_tests {
+    use super::*;
+    use crate::email::Emails;
+    use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
+    use crate::test_util::test_db_connection;
+    use std::collections::BTreeMap;
+
+    fn user(conn: &mut PgConnection) -> User {
+        NewUser::new(2, "login", None, None, "access_token")
+            .create_or_update(None, &Emails::new_in_memory(), conn)
+            .unwrap()
+    }
+
+    fn crate_and_version(conn: &mut PgConnection, user_id: i32) -> (Crate, Version) {
+        let krate = NewCrate {
+            name: "foo",
+            ..Default::default()
+        }
+        .create(conn, user_id)
+        .unwrap();
+        let version = NewVersion::new(
+            krate.id,
+            &semver::Version::parse("1.0.0").unwrap(),
+            &BTreeMap::new(),
+            None,
+            0,
+            user_id,
+            "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            None,
+            None,
+        )
+        .unwrap();
+        let version = version.save(conn, "someone@example.com").unwrap();
+        (krate, version)
+    }
+
+    #[test]
+    fn increment() {
+        use diesel::dsl::*;
+
+        let (_test_db, conn) = &mut test_db_connection();
+        let user = user(conn);
+        let (krate, version) = crate_and_version(conn, user.id);
+        insert_into(version_downloads::table)
+            .values(version_downloads::version_id.eq(version.id))
+            .execute(conn)
+            .unwrap();
+        insert_into(version_downloads::table)
+            .values((
+                version_downloads::version_id.eq(version.id),
+                version_downloads::date.eq(date(now - 1.day())),
+                version_downloads::processed.eq(true),
+            ))
+            .execute(conn)
+            .unwrap();
+
+        super::update(conn, true).unwrap();
+        let version_downloads = versions::table
+            .find(version.id)
+            .select(versions::downloads)
+            .first(conn);
+        assert_eq!(version_downloads, Ok(1));
+        let crate_downloads = crates::table
+            .find(krate.id)
+            .select(crates::downloads)
+            .first(conn);
+        assert_eq!(crate_downloads, Ok(1));
+        super::update(conn, true).unwrap();
+        let version_downloads = versions::table
+            .find(version.id)
+            .select(versions::downloads)
+            .first(conn);
+        assert_eq!(version_downloads, Ok(1));
+    }
+
+    #[test]
+    fn set_processed_true() {
+        use diesel::dsl::*;
+
+        let (_test_db, conn) = &mut test_db_connection();
+        let user = user(conn);
+        let (_, version) = crate_and_version(conn, user.id);
+        insert_into(version_downloads::table)
+            .values((
+                version_downloads::version_id.eq(version.id),
+                version_downloads::downloads.eq(2),
+                version_downloads::counted.eq(2),
+                version_downloads::date.eq(date(now - 2.days())),
+                version_downloads::processed.eq(false),
+            ))
+            .execute(conn)
+            .unwrap();
+        super::update(conn, true).unwrap();
+        let processed = version_downloads::table
+            .filter(version_downloads::version_id.eq(version.id))
+            .select(version_downloads::processed)
+            .first(conn);
+        assert_eq!(processed, Ok(true));
+    }
+
+    #[test]
+    fn dont_process_recent_row() {
+        use diesel::dsl::*;
+        let (_test_db, conn) = &mut test_db_connection();
+        let user = user(conn);
+        let (_, version) = crate_and_version(conn, user.id);
+        insert_into(version_downloads::table)
+            .values((
+                version_downloads::version_id.eq(version.id),
+                version_downloads::downloads.eq(2),
+                version_downloads::counted.eq(2),
+                version_downloads::date.eq(date(now)),
+                version_downloads::processed.eq(false),
+            ))
+            .execute(conn)
+            .unwrap();
+        super::update(conn, true).unwrap();
+        let processed = version_downloads::table
+            .filter(version_downloads::version_id.eq(version.id))
+            .select(version_downloads::processed)
+            .first(conn);
+        assert_eq!(processed, Ok(false));
+    }
+
+    #[test]
+    fn increment_a_little() {
+        use diesel::dsl::*;
+        use diesel::update;
+
+        let (_test_db, conn) = &mut test_db_connection();
+        let user = user(conn);
+        let (krate, version) = crate_and_version(conn, user.id);
+        update(versions::table)
+            .set(versions::updated_at.eq(now - 2.hours()))
+            .execute(conn)
+            .unwrap();
+        update(crates::table)
+            .set(crates::updated_at.eq(now - 2.hours()))
+            .execute(conn)
+            .unwrap();
+        insert_into(version_downloads::table)
+            .values((
+                version_downloads::version_id.eq(version.id),
+                version_downloads::downloads.eq(2),
+                version_downloads::counted.eq(1),
+                version_downloads::date.eq(date(now)),
+                version_downloads::processed.eq(false),
+            ))
+            .execute(conn)
+            .unwrap();
+        insert_into(version_downloads::table)
+            .values((
+                version_downloads::version_id.eq(version.id),
+                version_downloads::date.eq(date(now - 1.day())),
+            ))
+            .execute(conn)
+            .unwrap();
+
+        let version_before: Version = versions::table.find(version.id).first(conn).unwrap();
+        let krate_before: Crate = Crate::all()
+            .filter(crates::id.eq(krate.id))
+            .first(conn)
+            .unwrap();
+        super::update(conn, true).unwrap();
+        let version2: Version = versions::table.find(version.id).first(conn).unwrap();
+        assert_eq!(version2.downloads, 2);
+        assert_eq!(version2.updated_at, version_before.updated_at);
+        let krate2: Crate = Crate::all()
+            .filter(crates::id.eq(krate.id))
+            .first(conn)
+            .unwrap();
+        assert_eq!(krate2.downloads, 2);
+        assert_eq!(krate2.updated_at, krate_before.updated_at);
+        super::update(conn, true).unwrap();
+        let version3: Version = versions::table.find(version.id).first(conn).unwrap();
+        assert_eq!(version3.downloads, 2);
+    }
+
+    #[test]
+    fn set_processed_no_set_updated_at() {
+        use diesel::dsl::*;
+        use diesel::update;
+
+        let (_test_db, mut conn) = test_db_connection();
+
+        // This test is using a transaction to ensure `now` is the same for all
+        // queries within this test.
+        conn.begin_test_transaction().unwrap();
+
+        let conn = &mut conn;
+
+        let user = user(conn);
+        let (_, version) = crate_and_version(conn, user.id);
+        update(versions::table)
+            .set(versions::updated_at.eq(now - 2.days()))
+            .execute(conn)
+            .unwrap();
+        update(crates::table)
+            .set(crates::updated_at.eq(now - 2.days()))
+            .execute(conn)
+            .unwrap();
+        insert_into(version_downloads::table)
+            .values((
+                version_downloads::version_id.eq(version.id),
+                version_downloads::downloads.eq(2),
+                version_downloads::counted.eq(2),
+                version_downloads::date.eq(date(now - 2.days())),
+                version_downloads::processed.eq(false),
+            ))
+            .execute(conn)
+            .unwrap();
+
+        super::update(conn, true).unwrap();
         let versions_changed = versions::table
             .select(versions::updated_at.ne(now - 2.days()))
             .get_result(conn);

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -84,6 +84,7 @@ fn update(conn: &mut PgConnection, use_batch_update: bool) -> QueryResult<()> {
     Ok(())
 }
 
+#[instrument(skip_all)]
 fn batch_update(batch_size: i64, conn: &mut PgConnection) -> QueryResult<i64> {
     table! {
         /// Imaginary table to make Diesel happy when using the `sql_query` function.


### PR DESCRIPTION
The previous implementation to update the `versions` and `crates` table was quite slow and creating a lot of bloat in the database, since it updated the `crates` and `metadata` tables for every single version that was downloaded.

This commit adds a second implementation, guarded by the `BATCH_UPDATE_DOWNLOADS` feature flag, which updates the tables in batches with a static query that does not need to transfer data back and forth between the background worker and the database.

For more context, see https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/error.20in.20crates.2Eio.20summary.