### PR TITLE
util/errors: Convert `ClosedConnection` errors to "503 Service Unavailable" responses

### DIFF
--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -20,7 +20,7 @@ use std::fmt;
 
 use axum::Extension;
 use chrono::NaiveDateTime;
-use diesel::result::Error as DieselError;
+use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use http::StatusCode;
 use tokio::task::JoinError;
 
@@ -150,6 +150,9 @@ impl From<DieselError> for BoxedAppError {
                 if info.message().ends_with("read-only transaction") =>
             {
                 Box::new(ReadOnlyMode)
+            }
+            DieselError::DatabaseError(DatabaseErrorKind::ClosedConnection, _) => {
+                service_unavailable()
             }
             _ => Box::new(err),
         }


### PR DESCRIPTION
If the database server closes the connection while we're still connected then it's usually a signal that the database is no longer available. For the r2d2-based connection pool we detect these situations and convert them to `UnhealthyPool` errors, but with `deadpool` we will see raw `ClosedConnection` errors instead.

Similar to #8429, this PR adjusts our code so that the `deadpool`-using code behaves roughly similar to the `r2d2` code.