### PR TITLE
Fix build metadata race condition

### DIFF
--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -989,6 +989,8 @@ diesel::table! {
         bin_names -> Nullable<Array<Nullable<Text>>>,
         /// message associated with a yanked version
         yank_message -> Nullable<Text>,
+        /// This is the same as `num` without the optional "build metadata" part (except for some versions that were published before we started validating this).
+        num_no_build -> Nullable<Varchar>,
     }
 }
 

--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -990,7 +990,7 @@ diesel::table! {
         /// message associated with a yanked version
         yank_message -> Nullable<Text>,
         /// This is the same as `num` without the optional "build metadata" part (except for some versions that were published before we started validating this).
-        num_no_build -> Nullable<Varchar>,
+        num_no_build -> Varchar,
     }
 }
 

--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -220,6 +220,7 @@ dependencies = ["crates", "users"]
 id = "public"
 crate_id = "public"
 num = "public"
+num_no_build = "public"
 updated_at = "public"
 created_at = "public"
 downloads = "public"

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
@@ -17,7 +17,7 @@ BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
     \copy "crates_keywords" ("crate_id", "keyword_id") TO 'data/crates_keywords.csv' WITH CSV HEADER
     \copy (SELECT "crate_id", "created_at", "created_by", "owner_id", "owner_kind" FROM "crate_owners" WHERE NOT deleted) TO 'data/crate_owners.csv' WITH CSV HEADER
 
-    \copy "versions" ("bin_names", "checksum", "crate_id", "crate_size", "created_at", "downloads", "features", "has_lib", "id", "license", "links", "num", "published_by", "rust_version", "updated_at", "yanked") TO 'data/versions.csv' WITH CSV HEADER
+    \copy "versions" ("bin_names", "checksum", "crate_id", "crate_size", "created_at", "downloads", "features", "has_lib", "id", "license", "links", "num", "num_no_build", "published_by", "rust_version", "updated_at", "yanked") TO 'data/versions.csv' WITH CSV HEADER
     \copy "default_versions" ("crate_id", "version_id") TO 'data/default_versions.csv' WITH CSV HEADER
     \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") TO 'data/dependencies.csv' WITH CSV HEADER
     \copy "version_downloads" ("date", "downloads", "version_id") TO 'data/version_downloads.csv' WITH CSV HEADER

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -59,7 +59,7 @@ BEGIN;
     \copy "crates_categories" ("category_id", "crate_id") FROM 'data/crates_categories.csv' WITH CSV HEADER
     \copy "crates_keywords" ("crate_id", "keyword_id") FROM 'data/crates_keywords.csv' WITH CSV HEADER
     \copy "crate_owners" ("crate_id", "created_at", "created_by", "owner_id", "owner_kind") FROM 'data/crate_owners.csv' WITH CSV HEADER
-    \copy "versions" ("bin_names", "checksum", "crate_id", "crate_size", "created_at", "downloads", "features", "has_lib", "id", "license", "links", "num", "published_by", "rust_version", "updated_at", "yanked") FROM 'data/versions.csv' WITH CSV HEADER
+    \copy "versions" ("bin_names", "checksum", "crate_id", "crate_size", "created_at", "downloads", "features", "has_lib", "id", "license", "links", "num", "num_no_build", "published_by", "rust_version", "updated_at", "yanked") FROM 'data/versions.csv' WITH CSV HEADER
     \copy "default_versions" ("crate_id", "version_id") FROM 'data/default_versions.csv' WITH CSV HEADER
     \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") FROM 'data/dependencies.csv' WITH CSV HEADER
     \copy "version_downloads" ("date", "downloads", "version_id") FROM 'data/version_downloads.csv' WITH CSV HEADER

--- a/migrations/2024-10-24-133507_add-num-no-build-column/down.sql
+++ b/migrations/2024-10-24-133507_add-num-no-build-column/down.sql
@@ -1,0 +1,2 @@
+alter table versions
+    drop num_no_build;

--- a/migrations/2024-10-24-133507_add-num-no-build-column/up.sql
+++ b/migrations/2024-10-24-133507_add-num-no-build-column/up.sql
@@ -1,0 +1,29 @@
+alter table versions
+    add num_no_build varchar;
+
+comment on column versions.num_no_build is 'This is the same as `num` without the optional "build metadata" part (except for some versions that were published before we started validating this).';
+
+-- to be run manually:
+
+-- update versions
+--     set num_no_build = split_part(num, '+', 1);
+--
+-- with duplicates as (
+--     -- find all versions that have the same `crate_id` and `num_no_build`
+--     select crate_id, num_no_build, array_agg(num ORDER BY id) as nums
+--     from versions
+--     group by crate_id, num_no_build
+--     having count(*) > 1
+-- ),
+-- duplicates_to_update as (
+--     -- for each group of duplicates, update all versions except the one that
+--     -- doesn't have "build metadata", or the first one that was published if
+--     -- all versions have "build metadata"
+--     select crate_id, num_no_build, unnest(case when array_position(nums, num_no_build) IS NOT NULL then array_remove(nums, num_no_build) else nums[2:] end) as num
+--     from duplicates
+-- )
+-- update versions
+--     set num_no_build = duplicates_to_update.num
+--     from duplicates_to_update
+--     where versions.crate_id = duplicates_to_update.crate_id
+--     and versions.num = duplicates_to_update.num;

--- a/migrations/2024-10-24-134209_make-unique-num-not-null/down.sql
+++ b/migrations/2024-10-24-134209_make-unique-num-not-null/down.sql
@@ -1,0 +1,2 @@
+alter table versions
+    alter column num_no_build drop not null;

--- a/migrations/2024-10-24-134209_make-unique-num-not-null/up.sql
+++ b/migrations/2024-10-24-134209_make-unique-num-not-null/up.sql
@@ -1,0 +1,2 @@
+alter table versions
+    alter column num_no_build set not null;

--- a/migrations/2024-10-25-112826_make-unique-version-unique/down.sql
+++ b/migrations/2024-10-25-112826_make-unique-version-unique/down.sql
@@ -1,0 +1,2 @@
+alter table versions
+    drop constraint versions_crate_id_num_no_build_uindex;

--- a/migrations/2024-10-25-112826_make-unique-version-unique/metadata.toml
+++ b/migrations/2024-10-25-112826_make-unique-version-unique/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2024-10-25-112826_make-unique-version-unique/up.sql
+++ b/migrations/2024-10-25-112826_make-unique-version-unique/up.sql
@@ -1,0 +1,2 @@
+create unique index concurrently if not exists versions_crate_id_num_no_build_uindex
+    on versions (crate_id, num_no_build);

--- a/src/models/default_versions.rs
+++ b/src/models/default_versions.rs
@@ -245,6 +245,7 @@ mod tests {
             .values((
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(num),
+                versions::num_no_build.eq(num),
                 versions::checksum.eq(""),
             ))
             .execute(conn)

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -34,7 +34,7 @@ pub struct Version {
     pub has_lib: Option<bool>,
     pub bin_names: Option<Vec<Option<String>>>,
     pub yank_message: Option<String>,
-    pub num_no_build: Option<String>,
+    pub num_no_build: String,
 }
 
 impl Version {
@@ -85,6 +85,8 @@ pub struct NewVersion<'a> {
     crate_id: i32,
     #[builder(start_fn)]
     num: &'a str,
+    #[builder(default = strip_build_metadata(num))]
+    num_no_build: &'a str,
     created_at: Option<&'a NaiveDateTime>,
     yanked: Option<bool>,
     #[builder(default = serde_json::Value::Object(Default::default()))]

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -34,6 +34,7 @@ pub struct Version {
     pub has_lib: Option<bool>,
     pub bin_names: Option<Vec<Option<String>>>,
     pub yank_message: Option<String>,
+    pub num_no_build: Option<String>,
 }
 
 impl Version {

--- a/src/tests/worker/rss/sync_crate_feed.rs
+++ b/src/tests/worker/rss/sync_crate_feed.rs
@@ -69,6 +69,7 @@ async fn create_version(
         .values((
             versions::crate_id.eq(crate_id),
             versions::num.eq(version),
+            versions::num_no_build.eq(version),
             versions::created_at.eq(publish_time),
             versions::updated_at.eq(publish_time),
             versions::checksum.eq("checksum"),

--- a/src/tests/worker/rss/sync_updates_feed.rs
+++ b/src/tests/worker/rss/sync_updates_feed.rs
@@ -75,6 +75,7 @@ async fn create_version(
         .values((
             versions::crate_id.eq(crate_id),
             versions::num.eq(version),
+            versions::num_no_build.eq(version),
             versions::created_at.eq(publish_time),
             versions::updated_at.eq(publish_time),
             versions::checksum.eq("checksum"),

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -397,6 +397,7 @@ mod tests {
             .values((
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(num),
+                versions::num_no_build.eq(num),
                 versions::checksum.eq(""),
             ))
             .returning(versions::id)

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -511,6 +511,7 @@ mod tests {
             .values((
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(version),
+                versions::num_no_build.eq(version),
                 versions::checksum.eq("checksum"),
             ))
             .execute(conn)

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -254,10 +254,12 @@ mod tests {
         version: impl Into<Cow<'static, str>>,
         publish_time: NaiveDateTime,
     ) -> impl Future<Output = i32> {
+        let version = version.into();
         let future = diesel::insert_into(versions::table)
             .values((
                 versions::crate_id.eq(crate_id),
-                versions::num.eq(version.into()),
+                versions::num.eq(version.clone()),
+                versions::num_no_build.eq(version),
                 versions::created_at.eq(publish_time),
                 versions::updated_at.eq(publish_time),
                 versions::checksum.eq("checksum"),

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -248,10 +248,12 @@ mod tests {
         version: impl Into<Cow<'static, str>>,
         publish_time: NaiveDateTime,
     ) -> impl Future<Output = i32> {
+        let version = version.into();
         let future = diesel::insert_into(versions::table)
             .values((
                 versions::crate_id.eq(crate_id),
-                versions::num.eq(version.into()),
+                versions::num.eq(version.clone()),
+                versions::num_no_build.eq(version),
                 versions::created_at.eq(publish_time),
                 versions::updated_at.eq(publish_time),
                 versions::checksum.eq("checksum"),


### PR DESCRIPTION
This PR fixes a race condition in our publish endpoint. When two versions, `1.0.0+foo` and `1.0.0+bar` are published concurrently we previously could get into a situation where the "unique version number excluding build metadata" check succeeds for both, and then both versions are added to the database, when only one such version should exist.

This PR adds a new `unique` constraint on `(crate_id, num_no_build)` to prevent this from happening.

We currently have around 650 such cases still in the database though. In those cases the `num_no_build` column is adjusted to actually contain the build metadata too (see column comment).

Finally, this PR needs to be merged/deployed in multiple stages. The initial migration adds the column in a nullable way, because the SQL script to backfill the data for the column takes about 30 sec (on my machine), and this shouldn't prevent the API server from booting up because of a running schema migration. **It is recommended to merge/deploy each migration in this PR independently!**