### PR TITLE
admin/render_readmes: Use async `reqwest` client and `diesel-async` queries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ postgres-native-tls = "=0.5.0"
 prometheus = { version = "=0.13.4", default-features = false }
 quick-xml = "=0.37.0"
 rand = "=0.8.5"
-reqwest = { version = "=0.12.9", features = ["blocking", "gzip", "json"] }
+reqwest = { version = "=0.12.9", features = ["gzip", "json"] }
 rss = { version = "=2.0.9", default-features = false, features = ["atom"] }
 secrecy = "=0.10.3"
 semver = { version = "=1.0.23", features = ["serde"] }


### PR DESCRIPTION
This should be our last place that still used a sync `reqwest` client :)

I tested this locally by hardcoding `cdn_prefix: Some("https://static.crates.io".to_string())` and then running `cargo run --bin crates-admin render-readmes --crate mustache --page-size 5`. seemed to work fine from what I could tell.