### PR TITLE
Expose `versions.links` column on the API

### DIFF
--- a/src/tests/krate/publish/snapshots/all__krate__publish__manifest__boolean_readme-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__manifest__boolean_readme-2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/manifest.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "version": {
@@ -25,6 +25,7 @@ expression: response.into_json()
     "downloads": 0,
     "features": {},
     "id": "[id]",
+    "lib_links": null,
     "license": "MIT",
     "links": {
       "authors": "/api/v1/crates/foo/1.0.0/authors",

--- a/src/tests/routes/crates/snapshots/all__routes__crates__read__show.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__read__show.snap
@@ -57,6 +57,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 1,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/foo_show/1.0.0/authors",
@@ -80,6 +81,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 3,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/foo_show/0.5.1/authors",
@@ -109,6 +111,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 2,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/foo_show/0.5.0/authors",

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
@@ -31,6 +31,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 3,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/c3/1.0.0/authors",

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies.snap
@@ -31,6 +31,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 3,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/c2/1.1.0/authors",

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
@@ -43,6 +43,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 3,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/c3/3.0.0/authors",
@@ -72,6 +73,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 2,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/c2/2.0.0/authors",

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
@@ -31,6 +31,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 2,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/c2/1.0.18446744073709551615/authors",

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
@@ -31,6 +31,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 3,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/c2/2.0.0/authors",

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
@@ -31,6 +31,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 3,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/c2/2.0.0/authors",

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__versions.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__versions.snap
@@ -14,6 +14,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 2,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/foo_versions/1.0.0/authors",
@@ -37,6 +38,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 1,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/foo_versions/0.5.1/authors",
@@ -66,6 +68,7 @@ expression: response.json()
       "downloads": 0,
       "features": {},
       "id": 3,
+      "lib_links": null,
       "license": null,
       "links": {
         "authors": "/api/v1/crates/foo_versions/0.5.0/authors",

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
@@ -13,6 +13,7 @@ expression: json
     "downloads": 0,
     "features": {},
     "id": "[id]",
+    "lib_links": null,
     "license": null,
     "links": {
       "authors": "/api/v1/crates/foo_vers_show_no_pb/1.0.0/authors",

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -13,6 +13,7 @@ expression: json
     "downloads": 0,
     "features": {},
     "id": "[id]",
+    "lib_links": null,
     "license": null,
     "links": {
       "authors": "/api/v1/crates/foo_vers_show/2.0.0/authors",

--- a/src/views.rs
+++ b/src/views.rs
@@ -558,6 +558,7 @@ pub struct EncodableVersion {
     pub downloads: i32,
     pub features: serde_json::Value,
     pub yanked: bool,
+    pub lib_links: Option<String>,
     // NOTE: Used by shields.io, altering `license` requires a PR with shields.io
     pub license: Option<String>,
     pub links: EncodableVersionLinks,
@@ -583,6 +584,7 @@ impl EncodableVersion {
             downloads,
             features,
             yanked,
+            links: lib_links,
             license,
             crate_size,
             checksum,
@@ -607,6 +609,7 @@ impl EncodableVersion {
             downloads,
             features,
             yanked,
+            lib_links,
             license,
             links,
             crate_size,
@@ -728,6 +731,7 @@ mod tests {
             features: serde_json::from_str("{}").unwrap(),
             yanked: false,
             license: None,
+            lib_links: None,
             links: EncodableVersionLinks {
                 dependencies: "".to_string(),
                 version_downloads: "".to_string(),


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/2685 by adding a `lib_links` field to the version API responses. This field corresponds to the `versions.links` database column and the `links` field in the index.

As mentioned in the linked issue the name `links` is unfortunately already taken and changing the content would be a breaking change, which we are trying to avoid.