### PR TITLE
reqwest: Enable missing `blocking` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ parking_lot = "=0.12.1"
 paste = "=1.0.14"
 prometheus = { version = "=0.13.3", default-features = false }
 rand = "=0.8.5"
-reqwest = { version = "=0.11.27", features = ["gzip", "json"] }
+reqwest = { version = "=0.11.27", features = ["blocking", "gzip", "json"] }
 scheduled-thread-pool = "=0.2.7"
 secrecy = "=0.8.0"
 semver = { version = "=1.0.22", features = ["serde"] }


### PR DESCRIPTION
Some parts of our main crate are still using the `blocking` functionality...