### PR TITLE
models/version: Derive `NewVersion` builder struct

### DIFF
--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use diesel::{prelude::*, PgConnection};
 
 use crate::{
@@ -65,20 +63,13 @@ impl Faker {
             .set(crate_downloads::downloads.eq(downloads as i64))
             .execute(conn)?;
 
-        let version = NewVersion::new(
-            krate.id,
-            &semver::Version::parse("1.0.0")?,
-            &BTreeMap::new(),
-            None,
-            0,
-            user.id,
-            "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
-            None,
-            None,
-        )
-        .unwrap()
-        .save(conn, "someone@example.com")
-        .unwrap();
+        let version = NewVersion::builder(krate.id, "1.0.0")
+            .published_by(user.id)
+            .dummy_checksum()
+            .build()
+            .unwrap()
+            .save(conn, "someone@example.com")
+            .unwrap();
 
         Ok((krate, version))
     }

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -106,7 +106,6 @@ mod tests {
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
     use crate::schema::{crate_downloads, crates, versions};
     use crate::test_util::test_db_connection;
-    use std::collections::BTreeMap;
 
     fn user(conn: &mut PgConnection) -> User {
         NewUser::new(2, "login", None, None, "access_token")
@@ -121,18 +120,13 @@ mod tests {
         }
         .create(conn, user_id)
         .unwrap();
-        let version = NewVersion::new(
-            krate.id,
-            &semver::Version::parse("1.0.0").unwrap(),
-            &BTreeMap::new(),
-            None,
-            0,
-            user_id,
-            "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
-            None,
-            None,
-        )
-        .unwrap();
+
+        let version = NewVersion::builder(krate.id, "1.0.0")
+            .published_by(user_id)
+            .dummy_checksum()
+            .build()
+            .unwrap();
+
         let version = version.save(conn, "someone@example.com").unwrap();
         (krate, version)
     }


### PR DESCRIPTION
This finally solves the `clippy::too_many_arguments` warning, and makes the `NewVersion` struct slightly more ergonomic to use in our test code.