### PR TITLE
admin/dialoguer: Rename `async_confirm()` fn to `confirm()`

### DIFF
--- a/src/bin/crates-admin/delete_crate.rs
+++ b/src/bin/crates-admin/delete_crate.rs
@@ -54,9 +54,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
     }
     println!();
 
-    if !opts.yes
-        && !dialoguer::async_confirm("Do you want to permanently delete these crates?").await?
-    {
+    if !opts.yes && !dialoguer::confirm("Do you want to permanently delete these crates?").await? {
         return Ok(());
     }
 

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -58,8 +58,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         println!();
 
         if !opts.yes
-            && !dialoguer::async_confirm("Do you want to permanently delete these versions?")
-                .await?
+            && !dialoguer::confirm("Do you want to permanently delete these versions?").await?
         {
             return Ok(());
         }

--- a/src/bin/crates-admin/dialoguer.rs
+++ b/src/bin/crates-admin/dialoguer.rs
@@ -1,7 +1,7 @@
 use ::dialoguer::{theme::Theme, Confirm};
 use crates_io::tasks::spawn_blocking;
 
-pub async fn async_confirm(msg: impl Into<String>) -> anyhow::Result<bool> {
+pub async fn confirm(msg: impl Into<String>) -> anyhow::Result<bool> {
     let msg = msg.into();
     spawn_blocking(move || sync_confirm(msg).map_err(anyhow::Error::from)).await
 }

--- a/src/bin/crates-admin/dialoguer.rs
+++ b/src/bin/crates-admin/dialoguer.rs
@@ -3,10 +3,10 @@ use crates_io::tasks::spawn_blocking;
 
 pub async fn async_confirm(msg: impl Into<String>) -> anyhow::Result<bool> {
     let msg = msg.into();
-    spawn_blocking(move || confirm(msg).map_err(anyhow::Error::from)).await
+    spawn_blocking(move || sync_confirm(msg).map_err(anyhow::Error::from)).await
 }
 
-pub fn confirm(msg: impl Into<String>) -> dialoguer::Result<bool> {
+fn sync_confirm(msg: impl Into<String>) -> dialoguer::Result<bool> {
     Confirm::with_theme(&CustomTheme)
         .with_prompt(msg)
         .default(false)

--- a/src/bin/crates-admin/transfer_crates.rs
+++ b/src/bin/crates-admin/transfer_crates.rs
@@ -46,7 +46,7 @@ async fn transfer(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()
         println!("from: {:?}", from.gh_id);
         println!("to:   {:?}", to.gh_id);
 
-        if !dialoguer::async_confirm("continue?").await? {
+        if !dialoguer::confirm("continue?").await? {
             return Ok(());
         }
     }
@@ -55,7 +55,7 @@ async fn transfer(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()
         "Are you sure you want to transfer crates from {} to {}?",
         from.gh_login, to.gh_login
     );
-    if !dialoguer::async_confirm(&prompt).await? {
+    if !dialoguer::confirm(&prompt).await? {
         return Ok(());
     }
 
@@ -80,7 +80,7 @@ async fn transfer(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()
         }
     }
 
-    if !dialoguer::async_confirm("commit?").await? {
+    if !dialoguer::confirm("commit?").await? {
         return Ok(());
     }
 

--- a/src/bin/crates-admin/upload_index.rs
+++ b/src/bin/crates-admin/upload_index.rs
@@ -32,7 +32,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
     })
     .await?;
 
-    if !dialoguer::async_confirm("continue with upload?").await? {
+    if !dialoguer::confirm("continue with upload?").await? {
         return Ok(());
     }
 

--- a/src/bin/crates-admin/yank_version.rs
+++ b/src/bin/crates-admin/yank_version.rs
@@ -55,7 +55,7 @@ async fn yank(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()> {
             "Are you sure you want to yank {crate_name}#{version} ({})?",
             v.id
         );
-        if !dialoguer::async_confirm(&prompt).await? {
+        if !dialoguer::confirm(&prompt).await? {
             return Ok(());
         }
     }


### PR DESCRIPTION
The sync variant isn't used anywhere anymore, so we might as well make it private and only treat it as an "inner function" :)