### PR TITLE
Remove obsolete `postcss-nested` plugin

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -45,7 +45,6 @@ module.exports = function (defaults) {
     cssModules: {
       extension: 'module.css',
       plugins: {
-        before: [require('postcss-nested')],
         postprocess: [require('postcss-preset-env')({ browsers, preserve: false })],
       },
     },

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "miragejs": "0.1.48",
     "normalize.css": "8.0.1",
     "nyc": "15.1.0",
-    "postcss-nested": "6.0.1",
     "postcss-preset-env": "9.5.14",
     "prettier": "3.2.5",
     "qunit": "2.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,9 +294,6 @@ importers:
       nyc:
         specifier: 15.1.0
         version: 15.1.0
-      postcss-nested:
-        specifier: 6.0.1
-        version: 6.0.1(postcss@8.4.38)
       postcss-preset-env:
         specifier: 9.5.14
         version: 9.5.14(postcss@8.4.38)
@@ -6931,12 +6928,6 @@ packages:
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
-
-  postcss-nested@6.0.1:
-    resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
 
   postcss-nesting@12.1.5:
     resolution: {integrity: sha512-N1NgI1PDCiAGWPTYrwqm8wpjv0bgDmkYHH72pNsqTCv9CObxjxftdYu6AKtGN+pnJa7FQjMm3v4sp8QJbFsYdQ==}
@@ -18149,11 +18140,6 @@ snapshots:
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
-
-  postcss-nested@6.0.1(postcss@8.4.38):
-    dependencies:
-      postcss: 8.4.38
-      postcss-selector-parser: 6.0.16
 
   postcss-nesting@12.1.5(postcss@8.4.38):
     dependencies:


### PR DESCRIPTION
`postcss-preset-env` already includes https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-nesting, which makes `postcss-nested` redundant.