### PR TITLE
mirage: Add `yank_message` to `version` factory and serializer

### DIFF
--- a/mirage/factories/version.js
+++ b/mirage/factories/version.js
@@ -9,6 +9,7 @@ export default Factory.extend({
   updated_at: '2017-02-24T12:34:56Z',
 
   yanked: false,
+  yank_message: null,
   license: i => LICENSES[i % LICENSES.length],
 
   downloads: i => (((i + 13) * 42) % 13) * 1234,

--- a/mirage/serializers/version.js
+++ b/mirage/serializers/version.js
@@ -13,6 +13,7 @@ export default BaseSerializer.extend({
     'num',
     'updated_at',
     'yanked',
+    'yank_message',
     'license',
     'crate_size',
     'rust_version',

--- a/tests/mirage/crates/get-by-id-test.js
+++ b/tests/mirage/crates/get-by-id-test.js
@@ -68,6 +68,7 @@ module('Mirage | GET /api/v1/crates/:id', function (hooks) {
           rust_version: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
+          yank_message: null,
         },
       ],
     });
@@ -103,6 +104,7 @@ module('Mirage | GET /api/v1/crates/:id', function (hooks) {
         rust_version: null,
         updated_at: '2017-02-24T12:34:56Z',
         yanked: false,
+        yank_message: null,
       },
       {
         id: '2',
@@ -122,6 +124,7 @@ module('Mirage | GET /api/v1/crates/:id', function (hooks) {
         rust_version: null,
         updated_at: '2017-02-24T12:34:56Z',
         yanked: false,
+        yank_message: null,
       },
       {
         id: '1',
@@ -141,6 +144,7 @@ module('Mirage | GET /api/v1/crates/:id', function (hooks) {
         rust_version: null,
         updated_at: '2017-02-24T12:34:56Z',
         yanked: false,
+        yank_message: null,
       },
     ]);
   });

--- a/tests/mirage/crates/reverse-dependencies-test.js
+++ b/tests/mirage/crates/reverse-dependencies-test.js
@@ -92,6 +92,7 @@ module('Mirage | GET /api/v1/crates/:id/reverse_dependencies', function (hooks) 
           rust_version: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
+          yank_message: null,
         },
         {
           id: '2',
@@ -111,6 +112,7 @@ module('Mirage | GET /api/v1/crates/:id/reverse_dependencies', function (hooks) 
           rust_version: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
+          yank_message: null,
         },
       ],
       meta: {

--- a/tests/mirage/crates/versions/list-test.js
+++ b/tests/mirage/crates/versions/list-test.js
@@ -54,6 +54,7 @@ module('Mirage | GET /api/v1/crates/:id/versions', function (hooks) {
           rust_version: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
+          yank_message: null,
         },
         {
           id: '2',
@@ -79,6 +80,7 @@ module('Mirage | GET /api/v1/crates/:id/versions', function (hooks) {
           rust_version: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
+          yank_message: null,
         },
         {
           id: '3',
@@ -98,6 +100,7 @@ module('Mirage | GET /api/v1/crates/:id/versions', function (hooks) {
           rust_version: '1.69',
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
+          yank_message: null,
         },
       ],
     });

--- a/tests/mirage/me/updates/list-test.js
+++ b/tests/mirage/me/updates/list-test.js
@@ -49,6 +49,7 @@ module('Mirage | GET /api/v1/me/updates', function (hooks) {
           rust_version: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
+          yank_message: null,
         },
       ],
       meta: {


### PR DESCRIPTION
Extracted from https://github.com/rust-lang/crates.io/pull/9765 :)

Related:

- https://github.com/rust-lang/crates.io/pull/9437
- https://github.com/rust-lang/crates.io/pull/9765