### PR TITLE
Revert "Update Rust crate async-compression to v0.4.14"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7"
+checksum = "7e614738943d3f68c628ae3dbce7c3daffb196665f82f8c8ea6b65de73c79429"
 dependencies = [
  "brotli",
  "flate2",

--- a/crates/crates_io_cdn_logs/Cargo.toml
+++ b/crates/crates_io_cdn_logs/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 anyhow = "=1.0.89"
-async-compression = { version = "=0.4.14", features = ["gzip", "tokio", "zstd"] }
+async-compression = { version = "=0.4.13", features = ["gzip", "tokio", "zstd"] }
 chrono = { version = "=0.4.38", features = ["serde"] }
 derive_deref = "=1.1.1"
 percent-encoding = "=2.3.1"


### PR DESCRIPTION
Reverts rust-lang/crates.io#9622. Fixes https://github.com/rust-lang/crates.io/issues/9638.