### PR TITLE
Add support for pictures that react to the user's color scheme choice

### DIFF
--- a/app/components/rendered-html.hbs
+++ b/app/components/rendered-html.hbs
@@ -5,6 +5,7 @@
 <TextContent
   ...attributes
   {{highlight-syntax selector="pre > code:not(.language-mermaid)"}}
+  {{update-source-media this.colorScheme.resolvedScheme}}
   {{render-mermaids}}
 >
   {{html-safe @html}}

--- a/app/components/rendered-html.js
+++ b/app/components/rendered-html.js
@@ -1,0 +1,6 @@
+import { inject as service } from '@ember/service';
+import Component from '@glimmer/component';
+
+export default class extends Component {
+  @service colorScheme;
+}

--- a/app/modifiers/update-source-media.js
+++ b/app/modifiers/update-source-media.js
@@ -1,0 +1,34 @@
+import { modifier } from 'ember-modifier';
+
+/**
+ * This modifier updates the `media` attribute of the `source` elements
+ * based on the user's color scheme preference.
+ *
+ * The code was adapted from https://larsmagnus.co/blog/how-to-make-images-react-to-light-and-dark-mode.
+ */
+export default modifier((element, [colorPreference]) => {
+  let pictures = element.querySelectorAll('picture');
+
+  pictures.forEach(picture => {
+    let sources = picture.querySelectorAll(
+      'source[media*="prefers-color-scheme"], source[data-media*="prefers-color-scheme"]',
+    );
+
+    sources.forEach(source => {
+      // Preserve the source `media` as a data-attribute
+      // to be able to switch between preferences
+      if (source.media?.includes('prefers-color-scheme')) {
+        source.dataset.media = source.media;
+      }
+
+      // If the source element `media` target is the `preference`,
+      // override it to 'all' to show
+      // or set it to 'none' to hide
+      if (source.dataset.media.includes(colorPreference)) {
+        source.media = 'all';
+      } else if (source) {
+        source.media = 'none';
+      }
+    });
+  });
+});

--- a/crates/crates_io_markdown/lib.rs
+++ b/crates/crates_io_markdown/lib.rs
@@ -677,4 +677,20 @@ There can also be some text in between!
         <p align="center"><img src="https://img.shields.io/crates/v/clap.svg" alt=""></p>
         "###);
     }
+
+    #[test]
+    fn pictures_and_sources() {
+        let text = r#"
+<picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://test.crates.io/logo_dark.svg">
+    <img src="https://test.crates.io/logo.svg" alt="logo" width="200">
+</picture>
+        "#;
+        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+
+            
+            <img src="https://test.crates.io/logo.svg" alt="logo" width="200">
+
+        "###);
+    }
 }

--- a/crates/crates_io_markdown/lib.rs
+++ b/crates/crates_io_markdown/lib.rs
@@ -51,12 +51,13 @@ impl<'a> MarkdownRenderer<'a> {
 
         let mut html_sanitizer = Builder::default();
         html_sanitizer
-            .add_tags(&["input", "ol", "section"])
+            .add_tags(&["input", "ol", "picture", "section", "source"])
             .link_rel(Some("nofollow noopener noreferrer"))
             .add_generic_attributes(&["align"])
             .add_tag_attributes("a", &["id", "target"])
             .add_tag_attributes("input", &["checked", "disabled", "type"])
             .add_tag_attributes("li", &["id"])
+            .add_tag_attributes("source", &["media", "srcset"])
             .allowed_classes(allowed_classes)
             .url_relative(sanitize_url)
             .id_prefix(Some("user-content-"));
@@ -687,10 +688,10 @@ There can also be some text in between!
 </picture>
         "#;
         assert_snapshot!(markdown_to_html(text, None, ""), @r###"
-
-            
+        <picture>
+            <source media="(prefers-color-scheme: dark)" srcset="https://test.crates.io/logo_dark.svg">
             <img src="https://test.crates.io/logo.svg" alt="logo" width="200">
-
+        </picture>
         "###);
     }
 }


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/9093

GitHub allows this via e.g.:

```html
<picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://test.crates.io/logo_dark.svg">
    <img src="https://test.crates.io/logo.svg" alt="logo" width="200">
</picture>
```

but so far we haven't allowed the `picture` and `source` elements when rendering markdown files. This PR changes that.

This PR also adjusts our frontend code to make these `picture` elements work properly. Natively, these elements only react to the device's color scheme choice, but not to any overrides on the website itself. The `color-scheme` CSS attribute unfortunately does not influence the `media` resolution of the `source` elements. https://larsmagnus.co/blog/how-to-make-images-react-to-light-and-dark-mode presents a relatively straight-forward way to make this work with theme switchers, which I've adapted to make it work with our Ember.js frontend code.