### PR TITLE
Add tests for `PUT /user/:user_id/resend` route

### DIFF
--- a/src/controllers/user.rs
+++ b/src/controllers/user.rs
@@ -1,6 +1,8 @@
 pub mod me;
 pub mod other;
+mod resend;
 pub mod session;
 pub mod update;
 
+pub use resend::regenerate_token_and_send;
 pub use update::update_user;

--- a/src/controllers/user/resend.rs
+++ b/src/controllers/user/resend.rs
@@ -1,0 +1,54 @@
+use super::update::UserConfirmEmail;
+use crate::app::AppState;
+use crate::auth::AuthCheck;
+use crate::controllers::helpers::ok_true;
+use crate::models::Email;
+use crate::tasks::spawn_blocking;
+use crate::util::errors::bad_request;
+use crate::util::errors::AppResult;
+use axum::extract::Path;
+use axum::response::Response;
+use crates_io_database::schema::emails;
+use diesel::dsl::sql;
+use diesel::prelude::*;
+use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use http::request::Parts;
+
+/// Handles `PUT /user/:user_id/resend` route
+pub async fn regenerate_token_and_send(
+    state: AppState,
+    Path(param_user_id): Path<i32>,
+    req: Parts,
+) -> AppResult<Response> {
+    let mut conn = state.db_write().await?;
+    let auth = AuthCheck::default().check(&req, &mut conn).await?;
+    spawn_blocking(move || {
+        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
+
+        let user = auth.user();
+
+        // need to check if current user matches user to be updated
+        if user.id != param_user_id {
+            return Err(bad_request("current user does not match requested user"));
+        }
+
+        conn.transaction(|conn| -> AppResult<_> {
+            let email: Email = diesel::update(Email::belonging_to(user))
+                .set(emails::token.eq(sql("DEFAULT")))
+                .get_result(conn)
+                .optional()?
+                .ok_or_else(|| bad_request("Email could not be found"))?;
+
+            let email1 = UserConfirmEmail {
+                user_name: &user.gh_login,
+                domain: &state.emails.domain,
+                token: email.token,
+            };
+
+            state.emails.send(&email.email, email1).map_err(Into::into)
+        })?;
+
+        ok_true()
+    })
+    .await
+}

--- a/src/controllers/user/snapshots/crates_io__controllers__user__resend__tests__happy_path-2.snap
+++ b/src/controllers/user/snapshots/crates_io__controllers__user__resend__tests__happy_path-2.snap
@@ -1,0 +1,15 @@
+---
+source: src/controllers/user/resend.rs
+expression: app.emails_snapshot()
+snapshot_kind: text
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Please confirm your email address
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 7bit
+
+Hello foo! Welcome to crates.io. Please click the
+link below to verify your email address. Thank you!
+
+https://crates.io/confirm/[confirm-token]

--- a/src/router.rs
+++ b/src/router.rs
@@ -133,7 +133,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         )
         .route(
             "/api/v1/users/:user_id/resend",
-            put(user::update::regenerate_token_and_send),
+            put(user::regenerate_token_and_send),
         )
         .route(
             "/api/v1/site_metadata",

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -189,6 +189,9 @@ impl TestApp {
         static DATE_TIME_REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z").unwrap());
 
+        static EMAIL_CONFIRM_REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"/confirm/\w+").unwrap());
+
         static INVITE_TOKEN_REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"/accept-invite/\w+").unwrap());
 
@@ -199,6 +202,7 @@ impl TestApp {
             .map(|email| {
                 let email = EMAIL_HEADER_REGEX.replace_all(&email, "");
                 let email = DATE_TIME_REGEX.replace_all(&email, "[0000-00-00T00:00:00Z]");
+                let email = EMAIL_CONFIRM_REGEX.replace_all(&email, "/confirm/[confirm-token]");
                 let email = INVITE_TOKEN_REGEX.replace_all(&email, "/accept-invite/[invite-token]");
                 email.to_string()
             })


### PR DESCRIPTION
This unblocks https://github.com/rust-lang/crates.io/pull/9879 by adding a couple of basic tests for the route. 

Additionally, the route handler is moved to a dedicated module, making it easier to colocate the tests with the implementation in the same file.