### PR TITLE
worker: Replace `r2d2` with `deadpool`

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -15,7 +15,6 @@ extern crate tracing;
 
 use anyhow::Context;
 use crates_io::cloudfront::CloudFront;
-use crates_io::db::DieselPool;
 use crates_io::fastly::Fastly;
 use crates_io::storage::Storage;
 use crates_io::team_repo::TeamRepoImpl;
@@ -96,7 +95,6 @@ fn main() -> anyhow::Result<()> {
         .cloudfront(cloudfront)
         .fastly(fastly)
         .storage(storage)
-        .connection_pool(DieselPool::new_background_worker(connection_pool.clone()))
         .deadpool(deadpool)
         .emails(emails)
         .team_repo(Box::new(team_repo))

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -280,7 +280,6 @@ impl TestAppBuilder {
                 .config(app.config.clone())
                 .repository_config(repository_config)
                 .storage(app.storage.clone())
-                .connection_pool(app.primary_database.clone())
                 .deadpool(app.deadpool_primary.clone())
                 .emails(app.emails.clone())
                 .team_repo(Box::new(self.team_repo))

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -1,5 +1,4 @@
 use crate::cloudfront::CloudFront;
-use crate::db::DieselPool;
 use crate::fastly::Fastly;
 use crate::storage::Storage;
 use crate::team_repo::TeamRepo;
@@ -27,7 +26,6 @@ pub struct Environment {
     #[builder(default)]
     fastly: Option<Fastly>,
     pub storage: Arc<Storage>,
-    pub connection_pool: DieselPool,
     pub deadpool: DeadpoolPool,
     pub emails: Emails,
     pub team_repo: Box<dyn TeamRepo + Send + Sync>,


### PR DESCRIPTION
This PR ports all of our background worker jobs to use the async database connection pool (based on the `deadpool` crate) instead of `r2d2` (which does not support `diesel-async`).

This was initially causing failing and flaky tests, but those issues got resolved by:

- https://github.com/rust-lang/crates.io/pull/8382
- and https://github.com/rust-lang/crates.io/pull/8381