### PR TITLE
Move `MockSentryService` class into the `app` folder

### DIFF
--- a/app/initializers/app-hook.js
+++ b/app/initializers/app-hook.js
@@ -1,6 +1,6 @@
 import config from 'crates-io/config/environment';
 import { APP_HOOK_CUSTOM_EVENTS, APP_HOOK_KEY, SENTRY_HOOK_KEY } from 'crates-io/consts';
-import { MockSentryService } from 'crates-io/tests/helpers/sentry';
+import { MockSentryService } from 'crates-io/utils/sentry';
 
 export function initialize(app) {
   if (config.environment === 'production') {

--- a/app/utils/sentry.js
+++ b/app/utils/sentry.js
@@ -1,0 +1,34 @@
+import Service from '@ember/service';
+
+export class MockSentryService extends Service {
+  events = [];
+  scope = new MockScope();
+
+  captureException(error) {
+    let { scope, user } = this;
+    let { tags } = scope;
+    let event = { error, tags, user };
+    this.events.push(event);
+  }
+
+  getCurrentScope() {
+    return this.scope;
+  }
+
+  setUser(user) {
+    this.user = user;
+  }
+}
+
+class MockScope {
+  transaction = null;
+  tags = {};
+
+  setTag(key, value) {
+    this.tags[key] = value;
+  }
+
+  setTransactionName(transaction) {
+    this.transaction = transaction;
+  }
+}

--- a/tests/helpers/sentry.js
+++ b/tests/helpers/sentry.js
@@ -1,37 +1,4 @@
-import Service from '@ember/service';
-
-export class MockSentryService extends Service {
-  events = [];
-  scope = new MockScope();
-
-  captureException(error) {
-    let { scope, user } = this;
-    let { tags } = scope;
-    let event = { error, tags, user };
-    this.events.push(event);
-  }
-
-  getCurrentScope() {
-    return this.scope;
-  }
-
-  setUser(user) {
-    this.user = user;
-  }
-}
-
-class MockScope {
-  transaction = null;
-  tags = {};
-
-  setTag(key, value) {
-    this.tags[key] = value;
-  }
-
-  setTransactionName(transaction) {
-    this.transaction = transaction;
-  }
-}
+import { MockSentryService } from 'crates-io/utils/sentry';
 
 export function setupSentryMock(hooks) {
   hooks.beforeEach(function () {


### PR DESCRIPTION
The production build is currently broken because the `app-hook` initializer is unable to import the `MockSentryService` class from `crates-io/tests` because those test-only files are not included in the production build. Ideally we'd exclude this initializer from the production build, but I haven't found a straight-forward way for doing that yet. The current solution is not ideal because we are shipping these unnecessary bytes to our users, but until we find a better way this at least unblocks our `main` branch again.

/cc @eth3lbert 