### PR TITLE
Introduce length limit on the `description` field

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -38,6 +38,8 @@ const MISSING_RIGHTS_ERROR_MESSAGE: &str = "this crate exists but you don't seem
      to accept an invitation to be an owner before \
      publishing.";
 
+const MAX_DESCRIPTION_LENGTH: usize = 1000;
+
 /// Handles the `PUT /crates/new` route.
 /// Used by `cargo publish` to publish a new crate or to publish a new version of an
 /// existing crate.
@@ -158,6 +160,12 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         if !missing.is_empty() {
             let message = missing_metadata_error_message(&missing);
             return Err(bad_request(&message));
+        }
+
+        if let Some(description) = &description {
+            if description.len() > MAX_DESCRIPTION_LENGTH {
+                return Err(bad_request(format!("The `description` is too long. A maximum of {MAX_DESCRIPTION_LENGTH} characters are currently allowed.")));
+            }
         }
 
         if let Some(ref license) = license {

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -3,7 +3,7 @@ use crate::util::{RequestHelper, TestApp};
 use crates_io::models::krate::MAX_NAME_LENGTH;
 use googletest::prelude::*;
 use http::StatusCode;
-use insta::assert_json_snapshot;
+use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_json() {
@@ -85,6 +85,20 @@ async fn license_and_description_required() {
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_json_snapshot!(response.json());
+
+    assert_that!(app.stored_files().await, empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn long_description() {
+    let (app, _, _, token) = TestApp::full().with_token();
+
+    let description = "a".repeat(2000);
+    let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0").description(&description);
+
+    let response = token.publish_crate(crate_to_publish).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"The `description` is too long. A maximum of 1000 characters are currently allowed."}]}"###);
 
     assert_that!(app.stored_files().await, empty());
 }


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/discussions/8739

This PR introduces a limit on the length of the `description` field. Descriptions like https://crates.io/crates/docker-rust-api seem unreasonably long, so I've decided for an arbitrary limit of 1000 characters for now. As mentioned on the linked discussion, our frontend currently truncates the description to 200 characters in some places, so 1000 as a hard limit seem okay to me.