### PR TITLE
Unify CDN invalidation into a single method on `Environment`

### DIFF
--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -48,16 +48,8 @@ impl BackgroundJob for DumpDb {
         info!("Database dump tarball uploaded");
 
         info!("Invalidating CDN caches…");
-        if let Some(cloudfront) = env.cloudfront() {
-            if let Err(error) = cloudfront.invalidate(TAR_PATH).await {
-                warn!("Failed to invalidate CloudFront cache: {}", error);
-            }
-        }
-
-        if let Some(fastly) = env.fastly() {
-            if let Err(error) = fastly.invalidate(TAR_PATH).await {
-                warn!("Failed to invalidate Fastly cache: {}", error);
-            }
+        if let Err(error) = env.invalidate_cdns(TAR_PATH).await {
+            warn!("Failed to invalidate CDN caches: {error}");
         }
 
         info!("Uploading zip file…");
@@ -67,16 +59,8 @@ impl BackgroundJob for DumpDb {
         info!("Database dump zip file uploaded");
 
         info!("Invalidating CDN caches…");
-        if let Some(cloudfront) = env.cloudfront() {
-            if let Err(error) = cloudfront.invalidate(ZIP_PATH).await {
-                warn!("Failed to invalidate CloudFront cache: {}", error);
-            }
-        }
-
-        if let Some(fastly) = env.fastly() {
-            if let Err(error) = fastly.invalidate(ZIP_PATH).await {
-                warn!("Failed to invalidate Fastly cache: {}", error);
-            }
+        if let Err(error) = env.invalidate_cdns(ZIP_PATH).await {
+            warn!("Failed to invalidate CDN caches: {error}");
         }
 
         Ok(())

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -86,18 +86,8 @@ impl BackgroundJob for SyncCrateFeed {
         ctx.storage.upload_feed(&feed_id, &channel).await?;
 
         let path = object_store::path::Path::from(&feed_id);
-        if let Some(cloudfront) = ctx.cloudfront() {
-            info!(%path, "Invalidating CloudFront cache…");
-            cloudfront.invalidate(path.as_ref()).await?;
-        } else {
-            info!("Skipping CloudFront cache invalidation (CloudFront not configured)");
-        }
-
-        if let Some(fastly) = ctx.fastly() {
-            info!(%path, "Invalidating Fastly cache…");
-            fastly.invalidate(path.as_ref()).await?;
-        } else {
-            info!("Skipping Fastly cache invalidation (Fastly not configured)");
+        if let Err(error) = ctx.invalidate_cdns(path.as_ref()).await {
+            warn!("Failed to invalidate CDN caches: {error}");
         }
 
         info!("Finished syncing updates feed");

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -70,18 +70,8 @@ impl BackgroundJob for SyncUpdatesFeed {
         ctx.storage.upload_feed(&feed_id, &channel).await?;
 
         let path = object_store::path::Path::from(&feed_id);
-        if let Some(cloudfront) = ctx.cloudfront() {
-            info!(%path, "Invalidating CloudFront cache…");
-            cloudfront.invalidate(path.as_ref()).await?;
-        } else {
-            info!("Skipping CloudFront cache invalidation (CloudFront not configured)");
-        }
-
-        if let Some(fastly) = ctx.fastly() {
-            info!(%path, "Invalidating Fastly cache…");
-            fastly.invalidate(path.as_ref()).await?;
-        } else {
-            info!("Skipping Fastly cache invalidation (Fastly not configured)");
+        if let Err(error) = ctx.invalidate_cdns(path.as_ref()).await {
+            warn!("Failed to invalidate CDN caches: {error}");
         }
 
         info!("Finished syncing updates feed");


### PR DESCRIPTION
The index only uses CloudFront, so that still needs to go directly through `Environment::cloudfront()`, but there's no particular reason to have a bunch of background jobs with similar patterns for static.crates.io.