### PR TITLE
deadpool: Drop obsolete `async` suffixes

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -12,7 +12,7 @@ pub async fn index(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     // to paginate this.
     let options = PaginationOptions::builder().gather(&req)?;
 
-    let conn = app.db_read_async().await?;
+    let conn = app.db_read().await?;
     conn.interact(move |conn| {
         let query = req.query();
         let sort = query.get("sort").map_or("alpha", String::as_str);
@@ -38,7 +38,7 @@ pub async fn index(app: AppState, req: Parts) -> AppResult<Json<Value>> {
 
 /// Handles the `GET /categories/:category_id` route.
 pub async fn show(state: AppState, Path(slug): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let cat: Category = Category::by_slug(&slug).first(conn)?;
         let subcats = cat
@@ -71,7 +71,7 @@ pub async fn show(state: AppState, Path(slug): Path<String>) -> AppResult<Json<V
 
 /// Handles the `GET /category_slugs` route.
 pub async fn slugs(state: AppState) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let slugs: Vec<Slug> = categories::table
             .select((categories::slug, categories::slug, categories::description))

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -18,7 +18,7 @@ use tokio::runtime::Handle;
 
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
 pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
-    let conn = app.db_read_async().await?;
+    let conn = app.db_read().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::only_cookie().check(&req, conn)?;
         let user_id = auth.user_id();
@@ -58,7 +58,7 @@ pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
 
 /// Handles the `GET /api/private/crate_owner_invitations` route.
 pub async fn private_list(app: AppState, req: Parts) -> AppResult<Json<PrivateListResponse>> {
-    let conn = app.db_read_async().await?;
+    let conn = app.db_read().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::only_cookie().check(&req, conn)?;
 
@@ -265,7 +265,7 @@ pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Json
 
     let crate_invite = crate_invite.crate_owner_invite;
 
-    let conn = state.db_write_async().await?;
+    let conn = state.db_write().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::default().check(&req, conn)?;
         let user_id = auth.user_id();
@@ -289,7 +289,7 @@ pub async fn handle_invite_with_token(
     state: AppState,
     Path(token): Path<String>,
 ) -> AppResult<Json<Value>> {
-    let conn = state.db_write_async().await?;
+    let conn = state.db_write().await?;
     conn.interact(move |conn| {
         let config = &state.config;
 

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -255,7 +255,7 @@ pub async fn verify(
     let alerts: Vec<GitHubSecretAlert> = json::from_slice(&body)
         .map_err(|e| bad_request(format!("invalid secret alert request: {e:?}")))?;
 
-    let conn = state.db_write_async().await?;
+    let conn = state.db_write().await?;
     conn.interact(move |conn| {
         let feedback = alerts
             .into_iter()

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -26,7 +26,7 @@ pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppRes
 
     let query = query.pages_pagination(PaginationOptions::builder().gather(&req)?);
 
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let data: Paginated<Keyword> = query.load(conn)?;
         let total = data.total();
@@ -45,7 +45,7 @@ pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppRes
 
 /// Handles the `GET /keywords/:keyword_id` route.
 pub async fn show(Path(name): Path<String>, state: AppState) -> AppResult<Json<Value>> {
-    let conn = &mut state.db_read_async().await?;
+    let conn = &mut state.db_read().await?;
     conn.interact(move |conn| {
         let kw = Keyword::find_by_keyword(conn, &name)?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -15,7 +15,7 @@ use crate::views::EncodableVersionDownload;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         use diesel::dsl::*;
         use diesel::sql_types::BigInt;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -24,7 +24,7 @@ pub async fn follow(
     Path(crate_name): Path<String>,
     req: Parts,
 ) -> AppResult<Response> {
-    let conn = app.db_write_async().await?;
+    let conn = app.db_write().await?;
     conn.interact(move |conn| {
         let user_id = AuthCheck::default().check(&req, conn)?.user_id();
         let follow = follow_target(&crate_name, conn, user_id)?;
@@ -44,7 +44,7 @@ pub async fn unfollow(
     Path(crate_name): Path<String>,
     req: Parts,
 ) -> AppResult<Response> {
-    let conn = app.db_write_async().await?;
+    let conn = app.db_write().await?;
     conn.interact(move |conn| {
         let user_id = AuthCheck::default().check(&req, conn)?.user_id();
         let follow = follow_target(&crate_name, conn, user_id)?;
@@ -61,7 +61,7 @@ pub async fn following(
     Path(crate_name): Path<String>,
     req: Parts,
 ) -> AppResult<Json<Value>> {
-    let conn = app.db_read_prefer_primary_async().await?;
+    let conn = app.db_read_prefer_primary().await?;
     conn.interact(move |conn| {
         use diesel::dsl::exists;
 

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -27,7 +27,7 @@ pub async fn show_new(app: AppState, req: Parts) -> AppResult<Json<Value>> {
 
 /// Handles the `GET /crates/:crate_id` route.
 pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
-    let conn = app.db_read_async().await?;
+    let conn = app.db_read().await?;
     conn.interact(move |conn| {
         let include = req
             .query()
@@ -227,7 +227,7 @@ pub async fn reverse_dependencies(
     Path(name): Path<String>,
     req: Parts,
 ) -> AppResult<Json<Value>> {
-    let conn = app.db_read_async().await?;
+    let conn = app.db_read().await?;
     conn.interact(move |conn| {
         let pagination_options = PaginationOptions::builder().gather(&req)?;
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Handle;
 
 /// Handles the `GET /crates/:crate_id/owners` route.
 pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let krate: Crate = Crate::by_name(&crate_name)
             .first(conn)
@@ -30,7 +30,7 @@ pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResul
 
 /// Handles the `GET /crates/:crate_id/owner_team` route.
 pub async fn owner_team(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let krate: Crate = Crate::by_name(&crate_name)
             .first(conn)
@@ -49,7 +49,7 @@ pub async fn owner_team(state: AppState, Path(crate_name): Path<String>) -> AppR
 
 /// Handles the `GET /crates/:crate_id/owner_user` route.
 pub async fn owner_user(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let krate: Crate = Crate::by_name(&crate_name)
             .first(conn)
@@ -101,7 +101,7 @@ async fn modify_owners(
 ) -> AppResult<Json<Value>> {
     let logins = body.owners;
 
-    let conn = app.db_write_async().await?;
+    let conn = app.db_write().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::default()
             .with_endpoint_scope(EndpointScope::ChangeOwners)

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -71,7 +71,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
     request_log.add("crate_name", &*metadata.name);
     request_log.add("crate_version", &version_string);
 
-    let conn = app.db_write_async().await?;
+    let conn = app.db_write().await?;
     conn.interact(move |conn| {
 
         // this query should only be used for the endpoint scope calculation

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -39,7 +39,7 @@ use crate::sql::{array_agg, canon_crate_name, lower};
 /// function out to cover the different use cases, and create unit tests
 /// for them.
 pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
-    let conn = app.db_read_async().await?;
+    let conn = app.db_read().await?;
     conn.interact(move |conn| {
         use diesel::sql_types::Float;
         use seek::*;

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -19,7 +19,7 @@ pub async fn versions(
     Path(crate_name): Path<String>,
     req: Parts,
 ) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let crate_id: i32 = Crate::by_name(&crate_name)
             .select(crates::id)

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -23,7 +23,7 @@ pub async fn prometheus(app: AppState, Path(kind): Path<String>, req: Parts) -> 
 
     let metrics = match kind.as_str() {
         "service" => {
-            let conn = app.db_read_async().await?;
+            let conn = app.db_read().await?;
             conn.interact(move |conn| app.service_metrics.gather(conn))
                 .await??
         }

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 /// Handles the `GET /summary` route.
 pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let config = &state.config;
 

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -8,7 +8,7 @@ use crate::views::EncodableTeam;
 pub async fn show_team(state: AppState, Path(name): Path<String>) -> AppResult<Json<Value>> {
     use self::teams::dsl::{login, teams};
 
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     let team: Team = conn
         .interact(move |conn| teams.filter(login.eq(&name)).first(conn))
         .await??;

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -35,7 +35,7 @@ pub async fn list(
     Query(params): Query<GetParams>,
     req: Parts,
 ) -> AppResult<Json<Value>> {
-    let conn = &mut *app.db_read_prefer_primary_async().await?;
+    let conn = &mut *app.db_read_prefer_primary().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::only_cookie().check(&req, conn)?;
         let user = auth.user();
@@ -58,7 +58,7 @@ pub async fn list(
 
 /// Handles the `PUT /me/tokens` route.
 pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
-    let conn = &mut *app.db_write_async().await?;
+    let conn = &mut *app.db_write().await?;
     conn.interact(move |conn| {
         /// The incoming serialization format for the `ApiToken` model.
         #[derive(Deserialize)]
@@ -142,7 +142,7 @@ pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
 
 /// Handles the `DELETE /me/tokens/:id` route.
 pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
-    let conn = &mut *app.db_write_async().await?;
+    let conn = &mut *app.db_write().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::default().check(&req, conn)?;
         let user = auth.user();
@@ -157,7 +157,7 @@ pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult
 
 /// Handles the `DELETE /tokens/current` route.
 pub async fn revoke_current(app: AppState, req: Parts) -> AppResult<Response> {
-    let conn = &mut *app.db_write_async().await?;
+    let conn = &mut *app.db_write().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::default().check(&req, conn)?;
         let api_token_id = auth

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -15,7 +15,7 @@ use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCra
 
 /// Handles the `GET /me` route.
 pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
-    let conn = app.db_read_prefer_primary_async().await?;
+    let conn = app.db_read_prefer_primary().await?;
     conn.interact(move |conn| {
         let user_id = AuthCheck::only_cookie().check(&req, conn)?.user_id();
 
@@ -57,7 +57,7 @@ pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
 
 /// Handles the `GET /me/updates` route.
 pub async fn updates(app: AppState, req: Parts) -> AppResult<Json<Value>> {
-    let conn = app.db_read_prefer_primary_async().await?;
+    let conn = app.db_read_prefer_primary().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::only_cookie().check(&req, conn)?;
         let user = auth.user();
@@ -103,7 +103,7 @@ pub async fn update_user(
     Path(param_user_id): Path<i32>,
     req: BytesRequest,
 ) -> AppResult<Response> {
-    let conn = state.db_write_async().await?;
+    let conn = state.db_write().await?;
     conn.interact(move |conn| {
         use self::emails::user_id;
         use diesel::insert_into;
@@ -176,7 +176,7 @@ pub async fn update_user(
 
 /// Handles the `PUT /confirm/:email_token` route
 pub async fn confirm_user_email(state: AppState, Path(token): Path<String>) -> AppResult<Response> {
-    let conn = state.db_write_async().await?;
+    let conn = state.db_write().await?;
     conn.interact(move |conn| {
         use diesel::update;
 
@@ -199,7 +199,7 @@ pub async fn regenerate_token_and_send(
     Path(param_user_id): Path<i32>,
     req: Parts,
 ) -> AppResult<Response> {
-    let conn = state.db_write_async().await?;
+    let conn = state.db_write().await?;
     conn.interact(move |conn| {
         use diesel::dsl::sql;
         use diesel::update;
@@ -248,7 +248,7 @@ pub async fn update_email_notifications(app: AppState, req: BytesRequest) -> App
             .map(|c| (c.id, c.email_notifications))
             .collect();
 
-    let conn = app.db_write_async().await?;
+    let conn = app.db_write().await?;
     conn.interact(move |conn| {
         use diesel::pg::upsert::excluded;
 

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -8,7 +8,7 @@ use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
 pub async fn show(state: AppState, Path(user_name): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_prefer_primary_async().await?;
+    let conn = state.db_read_prefer_primary().await?;
     conn.interact(move |conn| {
         use self::users::dsl::{gh_login, id, users};
 
@@ -25,7 +25,7 @@ pub async fn show(state: AppState, Path(user_name): Path<String>) -> AppResult<J
 
 /// Handles the `GET /users/:user_id/stats` route.
 pub async fn stats(state: AppState, Path(user_id): Path<i32>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_prefer_primary_async().await?;
+    let conn = state.db_read_prefer_primary().await?;
     conn.interact(move |conn| {
         use diesel::dsl::sum;
 

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -86,7 +86,7 @@ pub async fn authorize(
     let app_clone = app.clone();
     let request_log = req.request_log().clone();
 
-    let conn = app.db_write_async().await?;
+    let conn = app.db_write().await?;
     conn.interact(move |conn| {
         // Make sure that the state we just got matches the session state that we
         // should have issued earlier.

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -36,7 +36,7 @@ pub async fn downloads(
         return Err(version_not_found(&crate_name, &version));
     }
 
-    let conn = app.db_read_async().await?;
+    let conn = app.db_read().await?;
     conn.interact(move |conn| {
         let (version, _) = version_and_crate(conn, &crate_name, &version)?;
 

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -27,7 +27,7 @@ pub async fn dependencies(
         return Err(version_not_found(&crate_name, &version));
     }
 
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let (version, _) = version_and_crate(conn, &crate_name, &version)?;
         let deps = version.dependencies(conn)?;
@@ -64,7 +64,7 @@ pub async fn show(
         return Err(version_not_found(&crate_name, &version));
     }
 
-    let conn = state.db_read_async().await?;
+    let conn = state.db_read().await?;
     conn.interact(move |conn| {
         let (version, krate) = version_and_crate(conn, &crate_name, &version)?;
         let published_by = version.published_by(conn);

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -53,7 +53,7 @@ async fn modify_yank(
         return Err(version_not_found(&crate_name, &version));
     }
 
-    let conn = state.db_write_async().await?;
+    let conn = state.db_write().await?;
     conn.interact(move |conn| {
         let auth = AuthCheck::default()
             .with_endpoint_scope(EndpointScope::Yank)

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -53,15 +53,15 @@ metrics! {
 impl InstanceMetrics {
     pub fn gather(&self, app: &App) -> prometheus::Result<Vec<MetricFamily>> {
         // Database pool stats
-        self.refresh_async_pool_stats("async_primary", &app.deadpool_primary)?;
-        if let Some(follower) = &app.deadpool_replica {
-            self.refresh_async_pool_stats("async_follower", follower)?;
+        self.refresh_pool_stats("async_primary", &app.primary_database)?;
+        if let Some(follower) = &app.replica_database {
+            self.refresh_pool_stats("async_follower", follower)?;
         }
 
         Ok(self.registry.gather())
     }
 
-    fn refresh_async_pool_stats(&self, name: &str, pool: &Pool) -> prometheus::Result<()> {
+    fn refresh_pool_stats(&self, name: &str, pool: &Pool) -> prometheus::Result<()> {
         let status = pool.status();
 
         self.database_idle_conns

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -41,7 +41,7 @@ fn http_error_with_unhealthy_database() {
 
     app.primary_db_chaosproxy().restore_networking().unwrap();
     app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().deadpool_primary));
+        .block_on(wait_until_healthy(&app.as_inner().primary_database));
 
     let response = anon.get::<()>("/api/v1/summary");
     assert_eq!(response.status(), StatusCode::OK);
@@ -65,7 +65,7 @@ fn fallback_to_replica_returns_user_info() {
     // restore primary database connection
     app.primary_db_chaosproxy().restore_networking().unwrap();
     app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().deadpool_primary));
+        .block_on(wait_until_healthy(&app.as_inner().primary_database));
 }
 
 #[test]
@@ -88,7 +88,7 @@ fn restored_replica_returns_user_info() {
     app.replica_db_chaosproxy().restore_networking().unwrap();
     let replica = app
         .as_inner()
-        .deadpool_replica
+        .replica_database
         .as_ref()
         .expect("no replica database configured");
     app.runtime().block_on(wait_until_healthy(replica));
@@ -99,7 +99,7 @@ fn restored_replica_returns_user_info() {
     // restore connection
     app.primary_db_chaosproxy().restore_networking().unwrap();
     app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().deadpool_primary));
+        .block_on(wait_until_healthy(&app.as_inner().primary_database));
 }
 
 #[test]
@@ -121,7 +121,7 @@ fn restored_primary_returns_user_info() {
     // Once the replica database is restored, it should serve as a fallback again
     app.primary_db_chaosproxy().restore_networking().unwrap();
     app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().deadpool_primary));
+        .block_on(wait_until_healthy(&app.as_inner().primary_database));
 
     let response = owner.get::<()>(URL);
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -73,8 +73,8 @@ impl Drop for TestAppInner {
         // implementation from failing because no tokio runtime is running.
         {
             let _rt_guard = self.runtime.enter();
-            self.app.deadpool_primary.close();
-            if let Some(pool) = &self.app.deadpool_replica {
+            self.app.primary_database.close();
+            if let Some(pool) = &self.app.replica_database {
                 pool.close();
             }
         }
@@ -278,7 +278,7 @@ impl TestAppBuilder {
                 .config(app.config.clone())
                 .repository_config(repository_config)
                 .storage(app.storage.clone())
-                .deadpool(app.deadpool_primary.clone())
+                .deadpool(app.primary_database.clone())
                 .emails(app.emails.clone())
                 .team_repo(Box::new(self.team_repo))
                 .build()
@@ -286,7 +286,7 @@ impl TestAppBuilder {
 
             let runner = Runner::new(
                 runtime.handle(),
-                app.deadpool_primary.clone(),
+                app.primary_database.clone(),
                 Arc::new(environment),
             )
             .shutdown_when_queue_empty()


### PR DESCRIPTION
This commit renames a couple of struct fields and functions to remove `async` and `deadpool` pre-/suffixes. This distinction is no longer needed, since we don't use sync database connection pools anymore.