### PR TITLE
rss: Remove explicit/duplicate XML escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,7 +1087,6 @@ dependencies = [
  "paste",
  "postgres-native-tls",
  "prometheus",
- "quick-xml 0.37.0",
  "rand",
  "regex",
  "reqwest 0.12.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,6 @@ parking_lot = "=0.12.3"
 paste = "=1.0.15"
 postgres-native-tls = "=0.5.0"
 prometheus = { version = "=0.13.4", default-features = false }
-quick-xml = "=0.37.0"
 rand = "=0.8.5"
 reqwest = { version = "=0.12.9", features = ["gzip", "json"] }
 rss = { version = "=2.0.10", default-features = false, features = ["atom"] }

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
@@ -21,7 +21,7 @@ snapshot_kind: text
         <item>
             <title>New crate created: baz</title>
             <link>https://crates.io/crates/baz</link>
-            <description><![CDATA[does it handle XML? &lt;item&gt;]]></description>
+            <description><![CDATA[does it handle XML? <item>]]></description>
             <guid>https://crates.io/crates/baz</guid>
             <pubDate>Fri, 21 Jun 2024 17:01:33 +0000</pubDate>
             <crates:name>baz</crates:name>

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
@@ -21,7 +21,7 @@ snapshot_kind: text
         <item>
             <title>New crate created: baz</title>
             <link>https://crates.io/crates/baz</link>
-            <description><![CDATA[does it handle XML? <item>]]></description>
+            <description><![CDATA[does it handle XML? <item> ]]]]><![CDATA[>]]></description>
             <guid>https://crates.io/crates/baz</guid>
             <pubDate>Fri, 21 Jun 2024 17:01:33 +0000</pubDate>
             <crates:name>baz</crates:name>

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_updates_feed__sync_updates_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_updates_feed__sync_updates_feed-2.snap
@@ -30,7 +30,7 @@ snapshot_kind: text
         <item>
             <title>New crate version published: bar v3.0.0-beta.1</title>
             <link>https://crates.io/crates/bar/3.0.0-beta.1</link>
-            <description><![CDATA[let's try & break this <item>]]></description>
+            <description><![CDATA[let's try & break this <item> ]]]]><![CDATA[>]]></description>
             <guid>https://crates.io/crates/bar/3.0.0-beta.1</guid>
             <pubDate>Fri, 21 Jun 2024 17:03:45 +0000</pubDate>
             <crates:name>bar</crates:name>

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_updates_feed__sync_updates_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_updates_feed__sync_updates_feed-2.snap
@@ -1,6 +1,7 @@
 ---
 source: src/tests/worker/rss/sync_updates_feed.rs
 expression: content
+snapshot_kind: text
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:crates="https://crates.io/">
@@ -29,7 +30,7 @@ expression: content
         <item>
             <title>New crate version published: bar v3.0.0-beta.1</title>
             <link>https://crates.io/crates/bar/3.0.0-beta.1</link>
-            <description><![CDATA[let&apos;s try &amp; break this &lt;item&gt;]]></description>
+            <description><![CDATA[let's try & break this <item>]]></description>
             <guid>https://crates.io/crates/bar/3.0.0-beta.1</guid>
             <pubDate>Fri, 21 Jun 2024 17:03:45 +0000</pubDate>
             <crates:name>bar</crates:name>

--- a/src/tests/worker/rss/sync_crates_feed.rs
+++ b/src/tests/worker/rss/sync_crates_feed.rs
@@ -15,7 +15,7 @@ async fn test_sync_crates_feed() {
     let description = Some("something something foo");
     create_crate(&mut conn, "foo", description, "2024-06-20T10:13:54Z").await;
     create_crate(&mut conn, "bar", None, "2024-06-20T12:45:12Z").await;
-    let description = Some("does it handle XML? <item>");
+    let description = Some("does it handle XML? <item> ]]>");
     create_crate(&mut conn, "baz", description, "2024-06-21T17:01:33Z").await;
     create_crate(&mut conn, "quux", None, "2024-06-21T17:03:45Z").await;
 

--- a/src/tests/worker/rss/sync_updates_feed.rs
+++ b/src/tests/worker/rss/sync_updates_feed.rs
@@ -12,7 +12,7 @@ async fn test_sync_updates_feed() {
     let (app, _) = TestApp::full().empty();
     let mut conn = app.async_db_conn().await;
 
-    let d = Some("let's try & break this <item>");
+    let d = Some("let's try & break this <item> ]]>");
 
     create_version(&mut conn, "foo", "0.1.0", None, "2024-06-20T10:13:54Z").await;
     create_version(&mut conn, "foo", "0.1.1", None, "2024-06-20T12:45:12Z").await;

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -125,10 +125,6 @@ impl NewCrate {
             permalink: true,
         };
 
-        let description = self
-            .description
-            .map(|d| quick_xml::escape::escape(&d).to_string());
-
         let name_extension = rss::extension::Extension {
             name: "crates:name".into(),
             value: Some(self.name),
@@ -144,7 +140,7 @@ impl NewCrate {
             guid: Some(guid),
             title: Some(title),
             link: Some(link),
-            description,
+            description: self.description,
             pub_date: Some(pub_date),
             extensions,
             ..Default::default()

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -125,6 +125,10 @@ impl NewCrate {
             permalink: true,
         };
 
+        let description = self
+            .description
+            .map(|d| d.replace("]]>", "]]]]><![CDATA[>"));
+
         let name_extension = rss::extension::Extension {
             name: "crates:name".into(),
             value: Some(self.name),
@@ -140,7 +144,7 @@ impl NewCrate {
             guid: Some(guid),
             title: Some(title),
             link: Some(link),
-            description: self.description,
+            description,
             pub_date: Some(pub_date),
             extensions,
             ..Default::default()

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -132,6 +132,10 @@ impl VersionUpdate {
             permalink: true,
         };
 
+        let description = self
+            .description
+            .map(|d| d.replace("]]>", "]]]]><![CDATA[>"));
+
         let name_extension = rss::extension::Extension {
             name: "crates:name".into(),
             value: Some(self.name),
@@ -156,7 +160,7 @@ impl VersionUpdate {
             guid: Some(guid),
             title: Some(title),
             link: Some(link),
-            description: self.description,
+            description,
             pub_date: Some(pub_date),
             extensions,
             ..Default::default()

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -132,10 +132,6 @@ impl VersionUpdate {
             permalink: true,
         };
 
-        let description = self
-            .description
-            .map(|d| quick_xml::escape::escape(&d).to_string());
-
         let name_extension = rss::extension::Extension {
             name: "crates:name".into(),
             value: Some(self.name),
@@ -160,7 +156,7 @@ impl VersionUpdate {
             guid: Some(guid),
             title: Some(title),
             link: Some(link),
-            description,
+            description: self.description,
             pub_date: Some(pub_date),
             extensions,
             ..Default::default()


### PR DESCRIPTION
XML tags inside `CDATA` sections don't need to be escaped, so this explicit escaping step led to an unnecessary duplicate escaping being applied.

Related:

- https://github.com/rust-syndication/rss/issues/167#issuecomment-2480138799