### PR TITLE
models/token: Remove unnecessary transaction

### DIFF
--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -1,32 +1,39 @@
+use crate::models::ApiToken;
 use crate::tests::util::MockRequestExt;
 use crate::tests::{RequestHelper, TestApp};
-use crate::{models::ApiToken, views::EncodableMe};
+use diesel::associations::HasTable;
 use diesel::prelude::*;
 use http::{header, StatusCode};
 use insta::assert_snapshot;
 
+fn get_token(conn: &mut PgConnection, id: i32) -> ApiToken {
+    ApiToken::table()
+        .find(id)
+        .select(ApiToken::as_select())
+        .first(conn)
+        .unwrap()
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn using_token_updates_last_used_at() {
-    let url = "/api/v1/me";
-    let (app, anon, user, token) = TestApp::init().with_token();
+    let (app, _, _, token_client) = TestApp::init().with_token();
 
-    anon.get(url).await.assert_forbidden();
-    user.get::<EncodableMe>(url).await.good();
-    assert_none!(token.as_model().last_used_at);
+    let token_id = token_client.as_model().id;
+    let token = app.db(|conn| get_token(conn, token_id));
+    assert_none!(token.last_used_at);
 
-    // Use the token once
-    token.search("following=1").await;
+    let response = token_client.get::<()>("/api/v1/crates?following=1").await;
+    assert_eq!(response.status(), StatusCode::OK);
 
-    let token: ApiToken = app.db(|conn| {
-        assert_ok!(ApiToken::belonging_to(user.as_model())
-            .select(ApiToken::as_select())
-            .first(conn))
-    });
-    assert_some!(token.last_used_at);
+    let token = app.db(|conn| get_token(conn, token_id));
+    let last_used_at1 = assert_some!(token.last_used_at);
 
-    // Would check that it updates the timestamp here, but the timestamp is
-    // based on the start of the database transaction so it doesn't work in
-    // this test framework.
+    let response = token_client.get::<()>("/api/v1/crates?following=1").await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let token = app.db(|conn| get_token(conn, token_id));
+    let last_used_at2 = assert_some!(token.last_used_at);
+    assert!(last_used_at2 > last_used_at1);
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
The transaction behavior was initially introduced in https://github.com/rust-lang/crates.io/commit/52862fab97dd00184a2034c4d6bffdfe241734e4 and the commit message mentions:

> Because our tests run in a single transaction, we need to wrap that update to ensure that the error doesn't poison the transaction.

but that first part is no longer true, so we don't need the transaction anymore AFAICT.

This PR also improves our test suite for this functionality a little to catch potential regressions.