### PR TITLE
Remove background color from preformatted code blocks within lists

### DIFF
--- a/app/components/text-content.module.css
+++ b/app/components/text-content.module.css
@@ -38,6 +38,12 @@
             margin: 0;
             padding: var(--space-4xs) var(--space-3xs);
         }
+        /* Remove background color and padding from preformatted code blocks within lists. */
+        /* See: https://github.com/rust-lang/crates.io/issues/8866 */
+        pre code {
+            background-color: initial;
+            padding: initial;
+        }
     }
 
     code {

--- a/app/components/text-content.module.css
+++ b/app/components/text-content.module.css
@@ -38,12 +38,6 @@
             margin: 0;
             padding: var(--space-4xs) var(--space-3xs);
         }
-        /* Remove background color and padding from preformatted code blocks within lists. */
-        /* See: https://github.com/rust-lang/crates.io/issues/8866 */
-        pre code {
-            background-color: initial;
-            padding: initial;
-        }
     }
 
     code {
@@ -89,6 +83,14 @@
                 color: var(--main-color);
             }
         }
+    }
+
+    /* Reset background color, padding and font-size for syntax-highlighted code blocks. */
+    /* See: https://github.com/rust-lang/crates.io/issues/8866 */
+    :global(.hljs) {
+        background: unset;
+        padding: 0;
+        font-size: unset;
     }
 
     /*

--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -58,6 +58,22 @@ graph TD;
     C-->D;
 </code></pre>
 
+<ul>
+  <li>
+    <p>Delegate to a method with a different name</p>
+    <pre><code class="language-rust hljs" data-highlighted="yes"><span class="hljs-keyword">struct</span> <span class="hljs-title class_">Stack</span> { inner: <span class="hljs-type">Vec</span>&lt;<span class="hljs-type">u32</span>&gt; }
+<span class="hljs-keyword">impl</span> <span class="hljs-title class_">Stack</span> {
+    delegate! {
+        to <span class="hljs-keyword">self</span>.inner {
+            <span class="hljs-meta">#[call(push)]</span>
+            <span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title function_">add</span>(&amp;<span class="hljs-keyword">mut</span> <span class="hljs-keyword">self</span>, value: <span class="hljs-type">u32</span>);
+        }
+    }
+}
+</code></pre>
+  </li>
+</ul>
+
 <section class="footnotes">
 <ol>
 <li id="user-content-fn-1">
@@ -80,8 +96,8 @@ test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {
     await page.goto('/crates/serde');
     const readme = page.locator('[data-test-readme]');
     await expect(readme).toBeVisible();
-    await expect(readme.locator('ul > li')).toHaveCount(6);
-    await expect(readme.locator('pre > code.language-rust.hljs')).toBeVisible();
+    await expect(readme.locator('ul > li')).toHaveCount(7);
+    await expect(readme.locator('pre > code.language-rust.hljs')).toHaveCount(2);
     await expect(readme.locator('pre > code.language-mermaid svg')).toBeVisible();
 
     await percy.snapshot();

--- a/tests/acceptance/readme-rendering-test.js
+++ b/tests/acceptance/readme-rendering-test.js
@@ -64,6 +64,22 @@ graph TD;
     C-->D;
 </code></pre>
 
+<ul>
+  <li>
+    <p>Delegate to a method with a different name</p>
+    <pre><code class="language-rust hljs" data-highlighted="yes"><span class="hljs-keyword">struct</span> <span class="hljs-title class_">Stack</span> { inner: <span class="hljs-type">Vec</span>&lt;<span class="hljs-type">u32</span>&gt; }
+<span class="hljs-keyword">impl</span> <span class="hljs-title class_">Stack</span> {
+    delegate! {
+        to <span class="hljs-keyword">self</span>.inner {
+            <span class="hljs-meta">#[call(push)]</span>
+            <span class="hljs-keyword">pub</span> <span class="hljs-keyword">fn</span> <span class="hljs-title function_">add</span>(&amp;<span class="hljs-keyword">mut</span> <span class="hljs-keyword">self</span>, value: <span class="hljs-type">u32</span>);
+        }
+    }
+}
+</code></pre>
+  </li>
+</ul>
+
 <section class="footnotes">
 <ol>
 <li id="user-content-fn-1">
@@ -82,8 +98,8 @@ module('Acceptance | README rendering', function (hooks) {
 
     await visit('/crates/serde');
     assert.dom('[data-test-readme]').exists();
-    assert.dom('[data-test-readme] ul > li').exists({ count: 6 });
-    assert.dom('[data-test-readme] pre > code.language-rust.hljs').exists();
+    assert.dom('[data-test-readme] ul > li').exists({ count: 7 });
+    assert.dom('[data-test-readme] pre > code.language-rust.hljs').exists({ count: 2 });
     assert.dom('[data-test-readme] pre > code.language-mermaid svg').exists();
 
     await percySnapshot(assert);


### PR DESCRIPTION
This should resolve #8866. 

<img width="569" alt="image" src="https://github.com/rust-lang/crates.io/assets/2889664/204132a2-361a-4612-a820-7e983e81d7a1">
