### PR TITLE
frontend: change logic of when doc links are shown in search results

### DIFF
--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -61,8 +61,8 @@
     {{#if @crate.homepage}}
       <li><a href="{{@crate.homepage}}">Homepage</a></li>
     {{/if}}
-    {{#if @crate.documentation}}
-      <li><a href="{{@crate.documentation}}">Documentation</a></li>
+    {{#if @crate.documentationLink}}
+      <li><a href="{{@crate.documentationLink}}">Documentation</a></li>
     {{/if}}
     {{#if @crate.repository}}
       <li><a href="{{@crate.repository}}">Repository</a></li>


### PR DESCRIPTION
The crate version page uses a fallback to handle crates that don't define `documentation` keys in their manifests: if docs.rs has documentation for that crate version, that those docs are used.

The search results do not implement the same logic, so crates that don't have `documentation` keys don't get the handy documentation link in the crate row.

This copies the logic from the version model into the crate model, using the default crate version as the version to look for on docs.rs.

I strongly suspect there is a better way to do this than copying a bunch of code, and would welcome suggestions from those more familiar with Ember.

This would eventually fix #1484.