### PR TITLE
smoke_test: Set git username and email before committing

### DIFF
--- a/crates/crates_io_smoke_test/src/git.rs
+++ b/crates/crates_io_smoke_test/src/git.rs
@@ -3,6 +3,28 @@ use std::path::Path;
 use tokio::process::Command;
 
 #[allow(unstable_name_collisions)]
+pub async fn set_user_name(project_path: &Path, name: &str) -> anyhow::Result<()> {
+    Command::new("git")
+        .args(["config", "user.name", name])
+        .current_dir(project_path)
+        .status()
+        .await?
+        .exit_ok()
+        .map_err(Into::into)
+}
+
+#[allow(unstable_name_collisions)]
+pub async fn set_user_email(project_path: &Path, email: &str) -> anyhow::Result<()> {
+    Command::new("git")
+        .args(["config", "user.email", email])
+        .current_dir(project_path)
+        .status()
+        .await?
+        .exit_ok()
+        .map_err(Into::into)
+}
+
+#[allow(unstable_name_collisions)]
 pub async fn add_all(project_path: &Path) -> anyhow::Result<()> {
     Command::new("git")
         .args(["add", "--all"])

--- a/crates/crates_io_smoke_test/src/main.rs
+++ b/crates/crates_io_smoke_test/src/main.rs
@@ -226,6 +226,14 @@ description = "test crate"
     }
 
     info!("Creating initial git commit…");
+    git::set_user_name(&project_path, "crates-io-smoke-test")
+        .await
+        .context("Failed to set git user name")?;
+
+    git::set_user_email(&project_path, "smoke-test@crates.io")
+        .await
+        .context("Failed to set git user email")?;
+
     git::add_all(&project_path)
         .await
         .context("Failed to add initial changes to git")?;


### PR DESCRIPTION
On GitHub Actions the smoke test currently fails with:

```
Author identity unknown
*** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
Omit --global to set the identity only in this repository.
```

This change adds the necessary git commands to our setup to hopefully make the `git commit` call succeed now.

Related:

- #9405 