### PR TITLE
Avoid unnecessary allocations

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -65,12 +65,12 @@ pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppRes
             let versions = versions_and_publishers
                 .iter()
                 .map(|(v, _)| v)
-                .cloned()
                 .collect::<Vec<_>>();
+            let actions = VersionOwnerAction::for_versions(conn, &versions)?;
             Some(
                 versions_and_publishers
                     .into_iter()
-                    .zip(VersionOwnerAction::for_versions(conn, &versions)?)
+                    .zip(actions)
                     .map(|((v, pb), aas)| (v, pb, aas))
                     .collect::<Vec<_>>(),
             )
@@ -267,12 +267,12 @@ pub async fn reverse_dependencies(
             .load(conn)?;
         let versions = versions_and_publishers
             .iter()
-            .map(|(v, _, _)| v)
-            .cloned()
+            .map(|(v, ..)| v)
             .collect::<Vec<_>>();
+        let actions = VersionOwnerAction::for_versions(conn, &versions)?;
         let versions = versions_and_publishers
             .into_iter()
-            .zip(VersionOwnerAction::for_versions(conn, &versions)?)
+            .zip(actions)
             .map(|((version, krate_name, published_by), actions)| {
                 EncodableVersion::from(version, &krate_name, published_by, actions)
             })

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -68,12 +68,12 @@ pub async fn versions(
             .data
             .iter()
             .map(|(v, _)| v)
-            .cloned()
             .collect::<Vec<_>>();
+        let actions = VersionOwnerAction::for_versions(conn, &versions)?;
         let versions = versions_and_publishers
             .data
             .into_iter()
-            .zip(VersionOwnerAction::for_versions(conn, &versions)?)
+            .zip(actions)
             .map(|((v, pb), aas)| EncodableVersion::from(v, &crate_name, pb, aas))
             .collect::<Vec<_>>();
 

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -27,21 +27,14 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
             conn: &mut impl Conn,
             data: Vec<(Crate, i64, Option<i64>)>,
         ) -> AppResult<Vec<EncodableCrate>> {
-            let downloads = data
-                .iter()
-                .map(|&(_, total, recent)| (total, recent))
-                .collect::<Vec<_>>();
-
-            let krates = data.into_iter().map(|(c, _, _)| c).collect::<Vec<_>>();
-
+            let krates = data.iter().map(|(c, ..)| c).collect::<Vec<_>>();
             let versions: Vec<Version> = krates.versions().load(conn)?;
             versions
                 .grouped_by(&krates)
                 .into_iter()
                 .map(TopVersions::from_versions)
-                .zip(krates)
-                .zip(downloads)
-                .map(|((top_versions, krate), (total, recent))| {
+                .zip(data)
+                .map(|(top_versions, (krate, total, recent))| {
                     Ok(EncodableCrate::from_minimal(
                         krate,
                         Some(&top_versions),

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -85,10 +85,11 @@ pub async fn updates(app: AppState, req: Parts) -> AppResult<Json<Value>> {
             .pages_pagination(PaginationOptions::builder().gather(&req)?);
         let data: Paginated<(Version, String, Option<User>)> = query.load(conn)?;
         let more = data.next_page_params().is_some();
-        let versions = data.iter().map(|(v, _, _)| v).cloned().collect::<Vec<_>>();
+        let versions = data.iter().map(|(v, ..)| v).collect::<Vec<_>>();
+        let actions = VersionOwnerAction::for_versions(conn, &versions)?;
         let data = data
             .into_iter()
-            .zip(VersionOwnerAction::for_versions(conn, &versions)?)
+            .zip(actions)
             .map(|((v, cn, pb), voas)| (v, cn, pb, voas));
 
         let versions = data

--- a/src/models/action.rs
+++ b/src/models/action.rs
@@ -65,7 +65,7 @@ impl VersionOwnerAction {
 
     pub fn for_versions(
         conn: &mut impl Conn,
-        versions: &[Version],
+        versions: &[&Version],
     ) -> QueryResult<Vec<Vec<(Self, User)>>> {
         Ok(Self::belonging_to(versions)
             .inner_join(users::table)

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -494,6 +494,12 @@ impl CrateVersions for [Crate] {
     }
 }
 
+impl CrateVersions for [&Crate] {
+    fn all_versions(&self) -> versions::BoxedQuery<'_, Pg> {
+        Version::belonging_to(self).into_boxed()
+    }
+}
+
 #[derive(Debug, Eq, PartialEq, thiserror::Error)]
 pub enum InvalidFeature {
     #[error("feature cannot be empty")]


### PR DESCRIPTION
This PR modifies certain functions to accept slices of references, thereby avoiding unnecessary allocations.