### PR TITLE
frontend: Migrate to use `default_version` and `yanked`

### DIFF
--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -6,10 +6,10 @@
           {{@crate.name}}
         </a>
       {{/let}}
-      {{#if @crate.defaultVersion}}
-        <span local-class="version" data-test-version>v{{@crate.defaultVersion}}</span>
+      {{#if (and @crate.default_version (not @crate.yanked))}}
+        <span local-class="version" data-test-version>v{{@crate.default_version}}</span>
         <CopyButton
-          @copyText='{{@crate.name}} = "{{@crate.defaultVersion}}"'
+          @copyText='{{@crate.name}} = "{{@crate.default_version}}"'
           title="Copy Cargo.toml snippet to clipboard"
           local-class="copy-button"
           data-test-copy-toml-button

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -10,6 +10,13 @@ export default class Crate extends Model {
   @attr recent_downloads;
   @attr('date') created_at;
   @attr('date') updated_at;
+  /**
+   * This is the default version that will be shown when visiting the crate
+   * details page. Note that this value can be `null`, which may be unexpected.
+   * @return {string}
+   */
+  @attr default_version;
+  @attr yanked;
   @attr max_version;
   @attr max_stable_version;
   @attr newest_version;
@@ -26,21 +33,6 @@ export default class Crate extends Model {
   @hasMany('keyword', { async: true, inverse: null }) keywords;
   @hasMany('category', { async: true, inverse: null }) categories;
   @hasMany('dependency', { async: true, inverse: null }) reverse_dependencies;
-
-  /**
-   * This is the default version that will be shown when visiting the crate
-   * details page. Note that this can be `undefined` if all versions of the crate
-   * have been yanked.
-   * @return {string}
-   */
-  get defaultVersion() {
-    if (this.max_stable_version) {
-      return this.max_stable_version;
-    }
-    if (this.max_version && this.max_version !== '0.0.0') {
-      return this.max_version;
-    }
-  }
 
   @cached get versionIdsBySemver() {
     let versions = this.versions.toArray() ?? [];

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -13,7 +13,7 @@ export default class Crate extends Model {
   /**
    * This is the default version that will be shown when visiting the crate
    * details page. Note that this value can be `null`, which may be unexpected.
-   * @return {string}
+   * @type {string | null}
    */
   @attr default_version;
   @attr yanked;

--- a/app/routes/crate/dependencies.js
+++ b/app/routes/crate/dependencies.js
@@ -8,8 +8,8 @@ export default class VersionRoute extends Route {
     let crate = this.modelFor('crate');
     let versions = await crate.get('versions');
 
-    let { defaultVersion } = crate;
-    let version = versions.find(version => version.num === defaultVersion) ?? versions.lastObject;
+    let { default_version } = crate;
+    let version = versions.find(version => version.num === default_version) ?? versions.lastObject;
 
     this.router.replaceWith('crate.version-dependencies', crate, version.num);
   }

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -31,8 +31,8 @@ export default class VersionRoute extends Route {
         return this.router.replaceWith('catch-all', { transition, title });
       }
     } else {
-      let { defaultVersion } = crate;
-      version = versions.find(version => version.num === defaultVersion);
+      let { default_version } = crate;
+      version = versions.find(version => version.num === default_version);
 
       if (!version) {
         let versionNums = versions.map(it => it.num);


### PR DESCRIPTION
This PR completes the transition to `default_version` in the frontend, which was first introduced in #8484.