### PR TITLE
controllers/user/other: Read downloads from `crate_downloads` table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ aws-sdk-sqs = "=1.15.0"
 axum = { version = "=0.7.4", features = ["macros", "matched-path"] }
 axum-extra = { version = "=0.9.2", features = ["cookie-signed", "typed-header"] }
 base64 = "=0.22.0"
-bigdecimal = "=0.4.3"
+bigdecimal = { version = "=0.4.3", features = ["serde"] }
 cargo-manifest = "=0.13.0"
 crates_io_cdn_logs = { path = "crates_io_cdn_logs" }
 crates_io_env_vars = { path = "crates_io_env_vars" }


### PR DESCRIPTION
This is roughly similar to #8244 and switches the `/api/v1/users/:user_id/stats` endpoint over to using the `crate_downloads` database table instead of the `crates.downloads` column.