### PR TITLE
team_repo: Avoid `automock` for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ unicode-xid = "=0.2.6"
 bytes = "=1.8.0"
 crates_io_index = { path = "crates/crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates/crates_io_tarball", features = ["builder"] }
+crates_io_team_repo = { path = "crates/crates_io_team_repo", features = ["mock"] }
 crates_io_test_db = { path = "crates/crates_io_test_db" }
 claims = "=0.7.1"
 diesel = { version = "=2.2.4", features = ["r2d2"] }

--- a/crates/crates_io_team_repo/Cargo.toml
+++ b/crates/crates_io_team_repo/Cargo.toml
@@ -7,10 +7,13 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+mock = ["mockall"]
+
 [dependencies]
 anyhow = "=1.0.93"
 async-trait = "=0.1.83"
-mockall = "=0.13.0"
+mockall = { version = "=0.13.0", optional = true }
 reqwest = { version = "=0.12.9", features = ["gzip", "json"] }
 serde = { version = "=1.0.214", features = ["derive"] }
 

--- a/crates/crates_io_team_repo/src/lib.rs
+++ b/crates/crates_io_team_repo/src/lib.rs
@@ -6,13 +6,12 @@
 //! the trait.
 
 use async_trait::async_trait;
-use mockall::automock;
 use reqwest::{Certificate, Client};
 use serde::Deserialize;
 
 mod certs;
 
-#[automock]
+#[cfg_attr(feature = "mock", mockall::automock)]
 #[async_trait]
 pub trait TeamRepo {
     async fn get_permission(&self, name: &str) -> anyhow::Result<Permission>;


### PR DESCRIPTION
There is no need to derive a mock implementation for our release builds, since it won't be used. Might help ever so slightly with build times... 🤷‍♂️ 