### PR TITLE
Add `triagebot` config file

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,3 @@
+# Enable issue transfers within the org
+# Documentation at: https://forge.rust-lang.org/triagebot/transfer.html
+[transfer]


### PR DESCRIPTION
This only enables issue transfers within the rust-lang org, since that is all we currently need/want.

Related:

- https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/transferring.20issues.20not.20possible
- https://github.com/rust-lang/team/pull/1568