### PR TITLE
editorconfig: Adjust indentation for JSON files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,6 +17,10 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[*.json]
+indent_style = space
+indent_size = 2
+
 [*.ts]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
two spaces seems to be a lot more common in the JS world 😉 