### PR TITLE
Fix `replica_db_connection_config.read_only` assignment

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -116,7 +116,7 @@ impl App {
         let replica_database = if let Some(pool_config) = config.db.replica.as_ref() {
             let replica_db_connection_config = ConnectionConfig {
                 statement_timeout: config.db.statement_timeout,
-                read_only: true,
+                read_only: pool_config.read_only_mode,
             };
 
             let replica_db_config = r2d2::Pool::builder()


### PR DESCRIPTION
While `pool_config.read_only_mode` should always be `true` there's no need to hardcode this value in multiple places.