### PR TITLE
Revert "tests: Use `tracing::subscriber::DefaultGuard` to set subscriber (#8023)"

### DIFF
--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -3,7 +3,7 @@ use crates_io_test_db::TestDatabase;
 
 #[test]
 fn dump_db_and_reimport_dump() {
-    let _guard = crates_io::util::tracing::init_for_test();
+    crates_io::util::tracing::init_for_test();
 
     let db_one = TestDatabase::new();
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -23,12 +23,8 @@ use oauth2::{ClientId, ClientSecret};
 use std::collections::HashSet;
 use std::{rc::Rc, sync::Arc, time::Duration};
 use tokio::runtime::Runtime;
-use tracing::subscriber::DefaultGuard;
 
 struct TestAppInner {
-    #[allow(dead_code)]
-    tracing_guard: DefaultGuard,
-
     pub runtime: Runtime,
 
     app: Arc<App>,
@@ -81,10 +77,9 @@ pub struct TestApp(Rc<TestAppInner>);
 impl TestApp {
     /// Initialize an application with an `Uploader` that panics
     pub fn init() -> TestAppBuilder {
-        let tracing_guard = crates_io::util::tracing::init_for_test();
+        crates_io::util::tracing::init_for_test();
 
         TestAppBuilder {
-            tracing_guard,
             config: simple_config(),
             index: None,
             build_job_runner: false,
@@ -210,7 +205,6 @@ impl TestApp {
 }
 
 pub struct TestAppBuilder {
-    tracing_guard: DefaultGuard,
     config: config::Server,
     index: Option<UpstreamIndex>,
     build_job_runner: bool,
@@ -297,7 +291,6 @@ impl TestAppBuilder {
         };
 
         let test_app_inner = TestAppInner {
-            tracing_guard: self.tracing_guard,
             runtime,
             app,
             test_database,

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,5 +1,4 @@
 use sentry::integrations::tracing::EventFilter;
-use tracing::subscriber::DefaultGuard;
 use tracing::Level;
 use tracing::Metadata;
 use tracing_subscriber::filter::LevelFilter;
@@ -47,17 +46,15 @@ pub fn event_filter(metadata: &Metadata<'_>) -> EventFilter {
 }
 
 /// Initializes the `tracing` logging framework for usage in tests.
-pub fn init_for_test() -> DefaultGuard {
+pub fn init_for_test() {
     let env_filter = EnvFilter::builder()
         .with_default_directive(LevelFilter::INFO.into())
         .from_env_lossy();
 
-    let subscriber = tracing_subscriber::fmt()
+    let _ = tracing_subscriber::fmt()
         .compact()
         .with_env_filter(env_filter)
         .without_time()
         .with_test_writer()
-        .finish();
-
-    tracing::subscriber::set_default(subscriber)
+        .try_init();
 }

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -395,7 +395,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_cdn_log() {
-        let _guard = crate::util::tracing::init_for_test();
+        crate::util::tracing::init_for_test();
 
         let test_database = TestDatabase::new();
         let db_pool = build_connection_pool(test_database.url());

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -233,7 +233,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_cdn_log_queue() {
-        let _guard = crate::util::tracing::init_for_test();
+        crate::util::tracing::init_for_test();
 
         let mut queue = Box::new(MockSqsQueue::new());
         queue
@@ -263,7 +263,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_cdn_log_queue_multi_page() {
-        let _guard = crate::util::tracing::init_for_test();
+        crate::util::tracing::init_for_test();
 
         let mut queue = Box::new(MockSqsQueue::new());
         queue
@@ -323,7 +323,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_process_cdn_log_queue_parse_error() {
-        let _guard = crate::util::tracing::init_for_test();
+        crate::util::tracing::init_for_test();
 
         let mut queue = Box::new(MockSqsQueue::new());
         queue


### PR DESCRIPTION
This reverts commit aa0f7844be82350a43f593e547ff33cab6abc34a.

While this worked in theory, it apparently only worked on the thread where it was executed, but not on other threads like the background worker 🙈 