### PR TITLE
Add `clean_processed_log_files` background job

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -15,6 +15,7 @@ use secrecy::{ExposeSecret, SecretString};
 )]
 pub enum Command {
     UpdateDownloads,
+    CleanProcessedLogFiles,
     DumpDb {
         #[arg(env = "READ_ONLY_REPLICA_URL")]
         database_url: SecretString,
@@ -58,6 +59,9 @@ pub fn run(command: Command) -> Result<()> {
             } else {
                 jobs::UpdateDownloads.enqueue(conn)?;
             }
+        }
+        Command::CleanProcessedLogFiles => {
+            jobs::CleanProcessedLogFiles.enqueue(conn)?;
         }
         Command::DumpDb {
             database_url,

--- a/src/worker/jobs/downloads/clean_processed_log_files.rs
+++ b/src/worker/jobs/downloads/clean_processed_log_files.rs
@@ -1,0 +1,112 @@
+use crate::schema::processed_log_files;
+use crate::worker::Environment;
+use anyhow::anyhow;
+use crates_io_worker::BackgroundJob;
+use diesel::prelude::*;
+use std::sync::Arc;
+
+/// This job is responsible for cleaning up old entries in the
+/// `processed_log_files` table.
+///
+/// Rows older than one week will be deleted.
+#[derive(Serialize, Deserialize)]
+pub struct CleanProcessedLogFiles;
+
+impl BackgroundJob for CleanProcessedLogFiles {
+    const JOB_NAME: &'static str = "clean_processed_log_files";
+    const QUEUE: &'static str = "downloads";
+
+    type Context = Arc<Environment>;
+
+    async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
+        let conn = env.deadpool.get().await?;
+        conn.interact(run)
+            .await
+            .map_err(|err| anyhow!(err.to_string()))??;
+
+        Ok(())
+    }
+}
+
+fn run(conn: &mut PgConnection) -> QueryResult<()> {
+    let filter = processed_log_files::time.lt(cut_off_date());
+    diesel::delete(processed_log_files::table.filter(filter)).execute(conn)?;
+
+    Ok(())
+}
+
+fn cut_off_date() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now() - chrono::TimeDelta::try_weeks(1).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::test_db_connection;
+    use chrono::{DateTime, Utc};
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn test_cleanup() {
+        let (_test_db, conn) = &mut test_db_connection();
+
+        let now = chrono::Utc::now();
+        let cut_off_date = cut_off_date();
+        let one_hour = chrono::Duration::try_hours(1).unwrap();
+
+        insert(
+            conn,
+            vec![
+                ("very-old-file", cut_off_date - one_hour * 30 * 24),
+                ("old-file", cut_off_date - one_hour),
+                ("newish-file", cut_off_date + one_hour),
+                ("brand-new-file", now),
+                ("future-file", now + one_hour * 7 * 24),
+            ],
+        );
+        assert_debug_snapshot!(paths_in_table(conn), @r###"
+        [
+            "very-old-file",
+            "old-file",
+            "newish-file",
+            "brand-new-file",
+            "future-file",
+        ]
+        "###);
+
+        run(conn).unwrap();
+        assert_debug_snapshot!(paths_in_table(conn), @r###"
+        [
+            "newish-file",
+            "brand-new-file",
+            "future-file",
+        ]
+        "###);
+    }
+
+    /// Insert a list of paths and times into the `processed_log_files` table.
+    fn insert(conn: &mut PgConnection, inserts: Vec<(&str, DateTime<Utc>)>) {
+        let inserts = inserts
+            .into_iter()
+            .map(|(path, time)| {
+                (
+                    processed_log_files::path.eq(path),
+                    processed_log_files::time.eq(time),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        diesel::insert_into(processed_log_files::table)
+            .values(&inserts)
+            .execute(conn)
+            .unwrap();
+    }
+
+    /// Read all paths from the `processed_log_files` table.
+    fn paths_in_table(conn: &mut PgConnection) -> Vec<String> {
+        processed_log_files::table
+            .select(processed_log_files::path)
+            .load::<String>(conn)
+            .unwrap()
+    }
+}

--- a/src/worker/jobs/downloads/mod.rs
+++ b/src/worker/jobs/downloads/mod.rs
@@ -1,7 +1,9 @@
+mod clean_processed_log_files;
 mod process_log;
 mod queue;
 mod update_metadata;
 
+pub use clean_processed_log_files::CleanProcessedLogFiles;
 pub use process_log::ProcessCdnLog;
 pub use queue::ProcessCdnLogQueue;
 pub use update_metadata::UpdateDownloads;

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -14,7 +14,9 @@ mod sync_admins;
 mod typosquat;
 
 pub use self::daily_db_maintenance::DailyDbMaintenance;
-pub use self::downloads::{ProcessCdnLog, ProcessCdnLogQueue, UpdateDownloads};
+pub use self::downloads::{
+    CleanProcessedLogFiles, ProcessCdnLog, ProcessCdnLogQueue, UpdateDownloads,
+};
 pub use self::dump_db::DumpDb;
 pub use self::git::{NormalizeIndex, SquashIndex, SyncToGitIndex, SyncToSparseIndex};
 pub use self::readmes::RenderAndUploadReadme;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -20,6 +20,7 @@ pub trait RunnerExt {
 impl RunnerExt for Runner<Arc<Environment>> {
     fn register_crates_io_job_types(self) -> Self {
         self.register_job_type::<jobs::CheckTyposquat>()
+            .register_job_type::<jobs::CleanProcessedLogFiles>()
             .register_job_type::<jobs::DailyDbMaintenance>()
             .register_job_type::<jobs::DumpDb>()
             .register_job_type::<jobs::NormalizeIndex>()


### PR DESCRIPTION
Our `processed_log_files` is already at 35k+ rows and growing steadily. We don't want it to grow infinitely though, so this commit implements a new background job that can be run regularly to remove obsolete rows from the table. The cut off date is currently hardcoded to one week, which should be sufficient to prevent duplicate SQS events and keep the table at a reasonable size.