### PR TITLE
Add support for regenerating the token

### DIFF
--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -113,6 +113,14 @@
 
         <div local-class="actions">
           {{#unless token.isExpired}}
+            <LinkTo
+              @route="settings.tokens.new"
+              @query={{hash from=token.id}}
+              local-class="regenerate-button"
+              data-test-regenerate-token-button
+            >
+              Regenerate
+            </LinkTo>
             <button
               type="button"
               local-class="revoke-button"

--- a/app/components/settings/api-tokens.module.css
+++ b/app/components/settings/api-tokens.module.css
@@ -89,6 +89,12 @@
     border-radius: var(--space-3xs);
 }
 
+.regenerate-button {
+    composes: yellow-button small from '../../styles/shared/buttons.module.css';
+    flex-grow: 1;
+    border-radius: var(--space-3xs);
+}
+
 .new-token {
     margin-top: var(--space-s);
 }
@@ -190,9 +196,17 @@
         }
 
         .actions {
+            display: flex;
+            flex-direction: column;
             grid-area: actions;
             align-self: start;
             margin: 0 0 0 var(--space-xs);
+        }
+
+        .actions > * {
+            flex-grow: 1;
+            width: 100%;
+            margin-top: var(--space-xs);
         }
 
         .new-token {

--- a/e2e/acceptance/api-token.spec.ts
+++ b/e2e/acceptance/api-token.spec.ts
@@ -88,6 +88,15 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-error]')).toHaveCount(0);
   });
 
+  test('API tokens can be regenerated', async ({ page }) => {
+    await page.goto('/settings/tokens');
+    await expect(page).toHaveURL('/settings/tokens');
+    await expect(page.locator('[data-test-api-token]')).toHaveCount(3);
+
+    await page.click('[data-test-api-token="1"] [data-test-regenerate-token-button]');
+    await expect(page).toHaveURL('/settings/tokens/new?from=1');
+  });
+
   test('failed API tokens revocation shows an error', async ({ page, mirage }) => {
     await mirage.addHook(server => {
       server.delete('/api/v1/me/tokens/:id', {}, 500);

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -103,6 +103,17 @@ module('Acceptance | api-tokens', function (hooks) {
     assert.dom('[data-test-error]').doesNotExist();
   });
 
+  test('API tokens can be regenerated', async function (assert) {
+    prepare(this);
+
+    await visit('/settings/tokens');
+    assert.strictEqual(currentURL(), '/settings/tokens');
+    assert.dom('[data-test-api-token]').exists({ count: 3 });
+
+    await click('[data-test-api-token="1"] [data-test-regenerate-token-button]');
+    assert.strictEqual(currentURL(), '/settings/tokens/new?from=1');
+  });
+
   test('failed API tokens revocation shows an error', async function (assert) {
     prepare(this);
 


### PR DESCRIPTION
Resolves https://github.com/rust-lang/crates.io/issues/8717

The reason I chose "regenerate" instead of "copy" is that the latter is quite confusing. Users might think it means copying the token value.