### PR TITLE
CI: Run only frontend jobs for changes in the `e2e` folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           files_ignore: |
             app/**
+            e2e/**
             mirage/**
             public/**
             tests/**


### PR DESCRIPTION
There is no need to run the backend test suite if the changes are limited to the Playwright test suite.