### PR TITLE
auth: Convert `check()` and related blocking fns to async

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -28,9 +28,7 @@ use tokio::runtime::Handle;
 /// Handles the `GET /api/v1/me/crate_owner_invitations` route.
 pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     let mut conn = app.db_read().await?;
-    let auth = AuthCheck::only_cookie()
-        .async_check(&req, &mut conn)
-        .await?;
+    let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
@@ -72,9 +70,7 @@ pub async fn list(app: AppState, req: Parts) -> AppResult<Json<Value>> {
 /// Handles the `GET /api/private/crate_owner_invitations` route.
 pub async fn private_list(app: AppState, req: Parts) -> AppResult<Json<PrivateListResponse>> {
     let mut conn = app.db_read().await?;
-    let auth = AuthCheck::only_cookie()
-        .async_check(&req, &mut conn)
-        .await?;
+    let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
@@ -288,7 +284,7 @@ pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Json
     let crate_invite = crate_invite.crate_owner_invite;
 
     let mut conn = state.db_write().await?;
-    let auth = AuthCheck::default().async_check(&parts, &mut conn).await?;
+    let auth = AuthCheck::default().check(&parts, &mut conn).await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -35,10 +35,7 @@ pub async fn follow(
     req: Parts,
 ) -> AppResult<Response> {
     let mut conn = app.db_write().await?;
-    let user_id = AuthCheck::default()
-        .async_check(&req, &mut conn)
-        .await?
-        .user_id();
+    let user_id = AuthCheck::default().check(&req, &mut conn).await?.user_id();
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
@@ -62,10 +59,7 @@ pub async fn unfollow(
     req: Parts,
 ) -> AppResult<Response> {
     let mut conn = app.db_write().await?;
-    let user_id = AuthCheck::default()
-        .async_check(&req, &mut conn)
-        .await?
-        .user_id();
+    let user_id = AuthCheck::default().check(&req, &mut conn).await?.user_id();
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
@@ -87,7 +81,7 @@ pub async fn following(
 ) -> AppResult<Json<Value>> {
     let mut conn = app.db_read_prefer_primary().await?;
     let user_id = AuthCheck::only_cookie()
-        .async_check(&req, &mut conn)
+        .check(&req, &mut conn)
         .await?
         .user_id();
     spawn_blocking(move || {

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -130,16 +130,16 @@ async fn modify_owners(
         ));
     }
 
-    let conn = app.db_write().await?;
+    let mut conn = app.db_write().await?;
+    let auth = AuthCheck::default()
+        .with_endpoint_scope(EndpointScope::ChangeOwners)
+        .for_crate(&crate_name)
+        .async_check(&parts, &mut conn)
+        .await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-
-        let auth = AuthCheck::default()
-            .with_endpoint_scope(EndpointScope::ChangeOwners)
-            .for_crate(&crate_name)
-            .check(&parts, conn)?;
 
         let user = auth.user();
 

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -134,7 +134,7 @@ async fn modify_owners(
     let auth = AuthCheck::default()
         .with_endpoint_scope(EndpointScope::ChangeOwners)
         .for_crate(&crate_name)
-        .async_check(&parts, &mut conn)
+        .check(&parts, &mut conn)
         .await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -102,7 +102,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         let auth = AuthCheck::default()
             .with_endpoint_scope(endpoint_scope)
             .for_crate(&metadata.name)
-            .async_check(&req, &mut conn)
+            .check(&req, &mut conn)
             .await?;
         (existing_crate, auth)
     };

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -310,7 +310,7 @@ impl<'a> FilterParams<'a> {
         }
 
         let user_id = Handle::current()
-            .block_on(AuthCheck::default().async_check(req, conn))?
+            .block_on(AuthCheck::default().check(req, conn))?
             .user_id();
 
         // This should not fail, because of the `get()` check above

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -6,10 +6,12 @@ use axum::Json;
 use diesel::dsl::{exists, sql, InnerJoinQuerySource, LeftJoinQuerySource};
 use diesel::sql_types::{Array, Bool, Text};
 use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use diesel_async::AsyncPgConnection;
 use diesel_full_text_search::*;
 use http::request::Parts;
 use serde_json::Value;
 use std::cell::OnceCell;
+use tokio::runtime::Handle;
 
 use crate::app::AppState;
 use crate::controllers::helpers::Paginate;
@@ -22,7 +24,6 @@ use crate::controllers::helpers::pagination::{Page, Paginated, PaginationOptions
 use crate::models::krate::ALL_COLUMNS;
 use crate::sql::{array_agg, canon_crate_name, lower};
 use crate::tasks::spawn_blocking;
-use crate::util::diesel::Conn;
 use crate::util::RequestUtils;
 
 /// Handles the `GET /crates` route.
@@ -303,12 +304,14 @@ impl<'a> FilterParams<'a> {
             .as_deref()
     }
 
-    fn authed_user_id(&self, req: &Parts, conn: &mut impl Conn) -> AppResult<i32> {
+    fn authed_user_id(&self, req: &Parts, conn: &mut AsyncPgConnection) -> AppResult<i32> {
         if let Some(val) = self._auth_user_id.get() {
             return Ok(*val);
         }
 
-        let user_id = AuthCheck::default().check(req, conn)?.user_id();
+        let user_id = Handle::current()
+            .block_on(AuthCheck::default().async_check(req, conn))?
+            .user_id();
 
         // This should not fail, because of the `get()` check above
         let _ = self._auth_user_id.set(user_id);
@@ -319,7 +322,7 @@ impl<'a> FilterParams<'a> {
     fn make_query(
         &'a self,
         req: &Parts,
-        conn: &mut impl Conn,
+        conn: &mut AsyncPgConnection,
     ) -> AppResult<crates::BoxedQuery<'a, diesel::pg::Pg>> {
         let mut query = crates::table.into_boxed();
 

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -42,9 +42,7 @@ pub async fn list(
     req: Parts,
 ) -> AppResult<Json<Value>> {
     let mut conn = app.db_read_prefer_primary().await?;
-    let auth = AuthCheck::only_cookie()
-        .async_check(&req, &mut conn)
-        .await?;
+    let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
@@ -95,7 +93,7 @@ pub async fn new(
     }
 
     let mut conn = app.db_write().await?;
-    let auth = AuthCheck::default().async_check(&parts, &mut conn).await?;
+    let auth = AuthCheck::default().check(&parts, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
@@ -178,7 +176,7 @@ pub async fn new(
 /// Handles the `GET /me/tokens/:id` route.
 pub async fn show(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
     let mut conn = app.db_write().await?;
-    let auth = AuthCheck::default().async_check(&req, &mut conn).await?;
+    let auth = AuthCheck::default().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
@@ -198,7 +196,7 @@ pub async fn show(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<J
 /// Handles the `DELETE /me/tokens/:id` route.
 pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<Json<Value>> {
     let mut conn = app.db_write().await?;
-    let auth = AuthCheck::default().async_check(&req, &mut conn).await?;
+    let auth = AuthCheck::default().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
@@ -217,7 +215,7 @@ pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult
 /// Handles the `DELETE /tokens/current` route.
 pub async fn revoke_current(app: AppState, req: Parts) -> AppResult<Response> {
     let mut conn = app.db_write().await?;
-    let auth = AuthCheck::default().async_check(&req, &mut conn).await?;
+    let auth = AuthCheck::default().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -23,7 +23,7 @@ use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCra
 pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
     let mut conn = app.db_read_prefer_primary().await?;
     let user_id = AuthCheck::only_cookie()
-        .async_check(&req, &mut conn)
+        .check(&req, &mut conn)
         .await?
         .user_id();
     spawn_blocking(move || {
@@ -70,9 +70,7 @@ pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
 /// Handles the `GET /me/updates` route.
 pub async fn updates(app: AppState, req: Parts) -> AppResult<Json<Value>> {
     let mut conn = app.db_read_prefer_primary().await?;
-    let auth = AuthCheck::only_cookie()
-        .async_check(&req, &mut conn)
-        .await?;
+    let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
@@ -151,7 +149,7 @@ pub async fn update_email_notifications(app: AppState, req: BytesRequest) -> App
 
     let mut conn = app.db_write().await?;
     let user_id = AuthCheck::default()
-        .async_check(&parts, &mut conn)
+        .check(&parts, &mut conn)
         .await?
         .user_id();
     spawn_blocking(move || {

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -33,13 +33,13 @@ pub async fn update_user(
     req: Parts,
     Json(user_update): Json<UserUpdate>,
 ) -> AppResult<Response> {
-    let conn = state.db_write().await?;
+    let mut conn = state.db_write().await?;
+    let auth = AuthCheck::default().async_check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
-        let auth = AuthCheck::default().check(&req, conn)?;
         let user = auth.user();
 
         // need to check if current user matches user to be updated
@@ -120,13 +120,13 @@ pub async fn regenerate_token_and_send(
     Path(param_user_id): Path<i32>,
     req: Parts,
 ) -> AppResult<Response> {
-    let conn = state.db_write().await?;
+    let mut conn = state.db_write().await?;
+    let auth = AuthCheck::default().async_check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
-        let auth = AuthCheck::default().check(&req, conn)?;
         let user = auth.user();
 
         // need to check if current user matches user to be updated

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -34,7 +34,7 @@ pub async fn update_user(
     Json(user_update): Json<UserUpdate>,
 ) -> AppResult<Response> {
     let mut conn = state.db_write().await?;
-    let auth = AuthCheck::default().async_check(&req, &mut conn).await?;
+    let auth = AuthCheck::default().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 
@@ -121,7 +121,7 @@ pub async fn regenerate_token_and_send(
     req: Parts,
 ) -> AppResult<Response> {
     let mut conn = state.db_write().await?;
-    let auth = AuthCheck::default().async_check(&req, &mut conn).await?;
+    let auth = AuthCheck::default().check(&req, &mut conn).await?;
     spawn_blocking(move || {
         use diesel::RunQueryDsl;
 

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -176,7 +176,7 @@ pub async fn authenticate(
     AuthCheck::default()
         .with_endpoint_scope(EndpointScope::Yank)
         .for_crate(name)
-        .async_check(req, conn)
+        .check(req, conn)
         .await
 }
 

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -54,9 +54,9 @@ async fn modify_yank(
 
     let mut conn = state.db_write().await?;
     let (mut version, krate) = version_and_crate(&mut conn, &crate_name, &version).await?;
+    let auth = authenticate(&req, &mut conn, &crate_name).await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-        let auth = authenticate(&req, conn, &crate_name)?;
         perform_version_yank_update(
             &state,
             conn,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,4 +1,5 @@
 use chrono::NaiveDateTime;
+use diesel_async::AsyncPgConnection;
 use secrecy::SecretString;
 
 use crate::app::App;
@@ -32,6 +33,12 @@ impl User {
         use diesel::RunQueryDsl;
 
         users::table.find(id).first(conn)
+    }
+
+    pub async fn async_find(conn: &mut AsyncPgConnection, id: i32) -> QueryResult<User> {
+        use diesel_async::RunQueryDsl;
+
+        users::table.find(id).first(conn).await
     }
 
     pub fn find_by_login(conn: &mut impl Conn, login: &str) -> QueryResult<User> {


### PR DESCRIPTION
This PR focuses on converting the `check()` and related implementations to async, so there might be `spawn_blocking()`  fns in controllers that can be removed. However, I expect these changes to be made in a separate PR :)