### PR TITLE
Fix the broken entrypoint for frontend service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,7 @@ services:
     build:
       context: .
       dockerfile: frontend.Dockerfile
-    environment:
-      PROXY_BACKEND: http://backend:8888
-    entrypoint: pnpm start
+    entrypoint: pnpm start:docker
     links:
       - backend
     ports:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prettier:check": "prettier --check package.json '**/*.js' '**/*.mjs' '**/*.ts' '**/*.md'",
     "prettier:write": "prettier --write package.json '**/*.js' '**/*.mjs' '**/*.ts' '**/*.md'",
     "start": "ember serve",
+    "start:docker": "ember serve --proxy http://backend:8888",
     "start:live": "ember serve --proxy https://crates.io",
     "start:local": "ember serve --proxy http://127.0.0.1:8888",
     "start:staging": "ember serve --proxy https://staging-crates-io.herokuapp.com",


### PR DESCRIPTION
We don't use the PROXY_BACKEND env variable any more.

If we don't change it, it will try to use the mock server as the backend API.