### PR TITLE
mirage: Fix yank/unyank route handlers

### DIFF
--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -283,7 +283,7 @@ export function register(server) {
     version.yanked = true;
     version.save();
 
-    return {};
+    return { ok: true };
   });
 
   server.put('/api/v1/crates/:name/:version/unyank', (schema, request) => {
@@ -305,7 +305,7 @@ export function register(server) {
     version.yanked = false;
     version.save();
 
-    return {};
+    return { ok: true };
   });
 
   server.get('/api/v1/crates/:name/:version/readme', (schema, request) => {

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -280,8 +280,8 @@ export function register(server) {
     if (!version) {
       return notFound();
     }
-    version.yanked = true;
-    version.save();
+
+    version.update({ yanked: true });
 
     return { ok: true };
   });
@@ -302,8 +302,8 @@ export function register(server) {
     if (!version) {
       return notFound();
     }
-    version.yanked = false;
-    version.save();
+
+    version.update({ yanked: false });
 
     return { ok: true };
   });

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -275,6 +275,8 @@ export function register(server) {
     if (!version) {
       return notFound();
     }
+    version.yanked = true;
+    version.save();
 
     return {};
   });
@@ -290,6 +292,8 @@ export function register(server) {
     if (!version) {
       return notFound();
     }
+    version.yanked = false;
+    version.save();
 
     return {};
   });

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -265,6 +265,11 @@ export function register(server) {
   });
 
   server.delete('/api/v1/crates/:name/:version/yank', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
     const { name, version: versionNum } = request.params;
     const crate = schema.crates.findBy({ name });
     if (!crate) {
@@ -282,6 +287,11 @@ export function register(server) {
   });
 
   server.put('/api/v1/crates/:name/:version/unyank', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
     const { name, version: versionNum } = request.params;
     const crate = schema.crates.findBy({ name });
     if (!crate) {

--- a/tests/mirage/crates/versions/yank/unyank-test.js
+++ b/tests/mirage/crates/versions/yank/unyank-test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+
+import fetch from 'fetch';
+
+import { setupTest } from '../../../../helpers';
+import setupMirage from '../../../../helpers/setup-mirage';
+
+module('Mirage | PUT /api/v1/crates/:crateId/unyank', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('returns 403 if unauthenticated', async function (assert) {
+    let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
+    assert.strictEqual(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      errors: [{ detail: 'must be logged in to perform that action' }],
+    });
+  });
+
+  test('returns 404 for unknown crates', async function (assert) {
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
+    assert.strictEqual(response.status, 404);
+    assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+  });
+
+  test('returns 404 for unknown versions', async function (assert) {
+    this.server.create('crate', { name: 'foo' });
+
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
+    assert.strictEqual(response.status, 404);
+    assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+  });
+
+  test('unyanks the version', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    let version = this.server.create('version', { crate, num: '1.0.0', yanked: true });
+    assert.true(version.yanked);
+
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let response = await fetch('/api/v1/crates/foo/1.0.0/unyank', { method: 'PUT' });
+    assert.strictEqual(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+
+    user.reload();
+    assert.false(version.yanked);
+  });
+});

--- a/tests/mirage/crates/versions/yank/yank-test.js
+++ b/tests/mirage/crates/versions/yank/yank-test.js
@@ -1,0 +1,55 @@
+import { module, test } from 'qunit';
+
+import fetch from 'fetch';
+
+import { setupTest } from '../../../../helpers';
+import setupMirage from '../../../../helpers/setup-mirage';
+
+module('Mirage | DELETE /api/v1/crates/:crateId/yank', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('returns 403 if unauthenticated', async function (assert) {
+    let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
+    assert.strictEqual(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      errors: [{ detail: 'must be logged in to perform that action' }],
+    });
+  });
+
+  test('returns 404 for unknown crates', async function (assert) {
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
+    assert.strictEqual(response.status, 404);
+    assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+  });
+
+  test('returns 404 for unknown versions', async function (assert) {
+    this.server.create('crate', { name: 'foo' });
+
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
+    assert.strictEqual(response.status, 404);
+    assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+  });
+
+  test('yanks the version', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    let version = this.server.create('version', { crate, num: '1.0.0', yanked: false });
+    assert.false(version.yanked);
+
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let response = await fetch('/api/v1/crates/foo/1.0.0/yank', { method: 'DELETE' });
+    assert.strictEqual(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+
+    user.reload();
+    assert.true(version.yanked);
+  });
+});


### PR DESCRIPTION
This PR was partially extracted from https://github.com/rust-lang/crates.io/pull/9765 (thanks @Rustin170506!). I've added a couple of tests for the mirage implementation of these two endpoints and fixed the bugs that the tests uncovered.

Note that the mirage implementation currently does not check for crate ownership. I'm not sure yet whether the additional complexity for that case would be justified.