### PR TITLE
tests/util/test_app: Simplify `test_database` field

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -36,7 +36,7 @@ struct TestAppInner {
     replica_db_chaosproxy: Option<Arc<ChaosProxy>>,
 
     // Must be the last field of the struct!
-    test_database: Option<TestDatabase>,
+    test_database: TestDatabase,
 }
 
 impl Drop for TestAppInner {
@@ -109,10 +109,7 @@ impl TestApp {
     /// connection before making any API calls.  Once the closure returns, the connection is
     /// dropped, ensuring it is returned to the pool and available for any future API calls.
     pub fn db<T, F: FnOnce(&mut PgConnection) -> T>(&self, f: F) -> T {
-        match self.0.test_database.as_ref() {
-            Some(test_database) => f(&mut test_database.connect()),
-            None => f(&mut self.0.app.db_write().unwrap()),
-        }
+        f(&mut self.0.test_database.connect())
     }
 
     /// Create a new user with a verified email address in the database and return a mock user
@@ -233,9 +230,9 @@ impl TestAppBuilder {
 
         // Run each test inside a fresh database schema, deleted at the end of the test,
         // The schema will be cleared up once the app is dropped.
-        let (primary_db_chaosproxy, replica_db_chaosproxy, test_database) = {
-            let test_database = TestDatabase::new();
+        let test_database = TestDatabase::new();
 
+        let (primary_db_chaosproxy, replica_db_chaosproxy) = {
             let primary_proxy = if self.use_chaos_proxy {
                 let (primary_proxy, url) =
                     ChaosProxy::proxy_database_url(test_database.url()).unwrap();
@@ -260,7 +257,7 @@ impl TestAppBuilder {
                 }
             });
 
-            (primary_proxy, replica_proxy, Some(test_database))
+            (primary_proxy, replica_proxy)
         };
 
         let (app, router) = build_app(self.config);


### PR DESCRIPTION
We always assign this with `Some(_)`, so we might as well remove the `Option` wrapper.

As a side-effect, this brings us a little closer to removing the r2d2 connection pool, since it removes yet another `db_write()` fn call :)