### PR TITLE
tests/builders/krate: Remove `crates.downloads` column writes

### DIFF
--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -129,11 +129,6 @@ impl<'a> CrateBuilder<'a> {
             update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate.id)))
                 .set(crate_downloads::downloads.eq(downloads as i64))
                 .execute(connection)?;
-
-            krate = update(&krate)
-                .set(crates::downloads.eq(downloads))
-                .returning(Crate::as_returning())
-                .get_result(connection)?;
         }
 
         if self.versions.is_empty() {


### PR DESCRIPTION
Since https://github.com/rust-lang/crates.io/pull/8295 was merged we've no longer updated this column in production code. This PR removes updates from our test code too, so that it reflects the situation in production.