### PR TITLE
database: Use `CONCURRENTLY IF EXISTS` to drop the `index_follows_user_id` index

### DIFF
--- a/migrations/2024-02-12-120203_remove_unused_index/metadata.toml
+++ b/migrations/2024-02-12-120203_remove_unused_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2024-02-12-120203_remove_unused_index/up.sql
+++ b/migrations/2024-02-12-120203_remove_unused_index/up.sql
@@ -1,1 +1,1 @@
-DROP INDEX index_follows_user_id;
+DROP INDEX CONCURRENTLY IF EXISTS index_follows_user_id;


### PR DESCRIPTION

The `CONCURRENTLY` allows us to still use the associated table while the index is being dropped, and the `IF EXISTS` ensures that the migration succeeds even if the index does not exist. This allows us to manually drop the index before the migrations run, instead of dropping it as part of a migration which would block the server startup.