### PR TITLE
tests/util/test_app: Simplify `db_new_user()` fn

### DIFF
--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -4,7 +4,9 @@ use crate::config::{
 };
 use crate::middleware::cargo_compat::StatusCodeConfig;
 use crate::models::token::{CrateScope, EndpointScope};
+use crate::models::User;
 use crate::rate_limiter::{LimitedAction, RateLimiterConfig};
+use crate::schema::users;
 use crate::storage::StorageConfig;
 use crate::team_repo::MockTeamRepo;
 use crate::tests::util::chaosproxy::ChaosProxy;
@@ -126,8 +128,9 @@ impl TestApp {
         let user = self.db(|conn| {
             let email = format!("{username}@example.com");
 
-            let user = crate::tests::new_user(username)
-                .create_or_update(None, &self.0.app.emails, conn)
+            let user: User = diesel::insert_into(users::table)
+                .values(crate::tests::new_user(username))
+                .get_result(conn)
                 .unwrap();
             diesel::insert_into(emails::table)
                 .values((


### PR DESCRIPTION
For tests we don't need the "upsert" behavior of `create_or_update()` and since we're passing in `None` we don't need the email sending behavior either, so let's simplify this to only insert the user in the database and nothing else :)