### PR TITLE
Postgres: Set `application_name` to crates.io

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -52,6 +52,8 @@ pub struct ConnectionConfig {
 
 impl ConnectionConfig {
     fn apply(&self, conn: &mut PgConnection) -> QueryResult<()> {
+        diesel::sql_query("SET application_name = 'crates.io'").execute(conn)?;
+
         let statement_timeout = self.statement_timeout.as_millis();
         diesel::sql_query(format!("SET statement_timeout = {statement_timeout}")).execute(conn)?;
 


### PR DESCRIPTION
This makes queries from the application easier to recognize in the logs.

see https://www.postgresql.org/docs/current/runtime-config-logging.html#GUC-APPLICATION-NAME