### PR TITLE
insta: Update outdated `expression` fields in snapshots

### DIFF
--- a/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate_twice.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate_twice.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate_weird_version.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate_weird_version.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate_with_token.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__basics__new_krate_with_token.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__categories__good_categories.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__categories__good_categories.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/categories.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__keywords__good_keywords.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__keywords__good_keywords.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/keywords.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__manifest__boolean_readme.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__manifest__boolean_readme.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/manifest.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/max_size.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__readme__new_krate_with_empty_readme.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__readme__new_krate_with_empty_readme.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/readme.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__readme__new_krate_with_readme.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__readme__new_krate_with_readme.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/readme.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/all__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
+++ b/src/tests/krate/publish/snapshots/all__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/krate/publish/readme.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "crate": {

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_success.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_expiry_date.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_null_scopes.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__create__create_token_with_scopes.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
+++ b/src/tests/routes/me/tokens/snapshots/all__routes__me__tokens__list__list_tokens.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/list.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "api_tokens": [

--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_revoked_token.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_revoked_token.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/github_secret_scanning.rs
-expression: response.into_json()
+expression: response.json()
 ---
 [
   {

--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_unknown_token.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_for_unknown_token.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/github_secret_scanning.rs
-expression: response.into_json()
+expression: response.json()
 ---
 [
   {

--- a/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token.snap
+++ b/src/tests/snapshots/all__github_secret_scanning__github_secret_alert_revokes_token.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/github_secret_scanning.rs
-expression: response.into_json()
+expression: response.json()
 ---
 [
   {

--- a/src/tests/snapshots/all__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
+++ b/src/tests/snapshots/all__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/read_only_mode.rs
-expression: response.into_json()
+expression: response.json()
 ---
 {
   "errors": [

--- a/src/tests/snapshots/all__server__user_agent_is_required-2.snap
+++ b/src/tests/snapshots/all__server__user_agent_is_required-2.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/server.rs
-expression: resp.into_json()
+expression: resp.json()
 ---
 {
   "errors": [

--- a/src/tests/snapshots/all__server__user_agent_is_required.snap
+++ b/src/tests/snapshots/all__server__user_agent_is_required.snap
@@ -1,6 +1,6 @@
 ---
 source: src/tests/server.rs
-expression: resp.into_json()
+expression: resp.json()
 ---
 {
   "errors": [


### PR DESCRIPTION
Not sure why `insta` isn't doing this automatically, but I guess we can do that ourselves...