### PR TITLE
config/database_pools: Remove sync database pools

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -91,7 +91,7 @@ impl App {
 
             DeadpoolPool::builder(manager)
                 .runtime(Runtime::Tokio1)
-                .max_size(config.db.primary.async_pool_size)
+                .max_size(config.db.primary.pool_size)
                 .wait_timeout(Some(config.db.connection_timeout))
                 .post_create(primary_db_connection_config)
                 .build()
@@ -111,7 +111,7 @@ impl App {
 
             let pool = DeadpoolPool::builder(manager)
                 .runtime(Runtime::Tokio1)
-                .max_size(pool_config.async_pool_size)
+                .max_size(pool_config.pool_size)
                 .wait_timeout(Some(config.db.connection_timeout))
                 .post_create(replica_db_connection_config)
                 .build()

--- a/src/middleware/balance_capacity.rs
+++ b/src/middleware/balance_capacity.rs
@@ -64,7 +64,7 @@ pub async fn balance_capacity(app_state: AppState, request: Request, next: Next)
 
     // The _drop_on_exit ensures the counter is decremented for all exit paths (including panics)
     let (_drop_on_exit2, count) = RequestCounter::add_one(&state.in_flight_non_dl_requests);
-    let load = 100 * count / (db_capacity as usize);
+    let load = 100 * count / db_capacity;
 
     // Begin logging non-download request count so early stages of non-download load increase can be located
     if load >= config.log_at_percentage {

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -380,7 +380,6 @@ impl TestAppBuilder {
             url: primary.url.clone(),
             read_only_mode: true,
             pool_size: primary.pool_size,
-            async_pool_size: primary.async_pool_size,
             min_idle: primary.min_idle,
         });
 
@@ -399,7 +398,6 @@ fn simple_config() -> config::Server {
             url: String::from("invalid default url").into(),
             read_only_mode: false,
             pool_size: 3,
-            async_pool_size: 3,
             min_idle: None,
         },
         replica: None,


### PR DESCRIPTION
We don't have sync database pools anymore, so there is no need to keep the config code around.