### PR TITLE
renovate: Disable `pinDigest` updates for the whole `docker` datasource

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,9 +70,7 @@
             enabled: false,
         },
         {
-            // This is causing weird "Cannot find replaceString in current file content" errors,
-            // so we disable it for now.
-            matchFileNames: ["frontend.Dockerfile"],
+            // This is causing various issues, so we disable it for now.
             matchDatasources: ["docker"],
             matchUpdateTypes: ["pinDigest"],
             enabled: false


### PR DESCRIPTION
This does not seem to play well with the `regex` manager...