### PR TITLE
models/team: Replace `String` with `&str` for `NewTeam` struct fields

### DIFF
--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -39,8 +39,8 @@ pub struct Team {
 pub struct NewTeam<'a> {
     pub login: &'a str,
     pub github_id: i32,
-    pub name: Option<String>,
-    pub avatar: Option<String>,
+    pub name: Option<&'a str>,
+    pub avatar: Option<&'a str>,
     pub org_id: i32,
 }
 
@@ -49,8 +49,8 @@ impl<'a> NewTeam<'a> {
         login: &'a str,
         org_id: i32,
         github_id: i32,
-        name: Option<String>,
-        avatar: Option<String>,
+        name: Option<&'a str>,
+        avatar: Option<&'a str>,
     ) -> Self {
         NewTeam {
             login,
@@ -174,8 +174,8 @@ impl Team {
             &login.to_lowercase(),
             org_id,
             team.id,
-            team.name,
-            org.avatar_url,
+            team.name.as_deref(),
+            org.avatar_url.as_deref(),
         )
         .create_or_update(conn)
         .map_err(Into::into)

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -68,7 +68,7 @@ pub mod faker {
                 &format!("github:{org}:{team}"),
                 next_gh_id(),
                 next_gh_id(),
-                Some(team.to_string()),
+                Some(team),
                 None,
             )
             .create_or_update(conn)?,


### PR DESCRIPTION
For `INSERT` queries there is no need for allocations, so let's replace them with regular references.