### PR TITLE
Settings: Remove "Email Notifications" link

### DIFF
--- a/app/components/settings-page.hbs
+++ b/app/components/settings-page.hbs
@@ -1,7 +1,6 @@
 <div local-class="page" ...attributes>
   <SideMenu data-test-settings-menu as |menu|>
     <menu.Item @link={{link "settings.profile"}}>Profile</menu.Item>
-    <menu.Item @link={{link "settings.email-notifications"}}>Email Notifications</menu.Item>
     <menu.Item @link={{link "settings.tokens"}} data-test-tokens>API Tokens</menu.Item>
   </SideMenu>
 


### PR DESCRIPTION
We can add it again if that page actually has some content, but for now it's pointless to link to a page that hasn't had any content in years.

<img width="949" alt="Bildschirmfoto 2024-06-04 um 12 01 13" src="https://github.com/rust-lang/crates.io/assets/141300/928805d7-ce4c-471c-b9e6-bc0994c55a4d">
