### PR TITLE
tests/dump_db: Add basic end-to-end test

### DIFF
--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -1,8 +1,16 @@
 use crates_io::worker::jobs::dump_db;
 use crates_io_test_db::TestDatabase;
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+
+/// Mutex to ensure that only one test is dumping the database at a time, since
+/// the dump directory is shared between all invocations of the background job.
+static DUMP_DIR_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
 #[test]
 fn dump_db_and_reimport_dump() {
+    let _guard = DUMP_DIR_MUTEX.lock();
+
     crates_io::util::tracing::init_for_test();
 
     let db_one = TestDatabase::new();

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -1,11 +1,106 @@
-use crates_io::worker::jobs::dump_db;
+use crate::builders::CrateBuilder;
+use crate::util::TestApp;
+use bytes::Buf;
+use crates_io::worker::jobs::{dump_db, DumpDb};
 use crates_io_test_db::TestDatabase;
+use crates_io_worker::BackgroundJob;
+use flate2::read::GzDecoder;
+use insta::assert_snapshot;
 use once_cell::sync::Lazy;
+use secrecy::ExposeSecret;
+use std::io::Read;
 use std::sync::Mutex;
+use tar::Archive;
 
 /// Mutex to ensure that only one test is dumping the database at a time, since
 /// the dump directory is shared between all invocations of the background job.
 static DUMP_DIR_MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_dump_db_job() {
+    let _guard = DUMP_DIR_MUTEX.lock();
+
+    let (app, _, _, token) = TestApp::full().with_token();
+
+    app.db(|conn| {
+        CrateBuilder::new("test-crate", token.as_model().user_id).expect_build(conn);
+
+        let database_url = app.as_inner().config.db.primary.url.expose_secret();
+        DumpDb::new(database_url).enqueue(conn).unwrap();
+    });
+
+    app.run_pending_background_jobs().await;
+
+    let stored_files = app.stored_files().await;
+    assert_eq!(stored_files.len(), 1);
+    assert_eq!(stored_files[0], "db-dump.tar.gz");
+
+    let path = object_store::path::Path::parse("db-dump.tar.gz").unwrap();
+    let result = app.as_inner().storage.as_inner().get(&path).await.unwrap();
+    let bytes = result.bytes().await.unwrap();
+
+    let gz = GzDecoder::new(bytes.reader());
+    let mut tar = Archive::new(gz);
+    assert_snapshot!(replace_dates(&create_tar_snapshot(&mut tar)));
+}
+
+/// Create a stringified snapshot of the contents of a tar archive.
+///
+/// This function reads the contents of the tar archive and returns a string
+/// representation of the paths and contents of the files in the archive.
+///
+/// The contents of the files are assumed to be UTF-8 encoded text. Binary
+/// files are not supported.
+fn create_tar_snapshot<R: Read>(archive: &mut Archive<R>) -> String {
+    const SEPARATOR: &str = "\n----------------------------------------\n";
+
+    let mut contents = Vec::new();
+
+    for entry in archive.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        let path = entry.path().unwrap().display().to_string();
+
+        let mut content = Vec::new();
+        entry.read_to_end(&mut content).unwrap();
+        let content = String::from_utf8(content).unwrap();
+
+        contents.push((path, content));
+    }
+
+    let paths = contents
+        .iter()
+        .map(|(path, _)| format!("- {path}\n"))
+        .collect::<Vec<_>>()
+        .join("");
+
+    let contents = contents
+        .iter()
+        .map(|(path, content)| format!("{path}:\n\n{content}"))
+        .collect::<Vec<_>>()
+        .join(SEPARATOR);
+
+    format!("{paths}{SEPARATOR}{contents}")
+}
+
+/// Replace dates in a string with a fixed date to make snapshots stable.
+///
+/// This function replaces dates in the formats:
+///
+/// - `YYYY-MM-DD-HHMMSS` (e.g. `2024-12-24-123456`)
+/// - `YYYY-MM-DD HH:MM:SS.SSS` (e.g. `2024-12-24 12:34:56.789012`)
+/// - `YYYY-MM-DDTHH:MM:SS.SSSZ` (e.g. `2024-12-24T12:34:56.789012Z`)
+fn replace_dates(s: &str) -> String {
+    let path_date_regex = regex::Regex::new(r"\d{4}-\d{2}-\d{2}-\d{6}").unwrap();
+    let s = path_date_regex.replace_all(s, "2024-12-24-123456");
+
+    let sql_date_regex = regex::Regex::new(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d+").unwrap();
+    let s = sql_date_regex.replace_all(&s, "2024-12-24 12:34:56.789012");
+
+    let iso_date_regex = regex::Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d+Z").unwrap();
+    iso_date_regex
+        .replace_all(&s, "2024-12-24T12:34:56.789012Z")
+        .to_string()
+}
 
 #[test]
 fn dump_db_and_reimport_dump() {

--- a/src/tests/snapshots/all__dump_db__dump_db_job.snap
+++ b/src/tests/snapshots/all__dump_db__dump_db_job.snap
@@ -1,0 +1,2505 @@
+---
+source: src/tests/dump_db.rs
+expression: replace_dates(&create_tar_snapshot(&mut tar))
+---
+- 2024-12-24-123456
+- 2024-12-24-123456/schema.sql
+- 2024-12-24-123456/metadata.json
+- 2024-12-24-123456/README.md
+- 2024-12-24-123456/import.sql
+- 2024-12-24-123456/export.sql
+- 2024-12-24-123456/data
+- 2024-12-24-123456/data/categories.csv
+- 2024-12-24-123456/data/crate_downloads.csv
+- 2024-12-24-123456/data/crates.csv
+- 2024-12-24-123456/data/keywords.csv
+- 2024-12-24-123456/data/metadata.csv
+- 2024-12-24-123456/data/reserved_crate_names.csv
+- 2024-12-24-123456/data/teams.csv
+- 2024-12-24-123456/data/users.csv
+- 2024-12-24-123456/data/crates_categories.csv
+- 2024-12-24-123456/data/crates_keywords.csv
+- 2024-12-24-123456/data/crate_owners.csv
+- 2024-12-24-123456/data/versions.csv
+- 2024-12-24-123456/data/default_versions.csv
+- 2024-12-24-123456/data/dependencies.csv
+- 2024-12-24-123456/data/version_downloads.csv
+
+----------------------------------------
+2024-12-24-123456:
+
+
+----------------------------------------
+2024-12-24-123456/schema.sql:
+
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 13.15 (Postgres.app)
+-- Dumped by pg_dump version 16.1
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
+-- Name: ltree; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS ltree WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION ltree; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION ltree IS 'data type for hierarchical tree-like structures';
+
+
+--
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
+
+--
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pgcrypto; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+
+
+--
+-- Name: semver_triple; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.semver_triple AS (
+	major numeric,
+	minor numeric,
+	teeny numeric
+);
+
+
+--
+-- Name: canon_crate_name(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.canon_crate_name(text) RETURNS text
+    LANGUAGE sql
+    AS $_$
+                    SELECT replace(lower($1), '-', '_')
+                $_$;
+
+
+--
+-- Name: crate_owner_invitations_set_token_generated_at(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.crate_owner_invitations_set_token_generated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+  BEGIN
+    NEW.token_generated_at := CURRENT_TIMESTAMP;
+    RETURN NEW;
+  END
+$$;
+
+
+--
+-- Name: diesel_manage_updated_at(regclass); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.diesel_manage_updated_at(_tbl regclass) RETURNS void
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$;
+
+
+--
+-- Name: diesel_set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.diesel_set_updated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: emails_set_token_generated_at(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.emails_set_token_generated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+  BEGIN
+    NEW.token_generated_at := CURRENT_TIMESTAMP;
+    RETURN NEW;
+  END
+$$;
+
+
+--
+-- Name: ensure_crate_name_not_reserved(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.ensure_crate_name_not_reserved() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF canon_crate_name(NEW.name) IN (
+        SELECT canon_crate_name(name) FROM reserved_crate_names
+    ) THEN
+        RAISE EXCEPTION 'cannot upload crate with reserved name';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: ensure_reserved_name_not_in_use(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.ensure_reserved_name_not_in_use() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF canon_crate_name(NEW.name) IN (
+        SELECT canon_crate_name(name) FROM crates
+    ) THEN
+        RAISE EXCEPTION 'crate exists with name %', NEW.name;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: insert_crate_downloads_row(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.insert_crate_downloads_row() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+begin
+    insert into crate_downloads(crate_id) values (new.id);
+    return new;
+end;
+$$;
+
+
+--
+-- Name: random_string(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.random_string(integer) RETURNS text
+    LANGUAGE sql
+    AS $_$
+  SELECT (array_to_string(array(
+    SELECT substr(
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+      floor(random() * 62)::int4 + 1,
+      1
+    ) FROM generate_series(1, $1)
+  ), ''))
+$_$;
+
+
+--
+-- Name: reconfirm_email_on_email_change(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.reconfirm_email_on_email_change() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+  BEGIN
+    IF NEW.email IS DISTINCT FROM OLD.email THEN
+      NEW.token := random_string(26);
+      NEW.verified := false;
+    END IF;
+    RETURN NEW;
+  END
+$$;
+
+
+--
+-- Name: refresh_recent_crate_downloads(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.refresh_recent_crate_downloads() RETURNS void
+    LANGUAGE sql
+    AS $$
+  REFRESH MATERIALIZED VIEW CONCURRENTLY recent_crate_downloads;
+$$;
+
+
+--
+-- Name: set_category_path_to_slug(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.set_category_path_to_slug() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+ NEW.path = text2ltree('root.' || trim(replace(replace(NEW.slug, '-', '_'), '::', '.')));
+ RETURN NEW;
+END;
+    $$;
+
+
+--
+-- Name: set_updated_at(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.set_updated_at() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at = CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+
+--
+-- Name: to_semver_no_prerelease(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.to_semver_no_prerelease(text) RETURNS public.semver_triple
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE
+    AS $_$
+  SELECT (
+    split_part($1, '.', 1)::numeric,
+    split_part($1, '.', 2)::numeric,
+    split_part(split_part($1, '+', 1), '.', 3)::numeric
+  )::public.semver_triple
+  WHERE strpos(split_part($1, '+', 1), '-') = 0
+  $_$;
+
+
+--
+-- Name: touch_crate(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.touch_crate() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+                BEGIN
+                    IF TG_OP = 'DELETE' THEN
+                        UPDATE crates SET updated_at = CURRENT_TIMESTAMP WHERE
+                            id = OLD.crate_id;
+                        RETURN OLD;
+                    ELSE
+                        UPDATE crates SET updated_at = CURRENT_TIMESTAMP WHERE
+                            id = NEW.crate_id;
+                        RETURN NEW;
+                    END IF;
+                END
+                $$;
+
+
+--
+-- Name: touch_crate_on_version_modified(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.touch_crate_on_version_modified() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  IF (
+    TG_OP = 'INSERT' OR
+    NEW.updated_at IS DISTINCT FROM OLD.updated_at
+  ) THEN
+    UPDATE crates SET updated_at = CURRENT_TIMESTAMP WHERE
+      crates.id = NEW.crate_id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+
+--
+-- Name: trigger_crates_name_search(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.trigger_crates_name_search() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+                DECLARE kws TEXT;
+                begin
+                  SELECT array_to_string(array_agg(keyword), ',') INTO kws
+                    FROM keywords INNER JOIN crates_keywords
+                    ON keywords.id = crates_keywords.keyword_id
+                    WHERE crates_keywords.crate_id = new.id;
+                  new.textsearchable_index_col :=
+                     setweight(to_tsvector('pg_catalog.english',
+                                           coalesce(new.name, '')), 'A') ||
+                     setweight(to_tsvector('pg_catalog.english',
+                                           coalesce(kws, '')), 'B') ||
+                     setweight(to_tsvector('pg_catalog.english',
+                                           coalesce(new.description, '')), 'C') ||
+                     setweight(to_tsvector('pg_catalog.english',
+                                           coalesce(new.readme, '')), 'D');
+                  return new;
+                end
+                $$;
+
+
+--
+-- Name: update_categories_crates_cnt(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.update_categories_crates_cnt() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$ BEGIN IF (TG_OP = 'INSERT') THEN UPDATE categories SET crates_cnt = crates_cnt + 1 WHERE id = NEW.category_id; return NEW; ELSIF (TG_OP = 'DELETE') THEN UPDATE categories SET crates_cnt = crates_cnt - 1 WHERE id = OLD.category_id; return OLD; END IF; END $$;
+
+
+--
+-- Name: update_keywords_crates_cnt(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.update_keywords_crates_cnt() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+            BEGIN
+                IF (TG_OP = 'INSERT') THEN
+                    UPDATE keywords SET crates_cnt = crates_cnt + 1 WHERE id = NEW.keyword_id;
+                    return NEW;
+                ELSIF (TG_OP = 'DELETE') THEN
+                    UPDATE keywords SET crates_cnt = crates_cnt - 1 WHERE id = OLD.keyword_id;
+                    return OLD;
+                END IF;
+            END
+            $$;
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: __diesel_schema_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.__diesel_schema_migrations (
+    version character varying(50) NOT NULL,
+    run_on timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: api_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_tokens (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    token bytea NOT NULL,
+    name character varying NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    last_used_at timestamp without time zone,
+    revoked boolean DEFAULT false NOT NULL,
+    crate_scopes text[],
+    endpoint_scopes text[],
+    expired_at timestamp without time zone,
+    expiry_notification_at timestamp without time zone
+);
+
+
+--
+-- Name: COLUMN api_tokens.crate_scopes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.api_tokens.crate_scopes IS 'NULL or an array of crate scope patterns (see RFC #2947)';
+
+
+--
+-- Name: COLUMN api_tokens.endpoint_scopes; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.api_tokens.endpoint_scopes IS 'An array of endpoint scopes or NULL for the `legacy` endpoint scope (see RFC #2947)';
+
+
+--
+-- Name: COLUMN api_tokens.expiry_notification_at; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.api_tokens.expiry_notification_at IS 'timestamp of when the user was informed about their token''s impending expiration';
+
+
+--
+-- Name: api_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.api_tokens_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: api_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.api_tokens_id_seq OWNED BY public.api_tokens.id;
+
+
+--
+-- Name: background_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.background_jobs (
+    id bigint NOT NULL,
+    job_type text NOT NULL,
+    data jsonb NOT NULL,
+    retries integer DEFAULT 0 NOT NULL,
+    last_retry timestamp without time zone DEFAULT '1970-01-01 00:00:00'::timestamp without time zone NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    priority smallint DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: background_jobs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.background_jobs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: background_jobs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.background_jobs_id_seq OWNED BY public.background_jobs.id;
+
+
+--
+-- Name: categories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.categories (
+    id integer NOT NULL,
+    category character varying NOT NULL,
+    slug character varying NOT NULL,
+    description character varying DEFAULT ''::character varying NOT NULL,
+    crates_cnt integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    path public.ltree NOT NULL
+);
+
+
+--
+-- Name: categories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.categories_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: categories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.categories_id_seq OWNED BY public.categories.id;
+
+
+--
+-- Name: crate_downloads; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.crate_downloads (
+    crate_id integer NOT NULL,
+    downloads bigint DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: TABLE crate_downloads; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.crate_downloads IS 'Number of downloads per crate. This was extracted from the `crates` table for performance reasons.';
+
+
+--
+-- Name: COLUMN crate_downloads.crate_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.crate_downloads.crate_id IS 'Reference to the crate that this row belongs to.';
+
+
+--
+-- Name: COLUMN crate_downloads.downloads; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.crate_downloads.downloads IS 'The total number of downloads for this crate.';
+
+
+--
+-- Name: crate_owner_invitations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.crate_owner_invitations (
+    invited_user_id integer NOT NULL,
+    invited_by_user_id integer NOT NULL,
+    crate_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT now() NOT NULL,
+    token text DEFAULT public.random_string(26) NOT NULL,
+    token_generated_at timestamp without time zone
+);
+
+
+--
+-- Name: crate_owners; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.crate_owners (
+    crate_id integer NOT NULL,
+    owner_id integer NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_by integer,
+    deleted boolean DEFAULT false NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    owner_kind integer NOT NULL,
+    email_notifications boolean DEFAULT true NOT NULL
+);
+
+
+--
+-- Name: COLUMN crate_owners.owner_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.crate_owners.owner_id IS 'This refers either to the `users.id` or `teams.id` column, depending on the value of the `owner_kind` column';
+
+
+--
+-- Name: COLUMN crate_owners.owner_kind; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.crate_owners.owner_kind IS '`owner_kind = 0` refers to `users`, `owner_kind = 1` refers to `teams`.';
+
+
+--
+-- Name: crates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.crates (
+    id integer NOT NULL,
+    name character varying NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    description character varying,
+    homepage character varying,
+    documentation character varying,
+    readme character varying,
+    textsearchable_index_col tsvector NOT NULL,
+    repository character varying,
+    max_upload_size integer,
+    max_features smallint
+);
+
+
+--
+-- Name: crates_categories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.crates_categories (
+    crate_id integer NOT NULL,
+    category_id integer NOT NULL
+);
+
+
+--
+-- Name: crates_keywords; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.crates_keywords (
+    crate_id integer NOT NULL,
+    keyword_id integer NOT NULL
+);
+
+
+--
+-- Name: default_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.default_versions (
+    crate_id integer NOT NULL,
+    version_id integer NOT NULL
+);
+
+
+--
+-- Name: TABLE default_versions; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.default_versions IS 'A mapping from crates to the versions that the frontend will display by default.';
+
+
+--
+-- Name: COLUMN default_versions.crate_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.default_versions.crate_id IS 'Reference to the crate in the `crates` table.';
+
+
+--
+-- Name: COLUMN default_versions.version_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.default_versions.version_id IS 'Reference to the version in the `versions` table.';
+
+
+--
+-- Name: dependencies; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.dependencies (
+    id integer NOT NULL,
+    version_id integer NOT NULL,
+    crate_id integer NOT NULL,
+    req character varying NOT NULL,
+    optional boolean NOT NULL,
+    default_features boolean NOT NULL,
+    features text[] NOT NULL,
+    target character varying,
+    kind integer DEFAULT 0 NOT NULL,
+    explicit_name character varying
+);
+
+
+--
+-- Name: dependencies_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.dependencies_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: dependencies_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.dependencies_id_seq OWNED BY public.dependencies.id;
+
+
+--
+-- Name: emails; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.emails (
+    id integer NOT NULL,
+    user_id integer NOT NULL,
+    email character varying NOT NULL,
+    verified boolean DEFAULT false NOT NULL,
+    token text DEFAULT public.random_string(26) NOT NULL,
+    token_generated_at timestamp without time zone
+);
+
+
+--
+-- Name: emails_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.emails_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.emails_id_seq OWNED BY public.emails.id;
+
+
+--
+-- Name: follows; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.follows (
+    user_id integer NOT NULL,
+    crate_id integer NOT NULL
+);
+
+
+--
+-- Name: keywords; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.keywords (
+    id integer NOT NULL,
+    keyword text NOT NULL,
+    crates_cnt integer DEFAULT 0 NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: keywords_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.keywords_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: keywords_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.keywords_id_seq OWNED BY public.keywords.id;
+
+
+--
+-- Name: metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.metadata (
+    total_downloads bigint NOT NULL
+);
+
+
+--
+-- Name: packages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.packages_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: packages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.packages_id_seq OWNED BY public.crates.id;
+
+
+--
+-- Name: processed_log_files; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.processed_log_files (
+    path character varying NOT NULL,
+    "time" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: TABLE processed_log_files; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON TABLE public.processed_log_files IS 'List of all processed CDN log files, used to avoid processing the same file multiple times.';
+
+
+--
+-- Name: COLUMN processed_log_files.path; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.processed_log_files.path IS 'Path of the log file inside the S3 bucket';
+
+
+--
+-- Name: COLUMN processed_log_files."time"; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.processed_log_files."time" IS 'Time when the log file was processed';
+
+
+--
+-- Name: publish_limit_buckets; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.publish_limit_buckets (
+    user_id integer NOT NULL,
+    tokens integer NOT NULL,
+    last_refill timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    action integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: publish_rate_overrides; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.publish_rate_overrides (
+    user_id integer NOT NULL,
+    burst integer NOT NULL,
+    expires_at timestamp without time zone,
+    action integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: readme_renderings; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.readme_renderings (
+    version_id integer NOT NULL,
+    rendered_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: version_downloads; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.version_downloads (
+    version_id integer NOT NULL,
+    downloads integer DEFAULT 1 NOT NULL,
+    counted integer DEFAULT 0 NOT NULL,
+    date date DEFAULT CURRENT_DATE NOT NULL,
+    processed boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.versions (
+    id integer NOT NULL,
+    crate_id integer NOT NULL,
+    num character varying NOT NULL,
+    updated_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    downloads integer DEFAULT 0 NOT NULL,
+    features jsonb DEFAULT '{}'::jsonb NOT NULL,
+    yanked boolean DEFAULT false NOT NULL,
+    license character varying,
+    crate_size integer,
+    published_by integer,
+    checksum character(64) NOT NULL,
+    links character varying,
+    rust_version character varying,
+    semver_no_prerelease public.semver_triple GENERATED ALWAYS AS (public.to_semver_no_prerelease((num)::text)) STORED
+);
+
+
+--
+-- Name: recent_crate_downloads; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.recent_crate_downloads AS
+ SELECT versions.crate_id,
+    sum(version_downloads.downloads) AS downloads
+   FROM (public.version_downloads
+     JOIN public.versions ON ((version_downloads.version_id = versions.id)))
+  WHERE (version_downloads.date > date((CURRENT_TIMESTAMP - '90 days'::interval)))
+  GROUP BY versions.crate_id
+  WITH NO DATA;
+
+
+--
+-- Name: reserved_crate_names; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reserved_crate_names (
+    name text NOT NULL
+);
+
+
+--
+-- Name: teams; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.teams (
+    id integer NOT NULL,
+    login character varying NOT NULL,
+    github_id integer NOT NULL,
+    name character varying,
+    avatar character varying,
+    org_id integer,
+    CONSTRAINT teams_login_lowercase_ck CHECK (((login)::text = lower((login)::text)))
+);
+
+
+--
+-- Name: COLUMN teams.login; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.teams.login IS 'Example: `github:foo:bar` means the `bar` team of the `foo` GitHub organization.';
+
+
+--
+-- Name: COLUMN teams.github_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.teams.github_id IS 'Unique team ID on the GitHub API. When teams are recreated with the same name then they will still get a different ID, so this allows us to avoid potential name reuse attacks.';
+
+
+--
+-- Name: COLUMN teams.org_id; Type: COMMENT; Schema: public; Owner: -
+--
+
+COMMENT ON COLUMN public.teams.org_id IS 'Unique organization ID on the GitHub API. When organizations are recreated with the same name then they will still get a different ID, so this allows us to avoid potential name reuse attacks.';
+
+
+--
+-- Name: teams_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.teams_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: teams_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.teams_id_seq OWNED BY public.teams.id;
+
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    gh_access_token character varying NOT NULL,
+    gh_login character varying NOT NULL,
+    name character varying,
+    gh_avatar character varying,
+    gh_id integer NOT NULL,
+    account_lock_reason character varying,
+    account_lock_until timestamp without time zone,
+    is_admin boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.users_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+
+
+--
+-- Name: version_owner_actions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.version_owner_actions (
+    id integer NOT NULL,
+    version_id integer NOT NULL,
+    user_id integer NOT NULL,
+    api_token_id integer,
+    action integer NOT NULL,
+    "time" timestamp without time zone DEFAULT now() NOT NULL
+);
+
+
+--
+-- Name: version_owner_actions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.version_owner_actions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: version_owner_actions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.version_owner_actions_id_seq OWNED BY public.version_owner_actions.id;
+
+
+--
+-- Name: versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.versions_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.versions_id_seq OWNED BY public.versions.id;
+
+
+--
+-- Name: versions_published_by; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.versions_published_by (
+    version_id integer NOT NULL,
+    email character varying NOT NULL
+);
+
+
+--
+-- Name: api_tokens id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_tokens ALTER COLUMN id SET DEFAULT nextval('public.api_tokens_id_seq'::regclass);
+
+
+--
+-- Name: background_jobs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.background_jobs ALTER COLUMN id SET DEFAULT nextval('public.background_jobs_id_seq'::regclass);
+
+
+--
+-- Name: categories id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.categories ALTER COLUMN id SET DEFAULT nextval('public.categories_id_seq'::regclass);
+
+
+--
+-- Name: crates id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates ALTER COLUMN id SET DEFAULT nextval('public.packages_id_seq'::regclass);
+
+
+--
+-- Name: dependencies id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dependencies ALTER COLUMN id SET DEFAULT nextval('public.dependencies_id_seq'::regclass);
+
+
+--
+-- Name: emails id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.emails ALTER COLUMN id SET DEFAULT nextval('public.emails_id_seq'::regclass);
+
+
+--
+-- Name: keywords id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.keywords ALTER COLUMN id SET DEFAULT nextval('public.keywords_id_seq'::regclass);
+
+
+--
+-- Name: teams id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teams ALTER COLUMN id SET DEFAULT nextval('public.teams_id_seq'::regclass);
+
+
+--
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Name: version_owner_actions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.version_owner_actions ALTER COLUMN id SET DEFAULT nextval('public.version_owner_actions_id_seq'::regclass);
+
+
+--
+-- Name: versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions ALTER COLUMN id SET DEFAULT nextval('public.versions_id_seq'::regclass);
+
+
+--
+-- Name: __diesel_schema_migrations __diesel_schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.__diesel_schema_migrations
+    ADD CONSTRAINT __diesel_schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: api_tokens api_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_tokens
+    ADD CONSTRAINT api_tokens_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: background_jobs background_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.background_jobs
+    ADD CONSTRAINT background_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: categories categories_category_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.categories
+    ADD CONSTRAINT categories_category_key UNIQUE (category);
+
+
+--
+-- Name: categories categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.categories
+    ADD CONSTRAINT categories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: categories categories_slug_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.categories
+    ADD CONSTRAINT categories_slug_key UNIQUE (slug);
+
+
+--
+-- Name: crate_downloads crate_downloads_pk; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_downloads
+    ADD CONSTRAINT crate_downloads_pk PRIMARY KEY (crate_id);
+
+
+--
+-- Name: crate_owner_invitations crate_owner_invitations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_owner_invitations
+    ADD CONSTRAINT crate_owner_invitations_pkey PRIMARY KEY (invited_user_id, crate_id);
+
+
+--
+-- Name: crate_owners crate_owners_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_owners
+    ADD CONSTRAINT crate_owners_pkey PRIMARY KEY (crate_id, owner_id, owner_kind);
+
+
+--
+-- Name: crates_categories crates_categories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates_categories
+    ADD CONSTRAINT crates_categories_pkey PRIMARY KEY (crate_id, category_id);
+
+
+--
+-- Name: crates_keywords crates_keywords_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates_keywords
+    ADD CONSTRAINT crates_keywords_pkey PRIMARY KEY (crate_id, keyword_id);
+
+
+--
+-- Name: default_versions default_versions_pk; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.default_versions
+    ADD CONSTRAINT default_versions_pk PRIMARY KEY (crate_id);
+
+
+--
+-- Name: dependencies dependencies_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dependencies
+    ADD CONSTRAINT dependencies_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: emails emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.emails
+    ADD CONSTRAINT emails_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: emails emails_user_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.emails
+    ADD CONSTRAINT emails_user_id_key UNIQUE (user_id);
+
+
+--
+-- Name: follows follows_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.follows
+    ADD CONSTRAINT follows_pkey PRIMARY KEY (user_id, crate_id);
+
+
+--
+-- Name: keywords keywords_keyword_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.keywords
+    ADD CONSTRAINT keywords_keyword_key UNIQUE (keyword);
+
+
+--
+-- Name: keywords keywords_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.keywords
+    ADD CONSTRAINT keywords_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: metadata metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.metadata
+    ADD CONSTRAINT metadata_pkey PRIMARY KEY (total_downloads);
+
+
+--
+-- Name: crates packages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates
+    ADD CONSTRAINT packages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: processed_log_files processed_log_files_pk; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.processed_log_files
+    ADD CONSTRAINT processed_log_files_pk PRIMARY KEY (path);
+
+
+--
+-- Name: publish_limit_buckets publish_limit_buckets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publish_limit_buckets
+    ADD CONSTRAINT publish_limit_buckets_pkey PRIMARY KEY (user_id, action);
+
+
+--
+-- Name: publish_rate_overrides publish_rate_overrides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publish_rate_overrides
+    ADD CONSTRAINT publish_rate_overrides_pkey PRIMARY KEY (user_id, action);
+
+
+--
+-- Name: readme_renderings readme_renderings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.readme_renderings
+    ADD CONSTRAINT readme_renderings_pkey PRIMARY KEY (version_id);
+
+
+--
+-- Name: reserved_crate_names reserved_crate_names_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reserved_crate_names
+    ADD CONSTRAINT reserved_crate_names_pkey PRIMARY KEY (name);
+
+
+--
+-- Name: teams teams_github_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teams
+    ADD CONSTRAINT teams_github_id_key UNIQUE (github_id);
+
+
+--
+-- Name: teams teams_login_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teams
+    ADD CONSTRAINT teams_login_key UNIQUE (login);
+
+
+--
+-- Name: teams teams_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.teams
+    ADD CONSTRAINT teams_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: versions unique_num; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions
+    ADD CONSTRAINT unique_num UNIQUE (crate_id, num);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: version_downloads version_downloads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.version_downloads
+    ADD CONSTRAINT version_downloads_pkey PRIMARY KEY (version_id, date);
+
+
+--
+-- Name: version_owner_actions version_owner_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.version_owner_actions
+    ADD CONSTRAINT version_owner_actions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: versions versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions
+    ADD CONSTRAINT versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: versions_published_by versions_published_by_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions_published_by
+    ADD CONSTRAINT versions_published_by_pkey PRIMARY KEY (version_id);
+
+
+--
+-- Name: api_tokens_token_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX api_tokens_token_idx ON public.api_tokens USING btree (token);
+
+
+--
+-- Name: crate_downloads_downloads_crate_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX crate_downloads_downloads_crate_id_index ON public.crate_downloads USING btree (downloads DESC, crate_id DESC);
+
+
+--
+-- Name: crate_owners_not_deleted; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX crate_owners_not_deleted ON public.crate_owners USING btree (crate_id, owner_id, owner_kind) WHERE (NOT deleted);
+
+
+--
+-- Name: default_versions_version_id_uindex; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX default_versions_version_id_uindex ON public.default_versions USING btree (version_id);
+
+
+--
+-- Name: dependencies_crate_id_version_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX dependencies_crate_id_version_id_idx ON public.dependencies USING btree (crate_id, version_id);
+
+
+--
+-- Name: index_crate_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crate_created_at ON public.crates USING btree (created_at);
+
+
+--
+-- Name: index_crate_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crate_updated_at ON public.crates USING btree (updated_at);
+
+
+--
+-- Name: index_crates_categories_category_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crates_categories_category_id ON public.crates_categories USING btree (category_id);
+
+
+--
+-- Name: index_crates_categories_crate_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crates_categories_crate_id ON public.crates_categories USING btree (crate_id);
+
+
+--
+-- Name: index_crates_keywords_crate_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crates_keywords_crate_id ON public.crates_keywords USING btree (crate_id);
+
+
+--
+-- Name: index_crates_keywords_keyword_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crates_keywords_keyword_id ON public.crates_keywords USING btree (keyword_id);
+
+
+--
+-- Name: index_crates_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_crates_name ON public.crates USING btree (public.canon_crate_name((name)::text));
+
+
+--
+-- Name: index_crates_name_ordering; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crates_name_ordering ON public.crates USING btree (name);
+
+
+--
+-- Name: index_crates_name_search; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crates_name_search ON public.crates USING gin (textsearchable_index_col);
+
+
+--
+-- Name: index_crates_name_tgrm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_crates_name_tgrm ON public.crates USING gin (public.canon_crate_name((name)::text) public.gin_trgm_ops);
+
+
+--
+-- Name: index_dependencies_crate_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_dependencies_crate_id ON public.dependencies USING btree (crate_id);
+
+
+--
+-- Name: index_dependencies_version_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_dependencies_version_id ON public.dependencies USING btree (version_id);
+
+
+--
+-- Name: index_keywords_crates_cnt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_keywords_crates_cnt ON public.keywords USING btree (crates_cnt);
+
+
+--
+-- Name: index_keywords_keyword; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_keywords_keyword ON public.keywords USING btree (keyword);
+
+
+--
+-- Name: index_keywords_lower_keyword; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_keywords_lower_keyword ON public.keywords USING btree (lower(keyword));
+
+
+--
+-- Name: index_recent_crate_downloads_by_downloads; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_recent_crate_downloads_by_downloads ON public.recent_crate_downloads USING btree (downloads);
+
+
+--
+-- Name: index_version_downloads_date; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_version_downloads_date ON public.version_downloads USING brin (date) WITH (pages_per_range='1');
+
+
+--
+-- Name: index_version_downloads_not_processed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_version_downloads_not_processed ON public.version_downloads USING btree (processed) WHERE (NOT processed);
+
+
+--
+-- Name: index_version_owner_actions_by_version_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_version_owner_actions_by_version_id ON public.version_owner_actions USING btree (version_id);
+
+
+--
+-- Name: index_versions_crate_id_semver_no_prerelease_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_versions_crate_id_semver_no_prerelease_id ON public.versions USING btree (crate_id, semver_no_prerelease DESC NULLS LAST, id DESC) WHERE (NOT yanked);
+
+
+--
+-- Name: lower_gh_login; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX lower_gh_login ON public.users USING btree (lower((gh_login)::text));
+
+
+--
+-- Name: path_gist_categories_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX path_gist_categories_idx ON public.categories USING gist (path);
+
+
+--
+-- Name: recent_crate_downloads_crate_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX recent_crate_downloads_crate_id ON public.recent_crate_downloads USING btree (crate_id);
+
+
+--
+-- Name: users_gh_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX users_gh_id ON public.users USING btree (gh_id) WHERE (gh_id > 0);
+
+
+--
+-- Name: crates insert_crate_downloads_row; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER insert_crate_downloads_row AFTER INSERT ON public.crates FOR EACH ROW EXECUTE FUNCTION public.insert_crate_downloads_row();
+
+
+--
+-- Name: categories set_category_path_insert; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_category_path_insert BEFORE INSERT ON public.categories FOR EACH ROW EXECUTE FUNCTION public.set_category_path_to_slug();
+
+
+--
+-- Name: categories set_category_path_update; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER set_category_path_update BEFORE UPDATE OF slug ON public.categories FOR EACH ROW EXECUTE FUNCTION public.set_category_path_to_slug();
+
+
+--
+-- Name: versions touch_crate; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER touch_crate BEFORE INSERT OR UPDATE ON public.versions FOR EACH ROW EXECUTE FUNCTION public.touch_crate_on_version_modified();
+
+
+--
+-- Name: crates_categories touch_crate_on_modify_categories; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER touch_crate_on_modify_categories AFTER INSERT OR DELETE ON public.crates_categories FOR EACH ROW EXECUTE FUNCTION public.touch_crate();
+
+
+--
+-- Name: crates_keywords touch_crate_on_modify_keywords; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER touch_crate_on_modify_keywords AFTER INSERT OR DELETE ON public.crates_keywords FOR EACH ROW EXECUTE FUNCTION public.touch_crate();
+
+
+--
+-- Name: crate_owner_invitations trigger_crate_owner_invitations_set_token_generated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_crate_owner_invitations_set_token_generated_at BEFORE INSERT OR UPDATE OF token ON public.crate_owner_invitations FOR EACH ROW EXECUTE FUNCTION public.crate_owner_invitations_set_token_generated_at();
+
+
+--
+-- Name: crate_owners trigger_crate_owners_set_updated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_crate_owners_set_updated_at BEFORE UPDATE ON public.crate_owners FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: crates trigger_crates_set_updated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_crates_set_updated_at BEFORE UPDATE ON public.crates FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: crates trigger_crates_tsvector_update; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_crates_tsvector_update BEFORE INSERT OR UPDATE OF updated_at ON public.crates FOR EACH ROW EXECUTE FUNCTION public.trigger_crates_name_search();
+
+
+--
+-- Name: emails trigger_emails_reconfirm; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_emails_reconfirm BEFORE UPDATE ON public.emails FOR EACH ROW EXECUTE FUNCTION public.reconfirm_email_on_email_change();
+
+
+--
+-- Name: emails trigger_emails_set_token_generated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_emails_set_token_generated_at BEFORE INSERT OR UPDATE OF token ON public.emails FOR EACH ROW EXECUTE FUNCTION public.emails_set_token_generated_at();
+
+
+--
+-- Name: crates trigger_ensure_crate_name_not_reserved; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_ensure_crate_name_not_reserved BEFORE INSERT OR UPDATE ON public.crates FOR EACH ROW EXECUTE FUNCTION public.ensure_crate_name_not_reserved();
+
+
+--
+-- Name: reserved_crate_names trigger_ensure_reserved_name_not_in_use; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_ensure_reserved_name_not_in_use BEFORE INSERT OR UPDATE ON public.reserved_crate_names FOR EACH ROW EXECUTE FUNCTION public.ensure_reserved_name_not_in_use();
+
+
+--
+-- Name: crates_categories trigger_update_categories_crates_cnt; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_update_categories_crates_cnt BEFORE INSERT OR DELETE ON public.crates_categories FOR EACH ROW EXECUTE FUNCTION public.update_categories_crates_cnt();
+
+
+--
+-- Name: crates_keywords trigger_update_keywords_crates_cnt; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_update_keywords_crates_cnt BEFORE INSERT OR DELETE ON public.crates_keywords FOR EACH ROW EXECUTE FUNCTION public.update_keywords_crates_cnt();
+
+
+--
+-- Name: versions trigger_versions_set_updated_at; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trigger_versions_set_updated_at BEFORE UPDATE OF yanked ON public.versions FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+
+--
+-- Name: api_tokens api_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_tokens
+    ADD CONSTRAINT api_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: crate_downloads crate_downloads_crates_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_downloads
+    ADD CONSTRAINT crate_downloads_crates_id_fk FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crate_owner_invitations crate_owner_invitations_crate_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_owner_invitations
+    ADD CONSTRAINT crate_owner_invitations_crate_id_fkey FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crate_owner_invitations crate_owner_invitations_invited_by_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_owner_invitations
+    ADD CONSTRAINT crate_owner_invitations_invited_by_user_id_fkey FOREIGN KEY (invited_by_user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crate_owner_invitations crate_owner_invitations_invited_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_owner_invitations
+    ADD CONSTRAINT crate_owner_invitations_invited_user_id_fkey FOREIGN KEY (invited_user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: default_versions default_versions_crates_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.default_versions
+    ADD CONSTRAINT default_versions_crates_id_fk FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: default_versions default_versions_versions_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.default_versions
+    ADD CONSTRAINT default_versions_versions_id_fk FOREIGN KEY (version_id) REFERENCES public.versions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crate_owners fk_crate_owners_crate_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_owners
+    ADD CONSTRAINT fk_crate_owners_crate_id FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crate_owners fk_crate_owners_created_by; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crate_owners
+    ADD CONSTRAINT fk_crate_owners_created_by FOREIGN KEY (created_by) REFERENCES public.users(id);
+
+
+--
+-- Name: crates_categories fk_crates_categories_category_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates_categories
+    ADD CONSTRAINT fk_crates_categories_category_id FOREIGN KEY (category_id) REFERENCES public.categories(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crates_categories fk_crates_categories_crate_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates_categories
+    ADD CONSTRAINT fk_crates_categories_crate_id FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crates_keywords fk_crates_keywords_crate_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates_keywords
+    ADD CONSTRAINT fk_crates_keywords_crate_id FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: crates_keywords fk_crates_keywords_keyword_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.crates_keywords
+    ADD CONSTRAINT fk_crates_keywords_keyword_id FOREIGN KEY (keyword_id) REFERENCES public.keywords(id);
+
+
+--
+-- Name: dependencies fk_dependencies_crate_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dependencies
+    ADD CONSTRAINT fk_dependencies_crate_id FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: dependencies fk_dependencies_version_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.dependencies
+    ADD CONSTRAINT fk_dependencies_version_id FOREIGN KEY (version_id) REFERENCES public.versions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: emails fk_emails_user_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.emails
+    ADD CONSTRAINT fk_emails_user_id FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: follows fk_follows_crate_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.follows
+    ADD CONSTRAINT fk_follows_crate_id FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: follows fk_follows_user_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.follows
+    ADD CONSTRAINT fk_follows_user_id FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: version_downloads fk_version_downloads_version_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.version_downloads
+    ADD CONSTRAINT fk_version_downloads_version_id FOREIGN KEY (version_id) REFERENCES public.versions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: versions fk_versions_crate_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions
+    ADD CONSTRAINT fk_versions_crate_id FOREIGN KEY (crate_id) REFERENCES public.crates(id) ON DELETE CASCADE;
+
+
+--
+-- Name: versions fk_versions_published_by; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions
+    ADD CONSTRAINT fk_versions_published_by FOREIGN KEY (published_by) REFERENCES public.users(id);
+
+
+--
+-- Name: publish_limit_buckets publish_limit_buckets_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publish_limit_buckets
+    ADD CONSTRAINT publish_limit_buckets_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: publish_rate_overrides publish_rate_overrides_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.publish_rate_overrides
+    ADD CONSTRAINT publish_rate_overrides_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: readme_renderings readme_renderings_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.readme_renderings
+    ADD CONSTRAINT readme_renderings_version_id_fkey FOREIGN KEY (version_id) REFERENCES public.versions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: version_owner_actions version_owner_actions_owner_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.version_owner_actions
+    ADD CONSTRAINT version_owner_actions_owner_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
+-- Name: version_owner_actions version_owner_actions_owner_token_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.version_owner_actions
+    ADD CONSTRAINT version_owner_actions_owner_token_id_fkey FOREIGN KEY (api_token_id) REFERENCES public.api_tokens(id);
+
+
+--
+-- Name: version_owner_actions version_owner_actions_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.version_owner_actions
+    ADD CONSTRAINT version_owner_actions_version_id_fkey FOREIGN KEY (version_id) REFERENCES public.versions(id) ON DELETE CASCADE;
+
+
+--
+-- Name: versions_published_by versions_published_by_version_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.versions_published_by
+    ADD CONSTRAINT versions_published_by_version_id_fkey FOREIGN KEY (version_id) REFERENCES public.versions(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+
+----------------------------------------
+2024-12-24-123456/metadata.json:
+
+{
+  "timestamp": "2024-12-24T12:34:56.789012Z",
+  "crates_io_commit": "unknown"
+}
+----------------------------------------
+2024-12-24-123456/README.md:
+
+# crates.io Database Dump
+
+This is a dump of the public information in the crates.io database.
+
+## Files
+
+- `data/` – the CSV files with the actual data.
+- `export.sql` – the `psql` script that was used to create this database dump. It is only included in the archive for reference.
+- `import.sql` – a `psql` script that can be used to restore the dump into a PostgreSQL database with the same schema as the `crates.io` database, destroying all current data.
+- `metadata.json` – some metadata of this dump.
+- `schema.sql` – a dump of the database schema to facilitate generating a new database from the data.
+
+## Metadata Fields
+
+- `timestamp` – the UTC time the dump was started.
+- `crates_io_commit` – the git commit hash of the deployed version of crates.io that created this dump.
+
+## Less Obvious Database Fields
+
+- `crate_owners.owner_kind` - if `0`, the crate owner is a user; if `1`, the crate owner is a team. (If another value, you should probably contact the crates.io team.)
+- `crate_owners.owner_id` - if the owner is a user, this is their ID in `users.id`, otherwise it's the ID in `teams.id`.
+- `teams.login` - this will look something like `github:foo:bar`, referring to the `bar` team in the `foo` organisation. At present, as we only support GitHub, the first component will always be `github`.
+
+## Restoring to a Local crates.io Database
+
+1.  Create a new database.
+
+        createdb DATABASE_NAME
+
+2.  Restore the database schema.
+
+        psql DATABASE_NAME < schema.sql
+
+3.  Run the import script.
+
+        psql DATABASE_URL < import.sql
+
+----------------------------------------
+2024-12-24-123456/import.sql:
+
+BEGIN;
+    -- Disable triggers on each table.
+
+    ALTER TABLE "categories" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "crate_downloads" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "crates" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "keywords" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "metadata" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "reserved_crate_names" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "teams" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "users" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "crates_categories" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "crates_keywords" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "crate_owners" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "versions" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "default_versions" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "dependencies" DISABLE TRIGGER ALL;
+
+    ALTER TABLE "version_downloads" DISABLE TRIGGER ALL;
+
+
+    -- Set defaults for non-nullable columns not included in the dump.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    ALTER TABLE "users" ALTER COLUMN "gh_access_token" SET DEFAULT '';
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    -- Truncate all tables.
+
+    TRUNCATE "categories" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "crate_downloads" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "crates" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "keywords" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "metadata" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "reserved_crate_names" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "teams" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "users" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "crates_categories" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "crates_keywords" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "crate_owners" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "versions" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "default_versions" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "dependencies" RESTART IDENTITY CASCADE;
+
+    TRUNCATE "version_downloads" RESTART IDENTITY CASCADE;
+
+
+    -- Enable this trigger so that `crates.textsearchable_index_col` can be excluded from the export
+    ALTER TABLE "crates" ENABLE TRIGGER "trigger_crates_tsvector_update";
+
+    -- Import the CSV data.
+
+    \copy "categories" ("category", "crates_cnt", "created_at", "description", "id", "path", "slug") FROM 'data/categories.csv' WITH CSV HEADER
+
+    \copy "crate_downloads" ("crate_id", "downloads") FROM 'data/crate_downloads.csv' WITH CSV HEADER
+
+    \copy "crates" ("created_at", "description", "documentation", "homepage", "id", "max_features", "max_upload_size", "name", "readme", "repository", "updated_at") FROM 'data/crates.csv' WITH CSV HEADER
+
+    \copy "keywords" ("crates_cnt", "created_at", "id", "keyword") FROM 'data/keywords.csv' WITH CSV HEADER
+
+    \copy "metadata" ("total_downloads") FROM 'data/metadata.csv' WITH CSV HEADER
+
+    \copy "reserved_crate_names" ("name") FROM 'data/reserved_crate_names.csv' WITH CSV HEADER
+
+    \copy "teams" ("avatar", "github_id", "id", "login", "name", "org_id") FROM 'data/teams.csv' WITH CSV HEADER
+
+    \copy "users" ("gh_avatar", "gh_id", "gh_login", "id", "name") FROM 'data/users.csv' WITH CSV HEADER
+
+    \copy "crates_categories" ("category_id", "crate_id") FROM 'data/crates_categories.csv' WITH CSV HEADER
+
+    \copy "crates_keywords" ("crate_id", "keyword_id") FROM 'data/crates_keywords.csv' WITH CSV HEADER
+
+    \copy "crate_owners" ("crate_id", "created_at", "created_by", "owner_id", "owner_kind") FROM 'data/crate_owners.csv' WITH CSV HEADER
+
+    \copy "versions" ("checksum", "crate_id", "crate_size", "created_at", "downloads", "features", "id", "license", "links", "num", "published_by", "rust_version", "updated_at", "yanked") FROM 'data/versions.csv' WITH CSV HEADER
+
+    \copy "default_versions" ("crate_id", "version_id") FROM 'data/default_versions.csv' WITH CSV HEADER
+
+    \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") FROM 'data/dependencies.csv' WITH CSV HEADER
+
+    \copy "version_downloads" ("date", "downloads", "version_id") FROM 'data/version_downloads.csv' WITH CSV HEADER
+
+
+    -- Drop the defaults again.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    ALTER TABLE "users" ALTER COLUMN "gh_access_token" DROP DEFAULT;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    -- Reenable triggers on each table.
+
+    ALTER TABLE "categories" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "crate_downloads" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "crates" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "keywords" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "metadata" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "reserved_crate_names" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "teams" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "users" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "crates_categories" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "crates_keywords" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "crate_owners" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "versions" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "default_versions" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "dependencies" ENABLE TRIGGER ALL;
+
+    ALTER TABLE "version_downloads" ENABLE TRIGGER ALL;
+
+COMMIT;
+----------------------------------------
+2024-12-24-123456/export.sql:
+
+BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
+
+
+    \copy "categories" ("category", "crates_cnt", "created_at", "description", "id", "path", "slug") TO 'data/categories.csv' WITH CSV HEADER
+
+
+
+    \copy "crate_downloads" ("crate_id", "downloads") TO 'data/crate_downloads.csv' WITH CSV HEADER
+
+
+
+    \copy "crates" ("created_at", "description", "documentation", "homepage", "id", "max_features", "max_upload_size", "name", "readme", "repository", "updated_at") TO 'data/crates.csv' WITH CSV HEADER
+
+
+
+    \copy "keywords" ("crates_cnt", "created_at", "id", "keyword") TO 'data/keywords.csv' WITH CSV HEADER
+
+
+
+    \copy "metadata" ("total_downloads") TO 'data/metadata.csv' WITH CSV HEADER
+
+
+
+    \copy "reserved_crate_names" ("name") TO 'data/reserved_crate_names.csv' WITH CSV HEADER
+
+
+
+    \copy "teams" ("avatar", "github_id", "id", "login", "name", "org_id") TO 'data/teams.csv' WITH CSV HEADER
+
+
+
+    \copy (SELECT "gh_avatar", "gh_id", "gh_login", "id", "name" FROM "users" WHERE id in (     SELECT owner_id AS user_id FROM crate_owners WHERE NOT deleted AND owner_kind = 0     UNION     SELECT published_by as user_id FROM versions )) TO 'data/users.csv' WITH CSV HEADER
+
+
+
+    \copy "crates_categories" ("category_id", "crate_id") TO 'data/crates_categories.csv' WITH CSV HEADER
+
+
+
+    \copy "crates_keywords" ("crate_id", "keyword_id") TO 'data/crates_keywords.csv' WITH CSV HEADER
+
+
+
+    \copy (SELECT "crate_id", "created_at", "created_by", "owner_id", "owner_kind" FROM "crate_owners" WHERE NOT deleted) TO 'data/crate_owners.csv' WITH CSV HEADER
+
+
+
+    \copy "versions" ("checksum", "crate_id", "crate_size", "created_at", "downloads", "features", "id", "license", "links", "num", "published_by", "rust_version", "updated_at", "yanked") TO 'data/versions.csv' WITH CSV HEADER
+
+
+
+    \copy "default_versions" ("crate_id", "version_id") TO 'data/default_versions.csv' WITH CSV HEADER
+
+
+
+    \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") TO 'data/dependencies.csv' WITH CSV HEADER
+
+
+
+    \copy (SELECT "date", "downloads", "version_id" FROM "version_downloads" WHERE date > current_date - interval '90 day') TO 'data/version_downloads.csv' WITH CSV HEADER
+
+
+COMMIT;
+----------------------------------------
+2024-12-24-123456/data:
+
+
+----------------------------------------
+2024-12-24-123456/data/categories.csv:
+
+category,crates_cnt,created_at,description,id,path,slug
+
+----------------------------------------
+2024-12-24-123456/data/crate_downloads.csv:
+
+crate_id,downloads
+1,0
+
+----------------------------------------
+2024-12-24-123456/data/crates.csv:
+
+created_at,description,documentation,homepage,id,max_features,max_upload_size,name,readme,repository,updated_at
+2024-12-24 12:34:56.789012,,,,1,,,test-crate,,,2024-12-24 12:34:56.789012
+
+----------------------------------------
+2024-12-24-123456/data/keywords.csv:
+
+crates_cnt,created_at,id,keyword
+
+----------------------------------------
+2024-12-24-123456/data/metadata.csv:
+
+total_downloads
+0
+
+----------------------------------------
+2024-12-24-123456/data/reserved_crate_names.csv:
+
+name
+alloc
+arena
+ast
+builtins
+collections
+compiler-builtins
+compiler-rt
+compiletest
+core
+coretest
+debug
+driver
+flate
+fmt_macros
+grammar
+graphviz
+macro
+macros
+proc_macro
+rbml
+rust-installer
+rustbook
+rustc
+rustc_back
+rustc_borrowck
+rustc_driver
+rustc_llvm
+rustc_resolve
+rustc_trans
+rustc_typeck
+rustdoc
+rustllvm
+rustuv
+serialize
+std
+syntax
+test
+unicode
+nul
+con
+prn
+aux
+com1
+com2
+com3
+com4
+com5
+com6
+com7
+com8
+com9
+lpt1
+lpt2
+lpt3
+lpt4
+lpt5
+lpt6
+lpt7
+lpt8
+lpt9
+com0
+lpt0
+
+----------------------------------------
+2024-12-24-123456/data/teams.csv:
+
+avatar,github_id,id,login,name,org_id
+
+----------------------------------------
+2024-12-24-123456/data/users.csv:
+
+gh_avatar,gh_id,gh_login,id,name
+,0,foo,1,
+
+----------------------------------------
+2024-12-24-123456/data/crates_categories.csv:
+
+category_id,crate_id
+
+----------------------------------------
+2024-12-24-123456/data/crates_keywords.csv:
+
+crate_id,keyword_id
+
+----------------------------------------
+2024-12-24-123456/data/crate_owners.csv:
+
+crate_id,created_at,created_by,owner_id,owner_kind
+1,2024-12-24 12:34:56.789012,1,1,0
+
+----------------------------------------
+2024-12-24-123456/data/versions.csv:
+
+checksum,crate_id,crate_size,created_at,downloads,features,id,license,links,num,published_by,rust_version,updated_at,yanked
+                                                                ,1,0,2024-12-24 12:34:56.789012,0,{},1,,,0.99.0,1,,2024-12-24 12:34:56.789012,f
+
+----------------------------------------
+2024-12-24-123456/data/default_versions.csv:
+
+crate_id,version_id
+
+----------------------------------------
+2024-12-24-123456/data/dependencies.csv:
+
+crate_id,default_features,explicit_name,features,id,kind,optional,req,target,version_id
+
+----------------------------------------
+2024-12-24-123456/data/version_downloads.csv:
+
+date,downloads,version_id


### PR DESCRIPTION
We haven't been testing this part of the codebase properly, so this PR adds an "end-to-end" test for the database dumping background worker job. It will create a test database, put some dummy data into it, enqueue the database dump background worker job, run the pending background jobs, assert that a tarball was uploaded to the (in-memory) object store, download the tarball, and finally compare the tarball contents against an insta snapshot. This should ensure that we are not unintentionally breaking the generation of our database dumps.

Additionally, this PR introduces a mutex on the database dump tests, since all invocations of the code currently share the same output directory. Once this has been fixed, the mutex can be removed again.