### PR TITLE
tests/util/test_app: Use `test_database.connect()` for `background_jobs` query

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -57,8 +57,11 @@ impl Drop for TestAppInner {
 
         // Manually verify that all jobs have completed successfully
         // This will catch any tests that enqueued a job but forgot to initialize the runner
-        let conn = &mut *self.app.db_write().unwrap();
-        let job_count: i64 = background_jobs::table.count().get_result(conn).unwrap();
+        let mut conn = self.test_database.connect();
+        let job_count: i64 = background_jobs::table
+            .count()
+            .get_result(&mut conn)
+            .unwrap();
         assert_eq!(
             0, job_count,
             "Unprocessed or failed jobs remain in the queue"


### PR DESCRIPTION
This allows us to get rid of the `db_write()` fn on the `App` struct soon... 🎉 