### PR TITLE
tests/util/test_app: Replace `db()` with `db_conn()`

### DIFF
--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -7,19 +7,19 @@ const URL: &str = "/api/v1/me";
 const LOCK_REASON: &str = "test lock reason";
 
 fn lock_account(app: &TestApp, user_id: i32, until: Option<NaiveDateTime>) {
-    app.db(|conn| {
-        use crate::schema::users;
-        use diesel::prelude::*;
+    use crate::schema::users;
+    use diesel::prelude::*;
 
-        diesel::update(users::table)
-            .set((
-                users::account_lock_reason.eq(LOCK_REASON),
-                users::account_lock_until.eq(until),
-            ))
-            .filter(users::id.eq(user_id))
-            .execute(conn)
-            .unwrap();
-    });
+    let mut conn = app.db_conn();
+
+    diesel::update(users::table)
+        .set((
+            users::account_lock_reason.eq(LOCK_REASON),
+            users::account_lock_until.eq(until),
+        ))
+        .filter(users::id.eq(user_id))
+        .execute(&mut conn)
+        .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -10,11 +10,11 @@ async fn test_non_blocked_download_route() {
         })
         .with_user();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo", user.as_model().id)
-            .version(VersionBuilder::new("1.0.0"))
-            .expect_build(conn);
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("foo", user.as_model().id)
+        .version(VersionBuilder::new("1.0.0"))
+        .expect_build(&mut conn);
 
     let status = anon
         .get::<()>("/api/v1/crates/foo/1.0.0/download")
@@ -34,11 +34,11 @@ async fn test_blocked_download_route() {
         })
         .with_user();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo", user.as_model().id)
-            .version(VersionBuilder::new("1.0.0"))
-            .expect_build(conn);
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("foo", user.as_model().id)
+        .version(VersionBuilder::new("1.0.0"))
+        .expect_build(&mut conn);
 
     let status = anon
         .get::<()>("/api/v1/crates/foo/1.0.0/download")

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -17,12 +17,11 @@ static PATH_DATE_RE: LazyLock<Regex> =
 #[tokio::test(flavor = "multi_thread")]
 async fn test_dump_db_job() {
     let (app, _, _, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("test-crate", token.as_model().user_id).expect_build(conn);
+    CrateBuilder::new("test-crate", token.as_model().user_id).expect_build(&mut conn);
 
-        DumpDb.enqueue(conn).unwrap();
-    });
+    DumpDb.enqueue(&mut conn).unwrap();
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -33,10 +33,9 @@ async fn test_unauthenticated_requests() {
     const CRATE_NAME: &str = "foo";
 
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(conn);
-    });
+    CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(&mut conn);
 
     let response = anon
         .get::<()>(&format!("/api/v1/crates/{CRATE_NAME}/following"))
@@ -62,10 +61,9 @@ async fn test_following() {
     const CRATE_NAME: &str = "foo_following";
 
     let (app, _, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(conn);
-    });
+    CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(&mut conn);
 
     // Check that initially we are not following the crate yet.
     assert_is_following(CRATE_NAME, false, &user).await;
@@ -119,12 +117,11 @@ async fn test_api_token_auth() {
     const CRATE_NOT_TO_FOLLOW: &str = "another_crate";
 
     let (app, _, user, token) = TestApp::init().with_token();
+    let mut conn = app.db_conn();
     let api_token = token.as_model();
 
-    app.db(|conn| {
-        CrateBuilder::new(CRATE_TO_FOLLOW, api_token.user_id).expect_build(conn);
-        CrateBuilder::new(CRATE_NOT_TO_FOLLOW, api_token.user_id).expect_build(conn);
-    });
+    CrateBuilder::new(CRATE_TO_FOLLOW, api_token.user_id).expect_build(&mut conn);
+    CrateBuilder::new(CRATE_NOT_TO_FOLLOW, api_token.user_id).expect_build(&mut conn);
 
     follow(CRATE_TO_FOLLOW, &token).await;
 

--- a/src/tests/krate/publish/audit_action.rs
+++ b/src/tests/krate/publish/audit_action.rs
@@ -8,7 +8,8 @@ async fn publish_records_an_audit_action() {
 
     let (app, anon, _, token) = TestApp::full().with_token();
 
-    app.db(|conn| assert!(VersionOwnerAction::all(conn).unwrap().is_empty()));
+    let mut conn = app.db_conn();
+    assert!(VersionOwnerAction::all(&mut conn).unwrap().is_empty());
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");

--- a/src/tests/krate/publish/categories.rs
+++ b/src/tests/krate/publish/categories.rs
@@ -8,12 +8,11 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn good_categories() {
     let (app, _, _, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        new_category("Category 1", "cat1", "Category 1 crates")
-            .create_or_update(conn)
-            .unwrap();
-    });
+    new_category("Category 1", "cat1", "Category 1 crates")
+        .create_or_update(&mut conn)
+        .unwrap();
 
     let crate_to_publish = PublishBuilder::new("foo_good_cat", "1.0.0").category("cat1");
     let response = token.publish_crate(crate_to_publish).await;

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -19,11 +19,10 @@ async fn invalid_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new-krate can depend on it
+    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
 
     let dependency = DependencyBuilder::new("package-name").rename("my-name");
 
@@ -37,11 +36,10 @@ async fn new_with_renamed_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_rename() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new-krate can depend on it
+    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
 
     let response = token
         .publish_crate(
@@ -57,11 +55,10 @@ async fn invalid_dependency_rename() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_starts_with_digit() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new-krate can depend on it
+    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
 
     let response = token
         .publish_crate(
@@ -77,11 +74,10 @@ async fn invalid_dependency_name_starts_with_digit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_contains_unicode_chars() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new-krate can depend on it
+    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
 
     let response = token
         .publish_crate(
@@ -97,11 +93,10 @@ async fn invalid_dependency_name_contains_unicode_chars() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_too_long_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new-krate can depend on it
+    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
 
     let response = token
         .publish_crate(
@@ -117,11 +112,11 @@ async fn invalid_too_long_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new-krate can depend on it
+    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+
     let response = token
         .publish_crate(
             PublishBuilder::new("new-krate", "1.0.0")
@@ -136,11 +131,10 @@ async fn empty_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_underscore_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new-krate can depend on it
-        CrateBuilder::new("package-name", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new-krate can depend on it
+    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
 
     let dependency = DependencyBuilder::new("package-name").rename("_my-name");
 
@@ -156,14 +150,13 @@ async fn new_krate_with_dependency() {
     use crate::tests::routes::crates::versions::dependencies::Deps;
 
     let (app, anon, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new_dep can depend on it
-        // The name choice of `foo-dep` is important! It has the property of
-        // name != canon_crate_name(name) and is a regression test for
-        // https://github.com/rust-lang/crates.io/issues/651
-        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new_dep can depend on it
+    // The name choice of `foo-dep` is important! It has the property of
+    // name != canon_crate_name(name) and is a regression test for
+    // https://github.com/rust-lang/crates.io/issues/651
+    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
 
     let dependency = DependencyBuilder::new("foo-dep").version_req("1.0.0");
 
@@ -188,14 +181,13 @@ async fn new_krate_with_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_broken_dependency_requirement() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new_dep can depend on it
-        // The name choice of `foo-dep` is important! It has the property of
-        // name != canon_crate_name(name) and is a regression test for
-        // https://github.com/rust-lang/crates.io/issues/651
-        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new_dep can depend on it
+    // The name choice of `foo-dep` is important! It has the property of
+    // name != canon_crate_name(name) and is a regression test for
+    // https://github.com/rust-lang/crates.io/issues/651
+    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
 
     let dependency = DependencyBuilder::new("foo-dep").version_req("broken");
 
@@ -209,10 +201,9 @@ async fn new_krate_with_broken_dependency_requirement() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reject_new_krate_with_non_exact_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(conn);
-    });
+    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
 
     // Use non-exact name for the dependency
     let dependency = DependencyBuilder::new("foo_dep");
@@ -228,10 +219,9 @@ async fn reject_new_krate_with_non_exact_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_allow_empty_alternative_registry_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo-dep", user.as_model().id).expect_build(conn);
-    });
+    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
 
     let dependency = DependencyBuilder::new("foo-dep").registry("");
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").dependency(dependency);
@@ -256,11 +246,10 @@ async fn reject_new_crate_with_alternative_registry_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_wildcard_dependency() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that new_wild can depend on it
-        CrateBuilder::new("foo_wild", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that new_wild can depend on it
+    CrateBuilder::new("foo_wild", user.as_model().id).expect_build(&mut conn);
 
     let dependency = DependencyBuilder::new("foo_wild").version_req("*");
 
@@ -290,12 +279,11 @@ async fn new_krate_dependency_missing() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_sorts_deps() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert crates directly into the database so that two-deps can depend on it
-        CrateBuilder::new("dep-a", user.as_model().id).expect_build(conn);
-        CrateBuilder::new("dep-b", user.as_model().id).expect_build(conn);
-    });
+    // Insert crates directly into the database so that two-deps can depend on it
+    CrateBuilder::new("dep-a", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("dep-b", user.as_model().id).expect_build(&mut conn);
 
     let dep_a = DependencyBuilder::new("dep-a");
     let dep_b = DependencyBuilder::new("dep-b");
@@ -331,10 +319,10 @@ async fn test_dep_limit() {
         .with_config(|config| config.max_dependencies = 1)
         .with_token();
 
-    app.db(|conn| {
-        CrateBuilder::new("dep-a", user.as_model().id).expect_build(conn);
-        CrateBuilder::new("dep-b", user.as_model().id).expect_build(conn);
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("dep-a", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("dep-b", user.as_model().id).expect_build(&mut conn);
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0")
         .dependency(DependencyBuilder::new("dep-a"))

--- a/src/tests/krate/publish/emails.rs
+++ b/src/tests/krate/publish/emails.rs
@@ -9,10 +9,9 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_without_any_email_fails() {
     let (app, _, _, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        delete(emails::table).execute(conn).unwrap();
-    });
+    delete(emails::table).execute(&mut conn).unwrap();
 
     let crate_to_publish = PublishBuilder::new("foo_no_email", "1.0.0");
 
@@ -26,13 +25,12 @@ async fn new_krate_without_any_email_fails() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_unverified_email_fails() {
     let (app, _, _, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        update(emails::table)
-            .set((emails::verified.eq(false),))
-            .execute(conn)
-            .unwrap();
-    });
+    update(emails::table)
+        .set((emails::verified.eq(false),))
+        .execute(&mut conn)
+        .unwrap();
 
     let crate_to_publish = PublishBuilder::new("foo_unverified_email", "1.0.0");
 

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -7,11 +7,10 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn features_version_2() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        // Insert a crate directly into the database so that foo_new can depend on it
-        CrateBuilder::new("bar", user.as_model().id).expect_build(conn);
-    });
+    // Insert a crate directly into the database so that foo_new can depend on it
+    CrateBuilder::new("bar", user.as_model().id).expect_build(&mut conn);
 
     let dependency = DependencyBuilder::new("bar");
 
@@ -124,11 +123,11 @@ async fn too_many_features_with_custom_limit() {
         })
         .with_token();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo", user.as_model().id)
-            .max_features(4)
-            .expect_build(conn)
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("foo", user.as_model().id)
+        .max_features(4)
+        .expect_build(&mut conn);
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("one", &[])
@@ -181,11 +180,11 @@ async fn too_many_enabled_features_with_custom_limit() {
         })
         .with_token();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo", user.as_model().id)
-            .max_features(4)
-            .expect_build(conn)
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("foo", user.as_model().id)
+        .max_features(4)
+        .expect_build(&mut conn);
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("default", &["one", "two", "three", "four", "five"]);

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -132,12 +132,11 @@ async fn new_krate_too_big() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_too_big_but_whitelisted() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo_whitelist", user.as_model().id)
-            .max_upload_size(2_000_000)
-            .expect_build(conn);
-    });
+    CrateBuilder::new("foo_whitelist", user.as_model().id)
+        .max_upload_size(2_000_000)
+        .expect_build(&mut conn);
 
     let crate_to_publish = PublishBuilder::new("foo_whitelist", "1.1.0")
         .add_file("foo_whitelist-1.1.0/big", vec![b'a'; 2000]);

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -71,14 +71,13 @@ async fn new_krate_with_readme_and_plus_version() {
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_after_removing_documentation() {
     let (app, anon, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
     // 1. Start with a crate with no documentation
-    app.db(|conn| {
-        CrateBuilder::new("docscrate", user.id)
-            .version("0.2.0")
-            .expect_build(conn);
-    });
+    CrateBuilder::new("docscrate", user.id)
+        .version("0.2.0")
+        .expect_build(&mut conn);
 
     // Verify that crates start without any documentation so the next assertion can *prove*
     // that it was the one that added the documentation

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -7,12 +7,11 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("Foo_similar", user.as_model().id)
-            .version("1.0.0")
-            .expect_build(conn);
-    });
+    CrateBuilder::new("Foo_similar", user.as_model().id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
 
     let crate_to_publish = PublishBuilder::new("foo_similar", "1.1.0");
     let response = token.publish_crate(crate_to_publish).await;
@@ -24,12 +23,11 @@ async fn new_crate_similar_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_hyphen() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo_bar_hyphen", user.as_model().id)
-            .version("1.0.0")
-            .expect_build(conn);
-    });
+    CrateBuilder::new("foo_bar_hyphen", user.as_model().id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
 
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen", "1.1.0");
     let response = token.publish_crate(crate_to_publish).await;
@@ -41,12 +39,11 @@ async fn new_crate_similar_name_hyphen() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_underscore() {
     let (app, _, user, token) = TestApp::full().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo-bar-underscore", user.as_model().id)
-            .version("1.0.0")
-            .expect_build(conn);
-    });
+    CrateBuilder::new("foo-bar-underscore", user.as_model().id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
 
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore", "1.1.0");
     let response = token.publish_crate(crate_to_publish).await;

--- a/src/tests/krate/publish/timestamps.rs
+++ b/src/tests/krate/publish/timestamps.rs
@@ -8,16 +8,15 @@ async fn uploading_new_version_touches_crate() {
     use diesel::{ExpressionMethods, RunQueryDsl};
 
     let (app, _, user) = TestApp::full().with_user();
+    let mut conn = app.db_conn();
 
     let crate_to_publish = PublishBuilder::new("foo_versions_updated_at", "1.0.0");
     user.publish_crate(crate_to_publish).await.good();
 
-    app.db(|conn| {
-        diesel::update(crates::table)
-            .set(crates::updated_at.eq(crates::updated_at - 1.hour()))
-            .execute(conn)
-            .unwrap();
-    });
+    diesel::update(crates::table)
+        .set(crates::updated_at.eq(crates::updated_at - 1.hour()))
+        .execute(&mut conn)
+        .unwrap();
 
     let json: CrateResponse = user.show_crate("foo_versions_updated_at").await;
     let updated_at_before = json.krate.updated_at;

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -12,13 +12,13 @@ async fn pagination_blocks_ip_from_cidr_block_list() {
             config.page_offset_cidr_blocklist = vec!["127.0.0.1/24".parse::<IpNetwork>().unwrap()];
         })
         .with_user();
+
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        CrateBuilder::new("pagination_links_1", user.id).expect_build(conn);
-        CrateBuilder::new("pagination_links_2", user.id).expect_build(conn);
-        CrateBuilder::new("pagination_links_3", user.id).expect_build(conn);
-    });
+    CrateBuilder::new("pagination_links_1", user.id).expect_build(&mut conn);
+    CrateBuilder::new("pagination_links_2", user.id).expect_build(&mut conn);
+    CrateBuilder::new("pagination_links_3", user.id).expect_build(&mut conn);
 
     let response = anon
         .get_with_query::<()>("/api/v1/crates", "page=2&per_page=1")

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -25,11 +25,11 @@ async fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
         })
         .with_token();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo_yank_read_only", user.as_model().id)
-            .version("1.0.0")
-            .expect_build(conn);
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("foo_yank_read_only", user.as_model().id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
 
     let response = token
         .delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
@@ -46,11 +46,11 @@ async fn can_download_crate_in_read_only_mode() {
         })
         .with_user();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo_download_read_only", user.as_model().id)
-            .version("1.0.0")
-            .expect_build(conn);
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("foo_download_read_only", user.as_model().id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download")
@@ -58,13 +58,12 @@ async fn can_download_crate_in_read_only_mode() {
     assert_eq!(response.status(), StatusCode::FOUND);
 
     // We're in read only mode so the download should not have been counted
-    app.db(|conn| {
-        use crate::schema::version_downloads;
-        use diesel::dsl::sum;
 
-        let dl_count: Result<Option<i64>, _> = version_downloads::table
-            .select(sum(version_downloads::downloads))
-            .get_result(conn);
-        assert_ok_eq!(dl_count, None);
-    })
+    use crate::schema::version_downloads;
+    use diesel::dsl::sum;
+
+    let dl_count: Result<Option<i64>, _> = version_downloads::table
+        .select(sum(version_downloads::downloads))
+        .get_result(&mut conn);
+    assert_ok_eq!(dl_count, None);
 }

--- a/src/tests/routes/categories/list.rs
+++ b/src/tests/routes/categories/list.rs
@@ -6,20 +6,19 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn index() {
     let (app, anon) = TestApp::init().empty();
+    let mut conn = app.db_conn();
 
     // List 0 categories if none exist
     let json: Value = anon.get("/api/v1/categories").await.good();
     assert_json_snapshot!(json);
 
     // Create a category and a subcategory
-    app.db(|conn| {
-        new_category("foo", "foo", "Foo crates")
-            .create_or_update(conn)
-            .unwrap();
-        new_category("foo::bar", "foo::bar", "Bar crates")
-            .create_or_update(conn)
-            .unwrap();
-    });
+    new_category("foo", "foo", "Foo crates")
+        .create_or_update(&mut conn)
+        .unwrap();
+    new_category("foo::bar", "foo::bar", "Bar crates")
+        .create_or_update(&mut conn)
+        .unwrap();
 
     // Only the top-level categories should be on the page
     let json: Value = anon.get("/api/v1/categories").await.good();

--- a/src/tests/routes/category_slugs/list.rs
+++ b/src/tests/routes/category_slugs/list.rs
@@ -6,14 +6,14 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn category_slugs_returns_all_slugs_in_alphabetical_order() {
     let (app, anon) = TestApp::init().empty();
-    app.db(|conn| {
-        new_category("Foo", "foo", "For crates that foo")
-            .create_or_update(conn)
-            .unwrap();
-        new_category("Bar", "bar", "For crates that bar")
-            .create_or_update(conn)
-            .unwrap();
-    });
+    let mut conn = app.db_conn();
+
+    new_category("Foo", "foo", "For crates that foo")
+        .create_or_update(&mut conn)
+        .unwrap();
+    new_category("Bar", "bar", "For crates that bar")
+        .create_or_update(&mut conn)
+        .unwrap();
 
     let response: Value = anon.get("/api/v1/category_slugs").await.good();
     assert_json_snapshot!(response);

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -13,13 +13,12 @@ async fn diesel_not_found_results_in_404() {
 #[tokio::test(flavor = "multi_thread")]
 async fn disallow_api_token_auth_for_get_crate_following_status() {
     let (app, _, _, token) = TestApp::init().with_token();
+    let mut conn = app.db_conn();
     let api_token = token.as_model();
 
     let a_crate = "a_crate";
 
-    app.db(|conn| {
-        CrateBuilder::new(a_crate, api_token.user_id).expect_build(conn);
-    });
+    CrateBuilder::new(a_crate, api_token.user_id).expect_build(&mut conn);
 
     // Token auth on GET for get following status is disallowed
     token

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -6,8 +6,10 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user();
+    let mut conn = app.db_conn();
+
     app.db_new_user("bar");
-    app.db(|conn| CrateBuilder::new("foo", user.as_model().id).expect_build(conn));
+    CrateBuilder::new("foo", user.as_model().id).expect_build(&mut conn);
 
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
@@ -52,8 +54,9 @@ async fn test_unknown_crate() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_user() {
     let (app, _, cookie) = TestApp::full().with_user();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
+    CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
 
     let body = serde_json::to_vec(&json!({ "owners": ["unknown"] })).unwrap();
     let response = cookie
@@ -66,8 +69,9 @@ async fn test_unknown_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_team() {
     let (app, _, cookie) = TestApp::full().with_user();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| CrateBuilder::new("foo", cookie.as_model().id).expect_build(conn));
+    CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
 
     let body = serde_json::to_vec(&json!({ "owners": ["github:unknown:unknown"] })).unwrap();
     let response = cookie

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -6,19 +6,19 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        let c1 = CrateBuilder::new("c1", user.id).expect_build(conn);
-        CrateBuilder::new("c2", user.id)
-            .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
-            .version(
-                VersionBuilder::new("1.1.0")
-                    .dependency(&c1, None)
-                    .dependency(&c1, Some("foo")),
-            )
-            .expect_build(conn);
-    });
+    let c1 = CrateBuilder::new("c1", user.id).expect_build(&mut conn);
+
+    CrateBuilder::new("c2", user.id)
+        .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
+        .version(
+            VersionBuilder::new("1.1.0")
+                .dependency(&c1, None)
+                .dependency(&c1, Some("foo")),
+        )
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -43,17 +43,17 @@ async fn reverse_dependencies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        let c1 = CrateBuilder::new("c1", user.id)
-            .version("1.1.0")
-            .expect_build(conn);
-        CrateBuilder::new("c2", user.id)
-            .version("1.0.0")
-            .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-            .expect_build(conn);
-    });
+    let c1 = CrateBuilder::new("c1", user.id)
+        .version("1.1.0")
+        .expect_build(&mut conn);
+
+    CrateBuilder::new("c2", user.id)
+        .version("1.0.0")
+        .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -68,17 +68,17 @@ async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        let c1 = CrateBuilder::new("c1", user.id)
-            .version("1.0.0")
-            .expect_build(conn);
-        CrateBuilder::new("c2", user.id)
-            .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
-            .version("2.0.0")
-            .expect_build(conn);
-    });
+    let c1 = CrateBuilder::new("c1", user.id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
+
+    CrateBuilder::new("c2", user.id)
+        .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
+        .version("2.0.0")
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -93,20 +93,21 @@ async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
 #[tokio::test(flavor = "multi_thread")]
 async fn prerelease_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        let c1 = CrateBuilder::new("c1", user.id)
-            .version("1.0.0")
-            .expect_build(conn);
-        CrateBuilder::new("c2", user.id)
-            .version("1.1.0-pre")
-            .expect_build(conn);
-        CrateBuilder::new("c3", user.id)
-            .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
-            .version("1.1.0-pre")
-            .expect_build(conn);
-    });
+    let c1 = CrateBuilder::new("c1", user.id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
+
+    CrateBuilder::new("c2", user.id)
+        .version("1.1.0-pre")
+        .expect_build(&mut conn);
+
+    CrateBuilder::new("c3", user.id)
+        .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
+        .version("1.1.0-pre")
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -121,17 +122,17 @@ async fn prerelease_versions_not_included_in_reverse_dependencies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn yanked_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        let c1 = CrateBuilder::new("c1", user.id)
-            .version("1.0.0")
-            .expect_build(conn);
-        CrateBuilder::new("c2", user.id)
-            .version("1.0.0")
-            .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-            .expect_build(conn);
-    });
+    let c1 = CrateBuilder::new("c1", user.id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
+
+    CrateBuilder::new("c2", user.id)
+        .version("1.0.0")
+        .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -142,15 +143,13 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
         ".versions[].updated_at" => "[datetime]",
     });
 
-    app.db(|conn| {
-        use crate::schema::versions;
-        use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+    use crate::schema::versions;
+    use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
 
-        diesel::update(versions::table.filter(versions::num.eq("2.0.0")))
-            .set(versions::yanked.eq(true))
-            .execute(conn)
-            .unwrap();
-    });
+    diesel::update(versions::table.filter(versions::num.eq("2.0.0")))
+        .set(versions::yanked.eq(true))
+        .execute(&mut conn)
+        .unwrap();
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -165,32 +164,31 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_includes_published_by_user_when_present() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        use crate::schema::versions;
-        use diesel::{update, ExpressionMethods, RunQueryDsl};
+    use crate::schema::versions;
+    use diesel::{update, ExpressionMethods, RunQueryDsl};
 
-        let c1 = CrateBuilder::new("c1", user.id)
-            .version("1.0.0")
-            .expect_build(conn);
-        CrateBuilder::new("c2", user.id)
-            .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-            .expect_build(conn);
+    let c1 = CrateBuilder::new("c1", user.id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
+    CrateBuilder::new("c2", user.id)
+        .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
+        .expect_build(&mut conn);
 
-        // Make c2's version (and,incidentally, c1's, but that doesn't matter) mimic a version
-        // published before we started recording who published versions
-        let none: Option<i32> = None;
-        update(versions::table)
-            .set(versions::published_by.eq(none))
-            .execute(conn)
-            .unwrap();
+    // Make c2's version (and,incidentally, c1's, but that doesn't matter) mimic a version
+    // published before we started recording who published versions
+    let none: Option<i32> = None;
+    update(versions::table)
+        .set(versions::published_by.eq(none))
+        .execute(&mut conn)
+        .unwrap();
 
-        // c3's version will have the published by info recorded
-        CrateBuilder::new("c3", user.id)
-            .version(VersionBuilder::new("3.0.0").dependency(&c1, None))
-            .expect_build(conn);
-    });
+    // c3's version will have the published by info recorded
+    CrateBuilder::new("c3", user.id)
+        .version(VersionBuilder::new("3.0.0").dependency(&c1, None))
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -205,18 +203,18 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_query_supports_u64_version_number_parts() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
     let large_but_valid_version_number = format!("1.0.{}", u64::MAX);
 
-    app.db(|conn| {
-        let c1 = CrateBuilder::new("c1", user.id).expect_build(conn);
-        // The crate that depends on c1...
-        CrateBuilder::new("c2", user.id)
-            // ...has a patch version at the limits of what the semver crate supports
-            .version(VersionBuilder::new(&large_but_valid_version_number).dependency(&c1, None))
-            .expect_build(conn);
-    });
+    let c1 = CrateBuilder::new("c1", user.id).expect_build(&mut conn);
+
+    // The crate that depends on c1...
+    CrateBuilder::new("c2", user.id)
+        // ...has a patch version at the limits of what the semver crate supports
+        .version(VersionBuilder::new(&large_but_valid_version_number).dependency(&c1, None))
+        .expect_build(&mut conn);
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -6,13 +6,12 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn authors() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo_authors", user.id)
-            .version("1.0.0")
-            .expect_build(conn);
-    });
+    CrateBuilder::new("foo_authors", user.id)
+        .version("1.0.0")
+        .expect_build(&mut conn);
 
     let json: Value = anon
         .get("/api/v1/crates/foo_authors/1.0.0/authors")

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -4,12 +4,11 @@ use crate::tests::util::{RequestHelper, TestApp};
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redirects() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo-download", user.as_model().id)
-            .version(VersionBuilder::new("1.0.0"))
-            .expect_build(conn);
-    });
+    CrateBuilder::new("foo-download", user.as_model().id)
+        .version(VersionBuilder::new("1.0.0"))
+        .expect_build(&mut conn);
 
     // Any redirect to an existing crate and version works correctly.
     anon.get::<()>("/api/v1/crates/foo-download/1.0.0/download")
@@ -35,13 +34,12 @@ async fn test_redirects() {
 #[tokio::test(flavor = "multi_thread")]
 async fn download_with_build_metadata() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo", user.id)
-            .version(VersionBuilder::new("1.0.0+bar"))
-            .expect_build(conn);
-    });
+    CrateBuilder::new("foo", user.id)
+        .version(VersionBuilder::new("1.0.0+bar"))
+        .expect_build(&mut conn);
 
     anon.get::<()>("/api/v1/crates/foo/1.0.0+bar/download")
         .await

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -7,16 +7,15 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn show_by_crate_name_and_version() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    let v = app.db(|conn| {
-        let krate = CrateBuilder::new("foo_vers_show", user.id).expect_build(conn);
-        VersionBuilder::new("2.0.0")
-            .size(1234)
-            .checksum("c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4")
-            .rust_version("1.64")
-            .expect_build(krate.id, user.id, conn)
-    });
+    let krate = CrateBuilder::new("foo_vers_show", user.id).expect_build(&mut conn);
+    let v = VersionBuilder::new("2.0.0")
+        .size(1234)
+        .checksum("c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4")
+        .rust_version("1.64")
+        .expect_build(krate.id, user.id, &mut conn);
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
     let json: Value = anon.get(url).await.good();
@@ -34,26 +33,23 @@ async fn show_by_crate_name_and_semver_no_published_by() {
     use diesel::{update, RunQueryDsl};
 
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    let v = app.db(|conn| {
-        let krate = CrateBuilder::new("foo_vers_show_no_pb", user.id).expect_build(conn);
-        let version = VersionBuilder::new("1.0.0").expect_build(krate.id, user.id, conn);
+    let krate = CrateBuilder::new("foo_vers_show_no_pb", user.id).expect_build(&mut conn);
+    let version = VersionBuilder::new("1.0.0").expect_build(krate.id, user.id, &mut conn);
 
-        // Mimic a version published before we started recording who published versions
-        let none: Option<i32> = None;
-        update(versions::table)
-            .set(versions::published_by.eq(none))
-            .execute(conn)
-            .unwrap();
-
-        version
-    });
+    // Mimic a version published before we started recording who published versions
+    let none: Option<i32> = None;
+    update(versions::table)
+        .set(versions::published_by.eq(none))
+        .execute(&mut conn)
+        .unwrap();
 
     let url = "/api/v1/crates/foo_vers_show_no_pb/1.0.0";
     let json: Value = anon.get(url).await.good();
     assert_json_snapshot!(json, {
-        ".version.id" => insta::id_redaction(v.id),
+        ".version.id" => insta::id_redaction(version.id),
         ".version.created_at" => "[datetime]",
         ".version.updated_at" => "[datetime]",
     });

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -17,13 +17,13 @@ struct KeywordMeta {
 async fn index() {
     let url = "/api/v1/keywords";
     let (app, anon) = TestApp::init().empty();
+    let mut conn = app.db_conn();
+
     let json: KeywordList = anon.get(url).await.good();
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
 
-    app.db(|conn| {
-        Keyword::find_or_create_all(conn, &["foo"]).unwrap();
-    });
+    Keyword::find_or_create_all(&mut conn, &["foo"]).unwrap();
 
     let json: KeywordList = anon.get(url).await.good();
     assert_eq!(json.keywords.len(), 1);

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -20,6 +20,7 @@ pub struct UserShowPrivateResponse {
 #[tokio::test(flavor = "multi_thread")]
 async fn me() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
 
     let response = anon.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -29,9 +30,7 @@ async fn me() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 
-    app.db(|conn| {
-        CrateBuilder::new("foo_my_packages", user.as_model().id).expect_build(conn);
-    });
+    CrateBuilder::new("foo_my_packages", user.as_model().id).expect_build(&mut conn);
 
     let response = user.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -41,12 +40,11 @@ async fn me() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
     let (app, _, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user_model = user.as_model();
 
-    app.db(|conn| {
-        let krate = CrateBuilder::new("foo_my_packages", user_model.id).expect_build(conn);
-        krate.owner_remove(conn, &user_model.gh_login).unwrap();
-    });
+    let krate = CrateBuilder::new("foo_my_packages", user_model.id).expect_build(&mut conn);
+    krate.owner_remove(&mut conn, &user_model.gh_login).unwrap();
 
     let json = user.show_me().await;
     assert_eq!(json.owned_crates.len(), 0);

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -28,13 +28,11 @@ async fn get_invitations(user: &MockCookieUser, query: &str) -> CrateOwnerInvita
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list() {
     let (app, _, owner, token) = TestApp::init().with_token();
+    let mut conn = app.db_conn();
 
-    let (crate1, crate2) = app.db(|conn| {
-        (
-            CrateBuilder::new("crate_1", owner.as_model().id).expect_build(conn),
-            CrateBuilder::new("crate_2", owner.as_model().id).expect_build(conn),
-        )
-    });
+    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
+    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
+
     let user1 = app.db_new_user("user_1");
     let user2 = app.db_new_user("user_2");
     token.add_named_owner("crate_1", "user_1").await.good();
@@ -167,14 +165,12 @@ async fn invitation_list() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_does_not_include_expired_invites() {
     let (app, _, owner, token) = TestApp::init().with_token();
+    let mut conn = app.db_conn();
     let user = app.db_new_user("invited_user");
 
-    let (crate1, crate2) = app.db(|conn| {
-        (
-            CrateBuilder::new("crate_1", owner.as_model().id).expect_build(conn),
-            CrateBuilder::new("crate_2", owner.as_model().id).expect_build(conn),
-        )
-    });
+    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
+    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
+
     token
         .add_named_owner("crate_1", "invited_user")
         .await
@@ -213,14 +209,12 @@ async fn invitations_list_does_not_include_expired_invites() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_paginated() {
     let (app, _, owner, token) = TestApp::init().with_token();
+    let mut conn = app.db_conn();
     let user = app.db_new_user("invited_user");
 
-    let (crate1, crate2) = app.db(|conn| {
-        (
-            CrateBuilder::new("crate_1", owner.as_model().id).expect_build(conn),
-            CrateBuilder::new("crate_2", owner.as_model().id).expect_build(conn),
-        )
-    });
+    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
+    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
+
     token
         .add_named_owner("crate_1", "invited_user")
         .await
@@ -331,11 +325,11 @@ async fn invitation_list_other_users() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list_other_crates() {
     let (app, _, owner, _) = TestApp::init().with_token();
+    let mut conn = app.db_conn();
     let other_user = app.db_new_user("other");
-    app.db(|conn| {
-        CrateBuilder::new("crate_1", owner.as_model().id).expect_build(conn);
-        CrateBuilder::new("crate_2", other_user.as_model().id).expect_build(conn);
-    });
+
+    CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("crate_2", other_user.as_model().id).expect_build(&mut conn);
 
     // Retrieving our own invitations work.
     let resp = owner

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -14,38 +14,37 @@ async fn user_total_downloads() {
     use diesel::{update, QueryDsl, RunQueryDsl};
 
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
     let another_user = app.db_new_user("bar");
     let another_user = another_user.as_model();
 
-    app.db(|conn| {
-        let krate = CrateBuilder::new("foo_krate1", user.id).expect_build(conn);
-        update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate.id)))
-            .set(crate_downloads::downloads.eq(10))
-            .execute(conn)
-            .unwrap();
+    let krate = CrateBuilder::new("foo_krate1", user.id).expect_build(&mut conn);
+    update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate.id)))
+        .set(crate_downloads::downloads.eq(10))
+        .execute(&mut conn)
+        .unwrap();
 
-        let krate2 = CrateBuilder::new("foo_krate2", user.id).expect_build(conn);
-        update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate2.id)))
-            .set(crate_downloads::downloads.eq(20))
-            .execute(conn)
-            .unwrap();
+    let krate2 = CrateBuilder::new("foo_krate2", user.id).expect_build(&mut conn);
+    update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate2.id)))
+        .set(crate_downloads::downloads.eq(20))
+        .execute(&mut conn)
+        .unwrap();
 
-        let another_krate = CrateBuilder::new("bar_krate1", another_user.id).expect_build(conn);
-        update(crate_downloads::table.filter(crate_downloads::crate_id.eq(another_krate.id)))
-            .set(crate_downloads::downloads.eq(2))
-            .execute(conn)
-            .unwrap();
+    let another_krate = CrateBuilder::new("bar_krate1", another_user.id).expect_build(&mut conn);
+    update(crate_downloads::table.filter(crate_downloads::crate_id.eq(another_krate.id)))
+        .set(crate_downloads::downloads.eq(2))
+        .execute(&mut conn)
+        .unwrap();
 
-        let no_longer_my_krate = CrateBuilder::new("nacho", user.id).expect_build(conn);
-        update(crate_downloads::table.filter(crate_downloads::crate_id.eq(no_longer_my_krate.id)))
-            .set(crate_downloads::downloads.eq(5))
-            .execute(conn)
-            .unwrap();
-        no_longer_my_krate
-            .owner_remove(conn, &user.gh_login)
-            .unwrap();
-    });
+    let no_longer_my_krate = CrateBuilder::new("nacho", user.id).expect_build(&mut conn);
+    update(crate_downloads::table.filter(crate_downloads::crate_id.eq(no_longer_my_krate.id)))
+        .set(crate_downloads::downloads.eq(5))
+        .execute(&mut conn)
+        .unwrap();
+    no_longer_my_krate
+        .owner_remove(&mut conn, &user.gh_login)
+        .unwrap();
 
     let url = format!("/api/v1/users/{}/stats", user.id);
     let stats: UserStats = anon.get(&url).await.good();

--- a/src/tests/schema_details.rs
+++ b/src/tests/schema_details.rs
@@ -71,11 +71,10 @@ fn get_fk_constraint_definitions(column_name: &str) -> Vec<TableNameAndConstrain
     use diesel::sql_query;
 
     let (app, _) = TestApp::init().empty();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        sql_query(include_str!("load_foreign_key_constraints.sql"))
-            .bind::<Text, _>(column_name)
-            .load(conn)
-            .unwrap()
-    })
+    sql_query(include_str!("load_foreign_key_constraints.sql"))
+        .bind::<Text, _>(column_name)
+        .load(&mut conn)
+        .unwrap()
 }

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -26,10 +26,9 @@ async fn user_agent_is_required() {
 #[tokio::test(flavor = "multi_thread")]
 async fn user_agent_is_not_required_for_download() {
     let (app, anon, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(conn);
-    });
+    CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(&mut conn);
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
@@ -45,9 +44,9 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
         })
         .with_user();
 
-    app.db(|conn| {
-        CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(conn);
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(&mut conn);
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
@@ -63,9 +62,9 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         })
         .with_user();
 
-    app.db(|conn| {
-        CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(conn);
-    });
+    let mut conn = app.db_conn();
+
+    CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(&mut conn);
 
     let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
         // A request with a header value we want to block isn't allowed

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -9,6 +9,7 @@ use insta::assert_snapshot;
 async fn using_token_updates_last_used_at() {
     let url = "/api/v1/me";
     let (app, anon, user, token) = TestApp::init().with_token();
+    let mut conn = app.db_conn();
 
     anon.get(url).await.assert_forbidden();
     user.get::<EncodableMe>(url).await.good();
@@ -17,11 +18,9 @@ async fn using_token_updates_last_used_at() {
     // Use the token once
     token.search("following=1").await;
 
-    let token: ApiToken = app.db(|conn| {
-        assert_ok!(ApiToken::belonging_to(user.as_model())
-            .select(ApiToken::as_select())
-            .first(conn))
-    });
+    let token: ApiToken = assert_ok!(ApiToken::belonging_to(user.as_model())
+        .select(ApiToken::as_select())
+        .first(&mut conn));
     assert_some!(token.last_used_at);
 
     // Would check that it updates the timestamp here, but the timestamp is

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -53,13 +53,12 @@ async fn http_error_with_unhealthy_database() {
 #[tokio::test(flavor = "multi_thread")]
 async fn download_requests_with_unhealthy_database_succeed() {
     let (app, anon, _, token) = TestApp::init().with_chaos_proxy().with_token();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        CrateBuilder::new("foo", token.as_model().user_id)
-            .version("1.0.0")
-            .build(conn)
-            .unwrap();
-    });
+    CrateBuilder::new("foo", token.as_model().user_id)
+        .version("1.0.0")
+        .build(&mut conn)
+        .unwrap();
 
     app.primary_db_chaosproxy().break_networking().unwrap();
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -299,17 +299,18 @@ impl MockCookieUser {
         endpoint_scopes: Option<Vec<EndpointScope>>,
         expired_at: Option<NaiveDateTime>,
     ) -> MockTokenUser {
-        let token = self.app.db(|conn| {
-            ApiToken::insert_with_scopes(
-                conn,
-                self.user.id,
-                name,
-                crate_scopes,
-                endpoint_scopes,
-                expired_at,
-            )
-            .unwrap()
-        });
+        let mut conn = self.app().db_conn();
+
+        let token = ApiToken::insert_with_scopes(
+            &mut conn,
+            self.user.id,
+            name,
+            crate_scopes,
+            endpoint_scopes,
+            expired_at,
+        )
+        .unwrap();
+
         MockTokenUser {
             app: self.app.clone(),
             token,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -131,23 +131,24 @@ impl TestApp {
         use crate::schema::emails;
         use diesel::prelude::*;
 
-        let user = self.db(|conn| {
-            let email = format!("{username}@example.com");
+        let mut conn = self.db_conn();
 
-            let user: User = diesel::insert_into(users::table)
-                .values(crate::tests::new_user(username))
-                .get_result(conn)
-                .unwrap();
-            diesel::insert_into(emails::table)
-                .values((
-                    emails::user_id.eq(user.id),
-                    emails::email.eq(email),
-                    emails::verified.eq(true),
-                ))
-                .execute(conn)
-                .unwrap();
-            user
-        });
+        let email = format!("{username}@example.com");
+
+        let user: User = diesel::insert_into(users::table)
+            .values(crate::tests::new_user(username))
+            .get_result(&mut conn)
+            .unwrap();
+
+        diesel::insert_into(emails::table)
+            .values((
+                emails::user_id.eq(user.id),
+                emails::email.eq(email),
+                emails::verified.eq(true),
+            ))
+            .execute(&mut conn)
+            .unwrap();
+
         MockCookieUser {
             app: self.clone(),
             user,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -17,6 +17,7 @@ use crates_io_index::{Credentials, RepositoryConfig};
 use crates_io_team_repo::MockTeamRepo;
 use crates_io_test_db::TestDatabase;
 use crates_io_worker::Runner;
+use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::PgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
@@ -114,7 +115,12 @@ impl TestApp {
     /// connection before making any API calls.  Once the closure returns, the connection is
     /// dropped, ensuring it is returned to the pool and available for any future API calls.
     pub fn db<T, F: FnOnce(&mut PgConnection) -> T>(&self, f: F) -> T {
-        f(&mut self.0.test_database.connect())
+        f(&mut self.db_conn())
+    }
+
+    /// Obtain a database connection.
+    pub fn db_conn(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
+        self.0.test_database.connect()
     }
 
     /// Create a new user with a verified email address in the database

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -109,15 +109,6 @@ impl TestApp {
         Self::init().with_git_index().with_job_runner()
     }
 
-    /// Obtain the database connection and pass it to the closure
-    ///
-    /// Within each test, the connection pool only has 1 connection so it is necessary to drop the
-    /// connection before making any API calls.  Once the closure returns, the connection is
-    /// dropped, ensuring it is returned to the pool and available for any future API calls.
-    pub fn db<T, F: FnOnce(&mut PgConnection) -> T>(&self, f: F) -> T {
-        f(&mut self.db_conn())
-    }
-
     /// Obtain a database connection.
     pub fn db_conn(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
         self.0.test_database.connect()

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -5,13 +5,12 @@ use crate::tests::TestApp;
 #[tokio::test(flavor = "multi_thread")]
 async fn record_rerendered_readme_time() {
     let (app, _, user) = TestApp::init().with_user();
+    let mut conn = app.db_conn();
     let user = user.as_model();
 
-    app.db(|conn| {
-        let c = CrateBuilder::new("foo_authors", user.id).expect_build(conn);
-        let version = VersionBuilder::new("1.0.0").expect_build(c.id, user.id, conn);
+    let c = CrateBuilder::new("foo_authors", user.id).expect_build(&mut conn);
+    let version = VersionBuilder::new("1.0.0").expect_build(c.id, user.id, &mut conn);
 
-        Version::record_readme_rendering(version.id, conn).unwrap();
-        Version::record_readme_rendering(version.id, conn).unwrap();
-    });
+    Version::record_readme_rendering(version.id, &mut conn).unwrap();
+    Version::record_readme_rendering(version.id, &mut conn).unwrap();
 }

--- a/src/tests/worker/rss/sync_crate_feed.rs
+++ b/src/tests/worker/rss/sync_crate_feed.rs
@@ -10,18 +10,17 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_crate_feed() {
     let (app, _) = TestApp::full().empty();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        create_version(conn, "foo", "0.1.0", "2024-06-20T10:13:54Z");
-        create_version(conn, "foo", "0.1.1", "2024-06-20T12:45:12Z");
-        create_version(conn, "foo", "1.0.0", "2024-06-21T17:01:33Z");
-        create_version(conn, "bar", "3.0.0-beta.1", "2024-06-21T17:03:45Z");
-        create_version(conn, "foo", "1.1.0", "2024-06-22T08:30:01Z");
-        create_version(conn, "foo", "1.2.0", "2024-06-22T15:57:19Z");
+    create_version(&mut conn, "foo", "0.1.0", "2024-06-20T10:13:54Z");
+    create_version(&mut conn, "foo", "0.1.1", "2024-06-20T12:45:12Z");
+    create_version(&mut conn, "foo", "1.0.0", "2024-06-21T17:01:33Z");
+    create_version(&mut conn, "bar", "3.0.0-beta.1", "2024-06-21T17:03:45Z");
+    create_version(&mut conn, "foo", "1.1.0", "2024-06-22T08:30:01Z");
+    create_version(&mut conn, "foo", "1.2.0", "2024-06-22T15:57:19Z");
 
-        let job = jobs::rss::SyncCrateFeed::new("foo".to_string());
-        job.enqueue(conn).unwrap();
-    });
+    let job = jobs::rss::SyncCrateFeed::new("foo".to_string());
+    job.enqueue(&mut conn).unwrap();
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/worker/rss/sync_crates_feed.rs
+++ b/src/tests/worker/rss/sync_crates_feed.rs
@@ -10,25 +10,24 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_crates_feed() {
     let (app, _) = TestApp::full().empty();
+    let mut conn = app.db_conn();
 
-    app.db(|conn| {
-        create_crate(
-            conn,
-            "foo",
-            Some("something something foo"),
-            "2024-06-20T10:13:54Z",
-        );
-        create_crate(conn, "bar", None, "2024-06-20T12:45:12Z");
-        create_crate(
-            conn,
-            "baz",
-            Some("does it handle XML? <item>"),
-            "2024-06-21T17:01:33Z",
-        );
-        create_crate(conn, "quux", None, "2024-06-21T17:03:45Z");
+    create_crate(
+        &mut conn,
+        "foo",
+        Some("something something foo"),
+        "2024-06-20T10:13:54Z",
+    );
+    create_crate(&mut conn, "bar", None, "2024-06-20T12:45:12Z");
+    create_crate(
+        &mut conn,
+        "baz",
+        Some("does it handle XML? <item>"),
+        "2024-06-21T17:01:33Z",
+    );
+    create_crate(&mut conn, "quux", None, "2024-06-21T17:03:45Z");
 
-        jobs::rss::SyncCratesFeed.enqueue(conn).unwrap();
-    });
+    jobs::rss::SyncCratesFeed.enqueue(&mut conn).unwrap();
 
     app.run_pending_background_jobs().await;
 


### PR DESCRIPTION
The `db()` function with its closure comes from a time where there was only a single database connection available for each test. This restriction had been lifted quite a while ago, so this is no longer needed and we can just return the connection directly from the function instead.

Review in "hide whitespace changes" mode recommended... 😅 