### PR TITLE
tests/owners: Add invite email snapshot assertions

### DIFF
--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -135,6 +135,8 @@ async fn new_crate_owner() {
     let user2 = app.db_new_user("Bar");
     token.add_named_owner("foo_owner", "BAR").await.good();
 
+    assert_snapshot!(app.emails_snapshot());
+
     // accept invitation for user to be added as owner
     let krate: Crate = app.db(|conn| Crate::by_name("foo_owner").first(conn).unwrap());
     user2
@@ -224,6 +226,8 @@ async fn modify_multiple_owners() {
     let user2 = create_and_add_owner(&app, &token, "user2", &krate).await;
     let user3 = create_and_add_owner(&app, &token, "user3", &krate).await;
 
+    assert_snapshot!(app.emails_snapshot());
+
     // Deleting all owners is not allowed.
     let response = token
         .remove_named_owners("owners_multiple", &[username, "user2", "user3"])
@@ -269,6 +273,8 @@ async fn modify_multiple_owners() {
             "ok": true,
         })
     );
+
+    assert_snapshot!(app.emails_snapshot());
 
     user2
         .accept_ownership_invitation(&krate.name, krate.id)

--- a/src/tests/snapshots/all__owners__modify_multiple_owners-2.snap
+++ b/src/tests/snapshots/all__owners__modify_multiple_owners-2.snap
@@ -1,0 +1,58 @@
+---
+source: src/tests/owners.rs
+expression: app.emails_snapshot()
+---
+To: user2@example.com
+From: noreply@crates.io
+Subject: crates.io: Ownership invitation for "owners_multiple"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+foo has invited you to become an owner of the crate owners_multiple!
+
+Visit https://crates.io/accept-invite/[invite-token] to accept =
+this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate o=
+wnership invitations.
+----------------------------------------
+
+To: user3@example.com
+From: noreply@crates.io
+Subject: crates.io: Ownership invitation for "owners_multiple"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+foo has invited you to become an owner of the crate owners_multiple!
+
+Visit https://crates.io/accept-invite/[invite-token] to accept =
+this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate o=
+wnership invitations.
+----------------------------------------
+
+To: user2@example.com
+From: noreply@crates.io
+Subject: crates.io: Ownership invitation for "owners_multiple"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+foo has invited you to become an owner of the crate owners_multiple!
+
+Visit https://crates.io/accept-invite/[invite-token] to accept =
+this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate o=
+wnership invitations.
+----------------------------------------
+
+To: user3@example.com
+From: noreply@crates.io
+Subject: crates.io: Ownership invitation for "owners_multiple"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+foo has invited you to become an owner of the crate owners_multiple!
+
+Visit https://crates.io/accept-invite/[invite-token] to accept =
+this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate o=
+wnership invitations.

--- a/src/tests/snapshots/all__owners__modify_multiple_owners.snap
+++ b/src/tests/snapshots/all__owners__modify_multiple_owners.snap
@@ -1,0 +1,30 @@
+---
+source: src/tests/owners.rs
+expression: app.emails_snapshot()
+---
+To: user2@example.com
+From: noreply@crates.io
+Subject: crates.io: Ownership invitation for "owners_multiple"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+foo has invited you to become an owner of the crate owners_multiple!
+
+Visit https://crates.io/accept-invite/[invite-token] to accept =
+this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate o=
+wnership invitations.
+----------------------------------------
+
+To: user3@example.com
+From: noreply@crates.io
+Subject: crates.io: Ownership invitation for "owners_multiple"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+foo has invited you to become an owner of the crate owners_multiple!
+
+Visit https://crates.io/accept-invite/[invite-token] to accept =
+this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate o=
+wnership invitations.

--- a/src/tests/snapshots/all__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/all__owners__new_crate_owner.snap
@@ -1,0 +1,16 @@
+---
+source: src/tests/owners.rs
+expression: app.emails_snapshot()
+---
+To: Bar@example.com
+From: noreply@crates.io
+Subject: crates.io: Ownership invitation for "foo_owner"
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+foo has invited you to become an owner of the crate foo_owner!
+
+Visit https://crates.io/accept-invite/[invite-token] to accept =
+this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate o=
+wnership invitations.

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -177,11 +177,18 @@ impl TestApp {
         static EMAIL_HEADER_REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"(Message-ID|Date): [^\r\n]+\r\n").unwrap());
 
+        static INVITE_TOKEN_REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"/accept-invite/\w+").unwrap());
+
         static SEPARATOR: &str = "\n----------------------------------------\n\n";
 
         self.emails()
-            .iter()
-            .map(|email| EMAIL_HEADER_REGEX.replace_all(email, ""))
+            .into_iter()
+            .map(|email| {
+                let email = EMAIL_HEADER_REGEX.replace_all(&email, "");
+                let email = INVITE_TOKEN_REGEX.replace_all(&email, "/accept-invite/[invite-token]");
+                email.to_string()
+            })
             .collect::<Vec<_>>()
             .join(SEPARATOR)
     }


### PR DESCRIPTION
This PR adjusts the `TestApp::emails_snapshot()` fn to redact invite tokens to make the snapshots stable across reruns, and then adds a couple more email snapshot assertions to the owner invite tests.