### PR TITLE
renovate: Disable `node` version pinning in frontend Dockerfile

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,9 +73,9 @@
             // This is causing weird "Cannot find replaceString in current file content" errors,
             // so we disable it for now.
             matchFileNames: ["frontend.Dockerfile"],
-            matchDepNames: ["node"],
-            matchUpdateTypes: ["pin"],
-            enabled: false,
+            matchDatasources: ["docker"],
+            matchUpdateTypes: ["pinDigest"],
+            enabled: false
         },
     ],
 }


### PR DESCRIPTION
Second try... hopefully this works