### PR TITLE
workers/jobs/dump_db: Remove unnecessary `target_name` field

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -25,8 +25,6 @@ pub enum Command {
     DumpDb {
         #[arg(env = "READ_ONLY_REPLICA_URL")]
         database_url: SecretString,
-        #[arg(default_value = "db-dump.tar.gz")]
-        target_name: String,
     },
     DailyDbMaintenance,
     SquashIndex,
@@ -76,11 +74,8 @@ pub fn run(command: Command) -> Result<()> {
         Command::CleanProcessedLogFiles => {
             jobs::CleanProcessedLogFiles.enqueue(conn)?;
         }
-        Command::DumpDb {
-            database_url,
-            target_name,
-        } => {
-            jobs::DumpDb::new(database_url.expose_secret(), target_name).enqueue(conn)?;
+        Command::DumpDb { database_url } => {
+            jobs::DumpDb::new(database_url.expose_secret()).enqueue(conn)?;
         }
         Command::SyncAdmins { force } => {
             if !force {


### PR DESCRIPTION
We haven't used this in years and it makes it a bit more complicated to support other file types in the future.

Related:
- https://github.com/rust-lang/crates.io/issues/2078