### PR TITLE
models/version: Convert `record_readme_rendering()` to async fn

### DIFF
--- a/src/bin/crates-admin/render_readmes.rs
+++ b/src/bin/crates-admin/render_readmes.rs
@@ -115,7 +115,8 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
 
             let mut tasks = Vec::with_capacity(page_size);
             for (version, krate_name) in versions {
-                Version::record_readme_rendering(version.id, &mut conn)
+                Handle::current()
+                    .block_on(Version::record_readme_rendering(version.id, &mut conn))
                     .context("Couldn't record rendering time")?;
 
                 let client = client.clone();

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -11,6 +11,11 @@ async fn record_rerendered_readme_time() {
     let c = CrateBuilder::new("foo_authors", user.id).expect_build(&mut conn);
     let version = VersionBuilder::new("1.0.0").expect_build(c.id, user.id, &mut conn);
 
-    Version::record_readme_rendering(version.id, &mut conn).unwrap();
-    Version::record_readme_rendering(version.id, &mut conn).unwrap();
+    let mut conn = app.async_db_conn().await;
+    Version::record_readme_rendering(version.id, &mut conn)
+        .await
+        .unwrap();
+    Version::record_readme_rendering(version.id, &mut conn)
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
... which allows us to remove a `spawn_blocking()` call from the `RenderAndUploadReadme` background job :)