### PR TITLE
Remove/replace references to the "crawler policy"

### DIFF
--- a/app/templates/data-access.hbs
+++ b/app/templates/data-access.hbs
@@ -65,8 +65,7 @@
     the
     <a href="https://doc.rust-lang.org/cargo/reference/registry-web-api.html">Cargo Web API</a>.
     Should you be unable to use one of the previous options, you are welcome to
-    use the crates.io API provided you abide by the same limits as
-    <LinkTo @route="policies">the crawling policy</LinkTo>. In summary:
+    use the crates.io API provided you abide by the following limits:
   </p>
 
   <ol>

--- a/src/middleware/block_traffic.rs
+++ b/src/middleware/block_traffic.rs
@@ -72,11 +72,9 @@ fn rejection_response_from(state: &AppState, headers: &HeaderMap) -> Response {
 
     let body = format!(
         "We are unable to process your request at this time. \
-                 This usually means that you are in violation of our crawler \
-                 policy (https://{domain_name}/policies#crawlers). \
-                 Please open an issue at https://github.com/rust-lang/crates.io \
-                 or email help@crates.io \
-                 and provide the request id {request_id}"
+         This usually means that you are in violation of our API data access \
+         policy (https://{domain_name}/data-access). \
+         Please email help@crates.io and provide the request id {request_id}"
     );
 
     (StatusCode::FORBIDDEN, body).into_response()

--- a/src/tests/snapshots/all__server__block_traffic_via_arbitrary_header_and_value.snap
+++ b/src/tests/snapshots/all__server__block_traffic_via_arbitrary_header_and_value.snap
@@ -1,11 +1,11 @@
 ---
 source: src/tests/server.rs
-expression: resp.into_json()
+expression: resp.json()
 ---
 {
   "errors": [
     {
-      "detail": "We are unable to process your request at this time. This usually means that you are in violation of our crawler policy (https://crates.io/policies#crawlers). Please open an issue at https://github.com/rust-lang/crates.io or email help@crates.io and provide the request id abcd"
+      "detail": "We are unable to process your request at this time. This usually means that you are in violation of our API data access policy (https://crates.io/data-access). Please email help@crates.io and provide the request id abcd"
     }
   ]
 }

--- a/src/tests/snapshots/all__server__block_traffic_via_ip.snap
+++ b/src/tests/snapshots/all__server__block_traffic_via_ip.snap
@@ -1,11 +1,11 @@
 ---
 source: src/tests/server.rs
-expression: resp.into_json()
+expression: resp.json()
 ---
 {
   "errors": [
     {
-      "detail": "We are unable to process your request at this time. This usually means that you are in violation of our crawler policy (https://crates.io/policies#crawlers). Please open an issue at https://github.com/rust-lang/crates.io or email help@crates.io and provide the request id "
+      "detail": "We are unable to process your request at this time. This usually means that you are in violation of our API data access policy (https://crates.io/data-access). Please email help@crates.io and provide the request id "
     }
   ]
 }


### PR DESCRIPTION
We only have a data access policy at https://crates.io/data-access, which has replaced the `#crawler` part of `/policies`.