### PR TITLE
admin/dialoguer: Remove `.unwrap()` call from `confirm()` fn

### DIFF
--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -70,7 +70,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         }
         println!();
 
-        if !opts.yes && !dialoguer::confirm("Do you want to permanently delete these crates?") {
+        if !opts.yes && !dialoguer::confirm("Do you want to permanently delete these crates?")? {
             return Ok(());
         }
 

--- a/src/admin/delete_version.rs
+++ b/src/admin/delete_version.rs
@@ -47,7 +47,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         }
         println!();
 
-        if !opts.yes && !dialoguer::confirm("Do you want to permanently delete these versions?") {
+        if !opts.yes && !dialoguer::confirm("Do you want to permanently delete these versions?")? {
             return Ok(());
         }
 

--- a/src/admin/dialoguer.rs
+++ b/src/admin/dialoguer.rs
@@ -1,12 +1,11 @@
 use ::dialoguer::{theme::Theme, Confirm};
 
-pub fn confirm(msg: &str) -> bool {
+pub fn confirm(msg: &str) -> dialoguer::Result<bool> {
     Confirm::with_theme(&CustomTheme)
         .with_prompt(msg)
         .default(false)
         .wait_for_newline(true)
         .interact()
-        .unwrap()
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/admin/transfer_crates.rs
+++ b/src/admin/transfer_crates.rs
@@ -47,7 +47,7 @@ fn transfer(opts: Opts, conn: &mut PgConnection) -> anyhow::Result<()> {
         println!("from: {:?}", from.gh_id);
         println!("to:   {:?}", to.gh_id);
 
-        if !dialoguer::confirm("continue?") {
+        if !dialoguer::confirm("continue?")? {
             return Ok(());
         }
     }
@@ -56,7 +56,7 @@ fn transfer(opts: Opts, conn: &mut PgConnection) -> anyhow::Result<()> {
         "Are you sure you want to transfer crates from {} to {}?",
         from.gh_login, to.gh_login
     );
-    if !dialoguer::confirm(&prompt) {
+    if !dialoguer::confirm(&prompt)? {
         return Ok(());
     }
 
@@ -74,7 +74,7 @@ fn transfer(opts: Opts, conn: &mut PgConnection) -> anyhow::Result<()> {
         }
     }
 
-    if !dialoguer::confirm("commit?") {
+    if !dialoguer::confirm("commit?")? {
         return Ok(());
     }
 

--- a/src/admin/upload_index.rs
+++ b/src/admin/upload_index.rs
@@ -27,7 +27,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
 
         let files = repo.get_files_modified_since(opts.incremental_commit.as_deref())?;
         println!("found {} files to upload", files.len());
-        if !dialoguer::confirm("continue with upload?") {
+        if !dialoguer::confirm("continue with upload?")? {
             return Ok(());
         }
 

--- a/src/admin/yank_version.rs
+++ b/src/admin/yank_version.rs
@@ -53,7 +53,7 @@ fn yank(opts: Opts, conn: &mut PgConnection) -> anyhow::Result<()> {
             "Are you sure you want to yank {crate_name}#{version} ({})?",
             v.id
         );
-        if !dialoguer::confirm(&prompt) {
+        if !dialoguer::confirm(&prompt)? {
             return Ok(());
         }
     }


### PR DESCRIPTION
There is not much point in using `.unwrap()` when all callers can easily use the `?` operator...