### PR TITLE
Use `#[diesel::dsl::auto_type]` in some places

### DIFF
--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -16,7 +16,6 @@ pub struct Category {
 }
 
 type WithSlug<'a> = diesel::dsl::Eq<categories::slug, crate::sql::lower<&'a str>>;
-type BySlug<'a> = diesel::dsl::Filter<categories::table, WithSlug<'a>>;
 
 #[derive(Associations, Insertable, Identifiable, Debug, Clone, Copy)]
 #[diesel(
@@ -36,8 +35,10 @@ impl Category {
         categories::slug.eq(crate::sql::lower(slug))
     }
 
-    pub fn by_slug(slug: &str) -> BySlug<'_> {
-        categories::table.filter(Self::with_slug(slug))
+    #[dsl::auto_type(no_type_alias)]
+    pub fn by_slug<'a>(slug: &'a str) -> _ {
+        let filter: WithSlug<'a> = Self::with_slug(slug);
+        categories::table.filter(filter)
     }
 
     pub fn update_crate(


### PR DESCRIPTION
This commit replaces some of the manual written type aliases by [`#[diesel::dsl::auto_type]`](https://docs.diesel.rs/2.2.x/diesel/dsl/attr.auto_type.html) which just generates the correct return type based on the function content. This hopefully removes some complexity from the database code.

The main motivation for this change is to update the diesel [Composing Applications](https://diesel.rs/guides/composing-applications.html) guide which is based on this code. 

I'm not 100% happy with this as it's currently not possible to use `#[auto_type]` for all the the type defs due to the following reasons:

* `#[auto_type]` by default generates a type def alongside the function that names the return type. This cannot easily be done here as associated types for non-trait impls are not stable yet. (That's the reason for the `no_type_alias` option)
* This in turn requires that we specify the type in a few places so that the macro can pick up the correct type later