### PR TITLE
styles: Fix `:global { ... }` block usage

### DIFF
--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -164,16 +164,14 @@ noscript {
     font-size: 0.9em
 }
 
-:global {
-    .c-notification__icon {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-    }
+:global(.c-notification__icon) {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
 
-    .c-notification__content {
-        line-height: 1.5;
-    }
+:global(.c-notification__content) {
+    line-height: 1.5;
 }
 
 .width-limit {


### PR DESCRIPTION
This appears to not be compatible with the `postcss-nesting` plugin:

> postcss-nesting: crates.io/assets/crates-io.css:656:5: Failed to parse selectors : "" / "._c-notification__icon_17u5gr" with message: "Cannot read properties of undefined (reading 'type')"
> postcss-nesting: crates.io/assets/crates-io.css:662:5: Failed to parse selectors : "" / "._c-notification__content_17u5gr" with message: "Cannot read properties of undefined (reading 'type')"