### PR TITLE
Don't read .psqlrc for automated DB export

### DIFF
--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -180,6 +180,7 @@ pub fn run_psql(script: &Path, database_url: &str) -> anyhow::Result<()> {
         File::open(script).with_context(|| format!("Failed to open {}", script.display()))?;
 
     let psql = std::process::Command::new("psql")
+        .arg("--no-psqlrc")
         .arg(database_url)
         .current_dir(script.parent().unwrap())
         .stdin(psql_script)


### PR DESCRIPTION
The `dump_db_and_reimport_dump` test fails on my machine because my `.psqlrc` sets the session into "read-only" mode by default, causing the import step to fail.

Looking at how this is used, I don't think sourcing the `.psqlrc` file is intended - a user might have it do anything! It's not uncommon to `SET` various options on the connection, some of which might cause problems (timeouts, search paths, etc).

---

* fix: don't read .psqlrc for automated DB export (0c492d28)
      
      The dump_db::run_psql() function spawns a psql child process to run a an
      export script, but psql will automatically load and execute the content
      of the user's ~/.psqlrc file if it exists and execute it before the
      export script.
      
      The statements executed from the psqlrc file might change connection
      parameters (for example, the search path) in a way that causes the
      script to fail.
      
      This commit stops psql sourcing the psqlrc file at startup, meaning the
      connection should always be in a fresh / clean state.

