### PR TITLE
Add CORS tests

### DIFF
--- a/src/tests/all.rs
+++ b/src/tests/all.rs
@@ -25,6 +25,7 @@ mod authentication;
 mod blocked_routes;
 mod builders;
 mod categories;
+mod cors;
 mod dump_db;
 mod github_secret_scanning;
 mod krate;

--- a/src/tests/cors.rs
+++ b/src/tests/cors.rs
@@ -1,0 +1,52 @@
+use crate::util::{MockRequestExt, RequestHelper};
+use crate::TestApp;
+use http::StatusCode;
+use insta::assert_snapshot;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_with_matching_origin() {
+    let (_, _, cookie) = TestApp::init()
+        .with_config(|server| {
+            server.allowed_origins = "https://crates.io".parse().unwrap();
+        })
+        .with_user();
+
+    let mut request = cookie.get_request("/api/v1/me");
+    request.header("Origin", "https://crates.io");
+
+    let response = cookie.run::<()>(request).await;
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_with_unknown_origin() {
+    let (_, _, cookie) = TestApp::init()
+        .with_config(|server| {
+            server.allowed_origins = "https://crates.io".parse().unwrap();
+        })
+        .with_user();
+
+    let mut request = cookie.get_request("/api/v1/me");
+    request.header("Origin", "https://evil.hacker.io");
+
+    let response = cookie.run::<()>(request).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid origin header"}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_with_multiple_origins() {
+    let (_, _, cookie) = TestApp::init()
+        .with_config(|server| {
+            server.allowed_origins = "https://crates.io".parse().unwrap();
+        })
+        .with_user();
+
+    let mut request = cookie.get_request("/api/v1/me");
+    request.header("Origin", "https://evil.hacker.io");
+    request.header("Origin", "https://crates.io");
+
+    let response = cookie.run::<()>(request).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid origin header"}]}"#);
+}

--- a/src/tests/util/mock_request.rs
+++ b/src/tests/util/mock_request.rs
@@ -13,7 +13,7 @@ impl MockRequestExt for MockRequest {
         K: IntoHeaderName,
     {
         self.headers_mut()
-            .insert(name, HeaderValue::from_str(value).unwrap());
+            .append(name, HeaderValue::from_str(value).unwrap());
     }
 }
 


### PR DESCRIPTION
This PR adds a few basic tests for our `verify_origin()` implementation, which was essentially untested up until now...