### PR TITLE
typosquat/test_util: Simplify `Faker`

### DIFF
--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -163,7 +163,7 @@ impl From<crate::models::Owner> for Owner {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_util::test_db_connection, typosquat::test_util::Faker};
+    use crate::{test_util::test_db_connection, typosquat::test_util::faker};
     use thiserror::Error;
 
     use super::*;
@@ -172,21 +172,19 @@ mod tests {
     fn top_crates() -> Result<(), Error> {
         let (_test_db, mut conn) = test_db_connection();
 
-        let mut faker = Faker::new();
-
         // Set up two users.
-        let user_a = faker.user(&mut conn, "a")?;
-        let user_b = faker.user(&mut conn, "b")?;
+        let user_a = faker::user(&mut conn, "a")?;
+        let user_b = faker::user(&mut conn, "b")?;
 
         // Set up three crates with various ownership schemes.
-        let _top_a = faker.crate_and_version(&mut conn, "a", "Hello", &user_a, 2)?;
-        let top_b = faker.crate_and_version(&mut conn, "b", "Yes, this is dog", &user_b, 1)?;
-        let not_top_c = faker.crate_and_version(&mut conn, "c", "Unpopular", &user_a, 0)?;
+        let _top_a = faker::crate_and_version(&mut conn, "a", "Hello", &user_a, 2)?;
+        let top_b = faker::crate_and_version(&mut conn, "b", "Yes, this is dog", &user_b, 1)?;
+        let not_top_c = faker::crate_and_version(&mut conn, "c", "Unpopular", &user_a, 0)?;
 
         // Let's set up a team that owns both b and c, but not a.
-        let not_the_a_team = faker.team(&mut conn, "org", "team")?;
-        faker.add_crate_to_team(&mut conn, &user_b, &top_b.0, &not_the_a_team)?;
-        faker.add_crate_to_team(&mut conn, &user_b, &not_top_c.0, &not_the_a_team)?;
+        let not_the_a_team = faker::team(&mut conn, "org", "team")?;
+        faker::add_crate_to_team(&mut conn, &user_b, &top_b.0, &not_the_a_team)?;
+        faker::add_crate_to_team(&mut conn, &user_b, &not_top_c.0, &not_the_a_team)?;
 
         let top_crates = TopCrates::new(&mut conn, 2)?;
 

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -8,15 +8,10 @@ use crate::{
     schema::{crate_downloads, crate_owners, users},
 };
 
-pub struct Faker {}
-
-impl Faker {
-    pub fn new() -> Self {
-        Self {}
-    }
+pub mod faker {
+    use super::*;
 
     pub fn add_crate_to_team(
-        &mut self,
         conn: &mut PgConnection,
         user: &User,
         krate: &Crate,
@@ -38,7 +33,6 @@ impl Faker {
     }
 
     pub fn crate_and_version(
-        &mut self,
         conn: &mut PgConnection,
         name: &str,
         description: &str,
@@ -68,12 +62,7 @@ impl Faker {
         Ok((krate, version))
     }
 
-    pub fn team(
-        &mut self,
-        conn: &mut PgConnection,
-        org: &str,
-        team: &str,
-    ) -> anyhow::Result<Owner> {
+    pub fn team(conn: &mut PgConnection, org: &str, team: &str) -> anyhow::Result<Owner> {
         Ok(Owner::Team(
             NewTeam::new(
                 &format!("github:{org}:{team}"),
@@ -86,7 +75,7 @@ impl Faker {
         ))
     }
 
-    pub fn user(&mut self, conn: &mut PgConnection, login: &str) -> QueryResult<User> {
+    pub fn user(conn: &mut PgConnection, login: &str) -> QueryResult<User> {
         let user = NewUser::new(next_gh_id(), login, None, None, "token");
 
         diesel::insert_into(users::table)

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -5,19 +5,14 @@ use crate::{
     models::{
         Crate, CrateOwner, NewCrate, NewTeam, NewUser, NewVersion, Owner, OwnerKind, User, Version,
     },
-    schema::{crate_downloads, crate_owners},
-    Emails,
+    schema::{crate_downloads, crate_owners, users},
 };
 
-pub struct Faker {
-    emails: Emails,
-}
+pub struct Faker {}
 
 impl Faker {
     pub fn new() -> Self {
-        Self {
-            emails: Emails::new_in_memory(),
-        }
+        Self {}
     }
 
     pub fn add_crate_to_team(
@@ -91,13 +86,11 @@ impl Faker {
         ))
     }
 
-    pub fn user(&mut self, conn: &mut PgConnection, login: &str) -> anyhow::Result<User> {
-        Ok(
-            NewUser::new(next_gh_id(), login, None, None, "token").create_or_update(
-                None,
-                &self.emails,
-                conn,
-            )?,
-        )
+    pub fn user(&mut self, conn: &mut PgConnection, login: &str) -> QueryResult<User> {
+        let user = NewUser::new(next_gh_id(), login, None, None, "token");
+
+        diesel::insert_into(users::table)
+            .values(user)
+            .get_result(conn)
     }
 }

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -122,7 +122,7 @@ Specific squat checks that triggered:
 
 #[cfg(test)]
 mod tests {
-    use crate::{test_util::test_db_connection, typosquat::test_util::Faker};
+    use crate::{test_util::test_db_connection, typosquat::test_util::faker};
     use lettre::Address;
 
     use super::*;
@@ -131,25 +131,24 @@ mod tests {
     fn integration() -> anyhow::Result<()> {
         let emails = Emails::new_in_memory();
         let (_test_db, mut conn) = test_db_connection();
-        let mut faker = Faker::new();
 
         // Set up a user and a popular crate to match against.
-        let user = faker.user(&mut conn, "a")?;
-        faker.crate_and_version(&mut conn, "my-crate", "It's awesome", &user, 100)?;
+        let user = faker::user(&mut conn, "a")?;
+        faker::crate_and_version(&mut conn, "my-crate", "It's awesome", &user, 100)?;
 
         // Prime the cache so it only includes the crate we just created.
         let cache = Cache::new(vec!["admin@example.com".to_string()], &mut conn)?;
 
         // Now we'll create new crates: one problematic, one not so.
-        let other_user = faker.user(&mut conn, "b")?;
-        let (angel, _version) = faker.crate_and_version(
+        let other_user = faker::user(&mut conn, "b")?;
+        let (angel, _version) = faker::crate_and_version(
             &mut conn,
             "innocent-crate",
             "I'm just a simple, innocent crate",
             &other_user,
             0,
         )?;
-        let (demon, _version) = faker.crate_and_version(
+        let (demon, _version) = faker::crate_and_version(
             &mut conn,
             "mycrate",
             "I'm even more innocent, obviously",


### PR DESCRIPTION
We aren't actually using the `Emails` instance in this test suite, so we may as well remove it and simplify the `Faker` struct to be a module with regular functions instead :)

/cc @LawnGnome 