### PR TITLE
worker: Migrate tests suite to async database queries

### DIFF
--- a/crates/crates_io_worker/Cargo.toml
+++ b/crates/crates_io_worker/Cargo.toml
@@ -24,4 +24,4 @@ tracing = "=0.1.40"
 claims = "=0.7.1"
 crates_io_test_db = { path = "../crates_io_test_db" }
 insta = { version = "=1.41.1", features = ["json"] }
-tokio = { version = "=1.41.0", features = ["macros", "rt", "rt-multi-thread", "sync"]}
+tokio = { version = "=1.41.0", features = ["macros", "sync"]}

--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -317,12 +317,16 @@ async fn jobs_can_be_deduplicated() {
     runner.wait_for_shutdown().await;
 }
 
+fn pool(database_url: &str) -> Pool<AsyncPgConnection> {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    Pool::builder(manager).max_size(4).build().unwrap()
+}
+
 fn runner<Context: Clone + Send + Sync + 'static>(
     database_url: &str,
     context: Context,
 ) -> Runner<Context> {
-    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
-    let deadpool = Pool::builder(manager).max_size(4).build().unwrap();
+    let deadpool = pool(database_url);
 
     Runner::new(deadpool, context)
         .configure_default_queue(|queue| queue.num_workers(2))

--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -13,40 +13,37 @@ use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::Arc;
 use tokio::sync::Barrier;
 
-async fn all_jobs(conn: &mut AsyncPgConnection) -> Vec<(String, Value)> {
+async fn all_jobs(conn: &mut AsyncPgConnection) -> QueryResult<Vec<(String, Value)>> {
     background_jobs::table
         .select((background_jobs::job_type, background_jobs::data))
         .get_results(conn)
         .await
-        .unwrap()
 }
 
-async fn job_exists(id: i64, conn: &mut AsyncPgConnection) -> bool {
-    background_jobs::table
+async fn job_exists(id: i64, conn: &mut AsyncPgConnection) -> QueryResult<bool> {
+    Ok(background_jobs::table
         .find(id)
         .select(background_jobs::id)
         .get_result::<i64>(conn)
         .await
-        .optional()
-        .unwrap()
-        .is_some()
+        .optional()?
+        .is_some())
 }
 
-async fn job_is_locked(id: i64, conn: &mut AsyncPgConnection) -> bool {
-    background_jobs::table
+async fn job_is_locked(id: i64, conn: &mut AsyncPgConnection) -> QueryResult<bool> {
+    Ok(background_jobs::table
         .find(id)
         .select(background_jobs::id)
         .for_update()
         .skip_locked()
         .get_result::<i64>(conn)
         .await
-        .optional()
-        .unwrap()
-        .is_none()
+        .optional()?
+        .is_none())
 }
 
 #[tokio::test]
-async fn jobs_are_locked_when_fetched() {
+async fn jobs_are_locked_when_fetched() -> anyhow::Result<()> {
     #[derive(Clone)]
     struct TestContext {
         job_started_barrier: Arc<Barrier>,
@@ -74,30 +71,32 @@ async fn jobs_are_locked_when_fetched() {
         assertions_finished_barrier: Arc::new(Barrier::new(2)),
     };
 
-    let pool = pool(test_database.url());
-    let mut conn = pool.get().await.unwrap();
+    let pool = pool(test_database.url())?;
+    let mut conn = pool.get().await?;
 
     let runner = runner(pool, test_context.clone()).register_job_type::<TestJob>();
 
-    let job_id = TestJob.async_enqueue(&mut conn).await.unwrap().unwrap();
+    let job_id = assert_some!(TestJob.async_enqueue(&mut conn).await?);
 
-    assert!(job_exists(job_id, &mut conn).await);
-    assert!(!job_is_locked(job_id, &mut conn).await);
+    assert!(job_exists(job_id, &mut conn).await?);
+    assert!(!job_is_locked(job_id, &mut conn).await?);
 
     let runner = runner.start();
     test_context.job_started_barrier.wait().await;
 
-    assert!(job_exists(job_id, &mut conn).await);
-    assert!(job_is_locked(job_id, &mut conn).await);
+    assert!(job_exists(job_id, &mut conn).await?);
+    assert!(job_is_locked(job_id, &mut conn).await?);
 
     test_context.assertions_finished_barrier.wait().await;
     runner.wait_for_shutdown().await;
 
-    assert!(!job_exists(job_id, &mut conn).await);
+    assert!(!job_exists(job_id, &mut conn).await?);
+
+    Ok(())
 }
 
 #[tokio::test]
-async fn jobs_are_deleted_when_successfully_run() {
+async fn jobs_are_deleted_when_successfully_run() -> anyhow::Result<()> {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
 
@@ -110,33 +109,31 @@ async fn jobs_are_deleted_when_successfully_run() {
         }
     }
 
-    async fn remaining_jobs(conn: &mut AsyncPgConnection) -> i64 {
-        background_jobs::table
-            .count()
-            .get_result(&mut *conn)
-            .await
-            .unwrap()
+    async fn remaining_jobs(conn: &mut AsyncPgConnection) -> QueryResult<i64> {
+        background_jobs::table.count().get_result(conn).await
     }
 
     let test_database = TestDatabase::new();
 
-    let pool = pool(test_database.url());
-    let mut conn = pool.get().await.unwrap();
+    let pool = pool(test_database.url())?;
+    let mut conn = pool.get().await?;
 
     let runner = runner(pool, ()).register_job_type::<TestJob>();
 
-    assert_eq!(remaining_jobs(&mut conn).await, 0);
+    assert_eq!(remaining_jobs(&mut conn).await?, 0);
 
-    TestJob.async_enqueue(&mut conn).await.unwrap();
-    assert_eq!(remaining_jobs(&mut conn).await, 1);
+    TestJob.async_enqueue(&mut conn).await?;
+    assert_eq!(remaining_jobs(&mut conn).await?, 1);
 
     let runner = runner.start();
     runner.wait_for_shutdown().await;
-    assert_eq!(remaining_jobs(&mut conn).await, 0);
+    assert_eq!(remaining_jobs(&mut conn).await?, 0);
+
+    Ok(())
 }
 
 #[tokio::test]
-async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
+async fn failed_jobs_do_not_release_lock_before_updating_retry_time() -> anyhow::Result<()> {
     #[derive(Clone)]
     struct TestContext {
         job_started_barrier: Arc<Barrier>,
@@ -161,12 +158,12 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
         job_started_barrier: Arc::new(Barrier::new(2)),
     };
 
-    let pool = pool(test_database.url());
-    let mut conn = pool.get().await.unwrap();
+    let pool = pool(test_database.url())?;
+    let mut conn = pool.get().await?;
 
     let runner = runner(pool, test_context.clone()).register_job_type::<TestJob>();
 
-    TestJob.async_enqueue(&mut conn).await.unwrap();
+    TestJob.async_enqueue(&mut conn).await?;
 
     let runner = runner.start();
     test_context.job_started_barrier.wait().await;
@@ -180,8 +177,7 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
         .filter(background_jobs::retries.eq(0))
         .for_update()
         .load::<i64>(&mut conn)
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(available_jobs.len(), 0);
 
     // Sanity check to make sure the job actually is there
@@ -189,15 +185,16 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
         .select(background_jobs::id)
         .for_update()
         .load::<i64>(&mut conn)
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(total_jobs_including_failed.len(), 1);
 
     runner.wait_for_shutdown().await;
+
+    Ok(())
 }
 
 #[tokio::test]
-async fn panicking_in_jobs_updates_retry_counter() {
+async fn panicking_in_jobs_updates_retry_counter() -> anyhow::Result<()> {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
 
@@ -212,12 +209,12 @@ async fn panicking_in_jobs_updates_retry_counter() {
 
     let test_database = TestDatabase::new();
 
-    let pool = pool(test_database.url());
-    let mut conn = pool.get().await.unwrap();
+    let pool = pool(test_database.url())?;
+    let mut conn = pool.get().await?;
 
     let runner = runner(pool, ()).register_job_type::<TestJob>();
 
-    let job_id = TestJob.async_enqueue(&mut conn).await.unwrap().unwrap();
+    let job_id = assert_some!(TestJob.async_enqueue(&mut conn).await?);
 
     let runner = runner.start();
     runner.wait_for_shutdown().await;
@@ -227,13 +224,14 @@ async fn panicking_in_jobs_updates_retry_counter() {
         .select(background_jobs::retries)
         .for_update()
         .first::<i32>(&mut conn)
-        .await
-        .unwrap();
+        .await?;
     assert_eq!(tries, 1);
+
+    Ok(())
 }
 
 #[tokio::test]
-async fn jobs_can_be_deduplicated() {
+async fn jobs_can_be_deduplicated() -> anyhow::Result<()> {
     #[derive(Clone)]
     struct TestContext {
         runs: Arc<AtomicU8>,
@@ -276,18 +274,18 @@ async fn jobs_can_be_deduplicated() {
         assertions_finished_barrier: Arc::new(Barrier::new(2)),
     };
 
-    let pool = pool(test_database.url());
-    let mut conn = pool.get().await.unwrap();
+    let pool = pool(test_database.url())?;
+    let mut conn = pool.get().await?;
 
     let runner = runner(pool, test_context.clone()).register_job_type::<TestJob>();
 
     // Enqueue first job
-    assert_some!(TestJob::new("foo").async_enqueue(&mut conn).await.unwrap());
-    assert_compact_json_snapshot!(all_jobs(&mut conn).await, @r#"[["test", {"value": "foo"}]]"#);
+    assert_some!(TestJob::new("foo").async_enqueue(&mut conn).await?);
+    assert_compact_json_snapshot!(all_jobs(&mut conn).await?, @r#"[["test", {"value": "foo"}]]"#);
 
     // Try to enqueue the same job again, which should be deduplicated
-    assert_none!(TestJob::new("foo").async_enqueue(&mut conn).await.unwrap());
-    assert_compact_json_snapshot!(all_jobs(&mut conn).await, @r#"[["test", {"value": "foo"}]]"#);
+    assert_none!(TestJob::new("foo").async_enqueue(&mut conn).await?);
+    assert_compact_json_snapshot!(all_jobs(&mut conn).await?, @r#"[["test", {"value": "foo"}]]"#);
 
     // Start processing the first job
     let runner = runner.start();
@@ -295,26 +293,28 @@ async fn jobs_can_be_deduplicated() {
 
     // Enqueue the same job again, which should NOT be deduplicated,
     // since the first job already still running
-    assert_some!(TestJob::new("foo").async_enqueue(&mut conn).await.unwrap());
-    assert_compact_json_snapshot!(all_jobs(&mut conn).await, @r#"[["test", {"value": "foo"}], ["test", {"value": "foo"}]]"#);
+    assert_some!(TestJob::new("foo").async_enqueue(&mut conn).await?);
+    assert_compact_json_snapshot!(all_jobs(&mut conn).await?, @r#"[["test", {"value": "foo"}], ["test", {"value": "foo"}]]"#);
 
     // Try to enqueue the same job again, which should be deduplicated again
-    assert_none!(TestJob::new("foo").async_enqueue(&mut conn).await.unwrap());
-    assert_compact_json_snapshot!(all_jobs(&mut conn).await, @r#"[["test", {"value": "foo"}], ["test", {"value": "foo"}]]"#);
+    assert_none!(TestJob::new("foo").async_enqueue(&mut conn).await?);
+    assert_compact_json_snapshot!(all_jobs(&mut conn).await?, @r#"[["test", {"value": "foo"}], ["test", {"value": "foo"}]]"#);
 
     // Enqueue the same job but with different data, which should
     // NOT be deduplicated
-    assert_some!(TestJob::new("bar").async_enqueue(&mut conn).await.unwrap());
-    assert_compact_json_snapshot!(all_jobs(&mut conn).await, @r#"[["test", {"value": "foo"}], ["test", {"value": "foo"}], ["test", {"value": "bar"}]]"#);
+    assert_some!(TestJob::new("bar").async_enqueue(&mut conn).await?);
+    assert_compact_json_snapshot!(all_jobs(&mut conn).await?, @r#"[["test", {"value": "foo"}], ["test", {"value": "foo"}], ["test", {"value": "bar"}]]"#);
 
     // Resolve the final barrier to finish the test
     test_context.assertions_finished_barrier.wait().await;
     runner.wait_for_shutdown().await;
+
+    Ok(())
 }
 
-fn pool(database_url: &str) -> Pool<AsyncPgConnection> {
+fn pool(database_url: &str) -> anyhow::Result<Pool<AsyncPgConnection>> {
     let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
-    Pool::builder(manager).max_size(4).build().unwrap()
+    Ok(Pool::builder(manager).max_size(4).build()?)
 }
 
 fn runner<Context: Clone + Send + Sync + 'static>(

--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -45,7 +45,7 @@ async fn job_is_locked(id: i64, conn: &mut AsyncPgConnection) -> bool {
         .is_none()
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn jobs_are_locked_when_fetched() {
     #[derive(Clone)]
     struct TestContext {
@@ -96,7 +96,7 @@ async fn jobs_are_locked_when_fetched() {
     assert!(!job_exists(job_id, &mut conn).await);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn jobs_are_deleted_when_successfully_run() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
@@ -135,7 +135,7 @@ async fn jobs_are_deleted_when_successfully_run() {
     assert_eq!(remaining_jobs(&mut conn).await, 0);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
     #[derive(Clone)]
     struct TestContext {
@@ -196,7 +196,7 @@ async fn failed_jobs_do_not_release_lock_before_updating_retry_time() {
     runner.wait_for_shutdown().await;
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn panicking_in_jobs_updates_retry_counter() {
     #[derive(Serialize, Deserialize)]
     struct TestJob;
@@ -232,7 +232,7 @@ async fn panicking_in_jobs_updates_retry_counter() {
     assert_eq!(tries, 1);
 }
 
-#[tokio::test(flavor = "multi_thread")]
+#[tokio::test]
 async fn jobs_can_be_deduplicated() {
     #[derive(Clone)]
     struct TestContext {


### PR DESCRIPTION
... which allows us to get rid of the `flavor = "multi_thread"` declaration on the tests :D