### PR TITLE
Fix display for text in new token page

### DIFF
--- a/app/styles/settings/tokens/new.module.css
+++ b/app/styles/settings/tokens/new.module.css
@@ -10,6 +10,12 @@
     font-weight: 600;
 }
 
+.select-group {
+    display: flex;
+    align-content: center;
+    align-items: center;
+}
+
 .help-link {
     flex-shrink: 0;
     color: light-dark(var(--grey600), var(--grey700));

--- a/app/templates/settings/tokens/new.hbs
+++ b/app/templates/settings/tokens/new.hbs
@@ -30,41 +30,45 @@
   <div local-class="form-group" data-test-expiry-group>
     {{#let (unique-id) as |id|}}
       <label for={{id}} local-class="form-group-name">Expiration</label>
-
-      <select
-        id={{id}}
-        disabled={{this.saveTokenTask.isRunning}}
-        local-class="expiry-select"
-        data-test-expiry
-        {{on "change" this.updateExpirySelection}}
-      >
-        <option value="none">No expiration</option>
-        <option value="7">7 days</option>
-        <option value="30">30 days</option>
-        <option value="60">60 days</option>
-        <option value="90" selected>90 days</option>
-        <option value="365">365 days</option>
-        <option value="custom">Custom...</option>
-      </select>
     {{/let}}
 
-    {{#if (eq this.expirySelection "custom")}}
-      <Input
-        @type="date"
-        @value={{this.expiryDateInput}}
-        min={{this.today}}
-        disabled={{this.saveTokenTask.isRunning}}
-        aria-invalid={{if this.expiryDateInvalid "true" "false"}}
-        aria-label="Custom expiration date"
-        local-class="expiry-date-input"
-        data-test-expiry-date
-        {{on "input" this.resetExpiryDateValidation}}
-      />
-    {{else}}
-      <span local-class="expiry-description" data-test-expiry-description>
-        {{this.expiryDescription}}
-      </span>
-    {{/if}}
+    <div local-class="select-group">
+      {{#let (unique-id) as |id|}}
+        <select
+          id={{id}}
+          disabled={{this.saveTokenTask.isRunning}}
+          local-class="expiry-select"
+          data-test-expiry
+          {{on "change" this.updateExpirySelection}}
+        >
+          <option value="none">No expiration</option>
+          <option value="7">7 days</option>
+          <option value="30">30 days</option>
+          <option value="60">60 days</option>
+          <option value="90" selected>90 days</option>
+          <option value="365">365 days</option>
+          <option value="custom">Custom...</option>
+        </select>
+      {{/let}}
+
+      {{#if (eq this.expirySelection "custom")}}
+        <Input
+          @type="date"
+          @value={{this.expiryDateInput}}
+          min={{this.today}}
+          disabled={{this.saveTokenTask.isRunning}}
+          aria-invalid={{if this.expiryDateInvalid "true" "false"}}
+          aria-label="Custom expiration date"
+          local-class="expiry-date-input"
+          data-test-expiry-date
+          {{on "input" this.resetExpiryDateValidation}}
+        />
+      {{else}}
+        <span local-class="expiry-description" data-test-expiry-description>
+          {{this.expiryDescription}}
+        </span>
+      {{/if}}
+    </div>
   </div>
 
   <div local-class="form-group" data-test-scopes-group>


### PR DESCRIPTION
The text should not go under the select, this PR fixes it:

![image](https://github.com/user-attachments/assets/c190ea93-2818-47a8-9e55-bbc97aafc930)

r? @Turbo87 