### PR TITLE
Migrate the frontend to use the new yank API

### DIFF
--- a/app/adapters/version.js
+++ b/app/adapters/version.js
@@ -1,0 +1,9 @@
+import ApplicationAdapter from './application';
+
+export default class VersionAdapter extends ApplicationAdapter {
+  urlForUpdateRecord(id, modelName, snapshot) {
+    let crateName = snapshot.record.crate.id;
+    let num = snapshot.record.num;
+    return `/${this.namespace}/crates/${crateName}/${num}`;
+  }
+}

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -166,22 +166,42 @@ export default class Version extends Model {
   }
 
   yankTask = keepLatestTask(async () => {
-    let response = await fetch(`/api/v1/crates/${this.crate.id}/${this.num}/yank`, { method: 'DELETE' });
+    let response = await fetch(`/api/v1/crates/${this.crate.id}/${this.num}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        version: {
+          yanked: true,
+        },
+      }),
+    });
     if (!response.ok) {
       throw new Error(`Yank request for ${this.crateName} v${this.num} failed`);
     }
     this.set('yanked', true);
 
-    return await response.text();
+    return await response.json();
   });
 
   unyankTask = keepLatestTask(async () => {
-    let response = await fetch(`/api/v1/crates/${this.crate.id}/${this.num}/unyank`, { method: 'PUT' });
+    let response = await fetch(`/api/v1/crates/${this.crate.id}/${this.num}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        version: {
+          yanked: false,
+        },
+      }),
+    });
     if (!response.ok) {
       throw new Error(`Unyank request for ${this.crateName} v${this.num} failed`);
     }
     this.set('yanked', false);
 
-    return await response.text();
+    return await response.json();
   });
 }

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -1,5 +1,7 @@
 import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
+import { waitForPromise } from '@ember/test-waiters';
 
+import { apiAction } from '@mainmatter/ember-api-actions';
 import { keepLatestTask, task } from 'ember-concurrency';
 import fetch from 'fetch';
 import { alias } from 'macro-decorators';
@@ -166,42 +168,14 @@ export default class Version extends Model {
   }
 
   yankTask = keepLatestTask(async () => {
-    let response = await fetch(`/api/v1/crates/${this.crate.id}/${this.num}`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        version: {
-          yanked: true,
-        },
-      }),
-    });
-    if (!response.ok) {
-      throw new Error(`Yank request for ${this.crateName} v${this.num} failed`);
-    }
-    this.set('yanked', true);
-
-    return await response.json();
+    let data = { version: { yanked: true } };
+    let payload = await waitForPromise(apiAction(this, { method: 'PATCH', data }));
+    this.store.pushPayload(payload);
   });
 
   unyankTask = keepLatestTask(async () => {
-    let response = await fetch(`/api/v1/crates/${this.crate.id}/${this.num}`, {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        version: {
-          yanked: false,
-        },
-      }),
-    });
-    if (!response.ok) {
-      throw new Error(`Unyank request for ${this.crateName} v${this.num} failed`);
-    }
-    this.set('yanked', false);
-
-    return await response.json();
+    let data = { version: { yanked: false } };
+    let payload = await waitForPromise(apiAction(this, { method: 'PATCH', data }));
+    this.store.pushPayload(payload);
   });
 }

--- a/e2e/acceptance/sudo.spec.ts
+++ b/e2e/acceptance/sudo.spec.ts
@@ -112,8 +112,22 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
 
     await yankButton.click();
 
+    // Verify backend state after yanking
+    const yankedVersion = await page.evaluate(() => {
+      const crate = server.schema['crates'].findBy({ name: 'foo' });
+      return server.schema['versions'].findBy({ crateId: crate.id, num: '0.1.0', yanked: true });
+    });
+    expect(yankedVersion, 'The version should be yanked').toBeTruthy();
+
     await expect(unyankButton).toBeVisible();
     await unyankButton.click();
+
+    // Verify backend state after unyanking
+    const unyankedVersion = await page.evaluate(() => {
+      const crate = server.schema['crates'].findBy({ name: 'foo' });
+      return server.schema['versions'].findBy({ crateId: crate.id, num: '0.1.0', yanked: false });
+    });
+    expect(unyankedVersion, 'The version should be unyanked').toBeTruthy();
 
     await expect(yankButton).toBeVisible();
   });

--- a/tests/acceptance/sudo-test.js
+++ b/tests/acceptance/sudo-test.js
@@ -104,8 +104,13 @@ module('Acceptance | sudo', function (hooks) {
     await click('[data-test-version-yank-button="0.1.0"]');
 
     await waitFor('[data-test-version-unyank-button="0.1.0"]');
+    const crate = this.server.schema.crates.findBy({ name: 'foo' });
+    const version = this.server.schema.versions.findBy({ crateId: crate.id, num: '0.1.0' });
+    assert.true(version.yanked, 'The version should be yanked');
     assert.dom('[data-test-version-unyank-button="0.1.0"]').exists();
     await click('[data-test-version-unyank-button="0.1.0"]');
+    const updatedVersion = this.server.schema.versions.findBy({ crateId: crate.id, num: '0.1.0' });
+    assert.false(updatedVersion.yanked, 'The version should be unyanked');
 
     await waitFor('[data-test-version-yank-button="0.1.0"]');
     assert.dom('[data-test-version-yank-button="0.1.0"]').exists();


### PR DESCRIPTION
Moved to the new API before adding frontend support for the yank message.

Tested locally:



https://github.com/user-attachments/assets/bf3ce6c2-b6b5-499c-b878-5180e710fd7d

