### PR TITLE
worker/tests: Fix flaky deduplication test

### DIFF
--- a/crates/crates_io_worker/tests/runner.rs
+++ b/crates/crates_io_worker/tests/runner.rs
@@ -277,7 +277,9 @@ async fn jobs_can_be_deduplicated() -> anyhow::Result<()> {
     let pool = pool(test_database.url())?;
     let mut conn = pool.get().await?;
 
-    let runner = runner(pool, test_context.clone()).register_job_type::<TestJob>();
+    let runner = Runner::new(pool, test_context.clone())
+        .register_job_type::<TestJob>()
+        .shutdown_when_queue_empty();
 
     // Enqueue first job
     assert_some!(TestJob::new("foo").async_enqueue(&mut conn).await?);


### PR DESCRIPTION
The second `assert_none!()` in this test was occasionally failing due to a race condition. The `TestJob` that was enqueued right before this one would sometimes already be processed before we enqueue this one, leading to this one being actually enqueued instead of being deduplicated. The reason for this was that the `runner()` fn builds a `Runner` with two workers for the default queue. This commit changes the runner to only use a single worker, which avoids the race condition.