### PR TITLE
Update expiry notification to use the copy token link

### DIFF
--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -82,6 +82,7 @@ fn handle_expiring_token(
         debug!("Sending expiry notification to {}…", recipient);
         let email = ExpiryNotificationEmail {
             name: &user.gh_login,
+            token_id: token.id,
             token_name: &token.name,
             expiry_date: token.expired_at.unwrap().and_utc(),
         };
@@ -131,6 +132,7 @@ pub fn find_expiring_tokens(
 #[derive(Debug, Clone)]
 struct ExpiryNotificationEmail<'a> {
     name: &'a str,
+    token_id: i32,
     token_name: &'a str,
     expiry_date: chrono::DateTime<chrono::Utc>,
 }
@@ -144,13 +146,14 @@ impl<'a> Email for ExpiryNotificationEmail<'a> {
 
 We noticed your token "{}" will expire on {}.
 
-If this token is still needed, visit https://crates.io/settings/tokens/new to generate a new one.
+If this token is still needed, visit https://crates.io/settings/tokens/new?from={} to generate a new one.
 
 Thanks,
 The crates.io team"#,
             self.name,
             self.token_name,
-            self.expiry_date.to_rfc3339_opts(SecondsFormat::Secs, true)
+            self.expiry_date.to_rfc3339_opts(SecondsFormat::Secs, true),
+            self.token_id
         )
     }
 }


### PR DESCRIPTION
ref https://github.com/rust-lang/crates.io/issues/8717

Tested locally:
1. Start the crates.io in the docker
```console
crates.io on  rustin-patch-copy-token via 🐳 orbstack is 📦 v0.0.0 via  v20.13.0 via 🦀 v1.81.0-nightly took 2s 
❯ docker ps
CONTAINER ID   IMAGE               COMMAND                  CREATED          STATUS             PORTS                                       NAMES
7ce772c8b3b2   cratesio-worker     "cargo run --bin bac…"   4 minutes ago    Up 4 minutes                                                   cratesio-worker-1
5047a4401dfe   cratesio-frontend   "pnpm start"             10 minutes ago   Up 10 minutes      0.0.0.0:4200->4200/tcp, :::4200->4200/tcp   cratesio-frontend-1
e740cac267e7   cratesio-backend    "/app/docker_entrypo…"   10 minutes ago   Up 10 minutes      0.0.0.0:8888->8888/tcp, :::8888->8888/tcp   cratesio-backend-1
f7d983f426bb   postgres:16         "docker-entrypoint.s…"   12 days ago      Up About an hour   127.0.0.1:5432->5432/tcp                    cratesio-postgres-1
```
2. Create a new token which will expire within one day
<img width="803" alt="image" src="https://github.com/rust-lang/crates.io/assets/29879298/ef72c272-4a54-4363-87d8-5a36c84a8389">

3. Trigger a background job: ` DATABASE_URL=postgresql://postgres:password@localhost:5432/cargo_registry ./target/debug/crates-admin enqueue-job check_about_to_expire_token`

4. Check the email from the worker's tmp dir
<img width="693" alt="image" src="https://github.com/rust-lang/crates.io/assets/29879298/51b861b1-2e90-4a26-b32d-5f590c4f9bcc">
