### PR TITLE
index: Fix broken `git reset --hard`

### DIFF
--- a/crates/crates_io_index/repo.rs
+++ b/crates/crates_io_index/repo.rs
@@ -287,6 +287,9 @@ impl Repository {
 
         let head = self.head_oid()?;
         if head != original_head {
+            // Ensure that the internal state of `self.repository` is updated correctly
+            self.repository.checkout_head(None)?;
+
             info!("Index reset from {original_head} to {head}");
         }
 


### PR DESCRIPTION
Context: https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/Routing.20download.20traffic.20away.20from.20crates.2Eio/near/426076481

It turns out that https://github.com/rust-lang/crates.io/commit/47e3e6e5cabff53c3479a8af5854adf97264df42 was faulty. The `git reset --hard` call did reset the repository, but it seems like the git2 `Repository` has some kind of internal state (?) that is not correctly reset by that call. The documentation of `checkout_head()` claims that it "Updates files in the index and the working tree to match the content of the commit pointed at by HEAD" and that appears to solve the problem. The new test case confirms that.

Related:
- https://github.com/rust-lang/crates.io/pull/6473