### PR TITLE
util/errors: Convert `deadpool` errors to "503 Service Unavailable" responses

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -179,8 +179,8 @@ impl From<PoolError> for BoxedAppError {
 }
 
 impl From<deadpool_diesel::PoolError> for BoxedAppError {
-    fn from(err: deadpool_diesel::PoolError) -> BoxedAppError {
-        Box::new(err)
+    fn from(_err: deadpool_diesel::PoolError) -> BoxedAppError {
+        service_unavailable()
     }
 }
 


### PR DESCRIPTION
Previously, these were converted to "500 Internal Server Error", but this didn't match the behavior of the r2d2-based connection pool. This PR adjusts the error conversion code to return "503 Service Unavailable" responses instead.