### PR TITLE
Implement rate limiting for e-mail verifications

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -1,4 +1,6 @@
 use crate::auth::AuthCheck;
+use crate::rate_limiter::LimitedAction;
+use crate::rate_limiter::RateLimiter;
 use secrecy::{ExposeSecret, SecretString};
 use std::collections::HashMap;
 
@@ -159,11 +161,13 @@ pub async fn update_user(
             // an invalid email set in their GitHub profile, and we should let them sign in even though
             // we're trying to silently use their invalid address during signup and can't send them an
             // email. They'll then have to provide a valid email address.
-            let email = UserConfirmEmail {
-                user_name: &user.gh_login,
-                domain: &state.emails.domain,
+            let email = UserConfirmEmail::new(
+                &state.rate_limiter,
+                conn,
+                user,
+                &state.emails.domain,
                 token,
-            };
+            )?;
 
             let _ = state.emails.send(user_email, email);
 
@@ -222,11 +226,13 @@ pub async fn regenerate_token_and_send(
                 .optional()?
                 .ok_or_else(|| bad_request("Email could not be found"))?;
 
-            let email1 = UserConfirmEmail {
-                user_name: &user.gh_login,
-                domain: &state.emails.domain,
-                token: email.token,
-            };
+            let email1 = UserConfirmEmail::new(
+                &state.rate_limiter,
+                conn,
+                user,
+                &state.emails.domain,
+                email.token,
+            )?;
 
             state.emails.send(&email.email, email1).map_err(Into::into)
         })?;
@@ -300,9 +306,26 @@ pub async fn update_email_notifications(app: AppState, req: BytesRequest) -> App
 }
 
 pub struct UserConfirmEmail<'a> {
-    pub user_name: &'a str,
-    pub domain: &'a str,
-    pub token: SecretString,
+    user_name: &'a str,
+    domain: &'a str,
+    token: SecretString,
+}
+
+impl<'a> UserConfirmEmail<'a> {
+    pub fn new(
+        rate_limiter: &RateLimiter,
+        conn: &mut PgConnection,
+        user: &'a User,
+        domain: &'a str,
+        token: SecretString,
+    ) -> AppResult<Self> {
+        rate_limiter.check_rate_limit(user.id, LimitedAction::VerifyEmail, conn)?;
+        Ok(Self {
+            user_name: &user.gh_login,
+            domain,
+            token,
+        })
+    }
 }
 
 impl crate::email::Email for UserConfirmEmail<'_> {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -636,7 +636,12 @@ fn inactive_users_dont_get_invitations() {
             gh_avatar: None,
             gh_access_token: "some random token",
         }
-        .create_or_update(None, &app.as_inner().emails, conn)
+        .create_or_update(
+            None,
+            &app.as_inner().emails,
+            &app.as_inner().rate_limiter,
+            conn,
+        )
         .unwrap();
         CrateBuilder::new(krate_name, owner.id).expect_build(conn);
     });

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -20,7 +20,12 @@ fn index() {
 
     let krate = app.db(|conn| {
         let u = new_user("foo")
-            .create_or_update(None, &app.as_inner().emails, conn)
+            .create_or_update(
+                None,
+                &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
+                conn,
+            )
             .unwrap();
         CrateBuilder::new("fooindex", u.id).expect_build(conn)
     });

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -111,7 +111,12 @@ fn test_update_email_notifications_not_owned() {
 
     let not_my_crate = app.db(|conn| {
         let u = new_user("arbitrary_username")
-            .create_or_update(None, &app.as_inner().emails, conn)
+            .create_or_update(
+                None,
+                &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
+                conn,
+            )
             .unwrap();
         CrateBuilder::new("test_package", u.id).expect_build(conn)
     });

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -39,7 +39,12 @@ fn show_latest_user_case_insensitively() {
             None,
             "bar"
         )
-        .create_or_update(None, &app.as_inner().emails, conn));
+        .create_or_update(
+            None,
+            &app.as_inner().emails,
+            &app.as_inner().rate_limiter,
+            conn
+        ));
         assert_ok!(NewUser::new(
             2,
             "FOOBAR",
@@ -47,7 +52,12 @@ fn show_latest_user_case_insensitively() {
             None,
             "bar"
         )
-        .create_or_update(None, &app.as_inner().emails, conn));
+        .create_or_update(
+            None,
+            &app.as_inner().emails,
+            &app.as_inner().rate_limiter,
+            conn
+        ));
     });
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/fOObAr").good();

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -29,6 +29,7 @@ fn updating_existing_user_doesnt_change_api_token() {
             NewUser::new(gh_id, "bar", None, None, "bar_token").create_or_update(
                 None,
                 &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
                 conn
             )
         );
@@ -60,7 +61,12 @@ fn github_without_email_does_not_overwrite_email() {
     let user_without_github_email = app.db(|conn| {
         let u = new_user("arbitrary_username");
         let u = u
-            .create_or_update(None, &app.as_inner().emails, conn)
+            .create_or_update(
+                None,
+                &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
+                conn,
+            )
             .unwrap();
         MockCookieUser::new(&app, u)
     });
@@ -82,7 +88,12 @@ fn github_without_email_does_not_overwrite_email() {
             ..new_user("arbitrary_username")
         };
         let u = u
-            .create_or_update(None, &app.as_inner().emails, conn)
+            .create_or_update(
+                None,
+                &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
+                conn,
+            )
             .unwrap();
         MockCookieUser::new(&app, u)
     });
@@ -117,7 +128,12 @@ fn github_with_email_does_not_overwrite_email() {
             ..new_user("arbitrary_username")
         };
         let u = u
-            .create_or_update(Some(new_github_email), &app.as_inner().emails, conn)
+            .create_or_update(
+                Some(new_github_email),
+                &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
+                conn,
+            )
             .unwrap();
         MockCookieUser::new(&app, u)
     });
@@ -164,7 +180,12 @@ fn test_confirm_user_email() {
             ..new_user("arbitrary_username")
         };
         let u = u
-            .create_or_update(Some(email), &app.as_inner().emails, conn)
+            .create_or_update(
+                Some(email),
+                &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
+                conn,
+            )
             .unwrap();
         MockCookieUser::new(&app, u)
     });
@@ -204,7 +225,12 @@ fn test_existing_user_email() {
             ..new_user("arbitrary_username")
         };
         let u = u
-            .create_or_update(Some(email), &app.as_inner().emails, conn)
+            .create_or_update(
+                Some(email),
+                &app.as_inner().emails,
+                &app.as_inner().rate_limiter,
+                conn,
+            )
             .unwrap();
         update(Email::belonging_to(&u))
             // Users created before we added verification will have

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -127,7 +127,7 @@ impl TestApp {
             let email = "something@example.com";
 
             let user = crate::new_user(username)
-                .create_or_update(None, &self.0.app.emails, conn)
+                .create_or_update(None, &self.0.app.emails, &self.0.app.rate_limiter, conn)
                 .unwrap();
             diesel::insert_into(emails::table)
                 .values((

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -170,13 +170,19 @@ mod tests {
     use super::*;
     use crate::email::Emails;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
+    use crate::rate_limiter::RateLimiter;
     use crate::schema::{crate_downloads, crates, versions};
     use crate::test_util::test_db_connection;
     use std::collections::BTreeMap;
 
     fn user(conn: &mut PgConnection) -> User {
         NewUser::new(2, "login", None, None, "access_token")
-            .create_or_update(None, &Emails::new_in_memory(), conn)
+            .create_or_update(
+                None,
+                &Emails::new_in_memory(),
+                &RateLimiter::new(Default::default()),
+                conn,
+            )
             .unwrap()
     }
 


### PR DESCRIPTION
This applies a burst of 3 and a refill time of 30 minutes by default per user. (Not that I can imagine a scenario where we'd ever override this for a user, but using the same machinery as other user actions is obviously much simpler.)

I don't love that this ends up essentially prop-drilling the rate limiter into a bunch of new places, but I don't see an alternative other than prop-drilling the whole app struct through, which would be worse.

This doesn't address (sorry) per-address rate limiting, but is at least a reasonable starting point.