### PR TITLE
controllers: Replace `r2d2` with `deadpool`

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -18,8 +18,8 @@ use tokio::runtime::Handle;
 
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
 pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
-        let conn = &mut app.db_read()?;
+    let conn = app.db_read_async().await?;
+    conn.interact(move |conn| {
         let auth = AuthCheck::only_cookie().check(&req, conn)?;
         let user_id = auth.user_id();
 
@@ -53,13 +53,13 @@ pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
             "users": users,
         })))
     })
-    .await
+    .await?
 }
 
 /// Handles the `GET /api/private/crate_owner_invitations` route.
 pub async fn private_list(app: AppState, req: Parts) -> AppResult<Json<PrivateListResponse>> {
-    spawn_blocking(move || {
-        let conn = &mut app.db_read()?;
+    let conn = app.db_read_async().await?;
+    conn.interact(move |conn| {
         let auth = AuthCheck::only_cookie().check(&req, conn)?;
 
         let filter = if let Some(crate_name) = req.query().get("crate_name") {
@@ -73,7 +73,7 @@ pub async fn private_list(app: AppState, req: Parts) -> AppResult<Json<PrivateLi
         let list = prepare_list(&app, &req, auth, filter, conn)?;
         Ok(Json(list))
     })
-    .await
+    .await?
 }
 
 enum ListFilter {
@@ -260,14 +260,13 @@ struct OwnerInvitation {
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
 pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
-        let crate_invite: OwnerInvitation =
-            serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;
+    let crate_invite: OwnerInvitation =
+        serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;
 
-        let crate_invite = crate_invite.crate_owner_invite;
+    let crate_invite = crate_invite.crate_owner_invite;
 
-        let conn = &mut state.db_write()?;
-
+    let conn = state.db_write_async().await?;
+    conn.interact(move |conn| {
         let auth = AuthCheck::default().check(&req, conn)?;
         let user_id = auth.user_id();
 
@@ -282,7 +281,7 @@ pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Json
 
         Ok(Json(json!({ "crate_owner_invitation": crate_invite })))
     })
-    .await
+    .await?
 }
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/accept/:token` route.
@@ -290,9 +289,9 @@ pub async fn handle_invite_with_token(
     state: AppState,
     Path(token): Path<String>,
 ) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
+    let conn = state.db_write_async().await?;
+    conn.interact(move |conn| {
         let config = &state.config;
-        let conn = &mut state.db_write()?;
 
         let invitation = CrateOwnerInvitation::find_by_token(&token, conn)?;
         let crate_id = invitation.crate_id;
@@ -305,5 +304,5 @@ pub async fn handle_invite_with_token(
             },
         })))
     })
-    .await
+    .await?
 }

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -255,9 +255,8 @@ pub async fn verify(
     let alerts: Vec<GitHubSecretAlert> = json::from_slice(&body)
         .map_err(|e| bad_request(format!("invalid secret alert request: {e:?}")))?;
 
-    spawn_blocking(move || {
-        let conn = &mut *state.db_write()?;
-
+    let conn = state.db_write_async().await?;
+    conn.interact(move |conn| {
         let feedback = alerts
             .into_iter()
             .map(|alert| {
@@ -272,7 +271,7 @@ pub async fn verify(
 
         Ok(Json(feedback))
     })
-    .await
+    .await?
 }
 
 #[cfg(test)]

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -15,18 +15,19 @@ pub struct IndexQuery {
 
 /// Handles the `GET /keywords` route.
 pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
-        use crate::schema::keywords;
+    use crate::schema::keywords;
 
-        let mut query = keywords::table.into_boxed();
+    let mut query = keywords::table.into_boxed();
 
-        query = match &qp.sort {
-            Some(sort) if sort == "crates" => query.order(keywords::crates_cnt.desc()),
-            _ => query.order(keywords::keyword.asc()),
-        };
+    query = match &qp.sort {
+        Some(sort) if sort == "crates" => query.order(keywords::crates_cnt.desc()),
+        _ => query.order(keywords::keyword.asc()),
+    };
 
-        let query = query.pages_pagination(PaginationOptions::builder().gather(&req)?);
-        let conn = &mut state.db_read()?;
+    let query = query.pages_pagination(PaginationOptions::builder().gather(&req)?);
+
+    let conn = state.db_read_async().await?;
+    conn.interact(move |conn| {
         let data: Paginated<Keyword> = query.load(conn)?;
         let total = data.total();
         let kws = data
@@ -39,17 +40,16 @@ pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppRes
             "meta": { "total": total },
         })))
     })
-    .await
+    .await?
 }
 
 /// Handles the `GET /keywords/:keyword_id` route.
 pub async fn show(Path(name): Path<String>, state: AppState) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
-        let conn = &mut state.db_read()?;
-
+    let conn = &mut state.db_read_async().await?;
+    conn.interact(move |conn| {
         let kw = Keyword::find_by_keyword(conn, &name)?;
 
         Ok(Json(json!({ "keyword": EncodableKeyword::from(kw) })))
     })
-    .await
+    .await?
 }

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -15,11 +15,11 @@ use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
+    let conn = state.db_read_async().await?;
+    conn.interact(move |conn| {
         use diesel::dsl::*;
         use diesel::sql_types::BigInt;
 
-        let conn = &mut *state.db_read()?;
         let crate_id: i32 = Crate::by_name(&crate_name)
             .select(crates::id)
             .first(conn)
@@ -68,5 +68,5 @@ pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppRe
             },
         })))
     })
-    .await
+    .await?
 }

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -73,7 +73,7 @@ pub async fn add_owners(
     parts: Parts,
     Json(body): Json<ChangeOwnersRequest>,
 ) -> AppResult<Json<Value>> {
-    spawn_blocking(move || modify_owners(&app, &crate_name, parts, body, true)).await
+    modify_owners(app, crate_name, parts, body, true).await
 }
 
 /// Handles the `DELETE /crates/:crate_id/owners` route.
@@ -83,7 +83,7 @@ pub async fn remove_owners(
     parts: Parts,
     Json(body): Json<ChangeOwnersRequest>,
 ) -> AppResult<Json<Value>> {
-    spawn_blocking(move || modify_owners(&app, &crate_name, parts, body, false)).await
+    modify_owners(app, crate_name, parts, body, false).await
 }
 
 #[derive(Deserialize)]
@@ -92,74 +92,77 @@ pub struct ChangeOwnersRequest {
     owners: Vec<String>,
 }
 
-fn modify_owners(
-    app: &AppState,
-    crate_name: &str,
+async fn modify_owners(
+    app: AppState,
+    crate_name: String,
     parts: Parts,
     body: ChangeOwnersRequest,
     add: bool,
 ) -> AppResult<Json<Value>> {
     let logins = body.owners;
 
-    let conn = &mut *app.db_write()?;
-    let auth = AuthCheck::default()
-        .with_endpoint_scope(EndpointScope::ChangeOwners)
-        .for_crate(crate_name)
-        .check(&parts, conn)?;
+    spawn_blocking(move || {
+        let conn = &mut *app.db_write()?;
+        let auth = AuthCheck::default()
+            .with_endpoint_scope(EndpointScope::ChangeOwners)
+            .for_crate(&crate_name)
+            .check(&parts, conn)?;
 
-    let user = auth.user();
+        let user = auth.user();
 
-    conn.transaction(|conn| {
-        let krate: Crate = Crate::by_name(crate_name)
-            .first(conn)
-            .optional()?
-            .ok_or_else(|| crate_not_found(crate_name))?;
+        conn.transaction(|conn| {
+            let krate: Crate = Crate::by_name(&crate_name)
+                .first(conn)
+                .optional()?
+                .ok_or_else(|| crate_not_found(&crate_name))?;
 
-        let owners = krate.owners(conn)?;
+            let owners = krate.owners(conn)?;
 
-        match Handle::current().block_on(user.rights(app, &owners))? {
-            Rights::Full => {}
-            // Yes!
-            Rights::Publish => {
-                return Err(custom(
-                    StatusCode::FORBIDDEN,
-                    "team members don't have permission to modify owners",
-                ));
-            }
-            Rights::None => {
-                return Err(custom(
-                    StatusCode::FORBIDDEN,
-                    "only owners have permission to modify owners",
-                ));
-            }
-        }
-
-        let comma_sep_msg = if add {
-            let mut msgs = Vec::with_capacity(logins.len());
-            for login in &logins {
-                let login_test =
-                    |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
-                if owners.iter().any(login_test) {
-                    return Err(bad_request(format_args!("`{login}` is already an owner")));
+            match Handle::current().block_on(user.rights(&app, &owners))? {
+                Rights::Full => {}
+                // Yes!
+                Rights::Publish => {
+                    return Err(custom(
+                        StatusCode::FORBIDDEN,
+                        "team members don't have permission to modify owners",
+                    ));
                 }
-                let msg = krate.owner_add(app, conn, user, login)?;
-                msgs.push(msg);
+                Rights::None => {
+                    return Err(custom(
+                        StatusCode::FORBIDDEN,
+                        "only owners have permission to modify owners",
+                    ));
+                }
             }
-            msgs.join(",")
-        } else {
-            for login in &logins {
-                krate.owner_remove(conn, login)?;
-            }
-            if User::owning(&krate, conn)?.is_empty() {
-                return Err(bad_request(
-                    "cannot remove all individual owners of a crate. \
+
+            let comma_sep_msg = if add {
+                let mut msgs = Vec::with_capacity(logins.len());
+                for login in &logins {
+                    let login_test =
+                        |owner: &Owner| owner.login().to_lowercase() == *login.to_lowercase();
+                    if owners.iter().any(login_test) {
+                        return Err(bad_request(format_args!("`{login}` is already an owner")));
+                    }
+                    let msg = krate.owner_add(&app, conn, user, login)?;
+                    msgs.push(msg);
+                }
+                msgs.join(",")
+            } else {
+                for login in &logins {
+                    krate.owner_remove(conn, login)?;
+                }
+                if User::owning(&krate, conn)?.is_empty() {
+                    return Err(bad_request(
+                        "cannot remove all individual owners of a crate. \
                      Team member don't have permission to modify owners, so \
                      at least one individual owner is required.",
-                ));
-            }
-            "owners successfully removed".to_owned()
-        };
+                    ));
+                }
+                "owners successfully removed".to_owned()
+            };
 
-        Ok(Json(json!({ "ok": true, "msg": comma_sep_msg })))
+            Ok(Json(json!({ "ok": true, "msg": comma_sep_msg })))
+        })
     })
+    .await
 }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -71,8 +71,8 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
     request_log.add("crate_name", &*metadata.name);
     request_log.add("crate_version", &version_string);
 
-    spawn_blocking(move || {
-        let conn = &mut *app.db_write()?;
+    let conn = app.db_write_async().await?;
+    conn.interact(move |conn| {
 
         // this query should only be used for the endpoint scope calculation
         // since a race condition there would only cause `publish-new` instead of
@@ -421,7 +421,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             }))
         })
     })
-    .await
+    .await?
 }
 
 /// Counts the number of versions for `crate_id` that were published within

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -39,7 +39,8 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// function out to cover the different use cases, and create unit tests
 /// for them.
 pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
+    let conn = app.db_read_async().await?;
+    conn.interact(move |conn| {
         use diesel::sql_types::Float;
         use seek::*;
 
@@ -77,7 +78,6 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
             0_f32.into_sql::<Float>(),
         );
 
-        let conn = &mut *app.db_read()?;
         let mut seek: Option<Seek> = None;
         let mut query = filter_params
             .make_query(&req, conn)?
@@ -245,7 +245,7 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
             },
         })))
     })
-    .await
+    .await?
 }
 
 #[derive(Default)]

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -19,9 +19,8 @@ pub async fn versions(
     Path(crate_name): Path<String>,
     req: Parts,
 ) -> AppResult<Json<Value>> {
-    spawn_blocking(move || {
-        let conn = &mut *state.db_read()?;
-
+    let conn = state.db_read_async().await?;
+    conn.interact(move |conn| {
         let crate_id: i32 = Crate::by_name(&crate_name)
             .select(crates::id)
             .first(conn)
@@ -65,7 +64,7 @@ pub async fn versions(
             None => json!({ "versions": versions }),
         }))
     })
-    .await
+    .await?
 }
 
 /// Seek-based pagination of versions by date

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -26,7 +26,7 @@ pub async fn yank(
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,
 ) -> AppResult<Response> {
-    spawn_blocking(move || modify_yank(&crate_name, &version, &app, &req, true)).await
+    modify_yank(crate_name, version, app, req, true).await
 }
 
 /// Handles the `PUT /crates/:crate_id/:version/unyank` route.
@@ -35,73 +35,76 @@ pub async fn unyank(
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,
 ) -> AppResult<Response> {
-    spawn_blocking(move || modify_yank(&crate_name, &version, &app, &req, false)).await
+    modify_yank(crate_name, version, app, req, false).await
 }
 
 /// Changes `yanked` flag on a crate version record
-fn modify_yank(
-    crate_name: &str,
-    version: &str,
-    state: &AppState,
-    req: &Parts,
+async fn modify_yank(
+    crate_name: String,
+    version: String,
+    state: AppState,
+    req: Parts,
     yanked: bool,
 ) -> AppResult<Response> {
     // FIXME: Should reject bad requests before authentication, but can't due to
     // lifetime issues with `req`.
 
-    if semver::Version::parse(version).is_err() {
-        return Err(version_not_found(crate_name, version));
+    if semver::Version::parse(&version).is_err() {
+        return Err(version_not_found(&crate_name, &version));
     }
 
-    let conn = &mut *state.db_write()?;
+    spawn_blocking(move || {
+        let conn = &mut *state.db_write()?;
 
-    let auth = AuthCheck::default()
-        .with_endpoint_scope(EndpointScope::Yank)
-        .for_crate(crate_name)
-        .check(req, conn)?;
+        let auth = AuthCheck::default()
+            .with_endpoint_scope(EndpointScope::Yank)
+            .for_crate(&crate_name)
+            .check(&req, conn)?;
 
-    state
-        .rate_limiter
-        .check_rate_limit(auth.user_id(), LimitedAction::YankUnyank, conn)?;
+        state
+            .rate_limiter
+            .check_rate_limit(auth.user_id(), LimitedAction::YankUnyank, conn)?;
 
-    let (version, krate) = version_and_crate(conn, crate_name, version)?;
-    let api_token_id = auth.api_token_id();
-    let user = auth.user();
-    let owners = krate.owners(conn)?;
+        let (version, krate) = version_and_crate(conn, &crate_name, &version)?;
+        let api_token_id = auth.api_token_id();
+        let user = auth.user();
+        let owners = krate.owners(conn)?;
 
-    if Handle::current().block_on(user.rights(state, &owners))? < Rights::Publish {
-        if user.is_admin {
-            let action = if yanked { "yanking" } else { "unyanking" };
-            warn!(
-                "Admin {} is {action} {}@{}",
-                user.gh_login, krate.name, version.num
-            );
-        } else {
-            return Err(custom(
-                StatusCode::FORBIDDEN,
-                "must already be an owner to yank or unyank",
-            ));
+        if Handle::current().block_on(user.rights(&state, &owners))? < Rights::Publish {
+            if user.is_admin {
+                let action = if yanked { "yanking" } else { "unyanking" };
+                warn!(
+                    "Admin {} is {action} {}@{}",
+                    user.gh_login, krate.name, version.num
+                );
+            } else {
+                return Err(custom(
+                    StatusCode::FORBIDDEN,
+                    "must already be an owner to yank or unyank",
+                ));
+            }
         }
-    }
 
-    if version.yanked == yanked {
-        // The crate is already in the state requested, nothing to do
-        return ok_true();
-    }
+        if version.yanked == yanked {
+            // The crate is already in the state requested, nothing to do
+            return ok_true();
+        }
 
-    diesel::update(&version)
-        .set(versions::yanked.eq(yanked))
-        .execute(conn)?;
+        diesel::update(&version)
+            .set(versions::yanked.eq(yanked))
+            .execute(conn)?;
 
-    let action = if yanked {
-        VersionAction::Yank
-    } else {
-        VersionAction::Unyank
-    };
+        let action = if yanked {
+            VersionAction::Yank
+        } else {
+            VersionAction::Unyank
+        };
 
-    insert_version_owner_action(conn, version.id, user.id, api_token_id, action)?;
+        insert_version_owner_action(conn, version.id, user.id, api_token_id, action)?;
 
-    jobs::enqueue_sync_to_index(&krate.name, conn)?;
+        jobs::enqueue_sync_to_index(&krate.name, conn)?;
 
-    ok_true()
+        ok_true()
+    })
+    .await
 }

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -53,9 +53,8 @@ async fn modify_yank(
         return Err(version_not_found(&crate_name, &version));
     }
 
-    spawn_blocking(move || {
-        let conn = &mut *state.db_write()?;
-
+    let conn = state.db_write_async().await?;
+    conn.interact(move |conn| {
         let auth = AuthCheck::default()
             .with_endpoint_scope(EndpointScope::Yank)
             .for_crate(&crate_name)
@@ -106,5 +105,5 @@ async fn modify_yank(
 
         ok_true()
     })
-    .await
+    .await?
 }


### PR DESCRIPTION
This PR is roughly similar to #8385, but this time all of our API endpoints are ported from the sync `r2d2` database connection pool to the async `deadpool` equivalent.

A couple of minor refactorings were needed in some places, but the semantics should still be similar to before. I guess this is best reviewed commit-by-commit... 😅 