### PR TITLE
workers/jobs/dump_db: Use `Storage` from background job context

### DIFF
--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -1,5 +1,4 @@
 use self::configuration::VisibilityConfig;
-use crate::storage::Storage;
 use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use anyhow::{anyhow, Context};
@@ -44,7 +43,7 @@ impl BackgroundJob for DumpDb {
         .await?;
 
         info!("Uploading tarball");
-        Storage::from_environment()
+        env.storage
             .upload_db_dump(target_name, &tarball.tarball_path)
             .await?;
         info!("Database dump tarball uploaded");


### PR DESCRIPTION
There is no need for us to recreate the `Storage` instance for each job run, we already have it in the `Context`. This also makes it possible to properly test the background job now, since it's now using the in-memory storage instead.