### PR TITLE
Change default API token expiration to 90 days

### DIFF
--- a/app/controllers/settings/tokens/new.js
+++ b/app/controllers/settings/tokens/new.js
@@ -97,7 +97,7 @@ export default class NewTokenController extends Controller {
   reset() {
     this.name = '';
     this.nameInvalid = false;
-    this.expirySelection = 'none';
+    this.expirySelection = '90';
     this.expiryDateInput = null;
     this.expiryDateInvalid = false;
     this.scopes = [];

--- a/app/templates/settings/tokens/new.hbs
+++ b/app/templates/settings/tokens/new.hbs
@@ -38,11 +38,11 @@
         data-test-expiry
         {{on "change" this.updateExpirySelection}}
       >
-        <option value="none" selected>No expiration</option>
+        <option value="none">No expiration</option>
         <option value="7">7 days</option>
         <option value="30">30 days</option>
         <option value="60">60 days</option>
-        <option value="90">90 days</option>
+        <option value="90" selected>90 days</option>
         <option value="365">365 days</option>
         <option value="custom">Custom...</option>
       </select>

--- a/e2e/routes/settings/tokens/new.spec.ts
+++ b/e2e/routes/settings/tokens/new.spec.ts
@@ -36,6 +36,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await expect(page).toHaveURL('/settings/tokens/new');
 
     await page.fill('[data-test-name]', 'token-name');
+    await page.locator('[data-test-expiry]').selectOption('none');
     await page.click('[data-test-scope="publish-update"]');
     await page.click('[data-test-generate]');
 
@@ -64,6 +65,7 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
     await expect(page).toHaveURL('/settings/tokens/new');
 
     await page.fill('[data-test-name]', 'token-name');
+    await page.locator('[data-test-expiry]').selectOption('none');
     await page.click('[data-test-scope="publish-update"]');
     await page.click('[data-test-scope="yank"]');
 
@@ -152,14 +154,21 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
   test('token expiry', async ({ page }) => {
     await page.goto('/settings/tokens/new');
     await expect(page).toHaveURL('/settings/tokens/new');
-    await expect(page.locator('[data-test-expiry-description]')).toHaveText('The token will never expire');
-
-    await page.fill('[data-test-name]', 'token-name');
-    await page.locator('[data-test-expiry]').selectOption('30');
-
-    let expiryDate = new Date('2017-12-20T00:00:00');
+    await expect(page.locator('[data-test-name]')).toHaveValue('');
+    await expect(page.locator('[data-test-expiry]')).toHaveValue('90');
+    let expiryDate = new Date('2018-02-18T00:00:00');
     let expectedDate = expiryDate.toLocaleDateString(undefined, { dateStyle: 'long' });
     let expectedDescription = `The token will expire on ${expectedDate}`;
+    await expect(page.locator('[data-test-expiry-description]')).toHaveText(expectedDescription);
+
+    await page.fill('[data-test-name]', 'token-name');
+    await page.locator('[data-test-expiry]').selectOption('none');
+    await expect(page.locator('[data-test-expiry-description]')).toHaveText('The token will never expire');
+
+    await page.locator('[data-test-expiry]').selectOption('30');
+    expiryDate = new Date('2017-12-20T00:00:00');
+    expectedDate = expiryDate.toLocaleDateString(undefined, { dateStyle: 'long' });
+    expectedDescription = `The token will expire on ${expectedDate}`;
     await expect(page.locator('[data-test-expiry-description]')).toHaveText(expectedDescription);
 
     await page.click('[data-test-scope="publish-update"]');
@@ -190,9 +199,10 @@ test.describe('/settings/tokens/new', { tag: '@routes' }, () => {
   test('token expiry with custom date', async ({ page }) => {
     await page.goto('/settings/tokens/new');
     await expect(page).toHaveURL('/settings/tokens/new');
-    await expect(page.locator('[data-test-expiry-description]')).toHaveText('The token will never expire');
 
     await page.fill('[data-test-name]', 'token-name');
+    await page.locator('[data-test-expiry]').selectOption('none');
+    await expect(page.locator('[data-test-expiry-description]')).toHaveText('The token will never expire');
     await page.locator('[data-test-expiry]').selectOption('custom');
     await expect(page.locator('[data-test-expiry-description]')).toHaveCount(0);
 

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -56,6 +56,7 @@ module('/settings/tokens/new', function (hooks) {
     assert.strictEqual(currentURL(), '/settings/tokens/new');
 
     await fillIn('[data-test-name]', 'token-name');
+    await select('[data-test-expiry]', 'none');
     await click('[data-test-scope="publish-update"]');
     await click('[data-test-generate]');
 
@@ -81,6 +82,7 @@ module('/settings/tokens/new', function (hooks) {
     assert.strictEqual(currentURL(), '/settings/tokens/new');
 
     await fillIn('[data-test-name]', 'token-name');
+    await select('[data-test-expiry]', 'none');
     await click('[data-test-scope="publish-update"]');
     await click('[data-test-scope="yank"]');
 
@@ -150,14 +152,22 @@ module('/settings/tokens/new', function (hooks) {
 
     await visit('/settings/tokens/new');
     assert.strictEqual(currentURL(), '/settings/tokens/new');
-    assert.dom('[data-test-expiry-description]').hasText('The token will never expire');
-
-    await fillIn('[data-test-name]', 'token-name');
-    await select('[data-test-expiry]', '30');
-
-    let expiryDate = new Date('2017-12-20T00:00:00');
+    assert.dom('[data-test-name]').hasValue('');
+    assert.dom('[data-test-expiry]').hasValue('90');
+    let expiryDate = new Date('2018-02-18T00:00:00');
     let expectedDate = expiryDate.toLocaleDateString(undefined, { dateStyle: 'long' });
     let expectedDescription = `The token will expire on ${expectedDate}`;
+    assert.dom('[data-test-expiry-description]').hasText(expectedDescription);
+
+    await fillIn('[data-test-name]', 'token-name');
+
+    await select('[data-test-expiry]', 'none');
+    assert.dom('[data-test-expiry-description]').hasText('The token will never expire');
+
+    await select('[data-test-expiry]', '30');
+    expiryDate = new Date('2017-12-20T00:00:00');
+    expectedDate = expiryDate.toLocaleDateString(undefined, { dateStyle: 'long' });
+    expectedDescription = `The token will expire on ${expectedDate}`;
     assert.dom('[data-test-expiry-description]').hasText(expectedDescription);
 
     await click('[data-test-scope="publish-update"]');
@@ -183,9 +193,10 @@ module('/settings/tokens/new', function (hooks) {
 
     await visit('/settings/tokens/new');
     assert.strictEqual(currentURL(), '/settings/tokens/new');
-    assert.dom('[data-test-expiry-description]').hasText('The token will never expire');
 
     await fillIn('[data-test-name]', 'token-name');
+    await select('[data-test-expiry]', 'none');
+    assert.dom('[data-test-expiry-description]').hasText('The token will never expire');
     await select('[data-test-expiry]', 'custom');
     assert.dom('[data-test-expiry-description]').doesNotExist();
 


### PR DESCRIPTION
Now that we have token expiration warning emails and an easy way to create a new token based on the settings of an existing one, we can finally change the default value of this setting to a slightly more secure value.

Resolves https://github.com/rust-lang/crates.io/issues/6664