### PR TITLE
Extract `DeleteCrateFromStorage` background job

### DIFF
--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -3,6 +3,7 @@ use crate::worker::Environment;
 use anyhow::Context;
 use crates_io_worker::BackgroundJob;
 use std::sync::Arc;
+use tokio::try_join;
 
 /// A background job that deletes all files associated with a crate from the storage backend.
 #[derive(Serialize, Deserialize)]
@@ -24,18 +25,24 @@ impl BackgroundJob for DeleteCrateFromStorage {
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
         let name = &self.name;
 
-        info!("{name}: Deleting crate files from S3…");
-        let result = ctx.storage.delete_all_crate_files(name).await;
-        result.context("Failed to delete crate files from S3")?;
-
-        info!("{name}: Deleting readme files from S3…");
-        let result = ctx.storage.delete_all_readmes(name).await;
-        result.context("Failed to delete readme files from S3")?;
-
-        info!("{name}: Deleting RSS feed from S3…");
-        let feed_id = FeedId::Crate { name };
-        let result = ctx.storage.delete_feed(&feed_id).await;
-        result.context("Failed to delete RSS feed from S3")?;
+        try_join!(
+            async {
+                info!("{name}: Deleting crate files from S3…");
+                let result = ctx.storage.delete_all_crate_files(name).await;
+                result.context("Failed to delete crate files from S3")
+            },
+            async {
+                info!("{name}: Deleting readme files from S3…");
+                let result = ctx.storage.delete_all_readmes(name).await;
+                result.context("Failed to delete readme files from S3")
+            },
+            async {
+                info!("{name}: Deleting RSS feed from S3…");
+                let feed_id = FeedId::Crate { name };
+                let result = ctx.storage.delete_feed(&feed_id).await;
+                result.context("Failed to delete RSS feed from S3")
+            }
+        )?;
 
         info!("{name}: Successfully deleted crate from S3");
         Ok(())

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -1,0 +1,45 @@
+use crate::storage::FeedId;
+use crate::worker::Environment;
+use crates_io_worker::BackgroundJob;
+use std::sync::Arc;
+
+/// A background job that deletes all files associated with a crate from the storage backend.
+#[derive(Serialize, Deserialize)]
+pub struct DeleteCrateFromStorage {
+    name: String,
+}
+
+impl DeleteCrateFromStorage {
+    pub fn new(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl BackgroundJob for DeleteCrateFromStorage {
+    const JOB_NAME: &'static str = "delete_crate_from_storage";
+
+    type Context = Arc<Environment>;
+
+    async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
+        let name = &self.name;
+
+        info!("{name}: Deleting crate files from S3…");
+        if let Err(error) = ctx.storage.delete_all_crate_files(name).await {
+            warn!("{name}: Failed to delete crate files from S3: {error}");
+        }
+
+        info!("{name}: Deleting readme files from S3…");
+        if let Err(error) = ctx.storage.delete_all_readmes(name).await {
+            warn!("{name}: Failed to delete readme files from S3: {error}");
+        }
+
+        info!("{name}: Deleting RSS feed from S3…");
+        let feed_id = FeedId::Crate { name };
+        if let Err(error) = ctx.storage.delete_feed(&feed_id).await {
+            warn!("{name}: Failed to delete RSS feed from S3: {error}");
+        }
+
+        info!("{name}: Successfully deleted crate from S3");
+        Ok(())
+    }
+}

--- a/src/worker/jobs/mod.rs
+++ b/src/worker/jobs/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::Display;
 
 mod archive_version_downloads;
 mod daily_db_maintenance;
+mod delete_crate;
 mod downloads;
 pub mod dump_db;
 mod expiry_notification;
@@ -22,6 +23,7 @@ mod update_default_version;
 
 pub use self::archive_version_downloads::ArchiveVersionDownloads;
 pub use self::daily_db_maintenance::DailyDbMaintenance;
+pub use self::delete_crate::DeleteCrateFromStorage;
 pub use self::downloads::{
     CleanProcessedLogFiles, ProcessCdnLog, ProcessCdnLogQueue, UpdateDownloads,
 };

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -23,6 +23,7 @@ impl RunnerExt for Runner<Arc<Environment>> {
             .register_job_type::<jobs::CheckTyposquat>()
             .register_job_type::<jobs::CleanProcessedLogFiles>()
             .register_job_type::<jobs::DailyDbMaintenance>()
+            .register_job_type::<jobs::DeleteCrateFromStorage>()
             .register_job_type::<jobs::DumpDb>()
             .register_job_type::<jobs::IndexVersionDownloadsArchive>()
             .register_job_type::<jobs::NormalizeIndex>()


### PR DESCRIPTION
This background job can later be reused to implement https://rust-lang.github.io/rfcs/3660-crates-io-crate-deletions.html

Related:

- https://github.com/rust-lang/crates.io/issues/9352