### PR TITLE
tracing: Use JSON log format if `RUST_LOG_FORMAT=json` is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,6 +4869,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4878,12 +4888,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ toml = "=0.8.14"
 tower = "=0.4.13"
 tower-http = { version = "=0.5.2", features = ["add-extension", "fs", "catch-panic", "timeout", "compression-full"] }
 tracing = "=0.1.40"
-tracing-subscriber = { version = "=0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "=0.3.18", features = ["env-filter", "json"] }
 typomania = { version = "=0.1.2", default-features = false }
 url = "=2.5.1"
 unicode-xid = "=0.2.4"


### PR DESCRIPTION
As discussed in the team meeting on Friday, this PR adds support for a JSON log format. If the `RUST_LOG_FORMAT` environment variable is set to `json` our tracing code will start to use https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html for log formatting.