### PR TITLE
database: Change `num_no_build` to be `NOT NULL`

### DIFF
--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -990,7 +990,7 @@ diesel::table! {
         /// message associated with a yanked version
         yank_message -> Nullable<Text>,
         /// This is the same as `num` without the optional "build metadata" part (except for some versions that were published before we started validating this).
-        num_no_build -> Nullable<Varchar>,
+        num_no_build -> Varchar,
     }
 }
 

--- a/migrations/2024-10-24-134209_make-unique-num-not-null/down.sql
+++ b/migrations/2024-10-24-134209_make-unique-num-not-null/down.sql
@@ -1,0 +1,2 @@
+alter table versions
+    alter column num_no_build drop not null;

--- a/migrations/2024-10-24-134209_make-unique-num-not-null/up.sql
+++ b/migrations/2024-10-24-134209_make-unique-num-not-null/up.sql
@@ -1,0 +1,2 @@
+alter table versions
+    alter column num_no_build set not null;

--- a/src/models/default_versions.rs
+++ b/src/models/default_versions.rs
@@ -245,6 +245,7 @@ mod tests {
             .values((
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(num),
+                versions::num_no_build.eq(num),
                 versions::checksum.eq(""),
             ))
             .execute(conn)

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -34,7 +34,7 @@ pub struct Version {
     pub has_lib: Option<bool>,
     pub bin_names: Option<Vec<Option<String>>>,
     pub yank_message: Option<String>,
-    pub num_no_build: Option<String>,
+    pub num_no_build: String,
 }
 
 impl Version {
@@ -85,6 +85,8 @@ pub struct NewVersion<'a> {
     crate_id: i32,
     #[builder(start_fn)]
     num: &'a str,
+    #[builder(default = strip_build_metadata(num))]
+    num_no_build: &'a str,
     created_at: Option<&'a NaiveDateTime>,
     yanked: Option<bool>,
     #[builder(default = serde_json::Value::Object(Default::default()))]

--- a/src/tests/worker/rss/sync_crate_feed.rs
+++ b/src/tests/worker/rss/sync_crate_feed.rs
@@ -69,6 +69,7 @@ async fn create_version(
         .values((
             versions::crate_id.eq(crate_id),
             versions::num.eq(version),
+            versions::num_no_build.eq(version),
             versions::created_at.eq(publish_time),
             versions::updated_at.eq(publish_time),
             versions::checksum.eq("checksum"),

--- a/src/tests/worker/rss/sync_updates_feed.rs
+++ b/src/tests/worker/rss/sync_updates_feed.rs
@@ -75,6 +75,7 @@ async fn create_version(
         .values((
             versions::crate_id.eq(crate_id),
             versions::num.eq(version),
+            versions::num_no_build.eq(version),
             versions::created_at.eq(publish_time),
             versions::updated_at.eq(publish_time),
             versions::checksum.eq("checksum"),

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -397,6 +397,7 @@ mod tests {
             .values((
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(num),
+                versions::num_no_build.eq(num),
                 versions::checksum.eq(""),
             ))
             .returning(versions::id)

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -511,6 +511,7 @@ mod tests {
             .values((
                 versions::crate_id.eq(crate_id),
                 versions::num.eq(version),
+                versions::num_no_build.eq(version),
                 versions::checksum.eq("checksum"),
             ))
             .execute(conn)

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -254,10 +254,12 @@ mod tests {
         version: impl Into<Cow<'static, str>>,
         publish_time: NaiveDateTime,
     ) -> impl Future<Output = i32> {
+        let version = version.into();
         let future = diesel::insert_into(versions::table)
             .values((
                 versions::crate_id.eq(crate_id),
-                versions::num.eq(version.into()),
+                versions::num.eq(version.clone()),
+                versions::num_no_build.eq(version),
                 versions::created_at.eq(publish_time),
                 versions::updated_at.eq(publish_time),
                 versions::checksum.eq("checksum"),

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -248,10 +248,12 @@ mod tests {
         version: impl Into<Cow<'static, str>>,
         publish_time: NaiveDateTime,
     ) -> impl Future<Output = i32> {
+        let version = version.into();
         let future = diesel::insert_into(versions::table)
             .values((
                 versions::crate_id.eq(crate_id),
-                versions::num.eq(version.into()),
+                versions::num.eq(version.clone()),
+                versions::num_no_build.eq(version),
                 versions::created_at.eq(publish_time),
                 versions::updated_at.eq(publish_time),
                 versions::checksum.eq("checksum"),


### PR DESCRIPTION
This PR was extracted from https://github.com/rust-lang/crates.io/pull/9756, because it needs to be deploy separately from the other migrations in that PR.

The backfill SQL script in https://github.com/rust-lang/crates.io/pull/9766 has been run on the staging and production databases, so this should be good to go. `SELECT * FROM versions WHERE num_no_build IS NULL` returns zero rows.