### PR TITLE
Move `split_features()` fn into `crates_io_index` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "claims",
  "crates_io_env_vars",
  "git2",
+ "insta",
  "secrecy",
  "serde",
  "serde_json",

--- a/crates/crates_io_index/Cargo.toml
+++ b/crates/crates_io_index/Cargo.toml
@@ -29,3 +29,4 @@ url = "=2.5.2"
 
 [dev-dependencies]
 claims = "=0.7.1"
+insta = "=1.40.0"

--- a/crates/crates_io_index/data.rs
+++ b/crates/crates_io_index/data.rs
@@ -1,5 +1,5 @@
+use crate::features::FeaturesMap;
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Crate {
@@ -7,7 +7,7 @@ pub struct Crate {
     pub vers: String,
     pub deps: Vec<Dependency>,
     pub cksum: String,
-    pub features: BTreeMap<String, Vec<String>>,
+    pub features: FeaturesMap,
     /// This field contains features with new, extended syntax. Specifically,
     /// namespaced features (`dep:`) and weak dependencies (`pkg?/feat`).
     ///
@@ -18,7 +18,7 @@ pub struct Crate {
     /// will fail to load due to not being able to parse the new syntax, even
     /// with a `Cargo.lock` file.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub features2: Option<BTreeMap<String, Vec<String>>>,
+    pub features2: Option<FeaturesMap>,
     pub yanked: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<String>,

--- a/crates/crates_io_index/features.rs
+++ b/crates/crates_io_index/features.rs
@@ -51,6 +51,7 @@ pub fn split_features(
 mod tests {
     use super::*;
     use insta::{assert_compact_debug_snapshot, assert_debug_snapshot};
+    use serde_json::json;
 
     #[test]
     fn test_split_features_no_deps() {

--- a/crates/crates_io_index/lib.rs
+++ b/crates/crates_io_index/lib.rs
@@ -5,6 +5,7 @@ extern crate tracing;
 
 mod credentials;
 mod data;
+pub mod features;
 mod repo;
 mod ser;
 #[cfg(feature = "testing")]

--- a/crates/crates_io_index/snapshots/crates_io_index__features__tests__split_features_clap.snap
+++ b/crates/crates_io_index/snapshots/crates_io_index__features__tests__split_features_clap.snap
@@ -1,5 +1,5 @@
 ---
-source: src/models/feature.rs
+source: crates/crates_io_index/features.rs
 expression: split_features(features)
 ---
 (

--- a/src/models.rs
+++ b/src/models.rs
@@ -24,7 +24,6 @@ mod default_versions;
 pub mod dependency;
 mod download;
 mod email;
-pub mod feature;
 mod follow;
 mod keyword;
 pub mod krate;

--- a/src/models/feature.rs
+++ b/src/models/feature.rs
@@ -6,7 +6,9 @@ pub type FeaturesMap = BTreeMap<String, Vec<String>>;
 /// values.
 ///
 /// See <https://rust-lang.github.io/rfcs/3143-cargo-weak-namespaced-features.html>.
-pub fn split_features(features: FeaturesMap) -> (FeaturesMap, FeaturesMap) {
+pub fn split_features(
+    features: impl IntoIterator<Item = (String, Vec<String>)>,
+) -> (FeaturesMap, FeaturesMap) {
     const ITERATION_LIMIT: usize = 100;
 
     // First, we partition the features into two groups: those that use the new

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+use crates_io_index::features::split_features;
 use diesel::associations::Identifiable;
 use diesel::dsl;
 use diesel::pg::Pg;
@@ -8,7 +9,6 @@ use secrecy::SecretString;
 use thiserror::Error;
 
 use crate::controllers::helpers::pagination::*;
-use crate::models::feature::split_features;
 use crate::models::helpers::with_count::*;
 use crate::models::version::TopVersions;
 use crate::models::{

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -1,13 +1,13 @@
 use std::collections::BTreeMap;
 
 use chrono::NaiveDateTime;
+use crates_io_index::features::FeaturesMap;
 use derive_builder::Builder;
 use diesel::prelude::*;
 use serde::Deserialize;
 
 use crate::util::errors::{bad_request, AppResult};
 
-use crate::models::feature::FeaturesMap;
 use crate::models::{Crate, Dependency, User};
 use crate::schema::*;
 use crate::sql::split_part;


### PR DESCRIPTION
This fn is only relevant when writing out index files, so we can move it into our dedicated `crates_io_index` crate. This makes it faster to compile and test, since that crate compiles a lot faster than `crates_io` itself 😅 