### PR TITLE
fix(docs): crates-io-worker url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This service is maintained for you by the [crates.io team], with support from th
 
 We welcome contributions from the community! Whether you're fixing a bug, implementing a new feature, or improving documentation, your contributions help make [crates.io] better for everyone.
 
-[crates.io] is built with [Rust] for the backend services. More specifically, the [axum] web framework and [diesel] for database access, with a [custom-built background worker system](./crates_io_worker). The frontend is an [Ember.js] application written in JavaScript.
+[crates.io] is built with [Rust] for the backend services. More specifically, the [axum] web framework and [diesel] for database access, with a [custom-built background worker system](./crates/crates_io_worker). The frontend is an [Ember.js] application written in JavaScript.
 
 Please review our [contribution guidelines](./docs/CONTRIBUTING.md) before submitting your pull request. The same document also contains instructions on how to set up a local development environment.
 


### PR DESCRIPTION
Commit b9f92e0b6d355da065f627daf274d4475491c4f6 moved the `crates-io-worker` crate to `crates/` directory. This PR fixes the the relative URL in `README.md` to point to `crates/` directory.