### PR TITLE
Replace `&Crate` arguments with `crate_id: i32`

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -431,7 +431,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
 
             // Update all categories for this crate, collecting any invalid categories
             // in order to be able to return an error to the user.
-            let unknown_categories = Category::update_crate(conn, &krate, &categories)?;
+            let unknown_categories = Category::update_crate(conn, krate.id, &categories)?;
             if !unknown_categories.is_empty() {
                 let unknown_categories = unknown_categories.join(", ");
                 let domain = &app.config.domain_name;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -427,7 +427,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             }
 
             // Update all keywords for this crate
-            Keyword::update_crate(conn, &krate, &keywords)?;
+            Keyword::update_crate(conn, krate.id, &keywords)?;
 
             // Update all categories for this crate, collecting any invalid categories
             // in order to be able to return an error to the user.

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -44,7 +44,7 @@ impl Category {
 
     pub fn update_crate(
         conn: &mut impl Conn,
-        krate: &Crate,
+        crate_id: i32,
         slugs: &[&str],
     ) -> QueryResult<Vec<String>> {
         conn.transaction(|conn| {
@@ -60,14 +60,18 @@ impl Category {
                 .iter()
                 .map(|c| CrateCategory {
                     category_id: c.id,
-                    crate_id: krate.id,
+                    crate_id,
                 })
                 .collect::<Vec<_>>();
 
-            delete(CrateCategory::belonging_to(krate)).execute(conn)?;
+            delete(crates_categories::table)
+                .filter(crates_categories::crate_id.eq(crate_id))
+                .execute(conn)?;
+
             insert_into(crates_categories::table)
                 .values(&crate_categories)
                 .execute(conn)?;
+
             Ok(invalid_categories)
         })
     }

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -156,7 +156,7 @@ impl<'a> CrateBuilder<'a> {
         }
 
         if !self.categories.is_empty() {
-            Category::update_crate(connection, &krate, &self.categories)?;
+            Category::update_crate(connection, krate.id, &self.categories)?;
         }
 
         if !self.keywords.is_empty() {

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -160,7 +160,7 @@ impl<'a> CrateBuilder<'a> {
         }
 
         if !self.keywords.is_empty() {
-            Keyword::update_crate(connection, &krate, &self.keywords)?;
+            Keyword::update_crate(connection, krate.id, &self.keywords)?;
         }
 
         if let Some(updated_at) = self.updated_at {

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -59,38 +59,38 @@ async fn update_crate() {
     let krate = CrateBuilder::new("foo_crate", user.id).expect_build(&mut conn);
 
     // Updating with no categories has no effect
-    Category::update_crate(&mut conn, &krate, &[]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &[]).unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Happy path adding one category
-    Category::update_crate(&mut conn, &krate, &["cat1"]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &["cat1"]).unwrap();
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Replacing one category with another
-    Category::update_crate(&mut conn, &krate, &["category-2"]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &["category-2"]).unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing one category
-    Category::update_crate(&mut conn, &krate, &[]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &[]).unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Adding 2 categories
-    Category::update_crate(&mut conn, &krate, &["cat1", "category-2"]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &["cat1", "category-2"]).unwrap();
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing all categories
-    Category::update_crate(&mut conn, &krate, &[]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &[]).unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Attempting to add one valid category and one invalid category
     let invalid_categories =
-        Category::update_crate(&mut conn, &krate, &["cat1", "catnope"]).unwrap();
+        Category::update_crate(&mut conn, krate.id, &["cat1", "catnope"]).unwrap();
     assert_eq!(invalid_categories, vec!["catnope"]);
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 0);
@@ -102,7 +102,7 @@ async fn update_crate() {
     assert_eq!(json.meta.total, 2);
 
     // Attempting to add a category by display text; must use slug
-    Category::update_crate(&mut conn, &krate, &["Category 2"]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &["Category 2"]).unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
@@ -111,7 +111,7 @@ async fn update_crate() {
         .values(new_category("cat1::bar", "cat1::bar", "bar crates"))
         .execute(&mut conn));
 
-    Category::update_crate(&mut conn, &krate, &["cat1", "cat1::bar"]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &["cat1", "cat1::bar"]).unwrap();
 
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "cat1::bar").await, 1);

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -163,8 +163,8 @@ async fn index_queries() {
         .execute(&mut conn)
         .unwrap();
 
-    Category::update_crate(&mut conn, &krate, &["cat1"]).unwrap();
-    Category::update_crate(&mut conn, &krate2, &["cat1::bar"]).unwrap();
+    Category::update_crate(&mut conn, krate.id, &["cat1"]).unwrap();
+    Category::update_crate(&mut conn, krate2.id, &["cat1::bar"]).unwrap();
 
     for cl in search_both(&anon, "category=cat1").await {
         assert_eq!(cl.crates.len(), 2);
@@ -870,8 +870,8 @@ async fn test_default_sort_recent() {
         .execute(&mut conn)
         .unwrap();
 
-    Category::update_crate(&mut conn, &green_crate, &["animal"]).unwrap();
-    Category::update_crate(&mut conn, &potato_crate, &["animal"]).unwrap();
+    Category::update_crate(&mut conn, green_crate.id, &["animal"]).unwrap();
+    Category::update_crate(&mut conn, potato_crate.id, &["animal"]).unwrap();
 
     // test that index for categories is sorted by recent_downloads
     // by default

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -50,27 +50,27 @@ async fn update_crate() {
     Keyword::find_or_create_all(&mut conn, &["kw1", "kw2"]).unwrap();
     let krate = CrateBuilder::new("fookey", user.id).expect_build(&mut conn);
 
-    Keyword::update_crate(&mut conn, &krate, &[]).unwrap();
+    Keyword::update_crate(&mut conn, krate.id, &[]).unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::update_crate(&mut conn, &krate, &["kw1"]).unwrap();
+    Keyword::update_crate(&mut conn, krate.id, &["kw1"]).unwrap();
     assert_eq!(cnt("kw1", &anon).await, 1);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::update_crate(&mut conn, &krate, &["kw2"]).unwrap();
+    Keyword::update_crate(&mut conn, krate.id, &["kw2"]).unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 1);
 
-    Keyword::update_crate(&mut conn, &krate, &[]).unwrap();
+    Keyword::update_crate(&mut conn, krate.id, &[]).unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::update_crate(&mut conn, &krate, &["kw1", "kw2"]).unwrap();
+    Keyword::update_crate(&mut conn, krate.id, &["kw1", "kw2"]).unwrap();
     assert_eq!(cnt("kw1", &anon).await, 1);
     assert_eq!(cnt("kw2", &anon).await, 1);
 
-    Keyword::update_crate(&mut conn, &krate, &[]).unwrap();
+    Keyword::update_crate(&mut conn, krate.id, &[]).unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 }


### PR DESCRIPTION
This allows us to use these function even if we only have an id and not a full `Crate` instance.