### PR TITLE
Separate e2e snapshots and enable parallel test suites for percy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
   percy-nonce:
     name: Frontend / Percy Nonce
     runs-on: ubuntu-latest
+    needs: changed-files
+    if: needs.changed-files.outputs.non-rust == 'true'
 
     # persist job results to other jobs in the workflow
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,17 @@ jobs:
       non-rust: ${{ steps.changed-files-non-rust.outputs.any_modified }}
       rust-lockfile: ${{ steps.changed-files-rust-lockfile.outputs.any_modified }}
 
+  percy-nonce:
+    runs-on: ubuntu-latest
+    # persist job results to other jobs in the workflow
+    outputs:
+      nonce: ${{ steps.percy-nonce.outputs.nonce }}
+    steps:
+      # persist step results to other steps in the job
+      - id: percy-nonce
+        # adding a timestamp makes the nonce more unique for re-runs
+        run: echo "nonce=${{ github.run_id }}-$(date +%s)" >> $GITHUB_OUTPUT
+
   backend-lint:
     name: Backend / Lint
     runs-on: ubuntu-22.04
@@ -177,7 +188,7 @@ jobs:
   frontend-test:
     name: Frontend / Test
     runs-on: ubuntu-22.04
-    needs: changed-files
+    needs: [changed-files, percy-nonce]
     if: needs.changed-files.outputs.non-rust == 'true'
 
     env:
@@ -186,6 +197,8 @@ jobs:
       # Percy secrets are included here to enable Percy's GitHub integration
       # on community-submitted PRs
       PERCY_TOKEN: web_0a783d8086b6f996809f3e751d032dd6d156782082bcd1423b9b860113c75054
+      PERCY_PARALLEL_NONCE: ${{ needs.percy-nonce.outputs.nonce }}
+      PERCY_PARALLEL_TOTAL: 2
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -202,7 +215,7 @@ jobs:
       - run: pnpm install
 
       - if: github.repository == 'rust-lang/crates.io'
-        run: pnpm percy exec -- pnpm test-coverage
+        run: pnpm percy exec --parallel -- pnpm test-coverage
 
       - if: github.repository != 'rust-lang/crates.io'
         run: pnpm test-coverage
@@ -210,7 +223,7 @@ jobs:
   e2e-test:
     name: Frontend / Test (playwright)
     runs-on: ubuntu-22.04
-    needs: changed-files
+    needs: [changed-files, percy-nonce]
     timeout-minutes: 60
     if: needs.changed-files.outputs.non-rust == 'true'
 
@@ -220,6 +233,8 @@ jobs:
       # Percy secrets are included here to enable Percy's GitHub integration
       # on community-submitted PRs
       PERCY_TOKEN: web_0a783d8086b6f996809f3e751d032dd6d156782082bcd1423b9b860113c75054
+      PERCY_PARALLEL_NONCE: ${{ needs.percy-nonce.outputs.nonce }}
+      PERCY_PARALLEL_TOTAL: 2
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -238,7 +253,7 @@ jobs:
       - run: pnpm playwright install chromium
 
       - if: github.repository == 'rust-lang/crates.io'
-        run: pnpm percy exec -- pnpm e2e
+        run: pnpm percy exec --parallel -- pnpm e2e
 
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,13 @@ jobs:
       rust-lockfile: ${{ steps.changed-files-rust-lockfile.outputs.any_modified }}
 
   percy-nonce:
+    name: Frontend / Percy Nonce
     runs-on: ubuntu-latest
+
     # persist job results to other jobs in the workflow
     outputs:
       nonce: ${{ steps.percy-nonce.outputs.nonce }}
+
     steps:
       # persist step results to other steps in the job
       - id: percy-nonce

--- a/e2e/fixtures/percy.ts
+++ b/e2e/fixtures/percy.ts
@@ -14,7 +14,9 @@ export class PercyPage {
   private title(): string {
     // Skip the filename
     const paths = this.testInfo.titlePath.slice(1);
-    return paths.join(' | ');
+    // Add an "e2e" prefix to differentiate the snapshots from the QUnit tests.
+    // This address the visual changes caused by the font not loading in QUnit tests (#9052).
+    return ['e2e'].concat(paths).join(' | ');
   }
 
   async snapshot(options?: Parameters<typeof percySnapshot>[2]) {


### PR DESCRIPTION
This PR addresses #9052 by:

- Separates the e2e percy snapshots from the QUnit tests by prefixing them with `e2e` in their titles.
- Enables parallel test suites for percy in CI.

---

Changing only the title to separate snapshot sets **without** enabling parallel test suites is insufficient.  This will cause  finalized builds to not recognize each other and consider others **missing**.  Therefore, enabling parallel test suites for percy is necessary.

Thanks @Turbo87 for the information and guidance!