### PR TITLE
email: Change `from` to `crates.io <no-reply@crates.io>`

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -7,7 +7,7 @@ use lettre::transport::file::FileTransport;
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};
 use lettre::transport::smtp::SmtpTransport;
 use lettre::transport::stub::StubTransport;
-use lettre::{Message, Transport};
+use lettre::{Address, Message, Transport};
 use rand::distributions::{Alphanumeric, DistString};
 
 pub trait Email {
@@ -19,7 +19,7 @@ pub trait Email {
 pub struct Emails {
     backend: EmailBackend,
     pub domain: String,
-    from: Mailbox,
+    from: Address,
 }
 
 const DEFAULT_FROM: &str = "noreply@crates.io";
@@ -97,13 +97,15 @@ impl Emails {
             self.domain,
         );
 
+        let from = Mailbox::new(Some(self.domain.clone()), self.from.clone());
+
         let subject = email.subject();
         let body = email.body();
 
         let email = Message::builder()
             .message_id(Some(message_id.clone()))
             .to(recipient.parse()?)
-            .from(self.from.clone())
+            .from(from)
             .subject(subject)
             .header(ContentType::TEXT_PLAIN)
             .body(body)?;

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success-2.snap
@@ -3,7 +3,7 @@ source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
 ---
 To: foo@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: New API token "bar" created
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date-2.snap
@@ -3,7 +3,7 @@ source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
 ---
 To: foo@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: New API token "bar" created
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes-2.snap
@@ -3,7 +3,7 @@ source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
 ---
 To: foo@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: New API token "bar" created
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes-2.snap
@@ -3,7 +3,7 @@ source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
 ---
 To: foo@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: New API token "bar" created
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token-2.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token-2.snap
@@ -3,7 +3,7 @@ source: src/tests/github_secret_scanning.rs
 expression: app.emails_snapshot()
 ---
 To: foo@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Your API token "bar" has been revoked
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/snapshots/all__owners__modify_multiple_owners-2.snap
+++ b/src/tests/snapshots/all__owners__modify_multiple_owners-2.snap
@@ -3,7 +3,7 @@ source: src/tests/owners.rs
 expression: app.emails_snapshot()
 ---
 To: user2@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Ownership invitation for "owners_multiple"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
@@ -17,7 +17,7 @@ wnership invitations.
 ----------------------------------------
 
 To: user3@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Ownership invitation for "owners_multiple"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
@@ -31,7 +31,7 @@ wnership invitations.
 ----------------------------------------
 
 To: user2@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Ownership invitation for "owners_multiple"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
@@ -45,7 +45,7 @@ wnership invitations.
 ----------------------------------------
 
 To: user3@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Ownership invitation for "owners_multiple"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/snapshots/all__owners__modify_multiple_owners.snap
+++ b/src/tests/snapshots/all__owners__modify_multiple_owners.snap
@@ -3,7 +3,7 @@ source: src/tests/owners.rs
 expression: app.emails_snapshot()
 ---
 To: user2@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Ownership invitation for "owners_multiple"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
@@ -17,7 +17,7 @@ wnership invitations.
 ----------------------------------------
 
 To: user3@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Ownership invitation for "owners_multiple"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/snapshots/all__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/all__owners__new_crate_owner.snap
@@ -3,7 +3,7 @@ source: src/tests/owners.rs
 expression: app.emails_snapshot()
 ---
 To: Bar@example.com
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Ownership invitation for "foo_owner"
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable

--- a/src/tests/worker/snapshots/all__worker__sync_admins__sync_admins_job.snap
+++ b/src/tests/worker/snapshots/all__worker__sync_admins__sync_admins_job.snap
@@ -3,7 +3,7 @@ source: src/tests/worker/sync_admins.rs
 expression: app.emails_snapshot()
 ---
 To: existing-admin@crates.io
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Admin account changes
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit
@@ -18,7 +18,7 @@ Revoked admin access:
 ----------------------------------------
 
 To: obsolete-admin@crates.io
-From: noreply@crates.io
+From: crates.io <noreply@crates.io>
 Subject: crates.io: Admin account changes
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: 7bit


### PR DESCRIPTION
So far we had only used `no-reply@crates.io` without a `name` in the `Mailbox`. This changes the `Mailbox` instance to use the configured `domain` as the name, which means that users will see e.g. "crates.io" as the sender instead of "no-reply@crates.io".