### PR TITLE
oauth2: Enable default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3500,6 +3500,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
+ "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
  "log",
@@ -3507,17 +3508,21 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.11",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg 0.50.0",
 ]
 
@@ -4980,6 +4985,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ tikv-jemallocator = { version = "=0.5.4", features = ['unprefixed_malloc_on_supp
 lettre = { version = "=0.11.7", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
 minijinja = "=1.0.21"
 mockall = "=0.12.1"
-oauth2 = { version = "=4.4.2", default-features = false, features = ["reqwest"] }
+oauth2 = "=4.4.2"
 object_store = { version = "=0.10.0", features = ["aws"] }
 once_cell = "=1.19.0"
 p256 = "=0.13.2"


### PR DESCRIPTION
`deb82a6` unintentionally disabled the TLS feature of the old `reqwest` version that is still used by the `oauth2` crate, because we declared that we don't want the default features of the crate. This commit enables the default features again, which turns the TLS support in `reqwest` back on.

Resolves https://github.com/rust-lang/crates.io/issues/8536

For more debugging context see https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/failing.20logins :)