### PR TITLE
Remove controller preludes

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -18,46 +18,10 @@ mod prelude {
     pub use http::{header, request::Parts, StatusCode};
 
     pub use crate::app::AppState;
-    use crate::controllers::util::RequestPartsExt;
     pub use crate::middleware::app::RequestApp;
     pub use crate::tasks::spawn_blocking;
     pub use crate::util::errors::{AppResult, BoxedAppError};
-    pub use crate::util::BytesRequest;
-    use indexmap::IndexMap;
-
-    pub fn redirect(url: String) -> Response {
-        (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
-    }
-
-    pub trait RequestUtils {
-        fn query(&self) -> IndexMap<String, String>;
-        fn wants_json(&self) -> bool;
-        fn query_with_params(&self, params: IndexMap<String, String>) -> String;
-    }
-
-    impl<T: RequestPartsExt> RequestUtils for T {
-        fn query(&self) -> IndexMap<String, String> {
-            url::form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
-                .into_owned()
-                .collect()
-        }
-
-        fn wants_json(&self) -> bool {
-            self.headers()
-                .get_all(header::ACCEPT)
-                .iter()
-                .any(|val| val.to_str().unwrap_or_default().contains("json"))
-        }
-
-        fn query_with_params(&self, new_params: IndexMap<String, String>) -> String {
-            let mut params = self.query();
-            params.extend(new_params);
-            let query_string = url::form_urlencoded::Serializer::new(String::new())
-                .extend_pairs(params)
-                .finish();
-            format!("?{query_string}")
-        }
-    }
+    pub use crate::util::{redirect, BytesRequest, RequestUtils};
 }
 
 pub mod helpers;

--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -1,29 +1,3 @@
-mod cargo_prelude {
-    pub use super::prelude::*;
-}
-
-mod frontend_prelude {
-    pub use super::prelude::*;
-    pub use crate::util::errors::{bad_request, server_error};
-}
-
-mod prelude {
-    pub use super::helpers::ok_true;
-    pub use axum::extract::Path;
-    pub use axum::response::{IntoResponse, Response};
-    pub use axum::Json;
-    pub use diesel::prelude::*;
-    pub use serde_json::Value;
-
-    pub use http::{header, request::Parts, StatusCode};
-
-    pub use crate::app::AppState;
-    pub use crate::middleware::app::RequestApp;
-    pub use crate::tasks::spawn_blocking;
-    pub use crate::util::errors::{AppResult, BoxedAppError};
-    pub use crate::util::{redirect, BytesRequest, RequestUtils};
-}
-
 pub mod helpers;
 pub mod util;
 

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -1,10 +1,17 @@
 use super::helpers::pagination::*;
-use super::prelude::*;
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
-
+use crate::app::AppState;
 use crate::models::Category;
 use crate::schema::categories;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::AppResult;
+use crate::util::RequestUtils;
 use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
+use axum::extract::Path;
+use axum::Json;
+use diesel::prelude::*;
+use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+use serde_json::Value;
 
 /// Handles the `GET /categories` route.
 pub async fn index(app: AppState, req: Parts) -> AppResult<Json<Value>> {

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -1,20 +1,27 @@
-use super::frontend_prelude::*;
-
+use crate::app::AppState;
 use crate::auth::AuthCheck;
 use crate::auth::Authentication;
 use crate::controllers::helpers::pagination::{Page, PaginationOptions};
 use crate::models::{Crate, CrateOwnerInvitation, Rights, User};
 use crate::schema::{crate_owner_invitations, crates, users};
+use crate::tasks::spawn_blocking;
 use crate::util::diesel::Conn;
-use crate::util::errors::{forbidden, internal};
+use crate::util::errors::{bad_request, forbidden, internal, AppResult};
+use crate::util::{BytesRequest, RequestUtils};
 use crate::views::{
     EncodableCrateOwnerInvitation, EncodableCrateOwnerInvitationV1, EncodablePublicUser,
     InvitationResponse,
 };
+use axum::extract::Path;
+use axum::Json;
 use chrono::{Duration, Utc};
-use diesel::{pg::Pg, sql_types::Bool};
+use diesel::pg::Pg;
+use diesel::prelude::*;
+use diesel::sql_types::Bool;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
 use indexmap::IndexMap;
+use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use tokio::runtime::Handle;
 

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -1,14 +1,17 @@
 use crate::app::AppState;
-use crate::controllers::frontend_prelude::*;
 use crate::email::Email;
 use crate::models::{ApiToken, User};
 use crate::schema::api_tokens;
+use crate::tasks::spawn_blocking;
 use crate::util::diesel::Conn;
+use crate::util::errors::{bad_request, AppResult, BoxedAppError};
 use crate::util::token::HashedToken;
 use anyhow::{anyhow, Context};
 use axum::body::Bytes;
+use axum::Json;
 use base64::{engine::general_purpose, Engine};
 use crates_io_github::GitHubPublicKey;
+use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::HeaderMap;
 use p256::ecdsa::signature::Verifier;

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,5 +1,5 @@
-use crate::controllers::cargo_prelude::{AppResult, Response};
-use axum::response::IntoResponse;
+use crate::util::errors::AppResult;
+use axum::response::{IntoResponse, Response};
 use axum::Json;
 
 pub(crate) mod pagination;

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -1,17 +1,19 @@
 use crate::config::Server;
-use crate::controllers::prelude::*;
 use crate::controllers::util::RequestPartsExt;
+use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::RequestLogExt;
 use crate::middleware::real_ip::RealIp;
 use crate::models::helpers::with_count::*;
 use crate::util::errors::{bad_request, AppResult};
-use crate::util::HeaderMapExt;
+use crate::util::{HeaderMapExt, RequestUtils};
 
 use base64::{engine::general_purpose, Engine};
 use diesel::pg::Pg;
-use diesel::query_builder::*;
+use diesel::prelude::*;
+use diesel::query_builder::{AstPass, Query, QueryFragment, QueryId};
 use diesel::query_dsl::LoadQuery;
 use diesel::sql_types::BigInt;
+use http::header;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -1,13 +1,16 @@
-use super::prelude::*;
 use crate::app::AppState;
-use axum::extract::{Path, Query};
-use axum::Json;
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
-
 use crate::controllers::helpers::pagination::PaginationOptions;
 use crate::controllers::helpers::{pagination::Paginated, Paginate};
 use crate::models::Keyword;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::AppResult;
 use crate::views::EncodableKeyword;
+use axum::extract::{Path, Query};
+use axum::Json;
+use diesel::prelude::*;
+use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+use serde_json::Value;
 
 #[derive(Deserialize)]
 pub struct IndexQuery {

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -3,16 +3,18 @@
 //! The endpoint for downloading a crate and exposing version specific
 //! download counts are located in `version::downloads`.
 
-use std::cmp;
-
-use crate::controllers::frontend_prelude::*;
-
+use crate::app::AppState;
 use crate::models::{Crate, Version, VersionDownload};
 use crate::schema::{crates, version_downloads, versions};
 use crate::sql::to_char;
-use crate::util::errors::crate_not_found;
+use crate::util::errors::{crate_not_found, AppResult};
 use crate::views::EncodableVersionDownload;
+use axum::extract::Path;
+use axum::Json;
+use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde_json::Value;
+use std::cmp;
 
 /// Handles the `GET /crates/:crate_id/downloads` route.
 pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -1,12 +1,19 @@
 //! All routes related to managing owners of a crate
 
+use crate::app::AppState;
 use crate::auth::AuthCheck;
-use crate::controllers::prelude::*;
 use crate::models::token::EndpointScope;
 use crate::models::{Crate, Owner, Rights, Team, User};
-use crate::util::errors::{bad_request, crate_not_found, custom};
+use crate::tasks::spawn_blocking;
+use crate::util::errors::{bad_request, crate_not_found, custom, AppResult};
 use crate::views::EncodableOwner;
+use axum::extract::Path;
+use axum::Json;
+use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+use http::StatusCode;
+use serde_json::Value;
 use tokio::runtime::Handle;
 
 /// Handles the `GET /crates/:crate_id/owners` route.

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -1,18 +1,23 @@
 //! Endpoint for versions of a crate
 
+use axum::extract::Path;
+use axum::Json;
+use diesel::connection::DefaultLoadingMode;
+use diesel::prelude::*;
+use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+use indexmap::IndexMap;
+use serde_json::Value;
 use std::cmp::Reverse;
 
-use diesel::connection::DefaultLoadingMode;
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
-use indexmap::IndexMap;
-
-use crate::controllers::frontend_prelude::*;
+use crate::app::AppState;
 use crate::controllers::helpers::pagination::{encode_seek, Page, PaginationOptions};
-
 use crate::models::{Crate, User, Version, VersionOwnerAction};
 use crate::schema::{crates, users, versions};
+use crate::tasks::spawn_blocking;
 use crate::util::diesel::Conn;
-use crate::util::errors::crate_not_found;
+use crate::util::errors::{crate_not_found, AppResult};
+use crate::util::RequestUtils;
 use crate::views::EncodableVersion;
 
 /// Handles the `GET /crates/:crate_id/versions` route.

--- a/src/controllers/metrics.rs
+++ b/src/controllers/metrics.rs
@@ -1,5 +1,9 @@
-use crate::controllers::frontend_prelude::*;
-use crate::util::errors::{custom, forbidden, not_found};
+use crate::app::AppState;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::{custom, forbidden, not_found, AppResult, BoxedAppError};
+use axum::extract::Path;
+use http::request::Parts;
+use http::{header, StatusCode};
 use prometheus::TextEncoder;
 
 /// Handles the `GET /api/private/metrics/:kind` endpoint.

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -1,9 +1,9 @@
 use crate::app::AppState;
-use crate::controllers::cargo_prelude::AppResult;
 use crate::models::{Category, Crate, CrateVersions, Keyword, TopVersions, Version};
 use crate::schema::{crate_downloads, crates, keywords, metadata, recent_crate_downloads};
 use crate::tasks::spawn_blocking;
 use crate::util::diesel::Conn;
+use crate::util::errors::AppResult;
 use crate::views::{EncodableCategory, EncodableCrate, EncodableKeyword};
 use axum::Json;
 use diesel::prelude::*;

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -1,13 +1,16 @@
-use crate::controllers::frontend_prelude::*;
-
+use crate::app::AppState;
 use crate::models::Team;
-use crate::schema::teams;
+use crate::util::errors::AppResult;
 use crate::views::EncodableTeam;
+use axum::extract::Path;
+use axum::Json;
+use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde_json::Value;
 
 /// Handles the `GET /teams/:team_id` route.
 pub async fn show_team(state: AppState, Path(name): Path<String>) -> AppResult<Json<Value>> {
-    use self::teams::dsl::{login, teams};
+    use crate::schema::teams::dsl::{login, teams};
 
     let mut conn = state.db_read().await?;
     let team: Team = teams.filter(login.eq(&name)).first(&mut conn).await?;

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -1,19 +1,25 @@
-use super::frontend_prelude::*;
-
 use crate::models::ApiToken;
 use crate::schema::api_tokens;
-use crate::util::rfc3339;
+use crate::util::{rfc3339, BytesRequest};
 use crate::views::EncodableApiTokenWithToken;
 
+use crate::app::AppState;
 use crate::auth::AuthCheck;
 use crate::models::token::{CrateScope, EndpointScope};
-use axum::extract::Query;
-use axum::response::IntoResponse;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::{bad_request, AppResult};
+use axum::extract::{Path, Query};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
 use chrono::NaiveDateTime;
 use diesel::data_types::PgInterval;
 use diesel::dsl::{now, IntervalDsl};
+use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+use http::StatusCode;
 use serde_json as json;
+use serde_json::Value;
 
 #[derive(Deserialize)]
 pub struct GetParams {

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,17 +1,22 @@
-use crate::controllers::frontend_prelude::*;
+use axum::extract::Path;
+use axum::Json;
 use bigdecimal::{BigDecimal, ToPrimitive};
-
-use crate::models::{CrateOwner, OwnerKind, User};
-use crate::schema::{crate_downloads, crate_owners, crates, users};
-use crate::sql::lower;
-use crate::views::EncodablePublicUser;
+use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde_json::Value;
+
+use crate::app::AppState;
+use crate::models::{CrateOwner, OwnerKind, User};
+use crate::schema::{crate_downloads, crate_owners, crates};
+use crate::sql::lower;
+use crate::util::errors::AppResult;
+use crate::views::EncodablePublicUser;
 
 /// Handles the `GET /users/:user_id` route.
 pub async fn show(state: AppState, Path(user_name): Path<String>) -> AppResult<Json<Value>> {
     let mut conn = state.db_read_prefer_primary().await?;
 
-    use self::users::dsl::{gh_login, id, users};
+    use crate::schema::users::dsl::{gh_login, id, users};
 
     let name = lower(&user_name);
     let user: User = users

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -1,8 +1,9 @@
-use super::prelude::*;
+use crate::middleware::app::RequestApp;
 use crate::middleware::log_request::RequestLogExt;
 use crate::util::errors::{forbidden, AppResult};
+use crate::util::BytesRequest;
 use http::request::Parts;
-use http::{Extensions, HeaderMap, HeaderValue, Method, Request, Uri, Version};
+use http::{header, Extensions, HeaderMap, HeaderValue, Method, Request, Uri, Version};
 
 /// The Origin header (<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>)
 /// is sent with CORS requests and POST requests, and indicates where the request comes from.

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -2,17 +2,17 @@ pub mod downloads;
 pub mod metadata;
 pub mod yank;
 
-use super::prelude::*;
-
 use crate::models::{Crate, Version};
 use crate::util::diesel::Conn;
-use crate::util::errors::crate_not_found;
+use crate::util::errors::{crate_not_found, AppResult};
 
 fn version_and_crate(
     conn: &mut impl Conn,
     crate_name: &str,
     semver: &str,
 ) -> AppResult<(Version, Crate)> {
+    use diesel::prelude::*;
+
     let krate: Crate = Crate::by_name(crate_name)
         .first(conn)
         .optional()?

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -3,13 +3,21 @@
 //! Crate level functionality is located in `krate::downloads`.
 
 use super::version_and_crate;
-use crate::controllers::prelude::*;
+use crate::app::AppState;
 use crate::models::VersionDownload;
 use crate::schema::*;
-use crate::util::errors::version_not_found;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::{version_not_found, AppResult};
+use crate::util::{redirect, RequestUtils};
 use crate::views::EncodableVersionDownload;
+use axum::extract::Path;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
 use chrono::{Duration, NaiveDate, Utc};
+use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+use serde_json::Value;
 
 /// Handles the `GET /crates/:crate_id/:version/download` route.
 /// This returns a URL to the location where the crate is stored.

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -4,11 +4,15 @@
 //! index or cached metadata which was extracted (client side) from the
 //! `Cargo.toml` file.
 
-use crate::controllers::frontend_prelude::*;
+use axum::extract::Path;
+use axum::Json;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use serde_json::Value;
 
+use crate::app::AppState;
 use crate::models::VersionOwnerAction;
-use crate::util::errors::version_not_found;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::{version_not_found, AppResult};
 use crate::views::{EncodableDependency, EncodableVersion};
 
 use super::version_and_crate;

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -1,5 +1,8 @@
+use crate::controllers::util::RequestPartsExt;
+use axum::response::{IntoResponse, Response};
 use http::header::AsHeaderName;
-use http::HeaderMap;
+use http::{header, HeaderMap, StatusCode};
+use indexmap::IndexMap;
 
 pub trait HeaderMapExt {
     /// Returns the value of the request header, or an empty slice if it is not
@@ -16,5 +19,39 @@ impl HeaderMapExt for HeaderMap {
         self.get(key)
             .map(|value| value.to_str().unwrap_or_default())
             .unwrap_or_default()
+    }
+}
+
+pub fn redirect(url: String) -> Response {
+    (StatusCode::FOUND, [(header::LOCATION, url)]).into_response()
+}
+
+pub trait RequestUtils {
+    fn query(&self) -> IndexMap<String, String>;
+    fn wants_json(&self) -> bool;
+    fn query_with_params(&self, params: IndexMap<String, String>) -> String;
+}
+
+impl<T: RequestPartsExt> RequestUtils for T {
+    fn query(&self) -> IndexMap<String, String> {
+        url::form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
+            .into_owned()
+            .collect()
+    }
+
+    fn wants_json(&self) -> bool {
+        self.headers()
+            .get_all(header::ACCEPT)
+            .iter()
+            .any(|val| val.to_str().unwrap_or_default().contains("json"))
+    }
+
+    fn query_with_params(&self, new_params: IndexMap<String, String>) -> String {
+        let mut params = self.query();
+        params.extend(new_params);
+        let query_string = url::form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(params)
+            .finish();
+        format!("?{query_string}")
     }
 }


### PR DESCRIPTION
These can make it hard sometimes to understand where certain things are imported from and they unconditionally import the `diesel` prelude, which makes moving to `diesel_async` slightly harder in some cases. Since most Rust editor have an automatic import feature these days it should be viable to remove these preludes in favor of the additional code clarity.