### PR TITLE
renovate: Automerge `aws-ip-ranges` and `github-meta` crate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,10 @@
             groupName: "diesel packages",
         },
         {
+            "matchPackageNames": ["aws-ip-ranges", "github-meta"],
+            "automerge": true,
+        },
+        {
             matchUpdateTypes: ["digest"],
             enabled: false,
         },


### PR DESCRIPTION
The release of these crates is automated, so we might as well automate their updates too.