### PR TITLE
opensearch: Cargo -> crates.io

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -19,7 +19,7 @@
     {{content-for 'head-footer'}}
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/assets/cargo.png" type="image/png">
-    <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="Cargo">
+    <link rel="search" href="/opensearch.xml" type="application/opensearchdescription+xml" title="crates.io">
 
     <meta name="google" content="notranslate" />
 


### PR DESCRIPTION
ShortName was changed to crates.io in #8262, so it should be changed as well.