### PR TITLE
Remove obsolete `once_cell` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,7 +1032,6 @@ dependencies = [
  "mockall",
  "oauth2",
  "object_store",
- "once_cell",
  "p256",
  "parking_lot",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,7 +1094,6 @@ dependencies = [
  "anyhow",
  "claims",
  "dotenvy",
- "once_cell",
 ]
 
 [[package]]
@@ -1186,7 +1185,6 @@ dependencies = [
  "crates_io_env_vars",
  "diesel",
  "diesel_migrations",
- "once_cell",
  "rand",
  "tracing",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,6 @@ minijinja = "=2.1.0"
 mockall = "=0.13.0"
 oauth2 = "=4.4.2"
 object_store = { version = "=0.10.2", features = ["aws"] }
-once_cell = "=1.19.0"
 p256 = "=0.13.2"
 parking_lot = "=0.12.3"
 paste = "=1.0.15"

--- a/crates/crates_io_env_vars/Cargo.toml
+++ b/crates/crates_io_env_vars/Cargo.toml
@@ -13,4 +13,3 @@ dotenvy = "=0.15.7"
 
 [dev-dependencies]
 claims = "=0.7.1"
-once_cell = "=1.19.0"

--- a/crates/crates_io_env_vars/src/lib.rs
+++ b/crates/crates_io_env_vars/src/lib.rs
@@ -125,14 +125,13 @@ where
 mod tests {
     use super::*;
     use claims::*;
-    use once_cell::sync::Lazy;
-    use std::sync::Mutex;
+    use std::sync::{LazyLock, Mutex};
 
     const TEST_VAR: &str = "CRATES_IO_ENV_VARS_TEST_VAR";
 
     /// A mutex to ensure that the tests don't run in parallel, since they all
     /// modify the shared environment variable.
-    static MUTEX: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+    static MUTEX: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
     #[test]
     fn test_var() {

--- a/crates/crates_io_test_db/Cargo.toml
+++ b/crates/crates_io_test_db/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 crates_io_env_vars = { path = "../crates_io_env_vars" }
 diesel = { version = "=2.2.2", features = ["postgres", "r2d2"] }
 diesel_migrations = { version = "=2.2.0", features = ["postgres"] }
-once_cell = "=1.19.0"
 rand = "=0.8.5"
 tracing = "=0.1.40"
 url = "=2.5.2"

--- a/crates/crates_io_test_db/src/lib.rs
+++ b/crates/crates_io_test_db/src/lib.rs
@@ -3,8 +3,8 @@ use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool, PooledConnection};
 use diesel::sql_query;
 use diesel_migrations::{FileBasedMigrations, MigrationHarness};
-use once_cell::sync::Lazy;
 use rand::Rng;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tracing::{debug, instrument};
 use url::Url;
@@ -21,7 +21,7 @@ struct TemplateDatabase {
 impl TemplateDatabase {
     #[instrument]
     pub fn instance() -> &'static Self {
-        static INSTANCE: Lazy<TemplateDatabase> = Lazy::new(TemplateDatabase::new);
+        static INSTANCE: LazyLock<TemplateDatabase> = LazyLock::new(TemplateDatabase::new);
         &INSTANCE
     }
 

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -3,9 +3,9 @@ use async_trait::async_trait;
 use axum::extract::FromRequestParts;
 use http::request::Parts;
 use ipnetwork::IpNetwork;
-use once_cell::sync::Lazy;
 use std::fmt::Display;
 use std::net::IpAddr;
+use std::sync::LazyLock;
 
 #[derive(Copy, Clone, Debug)]
 pub enum CiService {
@@ -36,7 +36,7 @@ impl<S> FromRequestParts<S> for CiService {
 }
 
 fn is_github_actions_ip(ip: &IpAddr) -> bool {
-    static GITHUB_ACTIONS_CIDRS: Lazy<Vec<IpNetwork>> = Lazy::new(|| {
+    static GITHUB_ACTIONS_CIDRS: LazyLock<Vec<IpNetwork>> = LazyLock::new(|| {
         github_meta::META
             .actions
             .iter()

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -9,12 +9,12 @@ use axum::body::Bytes;
 use base64::{engine::general_purpose, Engine};
 use crates_io_github::GitHubPublicKey;
 use http::HeaderMap;
-use once_cell::sync::Lazy;
 use p256::ecdsa::signature::Verifier;
 use p256::ecdsa::VerifyingKey;
 use p256::PublicKey;
 use serde_json as json;
 use std::str::FromStr;
+use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
@@ -22,7 +22,7 @@ use tokio::sync::Mutex;
 const PUBLIC_KEY_CACHE_LIFETIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours
 
 // Cache of public keys that have been fetched from GitHub API
-static PUBLIC_KEY_CACHE: Lazy<Mutex<GitHubPublicKeyCache>> = Lazy::new(|| {
+static PUBLIC_KEY_CACHE: LazyLock<Mutex<GitHubPublicKeyCache>> = LazyLock::new(|| {
     let keys: Vec<GitHubPublicKey> = Vec::new();
     let cache = GitHubPublicKeyCache {
         keys,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -4,7 +4,7 @@ use crate::auth::AuthCheck;
 use diesel::dsl::*;
 use diesel::sql_types::{Array, Bool, Text};
 use diesel_full_text_search::*;
-use once_cell::sync::OnceCell;
+use std::cell::OnceCell;
 
 use crate::controllers::cargo_prelude::*;
 use crate::controllers::helpers::Paginate;
@@ -282,11 +282,17 @@ impl<'a> FilterParams<'a> {
             .as_deref()
     }
 
-    fn authed_user_id(&self, req: &Parts, conn: &mut PgConnection) -> AppResult<&i32> {
-        self._auth_user_id.get_or_try_init(|| {
-            let user_id = AuthCheck::default().check(req, conn)?.user_id();
-            Ok(user_id)
-        })
+    fn authed_user_id(&self, req: &Parts, conn: &mut PgConnection) -> AppResult<i32> {
+        if let Some(val) = self._auth_user_id.get() {
+            return Ok(*val);
+        }
+
+        let user_id = AuthCheck::default().check(req, conn)?.user_id();
+
+        // This should not fail, because of the `get()` check above
+        let _ = self._auth_user_id.set(user_id);
+
+        Ok(user_id)
     }
 
     fn make_query(

--- a/src/real_ip.rs
+++ b/src/real_ip.rs
@@ -1,13 +1,13 @@
 use http::{HeaderMap, HeaderValue};
 use ipnetwork::IpNetwork;
-use once_cell::sync::Lazy;
 use std::iter::Iterator;
 use std::net::IpAddr;
 use std::str::from_utf8;
+use std::sync::LazyLock;
 
 const X_FORWARDED_FOR: &str = "X-Forwarded-For";
 
-static CLOUD_FRONT_NETWORKS: Lazy<Vec<IpNetwork>> = Lazy::new(|| {
+static CLOUD_FRONT_NETWORKS: LazyLock<Vec<IpNetwork>> = LazyLock::new(|| {
     let ipv4_prefixes = aws_ip_ranges::IP_RANGES
         .prefixes
         .iter()

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -6,12 +6,13 @@ use crates_io_test_db::TestDatabase;
 use crates_io_worker::BackgroundJob;
 use flate2::read::GzDecoder;
 use insta::{assert_debug_snapshot, assert_snapshot};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use std::io::{Cursor, Read};
+use std::sync::LazyLock;
 use tar::Archive;
 
-static PATH_DATE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\d{4}-\d{2}-\d{2}-\d{6}").unwrap());
+static PATH_DATE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\d{4}-\d{2}-\d{2}-\d{6}").unwrap());
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_dump_db_job() {

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -7,8 +7,8 @@ use diesel::{dsl::*, prelude::*, update};
 use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_json_snapshot;
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn index() {
@@ -1084,7 +1084,8 @@ async fn crates_by_user_id_not_including_deleted_owners() {
     }
 }
 
-static PAGE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"((?:^page|&page|\?page)=\d+)").unwrap());
+static PAGE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"((?:^page|&page|\?page)=\d+)").unwrap());
 
 // search with both offset-based (prepend with `page=1` query) and seek-based pagination
 async fn search_both<U: RequestHelper>(anon: &U, query: &str) -> [crate::CrateList; 2] {


### PR DESCRIPTION
This functionality is now supplied by the std lib 🎉 

Related:

- https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#lazycell-and-lazylock