### PR TITLE
Add sudo mode acceptance tests, per #8210 feedback

### DIFF
--- a/app/components/header.hbs
+++ b/app/components/header.hbs
@@ -22,7 +22,7 @@
         <Dropdown data-test-user-menu as |dd|>
           <dd.Trigger local-class="dropdown-button" data-test-toggle>
             {{#if this.session.isSudoEnabled}}
-              <div local-class="wizard-hat">🧙</div>
+              <div data-test-wizard-hat local-class="wizard-hat">🧙</div>
             {{/if}}
             <UserAvatar @user={{this.session.currentUser}} @size="small" local-class="avatar" data-test-avatar />
             {{ this.session.currentUser.name }}
@@ -35,12 +35,12 @@
             {{#if this.session.isAdmin}}
               <menu.Item local-class='sudo'>
                 {{#if this.session.isSudoEnabled}}
-                  <button local-class='sudo-menu-item' type='button' {{on 'click' this.disableSudo}}>
+                  <button data-test-disable-admin-actions local-class='sudo-menu-item' type='button' {{on 'click' this.disableSudo}}>
                     Disable admin actions
                     <div local-class='expires-in'>expires at {{date-format this.session.sudoEnabledUntil 'HH:mm'}}</div>
                   </button>
                 {{else}}
-                  <button local-class='sudo-menu-item' type='button' {{on 'click' this.enableSudo}}>
+                  <button data-test-enable-admin-actions local-class='sudo-menu-item' type='button' {{on 'click' this.enableSudo}}>
                     Enable admin actions
                   </button>
                 {{/if}}

--- a/app/components/privileged-action.hbs
+++ b/app/components/privileged-action.hbs
@@ -9,7 +9,7 @@
     </div>
   {{else}}
     <div local-class='placeholder'>
-      <fieldset disabled="disabled">
+      <fieldset data-test-placeholder-fieldset disabled="disabled">
         {{yield}}
       </fieldset>
       <EmberTooltip>

--- a/tests/acceptance/sudo-test.js
+++ b/tests/acceptance/sudo-test.js
@@ -1,0 +1,100 @@
+import { click, find, waitFor } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import format from 'date-fns/format';
+
+import { setupApplicationTest } from 'crates-io/tests/helpers';
+
+import { visit } from '../helpers/visit-ignoring-abort';
+
+module('Acceptance | sudo', function (hooks) {
+  setupApplicationTest(hooks);
+
+  const prepare = context => {
+    const user = context.server.create('user', {
+      login: 'johnnydee',
+      name: 'John Doe',
+      email: 'john@doe.com',
+      avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
+      isAdmin: true,
+    });
+
+    const crate = context.server.create('crate', {
+      name: 'foo',
+      newest_version: '0.1.0',
+    });
+
+    const version = context.server.create('version', {
+      crate,
+      num: '0.1.0',
+    });
+
+    context.authenticateAs(user);
+    return { user, crate, version };
+  };
+
+  test('admin user is not initially in sudo mode', async function (assert) {
+    prepare(this);
+
+    await visit('/crates/foo/versions');
+
+    // Test the various header elements.
+    assert.dom('[data-test-wizard-hat]').doesNotExist();
+    assert.dom('[data-test-disable-admin-actions]').doesNotExist();
+    assert.dom('[data-test-enable-admin-actions]').exists();
+
+    // Test that the fieldset is present and disabled.
+    assert.dom('[data-test-placeholder-fieldset]').exists().isDisabled();
+
+    // From the perspective of the actual button, it isn't disabled, even though
+    // the fieldset effectively makes it unclickable.
+    assert.dom('[data-test-version-yank-button="0.1.0"]').exists();
+  });
+
+  test('admin user can enter sudo mode', async function (assert) {
+    prepare(this);
+
+    await visit('/crates/foo/versions');
+
+    const untilAbout = Date.now() + 6 * 60 * 60 * 1000;
+    await click('[data-test-enable-admin-actions]');
+
+    // Test the various header elements.
+    assert.dom('[data-test-wizard-hat]').exists();
+    assert.dom('[data-test-disable-admin-actions]').exists();
+    assert.dom('[data-test-enable-admin-actions]').doesNotExist();
+
+    // Test that the expiry time is sensible. We'll allow a minute either way in
+    // case of slow tests or slightly wonky clocks.
+    const disable = find('[data-test-disable-admin-actions] > div');
+    let seen = 0;
+    for (const ts of [untilAbout - 60 * 1000, untilAbout, untilAbout + 60 * 1000]) {
+      const time = format(new Date(ts), 'HH:mm');
+      if (disable.textContent.includes(time)) {
+        seen += 1;
+      }
+    }
+    assert.strictEqual(seen, 1);
+
+    // Test that the fieldset is not present.
+    assert.dom('[data-test-placeholder-fieldset]').doesNotExist();
+    assert.dom('[data-test-version-yank-button="0.1.0"]').exists();
+  });
+
+  test('admin can yank a crate in sudo mode', async function (assert) {
+    this.server.loadFixtures();
+    prepare(this);
+
+    await visit('/crates/foo/versions');
+    await click('[data-test-enable-admin-actions]');
+
+    await click('[data-test-version-yank-button="0.1.0"]');
+
+    await waitFor('[data-test-version-unyank-button="0.1.0"]');
+    assert.dom('[data-test-version-unyank-button="0.1.0"]').exists();
+    await click('[data-test-version-unyank-button="0.1.0"]');
+
+    await waitFor('[data-test-version-yank-button="0.1.0"]');
+    assert.dom('[data-test-version-yank-button="0.1.0"]').exists();
+  });
+});


### PR DESCRIPTION
Whichever stage of sudo grief we're at, we're now at acceptance.

I don't think there's anything surprising here. I used the yank button as a proxy for the general `PrivilegedAction` functionality rather than creating a new test-only component, since it's already on `main` and is unlikely to change significantly. Unit tests are covering all the actually interesting bits anyway.

The one thing that _I_ was surprised by is that the `qunit-dom` helpers were capable of clicking a button in a disabled `fieldset`, even though that's not possible from the browser UI, which means I can't write a sensible "failed to yank" style test. (I tried a few different ways just to be sure.)