### PR TITLE
Footer: Update the team link

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -5,7 +5,7 @@
       <ul role="list">
         <li><a href="https://www.rust-lang.org/">rust-lang.org</a></li>
         <li><a href="https://foundation.rust-lang.org/">Rust Foundation</a></li>
-        <li><a href="https://www.rust-lang.org/governance/teams/crates-io">The crates.io team</a></li>
+        <li><a href="https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io">The crates.io team</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
This PR updates the team link in the footer to reflect [Implement RFC#3595 Moving crates.io under devtools](https://github.com/rust-lang/team/pull/1439).

Closes #8552.