### PR TITLE
Remove `ReadOnlyMode` error struct

### DIFF
--- a/src/util/diesel.rs
+++ b/src/util/diesel.rs
@@ -1,9 +1,14 @@
 use diesel::connection::LoadConnection;
 use diesel::pg::Pg;
+use diesel::result::Error;
 
 pub trait Conn: LoadConnection<Backend = Pg> {}
 
 impl<T> Conn for T where T: LoadConnection<Backend = Pg> {}
+
+pub fn is_read_only_error(error: &Error) -> bool {
+    matches!(error, Error::DatabaseError(_, info) if info.message().ends_with("read-only transaction"))
+}
 
 pub mod prelude {
     //! Inline diesel prelude

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -33,7 +33,7 @@ use crate::email::EmailError;
 use crate::util::diesel::is_read_only_error;
 use crates_io_github::GitHubError;
 pub use json::TOKEN_FORMAT_ERROR;
-pub(crate) use json::{custom, InsecurelyGeneratedTokenRevoked, ReadOnlyMode, TooManyRequests};
+pub(crate) use json::{custom, InsecurelyGeneratedTokenRevoked, TooManyRequests};
 
 pub type BoxedAppError = Box<dyn AppError>;
 
@@ -146,7 +146,10 @@ impl From<DieselError> for BoxedAppError {
     fn from(err: DieselError) -> BoxedAppError {
         match err {
             DieselError::NotFound => not_found(),
-            e if is_read_only_error(&e) => Box::new(ReadOnlyMode),
+            e if is_read_only_error(&e) => {
+                let detail = "crates.io is currently in read-only mode for maintenance. Please try again later.";
+                custom(StatusCode::SERVICE_UNAVAILABLE, detail)
+            }
             DieselError::DatabaseError(DatabaseErrorKind::ClosedConnection, _) => {
                 service_unavailable()
             }

--- a/src/util/errors/json.rs
+++ b/src/util/errors/json.rs
@@ -17,25 +17,6 @@ fn json_error(detail: &str, status: StatusCode) -> Response {
     (status, json).into_response()
 }
 
-// The following structs are empty and do not provide a custom message to the user
-
-#[derive(Debug)]
-pub(crate) struct ReadOnlyMode;
-
-impl AppError for ReadOnlyMode {
-    fn response(&self) -> Response {
-        let detail = "crates.io is currently in read-only mode for maintenance. \
-                      Please try again later.";
-        json_error(detail, StatusCode::SERVICE_UNAVAILABLE)
-    }
-}
-
-impl fmt::Display for ReadOnlyMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        "Tried to write in read only mode".fmt(f)
-    }
-}
-
 // The following structs wrap owned data and provide a custom message to the user
 
 pub fn custom(status: StatusCode, detail: impl Into<Cow<'static, str>>) -> BoxedAppError {


### PR DESCRIPTION
First converting a `diesel::result::Error` to a `BoxedAppError` only to then rely on downcasting to check the content of the original error seems a bit over-complicated. This PR replaces the check with a much simpler `is_read_only_error()` fn and then gets rid of the `ReadOnlyMode` struct in favor of another `custom()` error helper call.