### PR TITLE
Expose the `yanked` field on the API

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -126,6 +126,7 @@ pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppRes
         let encodable_crate = EncodableCrate::from(
             krate.clone(),
             default_version.as_deref(),
+            None,
             top_versions.as_ref(),
             ids,
             kws.as_deref(),

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -519,7 +519,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 krate: EncodableCrate::from_minimal(
                     krate,
                     default_version.or(Some(version_string)).as_deref(),
-                    None,
+                    Some(false),
                     Some(&top_versions),
                     false,
                     downloads,

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -519,6 +519,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 krate: EncodableCrate::from_minimal(
                     krate,
                     default_version.or(Some(version_string)).as_deref(),
+                    None,
                     Some(&top_versions),
                     false,
                     downloads,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -235,6 +235,7 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
                     EncodableCrate::from_minimal(
                         krate,
                         default_version.as_deref(),
+                        None,
                         Some(&max_version),
                         perfect_match,
                         total,

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -88,6 +88,7 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
             recent_crate_downloads::downloads.nullable(),
             0_f32.into_sql::<Float>(),
             versions::num.nullable(),
+            versions::yanked.nullable(),
         );
 
         let mut seek: Option<Seek> = None;
@@ -117,6 +118,7 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
                         recent_crate_downloads::downloads.nullable(),
                         rank.clone(),
                         versions::num.nullable(),
+                        versions::yanked.nullable(),
                     ));
                     seek = Some(Seek::Relevance);
                     query = query.then_order_by(rank.desc())
@@ -128,6 +130,7 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
                         recent_crate_downloads::downloads.nullable(),
                         0_f32.into_sql::<Float>(),
                         versions::num.nullable(),
+                        versions::yanked.nullable(),
                     ));
                     seek = Some(Seek::Query);
                 }
@@ -231,11 +234,14 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
         let crates = versions
             .zip(data)
             .map(
-                |(max_version, (krate, perfect_match, total, recent, _, default_version))| {
+                |(
+                    max_version,
+                    (krate, perfect_match, total, recent, _, default_version, yanked),
+                )| {
                     EncodableCrate::from_minimal(
                         krate,
                         default_version.as_deref(),
-                        None,
+                        yanked,
                         Some(&max_version),
                         perfect_match,
                         total,
@@ -622,7 +628,7 @@ mod seek {
                 downloads,
                 recent_downloads,
                 rank,
-                _,
+                ..,
             ) = *record;
 
             match *self {
@@ -645,7 +651,15 @@ mod seek {
     }
 }
 
-type Record = (Crate, bool, i64, Option<i64>, f32, Option<String>);
+type Record = (
+    Crate,
+    bool,
+    i64,
+    Option<i64>,
+    f32,
+    Option<String>,
+    Option<bool>,
+);
 
 type QuerySource = LeftJoinQuerySource<
     LeftJoinQuerySource<

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -34,7 +34,7 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
 
         fn encode_crates(
             conn: &mut impl Conn,
-            data: Vec<(Crate, i64, Option<i64>, Option<String>)>,
+            data: Vec<Record>,
         ) -> AppResult<Vec<EncodableCrate>> {
             let krates = data.iter().map(|(c, ..)| c).collect::<Vec<_>>();
             let versions: Vec<Version> = krates.versions().load(conn)?;
@@ -43,17 +43,19 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
                 .into_iter()
                 .map(TopVersions::from_versions)
                 .zip(data)
-                .map(|(top_versions, (krate, total, recent, default_version))| {
-                    Ok(EncodableCrate::from_minimal(
-                        krate,
-                        default_version.as_deref(),
-                        None,
-                        Some(&top_versions),
-                        false,
-                        total,
-                        recent,
-                    ))
-                })
+                .map(
+                    |(top_versions, (krate, total, recent, default_version, yanked))| {
+                        Ok(EncodableCrate::from_minimal(
+                            krate,
+                            default_version.as_deref(),
+                            yanked,
+                            Some(&top_versions),
+                            false,
+                            total,
+                            recent,
+                        ))
+                    },
+                )
                 .collect()
         }
 
@@ -62,6 +64,7 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
             crate_downloads::downloads,
             recent_crate_downloads::downloads.nullable(),
             versions::num.nullable(),
+            versions::yanked.nullable(),
         );
 
         let new_crates = crates::table
@@ -137,3 +140,5 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
     })
     .await
 }
+
+type Record = (Crate, i64, Option<i64>, Option<String>, Option<bool>);

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -47,6 +47,7 @@ pub async fn summary(state: AppState) -> AppResult<Json<Value>> {
                     Ok(EncodableCrate::from_minimal(
                         krate,
                         default_version.as_deref(),
+                        None,
                         Some(&top_versions),
                         false,
                         total,

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
@@ -30,7 +30,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "warnings": {
     "invalid_badges": [],

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -717,7 +717,7 @@ async fn index_include_yanked() {
         assert_eq!(
             default_versions_iter(&json.crates)
                 .flat_map(|s| s.as_deref())
-                .zip(yanked_iter(&json.crates).flatten().cloned())
+                .zip(yanked_iter(&json.crates).cloned())
                 .collect::<Vec<_>>(),
             [
                 ("2.0.0", true),
@@ -737,7 +737,7 @@ async fn index_include_yanked() {
         assert_eq!(
             default_versions_iter(&json.crates)
                 .flat_map(|s| s.as_deref())
-                .zip(yanked_iter(&json.crates).flatten().cloned())
+                .zip(yanked_iter(&json.crates).cloned())
                 .collect::<Vec<_>>(),
             [("1.0.0", false), ("2.0.0", false), ("2.0.0", false),]
         );
@@ -759,7 +759,7 @@ async fn yanked_versions_are_not_considered_for_max_version() {
     for json in search_both(&anon, "q=foo").await {
         assert_eq!(json.meta.total, 1);
         assert_eq!(json.crates[0].default_version, Some("1.0.0".into()));
-        assert_eq!(json.crates[0].yanked, Some(false));
+        assert!(!json.crates[0].yanked);
         assert_eq!(json.crates[0].max_version, "1.0.0");
     }
 }
@@ -782,7 +782,7 @@ async fn max_stable_version() {
     for json in search_both(&anon, "q=foo").await {
         assert_eq!(json.meta.total, 1);
         assert_eq!(json.crates[0].default_version, Some("1.0.0".into()));
-        assert_eq!(json.crates[0].yanked, Some(false));
+        assert!(!json.crates[0].yanked);
         assert_eq!(json.crates[0].max_stable_version, Some("1.0.0".to_string()));
     }
 }
@@ -1159,7 +1159,6 @@ async fn page_with_seek<U: RequestHelper>(
             url = Some(new_url.to_owned());
             assert_ne!(resp.meta.total, 0);
             assert!(default_versions_iter(&resp.crates).all(Option::is_some));
-            assert!(yanked_iter(&resp.crates).all(Option::is_some));
         } else {
             assert_that!(resp.crates, empty());
             assert_eq!(resp.meta.total, 0);
@@ -1175,6 +1174,6 @@ fn default_versions_iter(
     crates.iter().map(|c| &c.default_version)
 }
 
-fn yanked_iter(crates: &[crate::tests::EncodableCrate]) -> impl Iterator<Item = &Option<bool>> {
+fn yanked_iter(crates: &[crate::tests::EncodableCrate]) -> impl Iterator<Item = &bool> {
     crates.iter().map(|c| &c.yanked)
 }

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -713,11 +713,18 @@ async fn index_include_yanked() {
         assert_eq!(json.crates[1].name, "newest_yanked");
         assert_eq!(json.crates[2].name, "oldest_yanked");
         assert_eq!(json.crates[3].name, "unyanked");
+
         assert_eq!(
             default_versions_iter(&json.crates)
-                .flatten()
+                .flat_map(|s| s.as_deref())
+                .zip(yanked_iter(&json.crates).flatten().cloned())
                 .collect::<Vec<_>>(),
-            ["2.0.0", "1.0.0", "2.0.0", "2.0.0",]
+            [
+                ("2.0.0", true),
+                ("1.0.0", false),
+                ("2.0.0", false),
+                ("2.0.0", false),
+            ]
         );
     }
 
@@ -729,9 +736,10 @@ async fn index_include_yanked() {
         assert_eq!(json.crates[2].name, "unyanked");
         assert_eq!(
             default_versions_iter(&json.crates)
-                .flatten()
+                .flat_map(|s| s.as_deref())
+                .zip(yanked_iter(&json.crates).flatten().cloned())
                 .collect::<Vec<_>>(),
-            ["1.0.0", "2.0.0", "2.0.0",]
+            [("1.0.0", false), ("2.0.0", false), ("2.0.0", false),]
         );
     }
 }
@@ -751,6 +759,7 @@ async fn yanked_versions_are_not_considered_for_max_version() {
     for json in search_both(&anon, "q=foo").await {
         assert_eq!(json.meta.total, 1);
         assert_eq!(json.crates[0].default_version, Some("1.0.0".into()));
+        assert_eq!(json.crates[0].yanked, Some(false));
         assert_eq!(json.crates[0].max_version, "1.0.0");
     }
 }
@@ -773,6 +782,7 @@ async fn max_stable_version() {
     for json in search_both(&anon, "q=foo").await {
         assert_eq!(json.meta.total, 1);
         assert_eq!(json.crates[0].default_version, Some("1.0.0".into()));
+        assert_eq!(json.crates[0].yanked, Some(false));
         assert_eq!(json.crates[0].max_stable_version, Some("1.0.0".to_string()));
     }
 }
@@ -1149,6 +1159,7 @@ async fn page_with_seek<U: RequestHelper>(
             url = Some(new_url.to_owned());
             assert_ne!(resp.meta.total, 0);
             assert!(default_versions_iter(&resp.crates).all(Option::is_some));
+            assert!(yanked_iter(&resp.crates).all(Option::is_some));
         } else {
             assert_that!(resp.crates, empty());
             assert_eq!(resp.meta.total, 0);
@@ -1162,4 +1173,8 @@ fn default_versions_iter(
     crates: &[crate::tests::EncodableCrate],
 ) -> impl Iterator<Item = &Option<String>> {
     crates.iter().map(|c| &c.default_version)
+}
+
+fn yanked_iter(crates: &[crate::tests::EncodableCrate]) -> impl Iterator<Item = &Option<bool>> {
+    crates.iter().map(|c| &c.yanked)
 }

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
@@ -31,7 +31,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "keywords": null,
   "versions": null

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_all_yanked.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_all_yanked.snap
@@ -26,19 +26,18 @@ expression: response.json()
       "version_downloads": "/api/v1/crates/foo_show/downloads",
       "versions": null
     },
-    "max_stable_version": "1.0.0",
-    "max_version": "1.0.0",
+    "max_stable_version": null,
+    "max_version": "0.0.0",
     "name": "foo_show",
-    "newest_version": "0.5.1",
+    "newest_version": "0.0.0",
     "recent_downloads": 10,
     "repository": null,
     "updated_at": "[datetime]",
     "versions": [
       1,
-      3,
       2
     ],
-    "yanked": false
+    "yanked": true
   },
   "keywords": [
     {
@@ -69,33 +68,6 @@ expression: response.json()
         "version_downloads": "/api/v1/crates/foo_show/1.0.0/downloads"
       },
       "num": "1.0.0",
-      "published_by": null,
-      "readme_path": "/api/v1/crates/foo_show/1.0.0/readme",
-      "rust_version": null,
-      "updated_at": "[datetime]",
-      "yank_message": null,
-      "yanked": false
-    },
-    {
-      "audit_actions": [],
-      "bin_names": null,
-      "checksum": "                                                                ",
-      "crate": "foo_show",
-      "crate_size": 0,
-      "created_at": "[datetime]",
-      "dl_path": "/api/v1/crates/foo_show/0.5.1/download",
-      "downloads": 0,
-      "features": {},
-      "has_lib": null,
-      "id": 3,
-      "lib_links": null,
-      "license": null,
-      "links": {
-        "authors": "/api/v1/crates/foo_show/0.5.1/authors",
-        "dependencies": "/api/v1/crates/foo_show/0.5.1/dependencies",
-        "version_downloads": "/api/v1/crates/foo_show/0.5.1/downloads"
-      },
-      "num": "0.5.1",
       "published_by": {
         "avatar": null,
         "id": 1,
@@ -103,11 +75,11 @@ expression: response.json()
         "name": null,
         "url": "https://github.com/foo"
       },
-      "readme_path": "/api/v1/crates/foo_show/0.5.1/readme",
+      "readme_path": "/api/v1/crates/foo_show/1.0.0/readme",
       "rust_version": null,
       "updated_at": "[datetime]",
       "yank_message": null,
-      "yanked": false
+      "yanked": true
     },
     {
       "audit_actions": [],
@@ -140,7 +112,7 @@ expression: response.json()
       "rust_version": null,
       "updated_at": "[datetime]",
       "yank_message": null,
-      "yanked": false
+      "yanked": true
     }
   ]
 }

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
@@ -31,7 +31,8 @@ expression: response.json()
     "recent_downloads": null,
     "repository": null,
     "updated_at": "[datetime]",
-    "versions": null
+    "versions": null,
+    "yanked": false
   },
   "keywords": null,
   "versions": null

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -100,7 +100,7 @@ async fn summary_new_crates() {
         json.most_downloaded[0].default_version,
         Some("0.2.0".into())
     );
-    assert_eq!(json.most_downloaded[0].yanked, Some(false));
+    assert!(!json.most_downloaded[0].yanked);
     assert_eq!(json.most_downloaded[0].downloads, 5000);
     assert_eq!(json.most_downloaded[0].recent_downloads, Some(50));
     assert_eq!(
@@ -111,7 +111,7 @@ async fn summary_new_crates() {
         json.most_recently_downloaded[0].default_version,
         Some("0.2.0".into())
     );
-    assert_eq!(json.most_recently_downloaded[0].yanked, Some(false));
+    assert!(!json.most_recently_downloaded[0].yanked);
     assert_eq!(json.most_recently_downloaded[0].recent_downloads, Some(50));
     assert_eq!(json.popular_keywords[0].keyword, "popular");
     assert_eq!(json.popular_categories[0].category, "Category 1");
@@ -119,19 +119,19 @@ async fn summary_new_crates() {
 
     assert_eq!(json.just_updated[0].name, "just_updated_patch");
     assert_eq!(json.just_updated[0].default_version, Some("0.2.0".into()));
-    assert_eq!(json.just_updated[0].yanked, Some(false));
+    assert!(!json.just_updated[0].yanked);
     assert_eq!(json.just_updated[0].max_version, "0.2.0");
     assert_eq!(json.just_updated[0].newest_version, "0.1.1");
 
     assert_eq!(json.just_updated[1].name, "just_updated");
     assert_eq!(json.just_updated[1].default_version, Some("0.1.2".into()));
-    assert_eq!(json.just_updated[1].yanked, Some(false));
+    assert!(!json.just_updated[1].yanked);
     assert_eq!(json.just_updated[1].max_version, "0.1.2");
     assert_eq!(json.just_updated[1].newest_version, "0.1.2");
 
     assert_eq!(json.new_crates[0].name, "with_downloads");
     assert_eq!(json.new_crates[0].default_version, Some("0.3.0".into()));
-    assert_eq!(json.new_crates[0].yanked, Some(false));
+    assert!(!json.new_crates[0].yanked);
     assert_eq!(json.new_crates.len(), 5);
 }
 
@@ -177,7 +177,7 @@ async fn excluded_crate_id() {
         json.most_downloaded[0].default_version,
         Some("0.1.0".into())
     );
-    assert_eq!(json.most_downloaded[0].yanked, Some(false));
+    assert!(!json.most_downloaded[0].yanked);
     assert_eq!(json.most_downloaded[0].downloads, 20);
 
     assert_eq!(json.most_recently_downloaded.len(), 1);
@@ -186,7 +186,7 @@ async fn excluded_crate_id() {
         json.most_recently_downloaded[0].default_version,
         Some("0.1.0".into())
     );
-    assert_eq!(json.most_recently_downloaded[0].yanked, Some(false));
+    assert!(!json.most_recently_downloaded[0].yanked);
     assert_eq!(json.most_recently_downloaded[0].recent_downloads, Some(10));
 }
 
@@ -232,7 +232,7 @@ async fn all_yanked() {
         json.most_downloaded[0].default_version,
         Some("0.2.0".into())
     );
-    assert_eq!(json.most_downloaded[0].yanked, Some(true));
+    assert!(json.most_downloaded[0].yanked);
     assert_eq!(json.most_downloaded[0].downloads, 20);
 
     assert_eq!(json.most_recently_downloaded.len(), 1);
@@ -241,6 +241,6 @@ async fn all_yanked() {
         json.most_recently_downloaded[0].default_version,
         Some("0.2.0".into())
     );
-    assert_eq!(json.most_recently_downloaded[0].yanked, Some(true));
+    assert!(json.most_recently_downloaded[0].yanked);
     assert_eq!(json.most_recently_downloaded[0].recent_downloads, Some(10));
 }

--- a/src/views.rs
+++ b/src/views.rs
@@ -209,6 +209,8 @@ pub struct EncodableCrate {
     pub downloads: i64,
     pub recent_downloads: Option<i64>,
     pub default_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub yanked: Option<bool>,
     // NOTE: Used by shields.io, altering `max_version` requires a PR with shields.io
     pub max_version: String,
     pub newest_version: String, // Most recently updated version, which may not be max
@@ -226,6 +228,7 @@ impl EncodableCrate {
     pub fn from(
         krate: Crate,
         default_version: Option<&str>,
+        yanked: Option<bool>,
         top_versions: Option<&TopVersions>,
         versions: Option<Vec<i32>>,
         keywords: Option<&[Keyword]>,
@@ -296,6 +299,7 @@ impl EncodableCrate {
             categories: category_ids,
             badges: [],
             default_version,
+            yanked,
             max_version,
             newest_version,
             max_stable_version,
@@ -318,6 +322,7 @@ impl EncodableCrate {
     pub fn from_minimal(
         krate: Crate,
         default_version: Option<&str>,
+        yanked: Option<bool>,
         top_versions: Option<&TopVersions>,
         exact_match: bool,
         downloads: i64,
@@ -326,6 +331,7 @@ impl EncodableCrate {
         Self::from(
             krate,
             default_version,
+            yanked,
             top_versions,
             None,
             None,
@@ -808,6 +814,7 @@ mod tests {
             downloads: 0,
             recent_downloads: None,
             default_version: None,
+            yanked: None,
             max_version: "".to_string(),
             newest_version: "".to_string(),
             max_stable_version: None,

--- a/src/views.rs
+++ b/src/views.rs
@@ -209,7 +209,6 @@ pub struct EncodableCrate {
     pub downloads: i64,
     pub recent_downloads: Option<i64>,
     pub default_version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub yanked: Option<bool>,
     // NOTE: Used by shields.io, altering `max_version` requires a PR with shields.io
     pub max_version: String,

--- a/src/views.rs
+++ b/src/views.rs
@@ -209,7 +209,7 @@ pub struct EncodableCrate {
     pub downloads: i64,
     pub recent_downloads: Option<i64>,
     pub default_version: Option<String>,
-    pub yanked: Option<bool>,
+    pub yanked: bool,
     // NOTE: Used by shields.io, altering `max_version` requires a PR with shields.io
     pub max_version: String,
     pub newest_version: String, // Most recently updated version, which may not be max
@@ -261,6 +261,7 @@ impl EncodableCrate {
             let message = format!("Crate `{name}` has no default version");
             sentry::capture_message(&message, sentry::Level::Info);
         }
+        let yanked = yanked.unwrap_or_default();
 
         let max_version = top_versions
             .and_then(|v| v.highest.as_ref())
@@ -813,7 +814,7 @@ mod tests {
             downloads: 0,
             recent_downloads: None,
             default_version: None,
-            yanked: None,
+            yanked: false,
             max_version: "".to_string(),
             newest_version: "".to_string(),
             max_stable_version: None,


### PR DESCRIPTION
This PR expose the `yanked` field on the API. The `yanked` state is based on the `default_version`. The `default_version` can only be yanked if all other versions are also yanked and a crate should only be yanked if all of its versions are yanked.