### PR TITLE
Playwright: Skip "Email Notifications" test

### DIFF
--- a/e2e/bugs/2329.spec.ts
+++ b/e2e/bugs/2329.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@/e2e/helper';
 
 test.describe('Bug #2329', { tag: '@bugs' }, () => {
-  test('is fixed', async ({ page, mirage }) => {
+  test.skip('is fixed', async ({ page, mirage }) => {
     await mirage.addHook(server => {
       let user = server.create('user');
 


### PR DESCRIPTION
The "Email Notifications" link doesn't exist anymore, so we can not click it in this test...