### PR TITLE
Add `yank_message` field to API version responses

### DIFF
--- a/src/tests/krate/publish/snapshots/all__krate__publish__links__crate_with_links_field-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__links__crate_with_links_field-2.snap
@@ -45,6 +45,7 @@ expression: response.json()
     "readme_path": "/api/v1/crates/foo/1.0.0/readme",
     "rust_version": null,
     "updated_at": "[datetime]",
+    "yank_message": null,
     "yanked": false
   }
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__manifest__boolean_readme-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__manifest__boolean_readme-2.snap
@@ -45,6 +45,7 @@ expression: response.json()
     "readme_path": "/api/v1/crates/foo/1.0.0/readme",
     "rust_version": "1.69",
     "updated_at": "[datetime]",
+    "yank_message": null,
     "yanked": false
   }
 }

--- a/src/tests/krate/publish/snapshots/all__krate__publish__manifest__lib_and_bin_crate-2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__manifest__lib_and_bin_crate-2.snap
@@ -48,6 +48,7 @@ expression: response.json()
     "readme_path": "/api/v1/crates/foo/1.0.0/readme",
     "rust_version": null,
     "updated_at": "[datetime]",
+    "yank_message": null,
     "yanked": false
   }
 }

--- a/src/tests/routes/crates/snapshots/all__routes__crates__read__show.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__read__show.snap
@@ -71,6 +71,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/foo_show/1.0.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     },
     {
@@ -103,6 +104,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/foo_show/0.5.1/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     },
     {
@@ -135,6 +137,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/foo_show/0.5.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
@@ -51,6 +51,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/c3/1.0.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies.snap
@@ -51,6 +51,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/c2/1.1.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
@@ -63,6 +63,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/c3/3.0.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     },
     {
@@ -89,6 +90,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/c2/2.0.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
@@ -51,6 +51,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/c2/1.0.18446744073709551615/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
@@ -51,6 +51,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/c2/2.0.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
@@ -51,6 +51,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/c2/2.0.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__versions.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__list__versions.snap
@@ -28,6 +28,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/foo_versions/1.0.0/readme",
       "rust_version": "1.64",
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     },
     {
@@ -60,6 +61,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/foo_versions/0.5.1/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     },
     {
@@ -92,6 +94,7 @@ expression: response.json()
       "readme_path": "/api/v1/crates/foo_versions/0.5.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
+      "yank_message": null,
       "yanked": false
     }
   ]

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
@@ -27,6 +27,7 @@ expression: json
     "readme_path": "/api/v1/crates/foo_vers_show_no_pb/1.0.0/readme",
     "rust_version": null,
     "updated_at": "[datetime]",
+    "yank_message": null,
     "yanked": false
   }
 }

--- a/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/all__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -33,6 +33,7 @@ expression: json
     "readme_path": "/api/v1/crates/foo_vers_show/2.0.0/readme",
     "rust_version": "1.64",
     "updated_at": "[datetime]",
+    "yank_message": null,
     "yanked": false
   }
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -558,6 +558,7 @@ pub struct EncodableVersion {
     pub downloads: i32,
     pub features: serde_json::Value,
     pub yanked: bool,
+    pub yank_message: Option<String>,
     pub lib_links: Option<String>,
     // NOTE: Used by shields.io, altering `license` requires a PR with shields.io
     pub license: Option<String>,
@@ -586,6 +587,7 @@ impl EncodableVersion {
             downloads,
             features,
             yanked,
+            yank_message,
             links: lib_links,
             license,
             crate_size,
@@ -613,6 +615,7 @@ impl EncodableVersion {
             downloads,
             features,
             yanked,
+            yank_message,
             lib_links,
             license,
             links,
@@ -736,6 +739,7 @@ mod tests {
             downloads: 0,
             features: serde_json::from_str("{}").unwrap(),
             yanked: false,
+            yank_message: None,
             license: None,
             lib_links: None,
             links: EncodableVersionLinks {


### PR DESCRIPTION
This field can currently only be set directly in the database, but introducing it in a dedicated commit/PR makes the diff of the commit/PR that introduces the update API much more manageable. This PR was extracted from the PR linked below :)

/cc @Rustin170506 

Related:
- #9193
- https://github.com/rust-lang/crates.io/pull/9423