### PR TITLE
Fix owner removal for duplicate logins

### DIFF
--- a/src/models/owner.rs
+++ b/src/models/owner.rs
@@ -79,26 +79,6 @@ impl Owner {
         }
     }
 
-    /// Finds the owner by name. Never recreates a team, to ensure that
-    /// organizations that were deleted after they were added can still be
-    /// removed.
-    ///
-    /// May be a user's GH login or a full team name. This is case
-    /// sensitive.
-    pub fn find_by_login(conn: &mut impl Conn, name: &str) -> AppResult<Owner> {
-        if name.contains(':') {
-            Team::find_by_login(conn, name)
-                .optional()?
-                .map(Owner::Team)
-                .ok_or_else(|| bad_request(format_args!("could not find team with login `{name}`")))
-        } else {
-            User::find_by_login(conn, name)
-                .optional()?
-                .map(Owner::User)
-                .ok_or_else(|| bad_request(format_args!("could not find user with login `{name}`")))
-        }
-    }
-
     pub fn kind(&self) -> i32 {
         match self {
             Owner::User(_) => OwnerKind::User as i32,

--- a/src/tests/issues/issue1205.rs
+++ b/src/tests/issues/issue1205.rs
@@ -41,7 +41,7 @@ async fn test_issue_1205() -> anyhow::Result<()> {
         .remove_named_owner(CRATE_NAME, "github:rustaudio:owners")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find team with login `github:rustaudio:owners`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `github:rustaudio:owners`"}]}"#);
 
     Ok(())
 }

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -1,0 +1,66 @@
+use crate::models::{CrateOwner, OwnerKind};
+use crate::tests::builders::CrateBuilder;
+use crate::tests::util::{RequestHelper, TestApp};
+use crates_io_database::schema::{crate_owners, users};
+use diesel::prelude::*;
+use http::StatusCode;
+use insta::assert_snapshot;
+
+/// See <https://github.com/rust-lang/crates.io/issues/2736>.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_issue_2736() -> anyhow::Result<()> {
+    let (app, _) = TestApp::full().empty();
+    let mut conn = app.db_conn();
+
+    // - A user had a GitHub account named, let's say, `foo`
+    let foo1 = app.db_new_user("foo");
+
+    // - Another user `someone_else` added them as an owner of a crate
+    let someone_else = app.db_new_user("someone_else");
+
+    let krate = CrateBuilder::new("crate1", someone_else.as_model().id).expect_build(&mut conn);
+
+    diesel::insert_into(crate_owners::table)
+        .values(CrateOwner {
+            crate_id: krate.id,
+            owner_id: foo1.as_model().id,
+            created_by: someone_else.as_model().id,
+            owner_kind: OwnerKind::User,
+            email_notifications: true,
+        })
+        .execute(&mut conn)?;
+
+    // - `foo` deleted their GitHub account (but crates.io has no real knowledge of this)
+    // - `foo` recreated their GitHub account with the same username (because it was still available), but in this situation GitHub assigns them a new ID
+    // - When `foo` now logs in to crates.io, it's a different account than their old `foo` crates.io account because of the new GitHub ID (and if it wasn't, this would be a security problem)
+    let foo2 = app.db_new_user("foo");
+
+    let github_ids = users::table
+        .filter(users::gh_login.eq("foo"))
+        .select(users::gh_id)
+        .load::<i32>(&mut conn)?;
+
+    assert_eq!(github_ids.len(), 2);
+    assert_ne!(github_ids[0], github_ids[1]);
+
+    // - The new `foo` account is NOT an owner of the crate
+    let owners = krate.owners(&mut conn)?;
+    assert_eq!(owners.len(), 2);
+    assert_none!(owners.iter().find(|o| o.id() == foo2.as_model().id));
+
+    // Removing an owner, whether it's valid/current or not, should always work (if performed by another valid owner, etc)
+    let response = someone_else.remove_named_owner("crate1", "foo").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_snapshot!(response.text(), @r#"{"msg":"owners successfully removed","ok":true}"#);
+
+    let owners = krate.owners(&mut conn)?;
+    assert_eq!(owners.len(), 1);
+    assert_eq!(owners[0].id(), someone_else.as_model().id);
+
+    // Once that removal works, it should be possible to add the new account as an owner
+    let response = someone_else.add_named_owner("crate1", "foo").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_snapshot!(response.text(), @r#"{"msg":"user foo has been invited to be an owner of crate crate1","ok":true}"#);
+
+    Ok(())
+}

--- a/src/tests/issues/mod.rs
+++ b/src/tests/issues/mod.rs
@@ -1,1 +1,2 @@
 mod issue1205;
+mod issue2736;

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -58,7 +58,7 @@ async fn test_unknown_user() {
 
     let response = cookie.remove_named_owner("foo", "unknown").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find user with login `unknown`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `unknown`"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -72,7 +72,7 @@ async fn test_unknown_team() {
         .remove_named_owner("foo", "github:unknown:unknown")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find team with login `github:unknown:unknown`"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `github:unknown:unknown`"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -270,13 +270,14 @@ async fn remove_nonexistent_team() {
         .execute(&mut conn)
         .expect("couldn't insert nonexistent team");
 
-    token
+    let response = token
         .remove_named_owner(
             "foo_remove_nonexistent",
             "github:test-org:this-does-not-exist",
         )
-        .await
-        .good();
+        .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"could not find owner with login `github:test-org:this-does-not-exist`"}]}"#);
 }
 
 /// Test trying to publish a crate we don't own


### PR DESCRIPTION
When users or teams on GitHub are deleted and recreated they might exist multiple times within our own database with the same `login`. When owners are deleted, only the newest matching `login` is considered for deletion though, which makes it impossible to delete older users/teams.

This commit fixes the problem by deleting **all** owners with a matching `login` instead.

Unfortunately, `diesel` does not support `UPDATE` queries with `JOINs`, so this has to be a "raw" SQL query with bindings instead…

Fixes #2736, ~~and AFAICT also fixes https://github.com/rust-lang/crates.io/issues/1205~~

Related:

- https://github.com/rust-lang/crates.io/issues/1205
- #2736
- https://github.com/rust-lang/crates.io/issues/1818
- https://github.com/rust-lang/crates.io/issues/1512
- https://github.com/rust-lang/crates.io/pull/7051