### PR TITLE
worker: Remove `spawn_blocking()` usage

### DIFF
--- a/crates/crates_io_worker/src/storage.rs
+++ b/crates/crates_io_worker/src/storage.rs
@@ -1,10 +1,10 @@
 use crate::schema::background_jobs;
-use diesel::connection::LoadConnection;
 use diesel::dsl::now;
 use diesel::pg::Pg;
 use diesel::prelude::*;
 use diesel::sql_types::{Bool, Integer, Interval};
 use diesel::{delete, update};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
 #[derive(Queryable, Selectable, Identifiable, Debug, Clone)]
 pub(super) struct BackgroundJob {
@@ -26,8 +26,8 @@ fn retriable() -> Box<dyn BoxableExpression<background_jobs::table, Pg, SqlType 
 
 /// Finds the next job that is unlocked, and ready to be retried. If a row is
 /// found, it will be locked.
-pub(super) fn find_next_unlocked_job(
-    conn: &mut impl LoadConnection<Backend = Pg>,
+pub(super) async fn find_next_unlocked_job(
+    conn: &mut AsyncPgConnection,
     job_types: &[String],
 ) -> QueryResult<BackgroundJob> {
     background_jobs::table
@@ -38,22 +38,26 @@ pub(super) fn find_next_unlocked_job(
         .for_update()
         .skip_locked()
         .first::<BackgroundJob>(conn)
+        .await
 }
 
 /// The number of jobs that have failed at least once
-pub(super) fn failed_job_count(conn: &mut impl LoadConnection<Backend = Pg>) -> QueryResult<i64> {
+pub(super) async fn failed_job_count(conn: &mut AsyncPgConnection) -> QueryResult<i64> {
     background_jobs::table
         .count()
         .filter(background_jobs::retries.gt(0))
         .get_result(conn)
+        .await
 }
 
 /// Deletes a job that has successfully completed running
-pub(super) fn delete_successful_job(
-    conn: &mut impl LoadConnection<Backend = Pg>,
+pub(super) async fn delete_successful_job(
+    conn: &mut AsyncPgConnection,
     job_id: i64,
 ) -> QueryResult<()> {
-    delete(background_jobs::table.find(job_id)).execute(conn)?;
+    delete(background_jobs::table.find(job_id))
+        .execute(conn)
+        .await?;
     Ok(())
 }
 
@@ -61,11 +65,12 @@ pub(super) fn delete_successful_job(
 ///
 /// Ignores any database errors that may have occurred. If the DB has gone away,
 /// we assume that just trying again with a new connection will succeed.
-pub(super) fn update_failed_job(conn: &mut impl LoadConnection<Backend = Pg>, job_id: i64) {
+pub(super) async fn update_failed_job(conn: &mut AsyncPgConnection, job_id: i64) {
     let _ = update(background_jobs::table.find(job_id))
         .set((
             background_jobs::retries.eq(background_jobs::retries + 1),
             background_jobs::last_retry.eq(now),
         ))
-        .execute(conn);
+        .execute(conn)
+        .await;
 }


### PR DESCRIPTION
No need for `spawn_blocking()`, we can just use `diesel-async` queries now :)