### PR TITLE
Use a consistent update order for the `version_downloads` table

### DIFF
--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -330,6 +330,7 @@ fn save_to_version_downloads(conn: &mut PgConnection) -> QueryResult<Vec<NameAnd
                 SELECT joined_data.id, joined_data.date, joined_data.downloads
                 FROM joined_data
                 WHERE joined_data.id IS NOT NULL
+                ORDER BY joined_data.id, joined_data.date
                 ON CONFLICT (version_id, date)
                 DO UPDATE SET downloads = version_downloads.downloads + EXCLUDED.downloads
                 RETURNING version_downloads.version_id

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -149,8 +149,11 @@ fn batch_update(batch_size: i64, conn: &mut PgConnection) -> QueryResult<i64> {
                 -- Sort the `downloads_batch` CTE by `version_id` and `date` to
                 -- ensure that the `version_downloads` table is updated in a
                 -- consistent order to avoid deadlocks.
-                SELECT version_id, date, downloads FROM downloads_batch
+                SELECT downloads_batch.*
+                FROM version_downloads
+                JOIN downloads_batch using (version_id, date)
                 ORDER BY version_id, date
+                FOR UPDATE
             ), updated_version_downloads AS (
                 -- Update the `counted` value for each version in the batch.
                 UPDATE version_downloads


### PR DESCRIPTION
Ensuring a consistent update order should reduce the risk of deadlocks between the two background jobs.