### PR TITLE
crates_io_worker: Replace `r2d2` with `deadpool`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "crates_io_test_db",
+ "deadpool-diesel",
  "diesel",
  "futures-util",
  "sentry-core",

--- a/crates/crates_io_worker/Cargo.toml
+++ b/crates/crates_io_worker/Cargo.toml
@@ -9,7 +9,8 @@ workspace = true
 
 [dependencies]
 anyhow = "=1.0.81"
-diesel = { version = "=2.1.5", features = ["postgres", "r2d2", "serde_json"] }
+deadpool-diesel = { version = "=0.6.0", features = ["postgres", "tracing"] }
+diesel = { version = "=2.1.5", features = ["postgres", "serde_json"] }
 futures-util = "=0.3.30"
 sentry-core = { version = "=0.32.2", features = ["client"] }
 serde = { version = "=1.0.197", features = ["derive"] }

--- a/crates/crates_io_worker/src/util.rs
+++ b/crates/crates_io_worker/src/util.rs
@@ -3,23 +3,6 @@ use sentry_core::Hub;
 use std::any::Any;
 use std::future::Future;
 use std::panic::PanicInfo;
-use tokio::task::JoinError;
-
-pub async fn spawn_blocking<F, R, E>(f: F) -> Result<R, E>
-where
-    F: FnOnce() -> Result<R, E> + Send + 'static,
-    R: Send + 'static,
-    E: Send + From<JoinError> + 'static,
-{
-    let current_span = tracing::Span::current();
-    let hub = Hub::current();
-    tokio::task::spawn_blocking(move || current_span.in_scope(|| Hub::run(hub, f)))
-        .await
-        // Convert `JoinError` to `E`
-        .map_err(Into::into)
-        // Flatten `Result<Result<_, E>, E>` to `Result<_, E>`
-        .and_then(std::convert::identity)
-}
 
 pub async fn with_sentry_transaction<F, R, E, Fut>(
     transaction_name: &str,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -283,7 +283,7 @@ impl TestAppBuilder {
 
             let runner = Runner::new(
                 runtime.handle(),
-                (*app.primary_database).clone(),
+                app.deadpool_primary.clone(),
                 Arc::new(environment),
             )
             .shutdown_when_queue_empty()

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -179,8 +179,8 @@ impl TestApp {
         let handle = runner.start();
         self.runtime().block_on(handle.wait_for_shutdown());
 
-        runner
-            .check_for_failed_jobs()
+        self.runtime()
+            .block_on(runner.check_for_failed_jobs())
             .expect("Could not determine if jobs failed");
     }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -396,7 +396,7 @@ fn simple_config() -> config::Server {
             url: String::from("invalid default url").into(),
             read_only_mode: false,
             pool_size: 3,
-            async_pool_size: 2,
+            async_pool_size: 3,
             min_idle: None,
         },
         replica: None,


### PR DESCRIPTION
While #8385 ported the individual background worker jobs from `r2d2` to `deadpool`, this PR ports the background worker system itself to it.

Note that the default `async_pool_size` for the test suite had to be increased because the background worker system now requires us to have one more connection available.