### PR TITLE
chaosproxy: Remove internal tokio runtime

### DIFF
--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -105,7 +105,8 @@ impl ServerBin {
 
         // Use a proxied fresh schema as the database url.
         let test_database = TestDatabase::new();
-        let (chaosproxy, db_url) = ChaosProxy::proxy_database_url(test_database.url(), &runtime)?;
+        let (chaosproxy, db_url) =
+            runtime.block_on(ChaosProxy::proxy_database_url(test_database.url()))?;
         env.remove("TEST_DATABASE_URL");
         env.insert("DATABASE_URL".into(), db_url.clone());
         env.insert("READ_ONLY_REPLICA_URL".into(), db_url.clone());

--- a/src/tests/server_binary.rs
+++ b/src/tests/server_binary.rs
@@ -13,6 +13,7 @@ use std::process::{Child, Command, Stdio};
 use std::result::Result;
 use std::sync::{mpsc::Sender, Arc};
 use std::time::Duration;
+use tokio::runtime::Runtime;
 use url::Url;
 
 const SERVER_BOOT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -78,6 +79,7 @@ fn initialize_dummy_crate(conn: &mut PgConnection) {
 }
 
 struct ServerBin {
+    _runtime: Runtime,
     chaosproxy: Arc<ChaosProxy>,
     db_url: String,
     env: HashMap<String, String>,
@@ -86,6 +88,8 @@ struct ServerBin {
 
 impl ServerBin {
     fn prepare() -> Result<Self, Error> {
+        let runtime = Runtime::new().expect("failed to create Tokio runtime");
+
         let mut env = dotenvy::vars().collect::<HashMap<_, _>>();
         // Bind a random port every time the server is started.
         env.insert("PORT".into(), "0".into());
@@ -101,12 +105,13 @@ impl ServerBin {
 
         // Use a proxied fresh schema as the database url.
         let test_database = TestDatabase::new();
-        let (chaosproxy, db_url) = ChaosProxy::proxy_database_url(test_database.url())?;
+        let (chaosproxy, db_url) = ChaosProxy::proxy_database_url(test_database.url(), &runtime)?;
         env.remove("TEST_DATABASE_URL");
         env.insert("DATABASE_URL".into(), db_url.clone());
         env.insert("READ_ONLY_REPLICA_URL".into(), db_url.clone());
 
         Ok(ServerBin {
+            _runtime: runtime,
             chaosproxy,
             db_url,
             env,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -235,8 +235,9 @@ impl TestAppBuilder {
 
         let (primary_db_chaosproxy, replica_db_chaosproxy) = {
             let primary_proxy = if self.use_chaos_proxy {
-                let (primary_proxy, url) =
-                    ChaosProxy::proxy_database_url(test_database.url(), &runtime).unwrap();
+                let (primary_proxy, url) = runtime
+                    .block_on(ChaosProxy::proxy_database_url(test_database.url()))
+                    .unwrap();
 
                 self.config.db.primary.url = url.into();
                 Some(primary_proxy)
@@ -247,8 +248,9 @@ impl TestAppBuilder {
 
             let replica_proxy = self.config.db.replica.as_mut().and_then(|replica| {
                 if self.use_chaos_proxy {
-                    let (primary_proxy, url) =
-                        ChaosProxy::proxy_database_url(test_database.url(), &runtime).unwrap();
+                    let (primary_proxy, url) = runtime
+                        .block_on(ChaosProxy::proxy_database_url(test_database.url()))
+                        .unwrap();
 
                     replica.url = url.into();
                     Some(primary_proxy)

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -225,9 +225,7 @@ pub struct TestAppBuilder {
 impl TestAppBuilder {
     /// Create a `TestApp` with an empty database
     pub fn empty(mut self) -> (TestApp, MockAnonymousUser) {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
+        let runtime = Runtime::new()
             .context("Failed to initialize tokio runtime")
             .unwrap();
 
@@ -238,7 +236,7 @@ impl TestAppBuilder {
         let (primary_db_chaosproxy, replica_db_chaosproxy) = {
             let primary_proxy = if self.use_chaos_proxy {
                 let (primary_proxy, url) =
-                    ChaosProxy::proxy_database_url(test_database.url()).unwrap();
+                    ChaosProxy::proxy_database_url(test_database.url(), &runtime).unwrap();
 
                 self.config.db.primary.url = url.into();
                 Some(primary_proxy)
@@ -250,7 +248,7 @@ impl TestAppBuilder {
             let replica_proxy = self.config.db.replica.as_mut().and_then(|replica| {
                 if self.use_chaos_proxy {
                     let (primary_proxy, url) =
-                        ChaosProxy::proxy_database_url(test_database.url()).unwrap();
+                        ChaosProxy::proxy_database_url(test_database.url(), &runtime).unwrap();
 
                     replica.url = url.into();
                     Some(primary_proxy)


### PR DESCRIPTION
Previously, the `ChaosProxy` would starts its own dedicated multi-thread runtime. After this PR the `ChaosProxy` entry point is an async function, which reuses the runtime that is used to run the async function. This slightly simplifies the setup and makes the runtimes a bit easier to reason about.

(it is also one more step towards an async test suite... 😉)