### PR TITLE
Change crates.io policy to not offer crate transfer mediation

### DIFF
--- a/app/templates/policies/index.hbs
+++ b/app/templates/policies/index.hbs
@@ -71,10 +71,10 @@
   <p>crates.io has a first-come, first-serve policy on crate names. Upon publishing a package, the publisher will be made
     owner of the package on crates.io.</p>
 
-  <p>If you want to take over a package, we require you to first try and contact the current owner directly. If the
-    current owner agrees, they can add you as an owner of the crate, and you can then remove them, if necessary. If the
-    current owner is not reachable or has not published any contact information the crates.io team may reach out to help
-    mediate the process of the ownership transfer.</p>
+  <p>If you want to take over a package, we recommend you try and contact the current owner directly. If the
+    current owner agrees, they can add you as an owner of the crate, and you can then remove them, if necessary.
+    For security reasons, the crates.io team will not transfer ownership of existing crates without the explicit
+    approval of the current owner.</p>
 
   <p>Crate deletion by their owners is not possible to keep the registry as immutable as possible. If you want to flag
     your crate as open for transferring ownership to others, you can publish a new version with a message in the README or


### PR DESCRIPTION
This PR implements https://github.com/rust-lang/rfcs/pull/3646. For some reason I thought this had already been implemented, but I just stumbled upon that section in the policies and was surprised that it was still in there... 😅