### PR TITLE
tests/util/github: Fix test flakyness

### DIFF
--- a/src/tests/util/github.rs
+++ b/src/tests/util/github.rs
@@ -5,7 +5,7 @@ use crates_io_github::{
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-static NEXT_GH_ID: AtomicUsize = AtomicUsize::new(0);
+static NEXT_GH_ID: AtomicUsize = AtomicUsize::new(1);
 
 pub fn next_gh_id() -> i32 {
     NEXT_GH_ID.fetch_add(1, Ordering::SeqCst) as i32


### PR DESCRIPTION
`gh_id = 0` has a special meaning within our database. Depending on the order of the tests we could sometimes see tests failing because the initial user was created with `gh_id = 0`. This commit fixes the flakiness by starting the `gh_id` values at 1 instead.

and yes, I thought I was going insane... 🙈 