### PR TITLE
Prefill "New API Token" page with existing values if requested

### DIFF
--- a/app/controllers/settings/tokens/new.js
+++ b/app/controllers/settings/tokens/new.js
@@ -141,7 +141,7 @@ export default class NewTokenController extends Controller {
   }
 }
 
-class CratePattern {
+export class CratePattern {
   @tracked pattern;
   @tracked showAsInvalid = false;
 

--- a/app/controllers/settings/tokens/new.js
+++ b/app/controllers/settings/tokens/new.js
@@ -132,8 +132,8 @@ export default class NewTokenController extends Controller {
     this.scopesInvalid = false;
   }
 
-  @action addCratePattern() {
-    this.crateScopes.push(new CratePattern(''));
+  @action addCratePattern(pattern) {
+    this.crateScopes.push(new CratePattern(pattern));
   }
 
   @action removeCrateScope(index) {
@@ -141,7 +141,7 @@ export default class NewTokenController extends Controller {
   }
 }
 
-export class CratePattern {
+class CratePattern {
   @tracked pattern;
   @tracked showAsInvalid = false;
 

--- a/app/routes/settings/tokens/new.js
+++ b/app/routes/settings/tokens/new.js
@@ -7,27 +7,26 @@ export default class TokenListRoute extends Route {
   @service store;
 
   queryParams = {
-    token_id: {
+    from: {
       refreshModel: true,
     },
   };
 
   async model(params, transition) {
-    const tokenId = params.token_id;
-    if (tokenId) {
-      try {
-        return await this.store.findRecord('api-token', tokenId);
-      } catch (error) {
-        if (error instanceof NotFoundError) {
-          let title = `Token not found`;
-          this.router.replaceWith('catch-all', { transition, title });
-        } else {
-          let title = `Failed to load token data`;
-          this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });
-        }
+    let tokenId = params.from;
+    if (!tokenId) return null;
+
+    try {
+      return await this.store.findRecord('api-token', tokenId);
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        let title = 'Token not found';
+        this.router.replaceWith('catch-all', { transition, title });
+      } else {
+        let title = 'Failed to load token data';
+        this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });
       }
     }
-    return null;
   }
 
   setupController(controller, model) {
@@ -49,6 +48,6 @@ export default class TokenListRoute extends Route {
 
   resetController(controller) {
     controller.saveTokenTask.cancelAll();
-    controller.set('token_id', null);
+    controller.set('from', null);
   }
 }

--- a/app/routes/settings/tokens/new.js
+++ b/app/routes/settings/tokens/new.js
@@ -1,6 +1,45 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+import { patternDescription } from '../../../utils/token-scopes';
 
 export default class TokenListRoute extends Route {
+  @service store;
+
+  queryParams = {
+    token_id: {
+      refreshModel: true,
+    },
+  };
+
+  async model(params) {
+    const tokenId = params.token_id;
+    if (tokenId) {
+      return await this.store.findRecord('api-token', tokenId);
+    }
+    return null;
+  }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+    if (model) {
+      const { name, endpoint_scopes, crate_scopes } = model;
+      let properties = {
+        name,
+        ...(endpoint_scopes && { scopes: endpoint_scopes }),
+        ...(crate_scopes && {
+          crateScopes: crate_scopes.map(pattern => ({
+            pattern,
+            showAsInvalid: false,
+            description: patternDescription(pattern),
+          })),
+        }),
+      };
+
+      controller.setProperties(properties);
+    }
+  }
+
   resetController(controller) {
     controller.saveTokenTask.cancelAll();
   }

--- a/app/routes/settings/tokens/new.js
+++ b/app/routes/settings/tokens/new.js
@@ -2,7 +2,7 @@ import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-import { patternDescription } from '../../../utils/token-scopes';
+import { CratePattern } from '../../../controllers/settings/tokens/new';
 
 export default class TokenListRoute extends Route {
   @service router;
@@ -40,11 +40,7 @@ export default class TokenListRoute extends Route {
         name,
         ...(endpoint_scopes && { scopes: endpoint_scopes }),
         ...(crate_scopes && {
-          crateScopes: crate_scopes.map(pattern => ({
-            pattern,
-            showAsInvalid: false,
-            description: patternDescription(pattern),
-          })),
+          crateScopes: crate_scopes.map(pattern => new CratePattern(pattern)),
         }),
       };
 
@@ -54,5 +50,6 @@ export default class TokenListRoute extends Route {
 
   resetController(controller) {
     controller.saveTokenTask.cancelAll();
+    controller.set('token_id', null);
   }
 }

--- a/app/routes/settings/tokens/new.js
+++ b/app/routes/settings/tokens/new.js
@@ -2,8 +2,6 @@ import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-import { CratePattern } from '../../../controllers/settings/tokens/new';
-
 export default class TokenListRoute extends Route {
   @service router;
   @service store;
@@ -36,15 +34,16 @@ export default class TokenListRoute extends Route {
     super.setupController(controller, model);
     if (model) {
       const { name, endpoint_scopes, crate_scopes } = model;
-      let properties = {
-        name,
-        ...(endpoint_scopes && { scopes: endpoint_scopes }),
-        ...(crate_scopes && {
-          crateScopes: crate_scopes.map(pattern => new CratePattern(pattern)),
-        }),
-      };
 
-      controller.setProperties(properties);
+      controller.name = name;
+      if (endpoint_scopes) {
+        controller.scopes = endpoint_scopes;
+      }
+      if (crate_scopes) {
+        for (let pattern of crate_scopes) {
+          controller.addCratePattern(pattern);
+        }
+      }
     }
   }
 

--- a/app/templates/settings/tokens/new.hbs
+++ b/app/templates/settings/tokens/new.hbs
@@ -160,7 +160,7 @@
         <button
           type="button"
           data-test-add-crate-pattern
-          {{on "click" this.addCratePattern}}
+          {{on "click" (fn this.addCratePattern "")}}
         >
           Add pattern
         </button>

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -320,6 +320,9 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     expect(newToken, 'New API token has been created in the backend database').toBeTruthy();
 
     await expect(page).toHaveURL('/settings/tokens');
+    await page.click('[data-test-new-token-button]');
+    // It should reset the token ID query parameter.
+    await expect(page).toHaveURL('/settings/tokens/new');
   });
 
   test('token not found', async ({ page }) => {

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -12,6 +12,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
       });
 
       authenticateAs(user);
+      globalThis.user = user;
     });
   });
 
@@ -280,6 +281,51 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await expect(page).toHaveURL('/settings/tokens/new');
     await expect(page.locator('[data-test-name-group] [data-test-error]')).toHaveCount(0);
     await expect(page.locator('[data-test-scopes-group] [data-test-error]')).toBeVisible();
+  });
+
+  test('prefill with the exist token', async ({ page, mirage }) => {
+    await mirage.addHook(server => {
+      const user = globalThis.user;
+
+      server.create('apiToken', {
+        user: user,
+        id: '1',
+        name: 'foo',
+        token: 'test',
+        createdAt: '2017-08-01T12:34:56',
+        lastUsedAt: '2017-11-02T01:45:14',
+        endpointScopes: ['publish-update'],
+      });
+    });
+
+    await page.goto('/settings/tokens/new?token_id=1');
+    await expect(page).toHaveURL('/settings/tokens/new?token_id=1');
+    await expect(page.locator('[data-test-crates-unrestricted]')).toBeVisible();
+    await expect(page.locator('[data-test-crate-pattern]')).toHaveCount(0);
+
+    await page.click('[data-test-add-crate-pattern]');
+    await expect(page.locator('[data-test-crates-unrestricted]')).toHaveCount(0);
+    await expect(page.locator('[data-test-crate-pattern]')).toHaveCount(1);
+
+    await page.fill('[data-test-crate-pattern="0"] input', 'serde');
+    await expect(page.locator('[data-test-crate-pattern="0"] [data-test-description]')).toHaveText(
+      'Matches only the serde crate',
+    );
+    await page.click('[data-test-generate]');
+
+    let newToken = await page.evaluate(() => {
+      let newToken = server.schema['apiTokens'].findBy({ name: 'foo', crateScopes: ['serde'] });
+      return JSON.parse(JSON.stringify(newToken));
+    });
+    expect(newToken, 'New API token has been created in the backend database').toBeTruthy();
+
+    await expect(page).toHaveURL('/settings/tokens');
+  });
+
+  test('token not found', async ({ page }) => {
+    await page.goto('/settings/tokens/new?token_id=1');
+    await expect(page).toHaveURL('/settings/tokens/new?token_id=1');
+    await expect(page.locator('[data-test-title]')).toHaveText('Token not found');
   });
 });
 

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@/e2e/helper';
+import { expect, test } from '@/e2e/helper';
 import { Response } from 'miragejs';
 
 test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
@@ -298,8 +298,8 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
       });
     });
 
-    await page.goto('/settings/tokens/new?token_id=1');
-    await expect(page).toHaveURL('/settings/tokens/new?token_id=1');
+    await page.goto('/settings/tokens/new?from=1');
+    await expect(page).toHaveURL('/settings/tokens/new?from=1');
     await expect(page.locator('[data-test-crates-unrestricted]')).toBeVisible();
     await expect(page.locator('[data-test-crate-pattern]')).toHaveCount(0);
 
@@ -326,8 +326,8 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
   });
 
   test('token not found', async ({ page }) => {
-    await page.goto('/settings/tokens/new?token_id=1');
-    await expect(page).toHaveURL('/settings/tokens/new?token_id=1');
+    await page.goto('/settings/tokens/new?from=1');
+    await expect(page).toHaveURL('/settings/tokens/new?from=1');
     await expect(page.locator('[data-test-title]')).toHaveText('Token not found');
   });
 });

--- a/mirage/route-handlers/me.js
+++ b/mirage/route-handlers/me.js
@@ -67,6 +67,22 @@ export function register(server) {
     return json;
   });
 
+  server.get('/api/v1/me/tokens/:tokenId', function (schema, request) {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
+    let { tokenId } = request.params;
+    let token = schema.apiTokens.findBy({ id: tokenId, userId: user.id });
+
+    if (!token) {
+      return new Response(404);
+    }
+
+    return this.serialize(token);
+  });
+
   server.delete('/api/v1/me/tokens/:tokenId', function (schema, request) {
     let { user } = getSession(schema);
     if (!user) {

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -286,8 +286,8 @@ module('/settings/tokens/new', function (hooks) {
       endpointScopes: ['publish-update'],
     });
 
-    await visit(`/settings/tokens/new?token_id=${token.id}`);
-    assert.strictEqual(currentURL(), `/settings/tokens/new?token_id=${token.id}`);
+    await visit(`/settings/tokens/new?from=${token.id}`);
+    assert.strictEqual(currentURL(), `/settings/tokens/new?from=${token.id}`);
     assert.dom('[data-test-crates-unrestricted]').exists();
     assert.dom('[data-test-crate-pattern]').doesNotExist();
 
@@ -317,8 +317,8 @@ module('/settings/tokens/new', function (hooks) {
       endpointScopes: ['publish-update'],
     });
 
-    await visit(`/settings/tokens/new?token_id=${token.id}`);
-    assert.strictEqual(currentURL(), `/settings/tokens/new?token_id=${token.id}`);
+    await visit(`/settings/tokens/new?from=${token.id}`);
+    assert.strictEqual(currentURL(), `/settings/tokens/new?from=${token.id}`);
     assert.dom('[data-test-crate-pattern]').exists({ count: 2 });
 
     await click('[data-test-add-crate-pattern]');
@@ -331,8 +331,8 @@ module('/settings/tokens/new', function (hooks) {
   test('token not found', async function (assert) {
     prepare(this);
 
-    await visit('/settings/tokens/new?token_id=1');
-    assert.strictEqual(currentURL(), '/settings/tokens/new?token_id=1');
+    await visit('/settings/tokens/new?from=1');
+    assert.strictEqual(currentURL(), '/settings/tokens/new?from=1');
     assert.dom('[data-test-title]').hasText('Token not found');
   });
 });

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -21,27 +21,8 @@ module('/settings/tokens/new', function (hooks) {
     });
 
     context.authenticateAs(user);
-  }
 
-  function prepareWithToken(context) {
-    let user = context.server.create('user', {
-      login: 'johnnydee',
-      name: 'John Doe',
-      email: 'john@doe.com',
-      avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
-    });
-
-    context.server.create('api-token', {
-      user,
-      id: 1,
-      name: 'foo',
-      token: 'test',
-      createdAt: '2017-08-01T12:34:56',
-      lastUsedAt: '2017-11-02T01:45:14',
-      endpointScopes: ['publish-update'],
-    });
-
-    context.authenticateAs(user);
+    return { user };
   }
 
   test('can navigate to the route', async function (assert) {
@@ -295,13 +276,18 @@ module('/settings/tokens/new', function (hooks) {
   });
 
   test('prefill with the exist token', async function (assert) {
-    prepareWithToken(this);
+    let { user } = prepare(this);
 
-    let token = this.server.schema.apiTokens.findBy({ name: 'foo' });
-    assert.ok(Boolean(token), 'API token has been created in the backend database');
+    let token = this.server.create('api-token', {
+      user,
+      name: 'foo',
+      createdAt: '2017-08-01T12:34:56',
+      lastUsedAt: '2017-11-02T01:45:14',
+      endpointScopes: ['publish-update'],
+    });
 
-    await visit('/settings/tokens/new?token_id=1');
-    assert.strictEqual(currentURL(), '/settings/tokens/new?token_id=1');
+    await visit(`/settings/tokens/new?token_id=${token.id}`);
+    assert.strictEqual(currentURL(), `/settings/tokens/new?token_id=${token.id}`);
     assert.dom('[data-test-crates-unrestricted]').exists();
     assert.dom('[data-test-crate-pattern]').doesNotExist();
 
@@ -311,13 +297,13 @@ module('/settings/tokens/new', function (hooks) {
     await fillIn('[data-test-crate-pattern="0"] input', 'serde');
     assert.dom('[data-test-crate-pattern="0"] [data-test-description]').hasText('Matches only the serde crate');
     await click('[data-test-generate]');
-
-    let newToken = this.server.schema.apiTokens.findBy({ name: 'foo', crateScopes: ['serde'] });
-    assert.ok(Boolean(newToken), 'New API token has been created in the backend database');
-
     assert.strictEqual(currentURL(), '/settings/tokens');
-    await click('[data-test-new-token-button]');
+
+    let tokens = this.server.schema.apiTokens.where({ name: 'foo' });
+    assert.strictEqual(tokens.length, 2, 'New API token has been created in the backend database');
+
     // It should reset the token ID query parameter.
+    await click('[data-test-new-token-button]');
     assert.strictEqual(currentURL(), '/settings/tokens/new');
   });
 

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -317,4 +317,12 @@ module('/settings/tokens/new', function (hooks) {
 
     assert.strictEqual(currentURL(), '/settings/tokens');
   });
+
+  test('token not found', async function (assert) {
+    prepare(this);
+
+    await visit('/settings/tokens/new?token_id=1');
+    assert.strictEqual(currentURL(), '/settings/tokens/new?token_id=1');
+    assert.dom('[data-test-title]').hasText('Token not found');
+  });
 });

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -307,6 +307,27 @@ module('/settings/tokens/new', function (hooks) {
     assert.strictEqual(currentURL(), '/settings/tokens/new');
   });
 
+  test('prefilled: crate scoped can be added', async function (assert) {
+    let { user } = prepare(this);
+
+    let token = this.server.create('api-token', {
+      user,
+      name: 'serde',
+      crateScopes: ['serde', 'serde-*'],
+      endpointScopes: ['publish-update'],
+    });
+
+    await visit(`/settings/tokens/new?token_id=${token.id}`);
+    assert.strictEqual(currentURL(), `/settings/tokens/new?token_id=${token.id}`);
+    assert.dom('[data-test-crate-pattern]').exists({ count: 2 });
+
+    await click('[data-test-add-crate-pattern]');
+    assert.dom('[data-test-crate-pattern]').exists({ count: 3 });
+    await fillIn('[data-test-crate-pattern="2"] input', 'serde2');
+    await click('[data-test-generate]');
+    assert.strictEqual(currentURL(), '/settings/tokens');
+  });
+
   test('token not found', async function (assert) {
     prepare(this);
 

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -316,6 +316,9 @@ module('/settings/tokens/new', function (hooks) {
     assert.ok(Boolean(newToken), 'New API token has been created in the backend database');
 
     assert.strictEqual(currentURL(), '/settings/tokens');
+    await click('[data-test-new-token-button]');
+    // It should reset the token ID query parameter.
+    assert.strictEqual(currentURL(), '/settings/tokens/new');
   });
 
   test('token not found', async function (assert) {


### PR DESCRIPTION
This PR added token info retrieval on the new token page.

I have introduced a new query parameter for the `new' page to allow us to pre-populate the original token information.  

Tested locally:

https://github.com/rust-lang/crates.io/assets/29879298/462919cb-0c5c-4804-9914-e01d0710fe22

Related:

- https://github.com/rust-lang/crates.io/issues/8717