### PR TITLE
test: generate per-user email

### DIFF
--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -34,7 +34,7 @@ async fn new_krate() {
             .select(versions_published_by::email)
             .first(conn)
             .unwrap();
-        assert_eq!(email, "something@example.com");
+        assert_eq!(email, "foo@example.com");
     });
 }
 

--- a/src/tests/routes/me/snapshots/all__routes__me__get__me-2.snap
+++ b/src/tests/routes/me/snapshots/all__routes__me__get__me-2.snap
@@ -1,12 +1,12 @@
 ---
 source: src/tests/routes/me/get.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "owned_crates": [],
   "user": {
     "avatar": null,
-    "email": "something@example.com",
+    "email": "foo@example.com",
     "email_verification_sent": true,
     "email_verified": true,
     "id": 1,

--- a/src/tests/routes/me/snapshots/all__routes__me__get__me-3.snap
+++ b/src/tests/routes/me/snapshots/all__routes__me__get__me-3.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/routes/me/get.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "owned_crates": [
@@ -12,7 +12,7 @@ expression: response.into_json()
   ],
   "user": {
     "avatar": null,
-    "email": "something@example.com",
+    "email": "foo@example.com",
     "email_verification_sent": true,
     "email_verified": true,
     "id": 1,

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -139,7 +139,7 @@ async fn test_email_get_and_put() {
     let (_app, _anon, user) = TestApp::init().with_user();
 
     let json = user.show_me().await;
-    assert_eq!(json.user.email.unwrap(), "something@example.com");
+    assert_eq!(json.user.email.unwrap(), "foo@example.com");
 
     user.update_email("mango@mangos.mango").await;
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -113,8 +113,8 @@ impl TestApp {
         f(&mut self.0.test_database.connect())
     }
 
-    /// Create a new user with a verified email address in the database and return a mock user
-    /// session
+    /// Create a new user with a verified email address in the database
+    /// (`<username>@example.com``) and return a mock user session.
     ///
     /// This method updates the database directly
     pub fn db_new_user(&self, username: &str) -> MockCookieUser {
@@ -122,7 +122,7 @@ impl TestApp {
         use diesel::prelude::*;
 
         let user = self.db(|conn| {
-            let email = "something@example.com";
+            let email = format!("{username}@example.com");
 
             let user = crate::new_user(username)
                 .create_or_update(None, &self.0.app.emails, conn)


### PR DESCRIPTION
When generating a test user, derive that user's email address from the username.

This makes asserting the correct recipient emails are used when inspecting emails in tests.

@domodwyer I extracted that from one of your branches, since it seems like a useful change on its own and is also used/needed for https://github.com/rust-lang/crates.io/pull/2705 :)