### PR TITLE
diesel: Replace `all_columns` with `as_select()`

### DIFF
--- a/src/admin/render_readmes.rs
+++ b/src/admin/render_readmes.rs
@@ -100,7 +100,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
             let versions: Vec<(Version, String)> = versions::table
                 .inner_join(crates::table)
                 .filter(versions::id.eq_any(version_ids_chunk))
-                .select((versions::all_columns, crates::name))
+                .select((Version::as_select(), crates::name))
                 .load(conn)
                 .context("error loading versions")?;
 

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -102,7 +102,7 @@ fn list_by_date(
     let mut query = versions::table
         .filter(versions::crate_id.eq(crate_id))
         .left_outer_join(users::table)
-        .select((versions::all_columns, users::all_columns.nullable()))
+        .select(<(Version, Option<User>)>::as_select())
         .into_boxed();
 
     let mut release_tracks = None;
@@ -239,7 +239,7 @@ fn list_by_semver(
             for result in versions::table
                 .filter(versions::crate_id.eq(crate_id))
                 .left_outer_join(users::table)
-                .select((versions::all_columns, users::all_columns.nullable()))
+                .select(<(Version, Option<User>)>::as_select())
                 .filter(versions::id.eq_any(ids))
                 .load_iter::<(Version, Option<User>), DefaultLoadingMode>(conn)?
             {
@@ -267,7 +267,7 @@ fn list_by_semver(
         let mut data: Vec<(Version, Option<User>)> = versions::table
             .filter(versions::crate_id.eq(crate_id))
             .left_outer_join(users::table)
-            .select((versions::all_columns, users::all_columns.nullable()))
+            .select(<(Version, Option<User>)>::as_select())
             .load(conn)?;
         data.sort_by_cached_key(|(version, _)| Reverse(semver::Version::parse(&version.num).ok()));
         let total = data.len();

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,7 +3,7 @@
 //! index files.
 
 use crate::models::{Crate, CrateVersions, Dependency, Version};
-use crate::schema::{crates, dependencies};
+use crate::schema::crates;
 use anyhow::Context;
 use crates_io_index::features::split_features;
 use diesel::prelude::*;
@@ -68,7 +68,7 @@ pub async fn index_metadata(
 
     let deps: Vec<(Dependency, String)> = Dependency::belonging_to(&versions)
         .inner_join(crates::table)
-        .select((dependencies::all_columns, crates::name))
+        .select((Dependency::as_select(), crates::name))
         .load(conn)
         .await?;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,7 +7,7 @@ pub use self::download::VersionDownload;
 pub use self::email::{Email, NewEmail};
 pub use self::follow::Follow;
 pub use self::keyword::{CrateKeyword, Keyword};
-pub use self::krate::{Crate, CrateVersions, NewCrate, RecentCrateDownloads};
+pub use self::krate::{Crate, CrateName, CrateVersions, NewCrate, RecentCrateDownloads};
 pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::rights::Rights;
 pub use self::team::{NewTeam, Team};

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -5,7 +5,7 @@ use crate::models::Crate;
 use crate::schema::*;
 use crate::util::diesel::Conn;
 
-#[derive(Clone, Identifiable, Queryable, QueryableByName, Debug)]
+#[derive(Clone, Identifiable, Queryable, QueryableByName, Debug, Selectable)]
 #[diesel(table_name = categories, check_for_backend(diesel::pg::Pg))]
 pub struct Category {
     pub id: i32,

--- a/src/models/dependency.rs
+++ b/src/models/dependency.rs
@@ -5,7 +5,7 @@ use crate::schema::*;
 use crate::sql::pg_enum;
 use crates_io_index::DependencyKind as IndexDependencyKind;
 
-#[derive(Identifiable, Associations, Debug, Queryable, QueryableByName)]
+#[derive(Identifiable, Associations, Debug, Queryable, QueryableByName, Selectable)]
 #[diesel(
     table_name = dependencies,
     check_for_backend(diesel::pg::Pg),

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -6,7 +6,7 @@ use crate::schema::*;
 use crate::sql::lower;
 use crate::util::diesel::Conn;
 
-#[derive(Clone, Identifiable, Queryable, Debug)]
+#[derive(Clone, Identifiable, Queryable, Debug, Selectable)]
 pub struct Keyword {
     pub id: i32,
     pub keyword: String,

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -34,6 +34,12 @@ pub struct RecentCrateDownloads {
     pub downloads: i32,
 }
 
+#[derive(Debug, Clone, Queryable, Selectable)]
+#[diesel(table_name = crates, check_for_backend(diesel::pg::Pg))]
+pub struct CrateName {
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Queryable, Identifiable, AsChangeset, QueryableByName, Selectable)]
 #[diesel(table_name = crates, check_for_backend(diesel::pg::Pg))]
 pub struct Crate {
@@ -338,14 +344,14 @@ impl Crate {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .filter(crate_owners::crate_id.eq(self.id))
             .inner_join(users::table)
-            .select(users::all_columns)
+            .select(User::as_select())
             .load(conn)?
             .into_iter()
             .map(Owner::User);
         let teams = CrateOwner::by_owner_kind(OwnerKind::Team)
             .filter(crate_owners::crate_id.eq(self.id))
             .inner_join(teams::table)
-            .select(teams::all_columns)
+            .select(Team::as_select())
             .load(conn)?
             .into_iter()
             .map(Owner::Team);

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -15,7 +15,7 @@ use crate::util::diesel::Conn;
 
 /// For now, just a Github Team. Can be upgraded to other teams
 /// later if desirable.
-#[derive(Queryable, Identifiable, Serialize, Deserialize, Debug)]
+#[derive(Queryable, Identifiable, Serialize, Deserialize, Debug, Selectable)]
 pub struct Team {
     /// Unique table id
     pub id: i32,
@@ -200,7 +200,7 @@ impl Team {
         let base_query = CrateOwner::belonging_to(krate).filter(crate_owners::deleted.eq(false));
         let teams = base_query
             .inner_join(teams::table)
-            .select(teams::all_columns)
+            .select(Team::as_select())
             .filter(crate_owners::owner_kind.eq(OwnerKind::Team))
             .load(conn)?
             .into_iter()

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -13,7 +13,7 @@ use crate::sql::lower;
 use crate::util::diesel::Conn;
 
 /// The model representing a row in the `users` database table.
-#[derive(Clone, Debug, PartialEq, Eq, Queryable, Identifiable, AsChangeset)]
+#[derive(Clone, Debug, PartialEq, Eq, Queryable, Identifiable, AsChangeset, Selectable)]
 pub struct User {
     pub id: i32,
     pub gh_access_token: String,
@@ -43,7 +43,7 @@ impl User {
     pub fn owning(krate: &Crate, conn: &mut impl Conn) -> QueryResult<Vec<Owner>> {
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(users::table)
-            .select(users::all_columns)
+            .select(User::as_select())
             .filter(crate_owners::crate_id.eq(krate.id))
             .load(conn)?
             .into_iter()

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -11,7 +11,7 @@ use crate::schema::*;
 use crate::util::diesel::Conn;
 
 // Queryable has a custom implementation below
-#[derive(Clone, Identifiable, Associations, Debug, Queryable)]
+#[derive(Clone, Identifiable, Associations, Debug, Queryable, Selectable)]
 #[diesel(belongs_to(Crate))]
 pub struct Version {
     pub id: i32,
@@ -39,7 +39,7 @@ impl Version {
     pub fn dependencies(&self, conn: &mut impl Conn) -> QueryResult<Vec<(Dependency, String)>> {
         Dependency::belonging_to(self)
             .inner_join(crates::table)
-            .select((dependencies::all_columns, crates::name))
+            .select((Dependency::as_select(), crates::name))
             .order((dependencies::optional, crates::name))
             .load(conn)
     }


### PR DESCRIPTION
With `all_columns` the field order inside the structs is very important and it is impossible to skip columns. `as_select()` solves both of these issues.