### PR TITLE
style: fix broken rustdoc comment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ rust_2018_compatibility = "warn"
 rust_2021_compatibility = "warn"
 unused = "warn"
 
+[workspace.lints.rustdoc]
+unescaped_backticks = "warn"
+
 [workspace.lints.clippy]
 dbg_macro = "warn"
 todo = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 //! implemented in the [category](category/index.html), [keyword](keyword/index.html),
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 
+// <https://doc.rust-lang.org/rustdoc/lints.html#unescaped_backticks>
+#![warn(rustdoc::unescaped_backticks)]
+
 #[cfg(test)]
 #[macro_use]
 extern crate claims;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,6 @@
 //! implemented in the [category](category/index.html), [keyword](keyword/index.html),
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 
-// <https://doc.rust-lang.org/rustdoc/lints.html#unescaped_backticks>
-#![warn(rustdoc::unescaped_backticks)]
-
 #[cfg(test)]
 #[macro_use]
 extern crate claims;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -116,7 +116,7 @@ impl TestApp {
     }
 
     /// Create a new user with a verified email address in the database
-    /// (`<username>@example.com``) and return a mock user session.
+    /// (`<username>@example.com`) and return a mock user session.
     ///
     /// This method updates the database directly
     pub fn db_new_user(&self, username: &str) -> MockCookieUser {


### PR DESCRIPTION
Cleans up the bad comment formatting I introduced in https://github.com/rust-lang/crates.io/pull/9322, and enables a [rustdoc lint] to try and catch repeats in the future.

[rustdoc lint]: https://doc.rust-lang.org/rustdoc/lints.html#unescaped_backticks

---

* ci: lint for broken inline code / backticks (559b51b18)
      
      Enables the rustdoc "unescaped_backticks" lint[1] at warn level.
      
      Unfortunately this only covers "prod" code, so it doesn't catch the
      actual broken backticks in the test code!
      
      [1]: https://doc.rust-lang.org/rustdoc/lints.html#unescaped_backticks

* style: remove spurious backtick (5c34d6602)
      
      This breaks the rustdoc rendering.

