### PR TITLE
refactor: separate `Crate::owner_add` model concerns

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -1,18 +1,19 @@
 //! All routes related to managing owners of a crate
 
-use crate::app::AppState;
-use crate::auth::AuthCheck;
-use crate::models::token::EndpointScope;
+use crate::models::{krate::NewOwnerInvite, token::EndpointScope};
 use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::tasks::spawn_blocking;
 use crate::util::errors::{bad_request, crate_not_found, custom, AppResult};
 use crate::views::EncodableOwner;
+use crate::{app::AppState, models::krate::OwnerAddError};
+use crate::{auth::AuthCheck, email::Email};
 use axum::extract::Path;
 use axum::Json;
 use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use http::StatusCode;
+use secrecy::{ExposeSecret, Secret};
 use serde_json::Value;
 use tokio::runtime::Handle;
 
@@ -171,11 +172,44 @@ async fn modify_owners(
                     if owners.iter().any(login_test) {
                         return Err(bad_request(format_args!("`{login}` is already an owner")));
                     }
-                    let (msg, maybe_email) = krate.owner_add(&app, conn, user, login)?;
-                    msgs.push(msg);
 
-                    if let Some(v) = maybe_email {
-                        emails.push(v);
+                    match krate.owner_add(&app, conn, user, login) {
+                        // A user was successfully invited, and they must accept
+                        // the invite, and a best-effort attempt should be made
+                        // to email them the invite token for one-click
+                        // acceptance.
+                        Ok(NewOwnerInvite::User(invitee, token)) => {
+                            msgs.push(format!(
+                                "user {} has been invited to be an owner of crate {}",
+                                invitee.gh_login, krate.name,
+                            ));
+
+                            if let Some(recipient) = invitee.verified_email(conn).ok().flatten() {
+                                emails.push(OwnerInviteEmail {
+                                    recipient_email_address: recipient,
+                                    inviter: user.gh_login.clone(),
+                                    domain: app.emails.domain.clone(),
+                                    crate_name: krate.name.clone(),
+                                    token,
+                                });
+                            }
+                        }
+
+                        // A team was successfully invited. They are immediately
+                        // added, and do not have an invite token.
+                        Ok(NewOwnerInvite::Team(team)) => msgs.push(format!(
+                            "team {} has been added as an owner of crate {}",
+                            team.login, krate.name
+                        )),
+
+                        // This user has a pending invite.
+                        Err(OwnerAddError::AlreadyInvited(user)) => msgs.push(format!(
+                            "user {} already has a pending invitation to be an owner of crate {}",
+                            user.gh_login, krate.name
+                        )),
+
+                        // An opaque error occurred.
+                        Err(OwnerAddError::AppError(e)) => return Err(e),
                     }
                 }
                 msgs.join(",")
@@ -209,4 +243,42 @@ async fn modify_owners(
         Ok(Json(json!({ "ok": true, "msg": comma_sep_msg })))
     })
     .await
+}
+
+pub struct OwnerInviteEmail {
+    /// The destination email address for this email.
+    recipient_email_address: String,
+
+    /// Email body variables.
+    inviter: String,
+    domain: String,
+    crate_name: String,
+    token: Secret<String>,
+}
+
+impl OwnerInviteEmail {
+    pub fn recipient_email_address(&self) -> &str {
+        &self.recipient_email_address
+    }
+}
+
+impl Email for OwnerInviteEmail {
+    fn subject(&self) -> String {
+        format!(
+            "crates.io: Ownership invitation for \"{}\"",
+            self.crate_name
+        )
+    }
+
+    fn body(&self) -> String {
+        format!(
+            "{user_name} has invited you to become an owner of the crate {crate_name}!\n
+Visit https://{domain}/accept-invite/{token} to accept this invitation,
+or go to https://{domain}/me/pending-invites to manage all of your crate ownership invitations.",
+            user_name = self.inviter,
+            domain = self.domain,
+            crate_name = self.crate_name,
+            token = self.token.expose_secret(),
+        )
+    }
 }

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -355,6 +355,32 @@ async fn check_ownership_one_crate() {
     assert_eq!(json.users[0].name, user.name);
 }
 
+/// Assert the error response when attempting to add a team as a crate owner
+/// when that team is already a crate owner.
+#[tokio::test(flavor = "multi_thread")]
+async fn add_existing_team() {
+    let (app, _, user, token) = TestApp::init().with_token();
+    let user = user.as_model();
+
+    let _team = app.db(|conn| {
+        let t = new_team("github:test_org:bananas")
+            .create_or_update(conn)
+            .unwrap();
+        let krate = CrateBuilder::new("best_crate", user.id).expect_build(conn);
+        add_team_to_crate(&t, &krate, user, conn).unwrap();
+        t
+    });
+
+    let ret = token
+        .add_named_owner("best_crate", "github:test_org:bananas")
+        .await;
+    assert_eq!(ret.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        ret.text(),
+        r#"{"errors":[{"detail":"`github:test_org:bananas` is already an owner"}]}"#
+    );
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn deleted_ownership_isnt_in_owner_user() {
     let (app, anon, user) = TestApp::init().with_user();


### PR DESCRIPTION
This PR pulls out the non-database concerns from `Crate::owner_add()`, moving them to the controller instead.

This gives the controller the responsibility of generating API responses and emails, giving it better visibility into what the model call did.

Part of https://github.com/rust-lang/crates.io/issues/2639

---

* refactor: separate Crate::owner_add model concerns (f38edb075)
      
      This separates out the concerns of interacting with the database via the
      Crate model, moving management of invites (emailing, response
      generation, what is considered success) to the controller.
      
      This will simplify future work on rust-lang/crates.io#2639 by allowing
      the controller to inspect the result of the owner_add() call to see if
      an invite was generated, or already existed without having to peek at
      strings.

* test: assert error response when re-inviting team (9c88b223a)
      
      Asserting an error response was returned when adding an existing user
      was covered, but not teams.

