### PR TITLE
crates_io_tarball: Use `insta` snapshots to simplify test code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,7 @@ dependencies = [
  "clap",
  "flate2",
  "indicatif",
+ "insta",
  "rayon",
  "serde",
  "serde_json",

--- a/crates/crates_io_tarball/Cargo.toml
+++ b/crates/crates_io_tarball/Cargo.toml
@@ -24,6 +24,7 @@ anyhow = "=1.0.86"
 claims = "=0.7.1"
 clap = { version = "=4.5.4", features = ["derive", "unicode", "wrap_help"] }
 indicatif = { version = "=0.17.8", features = ["rayon"] }
+insta = "=1.39.0"
 rayon = "=1.10.0"
 tracing-subscriber = { version = "=0.3.18", features = ["env-filter"] }
 walkdir = "=2.5.0"


### PR DESCRIPTION
This makes it easier to write the error assertions, and has the added benefit of testing the derived `Display` trait of the error enum.