### PR TITLE
Add `release_tracks` meta to pagination versions

### DIFF
--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -133,7 +133,11 @@ fn list_by_date(
 
     Ok(PaginatedVersionsAndPublishers {
         data,
-        meta: ResponseMeta { total, next_page },
+        meta: ResponseMeta {
+            total,
+            next_page,
+            release_tracks: None,
+        },
     })
 }
 
@@ -233,6 +237,7 @@ fn list_by_semver(
         meta: ResponseMeta {
             total: total as i64,
             next_page,
+            release_tracks: None,
         },
     })
 }
@@ -302,4 +307,180 @@ struct PaginatedVersionsAndPublishers {
 struct ResponseMeta {
     total: i64,
     next_page: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    release_tracks: Option<ReleaseTracks>,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize)]
+struct ReleaseTracks(IndexMap<ReleaseTrackName, ReleaseTrackDetails>);
+
+impl ReleaseTracks {
+    // Return the release tracks based on a sorted semver versions iterator (in descending order).
+    // **Remember to** filter out yanked versions manually before calling this function.
+    pub fn from_sorted_semver_iter<'a, I>(versions: I) -> Self
+    where
+        I: Iterator<Item = &'a semver::Version>,
+    {
+        let mut map = IndexMap::new();
+        for num in versions.filter(|num| num.pre.is_empty()) {
+            let key = ReleaseTrackName::from_semver(num);
+            let prev = map.last();
+            if prev.filter(|&(k, _)| *k == key).is_none() {
+                map.insert(
+                    key,
+                    ReleaseTrackDetails {
+                        highest: num.clone(),
+                    },
+                );
+            }
+        }
+
+        Self(map)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum ReleaseTrackName {
+    Minor(u64),
+    Major(u64),
+}
+
+impl ReleaseTrackName {
+    pub fn from_semver(version: &semver::Version) -> Self {
+        if version.major == 0 {
+            Self::Minor(version.minor)
+        } else {
+            Self::Major(version.major)
+        }
+    }
+}
+
+impl std::fmt::Display for ReleaseTrackName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Minor(minor) => write!(f, "0.{minor}"),
+            Self::Major(major) => write!(f, "{major}"),
+        }
+    }
+}
+
+impl serde::Serialize for ReleaseTrackName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+        Self: std::fmt::Display,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+struct ReleaseTrackDetails {
+    highest: semver::Version,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReleaseTrackDetails, ReleaseTrackName, ReleaseTracks};
+    use indexmap::IndexMap;
+
+    #[track_caller]
+    fn version(str: &str) -> semver::Version {
+        semver::Version::parse(str).unwrap()
+    }
+
+    #[test]
+    fn release_tracks_empty() {
+        let versions = [];
+        assert_eq!(
+            ReleaseTracks::from_sorted_semver_iter(versions.into_iter()),
+            ReleaseTracks(IndexMap::new())
+        );
+    }
+
+    #[test]
+    fn release_tracks_prerelease() {
+        let versions = [version("1.0.0-beta.5")];
+        assert_eq!(
+            ReleaseTracks::from_sorted_semver_iter(versions.iter()),
+            ReleaseTracks(IndexMap::new())
+        );
+    }
+
+    #[test]
+    fn release_tracks_multiple() {
+        let versions = [
+            "100.1.1",
+            "100.1.0",
+            "1.3.5",
+            "1.2.5",
+            "1.1.5",
+            "0.4.0-rc.1",
+            "0.3.23",
+            "0.3.22",
+            "0.3.21-pre.0",
+            "0.3.20",
+            "0.3.3",
+            "0.3.2",
+            "0.3.1",
+            "0.3.0",
+            "0.2.1",
+            "0.2.0",
+            "0.1.2",
+            "0.1.1",
+        ]
+        .map(version);
+
+        let release_tracks = ReleaseTracks::from_sorted_semver_iter(versions.iter());
+        assert_eq!(
+            release_tracks,
+            ReleaseTracks(IndexMap::from([
+                (
+                    ReleaseTrackName::Major(100),
+                    ReleaseTrackDetails {
+                        highest: version("100.1.1")
+                    }
+                ),
+                (
+                    ReleaseTrackName::Major(1),
+                    ReleaseTrackDetails {
+                        highest: version("1.3.5")
+                    }
+                ),
+                (
+                    ReleaseTrackName::Minor(3),
+                    ReleaseTrackDetails {
+                        highest: version("0.3.23")
+                    }
+                ),
+                (
+                    ReleaseTrackName::Minor(2),
+                    ReleaseTrackDetails {
+                        highest: version("0.2.1")
+                    }
+                ),
+                (
+                    ReleaseTrackName::Minor(1),
+                    ReleaseTrackDetails {
+                        highest: version("0.1.2")
+                    }
+                ),
+            ]))
+        );
+
+        let json = serde_json::from_str::<serde_json::Value>(
+            &serde_json::to_string(&release_tracks).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            json,
+            json!({
+                "100": { "highest": "100.1.1" },
+                "1": { "highest": "1.3.5" },
+                "0.3": { "highest": "0.3.23" },
+                "0.2": { "highest": "0.2.1" },
+                "0.1": { "highest": "0.1.2" }
+            })
+        );
+    }
 }

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -125,6 +125,10 @@ async fn test_sorting() {
     for (json, expect) in resp.iter().zip(&expects) {
         assert_eq!(json.versions[0].num, *expect);
         assert_eq!(json.meta.total as usize, expects.len());
+        assert_eq!(
+            json.meta.release_tracks,
+            Some(json!({"1": {"highest": "1.0.0"}}))
+        );
     }
     assert_eq!(calls as usize, expects.len() + 1);
 }
@@ -203,6 +207,91 @@ async fn test_seek_based_pagination_semver_sorting() {
     // A decodable seek value, MTAwCg (100), but doesn't actually exist
     let json: VersionList = anon
         .get_with_query(url, "per_page=10&sort=semver&seek=MTAwCg")
+        .await
+        .good();
+    assert_eq!(json.versions.len(), 0);
+    assert!(json.meta.next_page.is_none());
+    assert_eq!(json.meta.total, 0);
+    assert_eq!(json.meta.release_tracks, release_tracks);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_seek_based_pagination_date_sorting() {
+    let (app, anon, user) = TestApp::init().with_user();
+    let user = user.as_model();
+    app.db(|conn| {
+        CrateBuilder::new("foo_versions", user.id)
+            .version(VersionBuilder::new("0.5.1").yanked(true))
+            .version(VersionBuilder::new("1.0.0").rust_version("1.64"))
+            .version("0.5.0")
+            .expect_build(conn);
+        // Make version 1.0.0 mimic a version published before we started recording who published
+        // versions
+        let none: Option<i32> = None;
+        update(versions::table)
+            .filter(versions::num.eq("1.0.0"))
+            .set(versions::published_by.eq(none))
+            .execute(conn)
+            .unwrap();
+    });
+
+    let url = "/api/v1/crates/foo_versions/versions";
+    let expects = ["0.5.0", "1.0.0", "0.5.1"];
+    let release_tracks = Some(json!({
+        "1": {"highest": "1.0.0"},
+        "0.5": {"highest": "0.5.0"}
+    }));
+
+    // per_page larger than the number of versions
+    let json: VersionList = anon
+        .get_with_query(url, "per_page=10&sort=date")
+        .await
+        .good();
+    assert_eq!(nums(&json.versions), expects);
+    assert_eq!(json.meta.total as usize, expects.len());
+    assert_eq!(json.meta.release_tracks, release_tracks);
+
+    let json: VersionList = anon
+        .get_with_query(url, "per_page=1&sort=date")
+        .await
+        .good();
+    assert_eq!(nums(&json.versions), expects[0..1]);
+    assert_eq!(json.meta.total as usize, expects.len());
+    assert_eq!(json.meta.release_tracks, release_tracks);
+
+    let seek = json
+        .meta
+        .next_page
+        .map(|s| s.split_once("seek=").unwrap().1.to_owned())
+        .map(|p| p.split_once('&').map(|t| t.0.to_owned()).unwrap_or(p))
+        .unwrap();
+
+    // per_page larger than the number of remain versions
+    let json: VersionList = anon
+        .get_with_query(url, &format!("per_page=5&sort=date&seek={seek}"))
+        .await
+        .good();
+    assert_eq!(nums(&json.versions), expects[1..]);
+    assert!(json.meta.next_page.is_none());
+    assert_eq!(json.meta.total as usize, expects.len());
+    assert_eq!(json.meta.release_tracks, release_tracks);
+
+    // per_page euqal to the number of remain versions
+    let json: VersionList = anon
+        .get_with_query(url, &format!("per_page=2&sort=date&seek={seek}"))
+        .await
+        .good();
+    assert_eq!(nums(&json.versions), expects[1..]);
+    assert!(json.meta.next_page.is_some());
+    assert_eq!(json.meta.total as usize, expects.len());
+    assert_eq!(json.meta.release_tracks, release_tracks);
+
+    // A decodable seek value, WzE3Mjg1NjE5OTI3MzQ2NzMsNV0K ([1728561992734673,5]), but doesn't actually exist
+    let json: VersionList = anon
+        .get_with_query(
+            url,
+            "per_page=10&sort=date&seek=WzE3Mjg1NjE5OTI3MzQ2NzMsNV0K",
+        )
         .await
         .good();
     assert_eq!(json.versions.len(), 0);


### PR DESCRIPTION
This PR will add `release_tracks` information to the `meta` field for paginated versions. This is necessary for pagination because it only loads a portion of versions per page, while `release_tracks` may require all sorted versions to determine their values. Therefore, we also need to calculate these on the server side.

---

Tasks:
- [x] `release_tracks`
  - [x] sorted by semver
  - [x] sorted by date
  - [x] optional by `include` query param