### PR TITLE
db: Remove unused `oneoff_connection()` fns

### DIFF
--- a/src/bin/crates-admin/default_versions.rs
+++ b/src/bin/crates-admin/default_versions.rs
@@ -18,7 +18,7 @@ pub enum Command {
 }
 
 pub async fn run(command: Command) -> anyhow::Result<()> {
-    let mut conn = db::oneoff_async_connection()
+    let mut conn = db::oneoff_connection()
         .await
         .context("Failed to connect to the database")?;
 

--- a/src/bin/crates-admin/delete_crate.rs
+++ b/src/bin/crates-admin/delete_crate.rs
@@ -30,7 +30,7 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let mut conn = db::oneoff_async_connection()
+    let mut conn = db::oneoff_connection()
         .await
         .context("Failed to establish database connection")?;
 

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -30,7 +30,7 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let mut conn = db::oneoff_async_connection()
+    let mut conn = db::oneoff_connection()
         .await
         .context("Failed to establish database connection")?;
 

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -52,7 +52,7 @@ pub enum Command {
 }
 
 pub async fn run(command: Command) -> Result<()> {
-    let mut conn = db::oneoff_async_connection().await?;
+    let mut conn = db::oneoff_connection().await?;
     println!("Enqueueing background job: {command:?}");
 
     match command {

--- a/src/bin/crates-admin/migrate.rs
+++ b/src/bin/crates-admin/migrate.rs
@@ -39,7 +39,7 @@ pub async fn run(_opts: Opts) -> Result<(), Error> {
     }
 
     // The primary is online, access directly via `DATABASE_URL`.
-    let conn = crates_io::db::oneoff_async_connection()
+    let conn = crates_io::db::oneoff_connection()
         .await
         .context("Failed to connect to the database")?;
 

--- a/src/bin/crates-admin/populate.rs
+++ b/src/bin/crates-admin/populate.rs
@@ -17,7 +17,7 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let mut conn = db::oneoff_async_connection().await?;
+    let mut conn = db::oneoff_connection().await?;
     conn.transaction(|conn| update(opts, conn).scope_boxed())
         .await?;
     Ok(())

--- a/src/bin/crates-admin/render_readmes.rs
+++ b/src/bin/crates-admin/render_readmes.rs
@@ -44,7 +44,7 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let conn = db::oneoff_async_connection()
+    let conn = db::oneoff_connection()
         .await
         .context("Failed to connect to the database")?;
 

--- a/src/bin/crates-admin/transfer_crates.rs
+++ b/src/bin/crates-admin/transfer_crates.rs
@@ -21,7 +21,7 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let mut conn = db::oneoff_async_connection().await?;
+    let mut conn = db::oneoff_connection().await?;
     transfer(opts, &mut conn).await?;
     Ok(())
 }

--- a/src/bin/crates-admin/verify_token.rs
+++ b/src/bin/crates-admin/verify_token.rs
@@ -19,7 +19,7 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let conn = db::oneoff_async_connection()
+    let conn = db::oneoff_connection()
         .await
         .context("Failed to connect to the database")?;
 

--- a/src/bin/crates-admin/yank_version.rs
+++ b/src/bin/crates-admin/yank_version.rs
@@ -24,7 +24,7 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    let mut conn = db::oneoff_async_connection().await?;
+    let mut conn = db::oneoff_connection().await?;
 
     conn.transaction(|conn| yank(opts, conn).scope_boxed())
         .await?;

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -14,7 +14,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let conn = &mut db::oneoff_async_connection().await?;
+    let conn = &mut db::oneoff_connection().await?;
 
     check_failing_background_jobs(conn).await?;
     check_stalled_update_downloads(conn).await?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -11,16 +11,16 @@ use url::Url;
 
 use crate::config;
 
-pub async fn oneoff_async_connection_with_config(
+pub async fn oneoff_connection_with_config(
     config: &config::DatabasePools,
 ) -> ConnectionResult<AsyncPgConnection> {
     let url = connection_url(config, config.primary.url.expose_secret());
     establish_async_connection(&url, config.enforce_tls).await
 }
 
-pub async fn oneoff_async_connection() -> anyhow::Result<AsyncPgConnection> {
+pub async fn oneoff_connection() -> anyhow::Result<AsyncPgConnection> {
     let config = config::DatabasePools::full_from_environment(&config::Base::from_environment()?)?;
-    Ok(oneoff_async_connection_with_config(&config).await?)
+    Ok(oneoff_connection_with_config(&config).await?)
 }
 
 pub fn connection_url(config: &config::DatabasePools, url: &str) -> String {

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 use crate::certs::CRUNCHY;
-use diesel::{Connection, ConnectionResult, PgConnection, QueryResult};
+use diesel::{ConnectionResult, QueryResult};
 use diesel_async::pooled_connection::deadpool::{Hook, HookError};
 use diesel_async::pooled_connection::ManagerConfig;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -10,18 +10,6 @@ use std::time::Duration;
 use url::Url;
 
 use crate::config;
-
-pub fn oneoff_connection_with_config(
-    config: &config::DatabasePools,
-) -> ConnectionResult<PgConnection> {
-    let url = connection_url(config, config.primary.url.expose_secret());
-    PgConnection::establish(&url)
-}
-
-pub fn oneoff_connection() -> anyhow::Result<PgConnection> {
-    let config = config::DatabasePools::full_from_environment(&config::Base::from_environment()?)?;
-    oneoff_connection_with_config(&config).map_err(Into::into)
-}
 
 pub async fn oneoff_async_connection_with_config(
     config: &config::DatabasePools,


### PR DESCRIPTION
Those are not used anymore so we may as well make the async variant the default now :)