### PR TITLE
pagerduty/example: Read environment variables via `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "crates_io_env_vars",
  "reqwest 0.12.9",
  "secrecy",
  "serde",

--- a/crates/crates_io_pagerduty/Cargo.toml
+++ b/crates/crates_io_pagerduty/Cargo.toml
@@ -15,5 +15,4 @@ serde = { version = "=1.0.214", features = ["derive"] }
 
 [dev-dependencies]
 clap = { version = "=4.5.20", features = ["derive", "env", "unicode", "wrap_help"] }
-crates_io_env_vars = { path = "../crates_io_env_vars" }
 tokio = { version = "=1.41.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
This makes it possible to use CLI arguments instead, but also improves the error messages quite a bit :)