### PR TITLE
Sentry: Replace `@sentry/browser` with `@sentry/ember`

### DIFF
--- a/app/sentry.js
+++ b/app/sentry.js
@@ -1,16 +1,8 @@
-import { runInDebug } from '@ember/debug';
-
-import * as Sentry from '@sentry/browser';
-import { getGlobalObject, isInstanceOf, logger } from '@sentry/utils';
+import * as Sentry from '@sentry/ember';
 
 import config from './config/environment';
 
 export function init() {
-  let integrations = [];
-  if (config.environment === 'production') {
-    integrations.push(new Ember());
-  }
-
   let isProd = location.hostname === 'crates.io';
   let isStaging = location.hostname === 'staging.crates.io';
   let environment = isProd ? 'production' : isStaging ? 'staging' : 'unknown';
@@ -18,7 +10,6 @@ export function init() {
   Sentry.init({
     environment,
     ...config.sentry,
-    integrations,
 
     allowUrls: ['crates.io', 'crates-io.herokuapp.com', 'staging.crates-io', 'staging-crates-io.herokuapp.com'],
 
@@ -34,51 +25,4 @@ export function init() {
       return event;
     },
   });
-}
-
-export class Ember {
-  static id = 'Ember';
-
-  name = Ember.id;
-  _Ember;
-
-  constructor(options = {}) {
-    this._Ember = options.Ember || getGlobalObject().Ember;
-  }
-
-  setupOnce(_, getCurrentHub) {
-    if (!this._Ember) {
-      runInDebug(() => logger.error('EmberIntegration is missing an Ember instance'));
-      return;
-    }
-
-    const oldOnError = this._Ember.onerror;
-
-    // eslint-disable-next-line unicorn/prefer-add-event-listener
-    this._Ember.onerror = error => {
-      if (getCurrentHub().getIntegration(Ember)) {
-        getCurrentHub().captureException(error, { originalException: error });
-      }
-
-      if (typeof oldOnError === 'function') {
-        oldOnError.call(this._Ember, error);
-      } else if (this._Ember.testing) {
-        throw error;
-      }
-    };
-
-    this._Ember.RSVP.on('error', reason => {
-      if (getCurrentHub().getIntegration(Ember)) {
-        getCurrentHub().withScope(scope => {
-          if (isInstanceOf(reason, Error)) {
-            scope.setExtra('context', 'Unhandled Promise error detected');
-            getCurrentHub().captureException(reason, { originalException: reason });
-          } else {
-            scope.setExtra('reason', reason);
-            getCurrentHub().captureMessage('Unhandled Promise error detected');
-          }
-        });
-      }
-    });
-  }
 }

--- a/app/services/sentry.js
+++ b/app/services/sentry.js
@@ -1,6 +1,6 @@
 import Service from '@ember/service';
 
-import * as Sentry from '@sentry/browser';
+import * as Sentry from '@sentry/ember';
 
 export default class SentryService extends Service {
   captureException(error, captureContext) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -34,6 +34,10 @@ module.exports = function (environment) {
       // We don't want to use Mirage if a proxy backend has been provided.
       enabled: !process.env.PROXY_BACKEND,
     },
+
+    '@sentry/ember': {
+      disablePerformance: true,
+    },
   };
 
   if (environment === 'development') {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
   },
   "dependencies": {
     "@juggle/resize-observer": "3.4.0",
-    "@sentry/browser": "7.116.0",
-    "@sentry/utils": "7.116.0",
+    "@sentry/ember": "7.116.0",
     "chart.js": "4.4.3",
     "date-fns": "3.6.0",
     "highlight.js": "11.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,12 +17,9 @@ importers:
       '@juggle/resize-observer':
         specifier: 3.4.0
         version: 3.4.0
-      '@sentry/browser':
+      '@sentry/ember':
         specifier: 7.116.0
-        version: 7.116.0
-      '@sentry/utils':
-        specifier: 7.116.0
-        version: 7.116.0
+        version: 7.116.0(webpack@5.91.0)
       chart.js:
         specifier: 4.4.3
         version: 4.4.3
@@ -1770,6 +1767,10 @@ packages:
   '@sentry/core@7.116.0':
     resolution: {integrity: sha512-J6Wmjjx+o7RwST0weTU1KaKUAlzbc8MGkJV1rcHM9xjNTWTva+nrcCM3vFBagnk2Gm/zhwv3h0PvWEqVyp3U1Q==}
     engines: {node: '>=8'}
+
+  '@sentry/ember@7.116.0':
+    resolution: {integrity: sha512-tz9Ee21a+CsLC6jj8UZo8oqabSg2nL3sf39dnxCgR+j23UVLU/MbIAHouZJOWXs3OHThY/Ocw2TkVkEnm0eWGg==}
+    engines: {node: 14.* || 16.* || >= 18}
 
   '@sentry/integrations@7.116.0':
     resolution: {integrity: sha512-UZb60gaF+7veh1Yv79RiGvgGYOnU6xA97H+hI6tKgc1uT20YpItO4X56Vhp0lvyEyUGFZzBRRH1jpMDPNGPkqw==}
@@ -11259,6 +11260,22 @@ snapshots:
     dependencies:
       '@sentry/types': 7.116.0
       '@sentry/utils': 7.116.0
+
+  '@sentry/ember@7.116.0(webpack@5.91.0)':
+    dependencies:
+      '@embroider/macros': 1.16.2
+      '@sentry/browser': 7.116.0
+      '@sentry/core': 7.116.0
+      '@sentry/types': 7.116.0
+      '@sentry/utils': 7.116.0
+      ember-auto-import: 2.7.3(webpack@5.91.0)
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 6.3.0
+      ember-cli-typescript: 5.3.0
+    transitivePeerDependencies:
+      - '@glint/template'
+      - supports-color
+      - webpack
 
   '@sentry/integrations@7.116.0':
     dependencies:


### PR DESCRIPTION
`@sentry/ember` seems mature enough to use these days and will make the transition to the v8 Sentry SDK easier.