### PR TITLE
Fix the issue of relevant search not working with spaces in them when using seek pagination

### DIFF
--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -429,7 +429,8 @@ fn index_sorting() {
     }
 
     // Sort by relevance
-    for query in ["q=foo_sort", "q=sort"] {
+    // Add query containing a space to ensure tsquery works
+    for query in ["q=foo_sort", "q=sort", "q=foo%20sort"] {
         let (resp, calls) = page_with_seek(&anon, query);
         assert_eq!(calls, resp[0].meta.total + 1);
         let decoded_seeks = resp


### PR DESCRIPTION
Revert `to_tsquery_with_search_config` usage for `TsQuery` to the original implementation to address the issue. This is the same process as in PR #8053.