### PR TITLE
worker/jobs: Use `DEDUPLICATED` for jobs where it makes sense

### DIFF
--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -48,6 +48,7 @@ impl Default for ArchiveVersionDownloads {
 
 impl BackgroundJob for ArchiveVersionDownloads {
     const JOB_NAME: &'static str = "archive_version_downloads";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/daily_db_maintenance.rs
+++ b/src/worker/jobs/daily_db_maintenance.rs
@@ -10,6 +10,7 @@ pub struct DailyDbMaintenance;
 
 impl BackgroundJob for DailyDbMaintenance {
     const JOB_NAME: &'static str = "daily_db_maintenance";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -19,6 +19,7 @@ impl DeleteCrateFromStorage {
 
 impl BackgroundJob for DeleteCrateFromStorage {
     const JOB_NAME: &'static str = "delete_crate_from_storage";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/downloads/clean_processed_log_files.rs
+++ b/src/worker/jobs/downloads/clean_processed_log_files.rs
@@ -16,6 +16,7 @@ pub struct CleanProcessedLogFiles;
 
 impl BackgroundJob for CleanProcessedLogFiles {
     const JOB_NAME: &'static str = "clean_processed_log_files";
+    const DEDUPLICATED: bool = true;
     const QUEUE: &'static str = "downloads";
 
     type Context = Arc<Environment>;

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -44,6 +44,7 @@ impl ProcessCdnLog {
 
 impl BackgroundJob for ProcessCdnLog {
     const JOB_NAME: &'static str = "process_cdn_log";
+    const DEDUPLICATED: bool = true;
     const QUEUE: &'static str = "downloads";
 
     type Context = Arc<Environment>;

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -14,6 +14,7 @@ pub struct UpdateDownloads;
 
 impl BackgroundJob for UpdateDownloads {
     const JOB_NAME: &'static str = "update_downloads";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -14,6 +14,7 @@ pub struct DumpDb;
 
 impl BackgroundJob for DumpDb {
     const JOB_NAME: &'static str = "dump_db";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -21,6 +21,7 @@ pub struct SendTokenExpiryNotifications;
 
 impl BackgroundJob for SendTokenExpiryNotifications {
     const JOB_NAME: &'static str = "send_token_expiry_notifications";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -12,6 +12,7 @@ pub struct SquashIndex;
 
 impl BackgroundJob for SquashIndex {
     const JOB_NAME: &'static str = "squash_index";
+    const DEDUPLICATED: bool = true;
     const QUEUE: &'static str = "repository";
 
     type Context = Arc<Environment>;

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -28,6 +28,7 @@ impl SyncToGitIndex {
 impl BackgroundJob for SyncToGitIndex {
     const JOB_NAME: &'static str = "sync_to_git_index";
     const PRIORITY: i16 = 100;
+    const DEDUPLICATED: bool = true;
     const QUEUE: &'static str = "repository";
 
     type Context = Arc<Environment>;
@@ -94,6 +95,7 @@ impl SyncToSparseIndex {
 impl BackgroundJob for SyncToSparseIndex {
     const JOB_NAME: &'static str = "sync_to_sparse_index";
     const PRIORITY: i16 = 100;
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/index_version_downloads_archive/mod.rs
+++ b/src/worker/jobs/index_version_downloads_archive/mod.rs
@@ -16,6 +16,7 @@ pub struct IndexVersionDownloadsArchive;
 
 impl BackgroundJob for IndexVersionDownloadsArchive {
     const JOB_NAME: &'static str = "index_version_downloads_archive";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -33,6 +33,7 @@ impl SyncCrateFeed {
 
 impl BackgroundJob for SyncCrateFeed {
     const JOB_NAME: &'static str = "sync_crate_feed";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -25,6 +25,7 @@ const NUM_ITEMS: i64 = 50;
 
 impl BackgroundJob for SyncCratesFeed {
     const JOB_NAME: &'static str = "sync_crates_feed";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -25,6 +25,7 @@ const NUM_ITEMS: i64 = 100;
 
 impl BackgroundJob for SyncUpdatesFeed {
     const JOB_NAME: &'static str = "sync_updates_feed";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -25,6 +25,7 @@ impl SendPublishNotificationsJob {
 
 impl BackgroundJob for SendPublishNotificationsJob {
     const JOB_NAME: &'static str = "send_publish_notifications";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/sync_admins.rs
+++ b/src/worker/jobs/sync_admins.rs
@@ -18,6 +18,7 @@ pub struct SyncAdmins;
 
 impl BackgroundJob for SyncAdmins {
     const JOB_NAME: &'static str = "sync_admins";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -28,6 +28,7 @@ impl CheckTyposquat {
 
 impl BackgroundJob for CheckTyposquat {
     const JOB_NAME: &'static str = "check_typosquat";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 

--- a/src/worker/jobs/update_default_version.rs
+++ b/src/worker/jobs/update_default_version.rs
@@ -19,6 +19,7 @@ impl UpdateDefaultVersion {
 impl BackgroundJob for UpdateDefaultVersion {
     const JOB_NAME: &'static str = "update_default_version";
     const PRIORITY: i16 = 80;
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 


### PR DESCRIPTION
Most of our background jobs don't need to be enqueued multiple times if there is already a similar one in the queue. This commit changes most of the jobs to use the new `DEDUPLICATED` flag on the `BackgroundJob` impl.