### PR TITLE
Replace `derive_builder` with `bon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -679,6 +679,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97493a391b4b18ee918675fb8663e53646fd09321c58b46afa04e8ce2499c869"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2af3eac944c12cdf4423eab70d310da0a8e5851a18ffb192c0a5e3f7ae1663"
+dependencies = [
+ "darling",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.82",
+]
+
+[[package]]
 name = "brotli"
 version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1017,7 @@ dependencies = [
  "axum-extra",
  "base64 0.22.1",
  "bigdecimal",
+ "bon",
  "bytes",
  "cargo-manifest",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,6 @@ dependencies = [
  "crates_io_worker",
  "csv",
  "deadpool-diesel",
- "derive_builder",
  "derive_deref",
  "dialoguer",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ chrono = { version = "=0.4.38", default-features = false, features = ["serde"] }
 clap = { version = "=4.5.20", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.18.1", features = ["secure"] }
 deadpool-diesel = { version = "=0.6.1", features = ["postgres", "tracing"] }
-derive_builder = "=0.20.2"
 derive_deref = "=1.1.1"
 dialoguer = "=0.11.0"
 diesel = { version = "=2.2.4", features = ["postgres", "serde_json", "chrono", "numeric"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ axum = { version = "=0.7.7", features = ["macros", "matched-path"] }
 axum-extra = { version = "=0.9.4", features = ["cookie-signed", "typed-header"] }
 base64 = "=0.22.1"
 bigdecimal = { version = "=0.4.5", features = ["serde"] }
+bon = "=2.3.0"
 cargo-manifest = "=0.15.2"
 crates_io_cdn_logs = { path = "crates/crates_io_cdn_logs" }
 crates_io_database = { path = "crates/crates_io_database" }

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -360,19 +360,18 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
 
             // Persist the new version of this crate
             let version = NewVersion::builder(krate.id, &version_string)
-                .features(&features)?
-                .license(license.as_deref())
+                .features(serde_json::to_value(&features)?)
+                .maybe_license(license.as_deref())
                 // Downcast is okay because the file length must be less than the max upload size
                 // to get here, and max upload sizes are way less than i32 max
                 .size(content_length as i32)
                 .published_by(user.id)
                 .checksum(&hex_cksum)
-                .links(package.links.as_deref())
-                .rust_version(rust_version.as_deref())
+                .maybe_links(package.links.as_deref())
+                .maybe_rust_version(rust_version.as_deref())
                 .has_lib(tarball_info.manifest.lib.is_some())
                 .bin_names(bin_names.as_slice())
                 .build()
-                .map_err(|error| internal(error.to_string()))?
                 .save(conn, &verified_email_address)?;
 
             insert_version_owner_action(

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -5,7 +5,6 @@ use crate::{
 };
 use std::collections::BTreeMap;
 
-use crate::util::errors::internal;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
@@ -102,17 +101,16 @@ impl VersionBuilder {
         let version = self.num.to_string();
 
         let new_version = NewVersion::builder(crate_id, &version)
-            .features(&self.features)?
-            .license(self.license.as_deref())
+            .features(serde_json::to_value(&self.features)?)
+            .maybe_license(self.license.as_deref())
             .size(self.size)
             .published_by(published_by)
             .checksum(&self.checksum)
-            .links(self.links.as_deref())
-            .rust_version(self.rust_version.as_deref())
+            .maybe_links(self.links.as_deref())
+            .maybe_rust_version(self.rust_version.as_deref())
             .yanked(self.yanked)
-            .created_at(self.created_at.as_ref())
-            .build()
-            .map_err(|error| internal(error.to_string()))?;
+            .maybe_created_at(self.created_at.as_ref())
+            .build();
 
         let vers = new_version.save(connection, "someone@example.com")?;
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -306,8 +306,7 @@ impl TestAppBuilder {
                 .deadpool(app.primary_database.clone())
                 .emails(app.emails.clone())
                 .team_repo(Box::new(self.team_repo))
-                .build()
-                .unwrap();
+                .build();
 
             let runner = Runner::new(app.primary_database.clone(), Arc::new(environment))
                 .shutdown_when_queue_empty()

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -53,9 +53,8 @@ pub mod faker {
 
         let version = NewVersion::builder(krate.id, "1.0.0")
             .published_by(user.id)
-            .dummy_checksum()
+            .checksum("0000000000000000000000000000000000000000000000000000000000000000")
             .build()
-            .unwrap()
             .save(conn, "someone@example.com")
             .unwrap();
 

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -126,9 +126,8 @@ mod tests {
 
         let version = NewVersion::builder(krate.id, "1.0.0")
             .published_by(user_id)
-            .dummy_checksum()
-            .build()
-            .unwrap();
+            .checksum("0000000000000000000000000000000000000000000000000000000000000000")
+            .build();
 
         let version = version.save(conn, "someone@example.com").unwrap();
         (krate, version)


### PR DESCRIPTION
`bon` uses the type system to ensure all required fields have been set, which means that we can catch issues at compile time. The necessary attributes are also less verbose due to better defaults inside `bon`. 

The only downside I've found is that custom builder fns like `dummy_checksum()` don't appear easy to implement at the moment, which is why I've inlined the two custom builder fns that we had. (/cc @Veetaha)