### PR TITLE
tests/dump_db: Add `schema.sql` to the test

### DIFF
--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -79,35 +79,26 @@ impl TestDatabase {
     /// the database is automatically deleted.
     #[instrument]
     pub fn new() -> TestDatabase {
-        let template = TemplateDatabase::instance();
-
-        let name = format!("{}_{}", template.prefix, generate_name().to_lowercase());
-
-        let mut conn = template.get_connection();
-        create_database_from_template(&name, &template.template_name, &mut conn)
-            .expect("failed to create test database");
-
-        let mut url = template.base_url.clone();
-        url.set_path(&format!("/{name}"));
-
-        let pool = Pool::builder()
-            .min_idle(Some(0))
-            .build_unchecked(ConnectionManager::new(url.as_ref()));
-
-        let pool = Some(pool);
-        TestDatabase { name, url, pool }
+        Self::new_inner(|name, conn| {
+            let template = TemplateDatabase::instance();
+            create_database_from_template(name, &template.template_name, conn)
+        })
     }
 
     /// Creates a new Postgres database. Once the `TestDatabase` instance is
     /// dropped, the database is automatically deleted.
     #[instrument]
     pub fn empty() -> TestDatabase {
+        Self::new_inner(create_database)
+    }
+
+    fn new_inner(f: impl Fn(&str, &mut PgConnection) -> QueryResult<()>) -> TestDatabase {
         let template = TemplateDatabase::instance();
 
         let name = format!("{}_{}", template.prefix, generate_name().to_lowercase());
 
         let mut conn = template.get_connection();
-        create_database(&name, &mut conn).expect("Failed to create test database");
+        f(&name, &mut conn).expect("Failed to create test database");
 
         let mut url = template.base_url.clone();
         url.set_path(&format!("/{name}"));

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -132,6 +132,13 @@ fn connect(database_url: &str) -> ConnectionResult<PgConnection> {
 }
 
 #[instrument(skip(conn))]
+fn create_database(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
+    debug!("Creating new database…");
+    sql_query(format!("CREATE DATABASE {name}")).execute(conn)?;
+    Ok(())
+}
+
+#[instrument(skip(conn))]
 fn create_template_database(name: &str, conn: &mut PgConnection) -> QueryResult<()> {
     table! {
         pg_database (datname) {
@@ -146,8 +153,7 @@ fn create_template_database(name: &str, conn: &mut PgConnection) -> QueryResult<
         .get_result(conn)?;
 
     if count == 0 {
-        debug!("Creating new template database…");
-        sql_query(format!("CREATE DATABASE {name}")).execute(conn)?;
+        create_database(name, conn)?;
     } else {
         debug!(%count, "Skipping template database creation");
     }

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -21,7 +21,10 @@ fn dump_db_and_reimport_dump() {
     let directory = dump_db::DumpDirectory::create().unwrap();
     directory.populate(db_one.url()).unwrap();
 
-    let db_two = TestDatabase::new();
+    let db_two = TestDatabase::empty();
+
+    let schema_script = directory.export_dir.join("schema.sql");
+    dump_db::run_psql(&schema_script, db_two.url()).unwrap();
 
     let import_script = directory.export_dir.join("import.sql");
     dump_db::run_psql(&import_script, db_two.url()).unwrap();


### PR DESCRIPTION
Instead of only running `import.sql` on a database with all migrations applied we can run the generated `schema.sql` file on an empty database. This ensures that the schema and data import scripts are compatible with each other.