### PR TITLE
Switch default color scheme to "System"

### DIFF
--- a/app/services/color-scheme.js
+++ b/app/services/color-scheme.js
@@ -6,7 +6,7 @@ import { restartableTask, waitForEvent } from 'ember-concurrency';
 
 import * as localStorage from '../utils/local-storage';
 
-const DEFAULT_SCHEME = 'light';
+const DEFAULT_SCHEME = 'system';
 const VALID_SCHEMES = new Set(['light', 'dark', 'system']);
 const LS_KEY = 'color-scheme';
 


### PR DESCRIPTION
We've ironed out most of the issues with the dark UI mode, so now it's time to change the default and have people automatically get the dark UI mode if their operating system demands it.