### PR TITLE
Remove obsolete `PoolError::TestConnectionUnavailable` variant

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -171,6 +171,4 @@ pub enum PoolError {
     R2D2(#[from] r2d2::PoolError),
     #[error("unhealthy database pool")]
     UnhealthyPool,
-    #[error("Failed to lock test database connection")]
-    TestConnectionUnavailable,
 }


### PR DESCRIPTION
With https://github.com/rust-lang/crates.io/pull/7422, this is no longer used anywhere.