### PR TITLE
models/user: Inline `find_by_api_token()` fn

### DIFF
--- a/src/admin/verify_token.rs
+++ b/src/admin/verify_token.rs
@@ -1,3 +1,4 @@
+use crate::models::ApiToken;
 use crate::{db, models::User};
 use anyhow::anyhow;
 
@@ -15,7 +16,9 @@ pub struct Opts {
 
 pub fn run(opts: Opts) -> anyhow::Result<()> {
     let conn = &mut db::oneoff_connection()?;
-    let user = User::find_by_api_token(conn, &opts.api_token).map_err(|err| anyhow!("{err}"))?;
+    let token =
+        ApiToken::find_by_api_token(conn, &opts.api_token).map_err(|err| anyhow!("{err}"))?;
+    let user = User::find(conn, token.user_id)?;
     println!("The token belongs to user {}", user.gh_login);
     Ok(())
 }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -7,7 +7,7 @@ use crate::controllers::user::me::UserConfirmEmail;
 use crate::email::Emails;
 use crate::util::errors::AppResult;
 
-use crate::models::{ApiToken, Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};
+use crate::models::{Crate, CrateOwner, Email, NewEmail, Owner, OwnerKind, Rights};
 use crate::schema::{crate_owners, emails, users};
 use crate::sql::lower;
 
@@ -120,13 +120,6 @@ impl<'a> NewUser<'a> {
 impl User {
     pub fn find(conn: &mut PgConnection, id: i32) -> QueryResult<User> {
         users::table.find(id).first(conn)
-    }
-
-    /// Queries the database for a user with a certain `api_token` value.
-    pub fn find_by_api_token(conn: &mut PgConnection, token: &str) -> AppResult<User> {
-        let api_token = ApiToken::find_by_api_token(conn, token)?;
-
-        Ok(Self::find(conn, api_token.user_id)?)
     }
 
     pub fn find_by_login(conn: &mut PgConnection, login: &str) -> QueryResult<User> {

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -3,7 +3,7 @@ use crate::{
     util::{MockCookieUser, RequestHelper},
     TestApp,
 };
-use crates_io::models::{Email, NewUser, User};
+use crates_io::models::{ApiToken, Email, NewUser, User};
 use diesel::prelude::*;
 use http::StatusCode;
 use secrecy::ExposeSecret;
@@ -34,7 +34,8 @@ async fn updating_existing_user_doesnt_change_api_token() {
         );
 
         // Use the original API token to find the now updated user
-        assert_ok!(User::find_by_api_token(conn, token.expose_secret()))
+        let api_token = assert_ok!(ApiToken::find_by_api_token(conn, token.expose_secret()));
+        assert_ok!(User::find(conn, api_token.user_id))
     });
 
     assert_eq!(user.gh_login, "bar");


### PR DESCRIPTION
This fn is only used in two non-production places and isn't saving a lot of characters, but creates a bi-directional coupling between the API token and user models, which we don't necessarily want to have.