### PR TITLE
Use snapshot tests for `app.stored_files()` assertions

### DIFF
--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -25,10 +25,10 @@ async fn test_dump_db_job() {
 
     app.run_pending_background_jobs().await;
 
-    let stored_files = app.stored_files().await;
-    assert_eq!(stored_files.len(), 2);
-    assert_eq!(stored_files[0], "db-dump.tar.gz");
-    assert_eq!(stored_files[1], "db-dump.zip");
+    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    db-dump.tar.gz
+    db-dump.zip
+    "###);
 
     let path = object_store::path::Path::parse("db-dump.tar.gz").unwrap();
     let result = app.as_inner().storage.as_inner().get(&path).await.unwrap();

--- a/src/tests/krate/publish/git.rs
+++ b/src/tests/krate/publish/git.rs
@@ -1,5 +1,6 @@
 use crate::builders::PublishBuilder;
 use crate::util::{RequestHelper, TestApp};
+use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_git_upload_with_conflicts() {
@@ -10,9 +11,8 @@ async fn new_krate_git_upload_with_conflicts() {
     let crate_to_publish = PublishBuilder::new("foo_conflicts", "1.0.0");
     token.publish_crate(crate_to_publish).await.good();
 
-    let expected_files = vec![
-        "crates/foo_conflicts/foo_conflicts-1.0.0.crate",
-        "index/fo/o_/foo_conflicts",
-    ];
-    assert_eq!(app.stored_files().await, expected_files);
+    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    crates/foo_conflicts/foo_conflicts-1.0.0.crate
+    index/fo/o_/foo_conflicts
+    "###);
 }

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -4,7 +4,7 @@ use crates_io_tarball::TarballBuilder;
 use flate2::Compression;
 use googletest::prelude::*;
 use http::StatusCode;
-use insta::assert_json_snapshot;
+use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tarball_between_default_axum_limit_and_max_upload_size() {
@@ -49,7 +49,10 @@ async fn tarball_between_default_axum_limit_and_max_upload_size() {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
-    assert_eq!(app.stored_files().await.len(), 2);
+    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    crates/foo/foo-1.1.0.crate
+    index/3/f/foo
+    "###);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -140,9 +143,8 @@ async fn new_krate_too_big_but_whitelisted() {
 
     token.publish_crate(crate_to_publish).await.good();
 
-    let expected_files = vec![
-        "crates/foo_whitelist/foo_whitelist-1.1.0.crate",
-        "index/fo/o_/foo_whitelist",
-    ];
-    assert_eq!(app.stored_files().await, expected_files);
+    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    crates/foo_whitelist/foo_whitelist-1.1.0.crate
+    index/fo/o_/foo_whitelist
+    "###);
 }

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -1,7 +1,7 @@
 use crate::builders::{CrateBuilder, PublishBuilder};
 use crate::util::{RequestHelper, TestApp};
 use http::StatusCode;
-use insta::assert_json_snapshot;
+use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_readme() {
@@ -15,12 +15,11 @@ async fn new_krate_with_readme() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    let expected_files = vec![
-        "crates/foo_readme/foo_readme-1.0.0.crate",
-        "index/fo/o_/foo_readme",
-        "readmes/foo_readme/foo_readme-1.0.0.html",
-    ];
-    assert_eq!(app.stored_files().await, expected_files);
+    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    crates/foo_readme/foo_readme-1.0.0.crate
+    index/fo/o_/foo_readme
+    readmes/foo_readme/foo_readme-1.0.0.html
+    "###);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -35,11 +34,10 @@ async fn new_krate_with_empty_readme() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    let expected_files = vec![
-        "crates/foo_readme/foo_readme-1.0.0.crate",
-        "index/fo/o_/foo_readme",
-    ];
-    assert_eq!(app.stored_files().await, expected_files);
+    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    crates/foo_readme/foo_readme-1.0.0.crate
+    index/fo/o_/foo_readme
+    "###);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -54,12 +52,11 @@ async fn new_krate_with_readme_and_plus_version() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    let expected_files = vec![
-        "crates/foo_readme/foo_readme-1.0.0+foo.crate",
-        "index/fo/o_/foo_readme",
-        "readmes/foo_readme/foo_readme-1.0.0+foo.html",
-    ];
-    assert_eq!(app.stored_files().await, expected_files);
+    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    crates/foo_readme/foo_readme-1.0.0+foo.crate
+    index/fo/o_/foo_readme
+    readmes/foo_readme/foo_readme-1.0.0+foo.html
+    "###);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This makes these assertions easier to update when the list of stored files changes (see #8908 😉).