### PR TITLE
worker/jobs/index/sync: Fix `krate.name` logging

### DIFF
--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -30,7 +30,7 @@ impl BackgroundJob for SyncToGitIndex {
     type Context = Arc<Environment>;
 
     /// Regenerates or removes an index file for a single crate
-    #[instrument(skip_all, fields(krate.name = ? self.krate))]
+    #[instrument(skip_all, fields(krate.name = self.krate))]
     async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to git index");
 
@@ -97,7 +97,7 @@ impl BackgroundJob for SyncToSparseIndex {
     type Context = Arc<Environment>;
 
     /// Regenerates or removes an index file for a single crate
-    #[instrument(skip_all, fields(krate.name = ?self.krate))]
+    #[instrument(skip_all, fields(krate.name = self.krate))]
     async fn run(&self, env: Self::Context) -> anyhow::Result<()> {
         info!("Syncing to sparse index");
 


### PR DESCRIPTION
We don't need to log this in a quoted way since we're using JSON output on production these days anyway

![Bildschirmfoto 2024-10-22 um 21 18 18](https://github.com/user-attachments/assets/1a8ff4a8-d813-4e3a-9f5c-00c35275a8ac)
