### PR TITLE
Inline `CrateVersions` trait fns

### DIFF
--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -7,8 +7,8 @@
 use crate::app::AppState;
 use crate::controllers::helpers::pagination::PaginationOptions;
 use crate::models::{
-    Category, Crate, CrateCategory, CrateKeyword, CrateName, CrateVersions, Keyword,
-    RecentCrateDownloads, User, Version, VersionOwnerAction,
+    Category, Crate, CrateCategory, CrateKeyword, CrateName, Keyword, RecentCrateDownloads, User,
+    Version, VersionOwnerAction,
 };
 use crate::schema::*;
 use crate::tasks::spawn_blocking;
@@ -67,11 +67,11 @@ pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppRes
             .ok_or_else(|| crate_not_found(&name))?;
 
         let versions_publishers_and_audit_actions = if include.versions {
-            let mut versions_and_publishers: Vec<(Version, Option<User>)> = krate
-                .all_versions()
-                .left_outer_join(users::table)
-                .select(<(Version, Option<User>)>::as_select())
-                .load(conn)?;
+            let mut versions_and_publishers: Vec<(Version, Option<User>)> =
+                Version::belonging_to(&krate)
+                    .left_outer_join(users::table)
+                    .select(<(Version, Option<User>)>::as_select())
+                    .load(conn)?;
             versions_and_publishers.sort_by_cached_key(|(version, _)| {
                 Reverse(semver::Version::parse(&version.num).ok())
             });

--- a/src/index.rs
+++ b/src/index.rs
@@ -2,7 +2,7 @@
 //! and is used by the corresponding background jobs to generate the
 //! index files.
 
-use crate::models::{Crate, CrateVersions, Dependency, Version};
+use crate::models::{Crate, Dependency, Version};
 use crate::schema::crates;
 use anyhow::Context;
 use crates_io_index::features::split_features;
@@ -59,7 +59,7 @@ pub async fn index_metadata(
     krate: &Crate,
     conn: &mut AsyncPgConnection,
 ) -> QueryResult<Vec<crates_io_index::Crate>> {
-    let mut versions: Vec<Version> = krate.all_versions().load(conn).await?;
+    let mut versions: Vec<Version> = Version::belonging_to(krate).load(conn).await?;
 
     // We sort by `created_at` by default, but since tests run within a
     // single database transaction the versions will all have the same

--- a/src/models.rs
+++ b/src/models.rs
@@ -7,7 +7,7 @@ pub use self::download::VersionDownload;
 pub use self::email::{Email, NewEmail};
 pub use self::follow::Follow;
 pub use self::keyword::{CrateKeyword, Keyword};
-pub use self::krate::{Crate, CrateName, CrateVersions, NewCrate, RecentCrateDownloads};
+pub use self::krate::{Crate, CrateName, NewCrate, RecentCrateDownloads};
 pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::rights::Rights;
 pub use self::team::{NewTeam, Team};


### PR DESCRIPTION
Having these "non-yanked" and "including yanked" variants is quite confusing and doesn't provide much benefit compared to using `Version::belonging_to(...)` directly...

Related:

- https://github.com/rust-lang/crates.io/pull/1459