### PR TITLE
Add `os::android-apis` category for Android bindings

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -414,6 +414,12 @@ description = """
 Bindings to operating system-specific APIs.\
 """
 
+[os.categories.android-apis]
+name = "Android APIs"
+description = """
+Bindings to Android-specific APIs.\
+"""
+
 [os.categories.linux-apis]
 name = "Linux APIs"
 description = """


### PR DESCRIPTION
Android is its own OS on top of Linux with _lots_ of custom/specific interfaces.  Many crates are wrapping (parts) of it, such as [the NDK crate].  Since there's an `os::XXX-apis` tag for many OSes already, Android also belongs in this list.

[the NDK crate]: https://crates.io/crates/ndk
