### PR TITLE
tests: Increase database pool size

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -383,7 +383,7 @@ fn simple_config() -> config::Server {
             // something is broken.
             url: String::from("invalid default url").into(),
             read_only_mode: false,
-            pool_size: 3,
+            pool_size: 5,
             min_idle: None,
         },
         replica: None,


### PR DESCRIPTION
This was decreased in 933576ae8cf92a1afdcbdafa209eeb73abbe00b2 when we were running the sync and async pools in parallel, but at this point we only use the async pool and can increase the pool size again. This should hopefully reduce the [current flakyness of our test suite](https://github.com/rust-lang/crates.io/actions/runs/9789499489/job/27029343419?pr=8993) a bit.