### PR TITLE
Fix "unconfigured TLS" panic in `db::oneoff_async_connection()` fn

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,7 @@ use crate::certs::CRUNCHY;
 use diesel::{Connection, ConnectionResult, PgConnection, QueryResult};
 use diesel_async::pooled_connection::deadpool::{Hook, HookError};
 use diesel_async::pooled_connection::ManagerConfig;
-use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use native_tls::{Certificate, TlsConnector};
 use postgres_native_tls::MakeTlsConnector;
 use secrecy::ExposeSecret;
@@ -27,7 +27,7 @@ pub async fn oneoff_async_connection_with_config(
     config: &config::DatabasePools,
 ) -> ConnectionResult<AsyncPgConnection> {
     let url = connection_url(config, config.primary.url.expose_secret());
-    AsyncPgConnection::establish(&url).await
+    establish_async_connection(&url, config.enforce_tls).await
 }
 
 pub async fn oneoff_async_connection() -> anyhow::Result<AsyncPgConnection> {


### PR DESCRIPTION
The `enqueue-job` admin tool has been silently failing on our staging environment since #9632 was merged. This PR fixes it by reusing our `establish_async_connection()` fn, which sets up the TLS configuration correctly.

It is a bit unforunate that this wasn't caught earlier though. We could potentially look into using TLS for the database connection on CI, but we'd also need to write tests for all of the admin tools (which we should do anyway...).

It is also a bit surprising that the Heroku Scheduler, which regularly uses this admin tool to enqueue regular tasks, didn't report any warnings about the tool crashing all the time, but I guess there is not much we can do on that front :-/