### PR TITLE
components/crate-sidebar: Use `=` prefixes if exact versions are shown

### DIFF
--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -16,13 +16,14 @@ export default class CrateSidebar extends Component {
 
   get cargoAddCommand() {
     return this.args.requestedVersion
-      ? `cargo add ${this.args.crate.name}@${this.args.requestedVersion}`
+      ? `cargo add ${this.args.crate.name}@=${this.args.requestedVersion}`
       : `cargo add ${this.args.crate.name}`;
   }
 
   get tomlSnippet() {
     let version = this.args.version.num.split('+')[0];
-    return `${this.args.crate.name} = "${version}"`;
+    let exact = this.args.requestedVersion ? '=' : '';
+    return `${this.args.crate.name} = "${exact}${version}"`;
   }
 
   get playgroundLink() {

--- a/tests/components/crate-sidebar/toml-snippet-test.js
+++ b/tests/components/crate-sidebar/toml-snippet-test.js
@@ -11,6 +11,23 @@ module('Component | CrateSidebar | toml snippet', function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
 
+  test('show version number with `=` prefix', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate, num: '1.0.0' });
+
+    let store = this.owner.lookup('service:store');
+    this.crate = await store.findRecord('crate', crate.name);
+    this.version = (await this.crate.versions).firstObject;
+
+    await render(hbs`<CrateSidebar @crate={{this.crate}} @version={{this.version}} />`);
+    assert.dom('[title="Copy command to clipboard"]').exists().hasText('cargo add foo');
+    assert.dom('[title="Copy Cargo.toml snippet to clipboard"]').exists().hasText('foo = "1.0.0"');
+
+    await render(hbs`<CrateSidebar @crate={{this.crate}} @version={{this.version}} @requestedVersion="1.0.0" />`);
+    assert.dom('[title="Copy command to clipboard"]').exists().hasText('cargo add foo@=1.0.0');
+    assert.dom('[title="Copy Cargo.toml snippet to clipboard"]').exists().hasText('foo = "=1.0.0"');
+  });
+
   test('show version number without build metadata', async function (assert) {
     let crate = this.server.create('crate', { name: 'foo' });
     this.server.create('version', { crate, num: '1.0.0+abcdef' });


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/7884