### PR TITLE
worker/jobs/downloads/update_metadata: Use `SELECT ... FOR UPDATE` in `batch_update()`

### DIFF
--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -112,6 +112,7 @@ fn batch_update(batch_size: i64, conn: &mut PgConnection) -> QueryResult<i64> {
                 INNER JOIN versions ON versions.id = version_id
                 WHERE NOT processed AND version_downloads.downloads != counted
                 LIMIT $1
+                FOR UPDATE
             ), version_downloads_batch AS (
                 -- Group the downloads by `version_id` and sum them up for the
                 -- `updated_versions` CTE.


### PR DESCRIPTION


We've seen a couple of deadlock errors in the logs originating from the query in the `batch_update()` function. It looks like in some cases when a `process_cdn_log` background job is running its `UPDATE` query leads to the deadlock observed in the logs. My assumption is that this happens between the initial `SELECT` in the `batch_update()` query, and the `UPDATE` at the end which sets the `counted` column to its new value. By using `FOR UPDATE` we can hopefully prevent the `process_cdn_log` from modifying the rows while the `batch_update()` function is working, which should prevent the deadlock.