### PR TITLE
FeedId: Remove unnecessary allocations

### DIFF
--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -104,7 +104,7 @@ pub fn run(opts: Opts) -> anyhow::Result<()> {
         }
 
         info!(%name, "Deleting RSS feed from S3");
-        let feed_id = FeedId::Crate { name: name.clone() };
+        let feed_id = FeedId::Crate { name };
         if let Err(error) = rt.block_on(store.delete_feed(&feed_id)) {
             warn!(%name, ?error, "Failed to delete RSS feed from S3");
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -209,7 +209,7 @@ impl Storage {
     }
 
     /// Returns the URL of an uploaded RSS feed.
-    pub fn feed_url(&self, feed_id: &FeedId) -> String {
+    pub fn feed_url(&self, feed_id: &FeedId<'_>) -> String {
         apply_cdn_prefix(&self.cdn_prefix, &feed_id.into()).replace('+', "%2B")
     }
 
@@ -238,7 +238,7 @@ impl Storage {
     }
 
     #[instrument(skip(self))]
-    pub async fn delete_feed(&self, feed_id: &FeedId) -> Result<()> {
+    pub async fn delete_feed(&self, feed_id: &FeedId<'_>) -> Result<()> {
         let path = feed_id.into();
         self.store.delete(&path).await
     }
@@ -270,7 +270,7 @@ impl Storage {
     #[instrument(skip(self, channel))]
     pub async fn upload_feed(
         &self,
-        feed_id: &FeedId,
+        feed_id: &FeedId<'_>,
         channel: &rss::Channel,
     ) -> anyhow::Result<()> {
         let path = feed_id.into();
@@ -385,14 +385,14 @@ fn apply_cdn_prefix(cdn_prefix: &Option<String>, path: &Path) -> String {
 }
 
 #[derive(Debug)]
-pub enum FeedId {
-    Crate { name: String },
+pub enum FeedId<'a> {
+    Crate { name: &'a str },
     Crates,
     Updates,
 }
 
-impl From<&FeedId> for Path {
-    fn from(feed_id: &FeedId) -> Path {
+impl From<&FeedId<'_>> for Path {
+    fn from(feed_id: &FeedId<'_>) -> Path {
         match feed_id {
             FeedId::Crate { name } => format!("rss/crates/{name}.xml").into(),
             FeedId::Crates => "rss/crates.xml".into(),

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -52,7 +52,7 @@ impl BackgroundJob for SyncCrateFeed {
         })
         .await?;
 
-        let feed_id = FeedId::Crate { name: name.clone() };
+        let feed_id = FeedId::Crate { name };
 
         let link = rss::extension::atom::Link {
             href: ctx.storage.feed_url(&feed_id),


### PR DESCRIPTION
We don't need ownership of the `String`, we can work with string slices instead. This removes a couple of unnecessary `.clone()` calls.