### PR TITLE
database: Add index on `crate_downloads` table

### DIFF
--- a/migrations/2024-03-05-120032_add-crate-downloads-index/down.sql
+++ b/migrations/2024-03-05-120032_add-crate-downloads-index/down.sql
@@ -1,0 +1,1 @@
+drop index concurrently crate_downloads_downloads_crate_id_index;

--- a/migrations/2024-03-05-120032_add-crate-downloads-index/metadata.toml
+++ b/migrations/2024-03-05-120032_add-crate-downloads-index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2024-03-05-120032_add-crate-downloads-index/up.sql
+++ b/migrations/2024-03-05-120032_add-crate-downloads-index/up.sql
@@ -1,0 +1,2 @@
+create index concurrently if not exists crate_downloads_downloads_crate_id_index
+    on crate_downloads (downloads desc, crate_id desc);


### PR DESCRIPTION
We discussed this change on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/.60crate_downloads.60.20table), and it looks like this will be a significant performance improvement for search queries that use the new `crate_downloads` table.