### PR TITLE
Change the README security link to crates.io's security page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 [Homepage][crates.io]
 | [Usage Policy](https://crates.io/policies)
-| [Security](https://www.rust-lang.org/policies/security)
+| [Security](https://crates.io/policies/security)
 | [Status](https://status.crates.io/)
 | [Contact](#️-contact)
 | [Contributing](#️-contributing)


### PR DESCRIPTION
Follow-up work to https://github.com/rust-lang/crates.io/pull/8791 now that the page is live.

This PR was extracted from https://github.com/rust-lang/crates.io/pull/9048 since that commit seems uncontroversial on its own :)