### PR TITLE
tracing: Enable time output in tests

### DIFF
--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -54,7 +54,6 @@ pub fn init_for_test() {
     let _ = tracing_subscriber::fmt()
         .compact()
         .with_env_filter(env_filter)
-        .without_time()
         .with_test_writer()
         .try_init();
 }


### PR DESCRIPTION
This PR enables time output for our test suites.

The DataDog and Papertrail logs in production already include timestamps, so we don't need these there, but the test suite runner does not provide them and while debugging #8449 they proved to be quite useful. 