### PR TITLE
Add `GET /api/v1/me/tokens/:id` API endpoint

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -104,7 +104,10 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .route("/api/v1/me", get(user::me::me))
         .route("/api/v1/me/updates", get(user::me::updates))
         .route("/api/v1/me/tokens", get(token::list).put(token::new))
-        .route("/api/v1/me/tokens/:id", delete(token::revoke))
+        .route(
+            "/api/v1/me/tokens/:id",
+            get(token::show).delete(token::revoke),
+        )
         .route("/api/v1/tokens/current", delete(token::revoke_current))
         .route(
             "/api/v1/me/crate_owner_invitations",

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -1,0 +1,7 @@
+use crate::util::{RequestHelper, TestApp};
+#[tokio::test(flavor = "multi_thread")]
+async fn show_token_non_existing() {
+    let url = "/api/v1/me/tokens/10086";
+    let (_, _, user, _) = TestApp::init().with_token();
+    user.get(url).await.assert_not_found();
+}

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -64,3 +64,10 @@ async fn show_token_with_scopes() {
         ".api_token.expired_at" => "[datetime]",
     });
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn show_with_anonymous_user() {
+    let url = "/api/v1/me/tokens/1";
+    let (_, anon) = TestApp::init().empty();
+    anon.get(url).await.assert_forbidden();
+}

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -1,7 +1,22 @@
 use crate::util::{RequestHelper, TestApp};
+use http::StatusCode;
+use insta::assert_json_snapshot;
+
 #[tokio::test(flavor = "multi_thread")]
 async fn show_token_non_existing() {
     let url = "/api/v1/me/tokens/10086";
     let (_, _, user, _) = TestApp::init().with_token();
     user.get(url).await.assert_not_found();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn show() {
+    let (_, _, user, token) = TestApp::init().with_token();
+    let token = token.as_model();
+    let url = format!("/api/v1/me/tokens/{}", token.id);
+    let response = user.get::<()>(&url).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_json_snapshot!(response.json(), {
+        ".api_token.created_at" => "[datetime]",
+    });
 }

--- a/src/tests/routes/me/tokens/mod.rs
+++ b/src/tests/routes/me/tokens/mod.rs
@@ -1,4 +1,5 @@
 pub mod create;
 pub mod delete;
 pub mod delete_current;
+pub mod get;
 pub mod list;

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__get__show.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__get__show.snap
@@ -1,0 +1,15 @@
+---
+source: src/tests/routes/me/tokens/get.rs
+expression: response.json()
+---
+{
+  "api_token": {
+    "crate_scopes": null,
+    "created_at": "[datetime]",
+    "endpoint_scopes": null,
+    "expired_at": null,
+    "id": 1,
+    "last_used_at": null,
+    "name": "bar"
+  }
+}

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__get__show_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__get__show_token_with_scopes.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/routes/me/tokens/get.rs
+expression: response.json()
+---
+{
+  "api_token": {
+    "crate_scopes": [
+      "serde",
+      "serde-*"
+    ],
+    "created_at": "[datetime]",
+    "endpoint_scopes": [
+      "publish-update"
+    ],
+    "expired_at": "[datetime]",
+    "id": 2,
+    "last_used_at": null,
+    "name": "baz"
+  }
+}


### PR DESCRIPTION
ref https://github.com/rust-lang/crates.io/issues/8717

In this PR I have added the `show` API for ApiToken to prepare to get the information by ID on the create token page.

And I also added some tests.