### PR TITLE
footer: Move Zulip link above X/Twitter

### DIFF
--- a/app/components/footer.hbs
+++ b/app/components/footer.hbs
@@ -34,8 +34,8 @@
       <h1>Social</h1>
       <ul role="list">
         <li><a href="https://github.com/rust-lang/crates.io/">{{svg-jar "github"}} rust-lang/crates.io</a></li>
-        <li><a href="https://twitter.com/cratesiostatus">{{svg-jar "twitter"}} @cratesiostatus</a></li>
         <li><a href="https://rust-lang.zulipchat.com/#streams/318791/t-crates-io">{{svg-jar "zulip"}} #t-crates-io</a></li>
+        <li><a href="https://twitter.com/cratesiostatus">{{svg-jar "twitter"}} @cratesiostatus</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Our Zulip channel has a lot more activity than our X/Twitter account, so let's move it up a bit to reflect the order of importance.