### PR TITLE
search: check for null bytes before querying

### DIFF
--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -67,13 +67,8 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
             .map(|s| s == "yes")
             .unwrap_or(true);
 
-        // Remove 0x00 characters from the query string because Postgres can not
-        // handle them and will return an error, which would cause us to throw
-        // an Internal Server Error ourselves.
-        let q_string = option_param("q")?.map(|q| q.replace('\u{0}', ""));
-
         let filter_params = FilterParams {
-            q_string: q_string.as_deref(),
+            q_string: option_param("q")?,
             include_yanked,
             category: option_param("category")?,
             all_keywords: option_param("all_keywords")?,
@@ -101,7 +96,7 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
             .left_join(recent_crate_downloads::table)
             .select(selection);
 
-        if let Some(q_string) = &q_string {
+        if let Some(q_string) = &filter_params.q_string {
             if !q_string.is_empty() {
                 let sort = sort.unwrap_or("relevance");
 

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -1016,6 +1016,17 @@ async fn test_pages_work_even_with_seek_based_pagination() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn invalid_params_with_null_bytes() {
+    let (_app, anon, _cookie) = TestApp::init().with_user();
+
+    for name in ["q", "category", "all_keywords", "keyword", "letter"] {
+        let response = anon.get::<()>(&format!("/api/v1/crates?{name}=%00")).await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_json_snapshot!(response.json());
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn invalid_seek_parameter() {
     let (_app, anon, _cookie) = TestApp::init().with_user();
 

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -193,11 +193,6 @@ async fn index_queries() {
         assert_eq!(cl.crates.len(), 0);
         assert_eq!(cl.meta.total, 0);
     }
-
-    // ignores 0x00 characters that Postgres does not support
-    for cl in search_both(&anon, "q=k%00w1").await {
-        assert_eq!(cl.meta.total, 3);
-    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-2.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/list.rs
+expression: response.json()
+---
+{
+  "errors": [
+    {
+      "detail": "parameter category cannot contain a null byte"
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-3.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-3.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/list.rs
+expression: response.json()
+---
+{
+  "errors": [
+    {
+      "detail": "parameter all_keywords cannot contain a null byte"
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-4.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-4.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/list.rs
+expression: response.json()
+---
+{
+  "errors": [
+    {
+      "detail": "parameter keyword cannot contain a null byte"
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-5.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes-5.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/list.rs
+expression: response.json()
+---
+{
+  "errors": [
+    {
+      "detail": "parameter letter cannot contain a null byte"
+    }
+  ]
+}

--- a/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes.snap
+++ b/src/tests/routes/crates/snapshots/all__routes__crates__list__invalid_params_with_null_bytes.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/routes/crates/list.rs
+expression: response.json()
+---
+{
+  "errors": [
+    {
+      "detail": "parameter q cannot contain a null byte"
+    }
+  ]
+}


### PR DESCRIPTION
[PostgreSQL has an unusual definition of `UTF8` that doesn't allow for null bytes][null-bytes], even though they are technically valid UTF-8 by any other definition (including Rust's `str` type). Sending a crate search request that includes a null byte will eventually result in a database error anyway, but let's save Sentry the trouble and just 400 out early.

I did a quick audit of other places that we use query parameters and don't see any other code paths where we use a string directly as a query parameter, but I won't pretend this was a super detailed survey. (Fun fact: I can actually see the power usage for my laptop increase on my fancy new charger when I hit "show references" on the `query` method in `RequestUtils`.)

Fixes #9444.

[null-bytes]: https://www.commandprompt.com/blog/null-characters-workarounds-arent-good-enough/