### PR TITLE
models/version: Fix `published_by()` error handling

### DIFF
--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -104,7 +104,7 @@ pub async fn show(
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
-        let published_by = version.published_by(conn);
+        let published_by = version.published_by(conn)?;
         let actions = VersionOwnerAction::by_version(conn, &version)?;
 
         let version = EncodableVersion::from(version, &krate.name, published_by, actions);
@@ -142,7 +142,7 @@ pub async fn update(
             update_request.version.yank_message,
         )?;
 
-        let published_by = version.published_by(conn);
+        let published_by = version.published_by(conn)?;
         let actions = VersionOwnerAction::by_version(conn, &version)?;
         let updated_version = EncodableVersion::from(version, &krate.name, published_by, actions);
         Ok(Json(json!({ "version": updated_version })))

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -49,12 +49,12 @@ impl Version {
 
     /// Gets the User who ran `cargo publish` for this version, if recorded.
     /// Not for use when you have a group of versions you need the publishers for.
-    pub fn published_by(&self, conn: &mut impl Conn) -> Option<User> {
+    pub fn published_by(&self, conn: &mut impl Conn) -> QueryResult<Option<User>> {
         use diesel::RunQueryDsl;
 
         match self.published_by {
-            Some(pb) => users::table.find(pb).first(conn).ok(),
-            None => None,
+            Some(pb) => users::table.find(pb).first(conn).optional(),
+            None => Ok(None),
         }
     }
 


### PR DESCRIPTION
If there is an error in this query we shouldn't silently fail and return `None`, we should propagate the error instead and let the caller decide what to do.