### PR TITLE
Add support for searching stopwords as keywords

### DIFF
--- a/migrations/2024-07-14-074318_enable-stopwords-in-textsearchable_index_col/down.sql
+++ b/migrations/2024-07-14-074318_enable-stopwords-in-textsearchable_index_col/down.sql
@@ -1,0 +1,17 @@
+DROP aggregate tsvector_agg (tsvector);
+
+CREATE OR REPLACE FUNCTION trigger_crates_name_search() RETURNS trigger AS $$
+DECLARE kws TEXT;
+begin
+  SELECT array_to_string(array_agg(keyword), ',') INTO kws
+    FROM keywords INNER JOIN crates_keywords
+      ON keywords.id = crates_keywords.keyword_id
+  WHERE crates_keywords.crate_id = new.id;
+    new.textsearchable_index_col :=
+      setweight(to_tsvector('pg_catalog.english', coalesce(new.name, '')), 'A') ||
+      setweight(to_tsvector('pg_catalog.english', coalesce(kws, '')), 'B') ||
+      setweight(to_tsvector('pg_catalog.english', coalesce(new.description, '')), 'C') ||
+      setweight(to_tsvector('pg_catalog.english', coalesce(new.readme, '')), 'D');
+  return new;
+end
+$$ LANGUAGE plpgsql;

--- a/migrations/2024-07-14-074318_enable-stopwords-in-textsearchable_index_col/up.sql
+++ b/migrations/2024-07-14-074318_enable-stopwords-in-textsearchable_index_col/up.sql
@@ -1,8 +1,35 @@
+-- This is an aggregation function that combines multiple rows of tsvector data into a single tsvector
+-- using the tsvector concat operator.
 CREATE OR REPLACE aggregate tsvector_agg (tsvector) (
   STYPE = pg_catalog.tsvector,
   SFUNC = pg_catalog.tsvector_concat,
   INITCOND = ''
 );
+-- e.g.
+-- WITH expected AS (
+--   SELECT
+--     'macro:1'::tsvector || 'any:1'::tsvector AS concat
+-- ),
+-- data as (
+--   SELECT *
+--   FROM (
+--     VALUES
+--       ('macro:1' :: tsvector),
+--       ('any:1' :: tsvector)
+--   ) k(tv)
+-- )
+-- SELECT
+--   ( SELECT concat FROM expected ),
+--   ( SELECT tsvector_agg(tv) FROM data ) AS agg,
+--   ( SELECT concat FROM expected ) = (
+--     SELECT tsvector_agg(tv) FROM data
+--   ) AS is_eq;
+--
+-- EOF
+--       concat       |        agg        | is_eq
+-- -------------------+-------------------+-------
+--  'any':2 'macro':1 | 'any':2 'macro':1 | t
+-- (1 row)
 
 -- Add support for storing keywords considered stopwords in `crates.textsearchable_index_col` by casting
 -- to tsvector

--- a/migrations/2024-07-14-074318_enable-stopwords-in-textsearchable_index_col/up.sql
+++ b/migrations/2024-07-14-074318_enable-stopwords-in-textsearchable_index_col/up.sql
@@ -1,0 +1,45 @@
+CREATE OR REPLACE aggregate tsvector_agg (tsvector) (
+  STYPE = pg_catalog.tsvector,
+  SFUNC = pg_catalog.tsvector_concat,
+  INITCOND = ''
+);
+
+-- Add support for storing keywords considered stopwords in `crates.textsearchable_index_col` by casting
+-- to tsvector
+CREATE OR REPLACE FUNCTION trigger_crates_name_search() RETURNS trigger AS $$
+DECLARE kws tsvector;
+begin
+  SELECT
+    tsvector_agg(
+      CASE WHEN length(to_tsvector('english', keyword)) != 0 THEN to_tsvector('english', keyword)
+      ELSE (keyword || ':1')::tsvector
+      END
+      ORDER BY keyword
+  	) INTO kws
+  FROM keywords INNER JOIN crates_keywords
+    ON keywords.id = crates_keywords.keyword_id
+  WHERE crates_keywords.crate_id = new.id;
+    new.textsearchable_index_col :=
+      setweight(to_tsvector('pg_catalog.english', coalesce(new.name, '')), 'A') ||
+      setweight(kws, 'B') ||
+      setweight(to_tsvector('pg_catalog.english', coalesce(new.description, '')), 'C') ||
+      setweight(to_tsvector('pg_catalog.english', coalesce(new.readme, '')), 'D')
+  ;
+  return new;
+end
+$$ LANGUAGE plpgsql;
+
+
+-- We could update those crates with the following sql
+--
+-- WITH keywords_with_stopwords as (
+--   SELECT crate_id, keyword
+--   FROM keywords INNER JOIN crates_keywords
+--     ON id = keyword_id
+--   WHERE length(to_tsvector('english', keyword)) = 0
+-- )
+-- UPDATE crates
+-- SET updated_at = updated_at
+-- FROM keywords_with_stopwords
+-- WHERE id = crate_id AND NOT (keyword || ':B')::tsquery @@ textsearchable_index_col
+-- ;


### PR DESCRIPTION
This PR adds support for searching query strings as keywords (weight B) in the `textsearchable_index_col` column if it is a `stopword`.

Should resolve #1407.

---

This PR should not impact query performance for <code><b>non</b>-stopword</code> searches. When searching with a `stopword`, it should maintain similar query performance to <code><b>non</b>-stopword</code> searches.

|  | **non**-stopword | stopword |
| --- | --- | --- |
| current | Execution Time: `32.545 ms` <br> Cost: `14684.48..14684.60` | Execution Time: `6.187 ms` <br> Cost: `1979.71..1979.83` |
| proposed | Execution Time: `34.072 ms` <br> Cost: `14684.48..14684.60` | Execution Time: `33.486 ms` <br> Cost: `14660.48..14660.60` |

<details>
<summary> Current <b>non</b>-stopword search <code>EXPLAIN ANALYZE</code> </summary>

```explain
Limit  (cost=14684.48..14684.60 rows=10 width=227) (actual time=32.429..32.435 rows=10 loops=1)
  Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, ($0)
  Buffers: shared hit=3833
  InitPlan 1 (returns $0)
    ->  Aggregate  (cost=4589.17..4589.18 rows=1 width=8) (actual time=1.948..1.949 rows=1 loops=1)
          Output: count(*)
          Buffers: shared hit=761
          ->  Bitmap Heap Scan on public.crates crates_1  (cost=2058.13..4587.26 rows=766 width=0) (actual time=1.726..1.935 rows=192 loops=1)
                Recheck Cond: (('''flex'''::tsquery @@ crates_1.textsearchable_index_col) OR (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text))
                Heap Blocks: exact=189
                Buffers: shared hit=761
                ->  BitmapOr  (cost=2058.13..2058.13 rows=767 width=0) (actual time=1.712..1.713 rows=0 loops=1)
                      Buffers: shared hit=513
                      ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..1241.64 rows=752 width=0) (actual time=0.546..0.546 rows=134 loops=1)
                            Index Cond: (crates_1.textsearchable_index_col @@ '''flex'''::tsquery)
                            Buffers: shared hit=309
                      ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..816.11 rows=15 width=0) (actual time=1.165..1.165 rows=84 loops=1)
                            Index Cond: (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text)
                            Buffers: shared hit=204
  ->  Subquery Scan on t  (cost=10095.29..10104.60 rows=745 width=227) (actual time=32.428..32.432 rows=10 loops=1)
        Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, $0
        Buffers: shared hit=3833
        ->  Sort  (cost=10095.29..10097.15 rows=745 width=219) (actual time=30.475..30.477 rows=10 loops=1)
              Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'flex'::text)), crate_downloads.downloads, recent_crate_downloads.downloads, (ts_rank_cd(crates.textsearchable_index_col, '''flex'''::tsquery))
              Sort Key: ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'flex'::text)) DESC, (ts_rank_cd(crates.textsearchable_index_col, '''flex'''::tsquery)) DESC, crates.name
              Sort Method: top-N heapsort  Memory: 30kB
              Buffers: shared hit=3072
              ->  Hash Right Join  (cost=7243.36..10059.75 rows=745 width=219) (actual time=16.221..30.360 rows=192 loops=1)
                    Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, (replace(lower((crates.name)::text), '-'::text, '_'::text) = 'flex'::text), crate_downloads.downloads, recent_crate_downloads.downloads, ts_rank_cd(crates.textsearchable_index_col, '''flex'''::tsquery)
                    Hash Cond: (recent_crate_downloads.crate_id = crates.id)
                    Buffers: shared hit=3061
                    ->  Seq Scan on public.recent_crate_downloads  (cost=0.00..2253.32 rows=146232 width=12) (actual time=0.005..5.630 rows=146232 loops=1)
                          Output: recent_crate_downloads.crate_id, recent_crate_downloads.downloads
                          Buffers: shared hit=791
                    ->  Hash  (cost=7234.05..7234.05 rows=745 width=413) (actual time=16.149..16.150 rows=192 loops=1)
                          Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col, crate_downloads.downloads
                          Buckets: 1024  Batches: 1  Memory Usage: 75kB
                          Buffers: shared hit=1677
                          ->  Hash Join  (cost=4596.83..7234.05 rows=745 width=413) (actual time=3.198..16.079 rows=192 loops=1)
                                Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col, crate_downloads.downloads
                                Inner Unique: true
                                Hash Cond: (crate_downloads.crate_id = crates.id)
                                Buffers: shared hit=1677
                                ->  Seq Scan on public.crate_downloads  (cost=0.00..2253.34 rows=146234 width=12) (actual time=0.003..5.462 rows=146234 loops=1)
                                      Output: crate_downloads.crate_id, crate_downloads.downloads
                                      Buffers: shared hit=791
                                ->  Hash  (cost=4587.26..4587.26 rows=766 width=405) (actual time=3.134..3.135 rows=192 loops=1)
                                      Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col
                                      Buckets: 1024  Batches: 1  Memory Usage: 73kB
                                      Buffers: shared hit=886
                                      ->  Bitmap Heap Scan on public.crates  (cost=2058.13..4587.26 rows=766 width=405) (actual time=2.466..3.072 rows=192 loops=1)
                                            Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col
                                            Recheck Cond: (('''flex'''::tsquery @@ crates.textsearchable_index_col) OR (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text))
                                            Heap Blocks: exact=189
                                            Buffers: shared hit=886
                                            ->  BitmapOr  (cost=2058.13..2058.13 rows=767 width=0) (actual time=2.447..2.447 rows=0 loops=1)
                                                  Buffers: shared hit=513
                                                  ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..1241.64 rows=752 width=0) (actual time=0.995..0.995 rows=134 loops=1)
                                                        Index Cond: (crates.textsearchable_index_col @@ '''flex'''::tsquery)
                                                        Buffers: shared hit=309
                                                  ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..816.11 rows=15 width=0) (actual time=1.452..1.452 rows=84 loops=1)
                                                        Index Cond: (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text)
                                                        Buffers: shared hit=204
Planning:
  Buffers: shared hit=553
Planning Time: 2.856 ms
Execution Time: 32.545 ms
```
</details>


<details>
<summary> Proposed <b>non</b>-stopword <code>EXPLAIN ANALYZE</code> </summary>

```explain
Limit  (cost=14684.48..14684.60 rows=10 width=227) (actual time=33.943..33.949 rows=10 loops=1)
  Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, ($0)
  Buffers: shared hit=3833
  InitPlan 1 (returns $0)
    ->  Aggregate  (cost=4589.17..4589.18 rows=1 width=8) (actual time=2.301..2.302 rows=1 loops=1)
          Output: count(*)
          Buffers: shared hit=761
          ->  Bitmap Heap Scan on public.crates crates_1  (cost=2058.13..4587.26 rows=766 width=0) (actual time=2.055..2.293 rows=192 loops=1)
                Recheck Cond: (('''flex'''::tsquery @@ crates_1.textsearchable_index_col) OR (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text))
                Heap Blocks: exact=189
                Buffers: shared hit=761
                ->  BitmapOr  (cost=2058.13..2058.13 rows=767 width=0) (actual time=2.038..2.038 rows=0 loops=1)
                      Buffers: shared hit=513
                      ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..1241.64 rows=752 width=0) (actual time=0.628..0.628 rows=134 loops=1)
                            Index Cond: (crates_1.textsearchable_index_col @@ '''flex'''::tsquery)
                            Buffers: shared hit=309
                      ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..816.11 rows=15 width=0) (actual time=1.409..1.410 rows=84 loops=1)
                            Index Cond: (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text)
                            Buffers: shared hit=204
  ->  Subquery Scan on t  (cost=10095.29..10104.60 rows=745 width=227) (actual time=33.942..33.946 rows=10 loops=1)
        Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, $0
        Buffers: shared hit=3833
        ->  Sort  (cost=10095.29..10097.15 rows=745 width=219) (actual time=31.638..31.639 rows=10 loops=1)
              Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'flex'::text)), crate_downloads.downloads, recent_crate_downloads.downloads, (ts_rank_cd(crates.textsearchable_index_col, '''flex'''::tsquery))
              Sort Key: ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'flex'::text)) DESC, (ts_rank_cd(crates.textsearchable_index_col, '''flex'''::tsquery)) DESC, crates.name
              Sort Method: top-N heapsort  Memory: 30kB
              Buffers: shared hit=3072
              ->  Hash Right Join  (cost=7243.36..10059.75 rows=745 width=219) (actual time=16.820..31.514 rows=192 loops=1)
                    Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, (replace(lower((crates.name)::text), '-'::text, '_'::text) = 'flex'::text), crate_downloads.downloads, recent_crate_downloads.downloads, ts_rank_cd(crates.textsearchable_index_col, '''flex'''::tsquery)
                    Hash Cond: (recent_crate_downloads.crate_id = crates.id)
                    Buffers: shared hit=3061
                    ->  Seq Scan on public.recent_crate_downloads  (cost=0.00..2253.32 rows=146232 width=12) (actual time=0.005..5.974 rows=146232 loops=1)
                          Output: recent_crate_downloads.crate_id, recent_crate_downloads.downloads
                          Buffers: shared hit=791
                    ->  Hash  (cost=7234.05..7234.05 rows=745 width=413) (actual time=16.738..16.739 rows=192 loops=1)
                          Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col, crate_downloads.downloads
                          Buckets: 1024  Batches: 1  Memory Usage: 75kB
                          Buffers: shared hit=1677
                          ->  Hash Join  (cost=4596.83..7234.05 rows=745 width=413) (actual time=3.101..16.655 rows=192 loops=1)
                                Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col, crate_downloads.downloads
                                Inner Unique: true
                                Hash Cond: (crate_downloads.crate_id = crates.id)
                                Buffers: shared hit=1677
                                ->  Seq Scan on public.crate_downloads  (cost=0.00..2253.34 rows=146234 width=12) (actual time=0.003..6.126 rows=146234 loops=1)
                                      Output: crate_downloads.crate_id, crate_downloads.downloads
                                      Buffers: shared hit=791
                                ->  Hash  (cost=4587.26..4587.26 rows=766 width=405) (actual time=3.036..3.037 rows=192 loops=1)
                                      Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col
                                      Buckets: 1024  Batches: 1  Memory Usage: 73kB
                                      Buffers: shared hit=886
                                      ->  Bitmap Heap Scan on public.crates  (cost=2058.13..4587.26 rows=766 width=405) (actual time=2.367..2.972 rows=192 loops=1)
                                            Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col
                                            Recheck Cond: (('''flex'''::tsquery @@ crates.textsearchable_index_col) OR (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text))
                                            Heap Blocks: exact=189
                                            Buffers: shared hit=886
                                            ->  BitmapOr  (cost=2058.13..2058.13 rows=767 width=0) (actual time=2.350..2.351 rows=0 loops=1)
                                                  Buffers: shared hit=513
                                                  ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..1241.64 rows=752 width=0) (actual time=0.972..0.972 rows=134 loops=1)
                                                        Index Cond: (crates.textsearchable_index_col @@ '''flex'''::tsquery)
                                                        Buffers: shared hit=309
                                                  ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..816.11 rows=15 width=0) (actual time=1.378..1.378 rows=84 loops=1)
                                                        Index Cond: (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%flex%'::text)
                                                        Buffers: shared hit=204
Planning:
  Buffers: shared hit=559
Planning Time: 2.408 ms
Execution Time: 34.072 ms
```
</details>


<details>
<summary> Current stopword search <code>EXPLAIN ANALYZE</code> </summary>

```explain
Limit  (cost=1979.71..1979.83 rows=10 width=227) (actual time=6.090..6.095 rows=10 loops=1)
  Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, ($0)
  Buffers: shared hit=4439
  InitPlan 1 (returns $0)
    ->  Aggregate  (cost=863.08..863.09 rows=1 width=8) (actual time=1.326..1.326 rows=1 loops=1)
          Output: count(*)
          Buffers: shared hit=1175
          ->  Bitmap Heap Scan on public.crates crates_1  (cost=804.12..863.05 rows=15 width=0) (actual time=0.891..1.316 rows=212 loops=1)
                Recheck Cond: ((''::tsquery @@ crates_1.textsearchable_index_col) OR (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%any%'::text))
                Heap Blocks: exact=615
                Buffers: shared hit=1175
                ->  BitmapOr  (cost=804.12..804.12 rows=15 width=0) (actual time=0.835..0.835 rows=0 loops=1)
                      Buffers: shared hit=201
                      ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..0.00 rows=1 width=0) (actual time=0.000..0.000 rows=0 loops=1)
                            Index Cond: (crates_1.textsearchable_index_col @@ ''::tsquery)
                      ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..804.11 rows=15 width=0) (actual time=0.835..0.835 rows=973 loops=1)
                            Index Cond: (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%any%'::text)
                            Buffers: shared hit=201
  ->  Subquery Scan on t  (cost=1116.61..1116.80 rows=15 width=227) (actual time=6.090..6.092 rows=10 loops=1)
        Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, $0
        Buffers: shared hit=4439
        ->  Sort  (cost=1116.61..1116.65 rows=15 width=219) (actual time=4.762..4.763 rows=10 loops=1)
              Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'any'::text)), crate_downloads.downloads, recent_crate_downloads.downloads, (ts_rank_cd(crates.textsearchable_index_col, ''::tsquery))
              Sort Key: ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'any'::text)) DESC, (ts_rank_cd(crates.textsearchable_index_col, ''::tsquery)) DESC, crates.name
              Sort Method: top-N heapsort  Memory: 29kB
              Buffers: shared hit=3264
              ->  Nested Loop Left Join  (cost=804.96..1116.32 rows=15 width=219) (actual time=1.314..4.622 rows=212 loops=1)
                    Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, (replace(lower((crates.name)::text), '-'::text, '_'::text) = 'any'::text), crate_downloads.downloads, recent_crate_downloads.downloads, ts_rank_cd(crates.textsearchable_index_col, ''::tsquery)
                    Inner Unique: true
                    Buffers: shared hit=3253
                    ->  Nested Loop  (cost=804.54..989.61 rows=15 width=413) (actual time=1.302..3.627 rows=212 loops=1)
                          Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col, crate_downloads.downloads
                          Inner Unique: true
                          Buffers: shared hit=2046
                          ->  Bitmap Heap Scan on public.crates  (cost=804.12..863.05 rows=15 width=405) (actual time=1.291..2.802 rows=212 loops=1)
                                Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.readme, crates.textsearchable_index_col, crates.repository, crates.max_upload_size, crates.max_features
                                Recheck Cond: ((''::tsquery @@ crates.textsearchable_index_col) OR (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%any%'::text))
                                Heap Blocks: exact=615
                                Buffers: shared hit=1198
                                ->  BitmapOr  (cost=804.12..804.12 rows=15 width=0) (actual time=1.187..1.188 rows=0 loops=1)
                                      Buffers: shared hit=201
                                      ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..0.00 rows=1 width=0) (actual time=0.002..0.002 rows=0 loops=1)
                                            Index Cond: (crates.textsearchable_index_col @@ ''::tsquery)
                                      ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..804.11 rows=15 width=0) (actual time=1.185..1.185 rows=973 loops=1)
                                            Index Cond: (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%any%'::text)
                                            Buffers: shared hit=201
                          ->  Index Scan using crate_downloads_pk on public.crate_downloads  (cost=0.42..8.44 rows=1 width=12) (actual time=0.004..0.004 rows=1 loops=212)
                                Output: crate_downloads.crate_id, crate_downloads.downloads
                                Index Cond: (crate_downloads.crate_id = crates.id)
                                Buffers: shared hit=848
                    ->  Index Scan using recent_crate_downloads_crate_id on public.recent_crate_downloads  (cost=0.42..8.44 rows=1 width=12) (actual time=0.003..0.003 rows=1 loops=212)
                          Output: recent_crate_downloads.crate_id, recent_crate_downloads.downloads
                          Index Cond: (recent_crate_downloads.crate_id = crates.id)
                          Buffers: shared hit=848
Planning:
  Buffers: shared hit=553
Planning Time: 2.759 ms
Execution Time: 6.187 ms
```
</details>


<details>
<summary> Proposed stopword search <code>EXPLAIN ANALYZE</code> </summary>

```explain
Limit  (cost=14660.48..14660.60 rows=10 width=227) (actual time=33.360..33.368 rows=10 loops=1)
  Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, ($0)
  Buffers: shared hit=5410
  InitPlan 1 (returns $0)
    ->  Aggregate  (cost=4577.17..4577.18 rows=1 width=8) (actual time=2.354..2.355 rows=1 loops=1)
          Output: count(*)
          Buffers: shared hit=1682
          ->  Bitmap Heap Scan on public.crates crates_1  (cost=2046.13..4575.26 rows=766 width=0) (actual time=1.527..2.341 rows=240 loops=1)
                Recheck Cond: (('''any'':B'::tsquery @@ crates_1.textsearchable_index_col) OR (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%any%'::text))
                Heap Blocks: exact=742
                Buffers: shared hit=1682
                ->  BitmapOr  (cost=2046.13..2046.13 rows=767 width=0) (actual time=1.471..1.471 rows=0 loops=1)
                      Buffers: shared hit=510
                      ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..1241.64 rows=752 width=0) (actual time=0.603..0.603 rows=1079 loops=1)
                            Index Cond: (crates_1.textsearchable_index_col @@ '''any'':B'::tsquery)
                            Buffers: shared hit=309
                      ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..804.11 rows=15 width=0) (actual time=0.867..0.867 rows=973 loops=1)
                            Index Cond: (replace(lower((crates_1.name)::text), '-'::text, '_'::text) ~~ '%any%'::text)
                            Buffers: shared hit=201
  ->  Subquery Scan on t  (cost=10083.29..10092.60 rows=745 width=227) (actual time=33.359..33.365 rows=10 loops=1)
        Output: t.id, t.name, t.updated_at, t.created_at, t.description, t.homepage, t.documentation, t.repository, t.max_upload_size, t.max_features, t."?column?", t.downloads, t.downloads_1, t.ts_rank_cd, $0
        Buffers: shared hit=5410
        ->  Sort  (cost=10083.29..10085.15 rows=745 width=219) (actual time=31.002..31.006 rows=10 loops=1)
              Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'any'::text)), crate_downloads.downloads, recent_crate_downloads.downloads, (ts_rank_cd(crates.textsearchable_index_col, '''any'':B'::tsquery))
              Sort Key: ((replace(lower((crates.name)::text), '-'::text, '_'::text) = 'any'::text)) DESC, (ts_rank_cd(crates.textsearchable_index_col, '''any'':B'::tsquery)) DESC, crates.name
              Sort Method: top-N heapsort  Memory: 29kB
              Buffers: shared hit=3728
              ->  Hash Right Join  (cost=7231.36..10047.75 rows=745 width=219) (actual time=16.917..30.868 rows=240 loops=1)
                    Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, (replace(lower((crates.name)::text), '-'::text, '_'::text) = 'any'::text), crate_downloads.downloads, recent_crate_downloads.downloads, ts_rank_cd(crates.textsearchable_index_col, '''any'':B'::tsquery)
                    Hash Cond: (recent_crate_downloads.crate_id = crates.id)
                    Buffers: shared hit=3717
                    ->  Seq Scan on public.recent_crate_downloads  (cost=0.00..2253.32 rows=146232 width=12) (actual time=0.010..5.591 rows=146232 loops=1)
                          Output: recent_crate_downloads.crate_id, recent_crate_downloads.downloads
                          Buffers: shared hit=791
                    ->  Hash  (cost=7222.05..7222.05 rows=745 width=413) (actual time=16.885..16.887 rows=240 loops=1)
                          Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col, crate_downloads.downloads
                          Buckets: 1024  Batches: 1  Memory Usage: 110kB
                          Buffers: shared hit=2496
                          ->  Hash Join  (cost=4584.83..7222.05 rows=745 width=413) (actual time=3.994..16.797 rows=240 loops=1)
                                Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col, crate_downloads.downloads
                                Inner Unique: true
                                Hash Cond: (crate_downloads.crate_id = crates.id)
                                Buffers: shared hit=2496
                                ->  Seq Scan on public.crate_downloads  (cost=0.00..2253.34 rows=146234 width=12) (actual time=0.003..5.398 rows=146234 loops=1)
                                      Output: crate_downloads.crate_id, crate_downloads.downloads
                                      Buffers: shared hit=791
                                ->  Hash  (cost=4575.26..4575.26 rows=766 width=405) (actual time=3.966..3.967 rows=240 loops=1)
                                      Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col
                                      Buckets: 1024  Batches: 1  Memory Usage: 107kB
                                      Buffers: shared hit=1705
                                      ->  Bitmap Heap Scan on public.crates  (cost=2046.13..4575.26 rows=766 width=405) (actual time=2.135..3.883 rows=240 loops=1)
                                            Output: crates.id, crates.name, crates.updated_at, crates.created_at, crates.description, crates.homepage, crates.documentation, crates.repository, crates.max_upload_size, crates.max_features, crates.textsearchable_index_col
                                            Recheck Cond: (('''any'':B'::tsquery @@ crates.textsearchable_index_col) OR (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%any%'::text))
                                            Heap Blocks: exact=742
                                            Buffers: shared hit=1705
                                            ->  BitmapOr  (cost=2046.13..2046.13 rows=767 width=0) (actual time=2.073..2.074 rows=0 loops=1)
                                                  Buffers: shared hit=510
                                                  ->  Bitmap Index Scan on index_crates_name_search  (cost=0.00..1241.64 rows=752 width=0) (actual time=1.000..1.000 rows=1079 loops=1)
                                                        Index Cond: (crates.textsearchable_index_col @@ '''any'':B'::tsquery)
                                                        Buffers: shared hit=309
                                                  ->  Bitmap Index Scan on index_crates_name_tgrm  (cost=0.00..804.11 rows=15 width=0) (actual time=1.072..1.073 rows=973 loops=1)
                                                        Index Cond: (replace(lower((crates.name)::text), '-'::text, '_'::text) ~~ '%any%'::text)
                                                        Buffers: shared hit=201
Planning:
  Buffers: shared hit=562
Planning Time: 2.619 ms
Execution Time: 33.486 ms
```
</details>
