### PR TITLE
Remove obsolete `copy-text-to-clipboard` dependency

### DIFF
--- a/app/components/copy-button.hbs
+++ b/app/components/copy-button.hbs
@@ -1,3 +1,3 @@
-<button type="button" ...attributes {{on "click" this.copy}}>
+<button type="button" ...attributes {{on "click" (perform this.copyTask)}}>
   {{yield}}
 </button>

--- a/app/components/copy-button.js
+++ b/app/components/copy-button.js
@@ -1,21 +1,18 @@
-import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
-import copy from 'copy-text-to-clipboard';
+import { restartableTask } from 'ember-concurrency';
 
 export default class CrateTomlCopy extends Component {
   @service notifications;
 
-  @action
-  copy() {
+  copyTask = restartableTask(async () => {
     let { copyText } = this.args;
-
-    let success = copy(copyText);
-    if (success) {
+    try {
+      await navigator.clipboard.writeText(copyText);
       this.notifications.success('Copied to clipboard!');
-    } else {
+    } catch {
       this.notifications.error('Copy to clipboard failed!');
     }
-  }
+  });
 }

--- a/app/helpers/is-clipboard-supported.js
+++ b/app/helpers/is-clipboard-supported.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
 
-const IS_SUPPORTED = document.queryCommandSupported && document.queryCommandSupported('copy');
+const IS_SUPPORTED = Boolean(navigator.clipboard?.writeText);
 
 export default helper(() => IS_SUPPORTED);

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@sentry/browser": "7.102.0",
     "@sentry/utils": "7.102.0",
     "chart.js": "4.4.1",
-    "copy-text-to-clipboard": "3.2.0",
     "date-fns": "3.3.1",
     "highlight.js": "11.9.0",
     "macro-decorators": "0.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ dependencies:
   chart.js:
     specifier: 4.4.1
     version: 4.4.1
-  copy-text-to-clipboard:
-    specifier: 3.2.0
-    version: 3.2.0
   date-fns:
     specifier: 3.3.1
     version: 3.3.1
@@ -6685,11 +6682,6 @@ packages:
     resolution: {integrity: sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /copy-text-to-clipboard@3.2.0:
-    resolution: {integrity: sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==}
-    engines: {node: '>=12'}
-    dev: false
 
   /core-js-compat@3.36.0:
     resolution: {integrity: sha512-iV9Pd/PsgjNWBXeq8XRtWVSgz2tKAfhfvBs7qxYty+RlRd+OCksaWmOnc4JKrTc1cToXL1N0s3l/vwlxPtdElw==}


### PR DESCRIPTION
The `Clipboard.writeText()` API is now available in all major browsers (see https://caniuse.com/mdn-api_clipboard_writetext), so we don't need this dependency anymore. Additionally, calling `copy()` of this dependency causes the current selection in the browser to be unselected, which makes it harder for us to fix #3952.