### PR TITLE
Sentry: Fix broken `configureScope()` call

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -77,7 +77,7 @@ export default class ApplicationRoute extends Route {
   setSentryTransaction(transition) {
     let name = transition.to?.name;
     if (name) {
-      this.sentry.configureScope(scope => scope.setTransactionName(name));
+      this.sentry.getCurrentScope().setTransactionName(name);
     }
   }
 }

--- a/app/services/sentry.js
+++ b/app/services/sentry.js
@@ -7,8 +7,8 @@ export default class SentryService extends Service {
     Sentry.captureException(error, captureContext);
   }
 
-  configureScope(callback) {
-    Sentry.configureScope(callback);
+  getCurrentScope() {
+    return Sentry.getCurrentScope();
   }
 
   setUser(user) {

--- a/tests/helpers/sentry.js
+++ b/tests/helpers/sentry.js
@@ -11,8 +11,8 @@ class MockSentryService extends Service {
     this.events.push(event);
   }
 
-  configureScope(callback) {
-    callback(this.scope);
+  getCurrentScope() {
+    return this.scope;
   }
 
   setUser(user) {


### PR DESCRIPTION
`configureScope()` has apparently been deprecated a while ago and was recently removed in https://github.com/getsentry/sentry-javascript/pull/9887. Since we are mocking Sentry in our test suite we unfortunately didn't notice the issue before it popped up on our staging environment.