### PR TITLE
CrateSidebar: Fix `@hasLib` assignment

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -52,7 +52,7 @@
         @crate={{@crate.name}}
         @version={{@version.num}}
         @exactVersion={{@requestedVersion}}
-        @hasLib={{not (@version.has_lib false)}}
+        @hasLib={{not (eq @version.has_lib false)}}
         @binNames={{@version.bin_names}}
       />
     </div>

--- a/app/components/crate-sidebar/install-instructions.module.css
+++ b/app/components/crate-sidebar/install-instructions.module.css
@@ -1,6 +1,10 @@
 .copy-help {
     font-size: 12px;
     overflow-wrap: break-word;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
 }
 
 .copy-button,


### PR DESCRIPTION
`has_lib: false` was still showing the "Install as library" section, and looking at the code I can only 🤦‍♂️ 😂 

This PR fixes the broken assignment so that https://crates.io/crates/ripgrep will no longer show that section. The PR also includes a tiny styling tweak to make the margins between the sidebar sections consistent in this case.