### PR TITLE
bin/crates-admin: Convert to async

### DIFF
--- a/src/admin/delete_version.rs
+++ b/src/admin/delete_version.rs
@@ -1,6 +1,7 @@
 use crate::models::update_default_version;
 use crate::schema::crates;
 use crate::storage::Storage;
+use crate::tasks::spawn_blocking;
 use crate::worker::jobs;
 use crate::{admin::dialoguer, db, schema::versions};
 use anyhow::Context;
@@ -25,86 +26,88 @@ pub struct Opts {
     yes: bool,
 }
 
-pub fn run(opts: Opts) -> anyhow::Result<()> {
-    let crate_name = &opts.crate_name;
+pub async fn run(opts: Opts) -> anyhow::Result<()> {
+    spawn_blocking(move || {
+        let crate_name = &opts.crate_name;
 
-    let conn = &mut db::oneoff_connection().context("Failed to establish database connection")?;
+        let conn = &mut db::oneoff_connection().context("Failed to establish database connection")?;
 
-    let store = Storage::from_environment();
+        let store = Storage::from_environment();
 
-    let crate_id: i32 = crates::table
-        .select(crates::id)
-        .filter(crates::name.eq(crate_name))
-        .first(conn)
-        .context("Failed to look up crate id from the database")?;
+        let crate_id: i32 = crates::table
+            .select(crates::id)
+            .filter(crates::name.eq(crate_name))
+            .first(conn)
+            .context("Failed to look up crate id from the database")?;
 
-    println!("Deleting the following versions of the `{crate_name}` crate:");
-    println!();
-    for version in &opts.versions {
-        println!(" - {version}");
-    }
-    println!();
+        println!("Deleting the following versions of the `{crate_name}` crate:");
+        println!();
+        for version in &opts.versions {
+            println!(" - {version}");
+        }
+        println!();
 
-    if !opts.yes && !dialoguer::confirm("Do you want to permanently delete these versions?") {
-        return Ok(());
-    }
+        if !opts.yes && !dialoguer::confirm("Do you want to permanently delete these versions?") {
+            return Ok(());
+        }
 
-    conn.transaction(|conn| {
-        info!(%crate_name, %crate_id, versions = ?opts.versions, "Deleting versions from the database");
-        let result = diesel::delete(
-            versions::table
-                .filter(versions::crate_id.eq(crate_id))
-                .filter(versions::num.eq_any(&opts.versions)),
-        )
-        .execute(conn);
+        conn.transaction(|conn| {
+            info!(%crate_name, %crate_id, versions = ?opts.versions, "Deleting versions from the database");
+            let result = diesel::delete(
+                versions::table
+                    .filter(versions::crate_id.eq(crate_id))
+                    .filter(versions::num.eq_any(&opts.versions)),
+            )
+            .execute(conn);
 
-        match result {
-            Ok(num_deleted) if num_deleted == opts.versions.len() => {}
-            Ok(num_deleted) => {
-                warn!(
-                    %crate_name,
-                    "Deleted only {num_deleted} of {num_expected} versions from the database",
-                    num_expected = opts.versions.len()
-                );
+            match result {
+                Ok(num_deleted) if num_deleted == opts.versions.len() => {}
+                Ok(num_deleted) => {
+                    warn!(
+                        %crate_name,
+                        "Deleted only {num_deleted} of {num_expected} versions from the database",
+                        num_expected = opts.versions.len()
+                    );
+                }
+                Err(error) => {
+                    warn!(%crate_name, ?error, "Failed to delete versions from the database")
+                }
             }
-            Err(error) => {
-                warn!(%crate_name, ?error, "Failed to delete versions from the database")
+
+            info!(%crate_name, %crate_id, "Updating default version in the database");
+            if let Err(error) = update_default_version(crate_id, conn) {
+                warn!(%crate_name, %crate_id, ?error, "Failed to update default version");
+            }
+
+            Ok::<_, anyhow::Error>(())
+        })?;
+
+        info!(%crate_name, "Enqueuing index sync jobs");
+        if let Err(error) = jobs::enqueue_sync_to_index(crate_name, conn) {
+            warn!(%crate_name, ?error, "Failed to enqueue index sync jobs");
+        }
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("Failed to initialize tokio runtime")?;
+
+        for version in &opts.versions {
+            debug!(%crate_name, %version, "Deleting crate file from S3");
+            if let Err(error) = rt.block_on(store.delete_crate_file(crate_name, version)) {
+                warn!(%crate_name, %version, ?error, "Failed to delete crate file from S3");
+            }
+
+            debug!(%crate_name, %version, "Deleting readme file from S3");
+            match rt.block_on(store.delete_readme(crate_name, version)) {
+                Err(object_store::Error::NotFound { .. }) => {}
+                Err(error) => {
+                    warn!(%crate_name, %version, ?error, "Failed to delete readme file from S3")
+                }
+                Ok(_) => {}
             }
         }
 
-        info!(%crate_name, %crate_id, "Updating default version in the database");
-        if let Err(error) = update_default_version(crate_id, conn) {
-            warn!(%crate_name, %crate_id, ?error, "Failed to update default version");
-        }
-
-        Ok::<_, anyhow::Error>(())
-    })?;
-
-    info!(%crate_name, "Enqueuing index sync jobs");
-    if let Err(error) = jobs::enqueue_sync_to_index(crate_name, conn) {
-        warn!(%crate_name, ?error, "Failed to enqueue index sync jobs");
-    }
-
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("Failed to initialize tokio runtime")?;
-
-    for version in &opts.versions {
-        debug!(%crate_name, %version, "Deleting crate file from S3");
-        if let Err(error) = rt.block_on(store.delete_crate_file(crate_name, version)) {
-            warn!(%crate_name, %version, ?error, "Failed to delete crate file from S3");
-        }
-
-        debug!(%crate_name, %version, "Deleting readme file from S3");
-        match rt.block_on(store.delete_readme(crate_name, version)) {
-            Err(object_store::Error::NotFound { .. }) => {}
-            Err(error) => {
-                warn!(%crate_name, %version, ?error, "Failed to delete readme file from S3")
-            }
-            Ok(_) => {}
-        }
-    }
-
-    Ok(())
+        Ok(())
+    }).await
 }

--- a/src/admin/enqueue_job.rs
+++ b/src/admin/enqueue_job.rs
@@ -1,5 +1,6 @@
 use crate::db;
 use crate::schema::{background_jobs, crates};
+use crate::tasks::spawn_blocking;
 use crate::worker::jobs;
 use anyhow::Result;
 use chrono::NaiveDate;
@@ -50,106 +51,109 @@ pub enum Command {
     SyncUpdatesFeed,
 }
 
-pub fn run(command: Command) -> Result<()> {
-    let conn = &mut db::oneoff_connection()?;
-    println!("Enqueueing background job: {command:?}");
+pub async fn run(command: Command) -> Result<()> {
+    spawn_blocking(move || {
+        let conn = &mut db::oneoff_connection()?;
+        println!("Enqueueing background job: {command:?}");
 
-    match command {
-        Command::ArchiveVersionDownloads { before } => {
-            before
-                .map(jobs::ArchiveVersionDownloads::before)
-                .unwrap_or_default()
-                .enqueue(conn)?;
-        }
-        Command::IndexVersionDownloadsArchive => {
-            jobs::IndexVersionDownloadsArchive.enqueue(conn)?;
-        }
-        Command::UpdateDownloads => {
-            let count: i64 = background_jobs::table
-                .filter(background_jobs::job_type.eq(jobs::UpdateDownloads::JOB_NAME))
-                .count()
-                .get_result(conn)?;
-
-            if count > 0 {
-                println!(
-                    "Did not enqueue {}, existing job already in progress",
-                    jobs::UpdateDownloads::JOB_NAME
-                );
-            } else {
-                jobs::UpdateDownloads.enqueue(conn)?;
+        match command {
+            Command::ArchiveVersionDownloads { before } => {
+                before
+                    .map(jobs::ArchiveVersionDownloads::before)
+                    .unwrap_or_default()
+                    .enqueue(conn)?;
             }
-        }
-        Command::CleanProcessedLogFiles => {
-            jobs::CleanProcessedLogFiles.enqueue(conn)?;
-        }
-        Command::DumpDb => {
-            jobs::DumpDb.enqueue(conn)?;
-        }
-        Command::SyncAdmins { force } => {
-            if !force {
-                // By default, we don't want to enqueue a sync if one is already
-                // in progress. If a sync fails due to e.g. an expired pinned
-                // certificate we don't want to keep adding new jobs to the
-                // queue, since the existing job will be retried until it
-                // succeeds.
+            Command::IndexVersionDownloadsArchive => {
+                jobs::IndexVersionDownloadsArchive.enqueue(conn)?;
+            }
+            Command::UpdateDownloads => {
+                let count: i64 = background_jobs::table
+                    .filter(background_jobs::job_type.eq(jobs::UpdateDownloads::JOB_NAME))
+                    .count()
+                    .get_result(conn)?;
 
-                let query = background_jobs::table
-                    .filter(background_jobs::job_type.eq(jobs::SyncAdmins::JOB_NAME));
-
-                if diesel::select(exists(query)).get_result(conn)? {
-                    info!(
+                if count > 0 {
+                    println!(
                         "Did not enqueue {}, existing job already in progress",
-                        jobs::SyncAdmins::JOB_NAME
+                        jobs::UpdateDownloads::JOB_NAME
                     );
-                    return Ok(());
+                } else {
+                    jobs::UpdateDownloads.enqueue(conn)?;
                 }
             }
-
-            jobs::SyncAdmins.enqueue(conn)?;
-        }
-        Command::DailyDbMaintenance => {
-            jobs::DailyDbMaintenance.enqueue(conn)?;
-        }
-        Command::ProcessCdnLogQueue(job) => {
-            job.enqueue(conn)?;
-        }
-        Command::SquashIndex => {
-            jobs::SquashIndex.enqueue(conn)?;
-        }
-        Command::NormalizeIndex { dry_run } => {
-            jobs::NormalizeIndex::new(dry_run).enqueue(conn)?;
-        }
-        Command::CheckTyposquat { name } => {
-            // The job will fail if the crate doesn't actually exist, so let's check that up front.
-            if crates::table
-                .filter(crates::name.eq(&name))
-                .count()
-                .get_result::<i64>(conn)?
-                == 0
-            {
-                anyhow::bail!(
-                    "cannot enqueue a typosquat check for a crate that doesn't exist: {name}"
-                );
+            Command::CleanProcessedLogFiles => {
+                jobs::CleanProcessedLogFiles.enqueue(conn)?;
             }
+            Command::DumpDb => {
+                jobs::DumpDb.enqueue(conn)?;
+            }
+            Command::SyncAdmins { force } => {
+                if !force {
+                    // By default, we don't want to enqueue a sync if one is already
+                    // in progress. If a sync fails due to e.g. an expired pinned
+                    // certificate we don't want to keep adding new jobs to the
+                    // queue, since the existing job will be retried until it
+                    // succeeds.
 
-            jobs::CheckTyposquat::new(&name).enqueue(conn)?;
-        }
-        Command::SendTokenExpiryNotifications => {
-            jobs::SendTokenExpiryNotifications.enqueue(conn)?;
-        }
-        Command::SyncCratesFeed => {
-            jobs::rss::SyncCratesFeed.enqueue(conn)?;
-        }
-        Command::SyncToGitIndex { name } => {
-            jobs::SyncToGitIndex::new(name).enqueue(conn)?;
-        }
-        Command::SyncToSparseIndex { name } => {
-            jobs::SyncToSparseIndex::new(name).enqueue(conn)?;
-        }
-        Command::SyncUpdatesFeed => {
-            jobs::rss::SyncUpdatesFeed.enqueue(conn)?;
-        }
-    };
+                    let query = background_jobs::table
+                        .filter(background_jobs::job_type.eq(jobs::SyncAdmins::JOB_NAME));
 
-    Ok(())
+                    if diesel::select(exists(query)).get_result(conn)? {
+                        info!(
+                            "Did not enqueue {}, existing job already in progress",
+                            jobs::SyncAdmins::JOB_NAME
+                        );
+                        return Ok(());
+                    }
+                }
+
+                jobs::SyncAdmins.enqueue(conn)?;
+            }
+            Command::DailyDbMaintenance => {
+                jobs::DailyDbMaintenance.enqueue(conn)?;
+            }
+            Command::ProcessCdnLogQueue(job) => {
+                job.enqueue(conn)?;
+            }
+            Command::SquashIndex => {
+                jobs::SquashIndex.enqueue(conn)?;
+            }
+            Command::NormalizeIndex { dry_run } => {
+                jobs::NormalizeIndex::new(dry_run).enqueue(conn)?;
+            }
+            Command::CheckTyposquat { name } => {
+                // The job will fail if the crate doesn't actually exist, so let's check that up front.
+                if crates::table
+                    .filter(crates::name.eq(&name))
+                    .count()
+                    .get_result::<i64>(conn)?
+                    == 0
+                {
+                    anyhow::bail!(
+                        "cannot enqueue a typosquat check for a crate that doesn't exist: {name}"
+                    );
+                }
+
+                jobs::CheckTyposquat::new(&name).enqueue(conn)?;
+            }
+            Command::SendTokenExpiryNotifications => {
+                jobs::SendTokenExpiryNotifications.enqueue(conn)?;
+            }
+            Command::SyncCratesFeed => {
+                jobs::rss::SyncCratesFeed.enqueue(conn)?;
+            }
+            Command::SyncToGitIndex { name } => {
+                jobs::SyncToGitIndex::new(name).enqueue(conn)?;
+            }
+            Command::SyncToSparseIndex { name } => {
+                jobs::SyncToSparseIndex::new(name).enqueue(conn)?;
+            }
+            Command::SyncUpdatesFeed => {
+                jobs::rss::SyncUpdatesFeed.enqueue(conn)?;
+            }
+        };
+
+        Ok(())
+    })
+    .await
 }

--- a/src/admin/migrate.rs
+++ b/src/admin/migrate.rs
@@ -1,3 +1,4 @@
+use crate::tasks::spawn_blocking;
 use anyhow::{anyhow, Error};
 use diesel_migrations::{
     embed_migrations, EmbeddedMigrations, HarnessWithOutput, MigrationHarness,
@@ -14,39 +15,42 @@ pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("./migrations");
 )]
 pub struct Opts;
 
-pub fn run(_opts: Opts) -> Result<(), Error> {
-    let config = crate::config::DatabasePools::full_from_environment(
-        &crate::config::Base::from_environment()?,
-    )?;
+pub async fn run(_opts: Opts) -> Result<(), Error> {
+    spawn_blocking(move || {
+        let config = crate::config::DatabasePools::full_from_environment(
+            &crate::config::Base::from_environment()?,
+        )?;
 
-    // TODO: Refactor logic so that we can also check things from App::new() here.
-    // If the app will panic due to bad configuration, it is better to error in the release phase
-    // to avoid launching dynos that will fail.
+        // TODO: Refactor logic so that we can also check things from App::new() here.
+        // If the app will panic due to bad configuration, it is better to error in the release phase
+        // to avoid launching dynos that will fail.
 
-    if config.are_all_read_only() {
-        // TODO: Check `any_pending_migrations()` with a read-only connection and error if true.
-        // It looks like this requires changes upstream to make this pub in `migration_macros`.
+        if config.are_all_read_only() {
+            // TODO: Check `any_pending_migrations()` with a read-only connection and error if true.
+            // It looks like this requires changes upstream to make this pub in `migration_macros`.
 
-        warn!("Skipping migrations and category sync (read-only mode)");
+            warn!("Skipping migrations and category sync (read-only mode)");
 
-        // The service is undergoing maintenance or mitigating an outage.
-        // Exit with success to ensure configuration changes can be made.
-        // Heroku will not launch new dynos if the release phase fails.
-        return Ok(());
-    }
+            // The service is undergoing maintenance or mitigating an outage.
+            // Exit with success to ensure configuration changes can be made.
+            // Heroku will not launch new dynos if the release phase fails.
+            return Ok(());
+        }
 
-    // The primary is online, access directly via `DATABASE_URL`.
-    let conn = &mut crate::db::oneoff_connection_with_config(&config)?;
+        // The primary is online, access directly via `DATABASE_URL`.
+        let conn = &mut crate::db::oneoff_connection_with_config(&config)?;
 
-    info!("Migrating the database");
-    let mut stdout = std::io::stdout();
-    let mut harness = HarnessWithOutput::new(conn, &mut stdout);
-    harness
-        .run_pending_migrations(MIGRATIONS)
-        .map_err(|err| anyhow!("Failed to run migrations: {err}"))?;
+        info!("Migrating the database");
+        let mut stdout = std::io::stdout();
+        let mut harness = HarnessWithOutput::new(conn, &mut stdout);
+        harness
+            .run_pending_migrations(MIGRATIONS)
+            .map_err(|err| anyhow!("Failed to run migrations: {err}"))?;
 
-    info!("Synchronizing crate categories");
-    crate::boot::categories::sync_with_connection(CATEGORIES_TOML, conn)?;
+        info!("Synchronizing crate categories");
+        crate::boot::categories::sync_with_connection(CATEGORIES_TOML, conn)?;
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }

--- a/src/admin/test_pagerduty.rs
+++ b/src/admin/test_pagerduty.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::str::FromStr;
 
 use crate::admin::on_call;
+use crate::tasks::spawn_blocking;
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]
 pub enum EventType {
@@ -31,20 +32,23 @@ pub struct Opts {
     description: Option<String>,
 }
 
-pub fn run(opts: Opts) -> Result<()> {
-    let event = match opts.event_type {
-        EventType::Trigger => on_call::Event::Trigger {
-            incident_key: Some("test".into()),
-            description: opts.description.unwrap_or_else(|| "Test event".into()),
-        },
-        EventType::Acknowledge => on_call::Event::Acknowledge {
-            incident_key: "test".into(),
-            description: opts.description,
-        },
-        EventType::Resolve => on_call::Event::Resolve {
-            incident_key: "test".into(),
-            description: opts.description,
-        },
-    };
-    event.send()
+pub async fn run(opts: Opts) -> Result<()> {
+    spawn_blocking(move || {
+        let event = match opts.event_type {
+            EventType::Trigger => on_call::Event::Trigger {
+                incident_key: Some("test".into()),
+                description: opts.description.unwrap_or_else(|| "Test event".into()),
+            },
+            EventType::Acknowledge => on_call::Event::Acknowledge {
+                incident_key: "test".into(),
+                description: opts.description,
+            },
+            EventType::Resolve => on_call::Event::Resolve {
+                incident_key: "test".into(),
+                description: opts.description,
+            },
+        };
+        event.send()
+    })
+    .await
 }

--- a/src/admin/upload_index.rs
+++ b/src/admin/upload_index.rs
@@ -1,5 +1,6 @@
 use crate::admin::dialoguer;
 use crate::storage::Storage;
+use crate::tasks::spawn_blocking;
 use anyhow::{anyhow, Context};
 use crates_io_index::{Repository, RepositoryConfig};
 use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
@@ -14,55 +15,58 @@ pub struct Opts {
     incremental_commit: Option<String>,
 }
 
-pub fn run(opts: Opts) -> anyhow::Result<()> {
-    let storage = Storage::from_environment();
+pub async fn run(opts: Opts) -> anyhow::Result<()> {
+    spawn_blocking(move || {
+        let storage = Storage::from_environment();
 
-    println!("fetching git repo");
-    let config = RepositoryConfig::from_environment()?;
-    let repo = Repository::open(&config)?;
-    repo.reset_head()?;
-    println!("HEAD is at {}", repo.head_oid()?);
+        println!("fetching git repo");
+        let config = RepositoryConfig::from_environment()?;
+        let repo = Repository::open(&config)?;
+        repo.reset_head()?;
+        println!("HEAD is at {}", repo.head_oid()?);
 
-    let files = repo.get_files_modified_since(opts.incremental_commit.as_deref())?;
-    println!("found {} files to upload", files.len());
-    if !dialoguer::confirm("continue with upload?") {
-        return Ok(());
-    }
-
-    let rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .context("Failed to initialize tokio runtime")?;
-
-    let pb = ProgressBar::new(files.len() as u64);
-    pb.set_style(ProgressStyle::with_template(
-        "{bar:60} ({pos}/{len}, ETA {eta})",
-    )?);
-
-    for file in files.iter().progress_with(pb.clone()) {
-        let file_name = file.file_name().ok_or_else(|| {
-            let file = file.display();
-            anyhow!("Failed to get file name from path: {file}")
-        })?;
-
-        let crate_name = file_name.to_str().ok_or_else(|| {
-            let file_name = file_name.to_string_lossy();
-            anyhow!("Failed to convert file name to utf8: {file_name}",)
-        })?;
-
-        let path = repo.index_file(crate_name);
-        if !path.exists() {
-            pb.suspend(|| println!("skipping file `{crate_name}`"));
-            continue;
+        let files = repo.get_files_modified_since(opts.incremental_commit.as_deref())?;
+        println!("found {} files to upload", files.len());
+        if !dialoguer::confirm("continue with upload?") {
+            return Ok(());
         }
 
-        let contents = std::fs::read_to_string(&path)?;
-        rt.block_on(storage.sync_index(crate_name, Some(contents)))?;
-    }
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("Failed to initialize tokio runtime")?;
 
-    println!(
-        "uploading completed; use `upload-index {}` for an incremental run",
-        repo.head_oid()?
-    );
-    Ok(())
+        let pb = ProgressBar::new(files.len() as u64);
+        pb.set_style(ProgressStyle::with_template(
+            "{bar:60} ({pos}/{len}, ETA {eta})",
+        )?);
+
+        for file in files.iter().progress_with(pb.clone()) {
+            let file_name = file.file_name().ok_or_else(|| {
+                let file = file.display();
+                anyhow!("Failed to get file name from path: {file}")
+            })?;
+
+            let crate_name = file_name.to_str().ok_or_else(|| {
+                let file_name = file_name.to_string_lossy();
+                anyhow!("Failed to convert file name to utf8: {file_name}",)
+            })?;
+
+            let path = repo.index_file(crate_name);
+            if !path.exists() {
+                pb.suspend(|| println!("skipping file `{crate_name}`"));
+                continue;
+            }
+
+            let contents = std::fs::read_to_string(&path)?;
+            rt.block_on(storage.sync_index(crate_name, Some(contents)))?;
+        }
+
+        println!(
+            "uploading completed; use `upload-index {}` for an incremental run",
+            repo.head_oid()?
+        );
+        Ok(())
+    })
+    .await
 }

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -5,7 +5,6 @@ use crates_io::admin::{
     default_versions, delete_crate, delete_version, enqueue_job, migrate, populate, render_readmes,
     test_pagerduty, transfer_crates, upload_index, verify_token, yank_version,
 };
-use crates_io::tasks::spawn_blocking;
 
 #[derive(clap::Parser, Debug)]
 #[command(name = "crates-admin")]
@@ -40,18 +39,18 @@ async fn main() -> anyhow::Result<()> {
     span.record("command", tracing::field::debug(&command));
 
     match command {
-        Command::DeleteCrate(opts) => spawn_blocking(move || delete_crate::run(opts)).await,
-        Command::DeleteVersion(opts) => spawn_blocking(move || delete_version::run(opts)).await,
-        Command::Populate(opts) => spawn_blocking(move || populate::run(opts)).await,
-        Command::RenderReadmes(opts) => spawn_blocking(move || render_readmes::run(opts)).await,
-        Command::TestPagerduty(opts) => spawn_blocking(move || test_pagerduty::run(opts)).await,
-        Command::TransferCrates(opts) => spawn_blocking(move || transfer_crates::run(opts)).await,
-        Command::VerifyToken(opts) => spawn_blocking(move || verify_token::run(opts)).await,
-        Command::Migrate(opts) => spawn_blocking(move || migrate::run(opts)).await,
-        Command::UploadIndex(opts) => spawn_blocking(move || upload_index::run(opts)).await,
-        Command::YankVersion(opts) => spawn_blocking(move || yank_version::run(opts)).await,
-        Command::EnqueueJob(command) => spawn_blocking(move || enqueue_job::run(command)).await,
-        Command::DefaultVersions(opts) => spawn_blocking(move || default_versions::run(opts)).await,
+        Command::DeleteCrate(opts) => delete_crate::run(opts).await,
+        Command::DeleteVersion(opts) => delete_version::run(opts).await,
+        Command::Populate(opts) => populate::run(opts).await,
+        Command::RenderReadmes(opts) => render_readmes::run(opts).await,
+        Command::TestPagerduty(opts) => test_pagerduty::run(opts).await,
+        Command::TransferCrates(opts) => transfer_crates::run(opts).await,
+        Command::VerifyToken(opts) => verify_token::run(opts).await,
+        Command::Migrate(opts) => migrate::run(opts).await,
+        Command::UploadIndex(opts) => upload_index::run(opts).await,
+        Command::YankVersion(opts) => yank_version::run(opts).await,
+        Command::EnqueueJob(command) => enqueue_job::run(command).await,
+        Command::DefaultVersions(opts) => default_versions::run(opts).await,
     }
 }
 

--- a/src/bin/crates-admin.rs
+++ b/src/bin/crates-admin.rs
@@ -5,6 +5,7 @@ use crates_io::admin::{
     default_versions, delete_crate, delete_version, enqueue_job, migrate, populate, render_readmes,
     test_pagerduty, transfer_crates, upload_index, verify_token, yank_version,
 };
+use crates_io::tasks::spawn_blocking;
 
 #[derive(clap::Parser, Debug)]
 #[command(name = "crates-admin")]
@@ -25,7 +26,8 @@ enum Command {
     DefaultVersions(default_versions::Command),
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let _sentry = crates_io::sentry::init();
 
     // Initialize logging
@@ -38,18 +40,18 @@ fn main() -> anyhow::Result<()> {
     span.record("command", tracing::field::debug(&command));
 
     match command {
-        Command::DeleteCrate(opts) => delete_crate::run(opts),
-        Command::DeleteVersion(opts) => delete_version::run(opts),
-        Command::Populate(opts) => populate::run(opts),
-        Command::RenderReadmes(opts) => render_readmes::run(opts),
-        Command::TestPagerduty(opts) => test_pagerduty::run(opts),
-        Command::TransferCrates(opts) => transfer_crates::run(opts),
-        Command::VerifyToken(opts) => verify_token::run(opts),
-        Command::Migrate(opts) => migrate::run(opts),
-        Command::UploadIndex(opts) => upload_index::run(opts),
-        Command::YankVersion(opts) => yank_version::run(opts),
-        Command::EnqueueJob(command) => enqueue_job::run(command),
-        Command::DefaultVersions(opts) => default_versions::run(opts),
+        Command::DeleteCrate(opts) => spawn_blocking(move || delete_crate::run(opts)).await,
+        Command::DeleteVersion(opts) => spawn_blocking(move || delete_version::run(opts)).await,
+        Command::Populate(opts) => spawn_blocking(move || populate::run(opts)).await,
+        Command::RenderReadmes(opts) => spawn_blocking(move || render_readmes::run(opts)).await,
+        Command::TestPagerduty(opts) => spawn_blocking(move || test_pagerduty::run(opts)).await,
+        Command::TransferCrates(opts) => spawn_blocking(move || transfer_crates::run(opts)).await,
+        Command::VerifyToken(opts) => spawn_blocking(move || verify_token::run(opts)).await,
+        Command::Migrate(opts) => spawn_blocking(move || migrate::run(opts)).await,
+        Command::UploadIndex(opts) => spawn_blocking(move || upload_index::run(opts)).await,
+        Command::YankVersion(opts) => spawn_blocking(move || yank_version::run(opts)).await,
+        Command::EnqueueJob(command) => spawn_blocking(move || enqueue_job::run(command)).await,
+        Command::DefaultVersions(opts) => spawn_blocking(move || default_versions::run(opts)).await,
     }
 }
 


### PR DESCRIPTION
This makes it easier to use async-only APIs in the admin tools and convert more functions to use `diesel_async` internally.