### PR TITLE
Validate email addresses before saving them to the database

### DIFF
--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -5,6 +5,7 @@ use axum::Json;
 use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
+use lettre::Address;
 use secrecy::{ExposeSecret, SecretString};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -151,6 +152,10 @@ pub async fn update_user(
         if user_email.is_empty() {
             return Err(bad_request("empty email rejected"));
         }
+
+        user_email
+            .parse::<Address>()
+            .map_err(|_| bad_request("invalid email address"))?;
 
         conn.transaction::<_, BoxedAppError, _>(|conn| {
             let new_email = NewEmail {

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -96,3 +96,13 @@ async fn test_other_users_cannot_change_my_email() {
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_email_address() {
+    let (_app, _, user) = TestApp::init().with_user();
+    let model = user.as_model();
+
+    let response = user.update_email_more_control(model.id, Some("foo")).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid email address"}]}"###);
+}


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/pull/921 introduced a way for users to change their registered email addresses, but the code in the PR did not check if the supplied email addresses are valid and only relied on the email verification process. This led us to having about two dozens "email addresses" in our database now that aren't actually valid email addresses (e.g. people replacing `@` with `[at]` and other fun examples).

This PR passes the supplied email address to a `.parse::<lettre::Address>()` call and returns an HTTP error if the supplied email is invalid.