### PR TITLE
worker/jobs: Simplify and inline `enqueue_sync_to_index()` fn

### DIFF
--- a/src/admin/delete_crate.rs
+++ b/src/admin/delete_crate.rs
@@ -97,8 +97,11 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             };
 
             info!("{name}: Enqueuing index sync jobs…");
-            if let Err(error) = jobs::enqueue_sync_to_index(name, conn) {
-                warn!("{name}: Failed to enqueue index sync jobs: {error}");
+            if let Err(error) = jobs::SyncToGitIndex::new(name).enqueue(conn) {
+                warn!("{name}: Failed to enqueue SyncToGitIndex job: {error}");
+            }
+            if let Err(error) = jobs::SyncToSparseIndex::new(name).enqueue(conn) {
+                warn!("{name}: Failed to enqueue SyncToSparseIndex job: {error}");
             }
 
             info!("{name}: Enqueuing DeleteCrateFromStorage job…");

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -442,7 +442,8 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 ))
                 .map_err(|e| internal(format!("failed to upload crate: {e}")))?;
 
-            jobs::enqueue_sync_to_index(&krate.name, conn)?;
+            jobs::SyncToGitIndex::new(&krate.name).enqueue(conn)?;
+            jobs::SyncToSparseIndex::new(&krate.name).enqueue(conn)?;
 
             SendPublishNotificationsJob::new(version.id).enqueue(conn)?;
 


### PR DESCRIPTION
Now that our background worker system supports automatic deduplication we don't need the `enqueue_sync_to_index()` fn anymore. The old fn had the advantage of only needing a single query to enqueue both jobs, but IMHO the additional complexity isn't worth it and with `diesel-async` supporting pipelining it should be possible to mitigate the performance impact too.