### PR TITLE
metrics/service: Reset `background_jobs` metric before setting new values

### DIFF
--- a/src/metrics/service.rs
+++ b/src/metrics/service.rs
@@ -45,6 +45,8 @@ impl ServiceMetrics {
                 count_star(),
             ))
             .load::<(String, i16, i64)>(conn)?;
+
+        self.background_jobs.reset();
         for (job, priority, count) in background_jobs {
             let priority = format!("{priority}");
             self.background_jobs


### PR DESCRIPTION
Without this the background jobs will never be reset to zero again... 🙈 