### PR TITLE
github: Use mockall to generate `MockGitHubClient` implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "mockall",
  "oauth2",
  "reqwest 0.12.9",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ unicode-xid = "=0.2.6"
 
 [dev-dependencies]
 bytes = "=1.8.0"
+crates_io_github = { path = "crates/crates_io_github", features = ["mock"] }
 crates_io_index = { path = "crates/crates_io_index", features = ["testing"] }
 crates_io_tarball = { path = "crates/crates_io_tarball", features = ["builder"] }
 crates_io_team_repo = { path = "crates/crates_io_team_repo", features = ["mock"] }

--- a/crates/crates_io_github/Cargo.toml
+++ b/crates/crates_io_github/Cargo.toml
@@ -7,9 +7,13 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+mock = ["dep:mockall"]
+
 [dependencies]
 anyhow = "=1.0.93"
 async-trait = "=0.1.83"
+mockall = { version = "=0.13.0", optional = true }
 oauth2 = { version = "=4.4.2", default-features = false }
 reqwest = { version = "=0.12.9", features = ["json"] }
 serde = { version = "=1.0.215", features = ["derive"] }

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -16,6 +16,7 @@ use serde::Deserialize;
 
 type Result<T> = std::result::Result<T, GitHubError>;
 
+#[cfg_attr(feature = "mock", mockall::automock)]
 #[async_trait]
 pub trait GitHubClient: Send + Sync {
     async fn current_user(&self, auth: &AccessToken) -> Result<GithubUser>;

--- a/src/tests/util/github.rs
+++ b/src/tests/util/github.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use crates_io_github::{
-    GitHubError, GitHubOrgMembership, GitHubOrganization, GitHubPublicKey, GitHubTeam,
-    GitHubTeamMembership, GithubUser, MockGitHubClient,
+    GitHubError, GitHubOrgMembership, GitHubOrganization, GitHubTeam, GitHubTeamMembership,
+    GithubUser, MockGitHubClient,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -49,14 +49,6 @@ pub(crate) const MOCK_GITHUB_DATA: MockData = MockData {
             email: "owner@example.com",
         },
     ],
-    // Test key from https://docs.github.com/en/developers/overview/secret-scanning-partner-program#create-a-secret-alert-service
-    public_keys: &[
-        MockPublicKey {
-            key_identifier: "f9525bf080f75b3506ca1ead061add62b8633a346606dc5fe544e29231c6ee0d",
-            key: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsz9ugWDj5jK5ELBK42ynytbo38gP\nHzZFI03Exwz8Lh/tCfL3YxwMdLjB+bMznsanlhK0RwcGP3IDb34kQDIo3Q==\n-----END PUBLIC KEY-----",
-            is_current: true,
-        },
-    ],
 };
 
 impl MockData {
@@ -79,9 +71,6 @@ impl MockData {
 
         mock.expect_org_membership()
             .returning(|org_id, username, _auth| self.org_membership(org_id, username));
-
-        mock.expect_public_keys()
-            .returning(|_username, _password| self.public_keys());
 
         mock
     }
@@ -178,10 +167,6 @@ impl MockData {
             Err(not_found())
         }
     }
-
-    fn public_keys(&self) -> Result<Vec<GitHubPublicKey>, GitHubError> {
-        Ok(self.public_keys.iter().map(Into::into).collect())
-    }
 }
 
 fn not_found() -> GitHubError {
@@ -191,7 +176,6 @@ fn not_found() -> GitHubError {
 pub(crate) struct MockData {
     orgs: &'static [MockOrg],
     users: &'static [MockUser],
-    public_keys: &'static [MockPublicKey],
 }
 
 struct MockUser {
@@ -212,20 +196,4 @@ struct MockTeam {
     id: i32,
     name: &'static str,
     members: &'static [&'static str],
-}
-
-struct MockPublicKey {
-    key_identifier: &'static str,
-    key: &'static str,
-    is_current: bool,
-}
-
-impl From<&'static MockPublicKey> for GitHubPublicKey {
-    fn from(k: &'static MockPublicKey) -> Self {
-        Self {
-            key_identifier: k.key_identifier.to_string(),
-            key: k.key.to_string(),
-            is_current: k.is_current,
-        }
-    }
 }

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -9,7 +9,7 @@ use crate::rate_limiter::{LimitedAction, RateLimiterConfig};
 use crate::schema::users;
 use crate::storage::StorageConfig;
 use crate::tests::util::chaosproxy::ChaosProxy;
-use crate::tests::util::github::{MockGitHubClient, MOCK_GITHUB_DATA};
+use crate::tests::util::github::MOCK_GITHUB_DATA;
 use crate::worker::{Environment, RunnerExt};
 use crate::{App, Emails, Env};
 use crates_io_index::testing::UpstreamIndex;
@@ -494,7 +494,7 @@ fn build_app(config: config::Server) -> (Arc<App>, axum::Router) {
 
     // Use a custom mock for the GitHub client, allowing to define the GitHub users and
     // organizations without actually having to create GitHub accounts.
-    let github = Box::new(MockGitHubClient::new(&MOCK_GITHUB_DATA));
+    let github = Box::new(MOCK_GITHUB_DATA.as_mock_client());
 
     let app = App::new(config, emails, github);
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -12,6 +12,7 @@ use crate::tests::util::chaosproxy::ChaosProxy;
 use crate::tests::util::github::MOCK_GITHUB_DATA;
 use crate::worker::{Environment, RunnerExt};
 use crate::{App, Emails, Env};
+use crates_io_github::MockGitHubClient;
 use crates_io_index::testing::UpstreamIndex;
 use crates_io_index::{Credentials, RepositoryConfig};
 use crates_io_team_repo::MockTeamRepo;
@@ -103,6 +104,7 @@ impl TestApp {
             build_job_runner: false,
             use_chaos_proxy: false,
             team_repo: MockTeamRepo::new(),
+            github: None,
         }
     }
 
@@ -252,6 +254,7 @@ pub struct TestAppBuilder {
     build_job_runner: bool,
     use_chaos_proxy: bool,
     team_repo: MockTeamRepo,
+    github: Option<MockGitHubClient>,
 }
 
 impl TestAppBuilder {
@@ -296,7 +299,7 @@ impl TestAppBuilder {
             (primary_proxy, replica_proxy)
         };
 
-        let (app, router) = build_app(self.config);
+        let (app, router) = build_app(self.config, self.github);
 
         let runner = if self.build_job_runner {
             let index = self
@@ -397,6 +400,11 @@ impl TestAppBuilder {
         self
     }
 
+    pub fn with_github(mut self, github: MockGitHubClient) -> Self {
+        self.github = Some(github);
+        self
+    }
+
     pub fn with_team_repo(mut self, team_repo: MockTeamRepo) -> Self {
         self.team_repo = team_repo;
         self
@@ -487,14 +495,13 @@ fn simple_config() -> config::Server {
     }
 }
 
-fn build_app(config: config::Server) -> (Arc<App>, axum::Router) {
+fn build_app(config: config::Server, github: Option<MockGitHubClient>) -> (Arc<App>, axum::Router) {
     // Use the in-memory email backend for all tests, allowing tests to analyze the emails sent by
     // the application. This will also prevent cluttering the filesystem.
     let emails = Emails::new_in_memory();
 
-    // Use a custom mock for the GitHub client, allowing to define the GitHub users and
-    // organizations without actually having to create GitHub accounts.
-    let github = Box::new(MOCK_GITHUB_DATA.as_mock_client());
+    let github = github.unwrap_or_else(|| MOCK_GITHUB_DATA.as_mock_client());
+    let github = Box::new(github);
 
     let app = App::new(config, emails, github);
 


### PR DESCRIPTION
This makes our mocking code for the `GitHubClient` a lot more flexible compared to only having a single source of stub data.