### PR TITLE
tests: Reduce pool sizes

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -391,8 +391,8 @@ fn simple_config() -> config::Server {
             // something is broken.
             url: String::from("invalid default url").into(),
             read_only_mode: false,
-            pool_size: 5,
-            async_pool_size: 5,
+            pool_size: 3,
+            async_pool_size: 2,
             min_idle: None,
         },
         replica: None,


### PR DESCRIPTION
Without this the tests sometimes break because all available database connections are already taken. This is particularly relevant for the tests that use `deadpool`, since those connections are cleaned up asynchronously.