### PR TITLE
Improve "403 Forbidden" error messages

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -68,19 +68,28 @@ impl AuthCheck {
                 let error_message =
                     "API Token authentication was explicitly disallowed for this API";
                 request.request_log().add("cause", error_message);
-                return Err(forbidden());
+
+                return Err(forbidden(
+                    "this action can only be performed on the crates.io website",
+                ));
             }
 
             if !self.endpoint_scope_matches(token.endpoint_scopes.as_ref()) {
                 let error_message = "Endpoint scope mismatch";
                 request.request_log().add("cause", error_message);
-                return Err(forbidden());
+
+                return Err(forbidden(
+                    "this token does not have the required permissions to perform this action",
+                ));
             }
 
             if !self.crate_scope_matches(token.crate_scopes.as_ref()) {
                 let error_message = "Crate scope mismatch";
                 request.request_log().add("cause", error_message);
-                return Err(forbidden());
+
+                return Err(forbidden(
+                    "this token does not have the required permissions to perform this action",
+                ));
             }
         }
 
@@ -207,7 +216,7 @@ fn authenticate_via_token<T: RequestPartsExt>(
             let cause = format!("invalid token caused by {e}");
             req.request_log().add("cause", cause);
 
-            forbidden()
+            forbidden("authentication failed")
         }
     })?;
 
@@ -244,7 +253,7 @@ fn authenticate<T: RequestPartsExt>(req: &T, conn: &mut PgConnection) -> AppResu
     let cause = "no cookie session or auth header found";
     req.request_log().add("cause", cause);
 
-    return Err(forbidden());
+    return Err(forbidden("this action requires authentication"));
 }
 
 fn ensure_not_locked(user: &User) -> AppResult<()> {

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -108,7 +108,8 @@ fn prepare_list(
                 let krate: Crate = Crate::by_name(&crate_name).first(conn)?;
                 let owners = krate.owners(conn)?;
                 if Handle::current().block_on(user.rights(state, &owners))? != Rights::Full {
-                    return Err(forbidden());
+                    let detail = "only crate owners can query pending invitations for their crate";
+                    return Err(forbidden(detail));
                 }
 
                 // Cache the crate name to avoid querying it from the database again
@@ -118,7 +119,8 @@ fn prepare_list(
             }
             ListFilter::InviteeId(invitee_id) => {
                 if invitee_id != user.id {
-                    return Err(forbidden());
+                    let detail = "only the invitee can query their pending invitations";
+                    return Err(forbidden(detail));
                 }
                 Box::new(crate_owner_invitations::invited_user_id.eq(invitee_id))
             }

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -12,7 +12,7 @@ pub async fn prometheus(app: AppState, Path(kind): Path<String>, req: Parts) -> 
             .and_then(|value| value.strip_prefix("Bearer "));
 
         if provided_token != Some(expected_token.as_str()) {
-            return Err(forbidden());
+            return Err(forbidden("invalid or missing authorization token"));
         }
     } else {
         // To avoid accidentally leaking metrics if the environment variable is not set, prevent

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -23,7 +23,8 @@ pub fn verify_origin<T: RequestPartsExt>(req: &T) -> AppResult<()> {
             format!("only same-origin requests can be authenticated. got {bad_origin:?}");
 
         req.request_log().add("cause", error_message);
-        return Err(forbidden());
+
+        return Err(forbidden("invalid origin header"));
     }
     Ok(())
 }

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -3,9 +3,9 @@ use crate::TestApp;
 
 use crate::util::encode_session_header;
 use http::{header, Method, StatusCode};
+use insta::assert_snapshot;
 
 static URL: &str = "/api/v1/me/updates";
-static MUST_LOGIN: &[u8] = br#"{"errors":[{"detail":"must be logged in to perform that action"}]}"#;
 
 #[test]
 fn anonymous_user_unauthorized() {
@@ -13,7 +13,7 @@ fn anonymous_user_unauthorized() {
     let response: Response<()> = anon.get(URL);
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(response.json().to_string().as_bytes(), MUST_LOGIN);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
 #[test]
@@ -24,7 +24,7 @@ fn token_auth_cannot_find_token() {
     let response: Response<()> = anon.run(request);
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(response.json().to_string().as_bytes(), MUST_LOGIN);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
 }
 
 // Ensure that an unexpected authentication error is available for logging.  The user would see

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -34,15 +34,15 @@ fn test_unauthenticated_requests() {
 
     let response = anon.get::<()>(&format!("/api/v1/crates/{CRATE_NAME}/following"));
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"must be logged in to perform that action"}]}"###);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
     let response = anon.put::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"), b"" as &[u8]);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"must be logged in to perform that action"}]}"###);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
     let response = anon.delete::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"));
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"must be logged in to perform that action"}]}"###);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
 #[test]

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -151,10 +151,7 @@ fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(
-        response.json(),
-        json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-    );
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
 }
 
 #[test]
@@ -173,10 +170,7 @@ fn owner_change_via_publish_token() {
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(
-        response.json(),
-        json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-    );
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
 }
 
 #[test]
@@ -194,10 +188,7 @@ fn owner_change_without_auth() {
     let body = serde_json::to_vec(&body).unwrap();
     let response = anon.put::<()>(&url, body);
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(
-        response.json(),
-        json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-    );
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
 #[test]

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -99,6 +99,7 @@ mod auth {
     use crates_io::models::token::{CrateScope, EndpointScope};
     use crates_io::schema::{crates, users, versions};
     use diesel::prelude::*;
+    use insta::assert_snapshot;
 
     const CRATE_NAME: &str = "fyk";
     const CRATE_VERSION: &str = "1.0.0";
@@ -130,18 +131,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
         assert!(!is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
         assert!(!is_yanked(&app));
     }
 
@@ -205,18 +200,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
         assert!(!is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
         assert!(!is_yanked(&app));
     }
 
@@ -249,18 +238,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
     }
 
@@ -319,18 +302,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
     }
 
@@ -346,18 +323,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION);
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_eq!(
-            response.json(),
-            json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-        );
+        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
     }
 

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -23,7 +23,7 @@ fn me() {
 
     let response = anon.get::<()>("/api/v1/me");
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"must be logged in to perform that action"}]}"###);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
     let response = user.get::<()>("/api/v1/me");
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -3,6 +3,7 @@ use crates_io::models::ApiToken;
 use crates_io::schema::api_tokens;
 use diesel::prelude::*;
 use http::StatusCode;
+use insta::assert_snapshot;
 
 #[test]
 fn revoke_current_token_success() {
@@ -38,10 +39,7 @@ fn revoke_current_token_without_auth() {
 
     let response = anon.delete::<()>("/api/v1/tokens/current");
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(
-        response.json(),
-        json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-    );
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
 #[test]

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -1,5 +1,6 @@
 use crate::util::{RequestHelper, Response, TestApp};
 use http::StatusCode;
+use insta::assert_snapshot;
 
 pub trait MockEmailHelper: RequestHelper {
     // TODO: I don't like the name of this method or `update_email` on the `MockCookieUser` impl;
@@ -89,8 +90,5 @@ fn test_other_users_cannot_change_my_email() {
         Some("pineapple@pineapples.pineapple"),
     );
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_eq!(
-        response.json(),
-        json!({ "errors": [{ "detail": "must be logged in to perform that action" }] })
-    );
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -15,6 +15,7 @@
 
 use axum::response::IntoResponse;
 use std::any::{Any, TypeId};
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt;
 
@@ -54,8 +55,7 @@ pub fn account_locked(reason: &str, until: Option<NaiveDateTime>) -> BoxedAppErr
     custom(StatusCode::FORBIDDEN, detail)
 }
 
-pub fn forbidden() -> BoxedAppError {
-    let detail = "must be logged in to perform that action";
+pub fn forbidden(detail: impl Into<Cow<'static, str>>) -> BoxedAppError {
     custom(StatusCode::FORBIDDEN, detail)
 }
 
@@ -289,7 +289,7 @@ mod tests {
 
         // Types for handling common error status codes
         assert_eq!(bad_request("").response().status(), StatusCode::BAD_REQUEST);
-        assert_eq!(forbidden().response().status(), StatusCode::FORBIDDEN);
+        assert_eq!(forbidden("").response().status(), StatusCode::FORBIDDEN);
         assert_eq!(
             BoxedAppError::from(DieselError::NotFound)
                 .response()


### PR DESCRIPTION
This PR adjusts our `forbidden()` error constructor fn by removing the hardcoded `details` message and replacing it with more contextual error messages.

Resolves https://github.com/rust-lang/crates.io/issues/8461