### PR TITLE
index: Convert `get_index_data()` fn to async

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -13,7 +13,13 @@ use sentry::Level;
 #[instrument(skip_all, fields(krate.name = ?name))]
 pub fn get_index_data(name: &str, conn: &mut impl Conn) -> anyhow::Result<Option<String>> {
     debug!("Looking up crate by name");
-    let Some(krate): Option<Crate> = Crate::by_exact_name(name).first(conn).optional()? else {
+    let krate = crates::table
+        .select(Crate::as_select())
+        .filter(crates::name.eq(name))
+        .first::<Crate>(conn)
+        .optional();
+
+    let Some(krate) = krate? else {
         return Ok(None);
     };
 


### PR DESCRIPTION
This reduces the amount of `spawn_blocking()` calls in the index sync background jobs, since the queries are now handled by `diesel-async` :)