### PR TITLE
tests: Explicitly close async database pools within the context of a tokio runtime

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -67,6 +67,16 @@ impl Drop for TestAppInner {
         );
 
         // TODO: If a runner was started, obtain the clone from it and ensure its HEAD matches the upstream index HEAD
+
+        // We manually close the connection pools here to prevent their `Drop`
+        // implementation from failing because no tokio runtime is running.
+        {
+            let _rt_guard = self.runtime.enter();
+            self.app.deadpool_primary.close();
+            if let Some(pool) = &self.app.deadpool_replica {
+                pool.close();
+            }
+        }
     }
 }
 


### PR DESCRIPTION


Without this, the `Drop` implementation of the the pool would complain about not running within a tokio runtime and ultimately panic the tests. This only happened to work so far because none of our integration tests had used the async database pool yet.