### PR TITLE
tests/builders/version: Simplify `license` field

### DIFF
--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -22,7 +22,7 @@ pub struct CrateBuilder<'a> {
     owner_id: i32,
     recent_downloads: Option<i32>,
     updated_at: Option<NaiveDateTime>,
-    versions: Vec<VersionBuilder<'a>>,
+    versions: Vec<VersionBuilder>,
 }
 
 impl<'a> CrateBuilder<'a> {
@@ -90,7 +90,7 @@ impl<'a> CrateBuilder<'a> {
 
     /// Adds a version record to be associated with the crate record when the crate record is
     /// built.
-    pub fn version<T: Into<VersionBuilder<'a>>>(mut self, version: T) -> Self {
+    pub fn version<T: Into<VersionBuilder>>(mut self, version: T) -> Self {
         self.versions.push(version.into());
         self
     }

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -9,11 +9,11 @@ use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
 /// A builder to create version records for the purpose of inserting directly into the database.
-pub struct VersionBuilder<'a> {
+pub struct VersionBuilder {
     created_at: Option<NaiveDateTime>,
     dependencies: Vec<(i32, Option<&'static str>)>,
     features: BTreeMap<String, Vec<String>>,
-    license: Option<&'a str>,
+    license: Option<String>,
     num: semver::Version,
     size: i32,
     yanked: bool,
@@ -23,7 +23,7 @@ pub struct VersionBuilder<'a> {
 }
 
 #[allow(dead_code)]
-impl<'a> VersionBuilder<'a> {
+impl VersionBuilder {
     /// Creates a VersionBuilder from a string slice `num` representing the version's number.
     ///
     /// # Panics
@@ -56,8 +56,8 @@ impl<'a> VersionBuilder<'a> {
     }
 
     /// Sets the version's `license` value.
-    pub fn license(mut self, license: Option<&'a str>) -> Self {
-        self.license = license;
+    pub fn license(mut self, license: impl Into<String>) -> Self {
+        self.license = Some(license.into());
         self
     }
 
@@ -166,7 +166,7 @@ impl<'a> VersionBuilder<'a> {
     }
 }
 
-impl<'a> From<&'a str> for VersionBuilder<'a> {
+impl<'a> From<&'a str> for VersionBuilder {
     fn from(num: &'a str) -> Self {
         VersionBuilder::new(num)
     }


### PR DESCRIPTION
We're using regular `Option<String>` already for `links` and `rust_version` and while the `&str` might be slightly more efficient it is also slightly less ergonomic. Switching the field type also allows us to remove the `'a` lifetime declaration from the struct which makes it a bit easier on the eyes too. If we ever feel like we need the raw speed we can always add it back.