### PR TITLE
opensearch: Adjust search engine name and description

### DIFF
--- a/public/opensearch.xml
+++ b/public/opensearch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
-    <ShortName>Cargo</ShortName>
-    <Description>Search for crates on crates.io</Description>
+    <ShortName>crates.io</ShortName>
+    <Description>Search for crates in the official Rust package registry</Description>
     <Image type="image/png">https://crates.io/assets/cargo.png</Image>
     <Url type="text/html" method="get" template="https://crates.io/search?q={searchTerms}"/>
 </OpenSearchDescription>


### PR DESCRIPTION
Searching "on Cargo" seemed a bit confusing when the page is called crates.io. I assume this was a remainder of the time before the cargo registry was rebranded to crates.io.