### PR TITLE
tracing: Use `json-subscriber` crate for JSON logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
  "indicatif",
  "insta",
  "ipnetwork",
+ "json-subscriber",
  "lettre",
  "minijinja",
  "mockall",
@@ -2730,6 +2731,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-subscriber"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b067109fbfeef7ae9403847119f28bc7b0470c08b80e9069411df90fe56a5b"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tracing",
+ "tracing-core",
+ "tracing-serde",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ hyper = { version = "=1.5.0", features = ["client", "http1"] }
 indexmap = { version = "=2.6.0", features = ["serde"] }
 indicatif = "=0.17.8"
 ipnetwork = "=0.20.0"
+json-subscriber = "=0.2.1"
 tikv-jemallocator = { version = "=0.6.0", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 lettre = { version = "=0.11.9", default-features = false, features = ["file-transport", "smtp-transport", "native-tls", "hostname", "builder"] }
 minijinja = "=2.3.1"

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -29,8 +29,9 @@ fn init_with_default_level(level: LevelFilter) {
         .unwrap_or_default();
 
     let log_layer = match log_format.as_deref() {
-        Some("json") => tracing_subscriber::fmt::layer()
-            .json()
+        Some("json") => json_subscriber::fmt::layer()
+            .flatten_event(true)
+            .with_flat_span_list(true)
             .with_filter(env_filter)
             .boxed(),
         _ => tracing_subscriber::fmt::layer()


### PR DESCRIPTION
This allows us to flatten the span fields, which makes them a lot easier to use within Datadog.