### PR TITLE
Fix links without href being hard to read on dark theme

### DIFF
--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -125,7 +125,7 @@ a, .link {
 
 /* Using `:not(...)` here for specificity reasons */
 a:not([href]) {
-    color: initial;
+    color: unset;
     cursor: initial;
 }
 


### PR DESCRIPTION
Fixes #9330 

In dark mode, `color: initial` was causing it to revert to the browser default of black which is too similar to the dark gray background.

Now links without href will use `color: unset` so it acts as if the text color is not changed from previous context, which seems to be the original intent of setting `color: initial`.