### PR TITLE
markdown: Remove hidden lines in Rust code blocks

### DIFF
--- a/crates/crates_io_markdown/lib.rs
+++ b/crates/crates_io_markdown/lib.rs
@@ -677,4 +677,42 @@ There can also be some text in between!
         <p align="center"><img src="https://img.shields.io/crates/v/clap.svg" alt=""></p>
         "###);
     }
+
+    #[test]
+    fn rust_comments() {
+        let text = r#"
+```rs
+# use std::time::Duration;
+# // Yes, this is cheating
+# fn sleep(_: Duration) { std::process::exit(0) }
+use service_skeleton::service;
+
+fn main() {
+    service("SayHello").run(|_cfg: ()| say_hello());
+}
+
+fn say_hello() {
+    println!("Hello world!");
+    sleep(Duration::from_secs(5));
+}
+```
+        "#;
+
+        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        <pre><code class="language-rust"># use std::time::Duration;
+        # // Yes, this is cheating
+        # fn sleep(_: Duration) { std::process::exit(0) }
+        use service_skeleton::service;
+
+        fn main() {
+            service("SayHello").run(|_cfg: ()| say_hello());
+        }
+
+        fn say_hello() {
+            println!("Hello world!");
+            sleep(Duration::from_secs(5));
+        }
+        </code></pre>
+        "###);
+    }
 }


### PR DESCRIPTION
This PR changes our markdown rendered to treat `# `-prefixed lines in Rust code blocks as hidden, similar to how rustdoc handles them (see https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html#hiding-portions-of-the-example).

This allows authors to use `#![doc = include_str!("../README.md")]` in combination with hidden lines. These lines will obviously still be rendered by the GitHub markdown renderer, but that tradeoff is up to the crate author to make.

Resolves https://github.com/rust-lang/crates.io/issues/8325