### PR TITLE
util/diesel: Add diesel prelude excluding `RunQueryDsl`

### DIFF
--- a/src/bin/crates-admin/render_readmes.rs
+++ b/src/bin/crates-admin/render_readmes.rs
@@ -10,9 +10,9 @@ use std::{io::Read, path::Path, sync::Arc, thread};
 use chrono::{NaiveDateTime, Utc};
 use crates_io::storage::Storage;
 use crates_io::tasks::spawn_blocking;
+use crates_io::util::diesel::prelude::*;
 use crates_io_markdown::text_to_html;
 use crates_io_tarball::{Manifest, StringOrBool};
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use diesel_async::AsyncPgConnection;
 use flate2::read::GzDecoder;
@@ -51,6 +51,8 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
 
     let mut conn = AsyncConnectionWrapper::<AsyncPgConnection>::from(conn);
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let storage = Arc::new(Storage::from_environment());
 
         let start_time = Utc::now();

--- a/src/boot/categories.rs
+++ b/src/boot/categories.rs
@@ -1,9 +1,9 @@
 // Sync available crate categories from `src/categories.toml`.
 // Runs when the server is started.
 
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 use anyhow::{Context, Result};
-use diesel::prelude::*;
 
 #[derive(Debug)]
 struct Category {
@@ -79,6 +79,7 @@ fn categories_from_toml(
 pub fn sync_with_connection(toml_str: &str, conn: &mut impl Conn) -> Result<()> {
     use crate::schema::categories;
     use diesel::pg::upsert::excluded;
+    use diesel::RunQueryDsl;
 
     let toml: toml::value::Table =
         toml::from_str(toml_str).context("Could not parse categories toml")?;

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -5,6 +5,7 @@ use crate::controllers::helpers::pagination::{Page, PaginationOptions};
 use crate::models::{Crate, CrateOwnerInvitation, Rights, User};
 use crate::schema::{crate_owner_invitations, crates, users};
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 use crate::util::errors::{bad_request, forbidden, internal, AppResult};
 use crate::util::{BytesRequest, RequestUtils};
@@ -16,7 +17,6 @@ use axum::extract::Path;
 use axum::Json;
 use chrono::{Duration, Utc};
 use diesel::pg::Pg;
-use diesel::prelude::*;
 use diesel::sql_types::Bool;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
@@ -101,6 +101,8 @@ fn prepare_list(
     filter: ListFilter,
     conn: &mut impl Conn,
 ) -> AppResult<PrivateListResponse> {
+    use diesel::RunQueryDsl;
+
     let pagination: PaginationOptions = PaginationOptions::builder()
         .enable_pages(false)
         .enable_seek(true)

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -3,6 +3,7 @@ use crate::email::Email;
 use crate::models::{ApiToken, User};
 use crate::schema::api_tokens;
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 use crate::util::errors::{bad_request, AppResult, BoxedAppError};
 use crate::util::token::HashedToken;
@@ -11,7 +12,6 @@ use axum::body::Bytes;
 use axum::Json;
 use base64::{engine::general_purpose, Engine};
 use crates_io_github::GitHubPublicKey;
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::HeaderMap;
 use p256::ecdsa::signature::Verifier;
@@ -134,6 +134,8 @@ fn alert_revoke_token(
     alert: &GitHubSecretAlert,
     conn: &mut impl Conn,
 ) -> QueryResult<GitHubSecretAlertFeedbackLabel> {
+    use diesel::RunQueryDsl;
+
     let hashed_token = HashedToken::hash(&alert.token);
 
     // Not using `ApiToken::find_by_api_token()` in order to preserve `last_used_at`

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -7,9 +7,9 @@ use crate::models::helpers::with_count::*;
 use crate::util::errors::{bad_request, AppResult};
 use crate::util::{HeaderMapExt, RequestUtils};
 
+use crate::util::diesel::prelude::*;
 use base64::{engine::general_purpose, Engine};
 use diesel::pg::Pg;
-use diesel::prelude::*;
 use diesel::query_builder::{AstPass, Query, QueryFragment, QueryId};
 use diesel::query_dsl::LoadQuery;
 use diesel::sql_types::BigInt;
@@ -272,7 +272,7 @@ impl<T: Query> Query for PaginatedQuery<T> {
     type SqlType = (T::SqlType, BigInt);
 }
 
-impl<T, DB> RunQueryDsl<DB> for PaginatedQuery<T> {}
+impl<T, DB> diesel::RunQueryDsl<DB> for PaginatedQuery<T> {}
 
 impl<T> QueryFragment<Pg> for PaginatedQuery<T>
 where
@@ -366,7 +366,7 @@ impl<
     type SqlType = (T::SqlType, BigInt);
 }
 
-impl<T, C, DB> RunQueryDsl<DB> for PaginatedQueryWithCountSubq<T, C> {}
+impl<T, C, DB> diesel::RunQueryDsl<DB> for PaginatedQueryWithCountSubq<T, C> {}
 
 impl<T, C> QueryFragment<Pg> for PaginatedQueryWithCountSubq<T, C>
 where

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -6,17 +6,19 @@ use crate::controllers::helpers::ok_true;
 use crate::models::{Crate, Follow};
 use crate::schema::*;
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 use crate::util::errors::{crate_not_found, AppResult};
 use axum::extract::Path;
 use axum::response::Response;
 use axum::Json;
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use serde_json::Value;
 
 fn follow_target(crate_name: &str, conn: &mut impl Conn, user_id: i32) -> AppResult<Follow> {
+    use diesel::RunQueryDsl;
+
     let crate_id = Crate::by_name(crate_name)
         .select(crates::id)
         .first(conn)
@@ -34,6 +36,8 @@ pub async fn follow(
 ) -> AppResult<Response> {
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let user_id = AuthCheck::default().check(&req, conn)?.user_id();
@@ -56,6 +60,8 @@ pub async fn unfollow(
 ) -> AppResult<Response> {
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let user_id = AuthCheck::default().check(&req, conn)?.user_id();
@@ -75,6 +81,8 @@ pub async fn following(
 ) -> AppResult<Json<Value>> {
     let conn = app.db_read_prefer_primary().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         use diesel::dsl::exists;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -12,6 +12,7 @@ use crate::models::{
 };
 use crate::schema::*;
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::errors::{bad_request, crate_not_found, AppResult, BoxedAppError};
 use crate::util::{redirect, RequestUtils};
 use crate::views::{
@@ -20,7 +21,6 @@ use crate::views::{
 use axum::extract::Path;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use serde_json::Value;
@@ -36,6 +36,8 @@ pub async fn show_new(app: AppState, req: Parts) -> AppResult<Json<Value>> {
 pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppResult<Json<Value>> {
     let conn = app.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let include = req
@@ -249,6 +251,8 @@ pub async fn reverse_dependencies(
 ) -> AppResult<Json<Value>> {
     let conn = app.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let pagination_options = PaginationOptions::builder().gather(&req)?;

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -3,13 +3,13 @@
 use crate::models::{krate::NewOwnerInvite, token::EndpointScope};
 use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::errors::{bad_request, crate_not_found, custom, AppResult};
 use crate::views::EncodableOwner;
 use crate::{app::AppState, models::krate::OwnerAddError};
 use crate::{auth::AuthCheck, email::Email};
 use axum::extract::Path;
 use axum::Json;
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use http::StatusCode;
@@ -21,6 +21,8 @@ use tokio::runtime::Handle;
 pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     let conn = state.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let krate: Crate = Crate::by_name(&crate_name)
@@ -43,6 +45,8 @@ pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResul
 pub async fn owner_team(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     let conn = state.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let krate: Crate = Crate::by_name(&crate_name)
@@ -64,6 +68,8 @@ pub async fn owner_team(state: AppState, Path(crate_name): Path<String>) -> AppR
 pub async fn owner_user(state: AppState, Path(crate_name): Path<String>) -> AppResult<Json<Value>> {
     let conn = state.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let krate: Crate = Crate::by_name(&crate_name)
@@ -126,6 +132,8 @@ async fn modify_owners(
 
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::default()

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -1,9 +1,9 @@
 //! Endpoint for searching and discovery functionality
 
 use crate::auth::AuthCheck;
+use crate::util::diesel::prelude::*;
 use axum::Json;
 use diesel::dsl::{exists, sql, InnerJoinQuerySource, LeftJoinQuerySource};
-use diesel::prelude::*;
 use diesel::sql_types::{Array, Bool, Text};
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use diesel_full_text_search::*;
@@ -49,6 +49,8 @@ use crate::util::RequestUtils;
 pub async fn search(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     let conn = app.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         use diesel::sql_types::Float;

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -1,10 +1,10 @@
 //! Endpoint for versions of a crate
 
+use crate::util::diesel::prelude::*;
 use axum::extract::Path;
 use axum::Json;
 use diesel::connection::DefaultLoadingMode;
 use diesel::dsl::not;
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use indexmap::{IndexMap, IndexSet};
@@ -30,6 +30,8 @@ pub async fn versions(
 ) -> AppResult<Json<Value>> {
     let conn = state.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let crate_id: i32 = Crate::by_name(&crate_name)
@@ -97,6 +99,7 @@ fn list_by_date(
     req: &Parts,
     conn: &mut impl Conn,
 ) -> AppResult<PaginatedVersionsAndPublishers> {
+    use diesel::RunQueryDsl;
     use seek::*;
 
     let mut query = versions::table
@@ -186,6 +189,7 @@ fn list_by_semver(
     req: &Parts,
     conn: &mut impl Conn,
 ) -> AppResult<PaginatedVersionsAndPublishers> {
+    use diesel::RunQueryDsl;
     use seek::*;
 
     let (data, total, release_tracks) = if let Some(options) = options {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -7,6 +7,7 @@ use crate::app::AppState;
 use crate::auth::AuthCheck;
 use crate::models::token::{CrateScope, EndpointScope};
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::errors::{bad_request, AppResult};
 use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Response};
@@ -14,7 +15,6 @@ use axum::Json;
 use chrono::NaiveDateTime;
 use diesel::data_types::PgInterval;
 use diesel::dsl::{now, IntervalDsl};
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use http::StatusCode;
@@ -43,6 +43,8 @@ pub async fn list(
 ) -> AppResult<Json<Value>> {
     let conn = app.db_read_prefer_primary().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::only_cookie().check(&req, conn)?;
@@ -92,6 +94,8 @@ pub async fn new(
 
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::default().check(&parts, conn)?;
@@ -173,6 +177,8 @@ pub async fn new(
 pub async fn show(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::default().check(&req, conn)?;
@@ -191,6 +197,8 @@ pub async fn show(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<J
 pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::default().check(&req, conn)?;
@@ -208,6 +216,8 @@ pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult
 pub async fn revoke_current(app: AppState, req: Parts) -> AppResult<Response> {
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::default().check(&req, conn)?;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -1,8 +1,8 @@
 use crate::auth::AuthCheck;
+use crate::util::diesel::prelude::*;
 use axum::extract::Path;
 use axum::response::Response;
 use axum::Json;
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use serde_json::Value;
@@ -23,6 +23,8 @@ use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCra
 pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
     let conn = app.db_read_prefer_primary().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let user_id = AuthCheck::only_cookie().check(&req, conn)?.user_id();
@@ -108,6 +110,8 @@ pub async fn updates(app: AppState, req: Parts) -> AppResult<Json<Value>> {
 pub async fn confirm_user_email(state: AppState, Path(token): Path<String>) -> AppResult<Response> {
     let conn = state.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         use diesel::update;
@@ -143,6 +147,8 @@ pub async fn update_email_notifications(app: AppState, req: BytesRequest) -> App
 
     let conn = app.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         use diesel::pg::upsert::excluded;

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -4,12 +4,12 @@ use crate::controllers::helpers::ok_true;
 use crate::models::{Email, NewEmail};
 use crate::schema::{emails, users};
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::errors::{bad_request, server_error, AppResult};
 use axum::extract::Path;
 use axum::response::Response;
 use axum::Json;
 use diesel::dsl::sql;
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use lettre::Address;
@@ -35,6 +35,8 @@ pub async fn update_user(
 ) -> AppResult<Response> {
     let conn = state.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::default().check(&req, conn)?;
@@ -120,6 +122,8 @@ pub async fn regenerate_token_and_send(
 ) -> AppResult<Response> {
     let conn = state.db_write().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let auth = AuthCheck::default().check(&req, conn)?;

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -11,7 +11,8 @@ fn version_and_crate(
     crate_name: &str,
     semver: &str,
 ) -> AppResult<(Version, Crate)> {
-    use diesel::prelude::*;
+    use crate::util::diesel::prelude::*;
+    use diesel::RunQueryDsl;
 
     let krate: Crate = Crate::by_name(crate_name)
         .first(conn)

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -7,6 +7,7 @@ use crate::app::AppState;
 use crate::models::VersionDownload;
 use crate::schema::*;
 use crate::tasks::spawn_blocking;
+use crate::util::diesel::prelude::*;
 use crate::util::errors::{version_not_found, AppResult};
 use crate::util::{redirect, RequestUtils};
 use crate::views::EncodableVersionDownload;
@@ -14,7 +15,6 @@ use axum::extract::Path;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use chrono::{Duration, NaiveDate, Utc};
-use diesel::prelude::*;
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use http::request::Parts;
 use serde_json::Value;
@@ -47,6 +47,8 @@ pub async fn downloads(
 
     let conn = app.db_read().await?;
     spawn_blocking(move || {
+        use diesel::RunQueryDsl;
+
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let (version, _) = version_and_crate(conn, &crate_name, &version)?;

--- a/src/models/action.rs
+++ b/src/models/action.rs
@@ -1,9 +1,9 @@
 use crate::models::{ApiToken, User, Version};
 use crate::schema::*;
 use crate::sql::pg_enum;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 
 pg_enum! {
     pub enum VersionAction {
@@ -50,10 +50,13 @@ pub struct VersionOwnerAction {
 
 impl VersionOwnerAction {
     pub fn all(conn: &mut impl Conn) -> QueryResult<Vec<Self>> {
+        use diesel::RunQueryDsl;
+
         version_owner_actions::table.load(conn)
     }
 
     pub fn by_version(conn: &mut impl Conn, version: &Version) -> QueryResult<Vec<(Self, User)>> {
+        use diesel::RunQueryDsl;
         use version_owner_actions::dsl::version_id;
 
         version_owner_actions::table
@@ -67,6 +70,8 @@ impl VersionOwnerAction {
         conn: &mut impl Conn,
         versions: &[&Version],
     ) -> QueryResult<Vec<Vec<(Self, User)>>> {
+        use diesel::RunQueryDsl;
+
         Ok(Self::belonging_to(versions)
             .inner_join(users::table)
             .order(version_owner_actions::dsl::id)
@@ -82,6 +87,7 @@ pub fn insert_version_owner_action(
     api_token_id_: Option<i32>,
     action_: VersionAction,
 ) -> QueryResult<VersionOwnerAction> {
+    use diesel::RunQueryDsl;
     use version_owner_actions::dsl::{action, api_token_id, user_id, version_id};
 
     diesel::insert_into(version_owner_actions::table)

--- a/src/models/default_versions.rs
+++ b/src/models/default_versions.rs
@@ -1,7 +1,7 @@
 use crate::schema::{default_versions, versions};
 use crate::sql::SemverVersion;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
-use diesel::prelude::*;
 
 /// A subset of the columns of the `versions` table.
 ///
@@ -57,6 +57,8 @@ impl Ord for Version {
 /// The default version is then written to the `default_versions` table.
 #[instrument(skip(conn))]
 pub fn update_default_version(crate_id: i32, conn: &mut impl Conn) -> QueryResult<()> {
+    use diesel::RunQueryDsl;
+
     let default_version = calculate_default_version(crate_id, conn)?;
 
     debug!(
@@ -80,6 +82,8 @@ pub fn update_default_version(crate_id: i32, conn: &mut impl Conn) -> QueryResul
 /// Verifies that the default version for the specified crate is up-to-date.
 #[instrument(skip(conn))]
 pub fn verify_default_version(crate_id: i32, conn: &mut impl Conn) -> QueryResult<()> {
+    use diesel::RunQueryDsl;
+
     let calculated = calculate_default_version(crate_id, conn)?;
 
     let saved = default_versions::table
@@ -109,6 +113,7 @@ pub fn verify_default_version(crate_id: i32, conn: &mut impl Conn) -> QueryResul
 
 fn calculate_default_version(crate_id: i32, conn: &mut impl Conn) -> QueryResult<Version> {
     use diesel::result::Error::NotFound;
+    use diesel::RunQueryDsl;
 
     debug!("Loading all versions for the crate…");
     let versions = versions::table
@@ -233,6 +238,8 @@ mod tests {
     }
 
     fn create_crate(name: &str, conn: &mut impl Conn) -> i32 {
+        use diesel::RunQueryDsl;
+
         diesel::insert_into(crates::table)
             .values(crates::name.eq(name))
             .returning(crates::id)
@@ -241,6 +248,8 @@ mod tests {
     }
 
     fn create_version(crate_id: i32, num: &str, conn: &mut impl Conn) {
+        use diesel::RunQueryDsl;
+
         diesel::insert_into(versions::table)
             .values((
                 versions::crate_id.eq(crate_id),
@@ -253,6 +262,8 @@ mod tests {
     }
 
     fn get_default_version(crate_id: i32, conn: &mut impl Conn) -> String {
+        use diesel::RunQueryDsl;
+
         default_versions::table
             .inner_join(versions::table)
             .select(versions::num)

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -1,9 +1,9 @@
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 
 use crate::models::Crate;
 use crate::schema::*;
 use crate::sql::lower;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 
 #[derive(Clone, Identifiable, Queryable, Debug, Selectable)]
@@ -29,12 +29,16 @@ pub struct CrateKeyword {
 
 impl Keyword {
     pub fn find_by_keyword(conn: &mut impl Conn, name: &str) -> QueryResult<Keyword> {
+        use diesel::RunQueryDsl;
+
         keywords::table
             .filter(keywords::keyword.eq(lower(name)))
             .first(conn)
     }
 
     pub fn find_or_create_all(conn: &mut impl Conn, names: &[&str]) -> QueryResult<Vec<Keyword>> {
+        use diesel::RunQueryDsl;
+
         let lowercase_names: Vec<_> = names.iter().map(|s| s.to_lowercase()).collect();
 
         let new_keywords: Vec<_> = lowercase_names
@@ -63,6 +67,8 @@ impl Keyword {
 
     pub fn update_crate(conn: &mut impl Conn, crate_id: i32, keywords: &[&str]) -> QueryResult<()> {
         conn.transaction(|conn| {
+            use diesel::RunQueryDsl;
+
             let keywords = Keyword::find_or_create_all(conn, keywords)?;
 
             diesel::delete(crates_keywords::table)
@@ -93,6 +99,8 @@ mod tests {
 
     #[test]
     fn dont_associate_with_non_lowercased_keywords() {
+        use diesel::RunQueryDsl;
+
         let (_test_db, conn) = &mut test_db_connection();
         // The code should be preventing lowercased keywords from existing,
         // but if one happens to sneak in there, don't associate crates with it.

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -1,4 +1,3 @@
-use diesel::prelude::*;
 use http::StatusCode;
 
 use crate::app::App;
@@ -11,6 +10,7 @@ use tokio::runtime::Handle;
 use crate::models::{Crate, CrateOwner, Owner, OwnerKind, User};
 use crate::schema::{crate_owners, teams};
 use crate::sql::lower;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 
 /// For now, just a Github Team. Can be upgraded to other teams
@@ -63,6 +63,7 @@ impl<'a> NewTeam<'a> {
 
     pub fn create_or_update(&self, conn: &mut impl Conn) -> QueryResult<Team> {
         use diesel::insert_into;
+        use diesel::RunQueryDsl;
 
         insert_into(teams::table)
             .values(self)
@@ -75,6 +76,8 @@ impl<'a> NewTeam<'a> {
 
 impl Team {
     pub fn find_by_login(conn: &mut impl Conn, login: &str) -> QueryResult<Self> {
+        use diesel::RunQueryDsl;
+
         teams::table
             .filter(lower(teams::login).eq(&login.to_lowercase()))
             .first(conn)
@@ -197,6 +200,8 @@ impl Team {
     }
 
     pub fn owning(krate: &Crate, conn: &mut impl Conn) -> QueryResult<Vec<Owner>> {
+        use diesel::RunQueryDsl;
+
         let base_query = CrateOwner::belonging_to(krate).filter(crate_owners::deleted.eq(false));
         let teams = base_query
             .inner_join(teams::table)

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -1,11 +1,11 @@
 mod scopes;
 
 use chrono::NaiveDateTime;
-use diesel::prelude::*;
 
 pub use self::scopes::{CrateScope, EndpointScope};
 use crate::models::User;
 use crate::schema::api_tokens;
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 use crate::util::rfc3339;
 use crate::util::token::{HashedToken, PlainToken};
@@ -46,6 +46,8 @@ impl ApiToken {
         endpoint_scopes: Option<Vec<EndpointScope>>,
         expired_at: Option<NaiveDateTime>,
     ) -> QueryResult<CreatedApiToken> {
+        use diesel::RunQueryDsl;
+
         let token = PlainToken::generate();
 
         let model: ApiToken = diesel::insert_into(api_tokens::table)
@@ -67,6 +69,7 @@ impl ApiToken {
     }
 
     pub fn find_by_api_token(conn: &mut impl Conn, token: &HashedToken) -> QueryResult<ApiToken> {
+        use diesel::RunQueryDsl;
         use diesel::{dsl::now, update};
 
         let tokens = api_tokens::table

--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -1,10 +1,10 @@
 use crate::schema::{publish_limit_buckets, publish_rate_overrides};
 use crate::sql::{date_part, floor, greatest, interval_part, least, pg_enum};
+use crate::util::diesel::prelude::*;
 use crate::util::diesel::Conn;
 use crate::util::errors::{AppResult, TooManyRequests};
 use chrono::{NaiveDateTime, Utc};
 use diesel::dsl::IntervalDsl;
-use diesel::prelude::*;
 use diesel::sql_types::Interval;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -108,6 +108,8 @@ impl RateLimiter {
         now: NaiveDateTime,
         conn: &mut impl Conn,
     ) -> QueryResult<Bucket> {
+        use diesel::RunQueryDsl;
+
         let config = self.config_for_action(performed_action);
         let refill_rate = (config.rate.as_millis() as i64).milliseconds();
 
@@ -522,6 +524,8 @@ mod tests {
 
     #[test]
     fn override_is_used_instead_of_global_burst_if_present() -> QueryResult<()> {
+        use diesel::RunQueryDsl;
+
         let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
@@ -552,6 +556,8 @@ mod tests {
 
     #[test]
     fn overrides_can_expire() -> QueryResult<()> {
+        use diesel::RunQueryDsl;
+
         let (_test_db, conn) = &mut test_db_connection();
         let now = now();
 
@@ -599,6 +605,8 @@ mod tests {
 
     #[test]
     fn override_is_different_for_each_action() -> QueryResult<()> {
+        use diesel::RunQueryDsl;
+
         let (_test_db, conn) = &mut test_db_connection();
         let now = now();
         let user_id = new_user(conn, "user")?;
@@ -653,6 +661,8 @@ mod tests {
         tokens: i32,
         now: NaiveDateTime,
     ) -> QueryResult<Bucket> {
+        use diesel::RunQueryDsl;
+
         diesel::insert_into(publish_limit_buckets::table)
             .values(Bucket {
                 user_id: new_user(conn, "new_user")?,

--- a/src/util/diesel.rs
+++ b/src/util/diesel.rs
@@ -4,3 +4,36 @@ use diesel::pg::Pg;
 pub trait Conn: LoadConnection<Backend = Pg> {}
 
 impl<T> Conn for T where T: LoadConnection<Backend = Pg> {}
+
+pub mod prelude {
+    //! Inline diesel prelude
+    pub use diesel::associations::{Associations, GroupedBy, Identifiable};
+    pub use diesel::connection::Connection;
+    pub use diesel::deserialize::{Queryable, QueryableByName};
+    pub use diesel::expression::IntoSql as _;
+    pub use diesel::expression::{
+        AppearsOnTable, BoxableExpression, Expression, IntoSql, Selectable, SelectableExpression,
+    };
+
+    pub use diesel::expression::functions::define_sql_function;
+
+    pub use diesel::expression::SelectableHelper;
+    pub use diesel::expression_methods::*;
+    pub use diesel::insertable::Insertable;
+    pub use diesel::prelude::{
+        allow_columns_to_appear_in_same_group_by_clause, allow_tables_to_appear_in_same_query,
+        joinable, table,
+    };
+    pub use diesel::query_builder::AsChangeset;
+    pub use diesel::query_builder::DecoratableTarget;
+    pub use diesel::query_dsl::{BelongingToDsl, CombineDsl, JoinOnDsl, QueryDsl, SaveChangesDsl};
+    pub use diesel::query_source::SizeRestrictedColumn as _;
+    pub use diesel::query_source::{Column, JoinTo, QuerySource, Table};
+    pub use diesel::result::{
+        ConnectionError, ConnectionResult, OptionalEmptyChangesetExtension, OptionalExtension,
+        QueryResult,
+    };
+
+    pub use diesel::prelude::ExecuteCopyFromDsl;
+    pub use diesel::prelude::PgConnection;
+}


### PR DESCRIPTION
This change simplifies the migration to `diesel_async`. Using
`use diesel::prelude::*` alongside `use diesel_async::RunQueryDsl` can
sometimes cause ambiguity when not all loading functions are migrated
to use `diesel_async` within a file. This can be quite annoying.

To migrate:
1. Replace `use diesel::prelude::*` with `use crate::util::diesel::prelude::*`
    for files that still need to migrate.
2. Add `use diesel::RunQueryDsl` within loading functions.
3. Once all loading functions within a file have been migrated to
       `diesel_async`, you can revert to using `use diesel::prelude::*`
       alongside `use diesel_async::RunQueryDsl` without issues.