### PR TITLE
controllers/user: Move `PUT /user/:user_id` endpoints to a dedicated module

### DIFF
--- a/src/controllers/user.rs
+++ b/src/controllers/user.rs
@@ -1,3 +1,6 @@
 pub mod me;
 pub mod other;
 pub mod session;
+pub mod update;
+
+pub use update::update_user;

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -1,0 +1,158 @@
+use crate::app::AppState;
+use crate::auth::AuthCheck;
+use crate::controllers::helpers::ok_true;
+use crate::models::{Email, NewEmail};
+use crate::schema::emails;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::{bad_request, server_error, AppResult};
+use crate::util::BytesRequest;
+use axum::extract::Path;
+use axum::response::Response;
+use diesel::dsl::sql;
+use diesel::prelude::*;
+use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+use lettre::Address;
+use secrecy::{ExposeSecret, SecretString};
+
+/// Handles the `PUT /users/:user_id` route.
+pub async fn update_user(
+    state: AppState,
+    Path(param_user_id): Path<i32>,
+    req: BytesRequest,
+) -> AppResult<Response> {
+    let conn = state.db_write().await?;
+    spawn_blocking(move || {
+        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+
+        let auth = AuthCheck::default().check(&req, conn)?;
+        let user = auth.user();
+
+        // need to check if current user matches user to be updated
+        if user.id != param_user_id {
+            return Err(bad_request("current user does not match requested user"));
+        }
+
+        #[derive(Deserialize)]
+        struct UserUpdate {
+            user: User,
+        }
+
+        #[derive(Deserialize)]
+        struct User {
+            email: Option<String>,
+        }
+
+        let user_update: UserUpdate =
+            serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;
+
+        let user_email = match &user_update.user.email {
+            Some(email) => email.trim(),
+            None => return Err(bad_request("empty email rejected")),
+        };
+
+        if user_email.is_empty() {
+            return Err(bad_request("empty email rejected"));
+        }
+
+        user_email
+            .parse::<Address>()
+            .map_err(|_| bad_request("invalid email address"))?;
+
+        let new_email = NewEmail {
+            user_id: user.id,
+            email: user_email,
+        };
+
+        let token = diesel::insert_into(emails::table)
+            .values(&new_email)
+            .on_conflict(emails::user_id)
+            .do_update()
+            .set(&new_email)
+            .returning(emails::token)
+            .get_result(conn)
+            .map(SecretString::new)
+            .map_err(|_| server_error("Error in creating token"))?;
+
+        // This swallows any errors that occur while attempting to send the email. Some users have
+        // an invalid email set in their GitHub profile, and we should let them sign in even though
+        // we're trying to silently use their invalid address during signup and can't send them an
+        // email. They'll then have to provide a valid email address.
+        let email = UserConfirmEmail {
+            user_name: &user.gh_login,
+            domain: &state.emails.domain,
+            token,
+        };
+
+        let _ = state.emails.send(user_email, email);
+
+        ok_true()
+    })
+    .await
+}
+
+/// Handles `PUT /user/:user_id/resend` route
+pub async fn regenerate_token_and_send(
+    state: AppState,
+    Path(param_user_id): Path<i32>,
+    req: Parts,
+) -> AppResult<Response> {
+    let conn = state.db_write().await?;
+    spawn_blocking(move || {
+        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+
+        let auth = AuthCheck::default().check(&req, conn)?;
+        let user = auth.user();
+
+        // need to check if current user matches user to be updated
+        if user.id != param_user_id {
+            return Err(bad_request("current user does not match requested user"));
+        }
+
+        conn.transaction(|conn| -> AppResult<_> {
+            let email: Email = diesel::update(Email::belonging_to(user))
+                .set(emails::token.eq(sql("DEFAULT")))
+                .get_result(conn)
+                .optional()?
+                .ok_or_else(|| bad_request("Email could not be found"))?;
+
+            let email1 = UserConfirmEmail {
+                user_name: &user.gh_login,
+                domain: &state.emails.domain,
+                token: email.token,
+            };
+
+            state.emails.send(&email.email, email1).map_err(Into::into)
+        })?;
+
+        ok_true()
+    })
+    .await
+}
+
+pub struct UserConfirmEmail<'a> {
+    pub user_name: &'a str,
+    pub domain: &'a str,
+    pub token: SecretString,
+}
+
+impl crate::email::Email for UserConfirmEmail<'_> {
+    fn subject(&self) -> String {
+        "crates.io: Please confirm your email address".into()
+    }
+
+    fn body(&self) -> String {
+        // Create a URL with token string as path to send to user
+        // If user clicks on path, look email/user up in database,
+        // make sure tokens match
+
+        format!(
+            "Hello {user_name}! Welcome to crates.io. Please click the
+link below to verify your email address. Thank you!\n
+https://{domain}/confirm/{token}",
+            user_name = self.user_name,
+            domain = self.domain,
+            token = self.token.expose_secret(),
+        )
+    }
+}

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -3,7 +3,7 @@ use diesel::prelude::*;
 use secrecy::SecretString;
 
 use crate::app::App;
-use crate::controllers::user::me::UserConfirmEmail;
+use crate::controllers::user::update::UserConfirmEmail;
 use crate::email::Emails;
 use crate::util::errors::AppResult;
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,6 +5,7 @@ use axum::Router;
 use http::{Method, StatusCode};
 
 use crate::app::AppState;
+use crate::controllers::user::update_user;
 use crate::controllers::*;
 use crate::util::errors::not_found;
 use crate::Env;
@@ -97,7 +98,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .route("/api/v1/category_slugs", get(category::slugs))
         .route(
             "/api/v1/users/:user_id",
-            get(user::other::show).put(user::me::update_user),
+            get(user::other::show).put(update_user),
         )
         .route("/api/v1/users/:user_id/stats", get(user::other::stats))
         .route("/api/v1/teams/:team_id", get(team::show_team))
@@ -132,7 +133,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         )
         .route(
             "/api/v1/users/:user_id/resend",
-            put(user::me::regenerate_token_and_send),
+            put(user::update::regenerate_token_and_send),
         )
         .route(
             "/api/v1/site_metadata",


### PR DESCRIPTION
This makes the code slightly easier to find, since these endpoints are unrelated to the ones in the `/me` namespace.