### PR TITLE
Remove `r2d2` database connection pools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ deadpool-diesel = { version = "=0.6.0", features = ["postgres", "tracing"] }
 derive_builder = "=0.20.0"
 derive_deref = "=1.1.1"
 dialoguer = "=0.11.0"
-diesel = { version = "=2.1.5", features = ["postgres", "serde_json", "chrono", "r2d2", "numeric"] }
+diesel = { version = "=2.1.5", features = ["postgres", "serde_json", "chrono", "numeric"] }
 diesel_full_text_search = "=2.1.1"
 diesel_migrations = { version = "=2.1.0", features = ["postgres"] }
 dotenvy = "=0.15.7"
@@ -126,6 +126,7 @@ crates_io_index = { path = "crates/crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates/crates_io_tarball", features = ["builder"] }
 crates_io_test_db = { path = "crates/crates_io_test_db" }
 claims = "=0.7.1"
+diesel = { version = "=2.1.5", features = ["r2d2"] }
 googletest = "=0.11.0"
 insta = { version = "=1.38.0", features = ["json", "redactions"] }
 regex = "=1.10.4"

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,109 +1,12 @@
 use deadpool_diesel::postgres::{Hook, HookError};
 use diesel::prelude::*;
-use diesel::r2d2::{self, ConnectionManager, CustomizeConnection, State};
-use prometheus::Histogram;
-use secrecy::{ExposeSecret, SecretString};
-use std::ops::Deref;
+use secrecy::ExposeSecret;
 use std::time::Duration;
-use thiserror::Error;
 use url::Url;
 
 use crate::config;
 
 pub mod sql_types;
-
-pub type ConnectionPool = r2d2::Pool<ConnectionManager<PgConnection>>;
-
-#[derive(Clone)]
-pub struct DieselPool {
-    pool: ConnectionPool,
-    time_to_obtain_connection_metric: Option<Histogram>,
-}
-
-impl DieselPool {
-    pub(crate) fn new(
-        url: &SecretString,
-        config: &config::DatabasePools,
-        r2d2_config: r2d2::Builder<ConnectionManager<PgConnection>>,
-        time_to_obtain_connection_metric: Histogram,
-    ) -> Result<DieselPool, PoolError> {
-        let manager = ConnectionManager::new(connection_url(config, url.expose_secret()));
-
-        // For crates.io we want the behavior of creating a database pool to be slightly different
-        // than the defaults of R2D2: the library's build() method assumes its consumers always
-        // need a database connection to operate, so it blocks creating a pool until a minimum
-        // number of connections is available.
-        //
-        // crates.io can actually operate in a limited capacity without a database connections,
-        // especially by serving download requests to our users. Because of that we don't want to
-        // block indefinitely waiting for a connection: we instead need to wait for a bit (to avoid
-        // serving errors for the first connections until the pool is initialized) and if we can't
-        // establish any connection continue booting up the application. The database pool will
-        // automatically be marked as unhealthy and the rest of the application will adapt.
-        let pool = DieselPool {
-            pool: r2d2_config.build_unchecked(manager),
-            time_to_obtain_connection_metric: Some(time_to_obtain_connection_metric),
-        };
-        match pool.wait_until_healthy(Duration::from_secs(5)) {
-            Ok(()) => {}
-            Err(PoolError::UnhealthyPool) => {}
-            Err(err) => return Err(err),
-        }
-
-        Ok(pool)
-    }
-
-    pub fn new_background_worker(pool: r2d2::Pool<ConnectionManager<PgConnection>>) -> Self {
-        Self {
-            pool,
-            time_to_obtain_connection_metric: None,
-        }
-    }
-
-    #[instrument(name = "db.connect", skip_all)]
-    pub fn get(&self) -> Result<DieselPooledConn, PoolError> {
-        match self.time_to_obtain_connection_metric.as_ref() {
-            Some(time_to_obtain_connection_metric) => time_to_obtain_connection_metric
-                .observe_closure_duration(|| {
-                    if let Some(conn) = self.pool.try_get() {
-                        Ok(conn)
-                    } else if !self.is_healthy() {
-                        Err(PoolError::UnhealthyPool)
-                    } else {
-                        Ok(self.pool.get()?)
-                    }
-                }),
-            None => Ok(self.pool.get()?),
-        }
-    }
-
-    pub fn state(&self) -> State {
-        self.pool.state()
-    }
-
-    #[instrument(skip_all)]
-    pub fn wait_until_healthy(&self, timeout: Duration) -> Result<(), PoolError> {
-        match self.pool.get_timeout(timeout) {
-            Ok(_) => Ok(()),
-            Err(_) if !self.is_healthy() => Err(PoolError::UnhealthyPool),
-            Err(err) => Err(PoolError::R2D2(err)),
-        }
-    }
-
-    fn is_healthy(&self) -> bool {
-        self.state().connections > 0
-    }
-}
-
-impl Deref for DieselPool {
-    type Target = ConnectionPool;
-
-    fn deref(&self) -> &Self::Target {
-        &self.pool
-    }
-}
-
-pub type DieselPooledConn = r2d2::PooledConnection<ConnectionManager<PgConnection>>;
 
 pub fn oneoff_connection_with_config(
     config: &config::DatabasePools,
@@ -160,12 +63,6 @@ impl ConnectionConfig {
     }
 }
 
-impl CustomizeConnection<PgConnection, r2d2::Error> for ConnectionConfig {
-    fn on_acquire(&self, conn: &mut PgConnection) -> Result<(), r2d2::Error> {
-        self.apply(conn).map_err(r2d2::Error::QueryError)
-    }
-}
-
 impl From<ConnectionConfig> for Hook {
     fn from(config: ConnectionConfig) -> Self {
         Hook::async_fn(move |conn, _| {
@@ -177,12 +74,4 @@ impl From<ConnectionConfig> for Hook {
             })
         })
     }
-}
-
-#[derive(Debug, Error)]
-pub enum PoolError {
-    #[error(transparent)]
-    R2D2(#[from] r2d2::PoolError),
-    #[error("unhealthy database pool")]
-    UnhealthyPool,
 }

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -24,7 +24,6 @@ use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use http::StatusCode;
 use tokio::task::JoinError;
 
-use crate::db::PoolError;
 use crate::middleware::log_request::ErrorField;
 
 mod json;
@@ -168,15 +167,6 @@ impl From<EmailError> for BoxedAppError {
                 error!(?error, "Failed to send email");
                 server_error("Failed to send the email")
             }
-        }
-    }
-}
-
-impl From<PoolError> for BoxedAppError {
-    fn from(err: PoolError) -> BoxedAppError {
-        match err {
-            PoolError::UnhealthyPool => service_unavailable(),
-            _ => Box::new(err),
         }
     }
 }


### PR DESCRIPTION
This PR completely removes the sync `r2d2` database connection pools from our backend server code. All of our code has now been migrated to the `deadpool` async pools.

There is one small caveat: our `crates_io_test_db` package is still using `r2d2` under the hood. If/How that can be migrated remains to be seen, since it's relying on `Drop` impls, which are complicated in an async world.