### PR TITLE
database: Remove obsolete `set_updated_at_ignore_downloads()` fn

### DIFF
--- a/migrations/2024-04-17-083100_remove-obsolete-fn/down.sql
+++ b/migrations/2024-04-17-083100_remove-obsolete-fn/down.sql
@@ -1,0 +1,19 @@
+create function set_updated_at_ignore_downloads() returns trigger
+    language plpgsql
+as
+$$
+DECLARE
+    new_downloads integer;
+BEGIN
+    new_downloads := NEW.downloads;
+    OLD.downloads := NEW.downloads;
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+        ) THEN
+        NEW.updated_at = CURRENT_TIMESTAMP;
+    END IF;
+    NEW.downloads := new_downloads;
+    RETURN NEW;
+END
+$$;

--- a/migrations/2024-04-17-083100_remove-obsolete-fn/up.sql
+++ b/migrations/2024-04-17-083100_remove-obsolete-fn/up.sql
@@ -1,0 +1,1 @@
+drop function set_updated_at_ignore_downloads;


### PR DESCRIPTION
This was used when the crate downloads were still saved in the `crates` table, but when we moved those to a dedicated table we changed the update trigger to use the regular `set_updated_at()` fn instead, making `set_updated_at_ignore_downloads()` unused.