### PR TITLE
controllers/version: Convert `version_and_crate()` to async

### DIFF
--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -2,24 +2,26 @@ pub mod downloads;
 pub mod metadata;
 pub mod yank;
 
+use diesel_async::AsyncPgConnection;
+
 use crate::models::{Crate, Version};
-use crate::util::diesel::Conn;
 use crate::util::errors::{crate_not_found, AppResult};
 
-fn version_and_crate(
-    conn: &mut impl Conn,
+async fn version_and_crate(
+    conn: &mut AsyncPgConnection,
     crate_name: &str,
     semver: &str,
 ) -> AppResult<(Version, Crate)> {
-    use crate::util::diesel::prelude::*;
-    use diesel::RunQueryDsl;
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
 
     let krate: Crate = Crate::by_name(crate_name)
         .first(conn)
+        .await
         .optional()?
         .ok_or_else(|| crate_not_found(crate_name))?;
 
-    let version = krate.find_version(conn, semver)?;
+    let version = krate.find_version(conn, semver).await?;
 
     Ok((version, krate))
 }

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -45,13 +45,12 @@ pub async fn downloads(
         return Err(version_not_found(&crate_name, &version));
     }
 
-    let conn = app.db_read().await?;
+    let mut conn = app.db_read().await?;
+    let (version, _) = version_and_crate(&mut conn, &crate_name, &version).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-
-        let (version, _) = version_and_crate(conn, &crate_name, &version)?;
 
         let cutoff_end_date = req
             .query()

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -52,10 +52,10 @@ async fn modify_yank(
         return Err(version_not_found(&crate_name, &version));
     }
 
-    let conn = state.db_write().await?;
+    let mut conn = state.db_write().await?;
+    let (mut version, krate) = version_and_crate(&mut conn, &crate_name, &version).await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-        let (mut version, krate) = version_and_crate(conn, &crate_name, &version)?;
         perform_version_yank_update(&state, &req, conn, &mut version, &krate, Some(yanked), None)?;
         ok_true()
     })


### PR DESCRIPTION
This PR converts`version_and_crate()` and related fns to async, and the next one will convert `AuthCheck::check()` and related fns. The conversion order is mostly based on the order in which they occur in `spawn_blocking()`.

