### PR TITLE
admin/default_versions: Implement `verify` mode

### DIFF
--- a/src/admin/mod.rs
+++ b/src/admin/mod.rs
@@ -1,3 +1,4 @@
+pub mod default_versions;
 pub mod delete_crate;
 pub mod delete_version;
 pub mod dialoguer;
@@ -9,7 +10,6 @@ pub mod populate;
 pub mod render_readmes;
 pub mod test_pagerduty;
 pub mod transfer_crates;
-pub mod update_default_versions;
 pub mod upload_index;
 pub mod verify_token;
 pub mod yank_version;

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -2,9 +2,8 @@
 extern crate tracing;
 
 use crates_io::admin::{
-    delete_crate, delete_version, enqueue_job, git_import, migrate, populate, render_readmes,
-    test_pagerduty, transfer_crates, update_default_versions, upload_index, verify_token,
-    yank_version,
+    default_versions, delete_crate, delete_version, enqueue_job, git_import, migrate, populate,
+    render_readmes, test_pagerduty, transfer_crates, upload_index, verify_token, yank_version,
 };
 
 #[derive(clap::Parser, Debug)]
@@ -23,7 +22,8 @@ enum Command {
     GitImport(git_import::Opts),
     #[clap(subcommand)]
     EnqueueJob(enqueue_job::Command),
-    UpdateDefaultVersions(update_default_versions::Opts),
+    #[clap(subcommand)]
+    DefaultVersions(default_versions::Command),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -51,7 +51,7 @@ fn main() -> anyhow::Result<()> {
         Command::YankVersion(opts) => yank_version::run(opts),
         Command::GitImport(opts) => git_import::run(opts),
         Command::EnqueueJob(command) => enqueue_job::run(command),
-        Command::UpdateDefaultVersions(opts) => update_default_versions::run(opts),
+        Command::DefaultVersions(opts) => default_versions::run(opts),
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,7 @@
 pub use self::action::{insert_version_owner_action, VersionAction, VersionOwnerAction};
 pub use self::category::{Category, CrateCategory, NewCategory};
 pub use self::crate_owner_invitation::{CrateOwnerInvitation, NewCrateOwnerInvitationOutcome};
-pub use self::default_versions::update_default_version;
+pub use self::default_versions::{update_default_version, verify_default_version};
 pub use self::dependency::{Dependency, DependencyKind, ReverseDependency};
 pub use self::download::VersionDownload;
 pub use self::email::{Email, NewEmail};


### PR DESCRIPTION
This changes `crates-admin update-default-versions` to `crates-admin default-versions update`, and adds an additional `crates-admin default-versions verify` command. This new command iterates over all crates, calculates the default version and compares it with the default version that is currently saved in the database. In case the results do not match it prints a warning message. This should allow us to verify that our code to update the `default_versions` table is working correctly and that we don't have any inconsistencies.