### PR TITLE
worker: Add `DEDUPLICATED` flag to the `BackgroundJob` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,11 +1200,13 @@ name = "crates_io_worker"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "claims",
  "crates_io_test_db",
  "deadpool-diesel",
  "diesel",
  "diesel-async",
  "futures-util",
+ "insta",
  "sentry-core",
  "serde",
  "serde_json",

--- a/crates/crates_io_worker/Cargo.toml
+++ b/crates/crates_io_worker/Cargo.toml
@@ -21,5 +21,7 @@ tokio = { version = "=1.40.0", features = ["rt", "time"]}
 tracing = "=0.1.40"
 
 [dev-dependencies]
+claims = "=0.7.1"
 crates_io_test_db = { path = "../crates_io_test_db" }
+insta = { version = "=1.40.0", features = ["json"] }
 tokio = { version = "=1.40.0", features = ["macros", "rt", "rt-multi-thread", "sync"]}

--- a/crates/crates_io_worker/src/background_job.rs
+++ b/crates/crates_io_worker/src/background_job.rs
@@ -1,8 +1,10 @@
 use crate::errors::EnqueueError;
 use crate::schema::background_jobs;
 use diesel::connection::LoadConnection;
+use diesel::dsl::{exists, not};
 use diesel::pg::Pg;
 use diesel::prelude::*;
+use diesel::sql_types::{Int2, Jsonb, Text};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::future::Future;
@@ -21,6 +23,12 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
     /// [Self::enqueue_with_priority] can be used to override the priority value.
     const PRIORITY: i16 = 0;
 
+    /// Whether the job should be deduplicated.
+    ///
+    /// If true, the job will not be enqueued if there is already an unstarted
+    /// job with the same data.
+    const DEDUPLICATED: bool = false;
+
     /// Job queue where this job will be executed.
     const QUEUE: &'static str = DEFAULT_QUEUE;
 
@@ -30,7 +38,10 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
     /// Execute the task. This method should define its logic.
     fn run(&self, ctx: Self::Context) -> impl Future<Output = anyhow::Result<()>> + Send;
 
-    fn enqueue(&self, conn: &mut impl LoadConnection<Backend = Pg>) -> Result<i64, EnqueueError> {
+    fn enqueue(
+        &self,
+        conn: &mut impl LoadConnection<Backend = Pg>,
+    ) -> Result<Option<i64>, EnqueueError> {
         self.enqueue_with_priority(conn, Self::PRIORITY)
     }
 
@@ -39,16 +50,48 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
         &self,
         conn: &mut impl LoadConnection<Backend = Pg>,
         job_priority: i16,
-    ) -> Result<i64, EnqueueError> {
+    ) -> Result<Option<i64>, EnqueueError> {
         let job_data = serde_json::to_value(self)?;
-        let id = diesel::insert_into(background_jobs::table)
-            .values((
-                background_jobs::job_type.eq(Self::JOB_NAME),
-                background_jobs::data.eq(job_data),
-                background_jobs::priority.eq(job_priority),
+
+        if Self::DEDUPLICATED {
+            let similar_jobs = background_jobs::table
+                .select(background_jobs::id)
+                .filter(background_jobs::job_type.eq(Self::JOB_NAME))
+                .filter(background_jobs::data.eq(&job_data))
+                .filter(background_jobs::priority.eq(job_priority))
+                .for_update()
+                .skip_locked();
+
+            let deduplicated_select = diesel::select((
+                Self::JOB_NAME.into_sql::<Text>(),
+                (&job_data).into_sql::<Jsonb>(),
+                job_priority.into_sql::<Int2>(),
             ))
-            .returning(background_jobs::id)
-            .get_result(conn)?;
-        Ok(id)
+            .filter(not(exists(similar_jobs)));
+
+            let id = diesel::insert_into(background_jobs::table)
+                .values(deduplicated_select)
+                .into_columns((
+                    background_jobs::job_type,
+                    background_jobs::data,
+                    background_jobs::priority,
+                ))
+                .returning(background_jobs::id)
+                .get_result::<i64>(conn)
+                .optional()?;
+
+            Ok(id)
+        } else {
+            let id = diesel::insert_into(background_jobs::table)
+                .values((
+                    background_jobs::job_type.eq(Self::JOB_NAME),
+                    background_jobs::data.eq(job_data),
+                    background_jobs::priority.eq(job_priority),
+                ))
+                .returning(background_jobs::id)
+                .get_result(conn)?;
+
+            Ok(Some(id))
+        }
     }
 }


### PR DESCRIPTION
This flag can be set when implementing background jobs to automatically deduplicate jobs when they are enqueued. If an unstarted job already exists in the queue the `enqueue()` fn will return `Ok(None)` instead of the job ID.

This should allow us to get rid of `enqueue_sync_to_index()` as a special case and make the same functionality available to other jobs as well.