### PR TITLE
models/crate_owner_invitation: Convert to async/await

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -311,13 +311,13 @@ pub async fn handle_invite_with_token(
     state: AppState,
     Path(token): Path<String>,
 ) -> AppResult<Json<Value>> {
-    let conn = state.db_write().await?;
+    let mut conn = state.db_write().await?;
+    let invitation = CrateOwnerInvitation::find_by_token(&token, &mut conn).await?;
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
         let config = &state.config;
 
-        let invitation = CrateOwnerInvitation::find_by_token(&token, conn)?;
         let crate_id = invitation.crate_id;
         invitation.accept(conn, config)?;
 

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -1,4 +1,5 @@
 use chrono::{NaiveDateTime, Utc};
+use diesel_async::AsyncPgConnection;
 use http::StatusCode;
 use secrecy::SecretString;
 
@@ -87,12 +88,17 @@ impl CrateOwnerInvitation {
         })
     }
 
-    pub fn find_by_id(user_id: i32, crate_id: i32, conn: &mut impl Conn) -> QueryResult<Self> {
-        use diesel::RunQueryDsl;
+    pub async fn find_by_id(
+        user_id: i32,
+        crate_id: i32,
+        conn: &mut AsyncPgConnection,
+    ) -> QueryResult<Self> {
+        use diesel_async::RunQueryDsl;
 
         crate_owner_invitations::table
             .find((user_id, crate_id))
             .first::<Self>(conn)
+            .await
     }
 
     pub fn find_by_token(token: &str, conn: &mut impl Conn) -> QueryResult<Self> {

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -101,12 +101,13 @@ impl CrateOwnerInvitation {
             .await
     }
 
-    pub fn find_by_token(token: &str, conn: &mut impl Conn) -> QueryResult<Self> {
-        use diesel::RunQueryDsl;
+    pub async fn find_by_token(token: &str, conn: &mut AsyncPgConnection) -> QueryResult<Self> {
+        use diesel_async::RunQueryDsl;
 
         crate_owner_invitations::table
             .filter(crate_owner_invitations::token.eq(token))
             .first::<Self>(conn)
+            .await
     }
 
     pub fn accept(self, conn: &mut impl Conn, config: &config::Server) -> AppResult<()> {

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -110,14 +110,20 @@ impl CrateOwnerInvitation {
             .await
     }
 
-    pub fn accept(self, conn: &mut impl Conn, config: &config::Server) -> AppResult<()> {
-        use diesel::RunQueryDsl;
+    pub async fn accept(
+        self,
+        conn: &mut AsyncPgConnection,
+        config: &config::Server,
+    ) -> AppResult<()> {
+        use diesel_async::scoped_futures::ScopedFutureExt;
+        use diesel_async::{AsyncConnection, RunQueryDsl};
 
         if self.is_expired(config) {
             let crate_name: String = crates::table
                 .find(self.crate_id)
                 .select(crates::name)
-                .first(conn)?;
+                .first(conn)
+                .await?;
 
             let detail = format!(
                 "The invitation to become an owner of the {crate_name} crate expired. \
@@ -128,33 +134,38 @@ impl CrateOwnerInvitation {
         }
 
         conn.transaction(|conn| {
-            diesel::insert_into(crate_owners::table)
-                .values(&CrateOwner {
-                    crate_id: self.crate_id,
-                    owner_id: self.invited_user_id,
-                    created_by: self.invited_by_user_id,
-                    owner_kind: OwnerKind::User,
-                    email_notifications: true,
-                })
-                .on_conflict(crate_owners::table.primary_key())
-                .do_update()
-                .set(crate_owners::deleted.eq(false))
-                .execute(conn)?;
+            async move {
+                diesel::insert_into(crate_owners::table)
+                    .values(&CrateOwner {
+                        crate_id: self.crate_id,
+                        owner_id: self.invited_user_id,
+                        created_by: self.invited_by_user_id,
+                        owner_kind: OwnerKind::User,
+                        email_notifications: true,
+                    })
+                    .on_conflict(crate_owners::table.primary_key())
+                    .do_update()
+                    .set(crate_owners::deleted.eq(false))
+                    .execute(conn)
+                    .await?;
 
-            diesel::delete(&self).execute(conn)?;
+                diesel::delete(&self).execute(conn).await?;
 
-            Ok(())
+                Ok(())
+            }
+            .scope_boxed()
         })
+        .await
     }
 
-    pub fn decline(self, conn: &mut impl Conn) -> QueryResult<()> {
-        use diesel::RunQueryDsl;
+    pub async fn decline(self, conn: &mut AsyncPgConnection) -> QueryResult<()> {
+        use diesel_async::RunQueryDsl;
 
         // The check to prevent declining expired invitations is *explicitly* missing. We do not
         // care if an expired invitation is declined, as that just removes the invitation from the
         // database.
 
-        diesel::delete(&self).execute(conn)?;
+        diesel::delete(&self).execute(conn).await?;
         Ok(())
     }
 


### PR DESCRIPTION
This PR converts most functions in the `crate_owner_invitation` model to async/await and removes unnecessary `spawn_blocking()` usage in the controller. The `create` function is left unconverted due to additional work required, which I plan to address in a future PR :)