### PR TITLE
Revert "Fix "Edge for Android" compatibility"

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -9,11 +9,5 @@ module.exports = {
     'last 1 Edge version',
     'last 1 UCAndroid version',
     'last 1 years',
-    // Edge for Android is currently (2021-08-18) using an outdated Chromium version (v77),
-    // which is not recognized by `browserslist` and `caniuse`. This can be removed once
-    // Edge for Android has promoted their "Edge for Android Beta" app to production, which
-    // is using a more up-to-date Chromium version.
-    // (see https://github.com/rust-lang/crates.io/issues/3838)
-    'Chrome 77',
   ],
 };


### PR DESCRIPTION
This reverts commit ac9dba740bdd84def5d66f384da0061edc4381f5.

It's been three years... Edge on Android is now apparently on v123, matching the desktop release version. It seems that we don't have to worry about this anymore.

This change is saving a couple dozens bytes since we can now use `?` syntax in JS without having to polyfill it.