### PR TITLE
Revert "jobs/rss/sync_crate_feed: Introduce temporary `SKIP_RSS_CLOUDFRONT_INVALIDATION` env var"

### DIFF
--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -3,7 +3,6 @@ use crate::storage::FeedId;
 use crate::worker::Environment;
 use anyhow::anyhow;
 use chrono::Duration;
-use crates_io_env_vars::var;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use std::sync::Arc;
@@ -83,13 +82,11 @@ impl BackgroundJob for SyncCrateFeed {
         ctx.storage.upload_feed(&feed_id, &channel).await?;
 
         let path = object_store::path::Path::from(&feed_id);
-        if !matches!(var("SKIP_RSS_CLOUDFRONT_INVALIDATION"), Ok(Some(_))) {
-            if let Some(cloudfront) = ctx.cloudfront() {
-                info!(%path, "Invalidating CloudFront cache…");
-                cloudfront.invalidate(path.as_ref()).await?;
-            } else {
-                info!("Skipping CloudFront cache invalidation (CloudFront not configured)");
-            }
+        if let Some(cloudfront) = ctx.cloudfront() {
+            info!(%path, "Invalidating CloudFront cache…");
+            cloudfront.invalidate(path.as_ref()).await?;
+        } else {
+            info!("Skipping CloudFront cache invalidation (CloudFront not configured)");
         }
 
         if let Some(fastly) = ctx.fastly() {


### PR DESCRIPTION
Reverts rust-lang/crates.io#9116

The initial sync of all crates has finished, so we no longer need this hotfix :)