### PR TITLE
Revert "Allow `/api/v1/summary` to be disabled from the environment"

### DIFF
--- a/app/styles/index.module.css
+++ b/app/styles/index.module.css
@@ -76,7 +76,6 @@
 
 .error-message {
     line-height: 1.5;
-    padding: 0 var(--space-s);
 }
 
 .try-again-button {

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -36,31 +36,24 @@
 </div>
 
 {{#if this.dataTask.lastComplete.error}}
-  {{#if (eq this.dataTask.lastComplete.error.cause.response.status 503)}}
-    <p local-class='error-message'>
-      crates.io summary data is currently unavailable due to an outage.
-    </p>
-  {{else}}
+  <p local-class="error-message" data-test-error-message>
+    Unfortunately something went wrong while loading the crates.io summary data.
+    Feel free to try again, or let the <a href="mailto:help@crates.io">crates.io
+    team</a> know if the problem persists.
+  </p>
 
-    <p local-class="error-message" data-test-error-message>
-      Unfortunately something went wrong while loading the crates.io summary data. Feel free to try again, or let the
-      <a href="mailto:help@crates.io">crates.io team</a>
-      know if the problem persists.
-    </p>
-
-    <button
-      type="button"
-      disabled={{this.dataTask.isRunning}}
-      local-class="try-again-button"
-      data-test-try-again-button
-      {{on "click" this.fetchData}}
-    >
-      Try Again
-      {{#if this.dataTask.isRunning}}
-        <LoadingSpinner local-class="spinner" data-test-spinner />
-      {{/if}}
-    </button>
-  {{/if}}
+  <button
+    type="button"
+    disabled={{this.dataTask.isRunning}}
+    local-class="try-again-button"
+    data-test-try-again-button
+    {{on "click" this.fetchData}}
+  >
+    Try Again
+    {{#if this.dataTask.isRunning}}
+      <LoadingSpinner local-class="spinner" data-test-spinner />
+    {{/if}}
+  </button>
 {{else}}
   <div local-class='lists' data-test-lists>
     <section data-test-new-crates >

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -84,9 +84,6 @@ pub struct Server {
     /// non-API requests?
     pub serve_html: bool,
 
-    /// Should the server serve the summary endpoint?
-    pub serve_summary: bool,
-
     pub content_security_policy: Option<HeaderValue>,
 }
 
@@ -122,8 +119,6 @@ impl Server {
     ///   endpoint even with a healthy database pool.
     /// - `BLOCKED_ROUTES`: A comma separated list of HTTP route patterns that are manually blocked
     ///   by an operator (e.g. `/crates/:crate_id/:version/download`).
-    /// - `DISABLE_SUMMARY`: Any non-empty string value will disable the `/api/v1/summary` endpoint
-    ///   gracefully. (Ish.)
     ///
     /// # Panics
     ///
@@ -232,10 +227,6 @@ impl Server {
                 .unwrap_or(StatusCodeConfig::AdjustAll),
             serve_dist: true,
             serve_html: true,
-            serve_summary: var("DISABLE_SUMMARY")?
-                .unwrap_or_default()
-                .trim()
-                .is_empty(),
             content_security_policy: Some(content_security_policy.parse()?),
         })
     }

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -15,7 +15,7 @@ use crate::models::{
     TopVersions, User, Version, VersionOwnerAction,
 };
 use crate::schema::*;
-use crate::util::errors::{crate_not_found, service_unavailable};
+use crate::util::errors::crate_not_found;
 use crate::views::{
     EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
 };
@@ -24,10 +24,6 @@ use crate::views::{
 pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
     spawn_blocking(move || {
         let config = &state.config;
-
-        if !config.serve_summary {
-            return Err(service_unavailable());
-        }
 
         let conn = &mut *state.db_read()?;
         let num_crates: i64 = crates::table.count().get_result(conn)?;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -464,8 +464,6 @@ fn simple_config() -> config::Server {
         // The frontend code is not needed for the backend tests.
         serve_dist: false,
         serve_html: false,
-
-        serve_summary: true,
         content_security_policy: None,
     }
 }


### PR DESCRIPTION
Reverts rust-lang/crates.io#8125.

I don't think we need this, and the implementation looks exactly as hacky as you'd expect for something thrown together in a few minutes.

@Turbo87, feel free to just go ahead and merge this, assuming you agree.