### PR TITLE
admin/upload_index: Reduce `spawn_blocking()` scope

### DIFF
--- a/src/bin/crates-admin/upload_index.rs
+++ b/src/bin/crates-admin/upload_index.rs
@@ -4,7 +4,6 @@ use crates_io::storage::Storage;
 use crates_io::tasks::spawn_blocking;
 use crates_io_index::{Repository, RepositoryConfig};
 use indicatif::{ProgressBar, ProgressIterator, ProgressStyle};
-use tokio::runtime::Handle;
 
 #[derive(clap::Parser, Debug)]
 #[command(
@@ -17,52 +16,55 @@ pub struct Opts {
 }
 
 pub async fn run(opts: Opts) -> anyhow::Result<()> {
-    spawn_blocking(move || {
-        let storage = Storage::from_environment();
+    let storage = Storage::from_environment();
 
-        println!("fetching git repo");
-        let config = RepositoryConfig::from_environment()?;
+    println!("fetching git repo");
+    let config = RepositoryConfig::from_environment()?;
+    let (repo, files) = spawn_blocking(move || {
         let repo = Repository::open(&config)?;
         repo.reset_head()?;
         println!("HEAD is at {}", repo.head_oid()?);
 
         let files = repo.get_files_modified_since(opts.incremental_commit.as_deref())?;
         println!("found {} files to upload", files.len());
-        if !dialoguer::confirm("continue with upload?")? {
-            return Ok(());
-        }
 
-        let pb = ProgressBar::new(files.len() as u64);
-        pb.set_style(ProgressStyle::with_template(
-            "{bar:60} ({pos}/{len}, ETA {eta})",
-        )?);
-
-        for file in files.iter().progress_with(pb.clone()) {
-            let file_name = file.file_name().ok_or_else(|| {
-                let file = file.display();
-                anyhow!("Failed to get file name from path: {file}")
-            })?;
-
-            let crate_name = file_name.to_str().ok_or_else(|| {
-                let file_name = file_name.to_string_lossy();
-                anyhow!("Failed to convert file name to utf8: {file_name}",)
-            })?;
-
-            let path = repo.index_file(crate_name);
-            if !path.exists() {
-                pb.suspend(|| println!("skipping file `{crate_name}`"));
-                continue;
-            }
-
-            let contents = std::fs::read_to_string(&path)?;
-            Handle::current().block_on(storage.sync_index(crate_name, Some(contents)))?;
-        }
-
-        println!(
-            "uploading completed; use `upload-index {}` for an incremental run",
-            repo.head_oid()?
-        );
-        Ok(())
+        Ok::<_, anyhow::Error>((repo, files))
     })
-    .await
+    .await?;
+
+    if !dialoguer::async_confirm("continue with upload?").await? {
+        return Ok(());
+    }
+
+    let pb = ProgressBar::new(files.len() as u64);
+    pb.set_style(ProgressStyle::with_template(
+        "{bar:60} ({pos}/{len}, ETA {eta})",
+    )?);
+
+    for file in files.iter().progress_with(pb.clone()) {
+        let file_name = file.file_name().ok_or_else(|| {
+            let file = file.display();
+            anyhow!("Failed to get file name from path: {file}")
+        })?;
+
+        let crate_name = file_name.to_str().ok_or_else(|| {
+            let file_name = file_name.to_string_lossy();
+            anyhow!("Failed to convert file name to utf8: {file_name}",)
+        })?;
+
+        let path = repo.index_file(crate_name);
+        if !path.exists() {
+            pb.suspend(|| println!("skipping file `{crate_name}`"));
+            continue;
+        }
+
+        let contents = tokio::fs::read_to_string(&path).await?;
+        storage.sync_index(crate_name, Some(contents)).await?;
+    }
+
+    println!(
+        "uploading completed; use `upload-index {}` for an incremental run",
+        repo.head_oid()?
+    );
+    Ok(())
 }


### PR DESCRIPTION
Only the initial repository cloning and file listing operations are synchronous, but the rest of the code can live outside of `spawn_blocking()` these days.

`repo.head_oid()` is arguably also synchronous, but it is a fast enough operation to not matter too much for an admin tool :)