### PR TITLE
Use `diesel-async` database pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
  "derive_deref",
  "dialoguer",
  "diesel",
+ "diesel-async",
  "diesel_full_text_search",
  "diesel_migrations",
  "dotenvy",
@@ -1197,6 +1198,7 @@ dependencies = [
  "crates_io_test_db",
  "deadpool-diesel",
  "diesel",
+ "diesel-async",
  "futures-util",
  "sentry-core",
  "serde",
@@ -1536,6 +1538,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-async"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb799bb6f8ca6a794462125d7b8983b0c86e6c93a33a9c55934a4a5de4409d3"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "diesel",
+ "futures-util",
+ "scoped-futures",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "diesel_derives"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,6 +1750,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -3331,6 +3354,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
+name = "postgres-protocol"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3933,6 +3985,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-futures"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+dependencies = [
+ "cfg-if",
+ "pin-utils",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4386,6 +4448,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,6 +4717,32 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -4921,6 +5020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5051,6 +5156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5144,6 +5255,17 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "whoami"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+dependencies = [
+ "redox_syscall 0.4.1",
+ "wasite",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ derive_builder = "=0.20.0"
 derive_deref = "=1.1.1"
 dialoguer = "=0.11.0"
 diesel = { version = "=2.2.2", features = ["postgres", "serde_json", "chrono", "numeric"] }
+diesel-async = { version = "=0.5.0", features = ["async-connection-wrapper", "deadpool", "postgres"] }
 diesel_full_text_search = "=2.2.0"
 diesel_migrations = { version = "=2.2.0", features = ["postgres"] }
 dotenvy = "=0.15.7"

--- a/crates/crates_io_worker/Cargo.toml
+++ b/crates/crates_io_worker/Cargo.toml
@@ -21,4 +21,4 @@ tracing = "=0.1.40"
 
 [dev-dependencies]
 crates_io_test_db = { path = "../crates_io_test_db" }
-tokio = { version = "=1.39.2", features = ["macros", "rt", "sync"]}
+tokio = { version = "=1.39.2", features = ["macros", "rt", "rt-multi-thread", "sync"]}

--- a/crates/crates_io_worker/Cargo.toml
+++ b/crates/crates_io_worker/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 anyhow = "=1.0.86"
 deadpool-diesel = { version = "=0.6.1", features = ["postgres", "tracing"] }
 diesel = { version = "=2.2.2", features = ["postgres", "serde_json"] }
+diesel-async = { version = "=0.5.0", features = ["async-connection-wrapper", "deadpool", "postgres"] }
 futures-util = "=0.3.30"
 sentry-core = { version = "=0.34.0", features = ["client"] }
 serde = { version = "=1.0.204", features = ["derive"] }

--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -1,9 +1,10 @@
 use crates_io_test_db::TestDatabase;
 use crates_io_worker::schema::background_jobs;
 use crates_io_worker::{BackgroundJob, Runner};
-use deadpool_diesel::postgres::{Manager, Pool};
-use deadpool_diesel::Runtime;
 use diesel::prelude::*;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::AsyncPgConnection;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::Barrier;
@@ -210,7 +211,7 @@ fn runner<Context: Clone + Send + Sync + 'static>(
     database_url: &str,
     context: Context,
 ) -> Runner<Context> {
-    let manager = Manager::new(database_url, Runtime::Tokio1);
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
     let deadpool = Pool::builder(manager).max_size(4).build().unwrap();
 
     Runner::new(deadpool, context)

--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -30,7 +30,7 @@ fn job_is_locked(id: i64, conn: &mut PgConnection) -> bool {
         .is_none()
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn jobs_are_locked_when_fetched() {
     #[derive(Clone)]
     struct TestContext {
@@ -79,7 +79,7 @@ async fn jobs_are_locked_when_fetched() {
     assert!(!job_exists(job_id, &mut conn));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn jobs_are_deleted_when_successfully_run() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
@@ -115,7 +115,7 @@ async fn jobs_are_deleted_when_successfully_run() {
     assert_eq!(remaining_jobs(&mut conn), 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
     #[derive(Clone)]
     struct TestContext {
@@ -172,7 +172,7 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
     runner.wait_for_shutdown().await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn panicking_in_jobs_updates_retry_counter() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -5,6 +5,7 @@ use crate::auth::Authentication;
 use crate::controllers::helpers::pagination::{Page, PaginationOptions};
 use crate::models::{Crate, CrateOwnerInvitation, Rights, User};
 use crate::schema::{crate_owner_invitations, crates, users};
+use crate::util::diesel::Conn;
 use crate::util::errors::{forbidden, internal};
 use crate::views::{
     EncodableCrateOwnerInvitation, EncodableCrateOwnerInvitationV1, EncodablePublicUser,
@@ -86,7 +87,7 @@ fn prepare_list(
     req: &Parts,
     auth: Authentication,
     filter: ListFilter,
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
 ) -> AppResult<PrivateListResponse> {
     let pagination: PaginationOptions = PaginationOptions::builder()
         .enable_pages(false)

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -3,6 +3,7 @@ use crate::controllers::frontend_prelude::*;
 use crate::email::Email;
 use crate::models::{ApiToken, User};
 use crate::schema::api_tokens;
+use crate::util::diesel::Conn;
 use crate::util::token::HashedToken;
 use anyhow::{anyhow, Context};
 use axum::body::Bytes;
@@ -127,7 +128,7 @@ struct GitHubSecretAlert {
 fn alert_revoke_token(
     state: &AppState,
     alert: &GitHubSecretAlert,
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
 ) -> QueryResult<GitHubSecretAlertFeedbackLabel> {
     let hashed_token = HashedToken::hash(&alert.token);
 
@@ -174,7 +175,7 @@ fn send_notification_email(
     token: &ApiToken,
     alert: &GitHubSecretAlert,
     state: &AppState,
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
 ) -> anyhow::Result<()> {
     let user = User::find(conn, token.user_id).context("Failed to find user")?;
     let Some(recipient) = user.email(conn)? else {

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -248,9 +248,9 @@ pub(crate) struct PaginatedQuery<T> {
 }
 
 impl<T> PaginatedQuery<T> {
-    pub(crate) fn load<'a, U>(self, conn: &mut PgConnection) -> QueryResult<Paginated<U>>
+    pub(crate) fn load<'a, U, Conn>(self, conn: &mut Conn) -> QueryResult<Paginated<U>>
     where
-        Self: LoadQuery<'a, PgConnection, WithCount<U>>,
+        Self: LoadQuery<'a, Conn, WithCount<U>>,
     {
         let options = self.options.clone();
         let records_and_total = self.internal_load(conn)?.collect::<QueryResult<_>>()?;
@@ -388,9 +388,9 @@ where
 }
 
 impl<T, C> PaginatedQueryWithCountSubq<T, C> {
-    pub(crate) fn load<'a, U>(self, conn: &mut PgConnection) -> QueryResult<Paginated<U>>
+    pub(crate) fn load<'a, U, Conn>(self, conn: &mut Conn) -> QueryResult<Paginated<U>>
     where
-        Self: LoadQuery<'a, PgConnection, WithCount<U>>,
+        Self: LoadQuery<'a, Conn, WithCount<U>>,
     {
         let options = self.options.clone();
         let records_and_total = self.internal_load(conn)?.collect::<QueryResult<_>>()?;

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -2,6 +2,7 @@ use super::prelude::*;
 use crate::app::AppState;
 use axum::extract::{Path, Query};
 use axum::Json;
+use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 
 use crate::controllers::helpers::pagination::PaginationOptions;
 use crate::controllers::helpers::{pagination::Paginated, Paginate};
@@ -27,7 +28,9 @@ pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppRes
     let query = query.pages_pagination(PaginationOptions::builder().gather(&req)?);
 
     let conn = state.db_read().await?;
-    conn.interact(move |conn| {
+    spawn_blocking(move || {
+        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+
         let data: Paginated<Keyword> = query.load(conn)?;
         let total = data.total();
         let kws = data
@@ -40,16 +43,18 @@ pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppRes
             "meta": { "total": total },
         })))
     })
-    .await?
+    .await
 }
 
 /// Handles the `GET /keywords/:keyword_id` route.
 pub async fn show(Path(name): Path<String>, state: AppState) -> AppResult<Json<Value>> {
-    let conn = &mut state.db_read().await?;
-    conn.interact(move |conn| {
+    let conn = state.db_read().await?;
+    spawn_blocking(move || {
+        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+
         let kw = Keyword::find_by_keyword(conn, &name)?;
 
         Ok(Json(json!({ "keyword": EncodableKeyword::from(kw) })))
     })
-    .await?
+    .await
 }

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -3,7 +3,6 @@
 //! The endpoint for downloading a crate and exposing version specific
 //! download counts are located in `version::downloads`.
 
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use std::cmp;
 
 use crate::controllers::frontend_prelude::*;
@@ -13,63 +12,64 @@ use crate::schema::{crates, version_downloads, versions};
 use crate::sql::to_char;
 use crate::util::errors::crate_not_found;
 use crate::views::EncodableVersionDownload;
+use diesel_async::RunQueryDsl;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read().await?;
-    spawn_blocking(move || {
-        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+    let mut conn = state.db_read().await?;
 
-        use diesel::dsl::*;
-        use diesel::sql_types::BigInt;
+    use diesel::dsl::*;
+    use diesel::sql_types::BigInt;
 
-        let crate_id: i32 = Crate::by_name(&crate_name)
-            .select(crates::id)
-            .first(conn)
-            .optional()?
-            .ok_or_else(|| crate_not_found(&crate_name))?;
+    let crate_id: i32 = Crate::by_name(&crate_name)
+        .select(crates::id)
+        .first(&mut conn)
+        .await
+        .optional()?
+        .ok_or_else(|| crate_not_found(&crate_name))?;
 
-        let mut versions: Vec<Version> = versions::table
-            .filter(versions::crate_id.eq(crate_id))
-            .load(conn)?;
-        versions
-            .sort_by_cached_key(|version| cmp::Reverse(semver::Version::parse(&version.num).ok()));
-        let (latest_five, rest) = versions.split_at(cmp::min(5, versions.len()));
+    let mut versions: Vec<Version> = versions::table
+        .filter(versions::crate_id.eq(crate_id))
+        .load(&mut conn)
+        .await?;
 
-        let downloads = VersionDownload::belonging_to(latest_five)
-            .filter(version_downloads::date.gt(date(now - 90.days())))
-            .order((
-                version_downloads::date.asc(),
-                version_downloads::version_id.desc(),
-            ))
-            .load(conn)?
-            .into_iter()
-            .map(VersionDownload::into)
-            .collect::<Vec<EncodableVersionDownload>>();
+    versions.sort_by_cached_key(|version| cmp::Reverse(semver::Version::parse(&version.num).ok()));
+    let (latest_five, rest) = versions.split_at(cmp::min(5, versions.len()));
 
-        let sum_downloads = sql::<BigInt>("SUM(version_downloads.downloads)");
-        let extra: Vec<ExtraDownload> = VersionDownload::belonging_to(rest)
-            .select((
-                to_char(version_downloads::date, "YYYY-MM-DD"),
-                sum_downloads,
-            ))
-            .filter(version_downloads::date.gt(date(now - 90.days())))
-            .group_by(version_downloads::date)
-            .order(version_downloads::date.asc())
-            .load(conn)?;
+    let downloads = VersionDownload::belonging_to(latest_five)
+        .filter(version_downloads::date.gt(date(now - 90.days())))
+        .order((
+            version_downloads::date.asc(),
+            version_downloads::version_id.desc(),
+        ))
+        .load(&mut conn)
+        .await?
+        .into_iter()
+        .map(VersionDownload::into)
+        .collect::<Vec<EncodableVersionDownload>>();
 
-        #[derive(Serialize, Queryable)]
-        struct ExtraDownload {
-            date: String,
-            downloads: i64,
-        }
+    let sum_downloads = sql::<BigInt>("SUM(version_downloads.downloads)");
+    let extra: Vec<ExtraDownload> = VersionDownload::belonging_to(rest)
+        .select((
+            to_char(version_downloads::date, "YYYY-MM-DD"),
+            sum_downloads,
+        ))
+        .filter(version_downloads::date.gt(date(now - 90.days())))
+        .group_by(version_downloads::date)
+        .order(version_downloads::date.asc())
+        .load(&mut conn)
+        .await?;
 
-        Ok(Json(json!({
-            "version_downloads": downloads,
-            "meta": {
-                "extra_downloads": extra,
-            },
-        })))
-    })
-    .await
+    #[derive(Serialize, Queryable)]
+    struct ExtraDownload {
+        date: String,
+        downloads: i64,
+    }
+
+    Ok(Json(json!({
+        "version_downloads": downloads,
+        "meta": {
+            "extra_downloads": extra,
+        },
+    })))
 }

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -6,9 +6,10 @@ use diesel::associations::Identifiable;
 use crate::controllers::frontend_prelude::*;
 use crate::models::{Crate, Follow};
 use crate::schema::*;
+use crate::util::diesel::Conn;
 use crate::util::errors::crate_not_found;
 
-fn follow_target(crate_name: &str, conn: &mut PgConnection, user_id: i32) -> AppResult<Follow> {
+fn follow_target(crate_name: &str, conn: &mut impl Conn, user_id: i32) -> AppResult<Follow> {
     let crate_id = Crate::by_name(crate_name)
         .select(crates::id)
         .first(conn)

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -16,6 +16,7 @@ use crate::views::EncodableCrate;
 use crate::controllers::helpers::pagination::{Page, Paginated, PaginationOptions};
 use crate::models::krate::ALL_COLUMNS;
 use crate::sql::{array_agg, canon_crate_name, lower};
+use crate::util::diesel::Conn;
 
 /// Handles the `GET /crates` route.
 /// Returns a list of crates. Called in a variety of scenarios in the
@@ -282,7 +283,7 @@ impl<'a> FilterParams<'a> {
             .as_deref()
     }
 
-    fn authed_user_id(&self, req: &Parts, conn: &mut PgConnection) -> AppResult<i32> {
+    fn authed_user_id(&self, req: &Parts, conn: &mut impl Conn) -> AppResult<i32> {
         if let Some(val) = self._auth_user_id.get() {
             return Ok(*val);
         }
@@ -298,7 +299,7 @@ impl<'a> FilterParams<'a> {
     fn make_query(
         &'a self,
         req: &Parts,
-        conn: &mut PgConnection,
+        conn: &mut impl Conn,
     ) -> AppResult<crates::BoxedQuery<'a, diesel::pg::Pg>> {
         let mut query = crates::table.into_boxed();
 

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -10,6 +10,7 @@ use crate::controllers::helpers::pagination::{encode_seek, Page, PaginationOptio
 
 use crate::models::{Crate, User, Version, VersionOwnerAction};
 use crate::schema::{crates, users, versions};
+use crate::util::diesel::Conn;
 use crate::util::errors::crate_not_found;
 use crate::views::EncodableVersion;
 
@@ -76,7 +77,7 @@ fn list_by_date(
     crate_id: i32,
     options: Option<&PaginationOptions>,
     req: &Parts,
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
 ) -> AppResult<PaginatedVersionsAndPublishers> {
     use seek::*;
 
@@ -140,7 +141,7 @@ fn list_by_semver(
     crate_id: i32,
     options: Option<&PaginationOptions>,
     req: &Parts,
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
 ) -> AppResult<PaginatedVersionsAndPublishers> {
     use seek::*;
 

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,6 +1,5 @@
 use crate::controllers::frontend_prelude::*;
 use crate::util::errors::{custom, forbidden, not_found};
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use prometheus::TextEncoder;
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.
@@ -24,12 +23,8 @@ pub async fn prometheus(app: AppState, Path(kind): Path<String>, req: Parts) -> 
 
     let metrics = match kind.as_str() {
         "service" => {
-            let conn = app.db_read().await?;
-            spawn_blocking(move || {
-                let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-                app.service_metrics.gather(conn)
-            })
-            .await?
+            let mut conn = app.db_read().await?;
+            app.service_metrics.gather(&mut conn).await?
         }
         "instance" => {
             spawn_blocking(move || Ok::<_, BoxedAppError>(app.instance_metrics.gather(&app)?))

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -2,6 +2,7 @@ use crate::app::AppState;
 use crate::controllers::cargo_prelude::AppResult;
 use crate::models::{Category, Crate, CrateVersions, Keyword, TopVersions, Version};
 use crate::schema::{crate_downloads, crates, keywords, metadata, recent_crate_downloads};
+use crate::util::diesel::Conn;
 use crate::views::{EncodableCategory, EncodableCrate, EncodableKeyword};
 use axum::Json;
 use diesel::prelude::*;
@@ -19,7 +20,7 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
             .get_result(conn)?;
 
         fn encode_crates(
-            conn: &mut PgConnection,
+            conn: &mut impl Conn,
             data: Vec<(Crate, i64, Option<i64>)>,
         ) -> AppResult<Vec<EncodableCrate>> {
             let downloads = data

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -1,19 +1,15 @@
 use crate::controllers::frontend_prelude::*;
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 
 use crate::models::Team;
 use crate::schema::teams;
 use crate::views::EncodableTeam;
+use diesel_async::RunQueryDsl;
 
 /// Handles the `GET /teams/:team_id` route.
 pub async fn show_team(state: AppState, Path(name): Path<String>) -> AppResult<Json<Value>> {
     use self::teams::dsl::{login, teams};
 
-    let conn = state.db_read().await?;
-    spawn_blocking(move || {
-        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-        let team: Team = teams.filter(login.eq(&name)).first(conn)?;
-        Ok(Json(json!({ "team": EncodableTeam::from(team) })))
-    })
-    .await
+    let mut conn = state.db_read().await?;
+    let team: Team = teams.filter(login.eq(&name)).first(&mut conn).await?;
+    Ok(Json(json!({ "team": EncodableTeam::from(team) })))
 }

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,49 +1,44 @@
 use crate::controllers::frontend_prelude::*;
 use bigdecimal::{BigDecimal, ToPrimitive};
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 
 use crate::models::{CrateOwner, OwnerKind, User};
 use crate::schema::{crate_downloads, crate_owners, crates, users};
 use crate::sql::lower;
 use crate::views::EncodablePublicUser;
+use diesel_async::RunQueryDsl;
 
 /// Handles the `GET /users/:user_id` route.
 pub async fn show(state: AppState, Path(user_name): Path<String>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_prefer_primary().await?;
-    spawn_blocking(move || {
-        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+    let mut conn = state.db_read_prefer_primary().await?;
 
-        use self::users::dsl::{gh_login, id, users};
+    use self::users::dsl::{gh_login, id, users};
 
-        let name = lower(&user_name);
-        let user: User = users
-            .filter(lower(gh_login).eq(name))
-            .order(id.desc())
-            .first(conn)?;
+    let name = lower(&user_name);
+    let user: User = users
+        .filter(lower(gh_login).eq(name))
+        .order(id.desc())
+        .first(&mut conn)
+        .await?;
 
-        Ok(Json(json!({ "user": EncodablePublicUser::from(user) })))
-    })
-    .await
+    Ok(Json(json!({ "user": EncodablePublicUser::from(user) })))
 }
 
 /// Handles the `GET /users/:user_id/stats` route.
 pub async fn stats(state: AppState, Path(user_id): Path<i32>) -> AppResult<Json<Value>> {
-    let conn = state.db_read_prefer_primary().await?;
-    spawn_blocking(move || {
-        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+    let mut conn = state.db_read_prefer_primary().await?;
 
-        use diesel::dsl::sum;
+    use diesel::dsl::sum;
+    use diesel_async::RunQueryDsl;
 
-        let data = CrateOwner::by_owner_kind(OwnerKind::User)
-            .inner_join(crates::table)
-            .inner_join(crate_downloads::table.on(crates::id.eq(crate_downloads::crate_id)))
-            .filter(crate_owners::owner_id.eq(user_id))
-            .select(sum(crate_downloads::downloads))
-            .first::<Option<BigDecimal>>(conn)?
-            .map(|d| d.to_u64().unwrap_or(u64::MAX))
-            .unwrap_or(0);
+    let data = CrateOwner::by_owner_kind(OwnerKind::User)
+        .inner_join(crates::table)
+        .inner_join(crate_downloads::table.on(crates::id.eq(crate_downloads::crate_id)))
+        .filter(crate_owners::owner_id.eq(user_id))
+        .select(sum(crate_downloads::downloads))
+        .first::<Option<BigDecimal>>(&mut conn)
+        .await?
+        .map(|d| d.to_u64().unwrap_or(u64::MAX))
+        .unwrap_or(0);
 
-        Ok(Json(json!({ "total_downloads": data })))
-    })
-    .await
+    Ok(Json(json!({ "total_downloads": data })))
 }

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -10,6 +10,7 @@ use crate::middleware::log_request::RequestLogExt;
 use crate::middleware::session::SessionExtension;
 use crate::models::{NewUser, User};
 use crate::schema::users;
+use crate::util::diesel::Conn;
 use crate::util::errors::ReadOnlyMode;
 use crate::views::EncodableMe;
 use crates_io_github::GithubUser;
@@ -125,7 +126,7 @@ fn save_user_to_database(
     user: &GithubUser,
     access_token: &str,
     emails: &Emails,
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
 ) -> AppResult<User> {
     NewUser::new(
         user.id,

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -5,10 +5,11 @@ pub mod yank;
 use super::prelude::*;
 
 use crate::models::{Crate, Version};
+use crate::util::diesel::Conn;
 use crate::util::errors::crate_not_found;
 
 fn version_and_crate(
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
     crate_name: &str,
     semver: &str,
 ) -> AppResult<(Version, Crate)> {

--- a/src/metrics/instance.rs
+++ b/src/metrics/instance.rs
@@ -19,7 +19,8 @@
 
 use crate::app::App;
 use crate::metrics::macros::metrics;
-use deadpool_diesel::postgres::Pool;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::AsyncPgConnection;
 use prometheus::{
     proto::MetricFamily, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec,
 };
@@ -61,7 +62,11 @@ impl InstanceMetrics {
         Ok(self.registry.gather())
     }
 
-    fn refresh_pool_stats(&self, name: &str, pool: &Pool) -> prometheus::Result<()> {
+    fn refresh_pool_stats(
+        &self,
+        name: &str,
+        pool: &Pool<AsyncPgConnection>,
+    ) -> prometheus::Result<()> {
         let status = pool.status();
 
         self.database_idle_conns

--- a/src/metrics/service.rs
+++ b/src/metrics/service.rs
@@ -12,8 +12,9 @@
 
 use crate::metrics::macros::metrics;
 use crate::schema::{background_jobs, crates, versions};
+use crate::util::diesel::Conn;
 use crate::util::errors::AppResult;
-use diesel::{dsl::count_star, prelude::*, PgConnection};
+use diesel::{dsl::count_star, prelude::*};
 use prometheus::{proto::MetricFamily, IntGauge, IntGaugeVec};
 
 metrics! {
@@ -31,7 +32,7 @@ metrics! {
 }
 
 impl ServiceMetrics {
-    pub(crate) fn gather(&self, conn: &mut PgConnection) -> AppResult<Vec<MetricFamily>> {
+    pub(crate) fn gather(&self, conn: &mut impl Conn) -> AppResult<Vec<MetricFamily>> {
         self.crates_total
             .set(crates::table.select(count_star()).first(conn)?);
         self.versions_total

--- a/src/models/action.rs
+++ b/src/models/action.rs
@@ -1,6 +1,7 @@
 use crate::models::{ApiToken, User, Version};
 use crate::schema::*;
 use crate::sql::pg_enum;
+use crate::util::diesel::Conn;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
@@ -48,14 +49,11 @@ pub struct VersionOwnerAction {
 }
 
 impl VersionOwnerAction {
-    pub fn all(conn: &mut PgConnection) -> QueryResult<Vec<Self>> {
+    pub fn all(conn: &mut impl Conn) -> QueryResult<Vec<Self>> {
         version_owner_actions::table.load(conn)
     }
 
-    pub fn by_version(
-        conn: &mut PgConnection,
-        version: &Version,
-    ) -> QueryResult<Vec<(Self, User)>> {
+    pub fn by_version(conn: &mut impl Conn, version: &Version) -> QueryResult<Vec<(Self, User)>> {
         use version_owner_actions::dsl::version_id;
 
         version_owner_actions::table
@@ -66,7 +64,7 @@ impl VersionOwnerAction {
     }
 
     pub fn for_versions(
-        conn: &mut PgConnection,
+        conn: &mut impl Conn,
         versions: &[Version],
     ) -> QueryResult<Vec<Vec<(Self, User)>>> {
         Ok(Self::belonging_to(versions)
@@ -78,7 +76,7 @@ impl VersionOwnerAction {
 }
 
 pub fn insert_version_owner_action(
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
     version_id_: i32,
     user_id_: i32,
     api_token_id_: Option<i32>,

--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -7,6 +7,7 @@ use crate::util::errors::{bad_request, AppResult};
 use crate::models::{Crate, Team, User};
 use crate::schema::crate_owners;
 use crate::sql::pg_enum;
+use crate::util::diesel::Conn;
 
 #[derive(Insertable, Associations, Identifiable, Debug, Clone, Copy)]
 #[diesel(
@@ -62,7 +63,7 @@ impl Owner {
     /// sensitive.
     pub fn find_or_create_by_login(
         app: &App,
-        conn: &mut PgConnection,
+        conn: &mut impl Conn,
         req_user: &User,
         name: &str,
     ) -> AppResult<Owner> {
@@ -84,7 +85,7 @@ impl Owner {
     ///
     /// May be a user's GH login or a full team name. This is case
     /// sensitive.
-    pub fn find_by_login(conn: &mut PgConnection, name: &str) -> AppResult<Owner> {
+    pub fn find_by_login(conn: &mut impl Conn, name: &str) -> AppResult<Owner> {
         if name.contains(':') {
             Team::find_by_login(conn, name)
                 .optional()?

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -6,6 +6,7 @@ use diesel::prelude::*;
 pub use self::scopes::{CrateScope, EndpointScope};
 use crate::models::User;
 use crate::schema::api_tokens;
+use crate::util::diesel::Conn;
 use crate::util::rfc3339;
 use crate::util::token::{HashedToken, PlainToken};
 
@@ -33,16 +34,12 @@ pub struct ApiToken {
 
 impl ApiToken {
     /// Generates a new named API token for a user
-    pub fn insert(
-        conn: &mut PgConnection,
-        user_id: i32,
-        name: &str,
-    ) -> QueryResult<CreatedApiToken> {
+    pub fn insert(conn: &mut impl Conn, user_id: i32, name: &str) -> QueryResult<CreatedApiToken> {
         Self::insert_with_scopes(conn, user_id, name, None, None, None)
     }
 
     pub fn insert_with_scopes(
-        conn: &mut PgConnection,
+        conn: &mut impl Conn,
         user_id: i32,
         name: &str,
         crate_scopes: Option<Vec<CrateScope>>,
@@ -69,10 +66,7 @@ impl ApiToken {
         })
     }
 
-    pub fn find_by_api_token(
-        conn: &mut PgConnection,
-        token: &HashedToken,
-    ) -> QueryResult<ApiToken> {
+    pub fn find_by_api_token(conn: &mut impl Conn, token: &HashedToken) -> QueryResult<ApiToken> {
         use diesel::{dsl::now, update};
 
         let tokens = api_tokens::table

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -1,12 +1,13 @@
 use crate::util::{RequestHelper, TestApp};
-use deadpool_diesel::postgres::Pool;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::AsyncPgConnection;
 use http::StatusCode;
 use std::time::{Duration, Instant};
 use tracing::info;
 
 const DB_HEALTHY_TIMEOUT: Duration = Duration::from_millis(2000);
 
-async fn wait_until_healthy(pool: &Pool) {
+async fn wait_until_healthy(pool: &Pool<AsyncPgConnection>) {
     info!("Waiting for the database to become healthy…");
 
     let start_time = Instant::now();

--- a/src/typosquat/cache.rs
+++ b/src/typosquat/cache.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use diesel::PgConnection;
+use crate::util::diesel::Conn;
 use thiserror::Error;
 use typomania::{
     checks::{Bitflips, Omitted, SwappedWords, Typos},
@@ -28,7 +28,7 @@ impl Cache {
     /// addresses to send notifications to, then invokes [`Cache::new`] to read popular crates from
     /// the database.
     #[instrument(skip_all, err)]
-    pub fn from_env(conn: &mut PgConnection) -> Result<Self, Error> {
+    pub fn from_env(conn: &mut impl Conn) -> Result<Self, Error> {
         let emails: Vec<String> = crates_io_env_vars::var(NOTIFICATION_EMAILS_ENV)
             .map_err(|e| Error::Environment {
                 name: NOTIFICATION_EMAILS_ENV.into(),
@@ -56,7 +56,7 @@ impl Cache {
     /// Instantiates a cache by querying popular crates and building them into a typomania harness.
     ///
     /// This relies on configuration in the `super::config` module.
-    pub fn new(emails: Vec<String>, conn: &mut PgConnection) -> Result<Self, Error> {
+    pub fn new(emails: Vec<String>, conn: &mut impl Conn) -> Result<Self, Error> {
         let top = TopCrates::new(conn, config::TOP_CRATES)?;
 
         Ok(Self {

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -5,7 +5,8 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
 };
 
-use diesel::{connection::DefaultLoadingMode, PgConnection, QueryResult};
+use crate::util::diesel::Conn;
+use diesel::{connection::DefaultLoadingMode, QueryResult};
 use typomania::{AuthorSet, Corpus, Package};
 
 /// A corpus of the current top crates on crates.io, as determined by their download counts, along
@@ -17,7 +18,7 @@ pub struct TopCrates {
 
 impl TopCrates {
     /// Retrieves the `num` top crates from the database.
-    pub fn new(conn: &mut PgConnection, num: i64) -> QueryResult<Self> {
+    pub fn new(conn: &mut impl Conn, num: i64) -> QueryResult<Self> {
         use crate::{
             models,
             schema::{crate_downloads, crate_owners},
@@ -103,7 +104,7 @@ pub struct Crate {
 
 impl Crate {
     /// Hydrates a crate and its owners from the database given the crate name.
-    pub fn from_name(conn: &mut PgConnection, name: &str) -> QueryResult<Self> {
+    pub fn from_name(conn: &mut impl Conn, name: &str) -> QueryResult<Self> {
         use crate::models;
         use diesel::prelude::*;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,7 @@ pub use self::io_util::{read_fill, read_le_u32};
 pub use self::request_helpers::*;
 
 mod bytes_request;
+pub mod diesel;
 pub mod errors;
 mod io_util;
 mod request_helpers;

--- a/src/util/diesel.rs
+++ b/src/util/diesel.rs
@@ -1,0 +1,6 @@
+use diesel::connection::LoadConnection;
+use diesel::pg::Pg;
+
+pub trait Conn: LoadConnection<Backend = Pg> {}
+
+impl<T> Conn for T where T: LoadConnection<Backend = Pg> {}

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -171,15 +171,9 @@ impl From<EmailError> for BoxedAppError {
     }
 }
 
-impl From<deadpool_diesel::PoolError> for BoxedAppError {
-    fn from(_err: deadpool_diesel::PoolError) -> BoxedAppError {
+impl From<diesel_async::pooled_connection::deadpool::PoolError> for BoxedAppError {
+    fn from(_err: diesel_async::pooled_connection::deadpool::PoolError) -> BoxedAppError {
         service_unavailable()
-    }
-}
-
-impl From<deadpool_diesel::InteractError> for BoxedAppError {
-    fn from(err: deadpool_diesel::InteractError) -> BoxedAppError {
-        Box::new(err)
     }
 }
 

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -6,9 +6,9 @@ use crate::typosquat;
 use crate::util::diesel::Conn;
 use crate::Emails;
 use crates_io_index::{Repository, RepositoryConfig};
-use deadpool_diesel::postgres::Pool as DeadpoolPool;
 use derive_builder::Builder;
-use diesel::PgConnection;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::AsyncPgConnection;
 use object_store::ObjectStore;
 use parking_lot::{Mutex, MutexGuard};
 use std::ops::{Deref, DerefMut};
@@ -30,7 +30,7 @@ pub struct Environment {
     pub storage: Arc<Storage>,
     #[builder(default)]
     pub downloads_archive_store: Option<Box<dyn ObjectStore>>,
-    pub deadpool: DeadpoolPool,
+    pub deadpool: Pool<AsyncPgConnection>,
     pub emails: Emails,
     pub team_repo: Box<dyn TeamRepo + Send + Sync>,
 

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -3,6 +3,7 @@ use crate::fastly::Fastly;
 use crate::storage::Storage;
 use crate::team_repo::TeamRepo;
 use crate::typosquat;
+use crate::util::diesel::Conn;
 use crate::Emails;
 use crates_io_index::{Repository, RepositoryConfig};
 use deadpool_diesel::postgres::Pool as DeadpoolPool;
@@ -73,7 +74,7 @@ impl Environment {
     /// Returns the typosquatting cache, initialising it if required.
     pub(crate) fn typosquat_cache(
         &self,
-        conn: &mut PgConnection,
+        conn: &mut impl Conn,
     ) -> Result<&typosquat::Cache, typosquat::CacheError> {
         // We have to pass conn back in here because the caller might be in a transaction, and
         // getting a new connection here to query crates can result in a deadlock.

--- a/src/worker/jobs/downloads/clean_processed_log_files.rs
+++ b/src/worker/jobs/downloads/clean_processed_log_files.rs
@@ -1,4 +1,5 @@
 use crate::schema::processed_log_files;
+use crate::util::diesel::Conn;
 use crate::worker::Environment;
 use anyhow::anyhow;
 use crates_io_worker::BackgroundJob;
@@ -28,7 +29,7 @@ impl BackgroundJob for CleanProcessedLogFiles {
     }
 }
 
-fn run(conn: &mut PgConnection) -> QueryResult<()> {
+fn run(conn: &mut impl Conn) -> QueryResult<()> {
     let filter = processed_log_files::time.lt(cut_off_date());
     diesel::delete(processed_log_files::table.filter(filter)).execute(conn)?;
 

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -1,5 +1,6 @@
 use crate::config::CdnLogQueueConfig;
 use crate::sqs::{MockSqsQueue, SqsQueue, SqsQueueImpl};
+use crate::util::diesel::Conn;
 use crate::worker::jobs::ProcessCdnLog;
 use crate::worker::Environment;
 use anyhow::{anyhow, Context};
@@ -202,7 +203,7 @@ fn is_ignored_path(path: &str) -> bool {
     path.contains("/index.staging.crates.io/") || path.contains("/index.crates.io/")
 }
 
-fn enqueue_jobs(jobs: Vec<ProcessCdnLog>, conn: &mut PgConnection) -> anyhow::Result<()> {
+fn enqueue_jobs(jobs: Vec<ProcessCdnLog>, conn: &mut impl Conn) -> anyhow::Result<()> {
     for job in jobs {
         let path = &job.path;
 
@@ -415,7 +416,7 @@ mod tests {
             .build()
     }
 
-    fn open_jobs(conn: &mut PgConnection) -> String {
+    fn open_jobs(conn: &mut impl Conn) -> String {
         let jobs = background_jobs::table
             .select((background_jobs::job_type, background_jobs::data))
             .load::<(String, serde_json::Value)>(conn)

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -1,15 +1,17 @@
 use crate::config::CdnLogQueueConfig;
 use crate::sqs::{MockSqsQueue, SqsQueue, SqsQueueImpl};
+use crate::tasks::spawn_blocking;
 use crate::util::diesel::Conn;
 use crate::worker::jobs::ProcessCdnLog;
 use crate::worker::Environment;
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use aws_credential_types::Credentials;
 use aws_sdk_sqs::config::Region;
 use aws_sdk_sqs::types::Message;
 use crates_io_worker::BackgroundJob;
-use deadpool_diesel::postgres::Pool;
-use diesel::PgConnection;
+use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use diesel_async::pooled_connection::deadpool::Pool;
+use diesel_async::AsyncPgConnection;
 use std::sync::Arc;
 
 /// A background job that processes messages from the CDN log queue.
@@ -67,7 +69,7 @@ fn build_queue(config: &CdnLogQueueConfig) -> Box<dyn SqsQueue + Send + Sync> {
 async fn run(
     queue: &impl SqsQueue,
     max_messages: usize,
-    connection_pool: &Pool,
+    connection_pool: &Pool<AsyncPgConnection>,
 ) -> anyhow::Result<()> {
     const MAX_BATCH_SIZE: usize = 10;
 
@@ -102,7 +104,7 @@ async fn run(
 async fn process_message(
     message: &Message,
     queue: &impl SqsQueue,
-    connection_pool: &Pool,
+    connection_pool: &Pool<AsyncPgConnection>,
 ) -> anyhow::Result<()> {
     debug!("Processing message…");
 
@@ -134,7 +136,7 @@ async fn process_message(
 /// warning and returns `Ok(())` instead. This is because we don't want to
 /// requeue the message in the case of a parsing error, as it would just be
 /// retried indefinitely.
-async fn process_body(body: &str, connection_pool: &Pool) -> anyhow::Result<()> {
+async fn process_body(body: &str, connection_pool: &Pool<AsyncPgConnection>) -> anyhow::Result<()> {
     let message = match serde_json::from_str::<super::message::Message>(body) {
         Ok(message) => message,
         Err(err) => {
@@ -155,9 +157,11 @@ async fn process_body(body: &str, connection_pool: &Pool) -> anyhow::Result<()> 
 
     let conn = connection_pool.get().await;
     let conn = conn.context("Failed to acquire database connection")?;
-    conn.interact(move |conn| enqueue_jobs(jobs, conn))
-        .await
-        .map_err(|err| anyhow!(err.to_string()))?
+    spawn_blocking(move || {
+        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+        enqueue_jobs(jobs, conn)
+    })
+    .await
 }
 
 /// Extracts a list of [`ProcessCdnLog`] jobs from a message.
@@ -225,10 +229,9 @@ mod tests {
     use aws_sdk_sqs::types::Message;
     use crates_io_test_db::TestDatabase;
     use crates_io_worker::schema::background_jobs;
-    use deadpool_diesel::postgres::Manager;
-    use deadpool_diesel::Runtime;
     use diesel::prelude::*;
     use diesel::QueryDsl;
+    use diesel_async::pooled_connection::AsyncDieselConnectionManager;
     use insta::assert_snapshot;
     use parking_lot::Mutex;
 
@@ -393,8 +396,8 @@ mod tests {
         deleted_handles
     }
 
-    fn build_connection_pool(url: &str) -> Pool {
-        let manager = Manager::new(url, Runtime::Tokio1);
+    fn build_connection_pool(url: &str) -> Pool<AsyncPgConnection> {
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
         Pool::builder(manager).build().unwrap()
     }
 

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -1,4 +1,5 @@
 use crate::schema::version_downloads;
+use crate::util::diesel::Conn;
 use crate::worker::Environment;
 use anyhow::anyhow;
 use crates_io_worker::BackgroundJob;
@@ -25,7 +26,7 @@ impl BackgroundJob for UpdateDownloads {
     }
 }
 
-fn update(conn: &mut PgConnection) -> QueryResult<()> {
+fn update(conn: &mut impl Conn) -> QueryResult<()> {
     use diesel::dsl::now;
     use diesel::select;
 
@@ -75,7 +76,7 @@ fn update(conn: &mut PgConnection) -> QueryResult<()> {
 }
 
 #[instrument(skip_all)]
-fn batch_update(batch_size: i64, conn: &mut PgConnection) -> QueryResult<i64> {
+fn batch_update(batch_size: i64, conn: &mut impl Conn) -> QueryResult<i64> {
     table! {
         /// Imaginary table to make Diesel happy when using the `sql_query` function.
         sql_query_results (count) {
@@ -107,13 +108,13 @@ mod tests {
     use crate::schema::{crate_downloads, crates, versions};
     use crate::test_util::test_db_connection;
 
-    fn user(conn: &mut PgConnection) -> User {
+    fn user(conn: &mut impl Conn) -> User {
         NewUser::new(2, "login", None, None, "access_token")
             .create_or_update(None, &Emails::new_in_memory(), conn)
             .unwrap()
     }
 
-    fn crate_and_version(conn: &mut PgConnection, user_id: i32) -> (Crate, Version) {
+    fn crate_and_version(conn: &mut impl Conn, user_id: i32) -> (Crate, Version) {
         let krate = NewCrate {
             name: "foo",
             ..Default::default()

--- a/src/worker/jobs/git.rs
+++ b/src/worker/jobs/git.rs
@@ -1,5 +1,6 @@
 use crate::models;
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::Conn;
 use crate::worker::Environment;
 use anyhow::{anyhow, Context};
 use chrono::Utc;
@@ -125,7 +126,7 @@ impl BackgroundJob for SyncToSparseIndex {
 }
 
 #[instrument(skip_all, fields(krate.name = ?name))]
-pub fn get_index_data(name: &str, conn: &mut PgConnection) -> anyhow::Result<Option<String>> {
+pub fn get_index_data(name: &str, conn: &mut impl Conn) -> anyhow::Result<Option<String>> {
     debug!("Looking up crate by name");
     let Some(krate): Option<models::Crate> =
         models::Crate::by_exact_name(name).first(conn).optional()?

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -1,3 +1,4 @@
+use crate::util::diesel::Conn;
 use crates_io_worker::schema::background_jobs;
 use crates_io_worker::{BackgroundJob, EnqueueError};
 use diesel::dsl::{exists, not};
@@ -40,7 +41,7 @@ pub use self::update_default_version::UpdateDefaultVersion;
 #[instrument(name = "swirl.enqueue", skip_all, fields(message = "sync_to_index", krate = %krate))]
 pub fn enqueue_sync_to_index<T: Display>(
     krate: T,
-    conn: &mut PgConnection,
+    conn: &mut impl Conn,
 ) -> Result<(), EnqueueError> {
     // Returns jobs with matching `job_type`, `data` and `priority`,
     // skipping ones that are already locked by the background worker.

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -1,5 +1,6 @@
 use crate::schema::{crates, versions};
 use crate::storage::FeedId;
+use crate::util::diesel::Conn;
 use crate::worker::Environment;
 use anyhow::anyhow;
 use chrono::Duration;
@@ -107,7 +108,7 @@ impl BackgroundJob for SyncCrateFeed {
 /// than [`ALWAYS_INCLUDE_AGE`]. If there are less than [`NUM_ITEMS`] versions
 /// then the list will be padded with older versions until [`NUM_ITEMS`] are
 /// returned.
-fn load_version_updates(name: &str, conn: &mut PgConnection) -> QueryResult<Vec<VersionUpdate>> {
+fn load_version_updates(name: &str, conn: &mut impl Conn) -> QueryResult<Vec<VersionUpdate>> {
     let threshold_dt = chrono::Utc::now().naive_utc() - ALWAYS_INCLUDE_AGE;
 
     let updates = versions::table
@@ -237,7 +238,7 @@ mod tests {
         assert_debug_snapshot!(updates.iter().map(|u| &u.version).collect::<Vec<_>>());
     }
 
-    fn create_crate(conn: &mut PgConnection, name: &str) -> i32 {
+    fn create_crate(conn: &mut impl Conn, name: &str) -> i32 {
         diesel::insert_into(crates::table)
             .values((crates::name.eq(name),))
             .returning(crates::id)
@@ -246,7 +247,7 @@ mod tests {
     }
 
     fn create_version(
-        conn: &mut PgConnection,
+        conn: &mut impl Conn,
         crate_id: i32,
         version: &str,
         publish_time: NaiveDateTime,

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -6,6 +6,7 @@ use diesel::PgConnection;
 use typomania::Package;
 
 use crate::email::Email;
+use crate::util::diesel::Conn;
 use crate::{
     typosquat::{Cache, Crate},
     worker::Environment,
@@ -44,12 +45,7 @@ impl BackgroundJob for CheckTyposquat {
     }
 }
 
-fn check(
-    emails: &Emails,
-    cache: &Cache,
-    conn: &mut PgConnection,
-    name: &str,
-) -> anyhow::Result<()> {
+fn check(emails: &Emails, cache: &Cache, conn: &mut impl Conn, name: &str) -> anyhow::Result<()> {
     if let Some(harness) = cache.get_harness() {
         info!(name, "Checking new crate for potential typosquatting");
 


### PR DESCRIPTION
This PR moves our codebase from `deadpool` database pools to `deadpool` database pools... essentially... well... it's complicated.

The codebase currently uses the database pools from `deadpool_diesel`. These database pools are async, but they still return a sync database connection that can be used with regular `diesel` queries. With this PR we are migrating to using database pools from `diesel-async` in their `deadpool` variant. These are returning an async connection, which can be wrapped in an `AsyncConnectionWrapper` to make them work with sync `diesel` queries (in combination with `spawn_blocking()`).

In other words: this is just an intermediate step that allows us to use async `diesel` queries (enabled by `diesel-async`), but a lot of the code is still using sync queries with the wrapper. I've started to port over some of the simpler endpoints to use async queries, but that migration is far from complete. It should however serve as a starting point to demonstrate the end goal of removing all the `spawn_blocking()` calls.

Note that I had to introduce a `Conn` trait to abstract over the `PgConnection` and `AsyncConnectionWrapper` structs. Both implement `LoadConnection<Backend = Pg>`, but since trait aliases are not stabilized yet and I didn't want to repeat that signature everywhere I decided to extract the `Conn` trait. After that I essentially searched for `&mut PgConnection` and replaced it with `&mut impl Conn`, which is equivalent, but also allows us to pass in `AsyncConnectionWrapper` instead.

I would recommend reviewing this commit-by-commit... 😅 