### PR TITLE
Add async database connection pools based on `deadpool`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,8 @@ dependencies = [
  "crates_io_test_db",
  "crates_io_worker",
  "dashmap",
+ "deadpool",
+ "deadpool-diesel",
  "derive_builder 0.20.0",
  "derive_deref",
  "dialoguer",
@@ -1387,6 +1389,48 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deadpool"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-diesel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8404d25ddc6cb0676d4a863bbd007613ee3fffb54db23e0e6341e1fe61c3e"
+dependencies = [
+ "deadpool",
+ "deadpool-sync",
+ "diesel",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63dfa964fe2a66f3fde91fc70b267fe193d822c7e603e2a675a49a7f46ad3f49"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-sync"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8db70494c13cae4ce67b4b4dafdaf828cf0df7237ab5b9e2fcabee4965d0a0a"
+dependencies = [
+ "deadpool-runtime",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ chrono = { version = "=0.4.34", default-features = false, features = ["serde"] }
 clap = { version = "=4.5.1", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.18.0", features = ["secure"] }
 dashmap = { version = "=5.5.3", features = ["raw-api"] }
+deadpool = "=0.10.0"
+deadpool-diesel = { version = "=0.5.0", features = ["postgres", "tracing"] }
 derive_builder = "=0.20.0"
 derive_deref = "=1.1.1"
 dialoguer = "=0.11.0"

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -26,7 +26,7 @@ use crates_io_env_vars::var;
 use crates_io_index::RepositoryConfig;
 use crates_io_worker::Runner;
 use deadpool::Runtime;
-use deadpool_diesel::postgres::{Manager, Pool};
+use deadpool_diesel::postgres::{Manager as DeadpoolManager, Pool as DeadpoolPool};
 use diesel::r2d2;
 use diesel::r2d2::ConnectionManager;
 use reqwest::Client;
@@ -87,8 +87,8 @@ fn main() -> anyhow::Result<()> {
         .min_idle(Some(0))
         .build_unchecked(ConnectionManager::new(&db_url));
 
-    let manager = Manager::new(db_url, Runtime::Tokio1);
-    let deadpool = Pool::builder(manager).max_size(10).build().unwrap();
+    let manager = DeadpoolManager::new(db_url, Runtime::Tokio1);
+    let deadpool = DeadpoolPool::builder(manager).max_size(10).build().unwrap();
 
     let environment = Environment::builder()
         .config(Arc::new(config))

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -48,6 +48,7 @@ pub struct DbPoolConfig {
     pub url: SecretString,
     pub read_only_mode: bool,
     pub pool_size: u32,
+    pub async_pool_size: usize,
     pub min_idle: Option<u32>,
 }
 
@@ -72,8 +73,12 @@ impl DatabasePools {
 
         let primary_pool_size =
             var_parsed("DB_PRIMARY_POOL_SIZE")?.unwrap_or(Self::DEFAULT_POOL_SIZE);
+        let primary_async_pool_size =
+            var_parsed("DB_PRIMARY_ASYNC_POOL_SIZE")?.unwrap_or(Self::DEFAULT_POOL_SIZE as usize);
         let replica_pool_size =
             var_parsed("DB_REPLICA_POOL_SIZE")?.unwrap_or(Self::DEFAULT_POOL_SIZE);
+        let replica_async_pool_size =
+            var_parsed("DB_REPLICA_ASYNC_POOL_SIZE")?.unwrap_or(Self::DEFAULT_POOL_SIZE as usize);
 
         let primary_min_idle = var_parsed("DB_PRIMARY_MIN_IDLE")?;
         let replica_min_idle = var_parsed("DB_REPLICA_MIN_IDLE")?;
@@ -101,6 +106,7 @@ impl DatabasePools {
                     })?,
                     read_only_mode: true,
                     pool_size: primary_pool_size,
+                    async_pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
                 },
                 replica: None,
@@ -116,6 +122,7 @@ impl DatabasePools {
                     url: leader_url,
                     read_only_mode,
                     pool_size: primary_pool_size,
+                    async_pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
                 },
                 replica: None,
@@ -130,6 +137,7 @@ impl DatabasePools {
                     url: leader_url,
                     read_only_mode,
                     pool_size: primary_pool_size,
+                    async_pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
                 },
                 replica: follower_url.map(|url| DbPoolConfig {
@@ -139,6 +147,7 @@ impl DatabasePools {
                     // connection is opened read-only even when attached to a writeable database.
                     read_only_mode: true,
                     pool_size: replica_pool_size,
+                    async_pool_size: replica_async_pool_size,
                     min_idle: replica_min_idle,
                 }),
                 tcp_timeout_ms,

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -6,13 +6,12 @@ use crate::views::EncodableTeam;
 
 /// Handles the `GET /teams/:team_id` route.
 pub async fn show_team(state: AppState, Path(name): Path<String>) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
-        use self::teams::dsl::{login, teams};
+    use self::teams::dsl::{login, teams};
 
-        let conn = &mut *state.db_read()?;
-        let team: Team = teams.filter(login.eq(&name)).first(conn)?;
+    let conn = state.db_read_async().await?;
+    let team: Team = conn
+        .interact(move |conn| teams.filter(login.eq(&name)).first(conn))
+        .await??;
 
-        Ok(Json(json!({ "team": EncodableTeam::from(team) })))
-    })
-    .await
+    Ok(Json(json!({ "team": EncodableTeam::from(team) })))
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -379,6 +379,7 @@ impl TestAppBuilder {
             url: primary.url.clone(),
             read_only_mode: true,
             pool_size: primary.pool_size,
+            async_pool_size: primary.async_pool_size,
             min_idle: primary.min_idle,
         });
 
@@ -397,6 +398,7 @@ fn simple_config() -> config::Server {
             url: String::from("invalid default url").into(),
             read_only_mode: false,
             pool_size: 5,
+            async_pool_size: 5,
             min_idle: None,
         },
         replica: None,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -277,6 +277,7 @@ impl TestAppBuilder {
                 .repository_config(repository_config)
                 .storage(app.storage.clone())
                 .connection_pool(app.primary_database.clone())
+                .deadpool(app.deadpool_primary.clone())
                 .emails(app.emails.clone())
                 .team_repo(Box::new(self.team_repo))
                 .build()

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -178,6 +178,18 @@ impl From<PoolError> for BoxedAppError {
     }
 }
 
+impl From<deadpool_diesel::PoolError> for BoxedAppError {
+    fn from(err: deadpool_diesel::PoolError) -> BoxedAppError {
+        Box::new(err)
+    }
+}
+
+impl From<deadpool_diesel::InteractError> for BoxedAppError {
+    fn from(err: deadpool_diesel::InteractError) -> BoxedAppError {
+        Box::new(err)
+    }
+}
+
 impl From<prometheus::Error> for BoxedAppError {
     fn from(err: prometheus::Error) -> BoxedAppError {
         Box::new(err)

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -6,6 +6,7 @@ use crate::team_repo::TeamRepo;
 use crate::typosquat;
 use crate::Emails;
 use crates_io_index::{Repository, RepositoryConfig};
+use deadpool_diesel::postgres::Pool;
 use derive_builder::Builder;
 use diesel::PgConnection;
 use parking_lot::{Mutex, MutexGuard};
@@ -27,6 +28,7 @@ pub struct Environment {
     fastly: Option<Fastly>,
     pub storage: Arc<Storage>,
     pub connection_pool: DieselPool,
+    pub deadpool: Pool,
     pub emails: Emails,
     pub team_repo: Box<dyn TeamRepo + Send + Sync>,
 

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -6,7 +6,7 @@ use crate::team_repo::TeamRepo;
 use crate::typosquat;
 use crate::Emails;
 use crates_io_index::{Repository, RepositoryConfig};
-use deadpool_diesel::postgres::Pool;
+use deadpool_diesel::postgres::Pool as DeadpoolPool;
 use derive_builder::Builder;
 use diesel::PgConnection;
 use parking_lot::{Mutex, MutexGuard};
@@ -28,7 +28,7 @@ pub struct Environment {
     fastly: Option<Fastly>,
     pub storage: Arc<Storage>,
     pub connection_pool: DieselPool,
-    pub deadpool: Pool,
+    pub deadpool: DeadpoolPool,
     pub emails: Emails,
     pub team_repo: Box<dyn TeamRepo + Send + Sync>,
 


### PR DESCRIPTION
We're currently using https://docs.rs/r2d2/ for our database connection pools, but unfortunately that is not supported by [diesel_async](https://github.com/weiznich/diesel_async) (see https://github.com/weiznich/diesel_async?tab=readme-ov-file#built-in-connection-pooling-support).

This PR introduces additional database connection pools based on `deadpool` next to the existing r2d2 pools and migrates one API endpoint and one background job to use these async connection pools instead.

All of the configuration options of the sync connection pools are still supported, with one exception: `min_size()`. `deadpool` does not shrink the pool size automatically and once `max_size` is reached these connections will be kept forever. This does not seem like a huge deal for our use case though, and if we discover that we need it we can build it ourselves using regular `Pool::retain()` calls.

Note that this does not migrate to diesel_async yet, but it meant as an intermediate step to ease the migration to that.