### PR TITLE
controllers/version/downloads: Remove unused `get_version_id()` fn

### DIFF
--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -26,16 +26,6 @@ pub async fn download(
     }
 }
 
-#[instrument("db.query", skip(conn), fields(message = "SELECT ... FROM versions"))]
-fn get_version_id(krate: &str, version: &str, conn: &mut PgConnection) -> QueryResult<i32> {
-    versions::table
-        .inner_join(crates::table)
-        .select(versions::id)
-        .filter(crates::name.eq(&krate))
-        .filter(versions::num.eq(&version))
-        .first::<i32>(conn)
-}
-
 /// Handles the `GET /crates/:crate_id/:version/downloads` route.
 pub async fn downloads(
     app: AppState,


### PR DESCRIPTION
This hasn't been used since 59377c8f5214f6800df37790328a268381c68c4e was merged