### PR TITLE
Replace deprecated `initCustomEvent()` usage

### DIFF
--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -55,8 +55,7 @@ export default class CrateVersionController extends Controller {
 
     if (typeof document !== 'undefined') {
       setTimeout(() => {
-        let e = document.createEvent('CustomEvent');
-        e.initCustomEvent('hashchange', true, true);
+        let e = new CustomEvent('hashchange');
         window.dispatchEvent(e);
       });
     }


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/Web/Events/Creating_and_triggering_events

The `bubbles` and `cancelable` options don't appear to be necessary, since the scrolling works fine without them.

Resolves https://github.com/rust-lang/crates.io/issues/4787