### PR TITLE
CI: Replace Docker-based PostgreSQL server with `apt-get` install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,26 +116,14 @@ jobs:
       RUSTFLAGS: "-D warnings -Cinstrument-coverage"
       MALLOC_CONF: "background_thread:true,abort_conf:true,abort:true,junk:true"
 
-    services:
-      postgres:
-        image: postgres:13@sha256:eee22204934b36935237e7c92355e3178cfdf3c5377dec9c19c848115cc4637b
-        env:
-          POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
 
       # Update `pg_dump` to the same version as the running PostgreSQL server
       - run: sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -v ${{ env.POSTGRES_VERSION }} -i -p
+      - run: sudo systemctl start postgresql.service
+      - run: sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres'"
 
       - run: cargo build --tests --workspace
       - run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ env:
   GRCOV_VERSION: 0.8.19
   # renovate: datasource=npm depName=pnpm
   PNPM_VERSION: 9.0.6
+  # renovate: datasource=docker depName=postgres
+  POSTGRES_VERSION: 13
 
 jobs:
   changed-files:
@@ -131,6 +133,10 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # v2.7.3
+
+      # Update `pg_dump` to the same version as the running PostgreSQL server
+      - run: sudo /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -v ${{ env.POSTGRES_VERSION }} -i -p
+
       - run: cargo build --tests --workspace
       - run: cargo test --workspace
 


### PR DESCRIPTION
The main goal of this PR was to ensure that the `pg_dump` version used by our database dump code matches the version of the database server that is used to run the test suite.

Since we already install the correct version on the system with the first change we can also just use `systemctl start postgresql.service` to start a PostgreSQL server, instead of having to install and boot up a dedicated Docker container for the same purpose. The second commit in this PR thus removes the Docker container and sets up the PostgreSQL server correctly so that we can use it in our test suite.

This should unblock #8578 by now installing a new enough `pg_dump` version that can be used by our test suite.