### PR TITLE
dump-db: Remove `version_downloads` export filter

### DIFF
--- a/src/tests/snapshots/all__dump_db__sql_scripts@export.sql.snap
+++ b/src/tests/snapshots/all__dump_db__sql_scripts@export.sql.snap
@@ -20,6 +20,5 @@ BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
     \copy "versions" ("bin_names", "checksum", "crate_id", "crate_size", "created_at", "downloads", "features", "has_lib", "id", "license", "links", "num", "published_by", "rust_version", "updated_at", "yanked") TO 'data/versions.csv' WITH CSV HEADER
     \copy "default_versions" ("crate_id", "version_id") TO 'data/default_versions.csv' WITH CSV HEADER
     \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") TO 'data/dependencies.csv' WITH CSV HEADER
-    \copy (SELECT "date", "downloads", "version_id" FROM "version_downloads" WHERE date > current_date - interval '90 day') TO 'data/version_downloads.csv' WITH CSV HEADER
-
+    \copy "version_downloads" ("date", "downloads", "version_id") TO 'data/version_downloads.csv' WITH CSV HEADER
 COMMIT;

--- a/src/worker/jobs/dump_db/dump-db.toml
+++ b/src/worker/jobs/dump_db/dump-db.toml
@@ -198,7 +198,6 @@ gh_access_token = "''"
 
 [version_downloads]
 dependencies = ["versions"]
-filter = "date > current_date - interval '90 day'"
 [version_downloads.columns]
 version_id = "public"
 downloads = "public"


### PR DESCRIPTION
We are regularly exporting the version downloads to S3 these days, so we don't need to actively filter the data anymore when preparing the database dump.