### PR TITLE
typosquat/database: Sort by downloads from `crate_downloads` table

### DIFF
--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -20,7 +20,7 @@ impl TopCrates {
     pub fn new(conn: &mut PgConnection, num: i64) -> QueryResult<Self> {
         use crate::{
             models,
-            schema::{crate_owners, crates},
+            schema::{crate_downloads, crate_owners},
         };
         use diesel::prelude::*;
 
@@ -43,7 +43,8 @@ impl TopCrates {
 
         let mut crates: BTreeMap<i32, (String, Crate)> = BTreeMap::new();
         for result in models::Crate::all()
-            .order(crates::downloads.desc())
+            .inner_join(crate_downloads::table)
+            .order(crate_downloads::downloads.desc())
             .limit(num)
             .load_iter::<models::Crate, DefaultLoadingMode>(conn)?
         {

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -6,7 +6,7 @@ use crate::{
     models::{
         Crate, CrateOwner, NewCrate, NewTeam, NewUser, NewVersion, Owner, OwnerKind, User, Version,
     },
-    schema::{crate_owners, crates},
+    schema::{crate_downloads, crate_owners},
     Emails,
 };
 
@@ -60,9 +60,9 @@ impl Faker {
         }
         .create(conn, user.id)?;
 
-        diesel::update(crates::table)
-            .filter(crates::id.eq(krate.id))
-            .set(crates::downloads.eq(downloads))
+        diesel::update(crate_downloads::table)
+            .filter(crate_downloads::crate_id.eq(krate.id))
+            .set(crate_downloads::downloads.eq(downloads as i64))
             .execute(conn)?;
 
         let version = NewVersion::new(


### PR DESCRIPTION
This is roughly similar to #8244 and switches the typosquatting detection code over to using the `crate_downloads` database table instead of the `crates.downloads` column.