### PR TITLE
models/user: Move `HashedToken::parse()` call outside `find_by_api_token()` fn

### DIFF
--- a/src/admin/verify_token.rs
+++ b/src/admin/verify_token.rs
@@ -1,6 +1,6 @@
 use crate::models::ApiToken;
+use crate::util::token::HashedToken;
 use crate::{db, models::User};
-use anyhow::anyhow;
 
 #[derive(clap::Parser, Debug)]
 #[command(
@@ -16,8 +16,8 @@ pub struct Opts {
 
 pub fn run(opts: Opts) -> anyhow::Result<()> {
     let conn = &mut db::oneoff_connection()?;
-    let token =
-        ApiToken::find_by_api_token(conn, &opts.api_token).map_err(|err| anyhow!("{err}"))?;
+    let token = HashedToken::parse(&opts.api_token)?;
+    let token = ApiToken::find_by_api_token(conn, &token)?;
     let user = User::find(conn, token.user_id)?;
     println!("The token belongs to user {}", user.gh_login);
     Ok(())

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -73,7 +73,8 @@ impl ApiToken {
     pub fn find_by_api_token(conn: &mut PgConnection, token: &str) -> AppResult<ApiToken> {
         use diesel::{dsl::now, update};
 
-        let token = HashedToken::parse(token).ok_or_else(InsecurelyGeneratedTokenRevoked::boxed)?;
+        let token =
+            HashedToken::parse(token).map_err(|_| InsecurelyGeneratedTokenRevoked::boxed())?;
 
         let tokens = api_tokens::table
             .filter(api_tokens::revoked.eq(false))

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -6,7 +6,6 @@ use diesel::prelude::*;
 pub use self::scopes::{CrateScope, EndpointScope};
 use crate::models::User;
 use crate::schema::api_tokens;
-use crate::util::errors::{AppResult, InsecurelyGeneratedTokenRevoked};
 use crate::util::rfc3339;
 use crate::util::token::{HashedToken, PlainToken};
 
@@ -70,11 +69,11 @@ impl ApiToken {
         })
     }
 
-    pub fn find_by_api_token(conn: &mut PgConnection, token: &str) -> AppResult<ApiToken> {
+    pub fn find_by_api_token(
+        conn: &mut PgConnection,
+        token: &HashedToken,
+    ) -> QueryResult<ApiToken> {
         use diesel::{dsl::now, update};
-
-        let token =
-            HashedToken::parse(token).map_err(|_| InsecurelyGeneratedTokenRevoked::boxed())?;
 
         let tokens = api_tokens::table
             .filter(api_tokens::revoked.eq(false))
@@ -83,7 +82,7 @@ impl ApiToken {
                     .is_null()
                     .or(api_tokens::expired_at.gt(now)),
             )
-            .filter(api_tokens::token.eq(&token));
+            .filter(api_tokens::token.eq(token));
 
         // If the database is in read only mode, we can't update last_used_at.
         // Try updating in a new transaction, if that fails, fall back to reading

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -4,6 +4,7 @@ use crate::{
     TestApp,
 };
 use crates_io::models::{ApiToken, Email, NewUser, User};
+use crates_io::util::token::HashedToken;
 use diesel::prelude::*;
 use http::StatusCode;
 use secrecy::ExposeSecret;
@@ -34,7 +35,8 @@ async fn updating_existing_user_doesnt_change_api_token() {
         );
 
         // Use the original API token to find the now updated user
-        let api_token = assert_ok!(ApiToken::find_by_api_token(conn, token.expose_secret()));
+        let hashed_token = assert_ok!(HashedToken::parse(token.expose_secret()));
+        let api_token = assert_ok!(ApiToken::find_by_api_token(conn, &hashed_token));
         assert_ok!(User::find(conn, api_token.user_id))
     });
 

--- a/src/util/token.rs
+++ b/src/util/token.rs
@@ -22,7 +22,7 @@ pub struct InvalidTokenError;
 pub struct HashedToken(SecretVec<u8>);
 
 impl HashedToken {
-    pub(crate) fn parse(plaintext: &str) -> Result<Self, InvalidTokenError> {
+    pub fn parse(plaintext: &str) -> Result<Self, InvalidTokenError> {
         // This will both reject tokens without a prefix and tokens of the wrong kind.
         if !plaintext.starts_with(TOKEN_PREFIX) {
             return Err(InvalidTokenError);


### PR DESCRIPTION
This reduces the coupling to the `AppResult` enum and improves the composability of the code. Incidentally it also simplifies the error handling in our authentication code.