### PR TITLE
pagerduty: Extract `PagerdutyClient` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "clap",
  "crates_io_env_vars",
  "reqwest 0.12.9",
+ "secrecy",
  "serde",
  "tokio",
 ]

--- a/crates/crates_io_pagerduty/Cargo.toml
+++ b/crates/crates_io_pagerduty/Cargo.toml
@@ -9,10 +9,11 @@ workspace = true
 
 [dependencies]
 anyhow = "=1.0.92"
-crates_io_env_vars = { path = "../crates_io_env_vars" }
 reqwest = { version = "=0.12.9", features = ["gzip", "json"] }
+secrecy = "=0.10.3"
 serde = { version = "=1.0.214", features = ["derive"] }
 
 [dev-dependencies]
 clap = { version = "=4.5.20", features = ["derive", "env", "unicode", "wrap_help"] }
+crates_io_env_vars = { path = "../crates_io_env_vars" }
 tokio = { version = "=1.41.0", features = ["macros", "rt-multi-thread"] }

--- a/crates/crates_io_pagerduty/examples/test_pagerduty.rs
+++ b/crates/crates_io_pagerduty/examples/test_pagerduty.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use std::str::FromStr;
 
+use crates_io_env_vars::required_var;
 use crates_io_pagerduty as pagerduty;
+use pagerduty::PagerdutyClient;
 
 #[derive(Debug, Copy, Clone, clap::ValueEnum)]
 pub enum EventType {
@@ -36,6 +38,11 @@ async fn main() -> Result<()> {
     use clap::Parser;
 
     let opts = Opts::parse();
+
+    let api_token = required_var("PAGERDUTY_API_TOKEN")?.into();
+    let service_key = required_var("PAGERDUTY_INTEGRATION_KEY")?;
+    let client = PagerdutyClient::new(api_token, service_key);
+
     let event = match opts.event_type {
         EventType::Trigger => pagerduty::Event::Trigger {
             incident_key: Some("test".into()),
@@ -50,5 +57,6 @@ async fn main() -> Result<()> {
             description: opts.description,
         },
     };
-    event.send().await
+
+    client.send(event).await
 }

--- a/crates/crates_io_pagerduty/examples/test_pagerduty.rs
+++ b/crates/crates_io_pagerduty/examples/test_pagerduty.rs
@@ -58,5 +58,5 @@ async fn main() -> Result<()> {
         },
     };
 
-    client.send(event).await
+    client.send(&event).await
 }

--- a/crates/crates_io_pagerduty/src/lib.rs
+++ b/crates/crates_io_pagerduty/src/lib.rs
@@ -40,9 +40,9 @@ impl PagerdutyClient {
     ///
     /// If the variant is `Trigger`, this will page whoever is on call
     /// (potentially waking them up at 3 AM).
-    pub async fn send(&self, event: Event) -> Result<()> {
+    pub async fn send(&self, event: &Event) -> Result<()> {
         let api_token = self.api_token.expose_secret();
-        let service_key = self.service_key.clone();
+        let service_key = &self.service_key;
 
         let response = Client::new()
             .post("https://events.pagerduty.com/generic/2010-04-15/create_event.json")
@@ -69,10 +69,10 @@ impl PagerdutyClient {
 }
 
 #[derive(serde::Serialize, Debug)]
-struct FullEvent {
-    service_key: String,
+struct FullEvent<'a> {
+    service_key: &'a str,
     #[serde(flatten)]
-    event: Event,
+    event: &'a Event,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/bin/monitor.rs
+++ b/src/bin/monitor.rs
@@ -183,5 +183,5 @@ async fn log_and_trigger_event(pagerduty: &PagerdutyClient, event: pagerduty::Ev
         } => println!("{description}"),
         _ => {} // noop
     }
-    pagerduty.send(event).await
+    pagerduty.send(&event).await
 }


### PR DESCRIPTION
This decouples the Pagerduty implementation from the `PAGERDUTY` environment variables and allows us to fail early if they are missing.