### PR TITLE
admin/yank_version: Remove `spawn_blocking()` usage

### DIFF
--- a/src/admin/yank_version.rs
+++ b/src/admin/yank_version.rs
@@ -2,10 +2,11 @@ use crate::admin::dialoguer;
 use crate::db;
 use crate::models::{Crate, Version};
 use crate::schema::versions;
-use crate::tasks::spawn_blocking;
 use crate::worker::jobs::{SyncToGitIndex, SyncToSparseIndex, UpdateDefaultVersion};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 
 #[derive(clap::Parser, Debug)]
 #[command(
@@ -23,24 +24,26 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    spawn_blocking(move || {
-        let mut conn = db::oneoff_connection()?;
-        conn.transaction(|conn| yank(opts, conn))?;
-        Ok(())
-    })
-    .await
+    let mut conn = db::oneoff_async_connection().await?;
+
+    conn.transaction(|conn| yank(opts, conn).scope_boxed())
+        .await?;
+
+    Ok(())
 }
 
-fn yank(opts: Opts, conn: &mut PgConnection) -> anyhow::Result<()> {
+async fn yank(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()> {
     let Opts {
         crate_name,
         version,
         yes,
     } = opts;
-    let krate: Crate = Crate::by_name(&crate_name).first(conn)?;
+    let krate: Crate = Crate::by_name(&crate_name).first(conn).await?;
+
     let v: Version = Version::belonging_to(&krate)
         .filter(versions::num.eq(&version))
-        .first(conn)?;
+        .first(conn)
+        .await?;
 
     if v.yanked {
         println!("Version {version} of crate {crate_name} is already yanked");
@@ -52,7 +55,7 @@ fn yank(opts: Opts, conn: &mut PgConnection) -> anyhow::Result<()> {
             "Are you sure you want to yank {crate_name}#{version} ({})?",
             v.id
         );
-        if !dialoguer::confirm(&prompt)? {
+        if !dialoguer::async_confirm(&prompt).await? {
             return Ok(());
         }
     }
@@ -60,11 +63,18 @@ fn yank(opts: Opts, conn: &mut PgConnection) -> anyhow::Result<()> {
     println!("yanking version {} ({})", v.num, v.id);
     diesel::update(&v)
         .set(versions::yanked.eq(true))
-        .execute(conn)?;
+        .execute(conn)
+        .await?;
 
-    SyncToGitIndex::new(&krate.name).enqueue(conn)?;
-    SyncToSparseIndex::new(&krate.name).enqueue(conn)?;
-    UpdateDefaultVersion::new(krate.id).enqueue(conn)?;
+    SyncToGitIndex::new(&krate.name).async_enqueue(conn).await?;
+
+    SyncToSparseIndex::new(&krate.name)
+        .async_enqueue(conn)
+        .await?;
+
+    UpdateDefaultVersion::new(krate.id)
+        .async_enqueue(conn)
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
similar to https://github.com/rust-lang/crates.io/pull/9619, but now that background jobs can be enqueued async, this should actually work 😅 