### PR TITLE
views: Remove `badges` arguments from `EncodableCrate` constructors

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -117,8 +117,6 @@ pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppRes
             None
         };
 
-        let badges = if include.badges { Some(vec![]) } else { None };
-
         let top_versions = if include.versions {
             Some(krate.top_versions(conn)?)
         } else {
@@ -132,7 +130,6 @@ pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppRes
             ids,
             kws.as_deref(),
             cats.as_deref(),
-            badges,
             false,
             downloads,
             recent_downloads,

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -512,7 +512,6 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                     krate,
                     default_version.or(Some(version_string)).as_deref(),
                     Some(&top_versions),
-                    None,
                     false,
                     downloads,
                     None,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -236,7 +236,6 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
                         krate,
                         default_version.as_deref(),
                         Some(&max_version),
-                        Some(vec![]),
                         perfect_match,
                         total,
                         Some(recent.unwrap_or(0)),

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -41,7 +41,6 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
                         krate,
                         default_version.as_deref(),
                         Some(&top_versions),
-                        None,
                         false,
                         total,
                         recent,

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "2.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "2.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "0.0.0-pre",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0+foo",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0-beta.1",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0+foo",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.1.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
@@ -4,7 +4,7 @@ expression: response.json()
 ---
 {
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0+foo",

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
@@ -5,7 +5,7 @@ expression: response.json()
 {
   "categories": null,
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "0.99.0",

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
@@ -5,7 +5,7 @@ expression: response.json()
 {
   "categories": null,
   "crate": {
-    "badges": null,
+    "badges": [],
     "categories": null,
     "created_at": "[datetime]",
     "default_version": "1.0.0",

--- a/src/views.rs
+++ b/src/views.rs
@@ -202,7 +202,7 @@ pub struct EncodableCrate {
     pub versions: Option<Vec<i32>>,
     pub keywords: Option<Vec<String>>,
     pub categories: Option<Vec<String>>,
-    pub badges: Option<Vec<()>>,
+    pub badges: [(); 0],
     #[serde(with = "rfc3339")]
     pub created_at: NaiveDateTime,
     // NOTE: Used by shields.io, altering `downloads` requires a PR with shields.io
@@ -230,7 +230,6 @@ impl EncodableCrate {
         versions: Option<Vec<i32>>,
         keywords: Option<&[Keyword]>,
         categories: Option<&[Category]>,
-        badges: Option<Vec<()>>,
         exact_match: bool,
         downloads: i64,
         recent_downloads: Option<i64>,
@@ -251,7 +250,6 @@ impl EncodableCrate {
         };
         let keyword_ids = keywords.map(|kws| kws.iter().map(|kw| kw.keyword.clone()).collect());
         let category_ids = categories.map(|cats| cats.iter().map(|cat| cat.slug.clone()).collect());
-        let badges = badges.map(|_| vec![]);
         let homepage = remove_blocked_urls(homepage);
         let documentation = remove_blocked_urls(documentation);
         let repository = remove_blocked_urls(repository);
@@ -296,7 +294,7 @@ impl EncodableCrate {
             versions,
             keywords: keyword_ids,
             categories: category_ids,
-            badges,
+            badges: [],
             default_version,
             max_version,
             newest_version,
@@ -321,7 +319,6 @@ impl EncodableCrate {
         krate: Crate,
         default_version: Option<&str>,
         top_versions: Option<&TopVersions>,
-        badges: Option<Vec<()>>,
         exact_match: bool,
         downloads: i64,
         recent_downloads: Option<i64>,
@@ -333,7 +330,6 @@ impl EncodableCrate {
             None,
             None,
             None,
-            badges,
             exact_match,
             downloads,
             recent_downloads,
@@ -804,7 +800,7 @@ mod tests {
             versions: None,
             keywords: None,
             categories: None,
-            badges: None,
+            badges: [],
             created_at: NaiveDate::from_ymd_opt(2017, 1, 6)
                 .unwrap()
                 .and_hms_opt(14, 23, 12)


### PR DESCRIPTION
There are either set to `None` or `Some(vec![])` these days, but we might as well initialize them with an empty static array instead and never return `null`.