### PR TITLE
Remove generics from authentication code

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -275,8 +275,10 @@ struct OwnerInvitation {
 
 /// Handles the `PUT /api/v1/me/crate_owner_invitations/:crate_id` route.
 pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Json<Value>> {
+    let (parts, body) = req.0.into_parts();
+
     let crate_invite: OwnerInvitation =
-        serde_json::from_slice(req.body()).map_err(|_| bad_request("invalid json request"))?;
+        serde_json::from_slice(&body).map_err(|_| bad_request("invalid json request"))?;
 
     let crate_invite = crate_invite.crate_owner_invite;
 
@@ -284,7 +286,7 @@ pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Json
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
-        let auth = AuthCheck::default().check(&req, conn)?;
+        let auth = AuthCheck::default().check(&parts, conn)?;
         let user_id = auth.user_id();
 
         let config = &state.config;

--- a/src/controllers/util.rs
+++ b/src/controllers/util.rs
@@ -10,9 +10,9 @@ use http::{header, Extensions, HeaderMap, HeaderValue, Method, Request, Uri, Ver
 /// We don't want to accept authenticated requests that originated from other sites, so this
 /// function returns an error if the Origin header doesn't match what we expect "this site" to
 /// be: <https://crates.io> in production, or <http://localhost:port/> in development.
-pub fn verify_origin<T: RequestPartsExt>(req: &T) -> AppResult<()> {
-    let headers = req.headers();
-    let allowed_origins = &req.app().config.allowed_origins;
+pub fn verify_origin(parts: &Parts) -> AppResult<()> {
+    let headers = parts.headers();
+    let allowed_origins = &parts.app().config.allowed_origins;
 
     let bad_origin = headers
         .get_all(header::ORIGIN)
@@ -23,7 +23,7 @@ pub fn verify_origin<T: RequestPartsExt>(req: &T) -> AppResult<()> {
         let error_message =
             format!("only same-origin requests can be authenticated. got {bad_origin:?}");
 
-        req.request_log().add("cause", error_message);
+        parts.request_log().add("cause", error_message);
 
         return Err(forbidden("invalid origin header"));
     }


### PR DESCRIPTION
This prepares for moving some of the implementation into axum extractors, which only get access to `Parts`. Additionally it may speed up the compilation ever so slightly by removing unnecessary usage of generics :D