### PR TITLE
Revert "worker/jobs/downloads/update_metadata: Use `SELECT ... FOR UPDATE` in `batch_update()`"

### DIFF
--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -112,7 +112,6 @@ fn batch_update(batch_size: i64, conn: &mut PgConnection) -> QueryResult<i64> {
                 INNER JOIN versions ON versions.id = version_id
                 WHERE NOT processed AND version_downloads.downloads != counted
                 LIMIT $1
-                FOR UPDATE
             ), version_downloads_batch AS (
                 -- Group the downloads by `version_id` and sum them up for the
                 -- `updated_versions` CTE.


### PR DESCRIPTION
Reverts rust-lang/crates.io#8143

> Feb 17 15:31:30.791 Failed to run job error="deadlock detected"

Looks like this didn't have the desired effect, so we might as well revert it...