### PR TITLE
util/tracing: Enable debug tracing by default for tests

### DIFF
--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -48,7 +48,7 @@ pub fn event_filter(metadata: &Metadata<'_>) -> EventFilter {
 /// Initializes the `tracing` logging framework for usage in tests.
 pub fn init_for_test() {
     let env_filter = EnvFilter::builder()
-        .with_default_directive(LevelFilter::INFO.into())
+        .with_default_directive(LevelFilter::DEBUG.into())
         .from_env_lossy();
 
     let _ = tracing_subscriber::fmt()


### PR DESCRIPTION
tracing output is only shown for failed tests anyway, and since we are usually quite interested to debug failed tests it's probably better to show the debug output by default.