### PR TITLE
CI: Fix `changed-files` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         id: changed-files-non-rust
         with:
           files_ignore: |
-            crates_io_*/**
+            crates/**
             migrations/**
             src/**
             build.rs


### PR DESCRIPTION
The sub-crates have been moved to the `crates/` folder, but we forgot to adjust the path list here.

Related:

- #8263

/cc @hi-rustin 