### PR TITLE
fix: bound co-owner invites per request

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -108,6 +108,14 @@ async fn modify_owners(
 ) -> AppResult<Json<Value>> {
     let logins = body.owners;
 
+    // Bound the number of invites processed per request to limit the cost of
+    // processing them all.
+    if logins.len() > 10 {
+        return Err(bad_request(
+            "too many invites for this request - maximum 10",
+        ));
+    }
+
     let conn = app.db_write().await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -332,7 +332,10 @@ impl MockTokenUser {
     }
 
     /// Add to the specified crate the specified owners.
-    pub async fn add_named_owners(&self, krate_name: &str, owners: &[&str]) -> Response<OkBool> {
+    pub async fn add_named_owners<T>(&self, krate_name: &str, owners: &[T]) -> Response<OkBool>
+    where
+        T: serde::Serialize,
+    {
         let url = format!("/api/v1/crates/{krate_name}/owners");
         let body = json!({ "owners": owners }).to_string();
         self.put(&url, body).await


### PR DESCRIPTION
This limits an "add crate co-owner" request to inviting at most 10 users per request.

This bounds the amount of CPU time a single API request can take, and therefore limits how long the associated database connection and `spawn_blocking()` thread are monopolised for to service that request.

There's still some oddities around using a single transaction across all invites: it's possible to construct an API request that does the work to invite 9 people, and then aborts and rolls back any database changes. This can enable someone malicious to retry requests rapidly (including sending emails as a result). I think perhaps a refactor of the controller / model split is needed to solve this properly though.

---

* fix: bound co-owner invites per request (2ce40b3fa)
      
      Bound the number of co-owner invites that can be sent in a single API
      request, effectively bounding the work done per request.
      
      This limits the number of iterations the N^2 membership test loop has to
      perform, limiting the amount of CPU time and memory needed for both it
      and the subsequent database queries per invitee.

