### PR TITLE
Avoid mutations while still borrowed

### DIFF
--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -176,7 +176,10 @@ fn list_by_semver(
         }
         if let Some(start) = idx {
             let end = (start + options.per_page as usize).min(sorted_versions.len());
-            let ids = sorted_versions[start..end].keys().collect::<Vec<_>>();
+            let ids = sorted_versions[start..end]
+                .keys()
+                .cloned()
+                .collect::<Vec<_>>();
             for result in versions::table
                 .filter(versions::crate_id.eq(crate_id))
                 .left_outer_join(users::table)

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -67,7 +67,7 @@ impl TopCrates {
         // term.
         for result in crate_owners::table
             .filter(crate_owners::deleted.eq(false))
-            .filter(crate_owners::crate_id.eq_any(crates.keys().collect::<Vec<_>>()))
+            .filter(crate_owners::crate_id.eq_any(crates.keys().cloned().collect::<Vec<_>>()))
             .select((
                 crate_owners::crate_id,
                 crate_owners::owner_id,


### PR DESCRIPTION
For some reason the Rust borrow checker is not currently complaining about these, but once the code is migrated to `diesel-async` it starts to fail the build.