### PR TITLE
styles: Fix button text color when hovering

### DIFF
--- a/app/styles/shared/buttons.module.css
+++ b/app/styles/shared/buttons.module.css
@@ -34,7 +34,11 @@
     cursor: pointer;
 
     &:hover, &:active, &:visited {
-        color: var(--text-color);
+        /*
+         * This is using `important` to override the `a:hover` declaration which
+         * appears to have higher specificity than the `button:hover` declaration.
+         */
+        color: var(--text-color) !important;
     }
 
     img, svg {


### PR DESCRIPTION
Buttons were not meant to get a green text color when the cursor hovers over them...

There might be a better fix for it, but I'm not seeing it right now. Feel free to comment if you know how to improve this 😉 