### PR TITLE
clippy: Remove `all = "warn"` override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ rust_2021_compatibility = "warn"
 unused = "warn"
 
 [workspace.lints.clippy]
-all = "warn"
 dbg_macro = "warn"
 todo = "warn"
 


### PR DESCRIPTION
The `all` lint group represents all lints that are enabled by default. Since they are enabled by default there is not much point in us setting them to the `warn` level again. With Rust 1.80 this will also start to trigger https://rust-lang.github.io/rust-clippy/master/index.html#lint_groups_priority, which this change now avoids.