### PR TITLE
smoke_test: Run `git commit` to work around cargo bug

### DIFF
--- a/crates/crates_io_smoke_test/src/cargo.rs
+++ b/crates/crates_io_smoke_test/src/cargo.rs
@@ -18,7 +18,7 @@ pub async fn new_lib(parent_path: &Path, name: &str) -> anyhow::Result<()> {
 #[allow(unstable_name_collisions)]
 pub async fn package(project_path: &Path) -> anyhow::Result<()> {
     Command::new("cargo")
-        .args(["package", "--allow-dirty"])
+        .args(["package"])
         .current_dir(project_path)
         .env("CARGO_TERM_COLOR", "always")
         .status()
@@ -30,7 +30,7 @@ pub async fn package(project_path: &Path) -> anyhow::Result<()> {
 #[allow(unstable_name_collisions)]
 pub async fn publish(project_path: &Path, token: &SecretString) -> anyhow::Result<()> {
     Command::new("cargo")
-        .args(["publish", "--registry", "staging", "--allow-dirty"])
+        .args(["publish", "--registry", "staging"])
         .current_dir(project_path)
         .env("CARGO_TERM_COLOR", "always")
         .env(

--- a/crates/crates_io_smoke_test/src/cargo.rs
+++ b/crates/crates_io_smoke_test/src/cargo.rs
@@ -16,6 +16,18 @@ pub async fn new_lib(parent_path: &Path, name: &str) -> anyhow::Result<()> {
 }
 
 #[allow(unstable_name_collisions)]
+pub async fn package(project_path: &Path) -> anyhow::Result<()> {
+    Command::new("cargo")
+        .args(["package", "--allow-dirty"])
+        .current_dir(project_path)
+        .env("CARGO_TERM_COLOR", "always")
+        .status()
+        .await?
+        .exit_ok()
+        .map_err(Into::into)
+}
+
+#[allow(unstable_name_collisions)]
 pub async fn publish(project_path: &Path, token: &SecretString) -> anyhow::Result<()> {
     Command::new("cargo")
         .args(["publish", "--registry", "staging", "--allow-dirty"])

--- a/crates/crates_io_smoke_test/src/git.rs
+++ b/crates/crates_io_smoke_test/src/git.rs
@@ -1,0 +1,25 @@
+use crate::exit_status_ext::ExitStatusExt;
+use std::path::Path;
+use tokio::process::Command;
+
+#[allow(unstable_name_collisions)]
+pub async fn add_all(project_path: &Path) -> anyhow::Result<()> {
+    Command::new("git")
+        .args(["add", "--all"])
+        .current_dir(project_path)
+        .status()
+        .await?
+        .exit_ok()
+        .map_err(Into::into)
+}
+
+#[allow(unstable_name_collisions)]
+pub async fn commit(project_path: &Path, message: &str) -> anyhow::Result<()> {
+    Command::new("git")
+        .args(["commit", "--message", message])
+        .current_dir(project_path)
+        .status()
+        .await?
+        .exit_ok()
+        .map_err(Into::into)
+}

--- a/crates/crates_io_smoke_test/src/main.rs
+++ b/crates/crates_io_smoke_test/src/main.rs
@@ -1,6 +1,7 @@
 mod api;
 mod cargo;
 mod exit_status_ext;
+mod git;
 
 #[macro_use]
 extern crate tracing;
@@ -223,6 +224,15 @@ description = "test crate"
             .await
             .context("Failed to write `README.md` file content")?;
     }
+
+    info!("Creating initial git commit…");
+    git::add_all(&project_path)
+        .await
+        .context("Failed to add initial changes to git")?;
+
+    git::commit(&project_path, "initial commit")
+        .await
+        .context("Failed to commit initial changes")?;
 
     Ok(project_path)
 }


### PR DESCRIPTION
This is a workaround for https://github.com/rust-lang/cargo/issues/14354, which currently prevents us from running our smoke tests.

cargo currently (Rust 1.81) crashes when `cargo publish` (or `cargo package`) is used on a git repository that has no commits yet. Since that is the setup we had been using for our smoke tests we are currently running into this issue. The solution in this PR runs `git add --all` and `git commit` as part of creating our dummy project, which resolves the problem on our end. As a nice bonus, this allows us to remove the `--allow-dirty` argument from the `cargo publish` call, since we have now committed all of our changes.