### PR TITLE
components/search-form: Work around gap between focus shadow and submit button

### DIFF
--- a/app/components/search-form.module.css
+++ b/app/components/search-form.module.css
@@ -61,7 +61,8 @@
     composes: button-reset from '../styles/shared/buttons.module.css';
 
     position: absolute;
-    right: 0;
+    /* see https://github.com/rust-lang/crates.io/issues/8677 🤷 */
+    right: -.5px;
     top: 0;
     bottom: 0;
     display: inline-grid;


### PR DESCRIPTION
I've tried various things to make this work properly, but haven't found a proper solution. This commit works around the issue by slightly offsetting the submit button to the right. I'm not a fan of this "solution", but I've run out of ideas...

Resolves https://github.com/rust-lang/crates.io/issues/8677

### Before/After

<img width="205" alt="Bildschirmfoto 2024-05-19 um 11 50 14" src="https://github.com/rust-lang/crates.io/assets/141300/4ac580cc-7c3f-4026-aac9-08cc8efceb5a">
<img width="205" alt="Bildschirmfoto 2024-05-19 um 11 50 06" src="https://github.com/rust-lang/crates.io/assets/141300/a7089ab4-963c-4db1-92cb-3e9f2a82c0fc">

