### PR TITLE
tests/util/test_app: Remove duplicate background job assertion

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -53,8 +53,6 @@ impl Drop for TestAppInner {
         if let Some(runner) = &self.runner {
             let handle = runner.start();
             self.runtime.block_on(handle.wait_for_shutdown());
-
-            runner.check_for_failed_jobs().expect("Failed jobs remain");
         }
 
         // Manually verify that all jobs have completed successfully


### PR DESCRIPTION
The following `background_jobs::table.count() == 0` assertion covers this case already, so there is no need for us to run two queries.