### PR TITLE
Add API token creation notifications

### DIFF
--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -142,16 +142,15 @@ pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
         )?;
 
         if let Some(recipient) = recipient {
+            let email = NewTokenEmail {
+                user_name: &user.gh_login,
+                domain: &app.emails.domain,
+            };
+
             // At this point the token has been created so failing to send the
             // email should not cause an error response to be returned to the
             // caller.
-            let email_ret = app.emails.send(
-                &recipient,
-                NewTokenEmail {
-                    user_name: &user.gh_login,
-                    domain: &app.emails.domain,
-                },
-            );
+            let email_ret = app.emails.send(&recipient, email);
             if let Err(e) = email_ret {
                 error!("Failed to send token creation email: {e}")
             }

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -130,6 +130,8 @@ pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
             .transpose()
             .map_err(|_err| bad_request("invalid endpoint scope"))?;
 
+        let recipient = user.email(conn)?;
+
         let api_token = ApiToken::insert_with_scopes(
             conn,
             user.id,
@@ -138,9 +140,26 @@ pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
             endpoint_scopes,
             new.api_token.expired_at,
         )?;
-        let api_token = EncodableApiTokenWithToken::from(api_token);
 
-        Ok(Json(json!({ "api_token": api_token })))
+        if let Some(recipient) = recipient {
+            // At this point the token has been created so failing to send the
+            // email should not cause an error response to be returned to the
+            // caller.
+            let email_ret = app.emails.send(
+                &recipient,
+                NewTokenEmail {
+                    user_name: &user.gh_login,
+                    domain: &app.emails.domain,
+                },
+            );
+            if let Err(e) = email_ret {
+                error!("Failed to send token creation email: {e}")
+            }
+        }
+
+        Ok(Json(
+            json!({ "api_token": EncodableApiTokenWithToken::from(api_token) }),
+        ))
     })
     .await
 }
@@ -198,4 +217,26 @@ pub async fn revoke_current(app: AppState, req: Parts) -> AppResult<Response> {
         Ok(StatusCode::NO_CONTENT.into_response())
     })
     .await
+}
+
+struct NewTokenEmail<'a> {
+    user_name: &'a str,
+    domain: &'a str,
+}
+
+impl<'a> crate::email::Email for NewTokenEmail<'a> {
+    const SUBJECT: &'static str = "New API token created";
+
+    fn body(&self) -> String {
+        format!(
+            "\
+Hello {user_name}!
+
+A new API token was recently added to your crates.io account.
+
+If this wasn't you, you should revoke the token immediately: https://{domain}/settings/tokens",
+            user_name = self.user_name,
+            domain = self.domain,
+        )
+    }
 }

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -157,9 +157,9 @@ pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
             }
         }
 
-        Ok(Json(
-            json!({ "api_token": EncodableApiTokenWithToken::from(api_token) }),
-        ))
+        let api_token = EncodableApiTokenWithToken::from(api_token);
+
+        Ok(Json(json!({ "api_token": api_token })))
     })
     .await
 }

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -232,7 +232,7 @@ impl<'a> crate::email::Email for NewTokenEmail<'a> {
             "\
 Hello {user_name}!
 
-A new API token was recently added to your crates.io account.
+A new API token was recently added to your {domain} account.
 
 If this wasn't you, you should revoke the token immediately: https://{domain}/settings/tokens",
             user_name = self.user_name,

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -143,6 +143,7 @@ pub async fn new(app: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
 
         if let Some(recipient) = recipient {
             let email = NewTokenEmail {
+                token_name: name,
                 user_name: &user.gh_login,
                 domain: &app.emails.domain,
             };
@@ -219,6 +220,7 @@ pub async fn revoke_current(app: AppState, req: Parts) -> AppResult<Response> {
 }
 
 struct NewTokenEmail<'a> {
+    token_name: &'a str,
     user_name: &'a str,
     domain: &'a str,
 }
@@ -231,9 +233,10 @@ impl<'a> crate::email::Email for NewTokenEmail<'a> {
             "\
 Hello {user_name}!
 
-A new API token was recently added to your {domain} account.
+A new API token with the name \"{token_name}\" was recently added to your {domain} account.
 
 If this wasn't you, you should revoke the token immediately: https://{domain}/settings/tokens",
+            token_name = self.token_name,
             user_name = self.user_name,
             domain = self.domain,
         )


### PR DESCRIPTION
This PR will make crates.io email the user's registered email address when a new token is added to their account.

An email notification helps mitigate a sneaky 3rd party with access to the account from creating a token and using it to do nasty things later. Without the notification you'd only know about the token if you were periodically checking the token page.

Part of https://github.com/rust-lang/crates.io/issues/2639

---

* feat: token creation notification email (83c83135)
      
      When a new token is created for an account, send a notification email to
      the account owner.

