### PR TITLE
Heroku: Update buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,1 +1,1 @@
-https://github.com/Turbo87/heroku-buildpack-crates-io#57008548b11cecb39f28d2bb7cf3b104a301e751
+https://github.com/Turbo87/heroku-buildpack-crates-io#5005fb13c1a782285302e7d40712f746438a99d6


### PR DESCRIPTION
This fixes the current deployment failures by using the `amd64` instead of `i386` build of the `jq` tool. It also updated `jq` from 1.7 to 1.7.1.

see https://github.com/Turbo87/heroku-buildpack-crates-io/compare/57008548b11cecb39f28d2bb7cf3b104a301e751...5005fb13c1a782285302e7d40712f746438a99d6