### PR TITLE
models/token: Remove sync `find_by_api_token()` fn

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -214,7 +214,7 @@ async fn authenticate_via_token(
     let token =
         HashedToken::parse(header_value).map_err(|_| InsecurelyGeneratedTokenRevoked::boxed())?;
 
-    let token = ApiToken::async_find_by_api_token(conn, &token)
+    let token = ApiToken::find_by_api_token(conn, &token)
         .await
         .map_err(|e| {
             let cause = format!("invalid token caused by {e}");

--- a/src/bin/crates-admin/verify_token.rs
+++ b/src/bin/crates-admin/verify_token.rs
@@ -21,7 +21,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         .context("Failed to connect to the database")?;
 
     let token = HashedToken::parse(&opts.api_token)?;
-    let token = ApiToken::async_find_by_api_token(&mut conn, &token).await?;
+    let token = ApiToken::find_by_api_token(&mut conn, &token).await?;
     let user = User::async_find(&mut conn, token.user_id).await?;
     println!("The token belongs to user {}", user.gh_login);
     Ok(())

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -36,9 +36,8 @@ async fn updating_existing_user_doesnt_change_api_token() {
 
     // Use the original API token to find the now updated user
     let hashed_token = assert_ok!(HashedToken::parse(token.expose_secret()));
-    let mut conn = app.db_conn();
-    let api_token = assert_ok!(ApiToken::find_by_api_token(&mut conn, &hashed_token));
-    let user = assert_ok!(User::find(&mut conn, api_token.user_id));
+    let api_token = assert_ok!(ApiToken::async_find_by_api_token(&mut conn, &hashed_token).await);
+    let user = assert_ok!(User::async_find(&mut conn, api_token.user_id).await);
 
     assert_eq!(user.gh_login, "bar");
     assert_eq!(user.gh_access_token, "bar_token");

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -36,7 +36,7 @@ async fn updating_existing_user_doesnt_change_api_token() {
 
     // Use the original API token to find the now updated user
     let hashed_token = assert_ok!(HashedToken::parse(token.expose_secret()));
-    let api_token = assert_ok!(ApiToken::async_find_by_api_token(&mut conn, &hashed_token).await);
+    let api_token = assert_ok!(ApiToken::find_by_api_token(&mut conn, &hashed_token).await);
     let user = assert_ok!(User::async_find(&mut conn, api_token.user_id).await);
 
     assert_eq!(user.gh_login, "bar");


### PR DESCRIPTION
Everything is using the async variant now, so lets get rid of the sync one  🎉 