### PR TITLE
tests/builders/version: Simplify code by adding fields to `NewVersion` struct

### DIFF
--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -82,6 +82,10 @@ impl Version {
 pub struct NewVersion<'a> {
     crate_id: i32,
     num: &'a str,
+    #[builder(default)]
+    created_at: Option<&'a NaiveDateTime>,
+    #[builder(default, setter(strip_option))]
+    yanked: Option<bool>,
     #[builder(
         default = "serde_json::Value::Object(Default::default())",
         setter(custom)


### PR DESCRIPTION
`None` values are treated as using the default column value by `diesel` by default, and `#[builder(default)]` initializes these fields as `None`. This enables us to only overwrite these columns in tests, while the production code stays the same. This then enables us to get rid of two additional queries in the `VersionBuilder` test helper :)