### PR TITLE
insta: Update snapshots

### DIFF
--- a/crates/crates_io_cdn_logs/src/cloudfront.rs
+++ b/crates/crates_io_cdn_logs/src/cloudfront.rs
@@ -135,7 +135,7 @@ mod tests {
         let mut cursor = Cursor::new(include_bytes!("../test_data/cloudfront/basic.log"));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  bindgen@0.65.1 .. 1
             2024-01-16  cumulus-primitives-core@0.4.0 .. 1
@@ -157,7 +157,7 @@ mod tests {
             2024-01-17  smallvec@1.10.0 .. 1
             2024-01-17  tar@0.4.38 .. 1
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -169,11 +169,11 @@ mod tests {
         ));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-17  zstd-sys@2.0.8+zstd.1.5.5 .. 3
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -185,11 +185,11 @@ mod tests {
         ));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  bindgen@0.65.1 .. 2
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -201,11 +201,11 @@ mod tests {
         ));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  bindgen@0.65.1 .. 1
         }
-        "###);
+        ");
     }
 
     #[tokio::test]

--- a/crates/crates_io_cdn_logs/src/download_map.rs
+++ b/crates/crates_io_cdn_logs/src/download_map.rs
@@ -79,31 +79,31 @@ mod tests {
 
         // Add an entry to the map
         add(&mut downloads, "xmas", "2.0.0", "2023-12-25");
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2023-12-25  xmas@2.0.0 .. 1
         }
-        "###);
+        ");
 
         // Add the same entry again
         add(&mut downloads, "xmas", "2.0.0", "2023-12-25");
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2023-12-25  xmas@2.0.0 .. 2
         }
-        "###);
+        ");
 
         // Add other entries
         add(&mut downloads, "foo", "2.0.0", "2023-12-25");
         add(&mut downloads, "xmas", "1.0.0", "2023-12-25");
         add(&mut downloads, "xmas", "2.0.0", "2023-12-26");
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2023-12-25  foo@2.0.0 .. 1
             2023-12-25  xmas@1.0.0 .. 1
             2023-12-25  xmas@2.0.0 .. 2
             2023-12-26  xmas@2.0.0 .. 1
         }
-        "###);
+        ");
     }
 }

--- a/crates/crates_io_cdn_logs/src/fastly/json.rs
+++ b/crates/crates_io_cdn_logs/src/fastly/json.rs
@@ -72,7 +72,7 @@ mod tests {
     fn test_parse() {
         let input = r#"{"bytes":null,"date_time":"2024-01-16T16:03:04.44007323Z","ip":"45.79.107.220","method":"GET","status":403,"url":"https://static.staging.crates.io/?1705420437","version":"1"}"#;
         let output = assert_ok!(serde_json::from_str::<LogLine<'_>>(input));
-        assert_debug_snapshot!(output, @r###"
+        assert_debug_snapshot!(output, @r#"
         V1(
             LogLineV1 {
                 date_time: 2024-01-16T16:03:04.440073230Z,
@@ -81,7 +81,7 @@ mod tests {
                 status: 403,
             },
         )
-        "###);
+        "#);
 
         assert_eq!(
             output.date_time().to_string(),

--- a/crates/crates_io_cdn_logs/src/fastly/mod.rs
+++ b/crates/crates_io_cdn_logs/src/fastly/mod.rs
@@ -96,7 +96,7 @@ mod tests {
         let mut cursor = Cursor::new(include_bytes!("../../test_data/fastly/basic.log"));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  strsim@0.10.0 .. 1
             2024-01-16  tikv-jemalloc-sys@0.5.2+5.3.0-patched .. 1
@@ -121,7 +121,7 @@ mod tests {
             2024-01-17  xz2@0.1.7 .. 1
             2024-01-17  zstd-safe@7.0.0 .. 1
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -133,11 +133,11 @@ mod tests {
         ));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  tikv-jemalloc-sys@0.5.2+5.3.0-patched .. 2
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -149,11 +149,11 @@ mod tests {
         ));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  strsim@0.10.0 .. 2
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -165,10 +165,10 @@ mod tests {
         ));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  strsim@0.10.0 .. 1
         }
-        "###);
+        ");
     }
 }

--- a/crates/crates_io_cdn_logs/src/lib.rs
+++ b/crates/crates_io_cdn_logs/src/lib.rs
@@ -58,7 +58,7 @@ mod tests {
         let mut cursor = Cursor::new(include_bytes!("../test_data/cloudfront/basic.log"));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  bindgen@0.65.1 .. 1
             2024-01-16  cumulus-primitives-core@0.4.0 .. 1
@@ -80,7 +80,7 @@ mod tests {
             2024-01-17  smallvec@1.10.0 .. 1
             2024-01-17  tar@0.4.38 .. 1
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -94,7 +94,7 @@ mod tests {
 
         let downloads = assert_ok!(count_downloads(reader).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  bindgen@0.65.1 .. 1
             2024-01-16  cumulus-primitives-core@0.4.0 .. 1
@@ -116,7 +116,7 @@ mod tests {
             2024-01-17  smallvec@1.10.0 .. 1
             2024-01-17  tar@0.4.38 .. 1
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -126,7 +126,7 @@ mod tests {
         let mut cursor = Cursor::new(include_bytes!("../test_data/fastly/basic.log"));
         let downloads = assert_ok!(count_downloads(&mut cursor).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  strsim@0.10.0 .. 1
             2024-01-16  tikv-jemalloc-sys@0.5.2+5.3.0-patched .. 1
@@ -151,7 +151,7 @@ mod tests {
             2024-01-17  xz2@0.1.7 .. 1
             2024-01-17  zstd-safe@7.0.0 .. 1
         }
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -165,7 +165,7 @@ mod tests {
 
         let downloads = assert_ok!(count_downloads(reader).await);
 
-        assert_debug_snapshot!(downloads, @r###"
+        assert_debug_snapshot!(downloads, @r"
         DownloadsMap {
             2024-01-16  strsim@0.10.0 .. 1
             2024-01-16  tikv-jemalloc-sys@0.5.2+5.3.0-patched .. 1
@@ -190,7 +190,7 @@ mod tests {
             2024-01-17  xz2@0.1.7 .. 1
             2024-01-17  zstd-safe@7.0.0 .. 1
         }
-        "###);
+        ");
     }
 
     #[tokio::test]

--- a/crates/crates_io_database_dump/src/lib.rs
+++ b/crates/crates_io_database_dump/src/lib.rs
@@ -260,7 +260,7 @@ mod tests {
             .map(|entry| entry.unwrap().path().unwrap().display().to_string())
             .collect::<Vec<_>>();
 
-        assert_debug_snapshot!(paths, @r###"
+        assert_debug_snapshot!(paths, @r#"
         [
             "0000-00-00",
             "0000-00-00/README.md",
@@ -269,14 +269,14 @@ mod tests {
             "0000-00-00/data/users.csv",
             "0000-00-00/data/crate_owners.csv",
         ]
-        "###);
+        "#);
 
         let file = File::open(archives.zip.path()).unwrap();
         let reader = BufReader::new(file);
 
         let archive = zip::ZipArchive::new(reader).unwrap();
         let zip_paths = archive.file_names().collect::<Vec<_>>();
-        assert_debug_snapshot!(zip_paths, @r###"
+        assert_debug_snapshot!(zip_paths, @r#"
         [
             "README.md",
             "data/",
@@ -284,7 +284,7 @@ mod tests {
             "data/users.csv",
             "data/crate_owners.csv",
         ]
-        "###);
+        "#);
     }
 
     #[test]

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_database_dump/src/lib.rs
 expression: content
+snapshot_kind: text
 ---
 BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
 

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_database_dump/src/lib.rs
 expression: content
+snapshot_kind: text
 ---
 BEGIN;
     -- Disable triggers on each table.

--- a/crates/crates_io_index/snapshots/crates_io_index__features__tests__split_features_clap.snap
+++ b/crates/crates_io_index/snapshots/crates_io_index__features__tests__split_features_clap.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_index/features.rs
 expression: split_features(features)
+snapshot_kind: text
 ---
 (
     {

--- a/crates/crates_io_markdown/lib.rs
+++ b/crates/crates_io_markdown/lib.rs
@@ -327,45 +327,43 @@ mod tests {
     #[test]
     fn text_with_script_tag() {
         let text = "foo_readme\n\n<script>alert('Hello World')</script>";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r"
         <p>foo_readme</p>
         &lt;script&gt;alert('Hello World')&lt;/script&gt;
-        "###);
+        ");
     }
 
     #[test]
     fn text_with_iframe_tag() {
         let text = "foo_readme\n\n<iframe>alert('Hello World')</iframe>";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r"
         <p>foo_readme</p>
         &lt;iframe&gt;alert('Hello World')&lt;/iframe&gt;
-        "###);
+        ");
     }
 
     #[test]
     fn text_with_unknown_tag() {
         let text = "foo_readme\n\n<unknown>alert('Hello World')</unknown>";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r"
         <p>foo_readme</p>
         <p>alert('Hello World')</p>
-        "###);
+        ");
     }
 
     #[test]
     fn text_with_kbd_tag() {
         let text = "foo_readme\n\nHello <kbd>alert('Hello World')</kbd>";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r"
         <p>foo_readme</p>
         <p>Hello <kbd>alert('Hello World')</kbd></p>
-        "###);
+        ");
     }
 
     #[test]
     fn text_with_inline_javascript() {
         let text = r#"foo_readme\n\n<a href="https://crates.io/crates/cargo-registry" onclick="window.alert('Got you')">Crate page</a>"#;
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
-        <p>foo_readme\n\n<a href="https://crates.io/crates/cargo-registry" rel="nofollow noopener noreferrer">Crate page</a></p>
-        "###);
+        assert_snapshot!(markdown_to_html(text, None, ""), @r#"<p>foo_readme\n\n<a href="https://crates.io/crates/cargo-registry" rel="nofollow noopener noreferrer">Crate page</a></p>"#);
     }
 
     // See https://github.com/kivikakk/comrak/issues/37. This panic happened
@@ -373,73 +371,69 @@ mod tests {
     #[test]
     fn text_with_fancy_single_quotes() {
         let text = "wb’";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
-        <p>wb’</p>
-        "###);
+        assert_snapshot!(markdown_to_html(text, None, ""), @"<p>wb’</p>");
     }
 
     #[test]
     fn code_block_with_syntax_highlighting() {
         let code_block = "```rust\nprintln!(\"Hello World\");\n```";
-        assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(code_block, None, ""), @r#"
         <pre><code class="language-rust">println!("Hello World");
         </code></pre>
-        "###);
+        "#);
     }
 
     #[test]
     fn code_block_with_mermaid_highlighting() {
         let code_block = "```mermaid\ngraph LR\nA --> C\nC --> A\n```";
-        assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(code_block, None, ""), @r#"
         <pre><code class="language-mermaid">graph LR
         A --&gt; C
         C --&gt; A
         </code></pre>
-        "###);
+        "#);
     }
 
     #[test]
     fn code_block_with_syntax_highlighting_even_if_annot_has_no_run() {
         let code_block = "```rust, no_run\nprintln!(\"Hello World\");\n```";
-        assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(code_block, None, ""), @r#"
         <pre><code class="language-rust">println!("Hello World");
         </code></pre>
-        "###);
+        "#);
     }
 
     #[test]
     fn code_block_with_syntax_highlighting_with_aliases() {
         let code_block = "```rs, no_run\nprintln!(\"Hello World\");\n```";
-        assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(code_block, None, ""), @r#"
         <pre><code class="language-rs">println!("Hello World");
         </code></pre>
-        "###);
+        "#);
 
         let code_block = "```markup, no_run\n<hello>World</hello>\n```";
-        assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(code_block, None, ""), @r#"
         <pre><code class="language-markup">&lt;hello&gt;World&lt;/hello&gt;
         </code></pre>
-        "###);
+        "#);
 
         let code_block = "```clike, no_run\nint main() { }\n```";
-        assert_snapshot!(markdown_to_html(code_block, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(code_block, None, ""), @r#"
         <pre><code class="language-clike">int main() { }
         </code></pre>
-        "###);
+        "#);
     }
 
     #[test]
     fn text_with_forbidden_class_attribute() {
         let text = "<p class='bad-class'>Hello World!</p>";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
-        <p>Hello World!</p>
-        "###);
+        assert_snapshot!(markdown_to_html(text, None, ""), @"<p>Hello World!</p>");
     }
 
     #[test]
     fn text_with_footnote() {
         let text = "Hello World![^1]\n\n[^1]: Hello Ferris, actually!";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r##"
         <p>Hello World!<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup></p>
         <section class="footnotes">
         <ol>
@@ -448,7 +442,7 @@ mod tests {
         </li>
         </ol>
         </section>
-        "###);
+        "##);
     }
 
     #[test]
@@ -467,7 +461,7 @@ There can also be some text in between!
 
     Add as many paragraphs as you like."#;
 
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r##"
         <p>Here's a simple footnote,<sup><a href="#user-content-fn-1" id="user-content-fnref-1" rel="nofollow noopener noreferrer">1</a></sup> and here's a longer one.<sup><a href="#user-content-fn-bignote" id="user-content-fnref-bignote" rel="nofollow noopener noreferrer">2</a></sup></p>
         <p>There can also be some text in between!</p>
         <section class="footnotes">
@@ -483,7 +477,7 @@ There can also be some text in between!
         </li>
         </ol>
         </section>
-        "###);
+        "##);
     }
 
     #[test]
@@ -573,22 +567,16 @@ There can also be some text in between!
         let text =
             "[![crates.io](https://img.shields.io/crates/v/clap.svg)](https://crates.io/crates/clap)";
         let repository = "https://github.com/kbknapp/clap-rs/";
-        assert_snapshot!(markdown_to_html(text, Some(repository), ""), @r###"
-        <p><a href="https://crates.io/crates/clap" rel="nofollow noopener noreferrer"><img src="https://img.shields.io/crates/v/clap.svg" alt="crates.io"></a></p>
-        "###);
+        assert_snapshot!(markdown_to_html(text, Some(repository), ""), @r#"<p><a href="https://crates.io/crates/clap" rel="nofollow noopener noreferrer"><img src="https://img.shields.io/crates/v/clap.svg" alt="crates.io"></a></p>"#);
     }
 
     #[test]
     fn rustdoc_links() {
         let repository = "https://github.com/foo/bar/";
 
-        assert_snapshot!(markdown_to_html("[stylish](::stylish)", Some(repository), ""), @r###"
-        <p><a rel="nofollow noopener noreferrer">stylish</a></p>
-        "###);
+        assert_snapshot!(markdown_to_html("[stylish](::stylish)", Some(repository), ""), @r#"<p><a rel="nofollow noopener noreferrer">stylish</a></p>"#);
 
-        assert_snapshot!(markdown_to_html("[Display](stylish::Display)", Some(repository), ""), @r###"
-        <p><a rel="nofollow noopener noreferrer">Display</a></p>
-        "###);
+        assert_snapshot!(markdown_to_html("[Display](stylish::Display)", Some(repository), ""), @r#"<p><a rel="nofollow noopener noreferrer">Display</a></p>"#);
     }
 
     #[test]
@@ -607,21 +595,11 @@ There can also be some text in between!
             );
         }
 
-        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "readme.md", Some("https://github.com/rust-lang/test"), None), @r###"
-        <p><em><a href="https://github.com/rust-lang/test/blob/HEAD/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>
-        "###);
-        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s/readme.md", Some("https://github.com/rust-lang/test"), None), @r###"
-        <p><em><a href="https://github.com/rust-lang/test/blob/HEAD/s/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>
-        "###);
-        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), None), @r###"
-        <p><em><a href="https://github.com/rust-lang/test/blob/HEAD/s1/s2/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>
-        "###);
-        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), Some("path/in/vcs/")), @r###"
-        <p><em><a href="https://github.com/rust-lang/test/blob/HEAD/path/in/vcs/s1/s2/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>
-        "###);
-        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), Some("path/in/vcs")), @r###"
-        <p><em><a href="https://github.com/rust-lang/test/blob/HEAD/path/in/vcs/s1/s2/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>
-        "###);
+        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "readme.md", Some("https://github.com/rust-lang/test"), None), @r#"<p><em><a href="https://github.com/rust-lang/test/blob/HEAD/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>"#);
+        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s/readme.md", Some("https://github.com/rust-lang/test"), None), @r#"<p><em><a href="https://github.com/rust-lang/test/blob/HEAD/s/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>"#);
+        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), None), @r#"<p><em><a href="https://github.com/rust-lang/test/blob/HEAD/s1/s2/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>"#);
+        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), Some("path/in/vcs/")), @r#"<p><em><a href="https://github.com/rust-lang/test/blob/HEAD/path/in/vcs/s1/s2/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>"#);
+        assert_snapshot!(text_to_html("*[lobster](docs/lobster)*", "s1/s2/readme.md", Some("https://github.com/rust-lang/test"), Some("path/in/vcs")), @r#"<p><em><a href="https://github.com/rust-lang/test/blob/HEAD/path/in/vcs/s1/s2/docs/lobster" rel="nofollow noopener noreferrer">lobster</a></em></p>"#);
     }
 
     #[test]
@@ -637,46 +615,42 @@ There can also be some text in between!
     #[test]
     fn header_has_tags() {
         let text = "# My crate\n\nHello, world!\n";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r##"
         <h1><a href="#my-crate" id="user-content-my-crate" rel="nofollow noopener noreferrer"></a>My crate</h1>
         <p>Hello, world!</p>
-        "###);
+        "##);
     }
 
     #[test]
     fn manual_anchor_is_sanitized() {
         let text =
             "<h1><a href=\"#my-crate\" id=\"my-crate\"></a>My crate</h1>\n<p>Hello, world!</p>\n";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r##"
         <h1><a href="#my-crate" id="user-content-my-crate" rel="nofollow noopener noreferrer"></a>My crate</h1>
         <p>Hello, world!</p>
-        "###);
+        "##);
     }
 
     #[test]
     fn tables_with_rowspan_and_colspan() {
         let text = "<table><tr><th rowspan=\"1\" colspan=\"2\">Target</th></tr></table>\n";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
-        <table><tbody><tr><th rowspan="1" colspan="2">Target</th></tr></tbody></table>
-        "###);
+        assert_snapshot!(markdown_to_html(text, None, ""), @r#"<table><tbody><tr><th rowspan="1" colspan="2">Target</th></tr></tbody></table>"#);
     }
 
     #[test]
     fn text_alignment() {
         let text = "<h1 align=\"center\">foo-bar</h1>\n<h5 align=\"center\">Hello World!</h5>\n";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r#"
         <h1 align="center">foo-bar</h1>
         <h5 align="center">Hello World!</h5>
-        "###);
+        "#);
     }
 
     #[test]
     fn image_alignment() {
         let text =
             "<p align=\"center\"><img src=\"https://img.shields.io/crates/v/clap.svg\" alt=\"\"></p>\n";
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
-        <p align="center"><img src="https://img.shields.io/crates/v/clap.svg" alt=""></p>
-        "###);
+        assert_snapshot!(markdown_to_html(text, None, ""), @r#"<p align="center"><img src="https://img.shields.io/crates/v/clap.svg" alt=""></p>"#);
     }
 
     #[test]
@@ -687,11 +661,11 @@ There can also be some text in between!
     <img src="https://test.crates.io/logo.svg" alt="logo" width="200">
 </picture>
         "#;
-        assert_snapshot!(markdown_to_html(text, None, ""), @r###"
+        assert_snapshot!(markdown_to_html(text, None, ""), @r#"
         <picture>
             <source media="(prefers-color-scheme: dark)" srcset="https://test.crates.io/logo_dark.svg">
             <img src="https://test.crates.io/logo.svg" alt="logo" width="200">
         </picture>
-        "###);
+        "#);
     }
 }

--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -318,10 +318,10 @@ mod tests {
         };
 
         let err = assert_err!(process("CARGO.TOML"));
-        assert_snapshot!(err, @r###"Cargo.toml manifest is incorrectly cased: "CARGO.TOML""###);
+        assert_snapshot!(err, @r#"Cargo.toml manifest is incorrectly cased: "CARGO.TOML""#);
 
         let err = assert_err!(process("Cargo.Toml"));
-        assert_snapshot!(err, @r###"Cargo.toml manifest is incorrectly cased: "Cargo.Toml""###);
+        assert_snapshot!(err, @r#"Cargo.toml manifest is incorrectly cased: "Cargo.Toml""#);
     }
 
     #[test]
@@ -338,13 +338,13 @@ mod tests {
         };
 
         let err = assert_err!(process(vec!["cargo.toml", "Cargo.toml"]));
-        assert_snapshot!(err, @r###"more than one Cargo.toml manifest in tarball: ["foo-0.0.1/Cargo.toml", "foo-0.0.1/cargo.toml"]"###);
+        assert_snapshot!(err, @r#"more than one Cargo.toml manifest in tarball: ["foo-0.0.1/Cargo.toml", "foo-0.0.1/cargo.toml"]"#);
 
         let err = assert_err!(process(vec!["Cargo.toml", "Cargo.Toml"]));
-        assert_snapshot!(err, @r###"more than one Cargo.toml manifest in tarball: ["foo-0.0.1/Cargo.Toml", "foo-0.0.1/Cargo.toml"]"###);
+        assert_snapshot!(err, @r#"more than one Cargo.toml manifest in tarball: ["foo-0.0.1/Cargo.Toml", "foo-0.0.1/Cargo.toml"]"#);
 
         let err = assert_err!(process(vec!["Cargo.toml", "cargo.toml", "CARGO.TOML"]));
-        assert_snapshot!(err, @r###"more than one Cargo.toml manifest in tarball: ["foo-0.0.1/CARGO.TOML", "foo-0.0.1/Cargo.toml", "foo-0.0.1/cargo.toml"]"###);
+        assert_snapshot!(err, @r#"more than one Cargo.toml manifest in tarball: ["foo-0.0.1/CARGO.TOML", "foo-0.0.1/Cargo.toml", "foo-0.0.1/cargo.toml"]"#);
     }
 
     #[test]

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__app.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__app.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: tarball_info.manifest.bin
+snapshot_kind: text
 ---
 [
     Product {

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: lib
+snapshot_kind: text
 ---
 Product {
     path: Some(

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-2.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-2.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: tarball_info.manifest.bin
+snapshot_kind: text
 ---
 [
     Product {

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-3.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-3.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: tarball_info.manifest.example
+snapshot_kind: text
 ---
 [
     Product {

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: lib
+snapshot_kind: text
 ---
 Product {
     path: Some(

--- a/src/controllers/user/resend.rs
+++ b/src/controllers/user/resend.rs
@@ -97,7 +97,7 @@ mod tests {
         let url = format!("/api/v1/users/{}/resend", user.as_model().id);
         let response = user.put::<()>(&url, "").await;
         assert_eq!(response.status(), StatusCode::OK);
-        assert_snapshot!(response.text(), @r###"{"ok":true}"###);
+        assert_snapshot!(response.text(), @r#"{"ok":true}"#);
 
         assert_snapshot!(app.emails_snapshot());
     }

--- a/src/middleware/cargo_compat.rs
+++ b/src/middleware/cargo_compat.rs
@@ -185,13 +185,13 @@ mod tests {
     async fn test_success_responses() {
         let (parts, bytes) = request("/api/ok").await.unwrap();
         assert_eq!(parts.status, StatusCode::OK);
-        assert_debug_snapshot!(parts.headers, @r###"
+        assert_debug_snapshot!(parts.headers, @r#"
         {
             "content-type": "text/plain; charset=utf-8",
             "content-length": "18",
         }
-        "###);
-        assert_debug_snapshot!(bytes, @r###"b"Everything is okay""###);
+        "#);
+        assert_debug_snapshot!(bytes, @r#"b"Everything is okay""#);
     }
 
     /// Check that 4xx text responses **are** converted to JSON, but only
@@ -200,23 +200,23 @@ mod tests {
     async fn test_client_errors() {
         let (parts, bytes) = request("/api/teapot").await.unwrap();
         assert_eq!(parts.status, StatusCode::IM_A_TEAPOT);
-        assert_debug_snapshot!(parts.headers, @r###"
+        assert_debug_snapshot!(parts.headers, @r#"
         {
             "content-type": "application/json",
             "content-length": "38",
         }
-        "###);
-        assert_debug_snapshot!(bytes, @r###"b"{\"errors\":[{\"detail\":\"I'm a teapot\"}]}""###);
+        "#);
+        assert_debug_snapshot!(bytes, @r#"b"{\"errors\":[{\"detail\":\"I'm a teapot\"}]}""#);
 
         let (parts, bytes) = request("/teapot").await.unwrap();
         assert_eq!(parts.status, StatusCode::IM_A_TEAPOT);
-        assert_debug_snapshot!(parts.headers, @r###"
+        assert_debug_snapshot!(parts.headers, @r#"
         {
             "content-type": "text/plain; charset=utf-8",
             "content-length": "12",
         }
-        "###);
-        assert_debug_snapshot!(bytes, @r###"b"I'm a teapot""###);
+        "#);
+        assert_debug_snapshot!(bytes, @r#"b"I'm a teapot""#);
     }
 
     /// Check that 5xx text responses **are** converted to JSON, but only
@@ -225,23 +225,23 @@ mod tests {
     async fn test_server_errors() {
         let (parts, bytes) = request("/api/500").await.unwrap();
         assert_eq!(parts.status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_debug_snapshot!(parts.headers, @r###"
+        assert_debug_snapshot!(parts.headers, @r#"
         {
             "content-type": "application/json",
             "content-length": "47",
         }
-        "###);
-        assert_debug_snapshot!(bytes, @r###"b"{\"errors\":[{\"detail\":\"Internal Server Error\"}]}""###);
+        "#);
+        assert_debug_snapshot!(bytes, @r#"b"{\"errors\":[{\"detail\":\"Internal Server Error\"}]}""#);
 
         let (parts, bytes) = request("/500").await.unwrap();
         assert_eq!(parts.status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_debug_snapshot!(parts.headers, @r###"
+        assert_debug_snapshot!(parts.headers, @r#"
         {
             "content-type": "text/plain; charset=utf-8",
             "content-length": "21",
         }
-        "###);
-        assert_debug_snapshot!(bytes, @r###"b"Internal Server Error""###);
+        "#);
+        assert_debug_snapshot!(bytes, @r#"b"Internal Server Error""#);
     }
 
     #[tokio::test]

--- a/src/models/default_versions.rs
+++ b/src/models/default_versions.rs
@@ -210,7 +210,7 @@ mod tests {
 
         versions.sort();
 
-        assert_snapshot!(format_versions(&versions), @r#"
+        assert_snapshot!(format_versions(&versions), @r"
         1.1.1-beta.1 (yanked)
         1.0.1 (yanked)
         1.1.1 (yanked)
@@ -222,7 +222,7 @@ mod tests {
         1.0.2
         1.0.3
         1.1.0
-        "#);
+        ");
     }
 
     fn format_versions(versions: &[Version]) -> String {

--- a/src/snapshots/crates_io__index__tests__index_metadata-2.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/index.rs
 expression: metadata
+snapshot_kind: text
 ---
 [
   {

--- a/src/snapshots/crates_io__index__tests__index_metadata.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata.snap
@@ -1,6 +1,7 @@
 ---
 source: src/index.rs
 expression: metadata
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -13,7 +13,7 @@ async fn anonymous_user_unauthorized() {
     let response: Response<()> = anon.get(URL).await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -24,7 +24,7 @@ async fn token_auth_cannot_find_token() {
     let response: Response<()> = anon.run(request).await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"authentication failed"}]}"#);
 }
 
 // Ensure that an unexpected authentication error is available for logging.  The user would see

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -24,10 +24,10 @@ async fn test_dump_db_job() {
 
     app.run_pending_background_jobs().await;
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     db-dump.tar.gz
     db-dump.zip
-    "###);
+    ");
 
     let path = object_store::path::Path::parse("db-dump.tar.gz").unwrap();
     let result = app.as_inner().storage.as_inner().get(&path).await.unwrap();
@@ -37,7 +37,7 @@ async fn test_dump_db_job() {
     let mut tar = Archive::new(gz);
 
     let paths = tar_paths(&mut tar);
-    assert_debug_snapshot!(paths, @r###"
+    assert_debug_snapshot!(paths, @r#"
     [
         "YYYY-MM-DD-HHMMSS",
         "YYYY-MM-DD-HHMMSS/README.md",
@@ -62,7 +62,7 @@ async fn test_dump_db_job() {
         "YYYY-MM-DD-HHMMSS/data/dependencies.csv",
         "YYYY-MM-DD-HHMMSS/data/version_downloads.csv",
     ]
-    "###);
+    "#);
 
     let path = object_store::path::Path::parse("db-dump.zip").unwrap();
     let result = app.as_inner().storage.as_inner().get(&path).await.unwrap();
@@ -70,7 +70,7 @@ async fn test_dump_db_job() {
 
     let archive = zip::ZipArchive::new(Cursor::new(bytes)).unwrap();
     let zip_paths = archive.file_names().collect::<Vec<_>>();
-    assert_debug_snapshot!(zip_paths, @r###"
+    assert_debug_snapshot!(zip_paths, @r#"
     [
         "README.md",
         "export.sql",
@@ -94,7 +94,7 @@ async fn test_dump_db_job() {
         "data/dependencies.csv",
         "data/version_downloads.csv",
     ]
-    "###);
+    "#);
 }
 
 fn tar_paths<R: Read>(archive: &mut Archive<R>) -> Vec<String> {

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -41,19 +41,19 @@ async fn test_unauthenticated_requests() {
         .get::<()>(&format!("/api/v1/crates/{CRATE_NAME}/following"))
         .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 
     let response = anon
         .put::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"), b"" as &[u8])
         .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 
     let response = anon
         .delete::<()>(&format!("/api/v1/crates/{CRATE_NAME}/follow"))
         .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -96,19 +96,19 @@ async fn test_unknown_crate() {
         .get::<()>("/api/v1/crates/unknown-crate/following")
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"#);
 
     let response = user
         .put::<()>("/api/v1/crates/unknown-crate/follow", b"" as &[u8])
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"#);
 
     let response = user
         .delete::<()>("/api/v1/crates/unknown-crate/follow")
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown-crate` does not exist"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -16,7 +16,7 @@ async fn new_wrong_token() {
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
     let response = anon.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 
     // Try to publish with the wrong token (by changing the token in the database)
     diesel::update(api_tokens::table)
@@ -28,7 +28,7 @@ async fn new_wrong_token() {
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"authentication failed"}]}"#);
     assert_that!(app.stored_files().await, empty());
     assert_that!(app.emails(), empty());
 }

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -23,13 +23,13 @@ async fn new_krate() {
     let crates = app.crates_from_index_head("foo_new");
     assert_json_snapshot!(crates);
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_new/foo_new-1.0.0.crate
     index/fo/o_/foo_new
     rss/crates.xml
     rss/crates/foo_new.xml
     rss/updates.xml
-    "###);
+    ");
 
     let email: String = versions_published_by::table
         .select(versions_published_by::email)
@@ -53,13 +53,13 @@ async fn new_krate_with_token() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_new/foo_new-1.0.0.crate
     index/fo/o_/foo_new
     rss/crates.xml
     rss/crates/foo_new.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -74,13 +74,13 @@ async fn new_krate_weird_version() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_weird/foo_weird-0.0.0-pre.crate
     index/fo/o_/foo_weird
     rss/crates.xml
     rss/crates/foo_weird.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -102,14 +102,14 @@ async fn new_krate_twice() {
     let crates = app.crates_from_index_head("foo_twice");
     assert_json_snapshot!(crates);
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_twice/foo_twice-0.99.0.crate
     crates/foo_twice/foo_twice-2.0.0.crate
     index/fo/o_/foo_twice
     rss/crates.xml
     rss/crates/foo_twice.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 // This is similar to the `new_krate_twice` case, but the versions are published in reverse order.
@@ -133,14 +133,14 @@ async fn new_krate_twice_alt() {
     let crates = app.crates_from_index_head("foo_twice");
     assert_json_snapshot!(crates);
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_twice/foo_twice-0.99.0.crate
     crates/foo_twice/foo_twice-2.0.0.crate
     index/fo/o_/foo_twice
     rss/crates.xml
     rss/crates/foo_twice.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -257,7 +257,7 @@ async fn new_krate_with_wildcard_dependency() {
 
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r##"{"errors":[{"detail":"wildcard (`*`) dependency constraints are not allowed on crates.io. Crate with this problem: `foo_wild` See https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies for more information"}]}"##);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"wildcard (`*`) dependency constraints are not allowed on crates.io. Crate with this problem: `foo_wild` See https://doc.rust-lang.org/cargo/faq.html#can-libraries-use--as-a-version-for-their-dependencies for more information"}]}"#);
     assert_that!(app.stored_files().await, empty());
 }
 
@@ -330,7 +330,7 @@ async fn test_dep_limit() {
 
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crates.io only allows a maximum number of 1 dependencies.\n\nIf you have a use case that requires an increase of this limit, please send us an email to help@crates.io to discuss the details."}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crates.io only allows a maximum number of 1 dependencies.\n\nIf you have a use case that requires an increase of this limit, please send us an email to help@crates.io to discuss the details."}]}"#);
 
     let crate_to_publish =
         PublishBuilder::new("foo", "1.0.0").dependency(DependencyBuilder::new("dep-a"));

--- a/src/tests/krate/publish/git.rs
+++ b/src/tests/krate/publish/git.rs
@@ -11,11 +11,11 @@ async fn new_krate_git_upload_with_conflicts() {
     let crate_to_publish = PublishBuilder::new("foo_conflicts", "1.0.0");
     token.publish_crate(crate_to_publish).await.good();
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_conflicts/foo_conflicts-1.0.0.crate
     index/fo/o_/foo_conflicts
     rss/crates.xml
     rss/crates/foo_conflicts.xml
     rss/updates.xml
-    "###);
+    ");
 }

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -49,13 +49,13 @@ async fn tarball_between_default_axum_limit_and_max_upload_size() {
         ".crate.created_at" => "[datetime]",
         ".crate.updated_at" => "[datetime]",
     });
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo/foo-1.1.0.crate
     index/3/f/foo
     rss/crates.xml
     rss/crates/foo.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -143,10 +143,10 @@ async fn new_krate_too_big_but_whitelisted() {
 
     token.publish_crate(crate_to_publish).await.good();
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_whitelist/foo_whitelist-1.1.0.crate
     index/fo/o_/foo_whitelist
     rss/crates/foo_whitelist.xml
     rss/updates.xml
-    "###);
+    ");
 }

--- a/src/tests/krate/publish/rate_limit.rs
+++ b/src/tests/krate/publish/rate_limit.rs
@@ -71,13 +71,13 @@ async fn publish_new_crate_ratelimit_expires() {
     let crate_to_publish = PublishBuilder::new("rate_limited", "1.0.0");
     token.publish_crate(crate_to_publish).await.good();
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited/rate_limited-1.0.0.crate
     index/ra/te/rate_limited
     rss/crates.xml
     rss/crates/rate_limited.xml
     rss/updates.xml
-    "###);
+    ");
 
     let json = anon.show_crate("rate_limited").await;
     assert_eq!(json.krate.max_version, "1.0.0");
@@ -111,13 +111,13 @@ async fn publish_new_crate_override_loosens_ratelimit() {
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
     token.publish_crate(crate_to_publish).await.good();
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     index/ra/te/rate_limited1
     rss/crates.xml
     rss/crates/rate_limited1.xml
     rss/updates.xml
-    "###);
+    ");
 
     let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
@@ -125,7 +125,7 @@ async fn publish_new_crate_override_loosens_ratelimit() {
     let crate_to_publish = PublishBuilder::new("rate_limited2", "1.0.0");
     token.publish_crate(crate_to_publish).await.good();
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     crates/rate_limited2/rate_limited2-1.0.0.crate
     index/ra/te/rate_limited1
@@ -134,7 +134,7 @@ async fn publish_new_crate_override_loosens_ratelimit() {
     rss/crates/rate_limited1.xml
     rss/crates/rate_limited2.xml
     rss/updates.xml
-    "###);
+    ");
 
     let json = anon.show_crate("rate_limited2").await;
     assert_eq!(json.krate.max_version, "1.0.0");
@@ -145,7 +145,7 @@ async fn publish_new_crate_override_loosens_ratelimit() {
         .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     crates/rate_limited2/rate_limited2-1.0.0.crate
     index/ra/te/rate_limited1
@@ -154,7 +154,7 @@ async fn publish_new_crate_override_loosens_ratelimit() {
     rss/crates/rate_limited1.xml
     rss/crates/rate_limited2.xml
     rss/updates.xml
-    "###);
+    ");
 
     let response = anon.get::<()>("/api/v1/crates/rate_limited3").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -189,13 +189,13 @@ async fn publish_new_crate_expired_override_ignored() {
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
     token.publish_crate(crate_to_publish).await.good();
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     index/ra/te/rate_limited1
     rss/crates.xml
     rss/crates/rate_limited1.xml
     rss/updates.xml
-    "###);
+    ");
 
     let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
@@ -206,13 +206,13 @@ async fn publish_new_crate_expired_override_ignored() {
         .await
         .assert_rate_limited(LimitedAction::PublishNew);
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     index/ra/te/rate_limited1
     rss/crates.xml
     rss/crates/rate_limited1.xml
     rss/updates.xml
-    "###);
+    ");
 
     let response = anon.get::<()>("/api/v1/crates/rate_limited2").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -246,13 +246,13 @@ async fn publish_existing_crate_rate_limited() {
 
     let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.0");
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     index/ra/te/rate_limited1
     rss/crates.xml
     rss/crates/rate_limited1.xml
     rss/updates.xml
-    "###);
+    ");
 
     // Uploading the first update to the crate works
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.1");
@@ -260,14 +260,14 @@ async fn publish_existing_crate_rate_limited() {
 
     let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.1");
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     crates/rate_limited1/rate_limited1-1.0.1.crate
     index/ra/te/rate_limited1
     rss/crates.xml
     rss/crates/rate_limited1.xml
     rss/updates.xml
-    "###);
+    ");
 
     // Uploading the second update to the crate is rate limited
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.2");
@@ -279,14 +279,14 @@ async fn publish_existing_crate_rate_limited() {
     // Check that  version 1.0.2 was not published
     let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.1");
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     crates/rate_limited1/rate_limited1-1.0.1.crate
     index/ra/te/rate_limited1
     rss/crates.xml
     rss/crates/rate_limited1.xml
     rss/updates.xml
-    "###);
+    ");
 
     // Wait for the limit to be up
     thread::sleep(RATE_LIMIT);
@@ -296,7 +296,7 @@ async fn publish_existing_crate_rate_limited() {
 
     let json = anon.show_crate("rate_limited1").await;
     assert_eq!(json.krate.max_version, "1.0.2");
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/rate_limited1/rate_limited1-1.0.0.crate
     crates/rate_limited1/rate_limited1-1.0.1.crate
     crates/rate_limited1/rate_limited1-1.0.2.crate
@@ -304,7 +304,7 @@ async fn publish_existing_crate_rate_limited() {
     rss/crates.xml
     rss/crates/rate_limited1.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -15,14 +15,14 @@ async fn new_krate_with_readme() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_readme/foo_readme-1.0.0.crate
     index/fo/o_/foo_readme
     readmes/foo_readme/foo_readme-1.0.0.html
     rss/crates.xml
     rss/crates/foo_readme.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -37,13 +37,13 @@ async fn new_krate_with_empty_readme() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_readme/foo_readme-1.0.0.crate
     index/fo/o_/foo_readme
     rss/crates.xml
     rss/crates/foo_readme.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -58,14 +58,14 @@ async fn new_krate_with_readme_and_plus_version() {
         ".crate.updated_at" => "[datetime]",
     });
 
-    assert_snapshot!(app.stored_files().await.join("\n"), @r###"
+    assert_snapshot!(app.stored_files().await.join("\n"), @r"
     crates/foo_readme/foo_readme-1.0.0+foo.crate
     index/fo/o_/foo_readme
     readmes/foo_readme/foo_readme-1.0.0+foo.html
     rss/crates.xml
     rss/crates/foo_readme.xml
     rss/updates.xml
-    "###);
+    ");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-4.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-4.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/categories.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_sorts_deps.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_sorts_deps.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_with_dependency.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_with_dependency.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_renamed_dependency.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_renamed_dependency.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_underscore_renamed_dependency.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_underscore_renamed_dependency.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_start_with_number_and_underscore.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_start_with_number_and_underscore.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_dot.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_dot.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_unicode_chars.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_unicode_chars.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__features_version_2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__features_version_2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/keywords.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/links.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/links.rs
 expression: crates
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/links.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/max_size.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/readme.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/readme.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/readme.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-10.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-10.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-4.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-4.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-5.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-5.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-6.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-6.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-7.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-7.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-8.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-8.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-9.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-9.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -95,7 +95,7 @@ async fn long_description() {
 
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"The `description` is too long. A maximum of 1000 characters are currently allowed."}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"The `description` is too long. A maximum of 1000 characters are currently allowed."}]}"#);
 
     assert_that!(app.stored_files().await, empty());
 }
@@ -108,7 +108,7 @@ async fn invalid_license() {
         .publish_crate(PublishBuilder::new("foo", "1.0.0").license("MIT AND foobar"))
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r##"{"errors":[{"detail":"unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers\nNote: If you have a non-standard license that is not listed by SPDX, use the license-file field to specify the path to a file containing the text of the license.\nSee https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.\nMIT AND foobar\n        ^^^^^^ unknown term"}]}"##);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"unknown or invalid license expression; see http://opensource.org/licenses for options, and http://spdx.org/licenses/ for their identifiers\nNote: If you have a non-standard license that is not listed by SPDX, use the license-file field to specify the path to a file containing the text of the license.\nSee https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields for more information.\nMIT AND foobar\n        ^^^^^^ unknown term"}]}"#);
     assert_that!(app.stored_files().await, empty());
 }
 

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-2.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-3.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-4.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-4.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-5.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-5.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-6.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-6.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -376,15 +376,15 @@ async fn test_unknown_crate() {
 
     let response = user.get::<()>("/api/v1/crates/unknown/owners").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown` does not exist"}]}"#);
 
     let response = user.get::<()>("/api/v1/crates/unknown/owner_team").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown` does not exist"}]}"#);
 
     let response = user.get::<()>("/api/v1/crates/unknown/owner_user").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown` does not exist"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__get__show.snap
+++ b/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__get__show.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/categories/get.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "category": {

--- a/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index-2.snap
+++ b/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/categories/list.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "categories": [

--- a/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index.snap
+++ b/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/categories/list.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "categories": [],

--- a/src/tests/routes/category_slugs/snapshots/crates_io__tests__routes__category_slugs__list__category_slugs_returns_all_slugs_in_alphabetical_order.snap
+++ b/src/tests/routes/category_slugs/snapshots/crates_io__tests__routes__category_slugs__list__category_slugs_returns_all_slugs_in_alphabetical_order.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/category_slugs/list.rs
 expression: response
+snapshot_kind: text
 ---
 {
   "category_slugs": [

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -142,7 +142,7 @@ async fn test_crate_downloads() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(
         response.text(),
-        @r###"{"errors":[{"detail":"crate `bar` does not exist"}]}"###
+        @r#"{"errors":[{"detail":"crate `bar` does not exist"}]}"#
     );
 
     // check non-canonical crate name
@@ -182,7 +182,7 @@ async fn test_version_downloads() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(
         response.text(),
-        @r###"{"errors":[{"detail":"crate `bar` does not exist"}]}"###
+        @r#"{"errors":[{"detail":"crate `bar` does not exist"}]}"#
     );
 
     // check non-canonical crate name
@@ -195,7 +195,7 @@ async fn test_version_downloads() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(
         response.text(),
-        @r###"{"errors":[{"detail":"crate `foo` does not have a version `2.0.0`"}]}"###
+        @r#"{"errors":[{"detail":"crate `foo` does not have a version `2.0.0`"}]}"#
     );
 
     // check invalid version
@@ -205,6 +205,6 @@ async fn test_version_downloads() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     assert_snapshot!(
         response.text(),
-        @r###"{"errors":[{"detail":"crate `foo` does not have a version `invalid-version`"}]}"###
+        @r#"{"errors":[{"detail":"crate `foo` does not have a version `invalid-version`"}]}"#
     );
 }

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -140,7 +140,7 @@ async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -160,7 +160,7 @@ async fn owner_change_via_publish_token() {
     let body = serde_json::to_vec(&body).unwrap();
     let response = token.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -178,7 +178,7 @@ async fn owner_change_without_auth() {
     let body = serde_json::to_vec(&body).unwrap();
     let response = anon.put::<()>(&url, body).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -194,7 +194,7 @@ async fn test_owner_change_with_legacy_field() {
         .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::OK);
-    assert_snapshot!(response.text(), @r###"{"msg":"user user2 has been invited to be an owner of crate foo","ok":true}"###);
+    assert_snapshot!(response.text(), @r#"{"msg":"user user2 has been invited to be an owner of crate foo","ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -211,7 +211,7 @@ async fn test_owner_change_with_invalid_json() {
         .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"#);
 
     // `owners` is not an array
     let input = r#"{"owners": "foo"}"#;
@@ -219,7 +219,7 @@ async fn test_owner_change_with_invalid_json() {
         .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"#);
 
     // missing `owners` and/or `users` fields
     let input = r#"{}"#;
@@ -227,7 +227,7 @@ async fn test_owner_change_with_invalid_json() {
         .put::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -299,7 +299,7 @@ async fn test_unknown_crate() {
 
     let response = user.put::<()>("/api/v1/crates/unknown/owners", body).await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown` does not exist"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -312,7 +312,7 @@ async fn test_unknown_user() {
     let body = serde_json::to_vec(&json!({ "owners": ["unknown"] })).unwrap();
     let response = cookie.put::<()>("/api/v1/crates/foo/owners", body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find user with login `unknown`"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find user with login `unknown`"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -325,7 +325,7 @@ async fn test_unknown_team() {
     let body = serde_json::to_vec(&json!({ "owners": ["github:unknown:unknown"] })).unwrap();
     let response = cookie.put::<()>("/api/v1/crates/foo/owners", body).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find the github team unknown/unknown. Make sure that you have the right permissions in GitHub. See https://doc.rust-lang.org/cargo/reference/publishing.html#github-permissions"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find the github team unknown/unknown. Make sure that you have the right permissions in GitHub. See https://doc.rust-lang.org/cargo/reference/publishing.html#github-permissions"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -17,7 +17,7 @@ async fn test_owner_change_with_invalid_json() {
         .delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to parse the request body as JSON: owners[1]: expected value at line 1 column 20"}]}"#);
 
     // `owners` is not an array
     let input = r#"{"owners": "foo"}"#;
@@ -25,7 +25,7 @@ async fn test_owner_change_with_invalid_json() {
         .delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: owners: invalid type: string \"foo\", expected a sequence at line 1 column 16"}]}"#);
 
     // missing `owners` and/or `users` fields
     let input = r#"{}"#;
@@ -33,7 +33,7 @@ async fn test_owner_change_with_invalid_json() {
         .delete_with_body::<()>("/api/v1/crates/foo/owners", input.as_bytes())
         .await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `owners` at line 1 column 2"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -48,7 +48,7 @@ async fn test_unknown_crate() {
         .delete_with_body::<()>("/api/v1/crates/unknown/owners", body)
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown` does not exist"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -63,7 +63,7 @@ async fn test_unknown_user() {
         .delete_with_body::<()>("/api/v1/crates/foo/owners", body)
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find user with login `unknown`"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find user with login `unknown`"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -78,5 +78,5 @@ async fn test_unknown_team() {
         .delete_with_body::<()>("/api/v1/crates/foo/owners", body)
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"could not find team with login `github:unknown:unknown`"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find team with login `github:unknown:unknown`"}]}"#);
 }

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -107,7 +107,7 @@ async fn test_missing() {
 
     let response = anon.get::<()>("/api/v1/crates/missing").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `missing` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `missing` does not exist"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -234,5 +234,5 @@ async fn test_unknown_crate() {
         .get::<()>("/api/v1/crates/unknown/reverse_dependencies")
         .await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown` does not exist"}]}"#);
 }

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__crate_downloads.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__crate_downloads.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/downloads.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "meta": {

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__version_downloads.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__version_downloads.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/downloads.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version_downloads": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-2.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-3.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-4.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-4.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-5.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-5.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "categories": null,

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "categories": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_all_yanked.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_all_yanked.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "categories": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "categories": null,

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_depended_but_new_doesnt.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_depended_but_new_doesnt.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -42,7 +42,7 @@ async fn test_unknown_crate() {
 
     let response = anon.get::<()>("/api/v1/crates/unknown/versions").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"crate `unknown` does not exist"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `unknown` does not exist"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__authors__authors.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__authors__authors.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/versions/authors.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "meta": {

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__list__versions.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__list__versions.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/versions/list.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "versions": [

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/versions/read.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/crates/versions/read.rs
 expression: json
+snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -163,12 +163,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
         assert!(!is_yanked(&app).await);
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
         assert!(!is_yanked(&app).await);
     }
 
@@ -232,12 +232,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"authentication failed"}]}"#);
         assert!(!is_yanked(&app).await);
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"authentication failed"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"authentication failed"}]}"#);
         assert!(!is_yanked(&app).await);
     }
 
@@ -270,12 +270,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
         assert!(!is_yanked(&app).await);
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
         assert!(!is_yanked(&app).await);
     }
 
@@ -334,12 +334,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
         assert!(!is_yanked(&app).await);
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
         assert!(!is_yanked(&app).await);
     }
 
@@ -355,12 +355,12 @@ mod auth {
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
         assert!(!is_yanked(&app).await);
 
         let response = client.unyank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
-        assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"###);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this token does not have the required permissions to perform this action"}]}"#);
         assert!(!is_yanked(&app).await);
     }
 

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -24,7 +24,7 @@ async fn me() {
 
     let response = anon.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 
     let response = user.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-2.snap
+++ b/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/get.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "owned_crates": [],

--- a/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-3.snap
+++ b/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/get.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "owned_crates": [

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -45,7 +45,7 @@ async fn revoke_current_token_without_auth() {
 
     let response = anon.delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/get.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show_token_with_scopes.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/get.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__list__list_tokens.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__list__list_tokens.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/me/tokens/list.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "api_tokens": [

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -55,7 +55,7 @@ async fn test_ignore_empty() {
     let payload = json!({"user": {}});
     let response = user.put::<()>(&url, payload.to_string()).await;
     assert_eq!(response.status(), StatusCode::OK);
-    assert_snapshot!(response.text(), @r###"{"ok":true}"###);
+    assert_snapshot!(response.text(), @r#"{"ok":true}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -67,7 +67,7 @@ async fn test_ignore_nulls() {
     let payload = json!({"user": { "email": null }});
     let response = user.put::<()>(&url, payload.to_string()).await;
     assert_eq!(response.status(), StatusCode::OK);
-    assert_snapshot!(response.text(), @r###"{"ok":true}"###);
+    assert_snapshot!(response.text(), @r#"{"ok":true}"#);
 }
 
 /// Check to make sure that neither other signed in users nor anonymous users can edit another
@@ -97,7 +97,7 @@ async fn test_other_users_cannot_change_my_email() {
         )
         .await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"this action requires authentication"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -107,7 +107,7 @@ async fn test_invalid_email_address() {
 
     let response = user.update_email_more_control(model.id, Some("foo")).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"invalid email address"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid email address"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -118,5 +118,5 @@ async fn test_invalid_json() {
     let url = format!("/api/v1/users/{}", model.id);
     let response = user.put::<()>(&url, r#"{ "user": foo }"#).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"Failed to parse the request body as JSON: user: expected ident at line 1 column 12"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to parse the request body as JSON: user: expected ident at line 1 column 12"}]}"#);
 }

--- a/src/tests/routes/users/update/publish_notifications.rs
+++ b/src/tests/routes/users/update/publish_notifications.rs
@@ -21,7 +21,7 @@ async fn test_unsubscribe_and_resubscribe() {
     let payload = json!({"user": { "publish_notifications": false }});
     let response = cookie.put::<()>(&user_url, payload.to_string()).await;
     assert_eq!(response.status(), StatusCode::OK);
-    assert_snapshot!(response.text(), @r###"{"ok":true}"###);
+    assert_snapshot!(response.text(), @r#"{"ok":true}"#);
 
     // Assert that the user gets an unsubscribe email
     assert_snapshot!(app.emails_snapshot());
@@ -38,7 +38,7 @@ async fn test_unsubscribe_and_resubscribe() {
     let payload = json!({"user": { "publish_notifications": true }});
     let response = cookie.put::<()>(&user_url, payload.to_string()).await;
     assert_eq!(response.status(), StatusCode::OK);
-    assert_snapshot!(response.text(), @r###"{"ok":true}"###);
+    assert_snapshot!(response.text(), @r#"{"ok":true}"#);
 
     // Publish the same crate again to check that the user doesn't get a publish email
     let pb = PublishBuilder::new("foo", "1.2.0");

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-3.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-4.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-4.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-6.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-6.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_revoked_token.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_revoked_token.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: response.json()
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_unknown_token.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_unknown_token.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: response.json()
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token-2.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: response.json()
+snapshot_kind: text
 ---
 [
   {

--- a/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners-6.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners-6.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: user2@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: user2@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__owners__new_crate_owner-2.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__new_crate_owner-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__new_crate_owner.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
+++ b/src/tests/snapshots/crates_io__tests__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/read_only_mode.rs
 expression: response.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__block_traffic_via_arbitrary_header_and_value.snap
+++ b/src/tests/snapshots/crates_io__tests__server__block_traffic_via_arbitrary_header_and_value.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__block_traffic_via_ip.snap
+++ b/src/tests/snapshots/crates_io__tests__server__block_traffic_via_ip.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__user_agent_is_required-2.snap
+++ b/src/tests/snapshots/crates_io__tests__server__user_agent_is_required-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__user_agent_is_required.snap
+++ b/src/tests/snapshots/crates_io__tests__server__user_agent_is_required.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
+snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__team__publish_owned.snap
+++ b/src/tests/snapshots/crates_io__tests__team__publish_owned.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/team.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: user-all-teams@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -77,7 +77,7 @@ async fn add_nonexistent_team() {
         .add_named_owner("foo_add_nonexistent", "github:test-org:this-does-not-exist")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r##"{"errors":[{"detail":"could not find the github team test-org/this-does-not-exist. Make sure that you have the right permissions in GitHub. See https://doc.rust-lang.org/cargo/reference/publishing.html#github-permissions"}]}"##);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find the github team test-org/this-does-not-exist. Make sure that you have the right permissions in GitHub. See https://doc.rust-lang.org/cargo/reference/publishing.html#github-permissions"}]}"#);
 }
 
 /// Test adding a renamed team

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/worker/rss/sync_crates_feed.rs
 expression: content
+snapshot_kind: text
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:crates="https://crates.io/">

--- a/src/tests/worker/snapshots/crates_io__tests__worker__sync_admins__sync_admins_job.snap
+++ b/src/tests/worker/snapshots/crates_io__tests__worker__sync_admins__sync_admins_job.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/worker/sync_admins.rs
 expression: app.emails_snapshot()
+snapshot_kind: text
 ---
 To: existing-admin@crates.io
 From: crates.io <noreply@crates.io>

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -304,11 +304,11 @@ mod tests {
 
         let csv_path = tempdir.path().join("2021-01-02.csv");
         let content = std::fs::read_to_string(csv_path).unwrap();
-        assert_snapshot!(content, @r###"
+        assert_snapshot!(content, @r"
         version_id,downloads
         1,200
         2,500
-        "###);
+        ");
     }
 
     #[tokio::test]
@@ -335,20 +335,20 @@ mod tests {
         let store_path = object_store::path::Path::from("2021-01-01.csv");
         let result = store.get(&store_path).await.unwrap();
         let bytes = result.bytes().await.unwrap();
-        assert_snapshot!(std::str::from_utf8(&bytes).unwrap(), @r###"
+        assert_snapshot!(std::str::from_utf8(&bytes).unwrap(), @r"
         version_id,downloads
         1,100
         2,400
-        "###);
+        ");
 
         let store_path = object_store::path::Path::from("2021-01-02.csv");
         let result = store.get(&store_path).await.unwrap();
         let bytes = result.bytes().await.unwrap();
-        assert_snapshot!(std::str::from_utf8(&bytes).unwrap(), @r###"
+        assert_snapshot!(std::str::from_utf8(&bytes).unwrap(), @r"
         version_id,downloads
         1,200
         2,500
-        "###);
+        ");
 
         let store_path = object_store::path::Path::from("2021-01-03.csv");
         assert_err!(store.get(&store_path).await);

--- a/src/worker/jobs/downloads/clean_processed_log_files.rs
+++ b/src/worker/jobs/downloads/clean_processed_log_files.rs
@@ -64,7 +64,7 @@ mod tests {
             ("future-file", now + one_hour * 7 * 24),
         ];
         insert(&mut conn, inserts).await;
-        assert_debug_snapshot!(paths_in_table(&mut conn).await, @r###"
+        assert_debug_snapshot!(paths_in_table(&mut conn).await, @r#"
         [
             "very-old-file",
             "old-file",
@@ -72,16 +72,16 @@ mod tests {
             "brand-new-file",
             "future-file",
         ]
-        "###);
+        "#);
 
         run(&mut conn).await.unwrap();
-        assert_debug_snapshot!(paths_in_table(&mut conn).await, @r###"
+        assert_debug_snapshot!(paths_in_table(&mut conn).await, @r#"
         [
             "newish-file",
             "brand-new-file",
             "future-file",
         ]
-        "###);
+        "#);
     }
 
     /// Insert a list of paths and times into the `processed_log_files` table.

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -308,7 +308,7 @@ mod tests {
         assert_ok!(run(&queue, 100, &connection_pool).await);
 
         assert_snapshot!(deleted_handles.lock().join(","), @"1,2,3,4,5,6,7,8,9,10,11");
-        assert_snapshot!(open_jobs(&mut connection_pool.get().await.unwrap()).await, @r###"
+        assert_snapshot!(open_jobs(&mut connection_pool.get().await.unwrap()).await, @r"
         us-west-1 | bucket | path1
         us-west-1 | bucket | path2
         us-west-1 | bucket | path3
@@ -320,7 +320,7 @@ mod tests {
         us-west-1 | bucket | path9
         us-west-1 | bucket | path10
         us-west-1 | bucket | path11
-        "###);
+        ");
     }
 
     #[tokio::test]

--- a/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-2.snap
+++ b/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/downloads/queue/message.rs
 expression: event
+snapshot_kind: text
 ---
 Message {
     records: [

--- a/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-3.snap
+++ b/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/downloads/queue/message.rs
 expression: event
+snapshot_kind: text
 ---
 Message {
     records: [

--- a/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse.snap
+++ b/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/downloads/queue/message.rs
 expression: event
+snapshot_kind: text
 ---
 Message {
     records: [],

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
+snapshot_kind: text
 ---
 <!DOCTYPE HTML>
 <html>

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html_empty.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html_empty.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
+snapshot_kind: text
 ---
 <!DOCTYPE HTML>
 <html>

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json.snap
@@ -1,5 +1,6 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
+snapshot_kind: text
 ---
 [{"name":"2024-08-01.csv","size":138},{"name":"2024-07-31.csv","size":123},{"name":"2024-07-30.csv","size":124},{"name":"2024-07-29.csv","size":234}]

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json_empty.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json_empty.snap
@@ -1,5 +1,6 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
+snapshot_kind: text
 ---
 [{"name":"2024-08-01.csv","size":138},{"name":"2024-07-31.csv","size":123},{"name":"2024-07-30.csv","size":124},{"name":"2024-07-29.csv","size":234}]

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__template_context.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__template_context.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
-expression: context.to_html()?
+expression: files.to_html()?
+snapshot_kind: text
 ---
 <!DOCTYPE HTML>
 <html>

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-2.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/rss/sync_crates_feed.rs
 expression: "new_crates.iter().map(|u| &u.name).collect::<Vec<_>>()"
+snapshot_kind: text
 ---
 [
     "crate-50",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-3.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-3.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/rss/sync_crates_feed.rs
 expression: "new_crates.iter().map(|u| &u.name).collect::<Vec<_>>()"
+snapshot_kind: text
 ---
 [
     "other-crate-60",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates.snap
@@ -1,6 +1,7 @@
 ---
 source: src/worker/jobs/rss/sync_crates_feed.rs
 expression: "new_crates.iter().map(|u| &u.name).collect::<Vec<_>>()"
+snapshot_kind: text
 ---
 [
     "qux",


### PR DESCRIPTION
`cargo-insta` changed a few minor serialization details. This commit is the result of `cargo insta test --all --force-update-snapshots --unreferenced delete` to update the existing snapshots. This avoids unrelated changes in future pull requests that actually change snapshot contents.