### PR TITLE
worker/jobs/expiry_notification: Adjust `JOB_NAME` to match struct name

### DIFF
--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -18,7 +18,7 @@ const MAX_ROWS: i64 = 10000;
 pub struct SendTokenExpiryNotifications;
 
 impl BackgroundJob for SendTokenExpiryNotifications {
-    const JOB_NAME: &'static str = "expiry_notification";
+    const JOB_NAME: &'static str = "send_token_expiry_notifications";
 
     type Context = Arc<Environment>;
 


### PR DESCRIPTION
`expiry_notification` is a bit generic and if we introduce other expiring resources this could cause confusion. This PR adjusts the `JOB_NAME` constant to match the struct name, which includes `token` in the name and resolves the potential confusion.