### PR TITLE
Correct frontend source dir

### DIFF
--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,7 +1,7 @@
 # Frontend Overview
 
-The frontend of crates.io is written in JavaScript using [Ember.js][]. Most of that code lives in
-the _src_ directory. We endeavor to follow Ember conventions and best practices, but we're Rust
+The frontend of crates.io is written in JavaScript using [Ember.js]. Most of that code lives in
+the `app` directory. We endeavor to follow Ember conventions and best practices, but we're Rust
 developers, so we don't always live up to this goal :)
 
 [Ember.js]: https://emberjs.com/


### PR DESCRIPTION
According to https://github.com/rust-lang/crates.io/blob/main/docs/ARCHITECTURE.md#frontend---emberjs, the frontend source directory should be `app`.