### PR TITLE
tests: Avoid `NewUser::create_or_update()` calls

### DIFF
--- a/src/rate_limiter.rs
+++ b/src/rate_limiter.rs
@@ -181,7 +181,7 @@ struct Bucket {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::email::Emails;
+    use crate::schema::users;
     use crate::test_util::*;
 
     #[test]
@@ -647,13 +647,17 @@ mod tests {
 
     fn new_user(conn: &mut impl Conn, gh_login: &str) -> QueryResult<i32> {
         use crate::models::NewUser;
+        use diesel::RunQueryDsl;
 
         let user = NewUser {
             gh_login,
             ..NewUser::default()
-        }
-        .create_or_update(None, &Emails::new_in_memory(), conn)?;
-        Ok(user.id)
+        };
+
+        diesel::insert_into(users::table)
+            .values(user)
+            .returning(users::id)
+            .get_result(conn)
     }
 
     fn new_user_bucket(

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -12,6 +12,7 @@ use crate::{
     },
 };
 
+use crate::schema::users;
 use chrono::{Duration, Utc};
 use diesel::prelude::*;
 use http::StatusCode;
@@ -724,15 +725,18 @@ async fn inactive_users_dont_get_invitations() {
     let invited_gh_login = "user_bar";
     let krate_name = "inactive_test";
 
-    NewUser {
+    let user = NewUser {
         gh_id: -1,
         gh_login: invited_gh_login,
         name: None,
         gh_avatar: None,
         gh_access_token: "some random token",
-    }
-    .create_or_update(None, &app.as_inner().emails, &mut conn)
-    .unwrap();
+    };
+
+    diesel::insert_into(users::table)
+        .values(user)
+        .execute(&mut conn)
+        .unwrap();
 
     CrateBuilder::new(krate_name, owner.id).expect_build(&mut conn);
 

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -105,14 +105,15 @@ fn batch_update(batch_size: i64, conn: &mut impl Conn) -> QueryResult<i64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::email::Emails;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
-    use crate::schema::{crate_downloads, crates, versions};
+    use crate::schema::{crate_downloads, crates, users, versions};
     use crate::test_util::test_db_connection;
 
     fn user(conn: &mut impl Conn) -> User {
-        NewUser::new(2, "login", None, None, "access_token")
-            .create_or_update(None, &Emails::new_in_memory(), conn)
+        let user = NewUser::new(2, "login", None, None, "access_token");
+        diesel::insert_into(users::table)
+            .values(user)
+            .get_result(conn)
             .unwrap()
     }
 


### PR DESCRIPTION
There is no need for an "upsert" operation here since we know that the database is in a clean state in our tests. Additionally, this drops the need for the `Emails` implementation, since all we want is a user in the database, but without any email address confirmation emails being sent out.

The motivation for this change is that it makes it easier to convert the `NewUser::create_or_update()` fn to async later, without having to adjust that many callers that don't need the extra behavior of that function.