### PR TITLE
worker/jobs/dump_db: Only export the `public` schema via `pg_dump`

### DIFF
--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -163,6 +163,7 @@ impl DumpDirectory {
             File::create(&path).with_context(|| format!("Failed to create {}", path.display()))?;
 
         let status = std::process::Command::new("pg_dump")
+            .arg("--schema=public")
             .arg("--schema-only")
             .arg("--no-owner")
             .arg("--no-acl")


### PR DESCRIPTION
Postgres databases sometimes have additional "schemas" in them, occasionally with different access permissions. One example of this is the `cron` schema that the Scheduler feature on CrunchyBridge creates. This schema is not accessible by the `application`, which causes `pg_dump` to break. By restricting `pg_dump` to the `public` schema we can fix this issue.