### PR TITLE
UI: Use `created_at` instead of `updated_at`

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -7,7 +7,7 @@
     <h2 local-class="heading">Metadata</h2>
 
     <time
-      datetime={{date-format-iso @version.updated_at}}
+      datetime={{date-format-iso @version.created_at}}
       local-class="date"
     >
       {{svg-jar "calendar"}}

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -50,7 +50,7 @@
       {{/if}}
 
       <time
-        datetime={{date-format-iso @version.updated_at}}
+        datetime={{date-format-iso @version.created_at}}
         local-class="date {{if @version.isNew "new"}}"
       >
         {{svg-jar "calendar"}}

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -15,7 +15,6 @@ export default class Version extends Model {
   @attr dl_path;
   @attr readme_path;
   @attr('date') created_at;
-  @attr('date') updated_at;
   @attr downloads;
   @attr features;
   @attr yanked;


### PR DESCRIPTION
For versions we only care about the publish date, not about e.g. the last update of the `yanked` column. The displayed value was already using `created_at`, just not the attribute on the `<time>` element yet, so this can be seen as fixing an inconsistency :)