### PR TITLE
models/krate_reverse_dependencies.sql: Read downloads from `crate_downloads` table

### DIFF
--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -1,4 +1,4 @@
-use diesel::sql_types::{Integer, Text};
+use diesel::sql_types::{BigInt, Text};
 
 use crate::models::{Crate, Version};
 use crate::schema::*;
@@ -29,8 +29,8 @@ pub struct Dependency {
 pub struct ReverseDependency {
     #[diesel(embed)]
     pub dependency: Dependency,
-    #[diesel(sql_type = Integer)]
-    pub crate_downloads: i32,
+    #[diesel(sql_type = BigInt)]
+    pub crate_downloads: i64,
     #[diesel(sql_type = Text, column_name = crate_name)]
     pub name: String,
 }

--- a/src/models/krate_reverse_dependencies.sql
+++ b/src/models/krate_reverse_dependencies.sql
@@ -4,7 +4,7 @@ FROM (
     -- Apply pagination to the crates
     SELECT *, COUNT(*) OVER () as total FROM (
         SELECT
-            crates.downloads AS crate_downloads,
+            crate_downloads.downloads AS crate_downloads,
             crates.name AS crate_name,
             versions.id AS version_id
         FROM
@@ -22,6 +22,8 @@ FROM (
         ) versions
         INNER JOIN crates
           ON crates.id = versions.crate_id
+        INNER JOIN crate_downloads
+          ON crate_downloads.crate_id = crates.id
         WHERE versions.id IN (SELECT version_id FROM dependencies WHERE crate_id = $1)
     ) c
     ORDER BY

--- a/src/views.rs
+++ b/src/views.rs
@@ -120,7 +120,7 @@ pub struct EncodableDependency {
     pub features: Vec<String>,
     pub target: Option<String>,
     pub kind: DependencyKind,
-    pub downloads: i32,
+    pub downloads: i64,
 }
 
 impl EncodableDependency {
@@ -134,7 +134,7 @@ impl EncodableDependency {
     }
 
     // `downloads` need only be specified when generating a reverse dependency
-    fn encode(dependency: Dependency, crate_name: &str, downloads: Option<i32>) -> Self {
+    fn encode(dependency: Dependency, crate_name: &str, downloads: Option<i64>) -> Self {
         Self {
             id: dependency.id,
             version_id: dependency.version_id,


### PR DESCRIPTION
This is roughly similar to #8244 and switches the reverse dependencies endpoint over to using the `crate_downloads` database table instead of the `crates.downloads` column.