### PR TITLE
admin/enqueue_job: Add `sync_to_git/sparse_index` subcommands

### DIFF
--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -41,6 +41,12 @@ pub enum Command {
     },
     SendTokenExpiryNotifications,
     SyncCratesFeed,
+    SyncToGitIndex {
+        name: String,
+    },
+    SyncToSparseIndex {
+        name: String,
+    },
     SyncUpdatesFeed,
 }
 
@@ -133,6 +139,12 @@ pub fn run(command: Command) -> Result<()> {
         }
         Command::SyncCratesFeed => {
             jobs::rss::SyncCratesFeed.enqueue(conn)?;
+        }
+        Command::SyncToGitIndex { name } => {
+            jobs::SyncToGitIndex::new(name).enqueue(conn)?;
+        }
+        Command::SyncToSparseIndex { name } => {
+            jobs::SyncToSparseIndex::new(name).enqueue(conn)?;
         }
         Command::SyncUpdatesFeed => {
             jobs::rss::SyncUpdatesFeed.enqueue(conn)?;


### PR DESCRIPTION
https://github.com/rust-lang/crates.io/pull/9551 slightly changed how `features` are serialized in the index. We know about a couple of cases that we want to fix, so this PR adds an option for us to manually trigger an index sync.