### PR TITLE
Remove unused `ember-cli-app-version` dependency

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -78,9 +78,7 @@ module.exports = function (environment) {
 
     // Heroku Git Hash support
     if (process.env.SOURCE_VERSION) {
-      let hash = process.env.SOURCE_VERSION.slice(0, 7);
-      ENV['ember-cli-app-version'] = { version: hash };
-      ENV.sentry.release = hash;
+      ENV.sentry.release = process.env.SOURCE_VERSION.slice(0, 7);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "ember-a11y-testing": "6.1.1",
     "ember-auto-import": "2.7.3",
     "ember-cli": "5.9.0",
-    "ember-cli-app-version": "6.0.1",
     "ember-cli-babel": "8.2.0",
     "ember-cli-bundle-analyzer": "1.0.0",
     "ember-cli-code-coverage": "3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,9 +132,6 @@ importers:
       ember-cli:
         specifier: 5.9.0
         version: 5.9.0(babel-core@6.26.3)(ejs@3.1.10)(handlebars@4.7.8)(underscore@1.13.6)
-      ember-cli-app-version:
-        specifier: 6.0.1
-        version: 6.0.1(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))
       ember-cli-babel:
         specifier: 8.2.0
         version: 8.2.0(@babel/core@7.24.7)
@@ -164,7 +161,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: 3.0.3
-        version: 3.0.3(@ember-data/model@4.12.8(@babel/core@7.24.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0)))(@ember/test-helpers@3.3.0(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(webpack@5.91.0))(ember-data@4.12.8(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(webpack@5.91.0))(ember-qunit@8.0.2(@ember/test-helpers@3.3.0(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(webpack@5.91.0))(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(qunit@2.21.0))(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(miragejs@0.1.48)(webpack@5.91.0)
+        version: 3.0.3(arpzmnxdcuw6qixdoalb4v7ilm)
       ember-cli-notifications:
         specifier: 9.0.0
         version: 9.0.0
@@ -4091,12 +4088,6 @@ packages:
     engines: {node: 14.* || >= 16}
     peerDependencies:
       ember-source: ^3.13.0 || ^4.0.0 || >= 5.0.0
-
-  ember-cli-app-version@6.0.1:
-    resolution: {integrity: sha512-XA1FwkWA5QytmWF0jcJqEr3jcZoiCl9Fb33TZgOVfClL7Voxe+/RwzISEprBRQgbf7j8z1xf8/RJCKfclUy3rQ==}
-    engines: {node: 14.* || 16.* || >= 18}
-    peerDependencies:
-      ember-source: ^3.28.0 || >= 4.0.0
 
   ember-cli-babel-plugin-helpers@1.1.1:
     resolution: {integrity: sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==}
@@ -14424,14 +14415,6 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  ember-cli-app-version@6.0.1(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0)):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-source: 5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0)
-      git-repo-info: 2.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   ember-cli-babel-plugin-helpers@1.1.1: {}
 
   ember-cli-babel@7.26.11:
@@ -14617,8 +14600,8 @@ snapshots:
 
   ember-cli-lodash-subset@2.0.1: {}
 
-  ? ember-cli-mirage@3.0.3(@ember-data/model@4.12.8(@babel/core@7.24.7)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0)))(@ember/test-helpers@3.3.0(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(webpack@5.91.0))(ember-data@4.12.8(@babel/core@7.24.7)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(webpack@5.91.0))(ember-qunit@8.0.2(@ember/test-helpers@3.3.0(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(webpack@5.91.0))(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(qunit@2.21.0))(ember-source@5.9.0(@babel/core@7.24.7)(@glimmer/component@1.1.2(@babel/core@7.24.7))(rsvp@4.8.5)(webpack@5.91.0))(miragejs@0.1.48)(webpack@5.91.0)
-  : dependencies:
+  ember-cli-mirage@3.0.3(arpzmnxdcuw6qixdoalb4v7ilm):
+    dependencies:
       '@babel/core': 7.24.7
       '@embroider/macros': 1.16.2
       broccoli-file-creator: 2.1.1


### PR DESCRIPTION
AFAICT we're not using this dependency in any way and we don't need to ship these bytes to the user if nothing is using them...