### PR TITLE
Convert to async tests

### DIFF
--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -21,12 +21,12 @@ fn lock_account(app: &TestApp, user_id: i32, until: Option<NaiveDateTime>) {
     });
 }
 
-#[test]
-fn account_locked_indefinitely() {
+#[tokio::test(flavor = "multi_thread")]
+async fn account_locked_indefinitely() {
     let (app, _anon, user) = TestApp::init().with_user();
     lock_account(&app, user.as_model().id, None);
 
-    let response = user.get::<()>(URL);
+    let response = user.async_get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
     let error_message = format!("This account is indefinitely locked. Reason: {LOCK_REASON}");
@@ -36,15 +36,15 @@ fn account_locked_indefinitely() {
     );
 }
 
-#[test]
-fn account_locked_with_future_expiry() {
+#[tokio::test(flavor = "multi_thread")]
+async fn account_locked_with_future_expiry() {
     let until = Utc::now().naive_utc() + Duration::days(1);
 
     let (app, _anon, user) = TestApp::init().with_user();
     lock_account(&app, user.as_model().id, Some(until));
 
     let until = until.format("%Y-%m-%d at %H:%M:%S UTC");
-    let response = user.get::<()>(URL);
+    let response = user.async_get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
     let error_message = format!("This account is locked until {until}. Reason: {LOCK_REASON}");
@@ -54,12 +54,12 @@ fn account_locked_with_future_expiry() {
     );
 }
 
-#[test]
-fn expired_account_lock() {
+#[tokio::test(flavor = "multi_thread")]
+async fn expired_account_lock() {
     let until = Utc::now().naive_utc() - Duration::days(1);
 
     let (app, _anon, user) = TestApp::init().with_user();
     lock_account(&app, user.as_model().id, Some(until));
 
-    user.get::<serde_json::Value>(URL).good();
+    user.async_get::<serde_json::Value>(URL).await.good();
 }

--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -26,7 +26,7 @@ async fn account_locked_indefinitely() {
     let (app, _anon, user) = TestApp::init().with_user();
     lock_account(&app, user.as_model().id, None);
 
-    let response = user.async_get::<()>(URL).await;
+    let response = user.get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
     let error_message = format!("This account is indefinitely locked. Reason: {LOCK_REASON}");
@@ -44,7 +44,7 @@ async fn account_locked_with_future_expiry() {
     lock_account(&app, user.as_model().id, Some(until));
 
     let until = until.format("%Y-%m-%d at %H:%M:%S UTC");
-    let response = user.async_get::<()>(URL).await;
+    let response = user.get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
     let error_message = format!("This account is locked until {until}. Reason: {LOCK_REASON}");
@@ -61,5 +61,5 @@ async fn expired_account_lock() {
     let (app, _anon, user) = TestApp::init().with_user();
     lock_account(&app, user.as_model().id, Some(until));
 
-    user.async_get::<serde_json::Value>(URL).await.good();
+    user.get::<serde_json::Value>(URL).await.good();
 }

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -10,7 +10,7 @@ static URL: &str = "/api/v1/me/updates";
 #[tokio::test(flavor = "multi_thread")]
 async fn anonymous_user_unauthorized() {
     let (_, anon) = TestApp::init().empty();
-    let response: Response<()> = anon.async_get(URL).await;
+    let response: Response<()> = anon.get(URL).await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
@@ -21,7 +21,7 @@ async fn token_auth_cannot_find_token() {
     let (_, anon) = TestApp::init().empty();
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::AUTHORIZATION, "cio1tkfake-token");
-    let response: Response<()> = anon.async_run(request).await;
+    let response: Response<()> = anon.run(request).await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
@@ -40,6 +40,6 @@ async fn cookie_auth_cannot_find_user() {
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::COOKIE, &cookie);
 
-    let error = anon.async_run::<()>(request).await;
+    let error = anon.run::<()>(request).await;
     assert_eq!(error.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -7,21 +7,21 @@ use insta::assert_snapshot;
 
 static URL: &str = "/api/v1/me/updates";
 
-#[test]
-fn anonymous_user_unauthorized() {
+#[tokio::test(flavor = "multi_thread")]
+async fn anonymous_user_unauthorized() {
     let (_, anon) = TestApp::init().empty();
-    let response: Response<()> = anon.get(URL);
+    let response: Response<()> = anon.async_get(URL).await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
-#[test]
-fn token_auth_cannot_find_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn token_auth_cannot_find_token() {
     let (_, anon) = TestApp::init().empty();
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::AUTHORIZATION, "cio1tkfake-token");
-    let response: Response<()> = anon.run(request);
+    let response: Response<()> = anon.async_run(request).await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
@@ -30,8 +30,8 @@ fn token_auth_cannot_find_token() {
 // Ensure that an unexpected authentication error is available for logging.  The user would see
 // status 500 instead of 403 as in other authentication tests.  Due to foreign-key constraints in
 // the database, it is not possible to implement this same test for a token.
-#[test]
-fn cookie_auth_cannot_find_user() {
+#[tokio::test(flavor = "multi_thread")]
+async fn cookie_auth_cannot_find_user() {
     let (app, anon) = TestApp::init().empty();
 
     let session_key = app.as_inner().session_key();
@@ -40,6 +40,6 @@ fn cookie_auth_cannot_find_user() {
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::COOKIE, &cookie);
 
-    let error = anon.run::<()>(request);
+    let error = anon.async_run::<()>(request).await;
     assert_eq!(error.status(), StatusCode::INTERNAL_SERVER_ERROR);
 }

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -17,7 +17,7 @@ async fn test_non_blocked_download_route() {
     });
 
     let status = anon
-        .async_get::<()>("/api/v1/crates/foo/1.0.0/download")
+        .get::<()>("/api/v1/crates/foo/1.0.0/download")
         .await
         .status();
     assert_eq!(status, StatusCode::FOUND);
@@ -41,7 +41,7 @@ async fn test_blocked_download_route() {
     });
 
     let status = anon
-        .async_get::<()>("/api/v1/crates/foo/1.0.0/download")
+        .get::<()>("/api/v1/crates/foo/1.0.0/download")
         .await
         .status();
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -2,8 +2,8 @@ use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 
-#[test]
-fn test_non_blocked_download_route() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_non_blocked_download_route() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.blocked_routes.clear();
@@ -16,12 +16,15 @@ fn test_non_blocked_download_route() {
             .expect_build(conn);
     });
 
-    let status = anon.get::<()>("/api/v1/crates/foo/1.0.0/download").status();
+    let status = anon
+        .async_get::<()>("/api/v1/crates/foo/1.0.0/download")
+        .await
+        .status();
     assert_eq!(status, StatusCode::FOUND);
 }
 
-#[test]
-fn test_blocked_download_route() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_blocked_download_route() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.blocked_routes.clear();
@@ -37,6 +40,9 @@ fn test_blocked_download_route() {
             .expect_build(conn);
     });
 
-    let status = anon.get::<()>("/api/v1/crates/foo/1.0.0/download").status();
+    let status = anon
+        .async_get::<()>("/api/v1/crates/foo/1.0.0/download")
+        .await
+        .status();
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -46,7 +46,7 @@ async fn github_secret_alert_revokes_token() {
     *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 
@@ -101,7 +101,7 @@ async fn github_secret_alert_for_revoked_token() {
     *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 
@@ -144,7 +144,7 @@ async fn github_secret_alert_for_unknown_token() {
     *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 
@@ -168,27 +168,27 @@ async fn github_secret_alert_invalid_signature_fails() {
 
     // No headers or request body
     let request = anon.post_request(URL);
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Request body but no headers
     let mut request = anon.post_request(URL);
     *request.body_mut() = GITHUB_ALERT.into();
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Headers but no request body
     let mut request = anon.post_request(URL);
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", GITHUB_PUBLIC_KEY_SIGNATURE);
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Request body but only key identifier header
     let mut request = anon.post_request(URL);
     *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Invalid signature
@@ -196,7 +196,7 @@ async fn github_secret_alert_invalid_signature_fails() {
     *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", "bad signature");
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
     // Invalid signature that is valid base64
@@ -204,6 +204,6 @@ async fn github_secret_alert_invalid_signature_fails() {
     *request.body_mut() = GITHUB_ALERT.into();
     request.header("GITHUB-PUBLIC-KEY-IDENTIFIER", GITHUB_PUBLIC_KEY_IDENTIFIER);
     request.header("GITHUB-PUBLIC-KEY-SIGNATURE", "YmFkIHNpZ25hdHVyZQ==");
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -4,26 +4,32 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_snapshot;
 
-fn assert_is_following(crate_name: &str, expected: bool, user: &impl RequestHelper) {
-    let response = user.get::<()>(&format!("/api/v1/crates/{crate_name}/following"));
+async fn assert_is_following(crate_name: &str, expected: bool, user: &impl RequestHelper) {
+    let response = user
+        .async_get::<()>(&format!("/api/v1/crates/{crate_name}/following"))
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.json(), json!({ "following": expected }));
 }
 
-fn follow(crate_name: &str, user: &impl RequestHelper) {
-    let response = user.put::<()>(&format!("/api/v1/crates/{crate_name}/follow"), b"" as &[u8]);
+async fn follow(crate_name: &str, user: &impl RequestHelper) {
+    let response = user
+        .async_put::<()>(&format!("/api/v1/crates/{crate_name}/follow"), b"" as &[u8])
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.json(), json!({ "ok": true }));
 }
 
-fn unfollow(crate_name: &str, user: &impl RequestHelper) {
-    let response = user.delete::<()>(&format!("/api/v1/crates/{crate_name}/follow"));
+async fn unfollow(crate_name: &str, user: &impl RequestHelper) {
+    let response = user
+        .async_delete::<()>(&format!("/api/v1/crates/{crate_name}/follow"))
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.json(), json!({ "ok": true }));
 }
 
-#[test]
-fn test_unauthenticated_requests() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unauthenticated_requests() {
     const CRATE_NAME: &str = "foo";
 
     let (app, anon, user) = TestApp::init().with_user();
@@ -32,21 +38,27 @@ fn test_unauthenticated_requests() {
         CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(conn);
     });
 
-    let response = anon.get::<()>(&format!("/api/v1/crates/{CRATE_NAME}/following"));
+    let response = anon
+        .async_get::<()>(&format!("/api/v1/crates/{CRATE_NAME}/following"))
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
-    let response = anon.put::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"), b"" as &[u8]);
+    let response = anon
+        .async_put::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"), b"" as &[u8])
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
-    let response = anon.delete::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"));
+    let response = anon
+        .async_delete::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"))
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
-#[test]
-fn test_following() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_following() {
     const CRATE_NAME: &str = "foo_following";
 
     let (app, _, user) = TestApp::init().with_user();
@@ -56,47 +68,53 @@ fn test_following() {
     });
 
     // Check that initially we are not following the crate yet.
-    assert_is_following(CRATE_NAME, false, &user);
+    assert_is_following(CRATE_NAME, false, &user).await;
 
     // Follow the crate and check that we are now following it.
-    follow(CRATE_NAME, &user);
-    assert_is_following(CRATE_NAME, true, &user);
-    assert_that!(user.search("following=1").crates, len(eq(1)));
+    follow(CRATE_NAME, &user).await;
+    assert_is_following(CRATE_NAME, true, &user).await;
+    assert_that!(user.async_search("following=1").await.crates, len(eq(1)));
 
     // Follow the crate again and check that we are still following it
     // (aka. the request is idempotent).
-    follow(CRATE_NAME, &user);
-    assert_is_following(CRATE_NAME, true, &user);
+    follow(CRATE_NAME, &user).await;
+    assert_is_following(CRATE_NAME, true, &user).await;
 
     // Unfollow the crate and check that we are not following it anymore.
-    unfollow(CRATE_NAME, &user);
-    assert_is_following(CRATE_NAME, false, &user);
-    assert_that!(user.search("following=1").crates, empty());
+    unfollow(CRATE_NAME, &user).await;
+    assert_is_following(CRATE_NAME, false, &user).await;
+    assert_that!(user.async_search("following=1").await.crates, empty());
 
     // Unfollow the crate again and check that this call is also idempotent.
-    unfollow(CRATE_NAME, &user);
-    assert_is_following(CRATE_NAME, false, &user);
+    unfollow(CRATE_NAME, &user).await;
+    assert_is_following(CRATE_NAME, false, &user).await;
 }
 
-#[test]
-fn test_unknown_crate() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_crate() {
     let (_, _, user) = TestApp::init().with_user();
 
-    let response = user.get::<()>("/api/v1/crates/unknown-crate/following");
+    let response = user
+        .async_get::<()>("/api/v1/crates/unknown-crate/following")
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
 
-    let response = user.put::<()>("/api/v1/crates/unknown-crate/follow", b"" as &[u8]);
+    let response = user
+        .async_put::<()>("/api/v1/crates/unknown-crate/follow", b"" as &[u8])
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
 
-    let response = user.delete::<()>("/api/v1/crates/unknown-crate/follow");
+    let response = user
+        .async_delete::<()>("/api/v1/crates/unknown-crate/follow")
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
 }
 
-#[test]
-fn test_api_token_auth() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_api_token_auth() {
     const CRATE_TO_FOLLOW: &str = "some_crate_to_follow";
     const CRATE_NOT_TO_FOLLOW: &str = "another_crate";
 
@@ -108,12 +126,12 @@ fn test_api_token_auth() {
         CrateBuilder::new(CRATE_NOT_TO_FOLLOW, api_token.user_id).expect_build(conn);
     });
 
-    follow(CRATE_TO_FOLLOW, &token);
+    follow(CRATE_TO_FOLLOW, &token).await;
 
     // Token auth on GET for get following status is disallowed
-    assert_is_following(CRATE_TO_FOLLOW, true, &user);
-    assert_is_following(CRATE_NOT_TO_FOLLOW, false, &user);
+    assert_is_following(CRATE_TO_FOLLOW, true, &user).await;
+    assert_is_following(CRATE_NOT_TO_FOLLOW, false, &user).await;
 
-    let json = token.search("following=1");
+    let json = token.async_search("following=1").await;
     assert_that!(json.crates, len(eq(1)));
 }

--- a/src/tests/krate/publish/audit_action.rs
+++ b/src/tests/krate/publish/audit_action.rs
@@ -1,7 +1,7 @@
 use googletest::prelude::*;
 
-#[test]
-fn publish_records_an_audit_action() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_records_an_audit_action() {
     use crate::builders::PublishBuilder;
     use crate::util::{RequestHelper, TestApp};
     use crates_io::models::VersionOwnerAction;
@@ -12,10 +12,10 @@ fn publish_records_an_audit_action() {
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     // Make sure it has one publish audit action
-    let json = anon.show_version("fyk", "1.0.0");
+    let json = anon.async_show_version("fyk", "1.0.0").await;
     let actions = json.version.audit_actions;
 
     assert_that!(actions, len(eq(1)));

--- a/src/tests/krate/publish/audit_action.rs
+++ b/src/tests/krate/publish/audit_action.rs
@@ -12,10 +12,10 @@ async fn publish_records_an_audit_action() {
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     // Make sure it has one publish audit action
-    let json = anon.async_show_version("fyk", "1.0.0").await;
+    let json = anon.show_version("fyk", "1.0.0").await;
     let actions = json.version.audit_actions;
 
     assert_that!(actions, len(eq(1)));

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -12,7 +12,7 @@ async fn new_wrong_token() {
 
     // Try to publish without a token
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
-    let response = anon.async_publish_crate(crate_to_publish).await;
+    let response = anon.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
@@ -25,10 +25,10 @@ async fn new_wrong_token() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -44,9 +44,9 @@ async fn new_krate_wrong_user() {
     let another_user = app.db_new_user("another").db_new_token("bar");
     let crate_to_publish = PublishBuilder::new("foo_wrong", "2.0.0");
 
-    let response = another_user.async_publish_crate(crate_to_publish).await;
+    let response = another_user.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -6,13 +6,13 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
 
-#[test]
-fn new_wrong_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_wrong_token() {
     let (app, anon, _, token) = TestApp::full().with_token();
 
     // Try to publish without a token
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
-    let response = anon.publish_crate(crate_to_publish);
+    let response = anon.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
@@ -25,14 +25,14 @@ fn new_wrong_token() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_wrong_user() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_wrong_user() {
     let (app, _, user) = TestApp::full().with_user();
 
     app.db(|conn| {
@@ -44,9 +44,9 @@ fn new_krate_wrong_user() {
     let another_user = app.db_new_user("another").db_new_token("bar");
     let crate_to_publish = PublishBuilder::new("foo_wrong", "2.0.0");
 
-    let response = another_user.publish_crate(crate_to_publish);
+    let response = another_user.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -11,7 +11,7 @@ async fn new_krate() {
     let (app, _, user) = TestApp::full().with_user();
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
-    let response = user.async_publish_crate(crate_to_publish).await;
+    let response = user.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -22,7 +22,7 @@ async fn new_krate() {
     assert_json_snapshot!(crates);
 
     let expected_files = vec!["crates/foo_new/foo_new-1.0.0.crate", "index/fo/o_/foo_new"];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 
     app.db(|conn| {
         let email: String = versions_published_by::table
@@ -38,7 +38,7 @@ async fn new_krate_with_token() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -46,7 +46,7 @@ async fn new_krate_with_token() {
     });
 
     let expected_files = vec!["crates/foo_new/foo_new-1.0.0.crate", "index/fo/o_/foo_new"];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -54,7 +54,7 @@ async fn new_krate_weird_version() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_weird", "0.0.0-pre");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -65,7 +65,7 @@ async fn new_krate_weird_version() {
         "crates/foo_weird/foo_weird-0.0.0-pre.crate",
         "index/fo/o_/foo_weird",
     ];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -73,11 +73,11 @@ async fn new_krate_twice() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_twice", "0.99.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     let crate_to_publish =
         PublishBuilder::new("foo_twice", "2.0.0").description("2.0.0 description");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -92,7 +92,7 @@ async fn new_krate_twice() {
         "crates/foo_twice/foo_twice-2.0.0.crate",
         "index/fo/o_/foo_twice",
     ];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -107,9 +107,9 @@ async fn new_krate_duplicate_version() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo_dupe", "1.0.0");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -6,12 +6,12 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn new_krate() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate() {
     let (app, _, user) = TestApp::full().with_user();
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
-    let response = user.publish_crate(crate_to_publish);
+    let response = user.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -22,7 +22,7 @@ fn new_krate() {
     assert_json_snapshot!(crates);
 
     let expected_files = vec!["crates/foo_new/foo_new-1.0.0.crate", "index/fo/o_/foo_new"];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 
     app.db(|conn| {
         let email: String = versions_published_by::table
@@ -33,12 +33,12 @@ fn new_krate() {
     });
 }
 
-#[test]
-fn new_krate_with_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_token() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -46,15 +46,15 @@ fn new_krate_with_token() {
     });
 
     let expected_files = vec!["crates/foo_new/foo_new-1.0.0.crate", "index/fo/o_/foo_new"];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }
 
-#[test]
-fn new_krate_weird_version() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_weird_version() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_weird", "0.0.0-pre");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -65,19 +65,19 @@ fn new_krate_weird_version() {
         "crates/foo_weird/foo_weird-0.0.0-pre.crate",
         "index/fo/o_/foo_weird",
     ];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }
 
-#[test]
-fn new_krate_twice() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_twice() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_twice", "0.99.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let crate_to_publish =
         PublishBuilder::new("foo_twice", "2.0.0").description("2.0.0 description");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -92,11 +92,11 @@ fn new_krate_twice() {
         "crates/foo_twice/foo_twice-2.0.0.crate",
         "index/fo/o_/foo_twice",
     ];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }
 
-#[test]
-fn new_krate_duplicate_version() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_duplicate_version() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -107,9 +107,9 @@ fn new_krate_duplicate_version() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo_dupe", "1.0.0");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }

--- a/src/tests/krate/publish/build_metadata.rs
+++ b/src/tests/krate/publish/build_metadata.rs
@@ -6,18 +6,14 @@ use insta::assert_json_snapshot;
 async fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token
-        .async_publish_crate(PublishBuilder::new("foo", v1))
-        .await;
+    let response = token.publish_crate(PublishBuilder::new("foo", v1)).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
 
-    let response = token
-        .async_publish_crate(PublishBuilder::new("foo", v2))
-        .await;
+    let response = token.publish_crate(PublishBuilder::new("foo", v2)).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),

--- a/src/tests/krate/publish/build_metadata.rs
+++ b/src/tests/krate/publish/build_metadata.rs
@@ -3,17 +3,21 @@ use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
+async fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(PublishBuilder::new("foo", v1));
+    let response = token
+        .async_publish_crate(PublishBuilder::new("foo", v1))
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
 
-    let response = token.publish_crate(PublishBuilder::new("foo", v2));
+    let response = token
+        .async_publish_crate(PublishBuilder::new("foo", v2))
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -21,35 +25,41 @@ fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
     );
 }
 
-#[test]
-fn version_with_build_metadata_1() {
-    insta::with_settings!({ snapshot_suffix => "build_metadata_1" }, {
-        version_with_build_metadata(
+#[tokio::test(flavor = "multi_thread")]
+async fn version_with_build_metadata_1() {
+    let mut settings = insta::Settings::new();
+    settings.set_snapshot_suffix("build_metadata_1");
+    settings
+        .bind_async(version_with_build_metadata(
             "1.0.0+foo",
             "1.0.0+bar",
             "crate version `1.0.0` is already uploaded",
-        );
-    });
+        ))
+        .await;
 }
 
-#[test]
-fn version_with_build_metadata_2() {
-    insta::with_settings!({ snapshot_suffix => "build_metadata_2" }, {
-        version_with_build_metadata(
+#[tokio::test(flavor = "multi_thread")]
+async fn version_with_build_metadata_2() {
+    let mut settings = insta::Settings::new();
+    settings.set_snapshot_suffix("build_metadata_2");
+    settings
+        .bind_async(version_with_build_metadata(
             "1.0.0-beta.1",
             "1.0.0-beta.1+2",
             "crate version `1.0.0-beta.1` is already uploaded",
-        );
-    });
+        ))
+        .await;
 }
 
-#[test]
-fn version_with_build_metadata_3() {
-    insta::with_settings!({ snapshot_suffix => "build_metadata_3" }, {
-        version_with_build_metadata(
+#[tokio::test(flavor = "multi_thread")]
+async fn version_with_build_metadata_3() {
+    let mut settings = insta::Settings::new();
+    settings.set_snapshot_suffix("build_metadata_3");
+    settings
+        .bind_async(version_with_build_metadata(
             "1.0.0+foo",
             "1.0.0",
             "crate version `1.0.0` is already uploaded",
-        );
-    });
+        ))
+        .await;
 }

--- a/src/tests/krate/publish/categories.rs
+++ b/src/tests/krate/publish/categories.rs
@@ -16,7 +16,7 @@ async fn good_categories() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo_good_cat", "1.0.0").category("cat1");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -29,7 +29,7 @@ async fn ignored_categories() {
     let (_, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_ignored_cat", "1.0.0").category("bar");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -42,7 +42,7 @@ async fn too_many_categories() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0")
                 .category("one")
                 .category("two")
@@ -54,5 +54,5 @@ async fn too_many_categories() {
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -4,20 +4,22 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
 
-#[test]
-fn invalid_dependency_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_dependency_name() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0").dependency(DependencyBuilder::new("🦀")),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0").dependency(DependencyBuilder::new("🦀")),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_with_renamed_dependency() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_with_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -28,14 +30,14 @@ fn new_with_renamed_dependency() {
     let dependency = DependencyBuilder::new("package-name").rename("my-name");
 
     let crate_to_publish = PublishBuilder::new("new-krate", "1.0.0").dependency(dependency);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let crates = app.crates_from_index_head("new-krate");
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn invalid_dependency_rename() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_dependency_rename() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -43,17 +45,19 @@ fn invalid_dependency_rename() {
         CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
     });
 
-    let response = token.publish_crate(
-        PublishBuilder::new("new-krate", "1.0.0")
-            .dependency(DependencyBuilder::new("package-name").rename("💩")),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("new-krate", "1.0.0")
+                .dependency(DependencyBuilder::new("package-name").rename("💩")),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn invalid_dependency_name_starts_with_digit() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_dependency_name_starts_with_digit() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -61,17 +65,19 @@ fn invalid_dependency_name_starts_with_digit() {
         CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
     });
 
-    let response = token.publish_crate(
-        PublishBuilder::new("new-krate", "1.0.0")
-            .dependency(DependencyBuilder::new("package-name").rename("1-foo")),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("new-krate", "1.0.0")
+                .dependency(DependencyBuilder::new("package-name").rename("1-foo")),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn invalid_dependency_name_contains_unicode_chars() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_dependency_name_contains_unicode_chars() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -79,17 +85,19 @@ fn invalid_dependency_name_contains_unicode_chars() {
         CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
     });
 
-    let response = token.publish_crate(
-        PublishBuilder::new("new-krate", "1.0.0")
-            .dependency(DependencyBuilder::new("package-name").rename("foo-🦀-bar")),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("new-krate", "1.0.0")
+                .dependency(DependencyBuilder::new("package-name").rename("foo-🦀-bar")),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn invalid_too_long_dependency_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_too_long_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -97,35 +105,38 @@ fn invalid_too_long_dependency_name() {
         CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
     });
 
-    let response =
-        token
-            .publish_crate(PublishBuilder::new("new-krate", "1.0.0").dependency(
-                DependencyBuilder::new("package-name").rename("f".repeat(65).as_str()),
-            ));
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("new-krate", "1.0.0")
+                .dependency(DependencyBuilder::new("package-name").rename("f".repeat(65).as_str())),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn empty_dependency_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
         // Insert a crate directly into the database so that new-krate can depend on it
         CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
     });
-    let response = token.publish_crate(
-        PublishBuilder::new("new-krate", "1.0.0")
-            .dependency(DependencyBuilder::new("package-name").rename("")),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("new-krate", "1.0.0")
+                .dependency(DependencyBuilder::new("package-name").rename("")),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_with_underscore_renamed_dependency() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_with_underscore_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -136,14 +147,14 @@ fn new_with_underscore_renamed_dependency() {
     let dependency = DependencyBuilder::new("package-name").rename("_my-name");
 
     let crate_to_publish = PublishBuilder::new("new-krate", "1.0.0").dependency(dependency);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let crates = app.crates_from_index_head("new-krate");
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn new_krate_with_dependency() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_dependency() {
     use crate::routes::crates::versions::dependencies::Deps;
 
     let (app, anon, user, token) = TestApp::full().with_token();
@@ -160,10 +171,11 @@ fn new_krate_with_dependency() {
 
     let crate_to_publish = PublishBuilder::new("new_dep", "1.0.0").dependency(dependency);
 
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let dependencies = anon
-        .get::<Deps>("/api/v1/crates/new_dep/1.0.0/dependencies")
+        .async_get::<Deps>("/api/v1/crates/new_dep/1.0.0/dependencies")
+        .await
         .good()
         .dependencies;
 
@@ -175,8 +187,8 @@ fn new_krate_with_dependency() {
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn new_krate_with_broken_dependency_requirement() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_broken_dependency_requirement() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -190,14 +202,14 @@ fn new_krate_with_broken_dependency_requirement() {
     let dependency = DependencyBuilder::new("foo-dep").version_req("broken");
 
     let crate_to_publish = PublishBuilder::new("new_dep", "1.0.0").dependency(dependency);
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn reject_new_krate_with_non_exact_dependency() {
+#[tokio::test(flavor = "multi_thread")]
+async fn reject_new_krate_with_non_exact_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -209,14 +221,14 @@ fn reject_new_krate_with_non_exact_dependency() {
 
     let crate_to_publish = PublishBuilder::new("new_dep", "1.0.0").dependency(dependency);
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_crate_allow_empty_alternative_registry_dependency() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_crate_allow_empty_alternative_registry_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -225,11 +237,11 @@ fn new_crate_allow_empty_alternative_registry_dependency() {
 
     let dependency = DependencyBuilder::new("foo-dep").registry("");
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").dependency(dependency);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 }
 
-#[test]
-fn reject_new_crate_with_alternative_registry_dependency() {
+#[tokio::test(flavor = "multi_thread")]
+async fn reject_new_crate_with_alternative_registry_dependency() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let dependency =
@@ -237,14 +249,14 @@ fn reject_new_crate_with_alternative_registry_dependency() {
 
     let crate_to_publish =
         PublishBuilder::new("depends-on-alt-registry", "1.0.0").dependency(dependency);
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_with_wildcard_dependency() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_wildcard_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -256,14 +268,14 @@ fn new_krate_with_wildcard_dependency() {
 
     let crate_to_publish = PublishBuilder::new("new_wild", "1.0.0").dependency(dependency);
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_dependency_missing() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_dependency_missing() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     // Deliberately not inserting this crate in the database to test behavior when a dependency
@@ -271,14 +283,14 @@ fn new_krate_dependency_missing() {
     let dependency = DependencyBuilder::new("bar_missing");
     let crate_to_publish = PublishBuilder::new("foo_missing", "1.0.0").dependency(dependency);
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_sorts_deps() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_sorts_deps() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -294,27 +306,29 @@ fn new_krate_sorts_deps() {
     let crate_to_publish = PublishBuilder::new("two-deps", "1.0.0")
         .dependency(dep_b)
         .dependency(dep_a);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let crates = app.crates_from_index_head("two-deps");
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn invalid_feature_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_feature_name() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0")
-            .dependency(DependencyBuilder::new("bar").add_feature("🍺")),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0")
+                .dependency(DependencyBuilder::new("bar").add_feature("🍺")),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn test_dep_limit() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dep_limit() {
     let (app, _, user, token) = TestApp::full()
         .with_config(|config| config.max_dependencies = 1)
         .with_token();
@@ -328,14 +342,14 @@ fn test_dep_limit() {
         .dependency(DependencyBuilder::new("dep-a"))
         .dependency(DependencyBuilder::new("dep-b"));
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crates.io only allows a maximum number of 1 dependencies.\n\nIf you have a use case that requires an increase of this limit, please send us an email to help@crates.io to discuss the details."}]}"###);
 
     let crate_to_publish =
         PublishBuilder::new("foo", "1.0.0").dependency(DependencyBuilder::new("dep-a"));
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",

--- a/src/tests/krate/publish/emails.rs
+++ b/src/tests/krate/publish/emails.rs
@@ -6,8 +6,8 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn new_krate_without_any_email_fails() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_without_any_email_fails() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -16,14 +16,14 @@ fn new_krate_without_any_email_fails() {
 
     let crate_to_publish = PublishBuilder::new("foo_no_email", "1.0.0");
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_with_unverified_email_fails() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_unverified_email_fails() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -35,8 +35,8 @@ fn new_krate_with_unverified_email_fails() {
 
     let crate_to_publish = PublishBuilder::new("foo_unverified_email", "1.0.0");
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }

--- a/src/tests/krate/publish/emails.rs
+++ b/src/tests/krate/publish/emails.rs
@@ -16,10 +16,10 @@ async fn new_krate_without_any_email_fails() {
 
     let crate_to_publish = PublishBuilder::new("foo_no_email", "1.0.0");
 
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -35,8 +35,8 @@ async fn new_krate_with_unverified_email_fails() {
 
     let crate_to_publish = PublishBuilder::new("foo_unverified_email", "1.0.0");
 
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -4,8 +4,8 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn features_version_2() {
+#[tokio::test(flavor = "multi_thread")]
+async fn features_version_2() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -19,85 +19,85 @@ fn features_version_2() {
         .dependency(dependency)
         .feature("new_feat", &["dep:bar", "bar?/feat"])
         .feature("old_feat", &[]);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let crates = app.crates_from_index_head("foo");
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn feature_name_with_dot() {
+#[tokio::test(flavor = "multi_thread")]
+async fn feature_name_with_dot() {
     let (app, _, _, token) = TestApp::full().with_token();
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo.bar", &[]);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
     let crates = app.crates_from_index_head("foo");
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn feature_name_start_with_number_and_underscore() {
+#[tokio::test(flavor = "multi_thread")]
+async fn feature_name_start_with_number_and_underscore() {
     let (app, _, _, token) = TestApp::full().with_token();
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0")
         .feature("0foo1.bar", &[])
         .feature("_foo2.bar", &[]);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
     let crates = app.crates_from_index_head("foo");
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn feature_name_with_unicode_chars() {
+#[tokio::test(flavor = "multi_thread")]
+async fn feature_name_with_unicode_chars() {
     let (app, _, _, token) = TestApp::full().with_token();
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo.你好世界", &[]);
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
     let crates = app.crates_from_index_head("foo");
     assert_json_snapshot!(crates);
 }
 
-#[test]
-fn empty_feature_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_feature_name() {
     let (app, _, _, token) = TestApp::full().with_token();
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("", &[]);
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert!(app.stored_files().is_empty());
+    assert!(app.async_stored_files().await.is_empty());
 }
 
-#[test]
-fn invalid_feature_name1() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_feature_name1() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("~foo", &[]);
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn invalid_feature_name2() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_feature_name2() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo", &["!bar"]);
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn invalid_feature_name_start_with_hyphen() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_feature_name_start_with_hyphen() {
     let (app, _, _, token) = TestApp::full().with_token();
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("-foo1.bar", &[]);
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert!(app.stored_files().is_empty());
+    assert!(app.async_stored_files().await.is_empty());
 }
 
-#[test]
-fn too_many_features() {
+#[tokio::test(flavor = "multi_thread")]
+async fn too_many_features() {
     let (app, _, _, token) = TestApp::full()
         .with_config(|config| {
             config.max_features = 3;
@@ -110,14 +110,14 @@ fn too_many_features() {
         .feature("three", &[])
         .feature("four", &[])
         .feature("five", &[]);
-    let response = token.publish_crate(publish_builder);
+    let response = token.async_publish_crate(publish_builder).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn too_many_features_with_custom_limit() {
+#[tokio::test(flavor = "multi_thread")]
+async fn too_many_features_with_custom_limit() {
     let (app, _, user, token) = TestApp::full()
         .with_config(|config| {
             config.max_features = 3;
@@ -136,17 +136,17 @@ fn too_many_features_with_custom_limit() {
         .feature("three", &[])
         .feature("four", &[])
         .feature("five", &[]);
-    let response = token.publish_crate(publish_builder);
+    let response = token.async_publish_crate(publish_builder).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("one", &[])
         .feature("two", &[])
         .feature("three", &[])
         .feature("four", &[]);
-    token.publish_crate(publish_builder).good();
+    token.async_publish_crate(publish_builder).await.good();
 
     // see https://github.com/rust-lang/crates.io/issues/7632
     let publish_builder = PublishBuilder::new("foo", "1.0.1")
@@ -154,11 +154,11 @@ fn too_many_features_with_custom_limit() {
         .feature("two", &[])
         .feature("three", &[])
         .feature("four", &[]);
-    token.publish_crate(publish_builder).good();
+    token.async_publish_crate(publish_builder).await.good();
 }
 
-#[test]
-fn too_many_enabled_features() {
+#[tokio::test(flavor = "multi_thread")]
+async fn too_many_enabled_features() {
     let (app, _, _, token) = TestApp::full()
         .with_config(|config| {
             config.max_features = 3;
@@ -167,14 +167,14 @@ fn too_many_enabled_features() {
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("default", &["one", "two", "three", "four", "five"]);
-    let response = token.publish_crate(publish_builder);
+    let response = token.async_publish_crate(publish_builder).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn too_many_enabled_features_with_custom_limit() {
+#[tokio::test(flavor = "multi_thread")]
+async fn too_many_enabled_features_with_custom_limit() {
     let (app, _, user, token) = TestApp::full()
         .with_config(|config| {
             config.max_features = 3;
@@ -189,12 +189,12 @@ fn too_many_enabled_features_with_custom_limit() {
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("default", &["one", "two", "three", "four", "five"]);
-    let response = token.publish_crate(publish_builder);
+    let response = token.async_publish_crate(publish_builder).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 
     let publish_builder =
         PublishBuilder::new("foo", "1.0.0").feature("default", &["one", "two", "three", "four"]);
-    token.publish_crate(publish_builder).good();
+    token.async_publish_crate(publish_builder).await.good();
 }

--- a/src/tests/krate/publish/git.rs
+++ b/src/tests/krate/publish/git.rs
@@ -1,18 +1,18 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
 
-#[test]
-fn new_krate_git_upload_with_conflicts() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_git_upload_with_conflicts() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     app.upstream_index().create_empty_commit().unwrap();
 
     let crate_to_publish = PublishBuilder::new("foo_conflicts", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let expected_files = vec![
         "crates/foo_conflicts/foo_conflicts-1.0.0.crate",
         "index/fo/o_/foo_conflicts",
     ];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }

--- a/src/tests/krate/publish/git.rs
+++ b/src/tests/krate/publish/git.rs
@@ -8,11 +8,11 @@ async fn new_krate_git_upload_with_conflicts() {
     app.upstream_index().create_empty_commit().unwrap();
 
     let crate_to_publish = PublishBuilder::new("foo_conflicts", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     let expected_files = vec![
         "crates/foo_conflicts/foo_conflicts-1.0.0.crate",
         "index/fo/o_/foo_conflicts",
     ];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 }

--- a/src/tests/krate/publish/inheritance.rs
+++ b/src/tests/krate/publish/inheritance.rs
@@ -8,7 +8,7 @@ async fn workspace_inheritance() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0")
                 .custom_manifest("[package]\nname = \"foo\"\nversion.workspace = true\n"),
         )
@@ -21,7 +21,7 @@ async fn workspace_inheritance() {
 async fn workspace_inheritance_with_dep() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
         "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nserde.workspace = true\n",
     )).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/src/tests/krate/publish/inheritance.rs
+++ b/src/tests/krate/publish/inheritance.rs
@@ -3,25 +3,27 @@ use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn workspace_inheritance() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_inheritance() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0")
-            .custom_manifest("[package]\nname = \"foo\"\nversion.workspace = true\n"),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0")
+                .custom_manifest("[package]\nname = \"foo\"\nversion.workspace = true\n"),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn workspace_inheritance_with_dep() {
+#[tokio::test(flavor = "multi_thread")]
+async fn workspace_inheritance_with_dep() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+    let response = token.async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
         "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nserde.workspace = true\n",
-    ));
+    )).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }

--- a/src/tests/krate/publish/keywords.rs
+++ b/src/tests/krate/publish/keywords.rs
@@ -4,14 +4,14 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn good_keywords() {
+#[tokio::test(flavor = "multi_thread")]
+async fn good_keywords() {
     let (_, _, _, token) = TestApp::full().with_token();
     let crate_to_publish = PublishBuilder::new("foo_good_key", "1.0.0")
         .keyword("c++")
         .keyword("crates-io_index")
         .keyword("1password");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -19,39 +19,41 @@ fn good_keywords() {
     });
 }
 
-#[test]
-fn bad_keywords() {
+#[tokio::test(flavor = "multi_thread")]
+async fn bad_keywords() {
     let (_, _, _, token) = TestApp::full().with_token();
     let crate_to_publish =
         PublishBuilder::new("foo_bad_key", "1.0.0").keyword("super-long-keyword-name-oh-no");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key", "1.0.0").keyword("?@?%");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key", "1.0.0").keyword("áccênts");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn too_many_keywords() {
+#[tokio::test(flavor = "multi_thread")]
+async fn too_many_keywords() {
     let (app, _, _, token) = TestApp::full().with_token();
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0")
-            .keyword("one")
-            .keyword("two")
-            .keyword("three")
-            .keyword("four")
-            .keyword("five")
-            .keyword("six"),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0")
+                .keyword("one")
+                .keyword("two")
+                .keyword("three")
+                .keyword("four")
+                .keyword("five")
+                .keyword("six"),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }

--- a/src/tests/krate/publish/keywords.rs
+++ b/src/tests/krate/publish/keywords.rs
@@ -11,7 +11,7 @@ async fn good_keywords() {
         .keyword("c++")
         .keyword("crates-io_index")
         .keyword("1password");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -24,17 +24,17 @@ async fn bad_keywords() {
     let (_, _, _, token) = TestApp::full().with_token();
     let crate_to_publish =
         PublishBuilder::new("foo_bad_key", "1.0.0").keyword("super-long-keyword-name-oh-no");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key", "1.0.0").keyword("?@?%");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_bad_key", "1.0.0").keyword("áccênts");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
@@ -43,7 +43,7 @@ async fn bad_keywords() {
 async fn too_many_keywords() {
     let (app, _, _, token) = TestApp::full().with_token();
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0")
                 .keyword("one")
                 .keyword("two")
@@ -55,5 +55,5 @@ async fn too_many_keywords() {
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -11,7 +11,7 @@ async fn boolean_readme() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+        .publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
             r#"[package]
             name = "foo"
             version = "1.0.0"
@@ -27,7 +27,7 @@ async fn boolean_readme() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    let response = token.async_get::<()>("/api/v1/crates/foo/1.0.0").await;
+    let response = token.get::<()>("/api/v1/crates/foo/1.0.0").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".version.id" => any_id_redaction(),
@@ -44,7 +44,7 @@ async fn missing_manifest() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(PublishBuilder::new("foo", "1.0.0").no_manifest())
+        .publish_crate(PublishBuilder::new("foo", "1.0.0").no_manifest())
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
@@ -55,7 +55,7 @@ async fn manifest_casing() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0")
                 .add_file(
                     "foo-1.0.0/CARGO.TOML",
@@ -73,7 +73,7 @@ async fn multiple_manifests() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0")
                 .add_file(
                     "foo-1.0.0/Cargo.toml",
@@ -95,7 +95,7 @@ async fn invalid_manifest() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(""))
+        .publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(""))
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
@@ -106,7 +106,7 @@ async fn invalid_manifest_missing_name() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nversion = \"1.0.0\""),
         )
         .await;
@@ -119,7 +119,7 @@ async fn invalid_manifest_missing_version() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nname = \"foo\""),
         )
         .await;
@@ -132,13 +132,13 @@ async fn invalid_rust_version() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response =
-        token.async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+        token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
             "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"\"\n",
         )).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    let response = token.async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
         "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"1.0.0-beta.2\"\n",
     )).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -4,28 +4,30 @@ use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn boolean_readme() {
+#[tokio::test(flavor = "multi_thread")]
+async fn boolean_readme() {
     // see https://github.com/rust-lang/crates.io/issues/6847
 
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
-        r#"[package]
+    let response = token
+        .async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+            r#"[package]
             name = "foo"
             version = "1.0.0"
             description = "description"
             license = "MIT"
             rust-version = "1.69"
             readme = false"#,
-    ));
+        ))
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
 
-    let response = token.get::<()>("/api/v1/crates/foo/1.0.0");
+    let response = token.async_get::<()>("/api/v1/crates/foo/1.0.0").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".version.id" => any_id_redaction(),
@@ -37,96 +39,108 @@ fn boolean_readme() {
     });
 }
 
-#[test]
-fn missing_manifest() {
+#[tokio::test(flavor = "multi_thread")]
+async fn missing_manifest() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").no_manifest());
+    let response = token
+        .async_publish_crate(PublishBuilder::new("foo", "1.0.0").no_manifest())
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn manifest_casing() {
+#[tokio::test(flavor = "multi_thread")]
+async fn manifest_casing() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0")
-            .add_file(
-                "foo-1.0.0/CARGO.TOML",
-                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
-            )
-            .no_manifest(),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0")
+                .add_file(
+                    "foo-1.0.0/CARGO.TOML",
+                    "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+                )
+                .no_manifest(),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn multiple_manifests() {
+#[tokio::test(flavor = "multi_thread")]
+async fn multiple_manifests() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0")
-            .add_file(
-                "foo-1.0.0/Cargo.toml",
-                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
-            )
-            .add_file(
-                "foo-1.0.0/cargo.toml",
-                "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
-            )
-            .no_manifest(),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0")
+                .add_file(
+                    "foo-1.0.0/Cargo.toml",
+                    "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+                )
+                .add_file(
+                    "foo-1.0.0/cargo.toml",
+                    "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n",
+                )
+                .no_manifest(),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn invalid_manifest() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_manifest() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(""));
+    let response = token
+        .async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(""))
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn invalid_manifest_missing_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_manifest_missing_name() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nversion = \"1.0.0\""),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nversion = \"1.0.0\""),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn invalid_manifest_missing_version() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_manifest_missing_version() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(
-        PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nname = \"foo\""),
-    );
+    let response = token
+        .async_publish_crate(
+            PublishBuilder::new("foo", "1.0.0").custom_manifest("[package]\nname = \"foo\""),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn invalid_rust_version() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_rust_version() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token();
 
     let response =
-        token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+        token.async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
             "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"\"\n",
-        ));
+        )).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+    let response = token.async_publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
         "[package]\nname = \"foo\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\nrust-version = \"1.0.0-beta.2\"\n",
-    ));
+    )).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 }

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -6,8 +6,8 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn tarball_between_default_axum_limit_and_max_upload_size() {
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_between_default_axum_limit_and_max_upload_size() {
     let max_upload_size = 5 * 1024 * 1024;
     let (app, _, _, token) = TestApp::full()
         .with_config(|config| {
@@ -43,17 +43,17 @@ fn tarball_between_default_axum_limit_and_max_upload_size() {
     let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
-    let response = token.publish_crate(body);
+    let response = token.async_publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
-    assert_eq!(app.stored_files().len(), 2);
+    assert_eq!(app.async_stored_files().await.len(), 2);
 }
 
-#[test]
-fn tarball_bigger_than_max_upload_size() {
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_bigger_than_max_upload_size() {
     let max_upload_size = 5 * 1024 * 1024;
     let (app, _, _, token) = TestApp::full()
         .with_config(|config| {
@@ -81,14 +81,14 @@ fn tarball_bigger_than_max_upload_size() {
     let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
-    let response = token.publish_crate(body);
+    let response = token.async_publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_gzip_bomb() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_gzip_bomb() {
     let (app, _, _, token) = TestApp::full()
         .with_config(|config| {
             config.max_upload_size = 3000;
@@ -99,15 +99,15 @@ fn new_krate_gzip_bomb() {
     let body = vec![0; 512 * 1024];
     let crate_to_publish = PublishBuilder::new("foo", "1.1.0").add_file("foo-1.1.0/a", body);
 
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_too_big() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_too_big() {
     let (app, _, user) = TestApp::full()
         .with_config(|config| {
             config.max_upload_size = 3000;
@@ -118,15 +118,15 @@ fn new_krate_too_big() {
     let builder =
         PublishBuilder::new("foo_big", "1.0.0").add_file("foo_big-1.0.0/big", vec![b'a'; 2000]);
 
-    let response = user.publish_crate(builder);
+    let response = user.async_publish_crate(builder).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_too_big_but_whitelisted() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_too_big_but_whitelisted() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -138,11 +138,11 @@ fn new_krate_too_big_but_whitelisted() {
     let crate_to_publish = PublishBuilder::new("foo_whitelist", "1.1.0")
         .add_file("foo_whitelist-1.1.0/big", vec![b'a'; 2000]);
 
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let expected_files = vec![
         "crates/foo_whitelist/foo_whitelist-1.1.0.crate",
         "index/fo/o_/foo_whitelist",
     ];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }

--- a/src/tests/krate/publish/rate_limit.rs
+++ b/src/tests/krate/publish/rate_limit.rs
@@ -31,13 +31,13 @@ async fn publish_new_crate_ratelimit_hit() {
 
     let crate_to_publish = PublishBuilder::new("rate_limited", "1.0.0");
     token
-        .async_publish_crate(crate_to_publish)
+        .publish_crate(crate_to_publish)
         .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_eq!(app.async_stored_files().await.len(), 0);
+    assert_eq!(app.stored_files().await.len(), 0);
 
-    let response = anon.async_get::<()>("/api/v1/crates/rate_limited").await;
+    let response = anon.get::<()>("/api/v1/crates/rate_limited").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
@@ -63,11 +63,11 @@ async fn publish_new_crate_ratelimit_expires() {
     });
 
     let crate_to_publish = PublishBuilder::new("rate_limited", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.async_stored_files().await.len(), 2);
+    assert_eq!(app.stored_files().await.len(), 2);
 
-    let json = anon.async_show_crate("rate_limited").await;
+    let json = anon.show_crate("rate_limited").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 }
 
@@ -96,30 +96,30 @@ async fn publish_new_crate_override_loosens_ratelimit() {
     });
 
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.async_stored_files().await.len(), 2);
+    assert_eq!(app.stored_files().await.len(), 2);
 
-    let json = anon.async_show_crate("rate_limited1").await;
+    let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.async_stored_files().await.len(), 4);
+    assert_eq!(app.stored_files().await.len(), 4);
 
-    let json = anon.async_show_crate("rate_limited2").await;
+    let json = anon.show_crate("rate_limited2").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     let crate_to_publish = PublishBuilder::new("rate_limited3", "1.0.0");
     token
-        .async_publish_crate(crate_to_publish)
+        .publish_crate(crate_to_publish)
         .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_eq!(app.async_stored_files().await.len(), 4);
+    assert_eq!(app.stored_files().await.len(), 4);
 
-    let response = anon.async_get::<()>("/api/v1/crates/rate_limited3").await;
+    let response = anon.get::<()>("/api/v1/crates/rate_limited3").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
@@ -149,22 +149,22 @@ async fn publish_new_crate_expired_override_ignored() {
     });
 
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.async_stored_files().await.len(), 2);
+    assert_eq!(app.stored_files().await.len(), 2);
 
-    let json = anon.async_show_crate("rate_limited1").await;
+    let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
     token
-        .async_publish_crate(crate_to_publish)
+        .publish_crate(crate_to_publish)
         .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_eq!(app.async_stored_files().await.len(), 2);
+    assert_eq!(app.stored_files().await.len(), 2);
 
-    let response = anon.async_get::<()>("/api/v1/crates/rate_limited2").await;
+    let response = anon.get::<()>("/api/v1/crates/rate_limited2").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
@@ -176,10 +176,10 @@ async fn publish_new_crate_rate_limit_doesnt_affect_existing_crates() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     let new_version = PublishBuilder::new("rate_limited1", "1.0.1");
-    token.async_publish_crate(new_version).await.good();
+    token.publish_crate(new_version).await.good();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -190,41 +190,41 @@ async fn publish_existing_crate_rate_limited() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
-    let json = anon.async_show_crate("rate_limited1").await;
+    let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
-    assert_eq!(app.async_stored_files().await.len(), 2);
+    assert_eq!(app.stored_files().await.len(), 2);
 
     // Uploading the first update to the crate works
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.1");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
-    let json = anon.async_show_crate("rate_limited1").await;
+    let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.1");
-    assert_eq!(app.async_stored_files().await.len(), 3);
+    assert_eq!(app.stored_files().await.len(), 3);
 
     // Uploading the second update to the crate is rate limited
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.2");
     token
-        .async_publish_crate(crate_to_publish)
+        .publish_crate(crate_to_publish)
         .await
         .assert_rate_limited(LimitedAction::PublishUpdate);
 
     // Check that  version 1.0.2 was not published
-    let json = anon.async_show_crate("rate_limited1").await;
+    let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.1");
-    assert_eq!(app.async_stored_files().await.len(), 3);
+    assert_eq!(app.stored_files().await.len(), 3);
 
     // Wait for the limit to be up
     thread::sleep(Duration::from_millis(500));
 
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.2");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
-    let json = anon.async_show_crate("rate_limited1").await;
+    let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.2");
-    assert_eq!(app.async_stored_files().await.len(), 4);
+    assert_eq!(app.stored_files().await.len(), 4);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -239,9 +239,9 @@ async fn publish_existing_crate_rate_limit_doesnt_affect_new_crates() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     // Upload a second new crate
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 }

--- a/src/tests/krate/publish/rate_limit.rs
+++ b/src/tests/krate/publish/rate_limit.rs
@@ -8,8 +8,8 @@ use http::StatusCode;
 use std::thread;
 use std::time::Duration;
 
-#[test]
-fn publish_new_crate_ratelimit_hit() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_new_crate_ratelimit_hit() {
     let (app, anon, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishNew, Duration::from_millis(500), 1)
         .with_token();
@@ -31,17 +31,18 @@ fn publish_new_crate_ratelimit_hit() {
 
     let crate_to_publish = PublishBuilder::new("rate_limited", "1.0.0");
     token
-        .publish_crate(crate_to_publish)
+        .async_publish_crate(crate_to_publish)
+        .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_eq!(app.stored_files().len(), 0);
+    assert_eq!(app.async_stored_files().await.len(), 0);
 
-    let response = anon.get::<()>("/api/v1/crates/rate_limited");
+    let response = anon.async_get::<()>("/api/v1/crates/rate_limited").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[test]
-fn publish_new_crate_ratelimit_expires() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_new_crate_ratelimit_expires() {
     let (app, anon, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishNew, Duration::from_millis(500), 1)
         .with_token();
@@ -62,16 +63,16 @@ fn publish_new_crate_ratelimit_expires() {
     });
 
     let crate_to_publish = PublishBuilder::new("rate_limited", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.stored_files().len(), 2);
+    assert_eq!(app.async_stored_files().await.len(), 2);
 
-    let json = anon.show_crate("rate_limited");
+    let json = anon.async_show_crate("rate_limited").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 }
 
-#[test]
-fn publish_new_crate_override_loosens_ratelimit() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_new_crate_override_loosens_ratelimit() {
     let (app, anon, _, token) = TestApp::full()
         // Most people get 1 new token every 1 day
         .with_rate_limit(
@@ -95,34 +96,35 @@ fn publish_new_crate_override_loosens_ratelimit() {
     });
 
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.stored_files().len(), 2);
+    assert_eq!(app.async_stored_files().await.len(), 2);
 
-    let json = anon.show_crate("rate_limited1");
+    let json = anon.async_show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.stored_files().len(), 4);
+    assert_eq!(app.async_stored_files().await.len(), 4);
 
-    let json = anon.show_crate("rate_limited2");
+    let json = anon.async_show_crate("rate_limited2").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     let crate_to_publish = PublishBuilder::new("rate_limited3", "1.0.0");
     token
-        .publish_crate(crate_to_publish)
+        .async_publish_crate(crate_to_publish)
+        .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_eq!(app.stored_files().len(), 4);
+    assert_eq!(app.async_stored_files().await.len(), 4);
 
-    let response = anon.get::<()>("/api/v1/crates/rate_limited3");
+    let response = anon.async_get::<()>("/api/v1/crates/rate_limited3").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[test]
-fn publish_new_crate_expired_override_ignored() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_new_crate_expired_override_ignored() {
     let (app, anon, _, token) = TestApp::full()
         // Most people get 1 new token every 1 day
         .with_rate_limit(
@@ -147,84 +149,86 @@ fn publish_new_crate_expired_override_ignored() {
     });
 
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
-    assert_eq!(app.stored_files().len(), 2);
+    assert_eq!(app.async_stored_files().await.len(), 2);
 
-    let json = anon.show_crate("rate_limited1");
+    let json = anon.async_show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
     token
-        .publish_crate(crate_to_publish)
+        .async_publish_crate(crate_to_publish)
+        .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_eq!(app.stored_files().len(), 2);
+    assert_eq!(app.async_stored_files().await.len(), 2);
 
-    let response = anon.get::<()>("/api/v1/crates/rate_limited2");
+    let response = anon.async_get::<()>("/api/v1/crates/rate_limited2").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
-#[test]
-fn publish_new_crate_rate_limit_doesnt_affect_existing_crates() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_new_crate_rate_limit_doesnt_affect_existing_crates() {
     let (_, _, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishNew, Duration::from_secs(60 * 60), 1)
         .with_token();
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     let new_version = PublishBuilder::new("rate_limited1", "1.0.1");
-    token.publish_crate(new_version).good();
+    token.async_publish_crate(new_version).await.good();
 }
 
-#[test]
-fn publish_existing_crate_rate_limited() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_existing_crate_rate_limited() {
     let (app, anon, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishUpdate, Duration::from_millis(500), 1)
         .with_token();
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
-    let json = anon.show_crate("rate_limited1");
+    let json = anon.async_show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
-    assert_eq!(app.stored_files().len(), 2);
+    assert_eq!(app.async_stored_files().await.len(), 2);
 
     // Uploading the first update to the crate works
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.1");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
-    let json = anon.show_crate("rate_limited1");
+    let json = anon.async_show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.1");
-    assert_eq!(app.stored_files().len(), 3);
+    assert_eq!(app.async_stored_files().await.len(), 3);
 
     // Uploading the second update to the crate is rate limited
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.2");
     token
-        .publish_crate(crate_to_publish)
+        .async_publish_crate(crate_to_publish)
+        .await
         .assert_rate_limited(LimitedAction::PublishUpdate);
 
     // Check that  version 1.0.2 was not published
-    let json = anon.show_crate("rate_limited1");
+    let json = anon.async_show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.1");
-    assert_eq!(app.stored_files().len(), 3);
+    assert_eq!(app.async_stored_files().await.len(), 3);
 
     // Wait for the limit to be up
     thread::sleep(Duration::from_millis(500));
 
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.2");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
-    let json = anon.show_crate("rate_limited1");
+    let json = anon.async_show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.2");
-    assert_eq!(app.stored_files().len(), 4);
+    assert_eq!(app.async_stored_files().await.len(), 4);
 }
 
-#[test]
-fn publish_existing_crate_rate_limit_doesnt_affect_new_crates() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_existing_crate_rate_limit_doesnt_affect_new_crates() {
     let (_, _, _, token) = TestApp::full()
         .with_rate_limit(
             LimitedAction::PublishUpdate,
@@ -235,9 +239,9 @@ fn publish_existing_crate_rate_limit_doesnt_affect_new_crates() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     // Upload a second new crate
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 }

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -3,12 +3,12 @@ use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn new_krate_with_readme() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_readme() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("hello world");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -20,15 +20,15 @@ fn new_krate_with_readme() {
         "index/fo/o_/foo_readme",
         "readmes/foo_readme/foo_readme-1.0.0.html",
     ];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }
 
-#[test]
-fn new_krate_with_empty_readme() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_empty_readme() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -39,15 +39,15 @@ fn new_krate_with_empty_readme() {
         "crates/foo_readme/foo_readme-1.0.0.crate",
         "index/fo/o_/foo_readme",
     ];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }
 
-#[test]
-fn new_krate_with_readme_and_plus_version() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_with_readme_and_plus_version() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0+foo").readme("hello world");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -59,11 +59,11 @@ fn new_krate_with_readme_and_plus_version() {
         "index/fo/o_/foo_readme",
         "readmes/foo_readme/foo_readme-1.0.0+foo.html",
     ];
-    assert_eq!(app.stored_files(), expected_files);
+    assert_eq!(app.async_stored_files().await, expected_files);
 }
 
-#[test]
-fn publish_after_removing_documentation() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_after_removing_documentation() {
     let (app, anon, user, token) = TestApp::full().with_token();
     let user = user.as_model();
 
@@ -76,24 +76,24 @@ fn publish_after_removing_documentation() {
 
     // Verify that crates start without any documentation so the next assertion can *prove*
     // that it was the one that added the documentation
-    let json = anon.show_crate("docscrate");
+    let json = anon.async_show_crate("docscrate").await;
     assert_eq!(json.krate.documentation, None);
 
     // 2. Add documentation
     let crate_to_publish = PublishBuilder::new("docscrate", "0.2.1").documentation("http://foo.rs");
-    let json = token.publish_crate(crate_to_publish).good();
+    let json = token.async_publish_crate(crate_to_publish).await.good();
     assert_eq!(json.krate.documentation, Some("http://foo.rs".to_owned()));
 
     // Ensure latest version also has the same documentation
-    let json = anon.show_crate("docscrate");
+    let json = anon.async_show_crate("docscrate").await;
     assert_eq!(json.krate.documentation, Some("http://foo.rs".to_owned()));
 
     // 3. Remove the documentation
     let crate_to_publish = PublishBuilder::new("docscrate", "0.2.2");
-    let json = token.publish_crate(crate_to_publish).good();
+    let json = token.async_publish_crate(crate_to_publish).await.good();
     assert_eq!(json.krate.documentation, None);
 
     // Ensure latest version no longer has documentation
-    let json = anon.show_crate("docscrate");
+    let json = anon.async_show_crate("docscrate").await;
     assert_eq!(json.krate.documentation, None);
 }

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -8,7 +8,7 @@ async fn new_krate_with_readme() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("hello world");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -20,7 +20,7 @@ async fn new_krate_with_readme() {
         "index/fo/o_/foo_readme",
         "readmes/foo_readme/foo_readme-1.0.0.html",
     ];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -28,7 +28,7 @@ async fn new_krate_with_empty_readme() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -39,7 +39,7 @@ async fn new_krate_with_empty_readme() {
         "crates/foo_readme/foo_readme-1.0.0.crate",
         "index/fo/o_/foo_readme",
     ];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -47,7 +47,7 @@ async fn new_krate_with_readme_and_plus_version() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0+foo").readme("hello world");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -59,7 +59,7 @@ async fn new_krate_with_readme_and_plus_version() {
         "index/fo/o_/foo_readme",
         "readmes/foo_readme/foo_readme-1.0.0+foo.html",
     ];
-    assert_eq!(app.async_stored_files().await, expected_files);
+    assert_eq!(app.stored_files().await, expected_files);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -76,24 +76,24 @@ async fn publish_after_removing_documentation() {
 
     // Verify that crates start without any documentation so the next assertion can *prove*
     // that it was the one that added the documentation
-    let json = anon.async_show_crate("docscrate").await;
+    let json = anon.show_crate("docscrate").await;
     assert_eq!(json.krate.documentation, None);
 
     // 2. Add documentation
     let crate_to_publish = PublishBuilder::new("docscrate", "0.2.1").documentation("http://foo.rs");
-    let json = token.async_publish_crate(crate_to_publish).await.good();
+    let json = token.publish_crate(crate_to_publish).await.good();
     assert_eq!(json.krate.documentation, Some("http://foo.rs".to_owned()));
 
     // Ensure latest version also has the same documentation
-    let json = anon.async_show_crate("docscrate").await;
+    let json = anon.show_crate("docscrate").await;
     assert_eq!(json.krate.documentation, Some("http://foo.rs".to_owned()));
 
     // 3. Remove the documentation
     let crate_to_publish = PublishBuilder::new("docscrate", "0.2.2");
-    let json = token.async_publish_crate(crate_to_publish).await.good();
+    let json = token.publish_crate(crate_to_publish).await.good();
     assert_eq!(json.krate.documentation, None);
 
     // Ensure latest version no longer has documentation
-    let json = anon.async_show_crate("docscrate").await;
+    let json = anon.show_crate("docscrate").await;
     assert_eq!(json.krate.documentation, None);
 }

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -4,8 +4,8 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn new_crate_similar_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_crate_similar_name() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -15,15 +15,15 @@ fn new_crate_similar_name() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo_similar", "1.1.0");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_crate_similar_name_hyphen() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_crate_similar_name_hyphen() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -33,15 +33,15 @@ fn new_crate_similar_name_hyphen() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen", "1.1.0");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_crate_similar_name_underscore() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_crate_similar_name_underscore() {
     let (app, _, user, token) = TestApp::full().with_token();
 
     app.db(|conn| {
@@ -51,9 +51,9 @@ fn new_crate_similar_name_underscore() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore", "1.1.0");
-    let response = token.publish_crate(crate_to_publish);
+    let response = token.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -15,11 +15,11 @@ async fn new_crate_similar_name() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo_similar", "1.1.0");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -33,11 +33,11 @@ async fn new_crate_similar_name_hyphen() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen", "1.1.0");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -51,9 +51,9 @@ async fn new_crate_similar_name_underscore() {
     });
 
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore", "1.1.0");
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-10.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-10.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-3.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-4.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-4.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-5.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-5.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-6.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-6.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-7.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-7.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-8.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-8.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-9.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name-9.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__validation__bad_name.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -13,14 +13,14 @@ async fn new_krate_wrong_files() {
         .add_file("foo-1.0.0/a", "")
         .add_file("bar-1.0.0/a", "");
 
-    let response = user.async_publish_crate(builder).await;
+    let response = user.publish_crate(builder).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid path found: bar-1.0.0/a" }] })
     );
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -44,42 +44,40 @@ async fn new_krate_tarball_with_hard_links() {
     let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
-    let response = token.async_publish_crate(body).await;
+    let response = token.publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_body() {
     let (app, _, user) = TestApp::full().with_user();
 
-    let response = user.async_publish_crate(&[] as &[u8]).await;
+    let response = user.publish_crate(&[] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn json_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.async_publish_crate(&[0u8, 0] as &[u8]).await;
+    let response = token.publish_crate(&[0u8, 0] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn json_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token
-        .async_publish_crate(&[100u8, 0, 0, 0, 0] as &[u8])
-        .await;
+    let response = token.publish_crate(&[100u8, 0, 0, 0, 0] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -87,11 +85,11 @@ async fn tarball_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8])
+        .publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8])
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -99,9 +97,9 @@ async fn tarball_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8])
+        .publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8])
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -5,26 +5,26 @@ use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn new_krate_wrong_files() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_wrong_files() {
     let (app, _, user) = TestApp::full().with_user();
 
     let builder = PublishBuilder::new("foo", "1.0.0")
         .add_file("foo-1.0.0/a", "")
         .add_file("bar-1.0.0/a", "");
 
-    let response = user.publish_crate(builder);
+    let response = user.async_publish_crate(builder).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "invalid path found: bar-1.0.0/a" }] })
     );
 
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn new_krate_tarball_with_hard_links() {
+#[tokio::test(flavor = "multi_thread")]
+async fn new_krate_tarball_with_hard_links() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let tarball = {
@@ -44,58 +44,64 @@ fn new_krate_tarball_with_hard_links() {
     let (json, _tarball) = PublishBuilder::new("foo", "1.1.0").build();
     let body = PublishBuilder::create_publish_body(&json, &tarball);
 
-    let response = token.publish_crate(body);
+    let response = token.async_publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn empty_body() {
+#[tokio::test(flavor = "multi_thread")]
+async fn empty_body() {
     let (app, _, user) = TestApp::full().with_user();
 
-    let response = user.publish_crate(&[] as &[u8]);
+    let response = user.async_publish_crate(&[] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn json_len_truncated() {
+#[tokio::test(flavor = "multi_thread")]
+async fn json_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(&[0u8, 0] as &[u8]);
+    let response = token.async_publish_crate(&[0u8, 0] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn json_bytes_truncated() {
+#[tokio::test(flavor = "multi_thread")]
+async fn json_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(&[100u8, 0, 0, 0, 0] as &[u8]);
+    let response = token
+        .async_publish_crate(&[100u8, 0, 0, 0, 0] as &[u8])
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn tarball_len_truncated() {
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8]);
+    let response = token
+        .async_publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8])
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }
 
-#[test]
-fn tarball_bytes_truncated() {
+#[tokio::test(flavor = "multi_thread")]
+async fn tarball_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token();
 
-    let response = token.publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8]);
+    let response = token
+        .async_publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8])
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.stored_files(), empty());
+    assert_that!(app.async_stored_files().await, empty());
 }

--- a/src/tests/krate/publish/timestamps.rs
+++ b/src/tests/krate/publish/timestamps.rs
@@ -1,5 +1,5 @@
-#[test]
-fn uploading_new_version_touches_crate() {
+#[tokio::test(flavor = "multi_thread")]
+async fn uploading_new_version_touches_crate() {
     use crate::builders::PublishBuilder;
     use crate::util::{RequestHelper, TestApp};
     use crate::CrateResponse;
@@ -10,7 +10,7 @@ fn uploading_new_version_touches_crate() {
     let (app, _, user) = TestApp::full().with_user();
 
     let crate_to_publish = PublishBuilder::new("foo_versions_updated_at", "1.0.0");
-    user.publish_crate(crate_to_publish).good();
+    user.async_publish_crate(crate_to_publish).await.good();
 
     app.db(|conn| {
         diesel::update(crates::table)
@@ -19,13 +19,13 @@ fn uploading_new_version_touches_crate() {
             .unwrap();
     });
 
-    let json: CrateResponse = user.show_crate("foo_versions_updated_at");
+    let json: CrateResponse = user.async_show_crate("foo_versions_updated_at").await;
     let updated_at_before = json.krate.updated_at;
 
     let crate_to_publish = PublishBuilder::new("foo_versions_updated_at", "2.0.0");
-    user.publish_crate(crate_to_publish).good();
+    user.async_publish_crate(crate_to_publish).await.good();
 
-    let json: CrateResponse = user.show_crate("foo_versions_updated_at");
+    let json: CrateResponse = user.async_show_crate("foo_versions_updated_at").await;
     let updated_at_after = json.krate.updated_at;
 
     assert_ne!(updated_at_before, updated_at_after);

--- a/src/tests/krate/publish/timestamps.rs
+++ b/src/tests/krate/publish/timestamps.rs
@@ -10,7 +10,7 @@ async fn uploading_new_version_touches_crate() {
     let (app, _, user) = TestApp::full().with_user();
 
     let crate_to_publish = PublishBuilder::new("foo_versions_updated_at", "1.0.0");
-    user.async_publish_crate(crate_to_publish).await.good();
+    user.publish_crate(crate_to_publish).await.good();
 
     app.db(|conn| {
         diesel::update(crates::table)
@@ -19,13 +19,13 @@ async fn uploading_new_version_touches_crate() {
             .unwrap();
     });
 
-    let json: CrateResponse = user.async_show_crate("foo_versions_updated_at").await;
+    let json: CrateResponse = user.show_crate("foo_versions_updated_at").await;
     let updated_at_before = json.krate.updated_at;
 
     let crate_to_publish = PublishBuilder::new("foo_versions_updated_at", "2.0.0");
-    user.async_publish_crate(crate_to_publish).await.good();
+    user.publish_crate(crate_to_publish).await.good();
 
-    let json: CrateResponse = user.async_show_crate("foo_versions_updated_at").await;
+    let json: CrateResponse = user.show_crate("foo_versions_updated_at").await;
     let updated_at_after = json.krate.updated_at;
 
     assert_ne!(updated_at_before, updated_at_after);

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -12,10 +12,10 @@ async fn empty_json() {
     let (_json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
     let body = PublishBuilder::create_publish_body("{}", &tarball);
 
-    let response = token.async_publish_crate(body).await;
+    let response = token.publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -24,7 +24,7 @@ async fn invalid_names() {
 
     async fn bad_name(name: &str, client: &impl RequestHelper) {
         let crate_to_publish = PublishBuilder::new(name, "1.0.0");
-        let response = client.async_publish_crate(crate_to_publish).await;
+        let response = client.publish_crate(crate_to_publish).await;
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         assert_json_snapshot!(response.json());
     }
@@ -41,7 +41,7 @@ async fn invalid_names() {
     bad_name("compiler_rt", &token).await;
     bad_name("coMpiLer_Rt", &token).await;
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -53,10 +53,10 @@ async fn invalid_version() {
     assert_ne!(json, new_json);
     let body = PublishBuilder::create_publish_body(&new_json, &tarball);
 
-    let response = token.async_publish_crate(body).await;
+    let response = token.publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -67,13 +67,13 @@ async fn license_and_description_required() {
         .unset_license()
         .unset_description();
 
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0").unset_description();
 
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
@@ -82,11 +82,11 @@ async fn license_and_description_required() {
         .license_file("foo")
         .unset_description();
 
-    let response = token.async_publish_crate(crate_to_publish).await;
+    let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -94,11 +94,11 @@ async fn invalid_license() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(PublishBuilder::new("foo", "1.0.0").license("MIT AND foobar"))
+        .publish_crate(PublishBuilder::new("foo", "1.0.0").license("MIT AND foobar"))
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -106,12 +106,12 @@ async fn invalid_urls() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let response = token
-        .async_publish_crate(
+        .publish_crate(
             PublishBuilder::new("foo", "1.0.0").documentation("javascript:alert('boom')"),
         )
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
 
-    assert_that!(app.async_stored_files().await, empty());
+    assert_that!(app.stored_files().await, empty());
 }

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -15,54 +15,54 @@ async fn yank_works_as_intended() {
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     let crates = app.crates_from_index_head("fyk");
     assert_that!(crates, len(eq(1)));
     assert_some_eq!(crates[0].yanked, false);
 
     // make sure it's not yanked
-    let json = anon.async_show_version("fyk", "1.0.0").await;
+    let json = anon.show_version("fyk", "1.0.0").await;
     assert!(!json.version.yanked);
 
     // yank it
-    token.async_yank("fyk", "1.0.0").await.good();
+    token.yank("fyk", "1.0.0").await.good();
 
     let crates = app.crates_from_index_head("fyk");
     assert_that!(crates, len(eq(1)));
     assert_some_eq!(crates[0].yanked, true);
 
-    let json = anon.async_show_version("fyk", "1.0.0").await;
+    let json = anon.show_version("fyk", "1.0.0").await;
     assert!(json.version.yanked);
 
     // un-yank it
-    token.async_unyank("fyk", "1.0.0").await.good();
+    token.unyank("fyk", "1.0.0").await.good();
 
     let crates = app.crates_from_index_head("fyk");
     assert_that!(crates, len(eq(1)));
     assert_some_eq!(crates[0].yanked, false);
 
-    let json = anon.async_show_version("fyk", "1.0.0").await;
+    let json = anon.show_version("fyk", "1.0.0").await;
     assert!(!json.version.yanked);
 
     // yank it
-    cookie.async_yank("fyk", "1.0.0").await.good();
+    cookie.yank("fyk", "1.0.0").await.good();
 
     let crates = app.crates_from_index_head("fyk");
     assert_that!(crates, len(eq(1)));
     assert_some_eq!(crates[0].yanked, true);
 
-    let json = anon.async_show_version("fyk", "1.0.0").await;
+    let json = anon.show_version("fyk", "1.0.0").await;
     assert!(json.version.yanked);
 
     // un-yank it
-    cookie.async_unyank("fyk", "1.0.0").await.good();
+    cookie.unyank("fyk", "1.0.0").await.good();
 
     let crates = app.crates_from_index_head("fyk");
     assert_that!(crates, len(eq(1)));
     assert_some_eq!(crates[0].yanked, false);
 
-    let json = anon.async_show_version("fyk", "1.0.0").await;
+    let json = anon.show_version("fyk", "1.0.0").await;
     assert!(!json.version.yanked);
 }
 
@@ -96,12 +96,12 @@ async fn yank_ratelimit_hit() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("yankable", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
     check_yanked(&app, false);
 
     // Yank it and wait for the ratelimit to hit.
     token
-        .async_yank("yankable", "1.0.0")
+        .yank("yankable", "1.0.0")
         .await
         .assert_rate_limited(LimitedAction::YankUnyank);
     check_yanked(&app, false);
@@ -130,10 +130,10 @@ async fn yank_ratelimit_expires() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("yankable", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
     check_yanked(&app, false);
 
-    token.async_yank("yankable", "1.0.0").await.good();
+    token.yank("yankable", "1.0.0").await.good();
     check_yanked(&app, true);
 }
 
@@ -143,51 +143,51 @@ async fn yank_max_version() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk_max", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     // double check the max version
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     // add version 2.0.0
     let crate_to_publish = PublishBuilder::new("fyk_max", "2.0.0");
-    let json = token.async_publish_crate(crate_to_publish).await.good();
+    let json = token.publish_crate(crate_to_publish).await.good();
     assert_eq!(json.krate.max_version, "2.0.0");
 
     // yank version 1.0.0
-    token.async_yank("fyk_max", "1.0.0").await.good();
+    token.yank("fyk_max", "1.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "2.0.0");
 
     // unyank version 1.0.0
-    token.async_unyank("fyk_max", "1.0.0").await.good();
+    token.unyank("fyk_max", "1.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "2.0.0");
 
     // yank version 2.0.0
-    token.async_yank("fyk_max", "2.0.0").await.good();
+    token.yank("fyk_max", "2.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     // yank version 1.0.0
-    token.async_yank("fyk_max", "1.0.0").await.good();
+    token.yank("fyk_max", "1.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "0.0.0");
 
     // unyank version 2.0.0
-    token.async_unyank("fyk_max", "2.0.0").await.good();
+    token.unyank("fyk_max", "2.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "2.0.0");
 
     // unyank version 1.0.0
-    token.async_unyank("fyk_max", "1.0.0").await.good();
+    token.unyank("fyk_max", "1.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "2.0.0");
 }
 
@@ -197,26 +197,26 @@ async fn publish_after_yank_max_version() {
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk_max", "1.0.0");
-    token.async_publish_crate(crate_to_publish).await.good();
+    token.publish_crate(crate_to_publish).await.good();
 
     // double check the max version
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "1.0.0");
 
     // yank version 1.0.0
-    token.async_yank("fyk_max", "1.0.0").await.good();
+    token.yank("fyk_max", "1.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "0.0.0");
 
     // add version 2.0.0
     let crate_to_publish = PublishBuilder::new("fyk_max", "2.0.0");
-    let json = token.async_publish_crate(crate_to_publish).await.good();
+    let json = token.publish_crate(crate_to_publish).await.good();
     assert_eq!(json.krate.max_version, "2.0.0");
 
     // unyank version 1.0.0
-    token.async_unyank("fyk_max", "1.0.0").await.good();
+    token.unyank("fyk_max", "1.0.0").await.good();
 
-    let json = anon.async_show_crate("fyk_max").await;
+    let json = anon.show_crate("fyk_max").await;
     assert_eq!(json.krate.max_version, "2.0.0");
 }

--- a/src/tests/middleware/head.rs
+++ b/src/tests/middleware/head.rs
@@ -1,22 +1,22 @@
 use crate::util::{RequestHelper, TestApp};
 use http::{Method, StatusCode};
 
-#[test]
-fn head_method_works() {
+#[tokio::test(flavor = "multi_thread")]
+async fn head_method_works() {
     let (_, anon) = TestApp::init().empty();
 
     let req = anon.request_builder(Method::HEAD, "/api/v1/summary");
-    let res = anon.run::<()>(req);
+    let res = anon.async_run::<()>(req).await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text(), "");
 }
 
-#[test]
-fn head_method_works_for_404() {
+#[tokio::test(flavor = "multi_thread")]
+async fn head_method_works_for_404() {
     let (_, anon) = TestApp::init().empty();
 
     let req = anon.request_builder(Method::HEAD, "/unknown");
-    let res = anon.run::<()>(req);
+    let res = anon.async_run::<()>(req).await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text(), "");
 }

--- a/src/tests/middleware/head.rs
+++ b/src/tests/middleware/head.rs
@@ -6,7 +6,7 @@ async fn head_method_works() {
     let (_, anon) = TestApp::init().empty();
 
     let req = anon.request_builder(Method::HEAD, "/api/v1/summary");
-    let res = anon.async_run::<()>(req).await;
+    let res = anon.run::<()>(req).await;
     assert_eq!(res.status(), StatusCode::OK);
     assert_eq!(res.text(), "");
 }
@@ -16,7 +16,7 @@ async fn head_method_works_for_404() {
     let (_, anon) = TestApp::init().empty();
 
     let req = anon.request_builder(Method::HEAD, "/unknown");
-    let res = anon.async_run::<()>(req).await;
+    let res = anon.run::<()>(req).await;
     assert_eq!(res.status(), StatusCode::NOT_FOUND);
     assert_eq!(res.text(), "");
 }

--- a/src/tests/not_found_error.rs
+++ b/src/tests/not_found_error.rs
@@ -1,11 +1,11 @@
 use crate::{RequestHelper, TestApp};
 use http::StatusCode;
 
-#[test]
-fn visiting_unknown_route_returns_404() {
+#[tokio::test(flavor = "multi_thread")]
+async fn visiting_unknown_route_returns_404() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.get::<()>("/does-not-exist");
+    let response = anon.async_get::<()>("/does-not-exist").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
         response.json(),
@@ -13,11 +13,11 @@ fn visiting_unknown_route_returns_404() {
     );
 }
 
-#[test]
-fn visiting_unknown_api_route_returns_404() {
+#[tokio::test(flavor = "multi_thread")]
+async fn visiting_unknown_api_route_returns_404() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.get::<()>("/api/v1/does-not-exist");
+    let response = anon.async_get::<()>("/api/v1/does-not-exist").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
         response.json(),

--- a/src/tests/not_found_error.rs
+++ b/src/tests/not_found_error.rs
@@ -5,7 +5,7 @@ use http::StatusCode;
 async fn visiting_unknown_route_returns_404() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.async_get::<()>("/does-not-exist").await;
+    let response = anon.get::<()>("/does-not-exist").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
         response.json(),
@@ -17,7 +17,7 @@ async fn visiting_unknown_route_returns_404() {
 async fn visiting_unknown_api_route_returns_404() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.async_get::<()>("/api/v1/does-not-exist").await;
+    let response = anon.get::<()>("/api/v1/does-not-exist").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
         response.json(),

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -136,7 +136,7 @@ fn new_crate_owner() {
     user2.accept_ownership_invitation("foo_owner", krate.id);
 
     // Make sure this shows up as one of their crates.
-    let crates = user2.search_by_user_id(user2.as_model().id);
+    let crates = user2.search(&format!("user_id={}", user2.as_model().id));
     assert_eq!(crates.crates.len(), 1);
 
     // And upload a new version as the second user
@@ -275,7 +275,7 @@ fn check_ownership_two_crates() {
     let krate_not_owned_by_team =
         app.db(|conn| CrateBuilder::new("bar", user2.id).expect_build(conn));
 
-    let json = anon.search_by_user_id(user2.id);
+    let json = anon.search(&format!("user_id={}", user2.id));
     assert_eq!(json.crates[0].name, krate_not_owned_by_team.name);
     assert_eq!(json.crates.len(), 1);
 

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -21,7 +21,7 @@ async fn pagination_blocks_ip_from_cidr_block_list() {
     });
 
     let response = anon
-        .async_get_with_query::<()>("/api/v1/crates", "page=2&per_page=1")
+        .get_with_query::<()>("/api/v1/crates", "page=2&per_page=1")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -4,8 +4,8 @@ use http::status::StatusCode;
 use ipnetwork::IpNetwork;
 use serde_json::json;
 
-#[test]
-fn pagination_blocks_ip_from_cidr_block_list() {
+#[tokio::test(flavor = "multi_thread")]
+async fn pagination_blocks_ip_from_cidr_block_list() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.max_allowed_page_offset = 1;
@@ -20,7 +20,9 @@ fn pagination_blocks_ip_from_cidr_block_list() {
         CrateBuilder::new("pagination_links_3", user.id).expect_build(conn);
     });
 
-    let response = anon.get_with_query::<()>("/api/v1/crates", "page=2&per_page=1");
+    let response = anon
+        .async_get_with_query::<()>("/api/v1/crates", "page=2&per_page=1")
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -13,7 +13,7 @@ async fn can_hit_read_only_endpoints_in_read_only_mode() {
         })
         .empty();
 
-    let response = anon.async_get::<()>("/api/v1/crates").await;
+    let response = anon.get::<()>("/api/v1/crates").await;
     assert_eq!(response.status(), StatusCode::OK);
 }
 
@@ -32,7 +32,7 @@ async fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
     });
 
     let response = token
-        .async_delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
+        .delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
         .await;
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     assert_json_snapshot!(response.json());
@@ -53,7 +53,7 @@ async fn can_download_crate_in_read_only_mode() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download")
+        .get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download")
         .await;
     assert_eq!(response.status(), StatusCode::FOUND);
 

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -5,20 +5,20 @@ use diesel::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
-#[test]
-fn can_hit_read_only_endpoints_in_read_only_mode() {
+#[tokio::test(flavor = "multi_thread")]
+async fn can_hit_read_only_endpoints_in_read_only_mode() {
     let (_app, anon) = TestApp::init()
         .with_config(|config| {
             config.db.primary.read_only_mode = true;
         })
         .empty();
 
-    let response = anon.get::<()>("/api/v1/crates");
+    let response = anon.async_get::<()>("/api/v1/crates").await;
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-#[test]
-fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
+#[tokio::test(flavor = "multi_thread")]
+async fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
     let (app, _, user, token) = TestApp::init()
         .with_config(|config| {
             config.db.primary.read_only_mode = true;
@@ -31,13 +31,15 @@ fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
             .expect_build(conn);
     });
 
-    let response = token.delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank");
+    let response = token
+        .async_delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
+        .await;
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn can_download_crate_in_read_only_mode() {
+#[tokio::test(flavor = "multi_thread")]
+async fn can_download_crate_in_read_only_mode() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.db.primary.read_only_mode = true;
@@ -50,7 +52,9 @@ fn can_download_crate_in_read_only_mode() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download")
+        .await;
     assert_eq!(response.status(), StatusCode::FOUND);
 
     // We're in read only mode so the download should not have been counted

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -11,7 +11,7 @@ async fn show() {
     let url = "/api/v1/categories/foo-bar";
 
     // Return not found if a category doesn't exist
-    anon.async_get(url).await.assert_not_found();
+    anon.get(url).await.assert_not_found();
 
     // Create a category and a subcategory
     app.db(|conn| {
@@ -22,7 +22,7 @@ async fn show() {
     });
 
     // The category and its subcategories should be in the json
-    let json: Value = anon.async_get(url).await.good();
+    let json: Value = anon.get(url).await.good();
     assert_json_snapshot!(json, {
         ".**.created_at" => "[datetime]",
     });
@@ -33,7 +33,7 @@ async fn show() {
 async fn update_crate() {
     // Convenience function to get the number of crates in a category
     async fn count(anon: &MockAnonymousUser, category: &str) -> usize {
-        let json = anon.async_show_category(category).await;
+        let json = anon.show_category(category).await;
         json.category.crates_cnt as usize
     }
 
@@ -90,7 +90,7 @@ async fn update_crate() {
 
     // Does not add the invalid category to the category list
     // (unlike the behavior of keywords)
-    let json = anon.async_show_category_list().await;
+    let json = anon.show_category_list().await;
     assert_eq!(json.categories.len(), 2);
     assert_eq!(json.meta.total, 2);
 

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -5,13 +5,13 @@ use crates_io::models::Category;
 use insta::assert_json_snapshot;
 use serde_json::Value;
 
-#[test]
-fn show() {
+#[tokio::test(flavor = "multi_thread")]
+async fn show() {
     let (app, anon) = TestApp::init().empty();
     let url = "/api/v1/categories/foo-bar";
 
     // Return not found if a category doesn't exist
-    anon.get(url).assert_not_found();
+    anon.async_get(url).await.assert_not_found();
 
     // Create a category and a subcategory
     app.db(|conn| {
@@ -22,18 +22,18 @@ fn show() {
     });
 
     // The category and its subcategories should be in the json
-    let json: Value = anon.get(url).good();
+    let json: Value = anon.async_get(url).await.good();
     assert_json_snapshot!(json, {
         ".**.created_at" => "[datetime]",
     });
 }
 
-#[test]
+#[tokio::test(flavor = "multi_thread")]
 #[allow(clippy::cognitive_complexity)]
-fn update_crate() {
+async fn update_crate() {
     // Convenience function to get the number of crates in a category
-    fn count(anon: &MockAnonymousUser, category: &str) -> usize {
-        let json = anon.show_category(category);
+    async fn count(anon: &MockAnonymousUser, category: &str) -> usize {
+        let json = anon.async_show_category(category).await;
         json.category.crates_cnt as usize
     }
 
@@ -51,33 +51,33 @@ fn update_crate() {
 
     // Updating with no categories has no effect
     app.db(|conn| Category::update_crate(conn, &krate, &[]).unwrap());
-    assert_eq!(count(&anon, "cat1"), 0);
-    assert_eq!(count(&anon, "category-2"), 0);
+    assert_eq!(count(&anon, "cat1").await, 0);
+    assert_eq!(count(&anon, "category-2").await, 0);
 
     // Happy path adding one category
     app.db(|conn| Category::update_crate(conn, &krate, &["cat1"]).unwrap());
-    assert_eq!(count(&anon, "cat1"), 1);
-    assert_eq!(count(&anon, "category-2"), 0);
+    assert_eq!(count(&anon, "cat1").await, 1);
+    assert_eq!(count(&anon, "category-2").await, 0);
 
     // Replacing one category with another
     app.db(|conn| Category::update_crate(conn, &krate, &["category-2"]).unwrap());
-    assert_eq!(count(&anon, "cat1"), 0);
-    assert_eq!(count(&anon, "category-2"), 1);
+    assert_eq!(count(&anon, "cat1").await, 0);
+    assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing one category
     app.db(|conn| Category::update_crate(conn, &krate, &[]).unwrap());
-    assert_eq!(count(&anon, "cat1"), 0);
-    assert_eq!(count(&anon, "category-2"), 0);
+    assert_eq!(count(&anon, "cat1").await, 0);
+    assert_eq!(count(&anon, "category-2").await, 0);
 
     // Adding 2 categories
     app.db(|conn| Category::update_crate(conn, &krate, &["cat1", "category-2"]).unwrap());
-    assert_eq!(count(&anon, "cat1"), 1);
-    assert_eq!(count(&anon, "category-2"), 1);
+    assert_eq!(count(&anon, "cat1").await, 1);
+    assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing all categories
     app.db(|conn| Category::update_crate(conn, &krate, &[]).unwrap());
-    assert_eq!(count(&anon, "cat1"), 0);
-    assert_eq!(count(&anon, "category-2"), 0);
+    assert_eq!(count(&anon, "cat1").await, 0);
+    assert_eq!(count(&anon, "category-2").await, 0);
 
     // Attempting to add one valid category and one invalid category
     app.db(|conn| {
@@ -85,19 +85,19 @@ fn update_crate() {
             Category::update_crate(conn, &krate, &["cat1", "catnope"]).unwrap();
         assert_eq!(invalid_categories, vec!["catnope"]);
     });
-    assert_eq!(count(&anon, "cat1"), 1);
-    assert_eq!(count(&anon, "category-2"), 0);
+    assert_eq!(count(&anon, "cat1").await, 1);
+    assert_eq!(count(&anon, "category-2").await, 0);
 
     // Does not add the invalid category to the category list
     // (unlike the behavior of keywords)
-    let json = anon.show_category_list();
+    let json = anon.async_show_category_list().await;
     assert_eq!(json.categories.len(), 2);
     assert_eq!(json.meta.total, 2);
 
     // Attempting to add a category by display text; must use slug
     app.db(|conn| Category::update_crate(conn, &krate, &["Category 2"]).unwrap());
-    assert_eq!(count(&anon, "cat1"), 0);
-    assert_eq!(count(&anon, "category-2"), 0);
+    assert_eq!(count(&anon, "cat1").await, 0);
+    assert_eq!(count(&anon, "category-2").await, 0);
 
     // Add a category and its subcategory
     app.db(|conn| {
@@ -105,7 +105,7 @@ fn update_crate() {
         Category::update_crate(conn, &krate, &["cat1", "cat1::bar"]).unwrap();
     });
 
-    assert_eq!(count(&anon, "cat1"), 1);
-    assert_eq!(count(&anon, "cat1::bar"), 1);
-    assert_eq!(count(&anon, "category-2"), 0);
+    assert_eq!(count(&anon, "cat1").await, 1);
+    assert_eq!(count(&anon, "cat1::bar").await, 1);
+    assert_eq!(count(&anon, "category-2").await, 0);
 }

--- a/src/tests/routes/categories/list.rs
+++ b/src/tests/routes/categories/list.rs
@@ -3,12 +3,12 @@ use crate::util::{RequestHelper, TestApp};
 use insta::assert_json_snapshot;
 use serde_json::Value;
 
-#[test]
-fn index() {
+#[tokio::test(flavor = "multi_thread")]
+async fn index() {
     let (app, anon) = TestApp::init().empty();
 
     // List 0 categories if none exist
-    let json: Value = anon.get("/api/v1/categories").good();
+    let json: Value = anon.async_get("/api/v1/categories").await.good();
     assert_json_snapshot!(json);
 
     // Create a category and a subcategory
@@ -22,7 +22,7 @@ fn index() {
     });
 
     // Only the top-level categories should be on the page
-    let json: Value = anon.get("/api/v1/categories").good();
+    let json: Value = anon.async_get("/api/v1/categories").await.good();
     assert_json_snapshot!(json, {
         ".categories[].created_at" => "[datetime]",
     });

--- a/src/tests/routes/categories/list.rs
+++ b/src/tests/routes/categories/list.rs
@@ -8,7 +8,7 @@ async fn index() {
     let (app, anon) = TestApp::init().empty();
 
     // List 0 categories if none exist
-    let json: Value = anon.async_get("/api/v1/categories").await.good();
+    let json: Value = anon.get("/api/v1/categories").await.good();
     assert_json_snapshot!(json);
 
     // Create a category and a subcategory
@@ -22,7 +22,7 @@ async fn index() {
     });
 
     // Only the top-level categories should be on the page
-    let json: Value = anon.async_get("/api/v1/categories").await.good();
+    let json: Value = anon.get("/api/v1/categories").await.good();
     assert_json_snapshot!(json, {
         ".categories[].created_at" => "[datetime]",
     });

--- a/src/tests/routes/category_slugs/list.rs
+++ b/src/tests/routes/category_slugs/list.rs
@@ -15,6 +15,6 @@ async fn category_slugs_returns_all_slugs_in_alphabetical_order() {
             .unwrap();
     });
 
-    let response: Value = anon.async_get("/api/v1/category_slugs").await.good();
+    let response: Value = anon.get("/api/v1/category_slugs").await.good();
     assert_json_snapshot!(response);
 }

--- a/src/tests/routes/category_slugs/list.rs
+++ b/src/tests/routes/category_slugs/list.rs
@@ -3,8 +3,8 @@ use crate::util::{RequestHelper, TestApp};
 use insta::assert_json_snapshot;
 use serde_json::Value;
 
-#[test]
-fn category_slugs_returns_all_slugs_in_alphabetical_order() {
+#[tokio::test(flavor = "multi_thread")]
+async fn category_slugs_returns_all_slugs_in_alphabetical_order() {
     let (app, anon) = TestApp::init().empty();
     app.db(|conn| {
         new_category("Foo", "foo", "For crates that foo")
@@ -15,6 +15,6 @@ fn category_slugs_returns_all_slugs_in_alphabetical_order() {
             .unwrap();
     });
 
-    let response: Value = anon.get("/api/v1/category_slugs").good();
+    let response: Value = anon.async_get("/api/v1/category_slugs").await.good();
     assert_json_snapshot!(response);
 }

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -43,9 +43,9 @@ pub async fn assert_dl_count(
 ) {
     let url = format!("/api/v1/crates/{name_and_version}/downloads");
     let downloads: Downloads = if let Some(query) = query {
-        anon.async_get_with_query(&url, query).await.good()
+        anon.get_with_query(&url, query).await.good()
     } else {
-        anon.async_get(&url).await.good()
+        anon.get(&url).await.good()
     };
     let total_downloads = downloads
         .version_downloads
@@ -57,7 +57,7 @@ pub async fn assert_dl_count(
 
 pub async fn download(client: &impl RequestHelper, name_and_version: &str) {
     let url = format!("/api/v1/crates/{name_and_version}/download");
-    let response = client.async_get::<()>(&url).await;
+    let response = client.get::<()>(&url).await;
     assert_eq!(response.status(), StatusCode::FOUND);
 }
 
@@ -135,7 +135,7 @@ async fn test_crate_downloads() {
         save_version_downloads("foo", "1.1.0", 1, conn);
     });
 
-    let response = anon.async_get::<()>("/api/v1/crates/foo/downloads").await;
+    let response = anon.get::<()>("/api/v1/crates/foo/downloads").await;
     assert_eq!(response.status(), StatusCode::OK);
     let json = response.json();
     assert_json_snapshot!(json, {
@@ -143,7 +143,7 @@ async fn test_crate_downloads() {
     });
 
     // check different crate name
-    let response = anon.async_get::<()>("/api/v1/crates/bar/downloads").await;
+    let response = anon.get::<()>("/api/v1/crates/bar/downloads").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(
         response.text(),
@@ -151,7 +151,7 @@ async fn test_crate_downloads() {
     );
 
     // check non-canonical crate name
-    let response = anon.async_get::<()>("/api/v1/crates/FOO/downloads").await;
+    let response = anon.get::<()>("/api/v1/crates/FOO/downloads").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.json(), json);
 }
@@ -178,9 +178,7 @@ async fn test_version_downloads() {
         save_version_downloads("foo", "1.1.0", 1, conn);
     });
 
-    let response = anon
-        .async_get::<()>("/api/v1/crates/foo/1.0.0/downloads")
-        .await;
+    let response = anon.get::<()>("/api/v1/crates/foo/1.0.0/downloads").await;
     assert_eq!(response.status(), StatusCode::OK);
     let json = response.json();
     assert_json_snapshot!(json, {
@@ -188,9 +186,7 @@ async fn test_version_downloads() {
     });
 
     // check different crate name
-    let response = anon
-        .async_get::<()>("/api/v1/crates/bar/1.0.0/downloads")
-        .await;
+    let response = anon.get::<()>("/api/v1/crates/bar/1.0.0/downloads").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(
         response.text(),
@@ -198,16 +194,12 @@ async fn test_version_downloads() {
     );
 
     // check non-canonical crate name
-    let response = anon
-        .async_get::<()>("/api/v1/crates/FOO/1.0.0/downloads")
-        .await;
+    let response = anon.get::<()>("/api/v1/crates/FOO/1.0.0/downloads").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.json(), json);
 
     // check missing version
-    let response = anon
-        .async_get::<()>("/api/v1/crates/foo/2.0.0/downloads")
-        .await;
+    let response = anon.get::<()>("/api/v1/crates/foo/2.0.0/downloads").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(
         response.text(),
@@ -216,7 +208,7 @@ async fn test_version_downloads() {
 
     // check invalid version
     let response = anon
-        .async_get::<()>("/api/v1/crates/foo/invalid-version/downloads")
+        .get::<()>("/api/v1/crates/foo/invalid-version/downloads")
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -5,7 +5,7 @@ use crate::util::{RequestHelper, TestApp};
 async fn diesel_not_found_results_in_404() {
     let (_, _, user) = TestApp::init().with_user();
 
-    user.async_get("/api/v1/crates/foo_following/following")
+    user.get("/api/v1/crates/foo_following/following")
         .await
         .assert_not_found();
 }
@@ -23,7 +23,7 @@ async fn disallow_api_token_auth_for_get_crate_following_status() {
 
     // Token auth on GET for get following status is disallowed
     token
-        .async_get(&format!("/api/v1/crates/{a_crate}/following"))
+        .get(&format!("/api/v1/crates/{a_crate}/following"))
         .await
         .assert_forbidden();
 }

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -1,16 +1,17 @@
 use crate::builders::CrateBuilder;
 use crate::util::{RequestHelper, TestApp};
 
-#[test]
-fn diesel_not_found_results_in_404() {
+#[tokio::test(flavor = "multi_thread")]
+async fn diesel_not_found_results_in_404() {
     let (_, _, user) = TestApp::init().with_user();
 
-    user.get("/api/v1/crates/foo_following/following")
+    user.async_get("/api/v1/crates/foo_following/following")
+        .await
         .assert_not_found();
 }
 
-#[test]
-fn disallow_api_token_auth_for_get_crate_following_status() {
+#[tokio::test(flavor = "multi_thread")]
+async fn disallow_api_token_auth_for_get_crate_following_status() {
     let (app, _, _, token) = TestApp::init().with_token();
     let api_token = token.as_model();
 
@@ -22,6 +23,7 @@ fn disallow_api_token_auth_for_get_crate_following_status() {
 
     // Token auth on GET for get following status is disallowed
     token
-        .get(&format!("/api/v1/crates/{a_crate}/following"))
+        .async_get(&format!("/api/v1/crates/{a_crate}/following"))
+        .await
         .assert_forbidden();
 }

--- a/src/tests/routes/crates/new.rs
+++ b/src/tests/routes/crates/new.rs
@@ -9,11 +9,11 @@ async fn daily_limit() {
     let max_daily_versions = app.as_inner().config.new_version_rate_limit.unwrap();
     for version in 1..=max_daily_versions {
         let crate_to_publish = PublishBuilder::new("foo_daily_limit", &format!("0.0.{version}"));
-        user.async_publish_crate(crate_to_publish).await.good();
+        user.publish_crate(crate_to_publish).await.good();
     }
 
     let crate_to_publish = PublishBuilder::new("foo_daily_limit", "1.0.0");
-    let response = user.async_publish_crate(crate_to_publish).await;
+    let response = user.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     let json = response.json();
     assert_eq!(

--- a/src/tests/routes/crates/new.rs
+++ b/src/tests/routes/crates/new.rs
@@ -2,18 +2,18 @@ use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 
-#[test]
-fn daily_limit() {
+#[tokio::test(flavor = "multi_thread")]
+async fn daily_limit() {
     let (app, _, user) = TestApp::full().with_user();
 
     let max_daily_versions = app.as_inner().config.new_version_rate_limit.unwrap();
     for version in 1..=max_daily_versions {
         let crate_to_publish = PublishBuilder::new("foo_daily_limit", &format!("0.0.{version}"));
-        user.publish_crate(crate_to_publish).good();
+        user.async_publish_crate(crate_to_publish).await.good();
     }
 
     let crate_to_publish = PublishBuilder::new("foo_daily_limit", "1.0.0");
-    let response = user.publish_crate(crate_to_publish);
+    let response = user.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
     let json = response.json();
     assert_eq!(

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -8,8 +8,8 @@ use insta::assert_snapshot;
 // This is testing Cargo functionality! ! !
 // specifically functions modify_owners and add_owners
 // which call the `PUT /crates/:crate_id/owners` route
-#[test]
-fn test_cargo_invite_owners() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cargo_invite_owners() {
     let (app, _, owner) = TestApp::init().with_user();
 
     let new_user = app.db_new_user("cilantro");
@@ -32,7 +32,8 @@ fn test_cargo_invite_owners() {
         owners: Some(vec![new_user.as_model().gh_login.clone()]),
     });
     let json: OwnerResp = owner
-        .put("/api/v1/crates/guacamole/owners", body.unwrap())
+        .async_put("/api/v1/crates/guacamole/owners", body.unwrap())
+        .await
         .good();
 
     // this ok:true field is what old versions of Cargo
@@ -47,8 +48,8 @@ fn test_cargo_invite_owners() {
     )
 }
 
-#[test]
-fn owner_change_via_cookie() {
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_change_via_cookie() {
     let (app, _, cookie) = TestApp::full().with_user();
 
     let user2 = app.db_new_user("user-2");
@@ -60,7 +61,7 @@ fn owner_change_via_cookie() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = cookie.put::<()>(&url, body);
+    let response = cookie.async_put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -68,8 +69,8 @@ fn owner_change_via_cookie() {
     );
 }
 
-#[test]
-fn owner_change_via_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_change_via_token() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let user2 = app.db_new_user("user-2");
@@ -81,7 +82,7 @@ fn owner_change_via_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, body);
+    let response = token.async_put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -89,8 +90,8 @@ fn owner_change_via_token() {
     );
 }
 
-#[test]
-fn owner_change_via_change_owner_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_change_via_change_owner_token() {
     let (app, _, _, token) =
         TestApp::full().with_scoped_token(None, Some(vec![EndpointScope::ChangeOwners]));
 
@@ -103,7 +104,7 @@ fn owner_change_via_change_owner_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, body);
+    let response = token.async_put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -111,8 +112,8 @@ fn owner_change_via_change_owner_token() {
     );
 }
 
-#[test]
-fn owner_change_via_change_owner_token_with_matching_crate_scope() {
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let crate_scopes = Some(vec![CrateScope::try_from("foo_crate").unwrap()]);
     let endpoint_scopes = Some(vec![EndpointScope::ChangeOwners]);
     let (app, _, _, token) = TestApp::full().with_scoped_token(crate_scopes, endpoint_scopes);
@@ -126,7 +127,7 @@ fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, body);
+    let response = token.async_put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -134,8 +135,8 @@ fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     );
 }
 
-#[test]
-fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let crate_scopes = Some(vec![CrateScope::try_from("bar").unwrap()]);
     let endpoint_scopes = Some(vec![EndpointScope::ChangeOwners]);
     let (app, _, _, token) = TestApp::full().with_scoped_token(crate_scopes, endpoint_scopes);
@@ -149,13 +150,13 @@ fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, body);
+    let response = token.async_put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
 }
 
-#[test]
-fn owner_change_via_publish_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_change_via_publish_token() {
     let (app, _, _, token) =
         TestApp::full().with_scoped_token(None, Some(vec![EndpointScope::PublishUpdate]));
 
@@ -168,13 +169,13 @@ fn owner_change_via_publish_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.put::<()>(&url, body);
+    let response = token.async_put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
 }
 
-#[test]
-fn owner_change_without_auth() {
+#[tokio::test(flavor = "multi_thread")]
+async fn owner_change_without_auth() {
     let (app, anon, cookie) = TestApp::full().with_user();
 
     let user2 = app.db_new_user("user-2");
@@ -186,50 +187,58 @@ fn owner_change_without_auth() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = anon.put::<()>(&url, body);
+    let response = anon.async_put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
-#[test]
-fn test_owner_change_with_legacy_field() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_owner_change_with_legacy_field() {
     let (app, _, user1) = TestApp::full().with_user();
     app.db(|conn| CrateBuilder::new("foo", user1.as_model().id).expect_build(conn));
     app.db_new_user("user2");
 
     let input = r#"{"users": ["user2"]}"#;
-    let response = user1.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    let response = user1
+        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r###"{"msg":"user user2 has been invited to be an owner of crate foo","ok":true}"###);
 }
 
-#[test]
-fn test_owner_change_with_invalid_json() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user();
     app.db_new_user("bar");
     app.db(|conn| CrateBuilder::new("foo", user.as_model().id).expect_build(conn));
 
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
-    let response = user.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    let response = user
+        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
 
     // `owners` is not an array
     let input = r#"{"owners": "foo"}"#;
-    let response = user.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    let response = user
+        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
 
     // missing `owners` and/or `users` fields
     let input = r#"{}"#;
-    let response = user.put::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    let response = user
+        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
 }
 
-#[test]
-fn invite_already_invited_user() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invite_already_invited_user() {
     let (app, _, _, owner) = TestApp::init().with_token();
     app.db_new_user("invited_user");
     app.db(|conn| CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(conn));
@@ -238,7 +247,9 @@ fn invite_already_invited_user() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Invite the user the first time
-    let response = owner.add_named_owner("crate_name", "invited_user");
+    let response = owner
+        .async_add_named_owner("crate_name", "invited_user")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -252,7 +263,9 @@ fn invite_already_invited_user() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
 
     // Then invite the user a second time, the message should point out the user is already invited
-    let response = owner.add_named_owner("crate_name", "invited_user");
+    let response = owner
+        .async_add_named_owner("crate_name", "invited_user")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -266,8 +279,8 @@ fn invite_already_invited_user() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
 }
 
-#[test]
-fn invite_with_existing_expired_invite() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invite_with_existing_expired_invite() {
     let (app, _, _, owner) = TestApp::init().with_token();
     app.db_new_user("invited_user");
     let krate =
@@ -277,7 +290,9 @@ fn invite_with_existing_expired_invite() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Invite the user the first time
-    let response = owner.add_named_owner("crate_name", "invited_user");
+    let response = owner
+        .async_add_named_owner("crate_name", "invited_user")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -294,7 +309,9 @@ fn invite_with_existing_expired_invite() {
     expire_invitation(&app, krate.id);
 
     // Then invite the user a second time, a new invite is created as the old one expired
-    let response = owner.add_named_owner("crate_name", "invited_user");
+    let response = owner
+        .async_add_named_owner("crate_name", "invited_user")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -308,39 +325,45 @@ fn invite_with_existing_expired_invite() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 2);
 }
 
-#[test]
-fn test_unknown_crate() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_crate() {
     let (app, _, user) = TestApp::full().with_user();
     app.db_new_user("bar");
 
     let body = json!({ "owners": ["bar"] });
     let body = serde_json::to_vec(&body).unwrap();
 
-    let response = user.put::<()>("/api/v1/crates/unknown/owners", body);
+    let response = user
+        .async_put::<()>("/api/v1/crates/unknown/owners", body)
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 }
 
-#[test]
-fn test_unknown_user() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_user() {
     let (app, _, cookie) = TestApp::full().with_user();
 
     app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
 
     let body = serde_json::to_vec(&json!({ "owners": ["unknown"] })).unwrap();
-    let response = cookie.put::<()>("/api/v1/crates/foo/owners", body);
+    let response = cookie
+        .async_put::<()>("/api/v1/crates/foo/owners", body)
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find user with login `unknown`"}]}"###);
 }
 
-#[test]
-fn test_unknown_team() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_team() {
     let (app, _, cookie) = TestApp::full().with_user();
 
     app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
 
     let body = serde_json::to_vec(&json!({ "owners": ["github:unknown:unknown"] })).unwrap();
-    let response = cookie.put::<()>("/api/v1/crates/foo/owners", body);
+    let response = cookie
+        .async_put::<()>("/api/v1/crates/foo/owners", body)
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find the github team unknown/unknown"}]}"###);
 }

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -32,7 +32,7 @@ async fn test_cargo_invite_owners() {
         owners: Some(vec![new_user.as_model().gh_login.clone()]),
     });
     let json: OwnerResp = owner
-        .async_put("/api/v1/crates/guacamole/owners", body.unwrap())
+        .put("/api/v1/crates/guacamole/owners", body.unwrap())
         .await
         .good();
 
@@ -61,7 +61,7 @@ async fn owner_change_via_cookie() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = cookie.async_put::<()>(&url, body).await;
+    let response = cookie.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -82,7 +82,7 @@ async fn owner_change_via_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.async_put::<()>(&url, body).await;
+    let response = token.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -104,7 +104,7 @@ async fn owner_change_via_change_owner_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.async_put::<()>(&url, body).await;
+    let response = token.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -127,7 +127,7 @@ async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.async_put::<()>(&url, body).await;
+    let response = token.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -150,7 +150,7 @@ async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.async_put::<()>(&url, body).await;
+    let response = token.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
 }
@@ -169,7 +169,7 @@ async fn owner_change_via_publish_token() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = token.async_put::<()>(&url, body).await;
+    let response = token.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
 }
@@ -187,7 +187,7 @@ async fn owner_change_without_auth() {
     let url = format!("/api/v1/crates/{}/owners", krate.name);
     let body = json!({ "owners": [user2.gh_login] });
     let body = serde_json::to_vec(&body).unwrap();
-    let response = anon.async_put::<()>(&url, body).await;
+    let response = anon.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
@@ -200,7 +200,7 @@ async fn test_owner_change_with_legacy_field() {
 
     let input = r#"{"users": ["user2"]}"#;
     let response = user1
-        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r###"{"msg":"user user2 has been invited to be an owner of crate foo","ok":true}"###);
@@ -215,7 +215,7 @@ async fn test_owner_change_with_invalid_json() {
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
     let response = user
-        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
@@ -223,7 +223,7 @@ async fn test_owner_change_with_invalid_json() {
     // `owners` is not an array
     let input = r#"{"owners": "foo"}"#;
     let response = user
-        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
@@ -231,7 +231,7 @@ async fn test_owner_change_with_invalid_json() {
     // missing `owners` and/or `users` fields
     let input = r#"{}"#;
     let response = user
-        .async_put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
@@ -247,9 +247,7 @@ async fn invite_already_invited_user() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Invite the user the first time
-    let response = owner
-        .async_add_named_owner("crate_name", "invited_user")
-        .await;
+    let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -263,9 +261,7 @@ async fn invite_already_invited_user() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
 
     // Then invite the user a second time, the message should point out the user is already invited
-    let response = owner
-        .async_add_named_owner("crate_name", "invited_user")
-        .await;
+    let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -290,9 +286,7 @@ async fn invite_with_existing_expired_invite() {
     assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
 
     // Invite the user the first time
-    let response = owner
-        .async_add_named_owner("crate_name", "invited_user")
-        .await;
+    let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -309,9 +303,7 @@ async fn invite_with_existing_expired_invite() {
     expire_invitation(&app, krate.id);
 
     // Then invite the user a second time, a new invite is created as the old one expired
-    let response = owner
-        .async_add_named_owner("crate_name", "invited_user")
-        .await;
+    let response = owner.add_named_owner("crate_name", "invited_user").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
         response.json(),
@@ -333,9 +325,7 @@ async fn test_unknown_crate() {
     let body = json!({ "owners": ["bar"] });
     let body = serde_json::to_vec(&body).unwrap();
 
-    let response = user
-        .async_put::<()>("/api/v1/crates/unknown/owners", body)
-        .await;
+    let response = user.put::<()>("/api/v1/crates/unknown/owners", body).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 }
@@ -347,9 +337,7 @@ async fn test_unknown_user() {
     app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
 
     let body = serde_json::to_vec(&json!({ "owners": ["unknown"] })).unwrap();
-    let response = cookie
-        .async_put::<()>("/api/v1/crates/foo/owners", body)
-        .await;
+    let response = cookie.put::<()>("/api/v1/crates/foo/owners", body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find user with login `unknown`"}]}"###);
 }
@@ -361,9 +349,7 @@ async fn test_unknown_team() {
     app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
 
     let body = serde_json::to_vec(&json!({ "owners": ["github:unknown:unknown"] })).unwrap();
-    let response = cookie
-        .async_put::<()>("/api/v1/crates/foo/owners", body)
-        .await;
+    let response = cookie.put::<()>("/api/v1/crates/foo/owners", body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find the github team unknown/unknown"}]}"###);
 }

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -3,64 +3,76 @@ use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 use insta::assert_snapshot;
 
-#[test]
-fn test_owner_change_with_invalid_json() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user();
     app.db_new_user("bar");
     app.db(|conn| CrateBuilder::new("foo", user.as_model().id).expect_build(conn));
 
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
-    let response = user.delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    let response = user
+        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
 
     // `owners` is not an array
     let input = r#"{"owners": "foo"}"#;
-    let response = user.delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    let response = user
+        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
 
     // missing `owners` and/or `users` fields
     let input = r#"{}"#;
-    let response = user.delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes());
+    let response = user
+        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
 }
 
-#[test]
-fn test_unknown_crate() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_crate() {
     let (app, _, user) = TestApp::full().with_user();
     app.db_new_user("bar");
 
     let body = json!({ "owners": ["bar"] });
     let body = serde_json::to_vec(&body).unwrap();
 
-    let response = user.delete_with_body::<()>("/api/v1/crates/unknown/owners", body);
+    let response = user
+        .async_delete_with_body::<()>("/api/v1/crates/unknown/owners", body)
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 }
 
-#[test]
-fn test_unknown_user() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_user() {
     let (app, _, cookie) = TestApp::full().with_user();
 
     app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
 
     let body = serde_json::to_vec(&json!({ "owners": ["unknown"] })).unwrap();
-    let response = cookie.delete_with_body::<()>("/api/v1/crates/foo/owners", body);
+    let response = cookie
+        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", body)
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find user with login `unknown`"}]}"###);
 }
 
-#[test]
-fn test_unknown_team() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_team() {
     let (app, _, cookie) = TestApp::full().with_user();
 
     app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
 
     let body = serde_json::to_vec(&json!({ "owners": ["github:unknown:unknown"] })).unwrap();
-    let response = cookie.delete_with_body::<()>("/api/v1/crates/foo/owners", body);
+    let response = cookie
+        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", body)
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find team with login `github:unknown:unknown`"}]}"###);
 }

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -12,7 +12,7 @@ async fn test_owner_change_with_invalid_json() {
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
     let response = user
-        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
@@ -20,7 +20,7 @@ async fn test_owner_change_with_invalid_json() {
     // `owners` is not an array
     let input = r#"{"owners": "foo"}"#;
     let response = user
-        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
@@ -28,7 +28,7 @@ async fn test_owner_change_with_invalid_json() {
     // missing `owners` and/or `users` fields
     let input = r#"{}"#;
     let response = user
-        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
+        .delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
@@ -43,7 +43,7 @@ async fn test_unknown_crate() {
     let body = serde_json::to_vec(&body).unwrap();
 
     let response = user
-        .async_delete_with_body::<()>("/api/v1/crates/unknown/owners", body)
+        .delete_with_body::<()>("/api/v1/crates/unknown/owners", body)
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
@@ -57,7 +57,7 @@ async fn test_unknown_user() {
 
     let body = serde_json::to_vec(&json!({ "owners": ["unknown"] })).unwrap();
     let response = cookie
-        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", body)
+        .delete_with_body::<()>("/api/v1/crates/foo/owners", body)
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find user with login `unknown`"}]}"###);
@@ -71,7 +71,7 @@ async fn test_unknown_team() {
 
     let body = serde_json::to_vec(&json!({ "owners": ["github:unknown:unknown"] })).unwrap();
     let response = cookie
-        .async_delete_with_body::<()>("/api/v1/crates/foo/owners", body)
+        .delete_with_body::<()>("/api/v1/crates/foo/owners", body)
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find team with login `github:unknown:unknown`"}]}"###);

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -37,7 +37,7 @@ async fn show() {
         krate
     });
 
-    let response = anon.async_get::<()>("/api/v1/crates/foo_show").await;
+    let response = anon.get::<()>("/api/v1/crates/foo_show").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",
@@ -68,7 +68,7 @@ async fn show_minimal() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/foo_show_minimal?include=")
+        .get::<()>("/api/v1/crates/foo_show_minimal?include=")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -81,7 +81,7 @@ async fn show_minimal() {
 async fn test_missing() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.async_get::<()>("/api/v1/crates/missing").await;
+    let response = anon.get::<()>("/api/v1/crates/missing").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `missing` does not exist"}]}"###);
 }
@@ -91,14 +91,14 @@ async fn version_size() {
     let (_, _, user) = TestApp::full().with_user();
 
     let crate_to_publish = PublishBuilder::new("foo_version_size", "1.0.0");
-    user.async_publish_crate(crate_to_publish).await.good();
+    user.publish_crate(crate_to_publish).await.good();
 
     // Add a file to version 2 so that it's a different size than version 1
     let crate_to_publish = PublishBuilder::new("foo_version_size", "2.0.0")
         .add_file("foo_version_size-2.0.0/big", "a");
-    user.async_publish_crate(crate_to_publish).await.good();
+    user.publish_crate(crate_to_publish).await.good();
 
-    let crate_json = user.async_show_crate("foo_version_size").await;
+    let crate_json = user.show_crate("foo_version_size").await;
 
     let version1 = crate_json
         .versions
@@ -130,7 +130,7 @@ async fn block_bad_documentation_url() {
             .expect_build(conn)
     });
 
-    let json = anon.async_show_crate("foo_bad_doc_url").await;
+    let json = anon.show_crate("foo_bad_doc_url").await;
     assert_eq!(json.krate.documentation, None);
 }
 
@@ -139,7 +139,7 @@ async fn test_new_name() {
     let (app, anon, user) = TestApp::init().with_user();
     app.db(|conn| CrateBuilder::new("new", user.as_model().id).expect_build(conn));
 
-    let response = anon.async_get::<()>("/api/v1/crates/new?include=").await;
+    let response = anon.get::<()>("/api/v1/crates/new?include=").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".crate.created_at" => "[datetime]",

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -3,8 +3,8 @@ use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
 
-#[test]
-fn reverse_dependencies() {
+#[tokio::test(flavor = "multi_thread")]
+async fn reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -20,7 +20,9 @@ fn reverse_dependencies() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -28,7 +30,9 @@ fn reverse_dependencies() {
     });
 
     // c1 has no dependent crates.
-    let response = anon.get::<()>("/api/v1/crates/c2/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c2/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -36,8 +40,8 @@ fn reverse_dependencies() {
     });
 }
 
-#[test]
-fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
+#[tokio::test(flavor = "multi_thread")]
+async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -51,7 +55,9 @@ fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -59,8 +65,8 @@ fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     });
 }
 
-#[test]
-fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
+#[tokio::test(flavor = "multi_thread")]
+async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -74,7 +80,9 @@ fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -82,8 +90,8 @@ fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     });
 }
 
-#[test]
-fn prerelease_versions_not_included_in_reverse_dependencies() {
+#[tokio::test(flavor = "multi_thread")]
+async fn prerelease_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -100,7 +108,9 @@ fn prerelease_versions_not_included_in_reverse_dependencies() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -108,8 +118,8 @@ fn prerelease_versions_not_included_in_reverse_dependencies() {
     });
 }
 
-#[test]
-fn yanked_versions_not_included_in_reverse_dependencies() {
+#[tokio::test(flavor = "multi_thread")]
+async fn yanked_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -123,7 +133,9 @@ fn yanked_versions_not_included_in_reverse_dependencies() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -140,7 +152,9 @@ fn yanked_versions_not_included_in_reverse_dependencies() {
             .unwrap();
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -148,8 +162,8 @@ fn yanked_versions_not_included_in_reverse_dependencies() {
     });
 }
 
-#[test]
-fn reverse_dependencies_includes_published_by_user_when_present() {
+#[tokio::test(flavor = "multi_thread")]
+async fn reverse_dependencies_includes_published_by_user_when_present() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -178,7 +192,9 @@ fn reverse_dependencies_includes_published_by_user_when_present() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -186,8 +202,8 @@ fn reverse_dependencies_includes_published_by_user_when_present() {
     });
 }
 
-#[test]
-fn reverse_dependencies_query_supports_u64_version_number_parts() {
+#[tokio::test(flavor = "multi_thread")]
+async fn reverse_dependencies_query_supports_u64_version_number_parts() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -202,7 +218,9 @@ fn reverse_dependencies_query_supports_u64_version_number_parts() {
             .expect_build(conn);
     });
 
-    let response = anon.get::<()>("/api/v1/crates/c1/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".versions[].created_at" => "[datetime]",
@@ -210,11 +228,13 @@ fn reverse_dependencies_query_supports_u64_version_number_parts() {
     });
 }
 
-#[test]
-fn test_unknown_crate() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unknown_crate() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.get::<()>("/api/v1/crates/unknown/reverse_dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/unknown/reverse_dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
 }

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -21,7 +21,7 @@ async fn reverse_dependencies() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -31,7 +31,7 @@ async fn reverse_dependencies() {
 
     // c1 has no dependent crates.
     let response = anon
-        .async_get::<()>("/api/v1/crates/c2/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c2/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -56,7 +56,7 @@ async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -81,7 +81,7 @@ async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -109,7 +109,7 @@ async fn prerelease_versions_not_included_in_reverse_dependencies() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -134,7 +134,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -153,7 +153,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -193,7 +193,7 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -219,7 +219,7 @@ async fn reverse_dependencies_query_supports_u64_version_number_parts() {
     });
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/c1/reverse_dependencies")
+        .get::<()>("/api/v1/crates/c1/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -233,7 +233,7 @@ async fn test_unknown_crate() {
     let (_, anon) = TestApp::init().empty();
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/unknown/reverse_dependencies")
+        .get::<()>("/api/v1/crates/unknown/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -3,8 +3,8 @@ use crate::util::{RequestHelper, TestApp};
 use insta::assert_json_snapshot;
 use serde_json::Value;
 
-#[test]
-fn authors() {
+#[tokio::test(flavor = "multi_thread")]
+async fn authors() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -14,7 +14,10 @@ fn authors() {
             .expect_build(conn);
     });
 
-    let json: Value = anon.get("/api/v1/crates/foo_authors/1.0.0/authors").good();
+    let json: Value = anon
+        .async_get("/api/v1/crates/foo_authors/1.0.0/authors")
+        .await
+        .good();
     let json = json.as_object().unwrap();
     assert_json_snapshot!(json);
 }

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -15,7 +15,7 @@ async fn authors() {
     });
 
     let json: Value = anon
-        .async_get("/api/v1/crates/foo_authors/1.0.0/authors")
+        .get("/api/v1/crates/foo_authors/1.0.0/authors")
         .await
         .good();
     let json = json.as_object().unwrap();

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -22,13 +22,13 @@ async fn dependencies() {
     });
 
     let deps: Deps = anon
-        .async_get("/api/v1/crates/foo_deps/1.0.0/dependencies")
+        .get("/api/v1/crates/foo_deps/1.0.0/dependencies")
         .await
         .good();
     assert_eq!(deps.dependencies[0].crate_id, "bar_deps");
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/missing-crate/1.0.0/dependencies")
+        .get::<()>("/api/v1/crates/missing-crate/1.0.0/dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
@@ -37,7 +37,7 @@ async fn dependencies() {
     );
 
     let response = anon
-        .async_get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies")
+        .get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -8,8 +8,8 @@ pub struct Deps {
     pub dependencies: Vec<EncodableDependency>,
 }
 
-#[test]
-fn dependencies() {
+#[tokio::test(flavor = "multi_thread")]
+async fn dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -22,18 +22,23 @@ fn dependencies() {
     });
 
     let deps: Deps = anon
-        .get("/api/v1/crates/foo_deps/1.0.0/dependencies")
+        .async_get("/api/v1/crates/foo_deps/1.0.0/dependencies")
+        .await
         .good();
     assert_eq!(deps.dependencies[0].crate_id, "bar_deps");
 
-    let response = anon.get::<()>("/api/v1/crates/missing-crate/1.0.0/dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/missing-crate/1.0.0/dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "crate `missing-crate` does not exist" }] })
     );
 
-    let response = anon.get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies");
+    let response = anon
+        .async_get::<()>("/api/v1/crates/foo_deps/1.0.2/dependencies")
+        .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_eq!(
         response.json(),

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -12,22 +12,22 @@ async fn test_redirects() {
     });
 
     // Any redirect to an existing crate and version works correctly.
-    anon.async_get::<()>("/api/v1/crates/foo-download/1.0.0/download")
+    anon.get::<()>("/api/v1/crates/foo-download/1.0.0/download")
         .await
         .assert_redirect_ends_with("/crates/foo-download/foo-download-1.0.0.crate");
 
     // Redirects to crates with wrong capitalization are performed unconditionally.
-    anon.async_get::<()>("/api/v1/crates/Foo_downloaD/1.0.0/download")
+    anon.get::<()>("/api/v1/crates/Foo_downloaD/1.0.0/download")
         .await
         .assert_redirect_ends_with("/crates/Foo_downloaD/Foo_downloaD-1.0.0.crate");
 
     // Redirects to missing versions are performed unconditionally.
-    anon.async_get::<()>("/api/v1/crates/foo-download/2.0.0/download")
+    anon.get::<()>("/api/v1/crates/foo-download/2.0.0/download")
         .await
         .assert_redirect_ends_with("/crates/foo-download/foo-download-2.0.0.crate");
 
     // Redirects to missing crates are performed unconditionally.
-    anon.async_get::<()>("/api/v1/crates/bar-download/1.0.0/download")
+    anon.get::<()>("/api/v1/crates/bar-download/1.0.0/download")
         .await
         .assert_redirect_ends_with("/crates/bar-download/bar-download-1.0.0.crate");
 }
@@ -43,11 +43,11 @@ async fn download_with_build_metadata() {
             .expect_build(conn);
     });
 
-    anon.async_get::<()>("/api/v1/crates/foo/1.0.0+bar/download")
+    anon.get::<()>("/api/v1/crates/foo/1.0.0+bar/download")
         .await
         .assert_redirect_ends_with("/crates/foo/foo-1.0.0%2Bbar.crate");
 
-    anon.async_get::<()>("/api/v1/crates/foo/1.0.0+bar/readme")
+    anon.get::<()>("/api/v1/crates/foo/1.0.0+bar/readme")
         .await
         .assert_redirect_ends_with("/readmes/foo/foo-1.0.0%2Bbar.html");
 }

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -1,8 +1,8 @@
 use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::util::{RequestHelper, TestApp};
 
-#[test]
-fn test_redirects() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_redirects() {
     let (app, anon, user) = TestApp::init().with_user();
 
     app.db(|conn| {
@@ -12,24 +12,28 @@ fn test_redirects() {
     });
 
     // Any redirect to an existing crate and version works correctly.
-    anon.get::<()>("/api/v1/crates/foo-download/1.0.0/download")
+    anon.async_get::<()>("/api/v1/crates/foo-download/1.0.0/download")
+        .await
         .assert_redirect_ends_with("/crates/foo-download/foo-download-1.0.0.crate");
 
     // Redirects to crates with wrong capitalization are performed unconditionally.
-    anon.get::<()>("/api/v1/crates/Foo_downloaD/1.0.0/download")
+    anon.async_get::<()>("/api/v1/crates/Foo_downloaD/1.0.0/download")
+        .await
         .assert_redirect_ends_with("/crates/Foo_downloaD/Foo_downloaD-1.0.0.crate");
 
     // Redirects to missing versions are performed unconditionally.
-    anon.get::<()>("/api/v1/crates/foo-download/2.0.0/download")
+    anon.async_get::<()>("/api/v1/crates/foo-download/2.0.0/download")
+        .await
         .assert_redirect_ends_with("/crates/foo-download/foo-download-2.0.0.crate");
 
     // Redirects to missing crates are performed unconditionally.
-    anon.get::<()>("/api/v1/crates/bar-download/1.0.0/download")
+    anon.async_get::<()>("/api/v1/crates/bar-download/1.0.0/download")
+        .await
         .assert_redirect_ends_with("/crates/bar-download/bar-download-1.0.0.crate");
 }
 
-#[test]
-fn download_with_build_metadata() {
+#[tokio::test(flavor = "multi_thread")]
+async fn download_with_build_metadata() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -39,9 +43,11 @@ fn download_with_build_metadata() {
             .expect_build(conn);
     });
 
-    anon.get::<()>("/api/v1/crates/foo/1.0.0+bar/download")
+    anon.async_get::<()>("/api/v1/crates/foo/1.0.0+bar/download")
+        .await
         .assert_redirect_ends_with("/crates/foo/foo-1.0.0%2Bbar.crate");
 
-    anon.get::<()>("/api/v1/crates/foo/1.0.0+bar/readme")
+    anon.async_get::<()>("/api/v1/crates/foo/1.0.0+bar/readme")
+        .await
         .assert_redirect_ends_with("/readmes/foo/foo-1.0.0%2Bbar.html");
 }

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -4,8 +4,8 @@ use crate::util::{RequestHelper, TestApp};
 use diesel::prelude::*;
 use serde_json::Value;
 
-#[test]
-fn show_by_crate_name_and_version() {
+#[tokio::test(flavor = "multi_thread")]
+async fn show_by_crate_name_and_version() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -19,7 +19,7 @@ fn show_by_crate_name_and_version() {
     });
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
-    let json: Value = anon.get(url).good();
+    let json: Value = anon.async_get(url).await.good();
     assert_json_snapshot!(json, {
         ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
@@ -28,8 +28,8 @@ fn show_by_crate_name_and_version() {
     });
 }
 
-#[test]
-fn show_by_crate_name_and_semver_no_published_by() {
+#[tokio::test(flavor = "multi_thread")]
+async fn show_by_crate_name_and_semver_no_published_by() {
     use crates_io::schema::versions;
     use diesel::{update, RunQueryDsl};
 
@@ -51,7 +51,7 @@ fn show_by_crate_name_and_semver_no_published_by() {
     });
 
     let url = "/api/v1/crates/foo_vers_show_no_pb/1.0.0";
-    let json: Value = anon.get(url).good();
+    let json: Value = anon.async_get(url).await.good();
     assert_json_snapshot!(json, {
         ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -19,7 +19,7 @@ async fn show_by_crate_name_and_version() {
     });
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
-    let json: Value = anon.async_get(url).await.good();
+    let json: Value = anon.get(url).await.good();
     assert_json_snapshot!(json, {
         ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",
@@ -51,7 +51,7 @@ async fn show_by_crate_name_and_semver_no_published_by() {
     });
 
     let url = "/api/v1/crates/foo_vers_show_no_pb/1.0.0";
-    let json: Value = anon.async_get(url).await.good();
+    let json: Value = anon.get(url).await.good();
     assert_json_snapshot!(json, {
         ".version.id" => insta::id_redaction(v.id),
         ".version.created_at" => "[datetime]",

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -45,8 +45,8 @@ impl<T: RequestHelper> YankRequestHelper for T {
     }
 }
 
-#[test]
-fn yank_by_a_non_owner_fails() {
+#[tokio::test(flavor = "multi_thread")]
+async fn yank_by_a_non_owner_fails() {
     let (app, _, _, token) = TestApp::full().with_token();
 
     let another_user = app.db_new_user("bar");
@@ -57,7 +57,7 @@ fn yank_by_a_non_owner_fails() {
             .expect_build(conn);
     });
 
-    let response = token.yank("foo_not", "1.0.0");
+    let response = token.async_yank("foo_not", "1.0.0").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -65,19 +65,19 @@ fn yank_by_a_non_owner_fails() {
     );
 }
 
-#[test]
-fn yank_records_an_audit_action() {
+#[tokio::test(flavor = "multi_thread")]
+async fn yank_records_an_audit_action() {
     let (_, anon, _, token) = TestApp::full().with_token();
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     // Yank it
-    token.yank("fyk", "1.0.0").good();
+    token.async_yank("fyk", "1.0.0").await.good();
 
     // Make sure it has one publish and one yank audit action
-    let json = anon.show_version("fyk", "1.0.0");
+    let json = anon.async_show_version("fyk", "1.0.0").await;
     let actions = json.version.audit_actions;
 
     assert_eq!(actions.len(), 2);
@@ -86,22 +86,22 @@ fn yank_records_an_audit_action() {
     assert_eq!(action.user.id, token.as_model().user_id);
 }
 
-#[test]
-fn unyank_records_an_audit_action() {
+#[tokio::test(flavor = "multi_thread")]
+async fn unyank_records_an_audit_action() {
     let (_, anon, _, token) = TestApp::full().with_token();
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
-    token.publish_crate(crate_to_publish).good();
+    token.async_publish_crate(crate_to_publish).await.good();
 
     // Yank version 1.0.0
-    token.yank("fyk", "1.0.0").good();
+    token.async_yank("fyk", "1.0.0").await.good();
 
     // Unyank version 1.0.0
-    token.unyank("fyk", "1.0.0").good();
+    token.async_unyank("fyk", "1.0.0").await.good();
 
     // Make sure it has one publish, one yank, and one unyank audit action
-    let json = anon.show_version("fyk", "1.0.0");
+    let json = anon.async_show_version("fyk", "1.0.0").await;
     let actions = json.version.audit_actions;
 
     assert_eq!(actions.len(), 3);
@@ -122,11 +122,11 @@ mod auth {
     const CRATE_NAME: &str = "fyk";
     const CRATE_VERSION: &str = "1.0.0";
 
-    fn prepare() -> (TestApp, MockAnonymousUser, MockCookieUser) {
+    async fn prepare() -> (TestApp, MockAnonymousUser, MockCookieUser) {
         let (app, anon, cookie) = TestApp::full().with_user();
 
         let pb = PublishBuilder::new(CRATE_NAME, CRATE_VERSION);
-        cookie.publish_crate(pb).good();
+        cookie.async_publish_crate(pb).await.good();
 
         (app, anon, cookie)
     }
@@ -143,110 +143,110 @@ mod auth {
         })
     }
 
-    #[test]
-    fn unauthenticated() {
-        let (app, client, _) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unauthenticated() {
+        let (app, client, _) = prepare().await;
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
         assert!(!is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn cookie_user() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cookie_user() {
+        let (app, _, client) = prepare().await;
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user() {
+        let (app, _, client) = prepare().await;
         let client = client.db_new_token("test-token");
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_not_expired() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_not_expired() {
         let expired_at = Utc::now() + Duration::days(7);
 
-        let (app, _, client) = prepare();
+        let (app, _, client) = prepare().await;
         let client =
             client.db_new_scoped_token("test-token", None, None, Some(expired_at.naive_utc()));
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_expired() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_expired() {
         let expired_at = Utc::now() - Duration::days(7);
 
-        let (app, _, client) = prepare();
+        let (app, _, client) = prepare().await;
         let client =
             client.db_new_scoped_token("test-token", None, None, Some(expired_at.naive_utc()));
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
         assert!(!is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_with_correct_endpoint_scope() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_with_correct_endpoint_scope() {
+        let (app, _, client) = prepare().await;
         let client =
             client.db_new_scoped_token("test-token", None, Some(vec![EndpointScope::Yank]), None);
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_with_incorrect_endpoint_scope() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_with_incorrect_endpoint_scope() {
+        let (app, _, client) = prepare().await;
         let client = client.db_new_scoped_token(
             "test-token",
             None,
@@ -254,20 +254,20 @@ mod auth {
             None,
         );
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_with_correct_crate_scope() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_with_correct_crate_scope() {
+        let (app, _, client) = prepare().await;
         let client = client.db_new_scoped_token(
             "test-token",
             Some(vec![CrateScope::try_from(CRATE_NAME).unwrap()]),
@@ -275,20 +275,20 @@ mod auth {
             None,
         );
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_with_correct_wildcard_crate_scope() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_with_correct_wildcard_crate_scope() {
+        let (app, _, client) = prepare().await;
         let wildcard = format!("{}*", CRATE_NAME.chars().next().unwrap());
         let client = client.db_new_scoped_token(
             "test-token",
@@ -297,20 +297,20 @@ mod auth {
             None,
         );
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_with_incorrect_crate_scope() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_with_incorrect_crate_scope() {
+        let (app, _, client) = prepare().await;
         let client = client.db_new_scoped_token(
             "test-token",
             Some(vec![CrateScope::try_from("foo").unwrap()]),
@@ -318,20 +318,20 @@ mod auth {
             None,
         );
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn token_user_with_incorrect_wildcard_crate_scope() {
-        let (app, _, client) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn token_user_with_incorrect_wildcard_crate_scope() {
+        let (app, _, client) = prepare().await;
         let client = client.db_new_scoped_token(
             "test-token",
             Some(vec![CrateScope::try_from("foo*").unwrap()]),
@@ -339,20 +339,20 @@ mod auth {
             None,
         );
 
-        let response = client.yank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
 
-        let response = client.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = client.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
         assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
         assert!(!is_yanked(&app));
     }
 
-    #[test]
-    fn admin() {
-        let (app, _, _) = prepare();
+    #[tokio::test(flavor = "multi_thread")]
+    async fn admin() {
+        let (app, _, _) = prepare().await;
 
         let admin = app.db_new_user("admin");
 
@@ -363,12 +363,12 @@ mod auth {
                 .unwrap();
         });
 
-        let response = admin.yank(CRATE_NAME, CRATE_VERSION);
+        let response = admin.async_yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(is_yanked(&app));
 
-        let response = admin.unyank(CRATE_NAME, CRATE_VERSION);
+        let response = admin.async_unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
         assert!(!is_yanked(&app));

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -5,36 +5,18 @@ use http::StatusCode;
 
 pub trait YankRequestHelper {
     /// Yank the specified version of the specified crate and run all pending background jobs
-    fn yank(&self, krate_name: &str, version: &str) -> Response<OkBool>;
-
-    /// Yank the specified version of the specified crate and run all pending background jobs
     async fn async_yank(&self, krate_name: &str, version: &str) -> Response<OkBool>;
-
-    /// Unyank the specified version of the specified crate and run all pending background jobs
-    fn unyank(&self, krate_name: &str, version: &str) -> Response<OkBool>;
 
     /// Unyank the specified version of the specified crate and run all pending background jobs
     async fn async_unyank(&self, krate_name: &str, version: &str) -> Response<OkBool>;
 }
 
 impl<T: RequestHelper> YankRequestHelper for T {
-    fn yank(&self, krate_name: &str, version: &str) -> Response<OkBool> {
-        self.app()
-            .runtime()
-            .block_on(self.async_yank(krate_name, version))
-    }
-
     async fn async_yank(&self, krate_name: &str, version: &str) -> Response<OkBool> {
         let url = format!("/api/v1/crates/{krate_name}/{version}/yank");
         let response = self.async_delete(&url).await;
         self.app().async_run_pending_background_jobs().await;
         response
-    }
-
-    fn unyank(&self, krate_name: &str, version: &str) -> Response<OkBool> {
-        self.app()
-            .runtime()
-            .block_on(self.async_unyank(krate_name, version))
     }
 
     async fn async_unyank(&self, krate_name: &str, version: &str) -> Response<OkBool> {

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -17,7 +17,7 @@ struct KeywordMeta {
 async fn index() {
     let url = "/api/v1/keywords";
     let (app, anon) = TestApp::init().empty();
-    let json: KeywordList = anon.async_get(url).await.good();
+    let json: KeywordList = anon.get(url).await.good();
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
 
@@ -25,7 +25,7 @@ async fn index() {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
     });
 
-    let json: KeywordList = anon.async_get(url).await.good();
+    let json: KeywordList = anon.get(url).await.good();
     assert_eq!(json.keywords.len(), 1);
     assert_eq!(json.meta.total, 1);
     assert_eq!(json.keywords[0].keyword.as_str(), "foo");

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -13,11 +13,11 @@ struct KeywordMeta {
     total: i32,
 }
 
-#[test]
-fn index() {
+#[tokio::test(flavor = "multi_thread")]
+async fn index() {
     let url = "/api/v1/keywords";
     let (app, anon) = TestApp::init().empty();
-    let json: KeywordList = anon.get(url).good();
+    let json: KeywordList = anon.async_get(url).await.good();
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
 
@@ -25,7 +25,7 @@ fn index() {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
     });
 
-    let json: KeywordList = anon.get(url).good();
+    let json: KeywordList = anon.async_get(url).await.good();
     assert_eq!(json.keywords.len(), 1);
     assert_eq!(json.meta.total, 1);
     assert_eq!(json.keywords[0].keyword.as_str(), "foo");

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -8,41 +8,44 @@ struct GoodKeyword {
     keyword: EncodableKeyword,
 }
 
-#[test]
-fn show() {
+#[tokio::test(flavor = "multi_thread")]
+async fn show() {
     let url = "/api/v1/keywords/foo";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_not_found();
+    anon.async_get(url).await.assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
     });
-    let json: GoodKeyword = anon.get(url).good();
+    let json: GoodKeyword = anon.async_get(url).await.good();
     assert_eq!(json.keyword.keyword.as_str(), "foo");
 }
 
-#[test]
-fn uppercase() {
+#[tokio::test(flavor = "multi_thread")]
+async fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
     let (app, anon) = TestApp::init().empty();
-    anon.get(url).assert_not_found();
+    anon.async_get(url).await.assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();
     });
-    let json: GoodKeyword = anon.get(url).good();
+    let json: GoodKeyword = anon.async_get(url).await.good();
     assert_eq!(json.keyword.keyword.as_str(), "upper");
 }
 
-#[test]
-fn update_crate() {
+#[tokio::test(flavor = "multi_thread")]
+async fn update_crate() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
-    let cnt = |kw: &str| {
-        let json: GoodKeyword = anon.get(&format!("/api/v1/keywords/{kw}")).good();
+    async fn cnt(kw: &str, client: &impl RequestHelper) -> usize {
+        let json: GoodKeyword = client
+            .async_get(&format!("/api/v1/keywords/{kw}"))
+            .await
+            .good();
         json.keyword.crates_cnt as usize
-    };
+    }
 
     let krate = app.db(|conn| {
         Keyword::find_or_create_all(conn, &["kw1", "kw2"]).unwrap();
@@ -52,36 +55,36 @@ fn update_crate() {
     app.db(|conn| {
         Keyword::update_crate(conn, &krate, &[]).unwrap();
     });
-    assert_eq!(cnt("kw1"), 0);
-    assert_eq!(cnt("kw2"), 0);
+    assert_eq!(cnt("kw1", &anon).await, 0);
+    assert_eq!(cnt("kw2", &anon).await, 0);
 
     app.db(|conn| {
         Keyword::update_crate(conn, &krate, &["kw1"]).unwrap();
     });
-    assert_eq!(cnt("kw1"), 1);
-    assert_eq!(cnt("kw2"), 0);
+    assert_eq!(cnt("kw1", &anon).await, 1);
+    assert_eq!(cnt("kw2", &anon).await, 0);
 
     app.db(|conn| {
         Keyword::update_crate(conn, &krate, &["kw2"]).unwrap();
     });
-    assert_eq!(cnt("kw1"), 0);
-    assert_eq!(cnt("kw2"), 1);
+    assert_eq!(cnt("kw1", &anon).await, 0);
+    assert_eq!(cnt("kw2", &anon).await, 1);
 
     app.db(|conn| {
         Keyword::update_crate(conn, &krate, &[]).unwrap();
     });
-    assert_eq!(cnt("kw1"), 0);
-    assert_eq!(cnt("kw2"), 0);
+    assert_eq!(cnt("kw1", &anon).await, 0);
+    assert_eq!(cnt("kw2", &anon).await, 0);
 
     app.db(|conn| {
         Keyword::update_crate(conn, &krate, &["kw1", "kw2"]).unwrap();
     });
-    assert_eq!(cnt("kw1"), 1);
-    assert_eq!(cnt("kw2"), 1);
+    assert_eq!(cnt("kw1", &anon).await, 1);
+    assert_eq!(cnt("kw2", &anon).await, 1);
 
     app.db(|conn| {
         Keyword::update_crate(conn, &krate, &[]).unwrap();
     });
-    assert_eq!(cnt("kw1"), 0);
-    assert_eq!(cnt("kw2"), 0);
+    assert_eq!(cnt("kw1", &anon).await, 0);
+    assert_eq!(cnt("kw2", &anon).await, 0);
 }

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -12,12 +12,12 @@ struct GoodKeyword {
 async fn show() {
     let url = "/api/v1/keywords/foo";
     let (app, anon) = TestApp::init().empty();
-    anon.async_get(url).await.assert_not_found();
+    anon.get(url).await.assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["foo"]).unwrap();
     });
-    let json: GoodKeyword = anon.async_get(url).await.good();
+    let json: GoodKeyword = anon.get(url).await.good();
     assert_eq!(json.keyword.keyword.as_str(), "foo");
 }
 
@@ -25,12 +25,12 @@ async fn show() {
 async fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
     let (app, anon) = TestApp::init().empty();
-    anon.async_get(url).await.assert_not_found();
+    anon.get(url).await.assert_not_found();
 
     app.db(|conn| {
         Keyword::find_or_create_all(conn, &["UPPER"]).unwrap();
     });
-    let json: GoodKeyword = anon.async_get(url).await.good();
+    let json: GoodKeyword = anon.get(url).await.good();
     assert_eq!(json.keyword.keyword.as_str(), "upper");
 }
 
@@ -40,10 +40,7 @@ async fn update_crate() {
     let user = user.as_model();
 
     async fn cnt(kw: &str, client: &impl RequestHelper) -> usize {
-        let json: GoodKeyword = client
-            .async_get(&format!("/api/v1/keywords/{kw}"))
-            .await
-            .good();
+        let json: GoodKeyword = client.get(&format!("/api/v1/keywords/{kw}")).await.good();
         json.keyword.crates_cnt as usize
     }
 

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -14,7 +14,7 @@ struct EmailNotificationsUpdate {
 impl crate::util::MockCookieUser {
     async fn update_email_notifications(&self, updates: Vec<EmailNotificationsUpdate>) {
         let response = self
-            .async_put::<()>("/api/v1/me/email_notifications", json!(updates).to_string())
+            .put::<()>("/api/v1/me/email_notifications", json!(updates).to_string())
             .await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
@@ -44,7 +44,7 @@ async fn test_update_email_notifications() {
         email_notifications: false,
     }])
     .await;
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
 
     assert!(
         !json
@@ -69,7 +69,7 @@ async fn test_update_email_notifications() {
         email_notifications: false,
     }])
     .await;
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
 
     assert!(
         !json
@@ -101,7 +101,7 @@ async fn test_update_email_notifications() {
         },
     ])
     .await;
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
 
     json.owned_crates.iter().for_each(|c| {
         assert!(c.email_notifications);

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -12,8 +12,10 @@ struct EmailNotificationsUpdate {
 }
 
 impl crate::util::MockCookieUser {
-    fn update_email_notifications(&self, updates: Vec<EmailNotificationsUpdate>) {
-        let response = self.put::<()>("/api/v1/me/email_notifications", json!(updates).to_string());
+    async fn update_email_notifications(&self, updates: Vec<EmailNotificationsUpdate>) {
+        let response = self
+            .async_put::<()>("/api/v1/me/email_notifications", json!(updates).to_string())
+            .await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
     }
@@ -21,8 +23,8 @@ impl crate::util::MockCookieUser {
 
 /// A user should be able to update the email notifications for crates they own. Only the crates that
 /// were sent in the request should be updated to the corresponding `email_notifications` value.
-#[test]
-fn test_update_email_notifications() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_email_notifications() {
     let (app, _, user) = TestApp::init().with_user();
 
     let my_crates = app.db(|conn| {
@@ -40,8 +42,9 @@ fn test_update_email_notifications() {
     user.update_email_notifications(vec![EmailNotificationsUpdate {
         id: a_id,
         email_notifications: false,
-    }]);
-    let json = user.show_me();
+    }])
+    .await;
+    let json = user.async_show_me().await;
 
     assert!(
         !json
@@ -64,8 +67,9 @@ fn test_update_email_notifications() {
     user.update_email_notifications(vec![EmailNotificationsUpdate {
         id: b_id,
         email_notifications: false,
-    }]);
-    let json = user.show_me();
+    }])
+    .await;
+    let json = user.async_show_me().await;
 
     assert!(
         !json
@@ -95,8 +99,9 @@ fn test_update_email_notifications() {
             id: b_id,
             email_notifications: true,
         },
-    ]);
-    let json = user.show_me();
+    ])
+    .await;
+    let json = user.async_show_me().await;
 
     json.owned_crates.iter().for_each(|c| {
         assert!(c.email_notifications);
@@ -105,8 +110,8 @@ fn test_update_email_notifications() {
 
 /// A user should not be able to update the `email_notifications` value for a crate that is not
 /// owned by them.
-#[test]
-fn test_update_email_notifications_not_owned() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_update_email_notifications_not_owned() {
     let (app, _, user) = TestApp::init().with_user();
 
     let not_my_crate = app.db(|conn| {
@@ -119,7 +124,8 @@ fn test_update_email_notifications_not_owned() {
     user.update_email_notifications(vec![EmailNotificationsUpdate {
         id: not_my_crate.id,
         email_notifications: false,
-    }]);
+    }])
+    .await;
 
     let email_notifications: bool = app
         .db(|conn| {

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -5,9 +5,9 @@ use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
 
 impl crate::util::MockCookieUser {
-    pub async fn async_show_me(&self) -> UserShowPrivateResponse {
+    pub async fn show_me(&self) -> UserShowPrivateResponse {
         let url = "/api/v1/me";
-        self.async_get(url).await.good()
+        self.get(url).await.good()
     }
 }
 
@@ -21,11 +21,11 @@ pub struct UserShowPrivateResponse {
 async fn me() {
     let (app, anon, user) = TestApp::init().with_user();
 
-    let response = anon.async_get::<()>("/api/v1/me").await;
+    let response = anon.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
-    let response = user.async_get::<()>("/api/v1/me").await;
+    let response = user.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 
@@ -33,7 +33,7 @@ async fn me() {
         CrateBuilder::new("foo_my_packages", user.as_model().id).expect_build(conn);
     });
 
-    let response = user.async_get::<()>("/api/v1/me").await;
+    let response = user.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 }
@@ -48,6 +48,6 @@ async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
         krate.owner_remove(conn, &user_model.gh_login).unwrap();
     });
 
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
     assert_eq!(json.owned_crates.len(), 0);
 }

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -6,8 +6,12 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 impl crate::util::MockCookieUser {
     pub fn show_me(&self) -> UserShowPrivateResponse {
+        self.app().runtime().block_on(self.async_show_me())
+    }
+
+    pub async fn async_show_me(&self) -> UserShowPrivateResponse {
         let url = "/api/v1/me";
-        self.get(url).good()
+        self.async_get(url).await.good()
     }
 }
 
@@ -17,15 +21,15 @@ pub struct UserShowPrivateResponse {
     pub owned_crates: Vec<OwnedCrate>,
 }
 
-#[test]
-fn me() {
+#[tokio::test(flavor = "multi_thread")]
+async fn me() {
     let (app, anon, user) = TestApp::init().with_user();
 
-    let response = anon.get::<()>("/api/v1/me");
+    let response = anon.async_get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 
-    let response = user.get::<()>("/api/v1/me");
+    let response = user.async_get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 
@@ -33,13 +37,13 @@ fn me() {
         CrateBuilder::new("foo_my_packages", user.as_model().id).expect_build(conn);
     });
 
-    let response = user.get::<()>("/api/v1/me");
+    let response = user.async_get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 }
 
-#[test]
-fn test_user_owned_crates_doesnt_include_deleted_ownership() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
     let (app, _, user) = TestApp::init().with_user();
     let user_model = user.as_model();
 
@@ -48,6 +52,6 @@ fn test_user_owned_crates_doesnt_include_deleted_ownership() {
         krate.owner_remove(conn, &user_model.gh_login).unwrap();
     });
 
-    let json = user.show_me();
+    let json = user.async_show_me().await;
     assert_eq!(json.owned_crates.len(), 0);
 }

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -5,10 +5,6 @@ use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
 
 impl crate::util::MockCookieUser {
-    pub fn show_me(&self) -> UserShowPrivateResponse {
-        self.app().runtime().block_on(self.async_show_me())
-    }
-
     pub async fn async_show_me(&self) -> UserShowPrivateResponse {
         let url = "/api/v1/me";
         self.async_get(url).await.good()

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -12,7 +12,7 @@ static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_logged_out() {
     let (_, anon) = TestApp::init().empty();
-    anon.async_put("/api/v1/me/tokens", NEW_BAR)
+    anon.put("/api/v1/me/tokens", NEW_BAR)
         .await
         .assert_forbidden();
 }
@@ -21,7 +21,7 @@ async fn create_token_logged_out() {
 async fn create_token_invalid_request() {
     let (_, _, user) = TestApp::init().with_user();
     let invalid: &[u8] = br#"{ "name": "" }"#;
-    let response = user.async_put::<()>("/api/v1/me/tokens", invalid).await;
+    let response = user.put::<()>("/api/v1/me/tokens", invalid).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -33,7 +33,7 @@ async fn create_token_invalid_request() {
 async fn create_token_no_name() {
     let (_, _, user) = TestApp::init().with_user();
     let empty_name: &[u8] = br#"{ "api_token": { "name": "" } }"#;
-    let response = user.async_put::<()>("/api/v1/me/tokens", empty_name).await;
+    let response = user.put::<()>("/api/v1/me/tokens", empty_name).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -50,7 +50,7 @@ async fn create_token_exceeded_tokens_per_user() {
             assert_ok!(ApiToken::insert(conn, id, &format!("token {i}")));
         }
     });
-    let response = user.async_put::<()>("/api/v1/me/tokens", NEW_BAR).await;
+    let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -62,7 +62,7 @@ async fn create_token_exceeded_tokens_per_user() {
 async fn create_token_success() {
     let (app, _, user) = TestApp::init().with_user();
 
-    let response = user.async_put::<()>("/api/v1/me/tokens", NEW_BAR).await;
+    let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
@@ -87,8 +87,8 @@ async fn create_token_success() {
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_multiple_have_different_values() {
     let (_, _, user) = TestApp::init().with_user();
-    let first: Value = user.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
-    let second: Value = user.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
+    let first: Value = user.put("/api/v1/me/tokens", NEW_BAR).await.good();
+    let second: Value = user.put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     assert_eq!(first["api_token"]["name"], second["api_token"]["name"]);
     assert_ne!(first["api_token"]["token"], second["api_token"]["token"]);
@@ -97,10 +97,10 @@ async fn create_token_multiple_have_different_values() {
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_multiple_users_have_different_values() {
     let (app, _, user1) = TestApp::init().with_user();
-    let first: Value = user1.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
+    let first: Value = user1.put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     let user2 = app.db_new_user("bar");
-    let second: Value = user2.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
+    let second: Value = user2.put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     assert_ne!(first["api_token"]["token"], second["api_token"]["token"]);
 }
@@ -109,7 +109,7 @@ async fn create_token_multiple_users_have_different_values() {
 async fn cannot_create_token_with_token() {
     let (_, _, _, token) = TestApp::init().with_token();
     let response = token
-        .async_put::<()>(
+        .put::<()>(
             "/api/v1/me/tokens",
             br#"{ "api_token": { "name": "baz" } }"# as &[u8],
         )
@@ -134,7 +134,7 @@ async fn create_token_with_scopes() {
     });
 
     let response = user
-        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -179,7 +179,7 @@ async fn create_token_with_null_scopes() {
     });
 
     let response = user
-        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
@@ -215,7 +215,7 @@ async fn create_token_with_empty_crate_scope() {
     });
 
     let response = user
-        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
@@ -237,7 +237,7 @@ async fn create_token_with_invalid_endpoint_scope() {
     });
 
     let response = user
-        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
@@ -260,7 +260,7 @@ async fn create_token_with_expiry_date() {
     });
 
     let response = user
-        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -9,17 +9,19 @@ use serde_json::Value;
 
 static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;
 
-#[test]
-fn create_token_logged_out() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_logged_out() {
     let (_, anon) = TestApp::init().empty();
-    anon.put("/api/v1/me/tokens", NEW_BAR).assert_forbidden();
+    anon.async_put("/api/v1/me/tokens", NEW_BAR)
+        .await
+        .assert_forbidden();
 }
 
-#[test]
-fn create_token_invalid_request() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_invalid_request() {
     let (_, _, user) = TestApp::init().with_user();
     let invalid: &[u8] = br#"{ "name": "" }"#;
-    let response = user.put::<()>("/api/v1/me/tokens", invalid);
+    let response = user.async_put::<()>("/api/v1/me/tokens", invalid).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -27,11 +29,11 @@ fn create_token_invalid_request() {
     );
 }
 
-#[test]
-fn create_token_no_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_no_name() {
     let (_, _, user) = TestApp::init().with_user();
     let empty_name: &[u8] = br#"{ "api_token": { "name": "" } }"#;
-    let response = user.put::<()>("/api/v1/me/tokens", empty_name);
+    let response = user.async_put::<()>("/api/v1/me/tokens", empty_name).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -39,8 +41,8 @@ fn create_token_no_name() {
     );
 }
 
-#[test]
-fn create_token_exceeded_tokens_per_user() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_exceeded_tokens_per_user() {
     let (app, _, user) = TestApp::init().with_user();
     let id = user.as_model().id;
     app.db(|conn| {
@@ -48,7 +50,7 @@ fn create_token_exceeded_tokens_per_user() {
             assert_ok!(ApiToken::insert(conn, id, &format!("token {i}")));
         }
     });
-    let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR);
+    let response = user.async_put::<()>("/api/v1/me/tokens", NEW_BAR).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -56,11 +58,11 @@ fn create_token_exceeded_tokens_per_user() {
     );
 }
 
-#[test]
-fn create_token_success() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_success() {
     let (app, _, user) = TestApp::init().with_user();
 
-    let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR);
+    let response = user.async_put::<()>("/api/v1/me/tokens", NEW_BAR).await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
@@ -82,34 +84,36 @@ fn create_token_success() {
     assert_eq!(tokens[0].endpoint_scopes, None);
 }
 
-#[test]
-fn create_token_multiple_have_different_values() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_multiple_have_different_values() {
     let (_, _, user) = TestApp::init().with_user();
-    let first: Value = user.put("/api/v1/me/tokens", NEW_BAR).good();
-    let second: Value = user.put("/api/v1/me/tokens", NEW_BAR).good();
+    let first: Value = user.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
+    let second: Value = user.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     assert_eq!(first["api_token"]["name"], second["api_token"]["name"]);
     assert_ne!(first["api_token"]["token"], second["api_token"]["token"]);
 }
 
-#[test]
-fn create_token_multiple_users_have_different_values() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_multiple_users_have_different_values() {
     let (app, _, user1) = TestApp::init().with_user();
-    let first: Value = user1.put("/api/v1/me/tokens", NEW_BAR).good();
+    let first: Value = user1.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     let user2 = app.db_new_user("bar");
-    let second: Value = user2.put("/api/v1/me/tokens", NEW_BAR).good();
+    let second: Value = user2.async_put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     assert_ne!(first["api_token"]["token"], second["api_token"]["token"]);
 }
 
-#[test]
-fn cannot_create_token_with_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn cannot_create_token_with_token() {
     let (_, _, _, token) = TestApp::init().with_token();
-    let response = token.put::<()>(
-        "/api/v1/me/tokens",
-        br#"{ "api_token": { "name": "baz" } }"# as &[u8],
-    );
+    let response = token
+        .async_put::<()>(
+            "/api/v1/me/tokens",
+            br#"{ "api_token": { "name": "baz" } }"# as &[u8],
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -117,8 +121,8 @@ fn cannot_create_token_with_token() {
     );
 }
 
-#[test]
-fn create_token_with_scopes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_with_scopes() {
     let (app, _, user) = TestApp::init().with_user();
 
     let json = json!({
@@ -129,7 +133,9 @@ fn create_token_with_scopes() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
+    let response = user
+        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
@@ -160,8 +166,8 @@ fn create_token_with_scopes() {
     );
 }
 
-#[test]
-fn create_token_with_null_scopes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_with_null_scopes() {
     let (app, _, user) = TestApp::init().with_user();
 
     let json = json!({
@@ -172,7 +178,9 @@ fn create_token_with_null_scopes() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
+    let response = user
+        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),
@@ -194,8 +202,8 @@ fn create_token_with_null_scopes() {
     assert_eq!(tokens[0].endpoint_scopes, None);
 }
 
-#[test]
-fn create_token_with_empty_crate_scope() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_with_empty_crate_scope() {
     let (_, _, user) = TestApp::init().with_user();
 
     let json = json!({
@@ -206,7 +214,9 @@ fn create_token_with_empty_crate_scope() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
+    let response = user
+        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -214,8 +224,8 @@ fn create_token_with_empty_crate_scope() {
     );
 }
 
-#[test]
-fn create_token_with_invalid_endpoint_scope() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_with_invalid_endpoint_scope() {
     let (_, _, user) = TestApp::init().with_user();
 
     let json = json!({
@@ -226,7 +236,9 @@ fn create_token_with_invalid_endpoint_scope() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
+    let response = user
+        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -234,8 +246,8 @@ fn create_token_with_invalid_endpoint_scope() {
     );
 }
 
-#[test]
-fn create_token_with_expiry_date() {
+#[tokio::test(flavor = "multi_thread")]
+async fn create_token_with_expiry_date() {
     let (_app, _, user) = TestApp::init().with_user();
 
     let json = json!({
@@ -247,7 +259,9 @@ fn create_token_with_expiry_date() {
         }
     });
 
-    let response = user.put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap());
+    let response = user
+        .async_put::<()>("/api/v1/me/tokens", serde_json::to_vec(&json).unwrap())
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".api_token.id" => insta::any_id_redaction(),

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -9,7 +9,7 @@ pub struct RevokedResponse {}
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_token_non_existing() {
     let (_, _, user) = TestApp::init().with_user();
-    let _json: RevokedResponse = user.async_delete("/api/v1/me/tokens/5").await.good();
+    let _json: RevokedResponse = user.delete("/api/v1/me/tokens/5").await.good();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -30,7 +30,7 @@ async fn revoke_token_doesnt_revoke_other_users_token() {
 
     // Try revoke the token as second user
     let _json: RevokedResponse = user2
-        .async_delete(&format!("/api/v1/me/tokens/{}", token.id))
+        .delete(&format!("/api/v1/me/tokens/{}", token.id))
         .await
         .good();
 
@@ -59,7 +59,7 @@ async fn revoke_token_success() {
 
     // Revoke the token
     let _json: RevokedResponse = user
-        .async_delete(&format!("/api/v1/me/tokens/{}", token.as_model().id))
+        .delete(&format!("/api/v1/me/tokens/{}", token.as_model().id))
         .await
         .good();
 

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -6,14 +6,14 @@ use diesel::prelude::*;
 #[derive(Deserialize)]
 pub struct RevokedResponse {}
 
-#[test]
-fn revoke_token_non_existing() {
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_token_non_existing() {
     let (_, _, user) = TestApp::init().with_user();
-    let _json: RevokedResponse = user.delete("/api/v1/me/tokens/5").good();
+    let _json: RevokedResponse = user.async_delete("/api/v1/me/tokens/5").await.good();
 }
 
-#[test]
-fn revoke_token_doesnt_revoke_other_users_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_token_doesnt_revoke_other_users_token() {
     let (app, _, user1, token) = TestApp::init().with_token();
     let user1 = user1.as_model();
     let token = token.as_model();
@@ -30,7 +30,8 @@ fn revoke_token_doesnt_revoke_other_users_token() {
 
     // Try revoke the token as second user
     let _json: RevokedResponse = user2
-        .delete(&format!("/api/v1/me/tokens/{}", token.id))
+        .async_delete(&format!("/api/v1/me/tokens/{}", token.id))
+        .await
         .good();
 
     // List tokens for first user still contains the token
@@ -43,8 +44,8 @@ fn revoke_token_doesnt_revoke_other_users_token() {
     });
 }
 
-#[test]
-fn revoke_token_success() {
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_token_success() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     // List tokens contains the token
@@ -58,7 +59,8 @@ fn revoke_token_success() {
 
     // Revoke the token
     let _json: RevokedResponse = user
-        .delete(&format!("/api/v1/me/tokens/{}", token.as_model().id))
+        .async_delete(&format!("/api/v1/me/tokens/{}", token.as_model().id))
+        .await
         .good();
 
     // List tokens no longer contains the token

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -5,8 +5,8 @@ use diesel::prelude::*;
 use http::StatusCode;
 use insta::assert_snapshot;
 
-#[test]
-fn revoke_current_token_success() {
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_current_token_success() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     // Ensure that the token currently exists in the database
@@ -20,7 +20,7 @@ fn revoke_current_token_success() {
     });
 
     // Revoke the token
-    let response = token.delete::<()>("/api/v1/tokens/current");
+    let response = token.async_delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
     // Ensure that the token was removed from the database
@@ -33,17 +33,17 @@ fn revoke_current_token_success() {
     });
 }
 
-#[test]
-fn revoke_current_token_without_auth() {
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_current_token_without_auth() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.delete::<()>("/api/v1/tokens/current");
+    let response = anon.async_delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
 
-#[test]
-fn revoke_current_token_with_cookie_user() {
+#[tokio::test(flavor = "multi_thread")]
+async fn revoke_current_token_with_cookie_user() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     // Ensure that the token currently exists in the database
@@ -57,7 +57,7 @@ fn revoke_current_token_with_cookie_user() {
     });
 
     // Revoke the token
-    let response = user.delete::<()>("/api/v1/tokens/current");
+    let response = user.async_delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -20,7 +20,7 @@ async fn revoke_current_token_success() {
     });
 
     // Revoke the token
-    let response = token.async_delete::<()>("/api/v1/tokens/current").await;
+    let response = token.delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
 
     // Ensure that the token was removed from the database
@@ -37,7 +37,7 @@ async fn revoke_current_token_success() {
 async fn revoke_current_token_without_auth() {
     let (_, anon) = TestApp::init().empty();
 
-    let response = anon.async_delete::<()>("/api/v1/tokens/current").await;
+    let response = anon.delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
@@ -57,7 +57,7 @@ async fn revoke_current_token_with_cookie_user() {
     });
 
     // Revoke the token
-    let response = user.async_delete::<()>("/api/v1/tokens/current").await;
+    let response = user.delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -5,30 +5,33 @@ use crates_io::models::token::{CrateScope, EndpointScope};
 use crates_io::models::ApiToken;
 use http::StatusCode;
 
-#[test]
-fn list_logged_out() {
+#[tokio::test(flavor = "multi_thread")]
+async fn list_logged_out() {
     let (_, anon) = TestApp::init().empty();
-    anon.get("/api/v1/me/tokens").assert_forbidden();
+    anon.async_get("/api/v1/me/tokens").await.assert_forbidden();
 }
 
-#[test]
-fn list_with_api_token_is_forbidden() {
+#[tokio::test(flavor = "multi_thread")]
+async fn list_with_api_token_is_forbidden() {
     let (_, _, _, token) = TestApp::init().with_token();
-    token.get("/api/v1/me/tokens").assert_forbidden();
+    token
+        .async_get("/api/v1/me/tokens")
+        .await
+        .assert_forbidden();
 }
 
-#[test]
-fn list_empty() {
+#[tokio::test(flavor = "multi_thread")]
+async fn list_empty() {
     let (_, _, user) = TestApp::init().with_user();
-    let response = user.get::<()>("/api/v1/me/tokens");
+    let response = user.async_get::<()>("/api/v1/me/tokens").await;
     assert_eq!(response.status(), StatusCode::OK);
     let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
     assert_eq!(response_tokens.len(), 0);
 }
 
-#[test]
-fn list_tokens() {
+#[tokio::test(flavor = "multi_thread")]
+async fn list_tokens() {
     let (app, _, user) = TestApp::init().with_user();
     let id = user.as_model().id;
     app.db(|conn| {
@@ -56,7 +59,7 @@ fn list_tokens() {
         ]
     });
 
-    let response = user.get::<()>("/api/v1/me/tokens");
+    let response = user.async_get::<()>("/api/v1/me/tokens").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json(), {
         ".api_tokens[].id" => insta::any_id_redaction(),
@@ -65,8 +68,8 @@ fn list_tokens() {
     });
 }
 
-#[test]
-fn list_recently_expired_tokens() {
+#[tokio::test(flavor = "multi_thread")]
+async fn list_recently_expired_tokens() {
     #[track_caller]
     fn assert_response_tokens_contain_name(response_tokens: &[serde_json::Value], name: &str) {
         assert_some!(response_tokens.iter().find(|token| token["name"] == name));
@@ -99,7 +102,9 @@ fn list_recently_expired_tokens() {
         ]
     });
 
-    let response = user.get::<()>("/api/v1/me/tokens?expired_days=30");
+    let response = user
+        .async_get::<()>("/api/v1/me/tokens?expired_days=30")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
@@ -107,7 +112,9 @@ fn list_recently_expired_tokens() {
     assert_response_tokens_contain_name(response_tokens, "bar");
     assert_response_tokens_contain_name(response_tokens, "recent");
 
-    let response = user.get::<()>("/api/v1/me/tokens?expired_days=60");
+    let response = user
+        .async_get::<()>("/api/v1/me/tokens?expired_days=60")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
@@ -117,8 +124,8 @@ fn list_recently_expired_tokens() {
     assert_response_tokens_contain_name(response_tokens, "recent");
 }
 
-#[test]
-fn list_tokens_exclude_revoked() {
+#[tokio::test(flavor = "multi_thread")]
+async fn list_tokens_exclude_revoked() {
     let (app, _, user) = TestApp::init().with_user();
     let id = user.as_model().id;
     let tokens = app.db(|conn| {
@@ -129,18 +136,20 @@ fn list_tokens_exclude_revoked() {
     });
 
     // List tokens expecting them all to be there.
-    let response = user.get::<()>("/api/v1/me/tokens");
+    let response = user.async_get::<()>("/api/v1/me/tokens").await;
     assert_eq!(response.status(), StatusCode::OK);
     let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();
     assert_eq!(response_tokens.len(), 2);
 
     // Revoke the first token.
-    let response = user.delete::<()>(&format!("/api/v1/me/tokens/{}", tokens[0].model.id));
+    let response = user
+        .async_delete::<()>(&format!("/api/v1/me/tokens/{}", tokens[0].model.id))
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Check that we now have one less token being listed.
-    let response = user.get::<()>("/api/v1/me/tokens");
+    let response = user.async_get::<()>("/api/v1/me/tokens").await;
     assert_eq!(response.status(), StatusCode::OK);
     let json = response.json();
     let response_tokens = json["api_tokens"].as_array().unwrap();

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -11,10 +11,7 @@ use http::StatusCode;
 #[tokio::test(flavor = "multi_thread")]
 async fn api_token_cannot_get_user_updates() {
     let (_, _, _, token) = TestApp::init().with_token();
-    token
-        .async_get("/api/v1/me/updates")
-        .await
-        .assert_forbidden();
+    token.get("/api/v1/me/updates").await.assert_forbidden();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -50,18 +47,18 @@ async fn following() {
             .expect_build(conn);
     });
 
-    let r: R = user.async_get("/api/v1/me/updates").await.good();
+    let r: R = user.get("/api/v1/me/updates").await.good();
     assert_that!(r.versions, empty());
     assert!(!r.meta.more);
 
-    user.async_put::<OkBool>("/api/v1/crates/foo_fighters/follow", b"" as &[u8])
+    user.put::<OkBool>("/api/v1/crates/foo_fighters/follow", b"" as &[u8])
         .await
         .good();
-    user.async_put::<OkBool>("/api/v1/crates/bar_fighters/follow", b"" as &[u8])
+    user.put::<OkBool>("/api/v1/crates/bar_fighters/follow", b"" as &[u8])
         .await
         .good();
 
-    let r: R = user.async_get("/api/v1/me/updates").await.good();
+    let r: R = user.get("/api/v1/me/updates").await.good();
     assert_that!(r.versions, len(eq(2)));
     assert!(!r.meta.more);
     let foo_version = r
@@ -81,24 +78,24 @@ async fn following() {
     );
 
     let r: R = user
-        .async_get_with_query("/api/v1/me/updates", "per_page=1")
+        .get_with_query("/api/v1/me/updates", "per_page=1")
         .await
         .good();
     assert_that!(r.versions, len(eq(1)));
     assert!(r.meta.more);
 
-    user.async_delete::<OkBool>("/api/v1/crates/bar_fighters/follow")
+    user.delete::<OkBool>("/api/v1/crates/bar_fighters/follow")
         .await
         .good();
     let r: R = user
-        .async_get_with_query("/api/v1/me/updates", "page=2&per_page=1")
+        .get_with_query("/api/v1/me/updates", "page=2&per_page=1")
         .await
         .good();
     assert_that!(r.versions, empty());
     assert!(!r.meta.more);
 
     let response = user
-        .async_get_with_query::<()>("/api/v1/me/updates", "page=0")
+        .get_with_query::<()>("/api/v1/me/updates", "page=0")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(

--- a/src/tests/routes/metrics.rs
+++ b/src/tests/routes/metrics.rs
@@ -2,84 +2,88 @@ use crate::util::{MockAnonymousUser, MockRequestExt, Response};
 use crate::{RequestHelper, TestApp};
 use http::StatusCode;
 
-#[test]
-fn metrics_endpoint_works() {
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_endpoint_works() {
     let (_, anon) = TestApp::init()
         .with_config(|config| config.metrics_authorization_token = Some("foobar".into()))
         .empty();
 
-    let resp = request_metrics(&anon, "service", Some("foobar"));
+    let resp = request_metrics(&anon, "service", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let resp = request_metrics(&anon, "instance", Some("foobar"));
+    let resp = request_metrics(&anon, "instance", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::OK);
 
-    let resp = request_metrics(&anon, "missing", Some("foobar"));
+    let resp = request_metrics(&anon, "missing", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-#[test]
-fn metrics_endpoint_wrong_auth() {
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_endpoint_wrong_auth() {
     let (_, anon) = TestApp::init()
         .with_config(|config| config.metrics_authorization_token = Some("secret".into()))
         .empty();
 
     // Wrong secret
 
-    let resp = request_metrics(&anon, "service", Some("foobar"));
+    let resp = request_metrics(&anon, "service", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-    let resp = request_metrics(&anon, "instance", Some("foobar"));
+    let resp = request_metrics(&anon, "instance", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-    let resp = request_metrics(&anon, "missing", Some("foobar"));
+    let resp = request_metrics(&anon, "missing", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     // No secret
 
-    let resp = request_metrics(&anon, "service", None);
+    let resp = request_metrics(&anon, "service", None).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-    let resp = request_metrics(&anon, "instance", None);
+    let resp = request_metrics(&anon, "instance", None).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-    let resp = request_metrics(&anon, "missing", None);
+    let resp = request_metrics(&anon, "missing", None).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
-#[test]
-fn metrics_endpoint_auth_disabled() {
+#[tokio::test(flavor = "multi_thread")]
+async fn metrics_endpoint_auth_disabled() {
     let (_, anon) = TestApp::init()
         .with_config(|config| config.metrics_authorization_token = None)
         .empty();
 
     // Wrong secret
 
-    let resp = request_metrics(&anon, "service", Some("foobar"));
+    let resp = request_metrics(&anon, "service", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
-    let resp = request_metrics(&anon, "instance", Some("foobar"));
+    let resp = request_metrics(&anon, "instance", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
-    let resp = request_metrics(&anon, "missing", Some("foobar"));
+    let resp = request_metrics(&anon, "missing", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
     // No secret
 
-    let resp = request_metrics(&anon, "service", None);
+    let resp = request_metrics(&anon, "service", None).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
-    let resp = request_metrics(&anon, "instance", None);
+    let resp = request_metrics(&anon, "instance", None).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 
-    let resp = request_metrics(&anon, "missing", None);
+    let resp = request_metrics(&anon, "missing", None).await;
     assert_eq!(resp.status(), StatusCode::NOT_FOUND);
 }
 
-fn request_metrics(anon: &MockAnonymousUser, kind: &str, token: Option<&str>) -> Response<()> {
+async fn request_metrics(
+    anon: &MockAnonymousUser,
+    kind: &str,
+    token: Option<&str>,
+) -> Response<()> {
     let mut req = anon.get_request(&format!("/api/private/metrics/{kind}"));
     if let Some(token) = token {
         req.header("Authorization", &format!("Bearer {token}"));
     }
-    anon.run(req)
+    anon.async_run(req).await
 }

--- a/src/tests/routes/metrics.rs
+++ b/src/tests/routes/metrics.rs
@@ -85,5 +85,5 @@ async fn request_metrics(
     if let Some(token) = token {
         req.header("Authorization", &format!("Bearer {token}"));
     }
-    anon.async_run(req).await
+    anon.run(req).await
 }

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -17,7 +17,7 @@ struct CrateOwnerInvitationsMeta {
 }
 
 async fn get_invitations(user: &MockCookieUser, query: &str) -> CrateOwnerInvitationsResponse {
-    user.async_get_with_query::<CrateOwnerInvitationsResponse>(
+    user.get_with_query::<CrateOwnerInvitationsResponse>(
         "/api/private/crate_owner_invitations",
         query,
     )
@@ -37,18 +37,9 @@ async fn invitation_list() {
     });
     let user1 = app.db_new_user("user_1");
     let user2 = app.db_new_user("user_2");
-    token
-        .async_add_named_owner("crate_1", "user_1")
-        .await
-        .good();
-    token
-        .async_add_named_owner("crate_1", "user_2")
-        .await
-        .good();
-    token
-        .async_add_named_owner("crate_2", "user_1")
-        .await
-        .good();
+    token.add_named_owner("crate_1", "user_1").await.good();
+    token.add_named_owner("crate_1", "user_2").await.good();
+    token.add_named_owner("crate_2", "user_1").await.good();
 
     // user1 has invites for both crates
     let invitations = get_invitations(&user1, &format!("invitee_id={}", user1.as_model().id)).await;
@@ -185,11 +176,11 @@ async fn invitations_list_does_not_include_expired_invites() {
         )
     });
     token
-        .async_add_named_owner("crate_1", "invited_user")
+        .add_named_owner("crate_1", "invited_user")
         .await
         .good();
     token
-        .async_add_named_owner("crate_2", "invited_user")
+        .add_named_owner("crate_2", "invited_user")
         .await
         .good();
 
@@ -231,11 +222,11 @@ async fn invitations_list_paginated() {
         )
     });
     token
-        .async_add_named_owner("crate_1", "invited_user")
+        .add_named_owner("crate_1", "invited_user")
         .await
         .good();
     token
-        .async_add_named_owner("crate_2", "invited_user")
+        .add_named_owner("crate_2", "invited_user")
         .await
         .good();
 
@@ -300,7 +291,7 @@ async fn invitation_list_with_no_filter() {
     let (_, _, owner, _) = TestApp::init().with_token();
 
     let resp = owner
-        .async_get::<()>("/api/private/crate_owner_invitations")
+        .get::<()>("/api/private/crate_owner_invitations")
         .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
@@ -320,7 +311,7 @@ async fn invitation_list_other_users() {
 
     // Retrieving our own invitations work.
     let resp = owner
-        .async_get_with_query::<()>(
+        .get_with_query::<()>(
             "/api/private/crate_owner_invitations",
             &format!("invitee_id={}", owner.as_model().id),
         )
@@ -329,7 +320,7 @@ async fn invitation_list_other_users() {
 
     // Retrieving other users' invitations doesn't work.
     let resp = owner
-        .async_get_with_query::<()>(
+        .get_with_query::<()>(
             "/api/private/crate_owner_invitations",
             &format!("invitee_id={}", other_user.as_model().id),
         )
@@ -348,13 +339,13 @@ async fn invitation_list_other_crates() {
 
     // Retrieving our own invitations work.
     let resp = owner
-        .async_get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_1")
+        .get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_1")
         .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     // Retrieving other users' invitations doesn't work.
     let resp = owner
-        .async_get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_2")
+        .get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_2")
         .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -37,9 +37,9 @@ fn invitation_list() {
     });
     let user1 = app.db_new_user("user_1");
     let user2 = app.db_new_user("user_2");
-    token.add_user_owner("crate_1", "user_1");
-    token.add_user_owner("crate_1", "user_2");
-    token.add_user_owner("crate_2", "user_1");
+    token.add_named_owner("crate_1", "user_1").good();
+    token.add_named_owner("crate_1", "user_2").good();
+    token.add_named_owner("crate_2", "user_1").good();
 
     // user1 has invites for both crates
     let invitations = get_invitations(&user1, &format!("invitee_id={}", user1.as_model().id));
@@ -175,8 +175,8 @@ fn invitations_list_does_not_include_expired_invites() {
             CrateBuilder::new("crate_2", owner.as_model().id).expect_build(conn),
         )
     });
-    token.add_user_owner("crate_1", "invited_user");
-    token.add_user_owner("crate_2", "invited_user");
+    token.add_named_owner("crate_1", "invited_user").good();
+    token.add_named_owner("crate_2", "invited_user").good();
 
     // Simulate one of the invitations expiring
     crate::owners::expire_invitation(&app, crate1.id);
@@ -215,8 +215,8 @@ fn invitations_list_paginated() {
             CrateBuilder::new("crate_2", owner.as_model().id).expect_build(conn),
         )
     });
-    token.add_user_owner("crate_1", "invited_user");
-    token.add_user_owner("crate_2", "invited_user");
+    token.add_named_owner("crate_1", "invited_user").good();
+    token.add_named_owner("crate_2", "invited_user").good();
 
     // Fetch the first page of results
     let invitations = get_invitations(

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -16,17 +16,17 @@ struct CrateOwnerInvitationsMeta {
     next_page: Option<String>,
 }
 
-#[track_caller]
-fn get_invitations(user: &MockCookieUser, query: &str) -> CrateOwnerInvitationsResponse {
-    user.get_with_query::<CrateOwnerInvitationsResponse>(
+async fn get_invitations(user: &MockCookieUser, query: &str) -> CrateOwnerInvitationsResponse {
+    user.async_get_with_query::<CrateOwnerInvitationsResponse>(
         "/api/private/crate_owner_invitations",
         query,
     )
+    .await
     .good()
 }
 
-#[test]
-fn invitation_list() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invitation_list() {
     let (app, _, owner, token) = TestApp::init().with_token();
 
     let (crate1, crate2) = app.db(|conn| {
@@ -37,12 +37,21 @@ fn invitation_list() {
     });
     let user1 = app.db_new_user("user_1");
     let user2 = app.db_new_user("user_2");
-    token.add_named_owner("crate_1", "user_1").good();
-    token.add_named_owner("crate_1", "user_2").good();
-    token.add_named_owner("crate_2", "user_1").good();
+    token
+        .async_add_named_owner("crate_1", "user_1")
+        .await
+        .good();
+    token
+        .async_add_named_owner("crate_1", "user_2")
+        .await
+        .good();
+    token
+        .async_add_named_owner("crate_2", "user_1")
+        .await
+        .good();
 
     // user1 has invites for both crates
-    let invitations = get_invitations(&user1, &format!("invitee_id={}", user1.as_model().id));
+    let invitations = get_invitations(&user1, &format!("invitee_id={}", user1.as_model().id)).await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -75,7 +84,7 @@ fn invitation_list() {
     );
 
     // user2 is only invited to a single crate
-    let invitations = get_invitations(&user2, &format!("invitee_id={}", user2.as_model().id));
+    let invitations = get_invitations(&user2, &format!("invitee_id={}", user2.as_model().id)).await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -97,7 +106,7 @@ fn invitation_list() {
     );
 
     // owner has no invites
-    let invitations = get_invitations(&owner, &format!("invitee_id={}", owner.as_model().id));
+    let invitations = get_invitations(&owner, &format!("invitee_id={}", owner.as_model().id)).await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -108,7 +117,7 @@ fn invitation_list() {
     );
 
     // crate1 has two available invitations
-    let invitations = get_invitations(&owner, "crate_name=crate_1");
+    let invitations = get_invitations(&owner, "crate_name=crate_1").await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -142,7 +151,7 @@ fn invitation_list() {
     );
 
     // crate2 has one available invitation
-    let invitations = get_invitations(&owner, "crate_name=crate_2");
+    let invitations = get_invitations(&owner, "crate_name=crate_2").await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -164,8 +173,8 @@ fn invitation_list() {
     );
 }
 
-#[test]
-fn invitations_list_does_not_include_expired_invites() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invitations_list_does_not_include_expired_invites() {
     let (app, _, owner, token) = TestApp::init().with_token();
     let user = app.db_new_user("invited_user");
 
@@ -175,14 +184,20 @@ fn invitations_list_does_not_include_expired_invites() {
             CrateBuilder::new("crate_2", owner.as_model().id).expect_build(conn),
         )
     });
-    token.add_named_owner("crate_1", "invited_user").good();
-    token.add_named_owner("crate_2", "invited_user").good();
+    token
+        .async_add_named_owner("crate_1", "invited_user")
+        .await
+        .good();
+    token
+        .async_add_named_owner("crate_2", "invited_user")
+        .await
+        .good();
 
     // Simulate one of the invitations expiring
     crate::owners::expire_invitation(&app, crate1.id);
 
     // user1 has an invite just for crate 2
-    let invitations = get_invitations(&user, &format!("invitee_id={}", user.as_model().id));
+    let invitations = get_invitations(&user, &format!("invitee_id={}", user.as_model().id)).await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -204,8 +219,8 @@ fn invitations_list_does_not_include_expired_invites() {
     );
 }
 
-#[test]
-fn invitations_list_paginated() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invitations_list_paginated() {
     let (app, _, owner, token) = TestApp::init().with_token();
     let user = app.db_new_user("invited_user");
 
@@ -215,14 +230,21 @@ fn invitations_list_paginated() {
             CrateBuilder::new("crate_2", owner.as_model().id).expect_build(conn),
         )
     });
-    token.add_named_owner("crate_1", "invited_user").good();
-    token.add_named_owner("crate_2", "invited_user").good();
+    token
+        .async_add_named_owner("crate_1", "invited_user")
+        .await
+        .good();
+    token
+        .async_add_named_owner("crate_2", "invited_user")
+        .await
+        .good();
 
     // Fetch the first page of results
     let invitations = get_invitations(
         &user,
         &format!("per_page=1&invitee_id={}", user.as_model().id),
-    );
+    )
+    .await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -250,7 +272,8 @@ fn invitations_list_paginated() {
     let invitations = get_invitations(
         &user,
         invitations.meta.next_page.unwrap().trim_start_matches('?'),
-    );
+    )
+    .await;
     assert_eq!(
         invitations,
         CrateOwnerInvitationsResponse {
@@ -272,11 +295,13 @@ fn invitations_list_paginated() {
     );
 }
 
-#[test]
-fn invitation_list_with_no_filter() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invitation_list_with_no_filter() {
     let (_, _, owner, _) = TestApp::init().with_token();
 
-    let resp = owner.get::<()>("/api/private/crate_owner_invitations");
+    let resp = owner
+        .async_get::<()>("/api/private/crate_owner_invitations")
+        .await;
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         resp.json(),
@@ -288,28 +313,32 @@ fn invitation_list_with_no_filter() {
     );
 }
 
-#[test]
-fn invitation_list_other_users() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invitation_list_other_users() {
     let (app, _, owner, _) = TestApp::init().with_token();
     let other_user = app.db_new_user("other");
 
     // Retrieving our own invitations work.
-    let resp = owner.get_with_query::<()>(
-        "/api/private/crate_owner_invitations",
-        &format!("invitee_id={}", owner.as_model().id),
-    );
+    let resp = owner
+        .async_get_with_query::<()>(
+            "/api/private/crate_owner_invitations",
+            &format!("invitee_id={}", owner.as_model().id),
+        )
+        .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     // Retrieving other users' invitations doesn't work.
-    let resp = owner.get_with_query::<()>(
-        "/api/private/crate_owner_invitations",
-        &format!("invitee_id={}", other_user.as_model().id),
-    );
+    let resp = owner
+        .async_get_with_query::<()>(
+            "/api/private/crate_owner_invitations",
+            &format!("invitee_id={}", other_user.as_model().id),
+        )
+        .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
-#[test]
-fn invitation_list_other_crates() {
+#[tokio::test(flavor = "multi_thread")]
+async fn invitation_list_other_crates() {
     let (app, _, owner, _) = TestApp::init().with_token();
     let other_user = app.db_new_user("other");
     app.db(|conn| {
@@ -318,12 +347,14 @@ fn invitation_list_other_crates() {
     });
 
     // Retrieving our own invitations work.
-    let resp =
-        owner.get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_1");
+    let resp = owner
+        .async_get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_1")
+        .await;
     assert_eq!(resp.status(), StatusCode::OK);
 
     // Retrieving other users' invitations doesn't work.
-    let resp =
-        owner.get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_2");
+    let resp = owner
+        .async_get_with_query::<()>("/api/private/crate_owner_invitations", "crate_name=crate_2")
+        .await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }

--- a/src/tests/routes/session/authorize.rs
+++ b/src/tests/routes/session/authorize.rs
@@ -1,10 +1,10 @@
 use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
 
-#[test]
-fn access_token_needs_data() {
+#[tokio::test(flavor = "multi_thread")]
+async fn access_token_needs_data() {
     let (_, anon) = TestApp::init().empty();
-    let response = anon.get::<()>("/api/private/session/authorize");
+    let response = anon.async_get::<()>("/api/private/session/authorize").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),

--- a/src/tests/routes/session/authorize.rs
+++ b/src/tests/routes/session/authorize.rs
@@ -4,7 +4,7 @@ use http::StatusCode;
 #[tokio::test(flavor = "multi_thread")]
 async fn access_token_needs_data() {
     let (_, anon) = TestApp::init().empty();
-    let response = anon.async_get::<()>("/api/private/session/authorize").await;
+    let response = anon.get::<()>("/api/private/session/authorize").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),

--- a/src/tests/routes/session/begin.rs
+++ b/src/tests/routes/session/begin.rs
@@ -9,6 +9,6 @@ struct AuthResponse {
 #[tokio::test(flavor = "multi_thread")]
 async fn auth_gives_a_token() {
     let (_, anon) = TestApp::init().empty();
-    let json: AuthResponse = anon.async_get("/api/private/session/begin").await.good();
+    let json: AuthResponse = anon.get("/api/private/session/begin").await.good();
     assert!(json.url.contains(&json.state));
 }

--- a/src/tests/routes/session/begin.rs
+++ b/src/tests/routes/session/begin.rs
@@ -6,9 +6,9 @@ struct AuthResponse {
     state: String,
 }
 
-#[test]
-fn auth_gives_a_token() {
+#[tokio::test(flavor = "multi_thread")]
+async fn auth_gives_a_token() {
     let (_, anon) = TestApp::init().empty();
-    let json: AuthResponse = anon.get("/api/private/session/begin").good();
+    let json: AuthResponse = anon.async_get("/api/private/session/begin").await.good();
     assert!(json.url.contains(&json.state));
 }

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -18,14 +18,16 @@ struct SummaryResponse {
     popular_categories: Vec<EncodableCategory>,
 }
 
-#[test]
-fn summary_doesnt_die() {
+#[tokio::test(flavor = "multi_thread")]
+async fn summary_doesnt_die() {
     let (_, anon) = TestApp::init().empty();
-    anon.get::<SummaryResponse>("/api/v1/summary").good();
+    anon.async_get::<SummaryResponse>("/api/v1/summary")
+        .await
+        .good();
 }
 
-#[test]
-fn summary_new_crates() {
+#[tokio::test(flavor = "multi_thread")]
+async fn summary_new_crates() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
     app.db(|conn| {
@@ -85,7 +87,7 @@ fn summary_new_crates() {
         });
     });
 
-    let json: SummaryResponse = anon.get("/api/v1/summary").good();
+    let json: SummaryResponse = anon.async_get("/api/v1/summary").await.good();
 
     assert_eq!(json.num_crates, 5);
     assert_eq!(json.num_downloads, 6000);
@@ -112,8 +114,8 @@ fn summary_new_crates() {
     assert_eq!(json.new_crates.len(), 5);
 }
 
-#[test]
-fn excluded_crate_id() {
+#[tokio::test(flavor = "multi_thread")]
+async fn excluded_crate_id() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.excluded_crate_names = vec![
@@ -144,7 +146,7 @@ fn excluded_crate_id() {
             .expect_build(conn);
     });
 
-    let json: SummaryResponse = anon.get("/api/v1/summary").good();
+    let json: SummaryResponse = anon.async_get("/api/v1/summary").await.good();
 
     assert_eq!(json.most_downloaded.len(), 1);
     assert_eq!(json.most_downloaded[0].name, "some_downloads");

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -21,9 +21,7 @@ struct SummaryResponse {
 #[tokio::test(flavor = "multi_thread")]
 async fn summary_doesnt_die() {
     let (_, anon) = TestApp::init().empty();
-    anon.async_get::<SummaryResponse>("/api/v1/summary")
-        .await
-        .good();
+    anon.get::<SummaryResponse>("/api/v1/summary").await.good();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -87,7 +85,7 @@ async fn summary_new_crates() {
         });
     });
 
-    let json: SummaryResponse = anon.async_get("/api/v1/summary").await.good();
+    let json: SummaryResponse = anon.get("/api/v1/summary").await.good();
 
     assert_eq!(json.num_crates, 5);
     assert_eq!(json.num_downloads, 6000);
@@ -146,7 +144,7 @@ async fn excluded_crate_id() {
             .expect_build(conn);
     });
 
-    let json: SummaryResponse = anon.async_get("/api/v1/summary").await.good();
+    let json: SummaryResponse = anon.get("/api/v1/summary").await.good();
 
     assert_eq!(json.most_downloaded.len(), 1);
     assert_eq!(json.most_downloaded[0].name, "some_downloads");

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -7,21 +7,21 @@ pub struct UserShowPublicResponse {
     pub user: EncodablePublicUser,
 }
 
-#[test]
-fn show() {
+#[tokio::test(flavor = "multi_thread")]
+async fn show() {
     let (app, anon, _) = TestApp::init().with_user();
     app.db_new_user("Bar");
 
-    let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").good();
+    let json: UserShowPublicResponse = anon.async_get("/api/v1/users/foo").await.good();
     assert_eq!(json.user.login, "foo");
 
-    let json: UserShowPublicResponse = anon.get("/api/v1/users/bAr").good();
+    let json: UserShowPublicResponse = anon.async_get("/api/v1/users/bAr").await.good();
     assert_eq!(json.user.login, "Bar");
     assert_eq!(json.user.url, "https://github.com/Bar");
 }
 
-#[test]
-fn show_latest_user_case_insensitively() {
+#[tokio::test(flavor = "multi_thread")]
+async fn show_latest_user_case_insensitively() {
     let (app, anon) = TestApp::init().empty();
 
     app.db(|conn| {
@@ -50,7 +50,7 @@ fn show_latest_user_case_insensitively() {
         .create_or_update(None, &app.as_inner().emails, conn));
     });
 
-    let json: UserShowPublicResponse = anon.get("/api/v1/users/fOObAr").good();
+    let json: UserShowPublicResponse = anon.async_get("/api/v1/users/fOObAr").await.good();
     assert_eq!(
         "I was second, I took the foobar username on github",
         json.user.name.unwrap()

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -12,10 +12,10 @@ async fn show() {
     let (app, anon, _) = TestApp::init().with_user();
     app.db_new_user("Bar");
 
-    let json: UserShowPublicResponse = anon.async_get("/api/v1/users/foo").await.good();
+    let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").await.good();
     assert_eq!(json.user.login, "foo");
 
-    let json: UserShowPublicResponse = anon.async_get("/api/v1/users/bAr").await.good();
+    let json: UserShowPublicResponse = anon.get("/api/v1/users/bAr").await.good();
     assert_eq!(json.user.login, "Bar");
     assert_eq!(json.user.url, "https://github.com/Bar");
 }
@@ -50,7 +50,7 @@ async fn show_latest_user_case_insensitively() {
         .create_or_update(None, &app.as_inner().emails, conn));
     });
 
-    let json: UserShowPublicResponse = anon.async_get("/api/v1/users/fOObAr").await.good();
+    let json: UserShowPublicResponse = anon.get("/api/v1/users/fOObAr").await.good();
     assert_eq!(
         "I was second, I took the foobar username on github",
         json.user.name.unwrap()

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -5,8 +5,8 @@ struct UserStats {
     total_downloads: i64,
 }
 
-#[test]
-fn user_total_downloads() {
+#[tokio::test(flavor = "multi_thread")]
+async fn user_total_downloads() {
     use crate::builders::CrateBuilder;
     use crate::util::{RequestHelper, TestApp};
     use crates_io::schema::crate_downloads;
@@ -48,17 +48,17 @@ fn user_total_downloads() {
     });
 
     let url = format!("/api/v1/users/{}/stats", user.id);
-    let stats: UserStats = anon.get(&url).good();
+    let stats: UserStats = anon.async_get(&url).await.good();
     // does not include crates user never owned (2) or no longer owns (5)
     assert_eq!(stats.total_downloads, 30);
 }
 
-#[test]
-fn user_total_downloads_no_crates() {
+#[tokio::test(flavor = "multi_thread")]
+async fn user_total_downloads_no_crates() {
     let (_, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
     let url = format!("/api/v1/users/{}/stats", user.id);
 
-    let stats: UserStats = anon.get(&url).good();
+    let stats: UserStats = anon.async_get(&url).await.good();
     assert_eq!(stats.total_downloads, 0);
 }

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -48,7 +48,7 @@ async fn user_total_downloads() {
     });
 
     let url = format!("/api/v1/users/{}/stats", user.id);
-    let stats: UserStats = anon.async_get(&url).await.good();
+    let stats: UserStats = anon.get(&url).await.good();
     // does not include crates user never owned (2) or no longer owns (5)
     assert_eq!(stats.total_downloads, 30);
 }
@@ -59,6 +59,6 @@ async fn user_total_downloads_no_crates() {
     let user = user.as_model();
     let url = format!("/api/v1/users/{}/stats", user.id);
 
-    let stats: UserStats = anon.async_get(&url).await.good();
+    let stats: UserStats = anon.get(&url).await.good();
     assert_eq!(stats.total_downloads, 0);
 }

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -6,7 +6,7 @@ pub trait MockEmailHelper: RequestHelper {
     // TODO: I don't like the name of this method or `update_email` on the `MockCookieUser` impl;
     // this is starting to look like a builder might help?
     // I want to explore alternative abstractions in any case.
-    fn update_email_more_control(&self, user_id: i32, email: Option<&str>) -> Response<()> {
+    async fn update_email_more_control(&self, user_id: i32, email: Option<&str>) -> Response<()> {
         // When updating your email in crates.io, the request goes to the user route with PUT.
         // Ember sends all the user attributes. We check to make sure the ID in the URL matches
         // the ID of the currently logged in user, then we ignore everything but the email address.
@@ -19,7 +19,7 @@ pub trait MockEmailHelper: RequestHelper {
             "kind": null
         }});
         let url = format!("/api/v1/users/{user_id}");
-        self.put(&url, body.to_string())
+        self.async_put(&url, body.to_string()).await
     }
 }
 
@@ -29,7 +29,10 @@ impl MockEmailHelper for crate::util::MockAnonymousUser {}
 impl crate::util::MockCookieUser {
     pub fn update_email(&self, email: &str) {
         let model = self.as_model();
-        let response = self.update_email_more_control(model.id, Some(email));
+        let response = self
+            .app()
+            .runtime()
+            .block_on(self.update_email_more_control(model.id, Some(email)));
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
     }
@@ -44,19 +47,19 @@ impl crate::util::MockCookieUser {
 /// This is checked on the frontend already, but I'd like to
 /// make sure that a user cannot get around that and delete
 /// their email by adding an empty string.
-#[test]
-fn test_empty_email_not_added() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_empty_email_not_added() {
     let (_app, _anon, user) = TestApp::init().with_user();
     let model = user.as_model();
 
-    let response = user.update_email_more_control(model.id, Some(""));
+    let response = user.update_email_more_control(model.id, Some("")).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "empty email rejected" }] })
     );
 
-    let response = user.update_email_more_control(model.id, None);
+    let response = user.update_email_more_control(model.id, None).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -69,26 +72,30 @@ fn test_empty_email_not_added() {
 ///
 /// If an attempt is made, update_user.rs will return an error indicating that the current user
 /// does not match the requested user.
-#[test]
-fn test_other_users_cannot_change_my_email() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_other_users_cannot_change_my_email() {
     let (app, anon, user) = TestApp::init().with_user();
     let another_user = app.db_new_user("not_me");
     let another_user_model = another_user.as_model();
 
-    let response = user.update_email_more_control(
-        another_user_model.id,
-        Some("pineapple@pineapples.pineapple"),
-    );
+    let response = user
+        .update_email_more_control(
+            another_user_model.id,
+            Some("pineapple@pineapples.pineapple"),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
         json!({ "errors": [{ "detail": "current user does not match requested user" }] })
     );
 
-    let response = anon.update_email_more_control(
-        another_user_model.id,
-        Some("pineapple@pineapples.pineapple"),
-    );
+    let response = anon
+        .update_email_more_control(
+            another_user_model.id,
+            Some("pineapple@pineapples.pineapple"),
+        )
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -27,12 +27,9 @@ impl MockEmailHelper for crate::util::MockCookieUser {}
 impl MockEmailHelper for crate::util::MockAnonymousUser {}
 
 impl crate::util::MockCookieUser {
-    pub fn update_email(&self, email: &str) {
+    pub async fn update_email(&self, email: &str) {
         let model = self.as_model();
-        let response = self
-            .app()
-            .runtime()
-            .block_on(self.update_email_more_control(model.id, Some(email)));
+        let response = self.update_email_more_control(model.id, Some(email)).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
     }

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -19,7 +19,7 @@ pub trait MockEmailHelper: RequestHelper {
             "kind": null
         }});
         let url = format!("/api/v1/users/{user_id}");
-        self.async_put(&url, body.to_string()).await
+        self.put(&url, body.to_string()).await
     }
 }
 

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -10,7 +10,7 @@ async fn user_agent_is_required() {
     let (_app, anon) = TestApp::init().empty();
 
     let req = Request::get("/api/v1/crates").body("").unwrap();
-    let resp = anon.async_run::<()>(req).await;
+    let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 
@@ -18,7 +18,7 @@ async fn user_agent_is_required() {
         .header(header::USER_AGENT, "")
         .body("")
         .unwrap();
-    let resp = anon.async_run::<()>(req).await;
+    let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 }
@@ -33,7 +33,7 @@ async fn user_agent_is_not_required_for_download() {
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
-    let resp = anon.async_run::<()>(req).await;
+    let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
@@ -51,7 +51,7 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
-    let resp = anon.async_run::<()>(req).await;
+    let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
@@ -74,7 +74,7 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         .body("")
         .unwrap();
 
-    let resp = anon.async_run::<()>(req).await;
+    let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 
@@ -88,7 +88,7 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         .body("")
         .unwrap();
 
-    let resp = anon.async_run::<()>(req).await;
+    let resp = anon.run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
@@ -100,7 +100,7 @@ async fn block_traffic_via_ip() {
         })
         .empty();
 
-    let resp = anon.async_get::<()>("/api/v1/crates").await;
+    let resp = anon.get::<()>("/api/v1/crates").await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 }

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -5,12 +5,12 @@ use std::collections::HashSet;
 use ::insta::assert_json_snapshot;
 use http::{header, Request, StatusCode};
 
-#[test]
-fn user_agent_is_required() {
+#[tokio::test(flavor = "multi_thread")]
+async fn user_agent_is_required() {
     let (_app, anon) = TestApp::init().empty();
 
     let req = Request::get("/api/v1/crates").body("").unwrap();
-    let resp = anon.run::<()>(req);
+    let resp = anon.async_run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 
@@ -18,13 +18,13 @@ fn user_agent_is_required() {
         .header(header::USER_AGENT, "")
         .body("")
         .unwrap();
-    let resp = anon.run::<()>(req);
+    let resp = anon.async_run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 }
 
-#[test]
-fn user_agent_is_not_required_for_download() {
+#[tokio::test(flavor = "multi_thread")]
+async fn user_agent_is_not_required_for_download() {
     let (app, anon, user) = TestApp::init().with_user();
 
     app.db(|conn| {
@@ -33,12 +33,12 @@ fn user_agent_is_not_required_for_download() {
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
-    let resp = anon.run::<()>(req);
+    let resp = anon.async_run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
-#[test]
-fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
+#[tokio::test(flavor = "multi_thread")]
+async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.blocked_traffic = vec![("Never-Given".into(), vec!["1".into()])];
@@ -51,12 +51,12 @@ fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
-    let resp = anon.run::<()>(req);
+    let resp = anon.async_run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
-#[test]
-fn block_traffic_via_arbitrary_header_and_value() {
+#[tokio::test(flavor = "multi_thread")]
+async fn block_traffic_via_arbitrary_header_and_value() {
     let (app, anon, user) = TestApp::init()
         .with_config(|config| {
             config.blocked_traffic = vec![("User-Agent".into(), vec!["1".into(), "2".into()])];
@@ -74,7 +74,7 @@ fn block_traffic_via_arbitrary_header_and_value() {
         .body("")
         .unwrap();
 
-    let resp = anon.run::<()>(req);
+    let resp = anon.async_run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 
@@ -88,19 +88,19 @@ fn block_traffic_via_arbitrary_header_and_value() {
         .body("")
         .unwrap();
 
-    let resp = anon.run::<()>(req);
+    let resp = anon.async_run::<()>(req).await;
     assert_eq!(resp.status(), StatusCode::FOUND);
 }
 
-#[test]
-fn block_traffic_via_ip() {
+#[tokio::test(flavor = "multi_thread")]
+async fn block_traffic_via_ip() {
     let (_app, anon) = TestApp::init()
         .with_config(|config| {
             config.blocked_ips = HashSet::from(["127.0.0.1".parse().unwrap()]);
         })
         .empty();
 
-    let resp = anon.get::<()>("/api/v1/crates");
+    let resp = anon.async_get::<()>("/api/v1/crates").await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     assert_json_snapshot!(resp.json());
 }

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -13,22 +13,27 @@ use http::StatusCode;
 
 impl crate::util::MockAnonymousUser {
     /// List the team owners of the specified crate.
-    fn crate_owner_teams(&self, krate_name: &str) -> crate::util::Response<OwnerTeamsResponse> {
+    async fn crate_owner_teams(
+        &self,
+        krate_name: &str,
+    ) -> crate::util::Response<OwnerTeamsResponse> {
         let url = format!("/api/v1/crates/{krate_name}/owner_team");
-        self.get(&url)
+        self.async_get(&url).await
     }
 }
 
 /// Test adding team without `github:`
-#[test]
-fn not_github() {
+#[tokio::test(flavor = "multi_thread")]
+async fn not_github() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     app.db(|conn| {
         CrateBuilder::new("foo_not_github", user.as_model().id).expect_build(conn);
     });
 
-    let response = token.add_named_owner("foo_not_github", "dropbox:foo:foo");
+    let response = token
+        .async_add_named_owner("foo_not_github", "dropbox:foo:foo")
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -36,15 +41,17 @@ fn not_github() {
     );
 }
 
-#[test]
-fn weird_name() {
+#[tokio::test(flavor = "multi_thread")]
+async fn weird_name() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     app.db(|conn| {
         CrateBuilder::new("foo_weird_name", user.as_model().id).expect_build(conn);
     });
 
-    let response = token.add_named_owner("foo_weird_name", "github:foo/../bar:wut");
+    let response = token
+        .async_add_named_owner("foo_weird_name", "github:foo/../bar:wut")
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -53,15 +60,17 @@ fn weird_name() {
 }
 
 /// Test adding team without second `:`
-#[test]
-fn one_colon() {
+#[tokio::test(flavor = "multi_thread")]
+async fn one_colon() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     app.db(|conn| {
         CrateBuilder::new("foo_one_colon", user.as_model().id).expect_build(conn);
     });
 
-    let response = token.add_named_owner("foo_one_colon", "github:foo");
+    let response = token
+        .async_add_named_owner("foo_one_colon", "github:foo")
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -69,16 +78,17 @@ fn one_colon() {
     );
 }
 
-#[test]
-fn add_nonexistent_team() {
+#[tokio::test(flavor = "multi_thread")]
+async fn add_nonexistent_team() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     app.db(|conn| {
         CrateBuilder::new("foo_add_nonexistent", user.as_model().id).expect_build(conn);
     });
 
-    let response =
-        token.add_named_owner("foo_add_nonexistent", "github:test-org:this-does-not-exist");
+    let response = token
+        .async_add_named_owner("foo_add_nonexistent", "github:test-org:this-does-not-exist")
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -87,8 +97,8 @@ fn add_nonexistent_team() {
 }
 
 /// Test adding a renamed team
-#[test]
-fn add_renamed_team() {
+#[tokio::test(flavor = "multi_thread")]
+async fn add_renamed_team() {
     let (app, anon) = TestApp::init().empty();
     let user = app.db_new_user("user-all-teams");
     let token = user.db_new_token("arbitrary token name");
@@ -100,7 +110,7 @@ fn add_renamed_team() {
         CrateBuilder::new("foo_renamed_team", owner_id).expect_build(conn);
 
         // create team with same ID and different name compared to http mock
-        // used for `add_named_owner`
+        // used for `async_add_named_owner`.await
         NewTeam::new(
             "github:test-org:old-core", // different team name
             1000,                       // same org ID
@@ -115,17 +125,18 @@ fn add_renamed_team() {
     });
 
     token
-        .add_named_owner("foo_renamed_team", "github:test-org:core")
+        .async_add_named_owner("foo_renamed_team", "github:test-org:core")
+        .await
         .good();
 
-    let json = anon.crate_owner_teams("foo_renamed_team").good();
+    let json = anon.crate_owner_teams("foo_renamed_team").await.good();
     assert_eq!(json.teams.len(), 1);
     assert_eq!(json.teams[0].login, "github:test-org:core");
 }
 
 /// Test adding team names with mixed case, when on the team
-#[test]
-fn add_team_mixed_case() {
+#[tokio::test(flavor = "multi_thread")]
+async fn add_team_mixed_case() {
     let (app, anon) = TestApp::init().empty();
     let user = app.db_new_user("user-all-teams");
     let token = user.db_new_token("arbitrary token name");
@@ -135,7 +146,8 @@ fn add_team_mixed_case() {
     });
 
     token
-        .add_named_owner("foo_mixed_case", "github:Test-Org:Core")
+        .async_add_named_owner("foo_mixed_case", "github:Test-Org:Core")
+        .await
         .good();
 
     app.db(|conn| {
@@ -146,13 +158,13 @@ fn add_team_mixed_case() {
         assert_eq!(owner.login(), owner.login().to_lowercase());
     });
 
-    let json = anon.crate_owner_teams("foo_mixed_case").good();
+    let json = anon.crate_owner_teams("foo_mixed_case").await.good();
     assert_eq!(json.teams.len(), 1);
     assert_eq!(json.teams[0].login, "github:test-org:core");
 }
 
-#[test]
-fn add_team_as_org_owner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn add_team_as_org_owner() {
     let (app, anon) = TestApp::init().empty();
     let user = app.db_new_user("user-org-owner");
     let token = user.db_new_token("arbitrary token name");
@@ -162,7 +174,8 @@ fn add_team_as_org_owner() {
     });
 
     token
-        .add_named_owner("foo_org_owner", "github:test-org:core")
+        .async_add_named_owner("foo_org_owner", "github:test-org:core")
+        .await
         .good();
 
     app.db(|conn| {
@@ -173,14 +186,14 @@ fn add_team_as_org_owner() {
         assert_eq!(owner.login(), owner.login().to_lowercase());
     });
 
-    let json = anon.crate_owner_teams("foo_org_owner").good();
+    let json = anon.crate_owner_teams("foo_org_owner").await.good();
     assert_eq!(json.teams.len(), 1);
     assert_eq!(json.teams[0].login, "github:test-org:core");
 }
 
 /// Test adding team as owner when not on it
-#[test]
-fn add_team_as_non_member() {
+#[tokio::test(flavor = "multi_thread")]
+async fn add_team_as_non_member() {
     let (app, _) = TestApp::init().empty();
     let user = app.db_new_user("user-one-team");
     let token = user.db_new_token("arbitrary token name");
@@ -189,7 +202,9 @@ fn add_team_as_non_member() {
         CrateBuilder::new("foo_team_non_member", user.as_model().id).expect_build(conn);
     });
 
-    let response = token.add_named_owner("foo_team_non_member", "github:test-org:core");
+    let response = token
+        .async_add_named_owner("foo_team_non_member", "github:test-org:core")
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -197,8 +212,8 @@ fn add_team_as_non_member() {
     );
 }
 
-#[test]
-fn remove_team_as_named_owner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn remove_team_as_named_owner() {
     let (app, _) = TestApp::full().empty();
     let username = "user-all-teams";
     let user_on_both_teams = app.db_new_user(username);
@@ -209,12 +224,15 @@ fn remove_team_as_named_owner() {
     });
 
     token_on_both_teams
-        .add_named_owner("foo_remove_team", "github:test-org:core")
+        .async_add_named_owner("foo_remove_team", "github:test-org:core")
+        .await
         .good();
 
     // Removing the individual owner is not allowed, since team members don't
     // have permission to manage ownership
-    let response = token_on_both_teams.remove_named_owner("foo_remove_team", username);
+    let response = token_on_both_teams
+        .async_remove_named_owner("foo_remove_team", username)
+        .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         response.json(),
@@ -222,12 +240,13 @@ fn remove_team_as_named_owner() {
     );
 
     token_on_both_teams
-        .remove_named_owner("foo_remove_team", "github:test-org:core")
+        .async_remove_named_owner("foo_remove_team", "github:test-org:core")
+        .await
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team");
     let crate_to_publish = PublishBuilder::new("foo_remove_team", "2.0.0");
-    let response = user_on_one_team.publish_crate(crate_to_publish);
+    let response = user_on_one_team.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -235,8 +254,8 @@ fn remove_team_as_named_owner() {
     );
 }
 
-#[test]
-fn remove_team_as_team_owner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn remove_team_as_team_owner() {
     let (app, _) = TestApp::init().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -247,14 +266,16 @@ fn remove_team_as_team_owner() {
     });
 
     token_on_both_teams
-        .add_named_owner("foo_remove_team_owner", "github:test-org:all")
+        .async_add_named_owner("foo_remove_team_owner", "github:test-org:all")
+        .await
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team");
     let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
 
-    let response =
-        token_on_one_team.remove_named_owner("foo_remove_team_owner", "github:test-org:all");
+    let response = token_on_one_team
+        .async_remove_named_owner("foo_remove_team_owner", "github:test-org:all")
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -263,8 +284,9 @@ fn remove_team_as_team_owner() {
 
     let user_org_owner = app.db_new_user("user-org-owner");
     let token_org_owner = user_org_owner.db_new_token("arbitrary token name");
-    let response =
-        token_org_owner.remove_named_owner("foo_remove_team_owner", "github:test-org:all");
+    let response = token_org_owner
+        .async_remove_named_owner("foo_remove_team_owner", "github:test-org:all")
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -272,8 +294,8 @@ fn remove_team_as_team_owner() {
     );
 }
 
-#[test]
-fn remove_nonexistent_team() {
+#[tokio::test(flavor = "multi_thread")]
+async fn remove_nonexistent_team() {
     let (app, _, user, token) = TestApp::init().with_token();
 
     app.db(|conn| {
@@ -288,16 +310,17 @@ fn remove_nonexistent_team() {
     });
 
     token
-        .remove_named_owner(
+        .async_remove_named_owner(
             "foo_remove_nonexistent",
             "github:test-org:this-does-not-exist",
         )
+        .await
         .good();
 }
 
 /// Test trying to publish a crate we don't own
-#[test]
-fn publish_not_owned() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_not_owned() {
     let (app, _) = TestApp::full().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -307,13 +330,14 @@ fn publish_not_owned() {
     });
 
     token_on_both_teams
-        .add_named_owner("foo_not_owned", "github:test-org:core")
+        .async_add_named_owner("foo_not_owned", "github:test-org:core")
+        .await
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team");
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned", "2.0.0");
-    let response = user_on_one_team.publish_crate(crate_to_publish);
+    let response = user_on_one_team.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -321,8 +345,8 @@ fn publish_not_owned() {
     );
 }
 
-#[test]
-fn publish_org_owner_owned() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_org_owner_owned() {
     let (app, _) = TestApp::full().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -332,13 +356,14 @@ fn publish_org_owner_owned() {
     });
 
     token_on_both_teams
-        .add_named_owner("foo_not_owned", "github:test-org:core")
+        .async_add_named_owner("foo_not_owned", "github:test-org:core")
+        .await
         .good();
 
     let user_org_owner = app.db_new_user("user-org-owner");
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned", "2.0.0");
-    let response = user_org_owner.publish_crate(crate_to_publish);
+    let response = user_org_owner.async_publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -347,8 +372,8 @@ fn publish_org_owner_owned() {
 }
 
 /// Test trying to publish a krate we do own (but only because of teams)
-#[test]
-fn publish_owned() {
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_owned() {
     let (app, _) = TestApp::full().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -358,18 +383,22 @@ fn publish_owned() {
     });
 
     token_on_both_teams
-        .add_named_owner("foo_team_owned", "github:test-org:all")
+        .async_add_named_owner("foo_team_owned", "github:test-org:all")
+        .await
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team");
 
     let crate_to_publish = PublishBuilder::new("foo_team_owned", "2.0.0");
-    user_on_one_team.publish_crate(crate_to_publish).good();
+    user_on_one_team
+        .async_publish_crate(crate_to_publish)
+        .await
+        .good();
 }
 
 /// Test trying to change owners (when only on an owning team)
-#[test]
-fn add_owners_as_org_owner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn add_owners_as_org_owner() {
     let (app, _) = TestApp::init().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -379,13 +408,16 @@ fn add_owners_as_org_owner() {
     });
 
     token_on_both_teams
-        .add_named_owner("foo_add_owner", "github:test-org:all")
+        .async_add_named_owner("foo_add_owner", "github:test-org:all")
+        .await
         .good();
 
     let user_org_owner = app.db_new_user("user-org-owner");
     let token_org_owner = user_org_owner.db_new_token("arbitrary token name");
 
-    let response = token_org_owner.add_named_owner("foo_add_owner", "arbitrary_username");
+    let response = token_org_owner
+        .async_add_named_owner("foo_add_owner", "arbitrary_username")
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -393,8 +425,8 @@ fn add_owners_as_org_owner() {
     );
 }
 
-#[test]
-fn add_owners_as_team_owner() {
+#[tokio::test(flavor = "multi_thread")]
+async fn add_owners_as_team_owner() {
     let (app, _) = TestApp::init().empty();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -404,13 +436,16 @@ fn add_owners_as_team_owner() {
     });
 
     token_on_both_teams
-        .add_named_owner("foo_add_owner", "github:test-org:all")
+        .async_add_named_owner("foo_add_owner", "github:test-org:all")
+        .await
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team");
     let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
 
-    let response = token_on_one_team.add_named_owner("foo_add_owner", "arbitrary_username");
+    let response = token_on_one_team
+        .async_add_named_owner("foo_add_owner", "arbitrary_username")
+        .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_eq!(
         response.json(),
@@ -418,8 +453,8 @@ fn add_owners_as_team_owner() {
     );
 }
 
-#[test]
-fn crates_by_team_id() {
+#[tokio::test(flavor = "multi_thread")]
+async fn crates_by_team_id() {
     let (app, anon, user) = TestApp::init().with_user();
     let user = user.as_model();
 
@@ -432,12 +467,12 @@ fn crates_by_team_id() {
         t
     });
 
-    let json = anon.search(&format!("team_id={}", team.id));
+    let json = anon.async_search(&format!("team_id={}", team.id)).await;
     assert_eq!(json.crates.len(), 1);
 }
 
-#[test]
-fn crates_by_team_id_not_including_deleted_owners() {
+#[tokio::test(flavor = "multi_thread")]
+async fn crates_by_team_id_not_including_deleted_owners() {
     let (app, anon) = TestApp::init().empty();
     let user = app.db_new_user("user-all-teams");
     let user = user.as_model();
@@ -453,6 +488,6 @@ fn crates_by_team_id_not_including_deleted_owners() {
         t
     });
 
-    let json = anon.search(&format!("team_id={}", team.id));
+    let json = anon.async_search(&format!("team_id={}", team.id)).await;
     assert_eq!(json.crates.len(), 0);
 }

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -9,12 +9,12 @@ async fn using_token_updates_last_used_at() {
     let url = "/api/v1/me";
     let (app, anon, user, token) = TestApp::init().with_token();
 
-    anon.async_get(url).await.assert_forbidden();
-    user.async_get::<EncodableMe>(url).await.good();
+    anon.get(url).await.assert_forbidden();
+    user.get::<EncodableMe>(url).await.good();
     assert_none!(token.as_model().last_used_at);
 
     // Use the token once
-    token.async_search("following=1").await;
+    token.search("following=1").await;
 
     let token: ApiToken = app.db(|conn| {
         assert_ok!(ApiToken::belonging_to(user.as_model())
@@ -35,7 +35,7 @@ async fn old_tokens_give_specific_error_message() {
 
     let mut request = anon.get_request(url);
     request.header(header::AUTHORIZATION, "oldtoken");
-    let response = anon.async_run::<()>(request).await;
+    let response = anon.run::<()>(request).await;
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     assert_eq!(
         response.json(),

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -27,28 +27,27 @@ async fn wait_until_healthy(pool: &Pool) {
     }
 }
 
-#[test]
-fn http_error_with_unhealthy_database() {
+#[tokio::test(flavor = "multi_thread")]
+async fn http_error_with_unhealthy_database() {
     let (app, anon) = TestApp::init().with_chaos_proxy().empty();
 
-    let response = anon.get::<()>("/api/v1/summary");
+    let response = anon.async_get::<()>("/api/v1/summary").await;
     assert_eq!(response.status(), StatusCode::OK);
 
     app.primary_db_chaosproxy().break_networking().unwrap();
 
-    let response = anon.get::<()>("/api/v1/summary");
+    let response = anon.async_get::<()>("/api/v1/summary").await;
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
     app.primary_db_chaosproxy().restore_networking().unwrap();
-    app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().primary_database));
+    wait_until_healthy(&app.as_inner().primary_database).await;
 
-    let response = anon.get::<()>("/api/v1/summary");
+    let response = anon.async_get::<()>("/api/v1/summary").await;
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-#[test]
-fn fallback_to_replica_returns_user_info() {
+#[tokio::test(flavor = "multi_thread")]
+async fn fallback_to_replica_returns_user_info() {
     const URL: &str = "/api/v1/users/foo";
 
     let (app, _, owner) = TestApp::init()
@@ -59,17 +58,16 @@ fn fallback_to_replica_returns_user_info() {
     app.primary_db_chaosproxy().break_networking().unwrap();
 
     // When the primary database is down, requests are forwarded to the replica database
-    let response = owner.get::<()>(URL);
+    let response = owner.async_get::<()>(URL).await;
     assert_eq!(response.status(), 200);
 
     // restore primary database connection
     app.primary_db_chaosproxy().restore_networking().unwrap();
-    app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().primary_database));
+    wait_until_healthy(&app.as_inner().primary_database).await;
 }
 
-#[test]
-fn restored_replica_returns_user_info() {
+#[tokio::test(flavor = "multi_thread")]
+async fn restored_replica_returns_user_info() {
     const URL: &str = "/api/v1/users/foo";
 
     let (app, _, owner) = TestApp::init()
@@ -81,7 +79,7 @@ fn restored_replica_returns_user_info() {
     app.replica_db_chaosproxy().break_networking().unwrap();
 
     // When both primary and replica database are down, the request returns an error
-    let response = owner.get::<()>(URL);
+    let response = owner.async_get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
     // Once the replica database is restored, it should serve as a fallback again
@@ -91,19 +89,18 @@ fn restored_replica_returns_user_info() {
         .replica_database
         .as_ref()
         .expect("no replica database configured");
-    app.runtime().block_on(wait_until_healthy(replica));
+    wait_until_healthy(replica).await;
 
-    let response = owner.get::<()>(URL);
+    let response = owner.async_get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // restore connection
     app.primary_db_chaosproxy().restore_networking().unwrap();
-    app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().primary_database));
+    wait_until_healthy(&app.as_inner().primary_database).await;
 }
 
-#[test]
-fn restored_primary_returns_user_info() {
+#[tokio::test(flavor = "multi_thread")]
+async fn restored_primary_returns_user_info() {
     const URL: &str = "/api/v1/users/foo";
 
     let (app, _, owner) = TestApp::init()
@@ -115,14 +112,13 @@ fn restored_primary_returns_user_info() {
     app.replica_db_chaosproxy().break_networking().unwrap();
 
     // When both primary and replica database are down, the request returns an error
-    let response = owner.get::<()>(URL);
+    let response = owner.async_get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
 
     // Once the replica database is restored, it should serve as a fallback again
     app.primary_db_chaosproxy().restore_networking().unwrap();
-    app.runtime()
-        .block_on(wait_until_healthy(&app.as_inner().primary_database));
+    wait_until_healthy(&app.as_inner().primary_database).await;
 
-    let response = owner.get::<()>(URL);
+    let response = owner.async_get::<()>(URL).await;
     assert_eq!(response.status(), StatusCode::OK);
 }

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -11,7 +11,7 @@ use secrecy::ExposeSecret;
 impl crate::util::MockCookieUser {
     async fn confirm_email(&self, email_token: &str) {
         let url = format!("/api/v1/confirm/{email_token}");
-        let response = self.async_put::<()>(&url, &[] as &[u8]).await;
+        let response = self.put::<()>(&url, &[] as &[u8]).await;
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(response.json(), json!({ "ok": true }));
     }
@@ -66,7 +66,7 @@ async fn github_without_email_does_not_overwrite_email() {
     });
     let user_without_github_email_model = user_without_github_email.as_model();
 
-    let json = user_without_github_email.async_show_me().await;
+    let json = user_without_github_email.show_me().await;
     // Check that the setup is correct and the user indeed has no email
     assert_eq!(json.user.email, None);
 
@@ -89,7 +89,7 @@ async fn github_without_email_does_not_overwrite_email() {
         MockCookieUser::new(&app, u)
     });
 
-    let json = again_user_without_github_email.async_show_me().await;
+    let json = again_user_without_github_email.show_me().await;
     assert_eq!(json.user.email.unwrap(), "apricot@apricots.apricot");
 }
 
@@ -124,7 +124,7 @@ async fn github_with_email_does_not_overwrite_email() {
         MockCookieUser::new(&app, u)
     });
 
-    let json = user_with_different_email_in_github.async_show_me().await;
+    let json = user_with_different_email_in_github.show_me().await;
     assert_eq!(json.user.email, Some(original_email));
 }
 
@@ -135,12 +135,12 @@ async fn github_with_email_does_not_overwrite_email() {
 async fn test_email_get_and_put() {
     let (_app, _anon, user) = TestApp::init().with_user();
 
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
     assert_eq!(json.user.email.unwrap(), "something@example.com");
 
     user.update_email("mango@mangos.mango").await;
 
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
     assert_eq!(json.user.email.unwrap(), "mango@mangos.mango");
     assert!(!json.user.email_verified);
     assert!(json.user.email_verification_sent);
@@ -181,7 +181,7 @@ async fn test_confirm_user_email() {
 
     user.confirm_email(&email_token).await;
 
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
     assert_eq!(json.user.email.unwrap(), "potato2@example.com");
     assert!(json.user.email_verified);
     assert!(json.user.email_verification_sent);
@@ -217,7 +217,7 @@ async fn test_existing_user_email() {
         MockCookieUser::new(&app, u)
     });
 
-    let json = user.async_show_me().await;
+    let json = user.show_me().await;
     assert_eq!(json.user.email.unwrap(), "potahto@example.com");
     assert!(!json.user.email_verified);
     assert!(!json.user.email_verification_sent);

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -444,9 +444,4 @@ impl MockTokenUser {
     pub fn remove_named_owner(&self, krate_name: &str, owner: &str) -> Response<OkBool> {
         self.remove_named_owners(krate_name, &[owner])
     }
-
-    /// Add a user as an owner for a crate.
-    pub fn add_user_owner(&self, krate_name: &str, username: &str) {
-        self.add_named_owner(krate_name, username).good();
-    }
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -433,12 +433,6 @@ impl MockTokenUser {
     }
 
     /// Add a single owner to the specified crate.
-    pub fn add_named_owner(&self, krate_name: &str, owner: &str) -> Response<OkBool> {
-        self.app()
-            .runtime()
-            .block_on(self.async_add_named_owner(krate_name, owner))
-    }
-
     pub async fn async_add_named_owner(&self, krate_name: &str, owner: &str) -> Response<OkBool> {
         self.async_add_named_owners(krate_name, &[owner]).await
     }
@@ -455,12 +449,6 @@ impl MockTokenUser {
     }
 
     /// Remove a single owner to the specified crate.
-    pub fn remove_named_owner(&self, krate_name: &str, owner: &str) -> Response<OkBool> {
-        self.app()
-            .runtime()
-            .block_on(self.async_remove_named_owner(krate_name, owner))
-    }
-
     pub async fn async_remove_named_owner(
         &self,
         krate_name: &str,

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -423,25 +423,61 @@ impl MockTokenUser {
 
     /// Add to the specified crate the specified owners.
     pub fn add_named_owners(&self, krate_name: &str, owners: &[&str]) -> Response<OkBool> {
+        self.app()
+            .runtime()
+            .block_on(self.async_add_named_owners(krate_name, owners))
+    }
+
+    pub async fn async_add_named_owners(
+        &self,
+        krate_name: &str,
+        owners: &[&str],
+    ) -> Response<OkBool> {
         let url = format!("/api/v1/crates/{krate_name}/owners");
         let body = json!({ "owners": owners }).to_string();
-        self.put(&url, body)
+        self.async_put(&url, body).await
     }
 
     /// Add a single owner to the specified crate.
     pub fn add_named_owner(&self, krate_name: &str, owner: &str) -> Response<OkBool> {
-        self.add_named_owners(krate_name, &[owner])
+        self.app()
+            .runtime()
+            .block_on(self.async_add_named_owner(krate_name, owner))
+    }
+
+    pub async fn async_add_named_owner(&self, krate_name: &str, owner: &str) -> Response<OkBool> {
+        self.async_add_named_owners(krate_name, &[owner]).await
     }
 
     /// Remove from the specified crate the specified owners.
     pub fn remove_named_owners(&self, krate_name: &str, owners: &[&str]) -> Response<OkBool> {
+        self.app()
+            .runtime()
+            .block_on(self.async_remove_named_owners(krate_name, owners))
+    }
+
+    pub async fn async_remove_named_owners(
+        &self,
+        krate_name: &str,
+        owners: &[&str],
+    ) -> Response<OkBool> {
         let url = format!("/api/v1/crates/{krate_name}/owners");
         let body = json!({ "owners": owners }).to_string();
-        self.delete_with_body(&url, body)
+        self.async_delete_with_body(&url, body).await
     }
 
     /// Remove a single owner to the specified crate.
     pub fn remove_named_owner(&self, krate_name: &str, owner: &str) -> Response<OkBool> {
-        self.remove_named_owners(krate_name, &[owner])
+        self.app()
+            .runtime()
+            .block_on(self.async_remove_named_owner(krate_name, owner))
+    }
+
+    pub async fn async_remove_named_owner(
+        &self,
+        krate_name: &str,
+        owner: &str,
+    ) -> Response<OkBool> {
+        self.async_remove_named_owners(krate_name, &[owner]).await
     }
 }

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -178,11 +178,6 @@ pub trait RequestHelper {
         self.get_with_query("/api/v1/crates", query).good()
     }
 
-    /// Search for crates owned by the specified user.
-    fn search_by_user_id(&self, id: i32) -> CrateList {
-        self.search(&format!("user_id={id}"))
-    }
-
     /// Publish the crate and run background jobs to completion
     ///
     /// Background jobs will publish to the git index and sync to the HTTP index.

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -422,12 +422,6 @@ impl MockTokenUser {
     }
 
     /// Add to the specified crate the specified owners.
-    pub fn add_named_owners(&self, krate_name: &str, owners: &[&str]) -> Response<OkBool> {
-        self.app()
-            .runtime()
-            .block_on(self.async_add_named_owners(krate_name, owners))
-    }
-
     pub async fn async_add_named_owners(
         &self,
         krate_name: &str,
@@ -450,12 +444,6 @@ impl MockTokenUser {
     }
 
     /// Remove from the specified crate the specified owners.
-    pub fn remove_named_owners(&self, krate_name: &str, owners: &[&str]) -> Response<OkBool> {
-        self.app()
-            .runtime()
-            .block_on(self.async_remove_named_owners(krate_name, owners))
-    }
-
     pub async fn async_remove_named_owners(
         &self,
         krate_name: &str,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -167,14 +167,14 @@ impl TestApp {
     }
 
     pub fn stored_files(&self) -> Vec<String> {
+        self.runtime().block_on(self.async_stored_files())
+    }
+
+    pub async fn async_stored_files(&self) -> Vec<String> {
         let store = self.as_inner().storage.as_inner();
 
-        let rt = self.runtime();
-
-        let list = rt.block_on(async {
-            let stream = store.list(None);
-            stream.try_collect::<Vec<_>>().await.unwrap()
-        });
+        let stream = store.list(None);
+        let list = stream.try_collect::<Vec<_>>().await.unwrap();
 
         list.into_iter()
             .map(|meta| meta.location.to_string())

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -232,30 +232,31 @@ impl TestAppBuilder {
         // Run each test inside a fresh database schema, deleted at the end of the test,
         // The schema will be cleared up once the app is dropped.
         let test_database = TestDatabase::new();
+        let db_url = test_database.url();
 
         let (primary_db_chaosproxy, replica_db_chaosproxy) = {
             let primary_proxy = if self.use_chaos_proxy {
                 let (primary_proxy, url) = runtime
-                    .block_on(ChaosProxy::proxy_database_url(test_database.url()))
+                    .block_on(ChaosProxy::proxy_database_url(db_url))
                     .unwrap();
 
                 self.config.db.primary.url = url.into();
                 Some(primary_proxy)
             } else {
-                self.config.db.primary.url = test_database.url().to_string().into();
+                self.config.db.primary.url = db_url.to_string().into();
                 None
             };
 
             let replica_proxy = self.config.db.replica.as_mut().and_then(|replica| {
                 if self.use_chaos_proxy {
                     let (primary_proxy, url) = runtime
-                        .block_on(ChaosProxy::proxy_database_url(test_database.url()))
+                        .block_on(ChaosProxy::proxy_database_url(db_url))
                         .unwrap();
 
                     replica.url = url.into();
                     Some(primary_proxy)
                 } else {
-                    replica.url = test_database.url().to_string().into();
+                    replica.url = db_url.to_string().into();
                     None
                 }
             });

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -166,10 +166,6 @@ impl TestApp {
             .unwrap()
     }
 
-    pub fn stored_files(&self) -> Vec<String> {
-        self.runtime().block_on(self.async_stored_files())
-    }
-
     pub async fn async_stored_files(&self) -> Vec<String> {
         let store = self.as_inner().storage.as_inner();
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -1,7 +1,6 @@
 use super::{MockAnonymousUser, MockCookieUser, MockTokenUser};
 use crate::util::chaosproxy::ChaosProxy;
 use crate::util::github::{MockGitHubClient, MOCK_GITHUB_DATA};
-use anyhow::Context;
 use crates_io::config::{
     self, Base, CdnLogQueueConfig, CdnLogStorageConfig, DatabasePools, DbPoolConfig,
 };
@@ -21,12 +20,10 @@ use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
 use std::collections::HashSet;
 use std::{rc::Rc, sync::Arc, time::Duration};
-use tokio::runtime::{Handle, Runtime};
+use tokio::runtime::Handle;
 use tokio::task::block_in_place;
 
 struct TestAppInner {
-    pub runtime: Option<Runtime>,
-
     app: Arc<App>,
     router: axum::Router,
     index: Option<UpstreamIndex>,
@@ -51,7 +48,6 @@ impl Drop for TestAppInner {
 
         // Lazily run any remaining jobs
         if let Some(runner) = &self.runner {
-            let _rt_guard = self.runtime.as_ref().map(|rt| rt.enter());
             block_in_place(move || {
                 Handle::current().block_on(async {
                     let handle = runner.start();
@@ -77,7 +73,6 @@ impl Drop for TestAppInner {
         // We manually close the connection pools here to prevent their `Drop`
         // implementation from failing because no tokio runtime is running.
         {
-            let _rt_guard = self.runtime.as_ref().map(|rt| rt.enter());
             self.app.primary_database.close();
             if let Some(pool) = &self.app.replica_database {
                 pool.close();
@@ -146,12 +141,6 @@ impl TestApp {
             app: self.clone(),
             user,
         }
-    }
-
-    #[track_caller]
-    pub fn runtime(&self) -> &Runtime {
-        let runtime = self.0.runtime.as_ref();
-        runtime.expect("TestApp was created without a runtime")
     }
 
     /// Obtain a reference to the upstream repository ("the index")
@@ -224,15 +213,6 @@ pub struct TestAppBuilder {
 impl TestAppBuilder {
     /// Create a `TestApp` with an empty database
     pub fn empty(mut self) -> (TestApp, MockAnonymousUser) {
-        let runtime = match Handle::try_current() {
-            Ok(_) => None,
-            Err(_) => Some(
-                Runtime::new()
-                    .context("Failed to initialize tokio runtime")
-                    .unwrap(),
-            ),
-        };
-
         // Run each test inside a fresh database schema, deleted at the end of the test,
         // The schema will be cleared up once the app is dropped.
         let test_database = TestDatabase::new();
@@ -305,7 +285,6 @@ impl TestAppBuilder {
         };
 
         let test_app_inner = TestAppInner {
-            runtime,
             app,
             test_database,
             router,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -155,7 +155,7 @@ impl TestApp {
             .unwrap()
     }
 
-    pub async fn async_stored_files(&self) -> Vec<String> {
+    pub async fn stored_files(&self) -> Vec<String> {
         let store = self.as_inner().storage.as_inner();
 
         let stream = store.list(None);
@@ -166,7 +166,7 @@ impl TestApp {
             .collect()
     }
 
-    pub async fn async_run_pending_background_jobs(&self) {
+    pub async fn run_pending_background_jobs(&self) {
         let runner = &self.0.runner;
         let runner = runner.as_ref().expect("Index has not been initialized");
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -177,12 +177,6 @@ impl TestApp {
             .collect()
     }
 
-    #[track_caller]
-    pub fn run_pending_background_jobs(&self) {
-        self.runtime()
-            .block_on(self.async_run_pending_background_jobs());
-    }
-
     pub async fn async_run_pending_background_jobs(&self) {
         let runner = &self.0.runner;
         let runner = runner.as_ref().expect("Index has not been initialized");

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -183,16 +183,19 @@ impl TestApp {
 
     #[track_caller]
     pub fn run_pending_background_jobs(&self) {
+        self.runtime()
+            .block_on(self.async_run_pending_background_jobs());
+    }
+
+    pub async fn async_run_pending_background_jobs(&self) {
         let runner = &self.0.runner;
         let runner = runner.as_ref().expect("Index has not been initialized");
 
-        self.runtime().block_on(async {
-            let handle = runner.start();
-            handle.wait_for_shutdown().await;
+        let handle = runner.start();
+        handle.wait_for_shutdown().await;
 
-            let result = runner.check_for_failed_jobs().await;
-            result.expect("Could not determine if jobs failed");
-        });
+        let result = runner.check_for_failed_jobs().await;
+        result.expect("Could not determine if jobs failed");
     }
 
     /// Obtain a reference to the inner `App` value

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -2,8 +2,8 @@ use crate::builders::{CrateBuilder, VersionBuilder};
 use crate::TestApp;
 use crates_io::models::Version;
 
-#[test]
-fn record_rerendered_readme_time() {
+#[tokio::test(flavor = "multi_thread")]
+async fn record_rerendered_readme_time() {
     let (app, _, user) = TestApp::init().with_user();
     let user = user.as_model();
 

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -13,14 +13,14 @@ async fn index_smoke_test() {
     // Add a new crate
 
     let body = PublishBuilder::new("serde", "1.0.0").body();
-    let response = token.async_put::<()>("/api/v1/crates/new", body).await;
+    let response = token.put::<()>("/api/v1/crates/new", body).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Check that the git index is updated asynchronously
     assert_ok_eq!(upstream.list_commits(), vec!["Initial Commit"]);
     assert_ok_eq!(upstream.crate_exists("serde"), false);
 
-    app.async_run_pending_background_jobs().await;
+    app.run_pending_background_jobs().await;
     assert_ok_eq!(
         upstream.list_commits(),
         vec!["Initial Commit", "Create crate `serde`"]
@@ -29,12 +29,10 @@ async fn index_smoke_test() {
 
     // Yank the crate
 
-    let response = token
-        .async_delete::<()>("/api/v1/crates/serde/1.0.0/yank")
-        .await;
+    let response = token.delete::<()>("/api/v1/crates/serde/1.0.0/yank").await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    app.async_run_pending_background_jobs().await;
+    app.run_pending_background_jobs().await;
     assert_ok_eq!(
         upstream.list_commits(),
         vec![
@@ -56,7 +54,7 @@ async fn index_smoke_test() {
         assert_ok!(jobs::enqueue_sync_to_index("serde", conn));
     });
 
-    app.async_run_pending_background_jobs().await;
+    app.run_pending_background_jobs().await;
     assert_ok_eq!(
         upstream.list_commits(),
         vec![
@@ -92,7 +90,7 @@ async fn test_config_changes() {
 
     // Add a new crate
     let body = PublishBuilder::new("serde", "1.0.0").body();
-    let response = token.async_publish_crate(body).await;
+    let response = token.publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Adjust the `config.json` file on the upstream index
@@ -101,7 +99,7 @@ async fn test_config_changes() {
 
     // Update the crate
     let body = PublishBuilder::new("serde", "1.1.0").body();
-    let response = token.async_publish_crate(body).await;
+    let response = token.publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Check that the `config.json` changes on the upstream index are preserved

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -5,22 +5,22 @@ use crates_io::worker::jobs;
 use diesel::prelude::*;
 use http::StatusCode;
 
-#[test]
-fn index_smoke_test() {
+#[tokio::test(flavor = "multi_thread")]
+async fn index_smoke_test() {
     let (app, _, _, token) = TestApp::full().with_token();
     let upstream = app.upstream_index();
 
     // Add a new crate
 
     let body = PublishBuilder::new("serde", "1.0.0").body();
-    let response = token.put::<()>("/api/v1/crates/new", body);
+    let response = token.async_put::<()>("/api/v1/crates/new", body).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Check that the git index is updated asynchronously
     assert_ok_eq!(upstream.list_commits(), vec!["Initial Commit"]);
     assert_ok_eq!(upstream.crate_exists("serde"), false);
 
-    app.run_pending_background_jobs();
+    app.async_run_pending_background_jobs().await;
     assert_ok_eq!(
         upstream.list_commits(),
         vec!["Initial Commit", "Create crate `serde`"]
@@ -29,10 +29,12 @@ fn index_smoke_test() {
 
     // Yank the crate
 
-    let response = token.delete::<()>("/api/v1/crates/serde/1.0.0/yank");
+    let response = token
+        .async_delete::<()>("/api/v1/crates/serde/1.0.0/yank")
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
 
-    app.run_pending_background_jobs();
+    app.async_run_pending_background_jobs().await;
     assert_ok_eq!(
         upstream.list_commits(),
         vec![
@@ -54,7 +56,7 @@ fn index_smoke_test() {
         assert_ok!(jobs::enqueue_sync_to_index("serde", conn));
     });
 
-    app.run_pending_background_jobs();
+    app.async_run_pending_background_jobs().await;
     assert_ok_eq!(
         upstream.list_commits(),
         vec![
@@ -69,8 +71,8 @@ fn index_smoke_test() {
 
 /// This test checks that changes to the `config.json` file on the git index
 /// are preserved when the background worker updates the index.
-#[test]
-fn test_config_changes() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_config_changes() {
     const ORIGINAL_CONFIG: &str = r#"{
         "dl": "https://crates.io/api/v1/crates",
         "api": "https://crates.io"
@@ -90,7 +92,7 @@ fn test_config_changes() {
 
     // Add a new crate
     let body = PublishBuilder::new("serde", "1.0.0").body();
-    let response = token.publish_crate(body);
+    let response = token.async_publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Adjust the `config.json` file on the upstream index
@@ -99,7 +101,7 @@ fn test_config_changes() {
 
     // Update the crate
     let body = PublishBuilder::new("serde", "1.1.0").body();
-    let response = token.publish_crate(body);
+    let response = token.async_publish_crate(body).await;
     assert_eq!(response.status(), StatusCode::OK);
 
     // Check that the `config.json` changes on the upstream index are preserved

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -34,7 +34,7 @@ async fn test_sync_admins_job() {
     assert_eq!(admins, expected_admins);
 
     app.db(|conn| SyncAdmins.enqueue(conn).unwrap());
-    app.async_run_pending_background_jobs().await;
+    app.run_pending_background_jobs().await;
 
     let admins = app.db(|conn| get_admins(conn).unwrap());
     let expected_admins = vec![("existing-admin".into(), 1), ("new-admin".into(), 3)];
@@ -52,7 +52,7 @@ async fn test_sync_admins_job() {
     // Run the job again to verify that no new emails are sent
     // for `new-admin-without-account`.
     app.db(|conn| SyncAdmins.enqueue(conn).unwrap());
-    app.async_run_pending_background_jobs().await;
+    app.run_pending_background_jobs().await;
 
     let emails = app.as_inner().emails.mails_in_memory().unwrap();
     assert_eq!(emails.len(), 2);

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -8,8 +8,8 @@ use diesel::{PgConnection, QueryResult, RunQueryDsl};
 use insta::assert_debug_snapshot;
 use regex::Regex;
 
-#[test]
-fn test_sync_admins_job() {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sync_admins_job() {
     let mock_response = mock_permission(vec![
         mock_person("existing-admin", 1),
         mock_person("new-admin", 3),
@@ -34,7 +34,7 @@ fn test_sync_admins_job() {
     assert_eq!(admins, expected_admins);
 
     app.db(|conn| SyncAdmins.enqueue(conn).unwrap());
-    app.run_pending_background_jobs();
+    app.async_run_pending_background_jobs().await;
 
     let admins = app.db(|conn| get_admins(conn).unwrap());
     let expected_admins = vec![("existing-admin".into(), 1), ("new-admin".into(), 3)];
@@ -52,7 +52,7 @@ fn test_sync_admins_job() {
     // Run the job again to verify that no new emails are sent
     // for `new-admin-without-account`.
     app.db(|conn| SyncAdmins.enqueue(conn).unwrap());
-    app.run_pending_background_jobs();
+    app.async_run_pending_background_jobs().await;
 
     let emails = app.as_inner().emails.mails_in_memory().unwrap();
     assert_eq!(emails.len(), 2);


### PR DESCRIPTION
I'm sorry for the size of this PR... really...! 😅 

If you feel like it, this is probably best reviewed commit-by-commit, though most of the changes have been fairly mechanical.

The gist of this PR is to migrate us from `#[test]` to `#[tokio::test]`. This currently involves a few places where `block_in_place()` was necessary for the migration, so the tests are using a multi-threaded runtime (instead of the default current-thread runtime).

The primary three things that are now using async/await instead of blocking are:
- anything that looks like an HTTP request
- the `run_pending_background_jobs()` fn
- the `stored_files()` fn

Everything else is still roughly the same as before, including `app.db()` calls. That means we are doing blocking IO on the runtime threads for now, but since this is limited to the test code it shouldn't be too much of an issue, and is certainly something that will be cleaned up in a follow-up PR. Consider this PR very much as an intermediate step! :)