### PR TITLE
mirage: Fix `PUT /api/v1/crates/:name/owners` implementation

### DIFF
--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -243,6 +243,7 @@ export function register(server) {
 
     let users = [];
     let teams = [];
+    let msgs = [];
     for (let login of body.owners) {
       if (login.includes(':')) {
         let team = schema.teams.findBy({ login });
@@ -251,6 +252,7 @@ export function register(server) {
         }
 
         teams.push(team);
+        msgs.push(`team ${login} has been added as an owner of crate ${crate.name}`);
       } else {
         let user = schema.users.findBy({ login });
         if (!user) {
@@ -258,6 +260,7 @@ export function register(server) {
         }
 
         users.push(user);
+        msgs.push(`user ${login} has been invited to be an owner of crate ${crate.name}`);
       }
     }
 
@@ -269,7 +272,8 @@ export function register(server) {
       schema.crateOwnerInvitations.create({ crate, inviter: user, invitee });
     }
 
-    return { ok: true };
+    let msg = msgs.join(',');
+    return { ok: true, msg };
   });
 
   server.delete('/api/v1/crates/:name/owners', (schema, request) => {

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -247,6 +247,8 @@ export function register(server) {
       return { errors: [{ detail: `could not find user with login \`${ownerId}\`` }] };
     }
 
+    schema.crateOwnerInvitations.create({ crate, inviter: user, invitee });
+
     return { ok: true };
   });
 

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -227,6 +227,11 @@ export function register(server) {
   });
 
   server.put('/api/v1/crates/:name/owners', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
     let { name } = request.params;
     let crate = schema.crates.findBy({ name });
 
@@ -236,9 +241,9 @@ export function register(server) {
 
     const body = JSON.parse(request.requestBody);
     const [ownerId] = body.owners;
-    const user = schema.users.findBy({ login: ownerId });
+    const invitee = schema.users.findBy({ login: ownerId });
 
-    if (!user) {
+    if (!invitee) {
       return { errors: [{ detail: `could not find user with login \`${ownerId}\`` }] };
     }
 
@@ -246,6 +251,11 @@ export function register(server) {
   });
 
   server.delete('/api/v1/crates/:name/owners', (schema, request) => {
+    let { user } = getSession(schema);
+    if (!user) {
+      return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
+    }
+
     let { name } = request.params;
     let crate = schema.crates.findBy({ name });
 

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -242,13 +242,27 @@ export function register(server) {
     const body = JSON.parse(request.requestBody);
 
     let users = [];
+    let teams = [];
     for (let login of body.owners) {
-      let user = schema.users.findBy({ login });
-      if (!user) {
-        return new Response(404, {}, { errors: [{ detail: `could not find user with login \`${login}\`` }] });
-      }
+      if (login.includes(':')) {
+        let team = schema.teams.findBy({ login });
+        if (!team) {
+          return new Response(404, {}, { errors: [{ detail: `could not find team with login \`${login}\`` }] });
+        }
 
-      users.push(user);
+        teams.push(team);
+      } else {
+        let user = schema.users.findBy({ login });
+        if (!user) {
+          return new Response(404, {}, { errors: [{ detail: `could not find user with login \`${login}\`` }] });
+        }
+
+        users.push(user);
+      }
+    }
+
+    for (let team of teams) {
+      schema.crateOwnerships.create({ crate, team });
     }
 
     for (let invitee of users) {

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -240,14 +240,20 @@ export function register(server) {
     }
 
     const body = JSON.parse(request.requestBody);
-    const [ownerId] = body.owners;
-    const invitee = schema.users.findBy({ login: ownerId });
 
-    if (!invitee) {
-      return { errors: [{ detail: `could not find user with login \`${ownerId}\`` }] };
+    let users = [];
+    for (let login of body.owners) {
+      let user = schema.users.findBy({ login });
+      if (!user) {
+        return new Response(404, {}, { errors: [{ detail: `could not find user with login \`${login}\`` }] });
+      }
+
+      users.push(user);
     }
 
-    schema.crateOwnerInvitations.create({ crate, inviter: user, invitee });
+    for (let invitee of users) {
+      schema.crateOwnerInvitations.create({ crate, inviter: user, invitee });
+    }
 
     return { ok: true };
   });

--- a/tests/adapters/crate-test.js
+++ b/tests/adapters/crate-test.js
@@ -1,8 +1,6 @@
 import { module, test } from 'qunit';
 
-import { setupMirage } from 'ember-cli-mirage/test-support';
-
-import { setupTest } from 'crates-io/tests/helpers';
+import { setupMirage, setupTest } from 'crates-io/tests/helpers';
 
 module('Adapter | crate', function (hooks) {
   setupTest(hooks);

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -3,6 +3,7 @@ import { setupApplicationTest as upstreamSetupApplicationTest } from 'ember-quni
 import { setupSentryMock } from './sentry';
 import setupMirage from './setup-mirage';
 
+export { default as setupMirage } from './setup-mirage';
 export { setupTest, setupRenderingTest } from 'ember-qunit';
 
 // see http://emberjs.github.io/rfcs/0637-customizable-test-setups.html

--- a/tests/mirage/crates/add-owner-test.js
+++ b/tests/mirage/crates/add-owner-test.js
@@ -1,0 +1,110 @@
+import { module, test } from 'qunit';
+
+import fetch from 'fetch';
+
+import { setupTest } from '../../helpers';
+import setupMirage from '../../helpers/setup-mirage';
+
+const ADD_USER_BODY = JSON.stringify({ owners: ['john-doe'] });
+
+module('Mirage | PUT /api/v1/crates/:name/owners', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('returns 403 if unauthenticated', async function (assert) {
+    let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body: ADD_USER_BODY });
+    assert.strictEqual(response.status, 403);
+    assert.deepEqual(await response.json(), {
+      errors: [{ detail: 'must be logged in to perform that action' }],
+    });
+  });
+
+  test('returns 404 for unknown crates', async function (assert) {
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body: ADD_USER_BODY });
+    assert.strictEqual(response.status, 404);
+    assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+  });
+
+  test('can add new owner', async function (assert) {
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('crate-ownership', { crate, user });
+
+    let user2 = this.server.create('user');
+
+    let body = JSON.stringify({ owners: [user2.login] });
+    let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
+    assert.strictEqual(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+
+    let owners = this.server.schema.crateOwnerships.where({ crateId: crate.id });
+    assert.strictEqual(owners.length, 1);
+    assert.strictEqual(owners.models[0].userId, user.id);
+
+    let invites = this.server.schema.crateOwnerInvitations.where({ crateId: crate.id });
+    assert.strictEqual(invites.length, 1);
+    assert.strictEqual(invites.models[0].inviterId, user.id);
+    assert.strictEqual(invites.models[0].inviteeId, user2.id);
+  });
+
+  test('can add team owner', async function (assert) {
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('crate-ownership', { crate, user });
+
+    let team = this.server.create('team');
+
+    let body = JSON.stringify({ owners: [team.login] });
+    let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
+    assert.strictEqual(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+
+    let owners = this.server.schema.crateOwnerships.where({ crateId: crate.id });
+    assert.strictEqual(owners.length, 2);
+    assert.strictEqual(owners.models[0].userId, user.id);
+    assert.strictEqual(owners.models[0].teamId, null);
+    assert.strictEqual(owners.models[1].userId, null);
+    assert.strictEqual(owners.models[1].teamId, user.id);
+
+    let invites = this.server.schema.crateOwnerInvitations.where({ crateId: crate.id });
+    assert.strictEqual(invites.length, 0);
+  });
+
+  test('can add multiple owners', async function (assert) {
+    let user = this.server.create('user');
+    this.authenticateAs(user);
+
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('crate-ownership', { crate, user });
+
+    let team = this.server.create('team');
+    let user2 = this.server.create('user');
+    let user3 = this.server.create('user');
+
+    let body = JSON.stringify({ owners: [user2.login, team.login, user3.login] });
+    let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
+    assert.strictEqual(response.status, 200);
+    assert.deepEqual(await response.json(), { ok: true });
+
+    let owners = this.server.schema.crateOwnerships.where({ crateId: crate.id });
+    assert.strictEqual(owners.length, 2);
+    assert.strictEqual(owners.models[0].userId, user.id);
+    assert.strictEqual(owners.models[0].teamId, null);
+    assert.strictEqual(owners.models[1].userId, null);
+    assert.strictEqual(owners.models[1].teamId, user.id);
+
+    let invites = this.server.schema.crateOwnerInvitations.where({ crateId: crate.id });
+    assert.strictEqual(invites.length, 2);
+    assert.strictEqual(invites.models[0].inviterId, user.id);
+    assert.strictEqual(invites.models[0].inviteeId, user2.id);
+    assert.strictEqual(invites.models[1].inviterId, user.id);
+    assert.strictEqual(invites.models[1].inviteeId, user3.id);
+  });
+});

--- a/tests/mirage/crates/add-owner-test.js
+++ b/tests/mirage/crates/add-owner-test.js
@@ -40,7 +40,10 @@ module('Mirage | PUT /api/v1/crates/:name/owners', function (hooks) {
     let body = JSON.stringify({ owners: [user2.login] });
     let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
     assert.strictEqual(response.status, 200);
-    assert.deepEqual(await response.json(), { ok: true });
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      msg: 'user user-2 has been invited to be an owner of crate foo',
+    });
 
     let owners = this.server.schema.crateOwnerships.where({ crateId: crate.id });
     assert.strictEqual(owners.length, 1);
@@ -64,7 +67,10 @@ module('Mirage | PUT /api/v1/crates/:name/owners', function (hooks) {
     let body = JSON.stringify({ owners: [team.login] });
     let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
     assert.strictEqual(response.status, 200);
-    assert.deepEqual(await response.json(), { ok: true });
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      msg: 'team github:rust-lang:team-1 has been added as an owner of crate foo',
+    });
 
     let owners = this.server.schema.crateOwnerships.where({ crateId: crate.id });
     assert.strictEqual(owners.length, 2);
@@ -91,7 +97,10 @@ module('Mirage | PUT /api/v1/crates/:name/owners', function (hooks) {
     let body = JSON.stringify({ owners: [user2.login, team.login, user3.login] });
     let response = await fetch('/api/v1/crates/foo/owners', { method: 'PUT', body });
     assert.strictEqual(response.status, 200);
-    assert.deepEqual(await response.json(), { ok: true });
+    assert.deepEqual(await response.json(), {
+      ok: true,
+      msg: 'user user-2 has been invited to be an owner of crate foo,team github:rust-lang:team-1 has been added as an owner of crate foo,user user-3 has been invited to be an owner of crate foo',
+    });
 
     let owners = this.server.schema.crateOwnerships.where({ crateId: crate.id });
     assert.strictEqual(owners.length, 2);

--- a/tests/models/crate-test.js
+++ b/tests/models/crate-test.js
@@ -2,9 +2,7 @@ import { module, test } from 'qunit';
 
 import AdapterError from '@ember-data/adapter/error';
 
-import { setupMirage } from 'ember-cli-mirage/test-support';
-
-import { setupTest } from 'crates-io/tests/helpers';
+import { setupMirage, setupTest } from 'crates-io/tests/helpers';
 
 module('Model | Crate', function (hooks) {
   setupTest(hooks);

--- a/tests/models/crate-test.js
+++ b/tests/models/crate-test.js
@@ -15,17 +15,23 @@ module('Model | Crate', function (hooks) {
   module('inviteOwner()', function () {
     test('happy path', async function (assert) {
       let user = this.server.create('user');
+      this.authenticateAs(user);
 
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 
+      let user2 = this.server.create('user');
+
       let crateRecord = await this.store.findRecord('crate', crate.name);
 
-      let result = await crateRecord.inviteOwner(user.login);
+      let result = await crateRecord.inviteOwner(user2.login);
       assert.deepEqual(result, { ok: true });
     });
 
     test('error handling', async function (assert) {
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 
@@ -41,17 +47,23 @@ module('Model | Crate', function (hooks) {
   module('removeOwner()', function () {
     test('happy path', async function (assert) {
       let user = this.server.create('user');
+      this.authenticateAs(user);
 
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 
+      let user2 = this.server.create('user');
+
       let crateRecord = await this.store.findRecord('crate', crate.name);
 
-      let result = await crateRecord.removeOwner(user.login);
+      let result = await crateRecord.removeOwner(user2.login);
       assert.deepEqual(result, { ok: true, msg: 'owners successfully removed' });
     });
 
     test('error handling', async function (assert) {
+      let user = this.server.create('user');
+      this.authenticateAs(user);
+
       let crate = this.server.create('crate');
       this.server.create('version', { crate });
 

--- a/tests/models/crate-test.js
+++ b/tests/models/crate-test.js
@@ -25,7 +25,7 @@ module('Model | Crate', function (hooks) {
       let crateRecord = await this.store.findRecord('crate', crate.name);
 
       let result = await crateRecord.inviteOwner(user2.login);
-      assert.deepEqual(result, { ok: true });
+      assert.deepEqual(result, { ok: true, msg: 'user user-2 has been invited to be an owner of crate crate-0' });
     });
 
     test('error handling', async function (assert) {

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -1,14 +1,10 @@
-import { setupTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-import { setupMirage } from 'ember-cli-mirage/test-support';
-
-import { setupFakeTimers } from '../helpers/fake-timers';
+import { setupMirage, setupTest } from 'crates-io/tests/helpers';
 
 module('Model | Version', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
-  setupFakeTimers(hooks);
 
   hooks.beforeEach(function () {
     this.store = this.owner.lookup('service:store');

--- a/tests/services/playground-test.js
+++ b/tests/services/playground-test.js
@@ -1,8 +1,6 @@
 import { module, test } from 'qunit';
 
-import { setupMirage } from 'ember-cli-mirage/test-support';
-
-import { setupTest } from 'crates-io/tests/helpers';
+import { setupMirage, setupTest } from 'crates-io/tests/helpers';
 
 module('Service | Playground', function (hooks) {
   setupTest(hooks);


### PR DESCRIPTION
The implementation of this endpoint of our dummy API had various bugs. This PR fixes most of them and adds a couple of tests for it.

Related:

- https://github.com/rust-lang/crates.io/issues/9797