### PR TITLE
models/default_versions: Fix `conn` argument type

### DIFF
--- a/src/models/default_versions.rs
+++ b/src/models/default_versions.rs
@@ -59,7 +59,7 @@ pub fn update_default_version(crate_id: i32, conn: &mut impl Conn) -> QueryResul
 
 /// Verifies that the default version for the specified crate is up-to-date.
 #[instrument(skip(conn))]
-pub fn verify_default_version(crate_id: i32, conn: &mut PgConnection) -> QueryResult<()> {
+pub fn verify_default_version(crate_id: i32, conn: &mut impl Conn) -> QueryResult<()> {
     let calculated = calculate_default_version(crate_id, conn)?;
 
     let saved = default_versions::table


### PR DESCRIPTION
The rest of the module is using `impl Conn` instead of the concrete `PgConnection` type, so this function should probably use the same...