### PR TITLE
worker/jobs/dump_db: Remove `database_url` field

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -6,7 +6,6 @@ use chrono::NaiveDate;
 use crates_io_worker::BackgroundJob;
 use diesel::dsl::exists;
 use diesel::prelude::*;
-use secrecy::{ExposeSecret, SecretString};
 
 #[derive(clap::Parser, Debug)]
 #[command(
@@ -22,10 +21,7 @@ pub enum Command {
     },
     UpdateDownloads,
     CleanProcessedLogFiles,
-    DumpDb {
-        #[arg(env = "READ_ONLY_REPLICA_URL")]
-        database_url: SecretString,
-    },
+    DumpDb,
     DailyDbMaintenance,
     SquashIndex,
     NormalizeIndex {
@@ -74,8 +70,8 @@ pub fn run(command: Command) -> Result<()> {
         Command::CleanProcessedLogFiles => {
             jobs::CleanProcessedLogFiles.enqueue(conn)?;
         }
-        Command::DumpDb { database_url } => {
-            jobs::DumpDb::new(database_url.expose_secret()).enqueue(conn)?;
+        Command::DumpDb => {
+            jobs::DumpDb.enqueue(conn)?;
         }
         Command::SyncAdmins { force } => {
             if !force {

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -8,7 +8,6 @@ use flate2::read::GzDecoder;
 use insta::{assert_debug_snapshot, assert_snapshot};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use secrecy::ExposeSecret;
 use std::io::{Cursor, Read};
 use tar::Archive;
 
@@ -21,8 +20,7 @@ async fn test_dump_db_job() {
     app.db(|conn| {
         CrateBuilder::new("test-crate", token.as_model().user_id).expect_build(conn);
 
-        let database_url = app.as_inner().config.db.primary.url.expose_secret();
-        DumpDb::new(database_url).enqueue(conn).unwrap();
+        DumpDb.enqueue(conn).unwrap();
     });
 
     app.run_pending_background_jobs().await;


### PR DESCRIPTION
On our staging environment we usually don't use a read-replica database, so `READ_ONLY_REPLICA_URL` might not always be set. Instead of saving the potentially secret database URL in the background job we can read it from the background worker config instead, and fall back to the primary database if a read-replica is not configured.

I'm not aware of us using the background job with a non-default `database_url` in the past couple of years, so this option will probably not be missed. :D