### PR TITLE
database: Add `versions.yank_message` column

### DIFF
--- a/migrations/2024-08-17-152408_add-yank-message/down.sql
+++ b/migrations/2024-08-17-152408_add-yank-message/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE versions DROP yank_message;

--- a/migrations/2024-08-17-152408_add-yank-message/up.sql
+++ b/migrations/2024-08-17-152408_add-yank-message/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE versions ADD COLUMN yank_message TEXT;
+
+COMMENT ON COLUMN versions.yank_message IS 'message associated with a yanked version';

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -31,6 +31,7 @@ pub struct Version {
     pub rust_version: Option<String>,
     pub has_lib: Option<bool>,
     pub bin_names: Option<Vec<Option<String>>>,
+    pub yank_message: Option<String>,
 }
 
 impl Version {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -985,6 +985,8 @@ diesel::table! {
         has_lib -> Nullable<Bool>,
         /// list of the names of all detected binaries in the version. the list may be empty which indicates that no binaries were detected in the version. the column may be NULL is the version has not been analyzed yet.
         bin_names -> Nullable<Array<Nullable<Text>>>,
+        /// message associated with a yanked version
+        yank_message -> Nullable<Text>,
     }
 }
 

--- a/src/worker/jobs/dump_db/dump-db.toml
+++ b/src/worker/jobs/dump_db/dump-db.toml
@@ -233,6 +233,7 @@ links = "public"
 rust_version = "public"
 has_lib = "public"
 bin_names = "public"
+yank_message = "private"
 
 [versions_published_by.columns]
 version_id = "private"


### PR DESCRIPTION
ref https://github.com/rust-lang/crates.io/issues/9193

In this PR, I added a new column to the `versions` table.

I picked the text here. For a simple text-based message, I think the length is enough.

I am not sure if we should consider using JSONB here to accommodate the possibility of needing to store more structured information in the future.

I also marked it private, I guess before we expose the new API to users, we should keep it private.