### PR TITLE
tests: Extract `TestApp::emails()` and `TestApp::emails_snapshot()` fns

### DIFF
--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -21,7 +21,7 @@ async fn github_secret_alert_revokes_token() {
     let (app, anon, user, token) = TestApp::init().with_token();
 
     // Ensure no emails were sent up to this point
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 
     // Ensure that the token currently exists in the database
     app.db(|conn| {
@@ -65,7 +65,7 @@ async fn github_secret_alert_revokes_token() {
     });
 
     // Ensure exactly one email was sent
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -73,7 +73,7 @@ async fn github_secret_alert_for_revoked_token() {
     let (app, anon, user, token) = TestApp::init().with_token();
 
     // Ensure no emails were sent up to this point
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 
     // Ensure that the token currently exists in the database
     app.db(|conn| {
@@ -120,7 +120,7 @@ async fn github_secret_alert_for_revoked_token() {
     });
 
     // Ensure still no emails were sent
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -128,7 +128,7 @@ async fn github_secret_alert_for_unknown_token() {
     let (app, anon, user, token) = TestApp::init().with_token();
 
     // Ensure no emails were sent up to this point
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 
     // Ensure that the token currently exists in the database
     app.db(|conn| {
@@ -159,7 +159,7 @@ async fn github_secret_alert_for_unknown_token() {
     });
 
     // Ensure still no emails were sent
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -5,7 +5,7 @@ use crates_io::{models::ApiToken, schema::api_tokens};
 use diesel::prelude::*;
 use googletest::prelude::*;
 use http::StatusCode;
-use insta::assert_json_snapshot;
+use insta::{assert_json_snapshot, assert_snapshot};
 
 static URL: &str = "/api/github/secret-scanning/verify";
 
@@ -65,7 +65,7 @@ async fn github_secret_alert_revokes_token() {
     });
 
     // Ensure exactly one email was sent
-    assert_eq!(app.emails().len(), 1);
+    assert_snapshot!(app.emails_snapshot());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -244,7 +244,7 @@ async fn invite_already_invited_user() {
     app.db(|conn| CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(conn));
 
     // Ensure no emails were sent up to this point
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 
     // Invite the user the first time
     let response = owner.add_named_owner("crate_name", "invited_user").await;
@@ -258,7 +258,7 @@ async fn invite_already_invited_user() {
     );
 
     // Check one email was sent, this will be the ownership invite email
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 
     // Then invite the user a second time, the message should point out the user is already invited
     let response = owner.add_named_owner("crate_name", "invited_user").await;
@@ -272,7 +272,7 @@ async fn invite_already_invited_user() {
     );
 
     // Check that no new email is sent after the second invitation
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -283,7 +283,7 @@ async fn invite_with_existing_expired_invite() {
         app.db(|conn| CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(conn));
 
     // Ensure no emails were sent up to this point
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 
     // Invite the user the first time
     let response = owner.add_named_owner("crate_name", "invited_user").await;
@@ -297,7 +297,7 @@ async fn invite_with_existing_expired_invite() {
     );
 
     // Check one email was sent, this will be the ownership invite email
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 
     // Simulate the previous invite expiring
     expire_invitation(&app, krate.id);
@@ -314,7 +314,7 @@ async fn invite_with_existing_expired_invite() {
     );
 
     // Check that the email for the second invite was sent
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 2);
+    assert_eq!(app.emails().len(), 2);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -395,7 +395,7 @@ async fn no_invite_emails_for_txn_rollback() {
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find user with login `bananas`"}]}"#);
 
     // No emails should have been sent.
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 0);
+    assert_eq!(app.emails().len(), 0);
 
     // Remove the bad username.
     let _ = usernames.pop();
@@ -404,5 +404,5 @@ async fn no_invite_emails_for_txn_rollback() {
     assert_eq!(response.status(), StatusCode::OK);
 
     // 9 emails to the good invitees should have been sent.
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 9);
+    assert_eq!(app.emails().len(), 9);
 }

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -27,7 +27,7 @@ async fn create_token_invalid_request() {
         response.json(),
         json!({ "errors": [{ "detail": "invalid new token request: Error(\"missing field `api_token`\", line: 1, column: 14)" }] })
     );
-    assert!(app.as_inner().emails.mails_in_memory().unwrap().is_empty());
+    assert!(app.emails().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -40,7 +40,7 @@ async fn create_token_no_name() {
         response.json(),
         json!({ "errors": [{ "detail": "name must have a value" }] })
     );
-    assert!(app.as_inner().emails.mails_in_memory().unwrap().is_empty());
+    assert!(app.emails().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -58,7 +58,7 @@ async fn create_token_exceeded_tokens_per_user() {
         response.json(),
         json!({ "errors": [{ "detail": "maximum tokens per user is: 500" }] })
     );
-    assert!(app.as_inner().emails.mails_in_memory().unwrap().is_empty());
+    assert!(app.emails().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -85,7 +85,7 @@ async fn create_token_success() {
     assert_eq!(tokens[0].last_used_at, None);
     assert_eq!(tokens[0].crate_scopes, None);
     assert_eq!(tokens[0].endpoint_scopes, None);
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -123,7 +123,7 @@ async fn cannot_create_token_with_token() {
         response.json(),
         json!({ "errors": [{ "detail": "cannot use an API token to create a new API token" }] })
     );
-    assert!(app.as_inner().emails.mails_in_memory().unwrap().is_empty());
+    assert!(app.emails().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -169,7 +169,7 @@ async fn create_token_with_scopes() {
         tokens[0].endpoint_scopes,
         Some(vec![EndpointScope::PublishUpdate])
     );
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -206,7 +206,7 @@ async fn create_token_with_null_scopes() {
     assert_eq!(tokens[0].last_used_at, None);
     assert_eq!(tokens[0].crate_scopes, None);
     assert_eq!(tokens[0].endpoint_scopes, None);
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -229,7 +229,7 @@ async fn create_token_with_empty_crate_scope() {
         response.json(),
         json!({ "errors": [{ "detail": "invalid crate scope" }] })
     );
-    assert!(app.as_inner().emails.mails_in_memory().unwrap().is_empty());
+    assert!(app.emails().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -252,7 +252,7 @@ async fn create_token_with_invalid_endpoint_scope() {
         response.json(),
         json!({ "errors": [{ "detail": "invalid endpoint scope" }] })
     );
-    assert!(app.as_inner().emails.mails_in_memory().unwrap().is_empty());
+    assert!(app.emails().is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -278,5 +278,5 @@ async fn create_token_with_expiry_date() {
         ".api_token.last_used_at" => "[datetime]",
         ".api_token.token" => insta::api_token_redaction(),
     });
-    assert_eq!(app.as_inner().emails.mails_in_memory().unwrap().len(), 1);
+    assert_eq!(app.emails().len(), 1);
 }

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -5,6 +5,7 @@ use crates_io::models::ApiToken;
 use diesel::prelude::*;
 use googletest::prelude::*;
 use http::StatusCode;
+use insta::assert_snapshot;
 use serde_json::Value;
 
 static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;
@@ -85,7 +86,8 @@ async fn create_token_success() {
     assert_eq!(tokens[0].last_used_at, None);
     assert_eq!(tokens[0].crate_scopes, None);
     assert_eq!(tokens[0].endpoint_scopes, None);
-    assert_eq!(app.emails().len(), 1);
+
+    assert_snapshot!(app.emails_snapshot());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -169,7 +171,8 @@ async fn create_token_with_scopes() {
         tokens[0].endpoint_scopes,
         Some(vec![EndpointScope::PublishUpdate])
     );
-    assert_eq!(app.emails().len(), 1);
+
+    assert_snapshot!(app.emails_snapshot());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -206,7 +209,8 @@ async fn create_token_with_null_scopes() {
     assert_eq!(tokens[0].last_used_at, None);
     assert_eq!(tokens[0].crate_scopes, None);
     assert_eq!(tokens[0].endpoint_scopes, None);
-    assert_eq!(app.emails().len(), 1);
+
+    assert_snapshot!(app.emails_snapshot());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -278,5 +282,6 @@ async fn create_token_with_expiry_date() {
         ".api_token.last_used_at" => "[datetime]",
         ".api_token.token" => insta::api_token_redaction(),
     });
-    assert_eq!(app.emails().len(), 1);
+
+    assert_snapshot!(app.emails_snapshot());
 }

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success-2.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/routes/me/tokens/create.rs
+expression: app.emails_snapshot()
+---
+To: foo@example.com
+From: noreply@crates.io
+Subject: New API token created
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello foo!
+
+A new API token with the name "bar" was recently added to your crates.io ac=
+count.
+
+If this wasn't you, you should revoke the token immediately: https://crates=
+.io/settings/tokens

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date-2.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/routes/me/tokens/create.rs
+expression: app.emails_snapshot()
+---
+To: foo@example.com
+From: noreply@crates.io
+Subject: New API token created
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello foo!
+
+A new API token with the name "bar" was recently added to your crates.io ac=
+count.
+
+If this wasn't you, you should revoke the token immediately: https://crates=
+.io/settings/tokens

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes-2.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/routes/me/tokens/create.rs
+expression: app.emails_snapshot()
+---
+To: foo@example.com
+From: noreply@crates.io
+Subject: New API token created
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello foo!
+
+A new API token with the name "bar" was recently added to your crates.io ac=
+count.
+
+If this wasn't you, you should revoke the token immediately: https://crates=
+.io/settings/tokens

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes-2.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/routes/me/tokens/create.rs
+expression: app.emails_snapshot()
+---
+To: foo@example.com
+From: noreply@crates.io
+Subject: New API token created
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello foo!
+
+A new API token with the name "bar" was recently added to your crates.io ac=
+count.
+
+If this wasn't you, you should revoke the token immediately: https://crates=
+.io/settings/tokens

--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token-2.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token-2.snap
@@ -1,0 +1,23 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: app.emails_snapshot()
+---
+To: foo@example.com
+From: noreply@crates.io
+Subject: Exposed API token found
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+GitHub has notified us that your crates.io API token bar
+
+has been exposed publicly. We have revoked this token as a precaution.
+
+Please review your account at https://crates.io to confirm that no
+
+unexpected changes have been made to your settings or crates.
+
+
+
+Source type: some_source
+
+URL where the token was found: some_url

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -18,7 +18,9 @@ use crates_io_worker::Runner;
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
+use regex::Regex;
 use std::collections::HashSet;
+use std::sync::LazyLock;
 use std::{rc::Rc, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 use tokio::task::block_in_place;
@@ -169,6 +171,19 @@ impl TestApp {
     pub fn emails(&self) -> Vec<String> {
         let emails = self.as_inner().emails.mails_in_memory().unwrap();
         emails.into_iter().map(|(_, email)| email).collect()
+    }
+
+    pub fn emails_snapshot(&self) -> String {
+        static EMAIL_HEADER_REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"(Message-ID|Date): [^\r\n]+\r\n").unwrap());
+
+        static SEPARATOR: &str = "\n----------------------------------------\n\n";
+
+        self.emails()
+            .iter()
+            .map(|email| EMAIL_HEADER_REGEX.replace_all(email, ""))
+            .collect::<Vec<_>>()
+            .join(SEPARATOR)
     }
 
     pub async fn run_pending_background_jobs(&self) {

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -166,6 +166,11 @@ impl TestApp {
             .collect()
     }
 
+    pub fn emails(&self) -> Vec<String> {
+        let emails = self.as_inner().emails.mails_in_memory().unwrap();
+        emails.into_iter().map(|(_, email)| email).collect()
+    }
+
     pub async fn run_pending_background_jobs(&self) {
         let runner = &self.0.runner;
         let runner = runner.as_ref().expect("Index has not been initialized");

--- a/src/tests/worker/snapshots/all__worker__sync_admins__sync_admins_job.snap
+++ b/src/tests/worker/snapshots/all__worker__sync_admins__sync_admins_job.snap
@@ -1,8 +1,31 @@
 ---
 source: src/tests/worker/sync_admins.rs
-expression: emails
+expression: app.emails_snapshot()
 ---
-[
-    "To: existing-admin@crates.io\r\nFrom: noreply@crates.io\r\nSubject: crates.io: Admin account changes\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nGranted admin access:\r\n\r\n- new-admin (github_id: 3)\r\n\r\nRevoked admin access:\r\n- obsolete-admin (github_id: 2)\r\n",
-    "To: obsolete-admin@crates.io\r\nFrom: noreply@crates.io\r\nSubject: crates.io: Admin account changes\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nGranted admin access:\r\n\r\n- new-admin (github_id: 3)\r\n\r\nRevoked admin access:\r\n- obsolete-admin (github_id: 2)\r\n",
-]
+To: existing-admin@crates.io
+From: noreply@crates.io
+Subject: crates.io: Admin account changes
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Granted admin access:
+
+- new-admin (github_id: 3)
+
+Revoked admin access:
+- obsolete-admin (github_id: 2)
+
+----------------------------------------
+
+To: obsolete-admin@crates.io
+From: noreply@crates.io
+Subject: crates.io: Admin account changes
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Granted admin access:
+
+- new-admin (github_id: 3)
+
+Revoked admin access:
+- obsolete-admin (github_id: 2)

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -41,11 +41,11 @@ async fn test_sync_admins_job() {
     assert_eq!(admins, expected_admins);
 
     let email_header_regex = Regex::new(r"(Message-ID|Date): [^\r\n]+\r\n").unwrap();
-    let emails = app.as_inner().emails.mails_in_memory().unwrap();
-    let emails = emails
-        .iter()
-        .map(|(_, email)| email_header_regex.replace_all(email, ""))
-        .collect::<Vec<_>>();
+    let emails = app
+        .emails()
+        .into_iter()
+        .map(|email| email_header_regex.replace_all(&email, "").into())
+        .collect::<Vec<String>>();
 
     assert_debug_snapshot!(emails);
 
@@ -54,8 +54,7 @@ async fn test_sync_admins_job() {
     app.db(|conn| SyncAdmins.enqueue(conn).unwrap());
     app.run_pending_background_jobs().await;
 
-    let emails = app.as_inner().emails.mails_in_memory().unwrap();
-    assert_eq!(emails.len(), 2);
+    assert_eq!(app.emails().len(), 2);
 }
 
 fn mock_permission(people: Vec<Person>) -> Permission {

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -5,8 +5,7 @@ use crates_io::worker::jobs::SyncAdmins;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel::{PgConnection, QueryResult, RunQueryDsl};
-use insta::assert_debug_snapshot;
-use regex::Regex;
+use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_admins_job() {
@@ -40,14 +39,7 @@ async fn test_sync_admins_job() {
     let expected_admins = vec![("existing-admin".into(), 1), ("new-admin".into(), 3)];
     assert_eq!(admins, expected_admins);
 
-    let email_header_regex = Regex::new(r"(Message-ID|Date): [^\r\n]+\r\n").unwrap();
-    let emails = app
-        .emails()
-        .into_iter()
-        .map(|email| email_header_regex.replace_all(&email, "").into())
-        .collect::<Vec<String>>();
-
-    assert_debug_snapshot!(emails);
+    assert_snapshot!(app.emails_snapshot());
 
     // Run the job again to verify that no new emails are sent
     // for `new-admin-without-account`.


### PR DESCRIPTION
This makes it slightly easier to write assertions for the emails that we are sending out. For `emails_snapshot()` the `Message-ID` and `Date` headers are automatically removed and the emails are then concatenated with a separator to work directly with the `assert_snapshot!()` macro from `insta`.