### PR TITLE
Convert `TestApp` fns to async/await

### DIFF
--- a/src/controllers/user/resend.rs
+++ b/src/controllers/user/resend.rs
@@ -64,7 +64,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_no_auth() {
-        let (app, anon, user) = TestApp::init().with_user();
+        let (app, anon, user) = TestApp::init().with_user().await;
 
         let url = format!("/api/v1/users/{}/resend", user.as_model().id);
         let response = anon.put::<()>(&url, "").await;
@@ -76,7 +76,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_wrong_user() {
-        let (app, _anon, user) = TestApp::init().with_user();
+        let (app, _anon, user) = TestApp::init().with_user().await;
         let user2 = app.db_new_user("bar");
 
         let url = format!("/api/v1/users/{}/resend", user2.as_model().id);
@@ -89,7 +89,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_happy_path() {
-        let (app, _anon, user) = TestApp::init().with_user();
+        let (app, _anon, user) = TestApp::init().with_user().await;
 
         let url = format!("/api/v1/users/{}/resend", user.as_model().id);
         let response = user.put::<()>(&url, "").await;

--- a/src/controllers/user/resend.rs
+++ b/src/controllers/user/resend.rs
@@ -77,7 +77,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_wrong_user() {
         let (app, _anon, user) = TestApp::init().with_user().await;
-        let user2 = app.db_new_user("bar");
+        let user2 = app.db_new_user("bar").await;
 
         let url = format!("/api/v1/users/{}/resend", user2.as_model().id);
         let response = user.put::<()>(&url, "").await;

--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -26,7 +26,7 @@ async fn lock_account(app: &TestApp, user_id: i32, until: Option<NaiveDateTime>)
 
 #[tokio::test(flavor = "multi_thread")]
 async fn account_locked_indefinitely() {
-    let (app, _anon, user) = TestApp::init().with_user();
+    let (app, _anon, user) = TestApp::init().with_user().await;
     lock_account(&app, user.as_model().id, None).await;
 
     let response = user.get::<()>(URL).await;
@@ -41,7 +41,7 @@ async fn account_locked_with_future_expiry() {
         .unwrap()
         .naive_utc();
 
-    let (app, _anon, user) = TestApp::init().with_user();
+    let (app, _anon, user) = TestApp::init().with_user().await;
     lock_account(&app, user.as_model().id, Some(until)).await;
 
     let response = user.get::<()>(URL).await;
@@ -53,7 +53,7 @@ async fn account_locked_with_future_expiry() {
 async fn expired_account_lock() {
     let until = Utc::now().naive_utc() - Duration::days(1);
 
-    let (app, _anon, user) = TestApp::init().with_user();
+    let (app, _anon, user) = TestApp::init().with_user().await;
     lock_account(&app, user.as_model().id, Some(until)).await;
 
     user.get::<serde_json::Value>(URL).await.good();

--- a/src/tests/authentication.rs
+++ b/src/tests/authentication.rs
@@ -9,7 +9,7 @@ static URL: &str = "/api/v1/me/updates";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn anonymous_user_unauthorized() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     let response: Response<()> = anon.get(URL).await;
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -18,7 +18,7 @@ async fn anonymous_user_unauthorized() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn token_auth_cannot_find_token() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     let mut request = anon.request_builder(Method::GET, URL);
     request.header(header::AUTHORIZATION, "cio1tkfake-token");
     let response: Response<()> = anon.run(request).await;
@@ -32,7 +32,7 @@ async fn token_auth_cannot_find_token() {
 // the database, it is not possible to implement this same test for a token.
 #[tokio::test(flavor = "multi_thread")]
 async fn cookie_auth_cannot_find_user() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
 
     let session_key = app.as_inner().session_key();
     let cookie = encode_session_header(session_key, -1);

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -8,7 +8,8 @@ async fn test_non_blocked_download_route() {
         .with_config(|config| {
             config.blocked_routes.clear();
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
 
@@ -32,7 +33,8 @@ async fn test_blocked_download_route() {
                 .blocked_routes
                 .insert("/api/v1/crates/:crate_id/:version/download".into());
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/cors.rs
+++ b/src/tests/cors.rs
@@ -9,7 +9,8 @@ async fn test_with_matching_origin() {
         .with_config(|server| {
             server.allowed_origins = "https://crates.io".parse().unwrap();
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut request = cookie.get_request("/api/v1/me");
     request.header("Origin", "https://crates.io");
@@ -24,7 +25,8 @@ async fn test_with_unknown_origin() {
         .with_config(|server| {
             server.allowed_origins = "https://crates.io".parse().unwrap();
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut request = cookie.get_request("/api/v1/me");
     request.header("Origin", "https://evil.hacker.io");
@@ -40,7 +42,8 @@ async fn test_with_multiple_origins() {
         .with_config(|server| {
             server.allowed_origins = "https://crates.io".parse().unwrap();
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut request = cookie.get_request("/api/v1/me");
     request.header("Origin", "https://evil.hacker.io");

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -15,7 +15,7 @@ static PATH_DATE_RE: LazyLock<Regex> =
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_dump_db_job() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("test-crate", token.as_model().user_id).expect_build(&mut conn);

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -211,7 +211,7 @@ async fn github_secret_alert_for_unknown_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_secret_alert_invalid_signature_fails() {
-    let (_, anon) = TestApp::init().with_github(github_mock()).empty();
+    let (_, anon) = TestApp::init().with_github(github_mock()).empty().await;
 
     // No headers or request body
     let request = anon.post_request(URL);

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -41,7 +41,10 @@ fn github_mock() -> MockGitHubClient {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_secret_alert_revokes_token() {
-    let (app, anon, user, token) = TestApp::init().with_github(github_mock()).with_token();
+    let (app, anon, user, token) = TestApp::init()
+        .with_github(github_mock())
+        .with_token()
+        .await;
     let mut conn = app.async_db_conn().await;
 
     // Ensure no emails were sent up to this point
@@ -99,7 +102,10 @@ async fn github_secret_alert_revokes_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_secret_alert_for_revoked_token() {
-    let (app, anon, user, token) = TestApp::init().with_github(github_mock()).with_token();
+    let (app, anon, user, token) = TestApp::init()
+        .with_github(github_mock())
+        .with_token()
+        .await;
     let mut conn = app.async_db_conn().await;
 
     // Ensure no emails were sent up to this point
@@ -160,7 +166,10 @@ async fn github_secret_alert_for_revoked_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn github_secret_alert_for_unknown_token() {
-    let (app, anon, user, token) = TestApp::init().with_github(github_mock()).with_token();
+    let (app, anon, user, token) = TestApp::init()
+        .with_github(github_mock())
+        .with_token()
+        .await;
     let mut conn = app.async_db_conn().await;
 
     // Ensure no emails were sent up to this point

--- a/src/tests/issues/issue1205.rs
+++ b/src/tests/issues/issue1205.rs
@@ -9,7 +9,10 @@ use insta::assert_snapshot;
 async fn test_issue_1205() -> anyhow::Result<()> {
     const CRATE_NAME: &str = "deepspeech-sys";
 
-    let (app, _, _, user) = TestApp::full().with_github(github_mock()).with_token();
+    let (app, _, _, user) = TestApp::full()
+        .with_github(github_mock())
+        .with_token()
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 /// See <https://github.com/rust-lang/crates.io/issues/2736>.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_issue_2736() -> anyhow::Result<()> {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
 
     // - A user had a GitHub account named, let's say, `foo`

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -13,10 +13,10 @@ async fn test_issue_2736() -> anyhow::Result<()> {
     let mut conn = app.db_conn();
 
     // - A user had a GitHub account named, let's say, `foo`
-    let foo1 = app.db_new_user("foo");
+    let foo1 = app.db_new_user("foo").await;
 
     // - Another user `someone_else` added them as an owner of a crate
-    let someone_else = app.db_new_user("someone_else");
+    let someone_else = app.db_new_user("someone_else").await;
 
     let krate = CrateBuilder::new("crate1", someone_else.as_model().id).expect_build(&mut conn);
 
@@ -33,7 +33,7 @@ async fn test_issue_2736() -> anyhow::Result<()> {
     // - `foo` deleted their GitHub account (but crates.io has no real knowledge of this)
     // - `foo` recreated their GitHub account with the same username (because it was still available), but in this situation GitHub assigns them a new ID
     // - When `foo` now logs in to crates.io, it's a different account than their old `foo` crates.io account because of the new GitHub ID (and if it wasn't, this would be a security problem)
-    let foo2 = app.db_new_user("foo");
+    let foo2 = app.db_new_user("foo").await;
 
     let github_ids = users::table
         .filter(users::gh_login.eq("foo"))

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -117,7 +117,7 @@ async fn test_api_token_auth() {
     const CRATE_TO_FOLLOW: &str = "some_crate_to_follow";
     const CRATE_NOT_TO_FOLLOW: &str = "another_crate";
 
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let api_token = token.as_model();
 

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -33,7 +33,7 @@ async fn unfollow(crate_name: &str, user: &impl RequestHelper) {
 async fn test_unauthenticated_requests() {
     const CRATE_NAME: &str = "foo";
 
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(&mut conn);
@@ -61,7 +61,7 @@ async fn test_unauthenticated_requests() {
 async fn test_following() {
     const CRATE_NAME: &str = "foo_following";
 
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(&mut conn);
@@ -91,7 +91,7 @@ async fn test_following() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
-    let (_, _, user) = TestApp::init().with_user();
+    let (_, _, user) = TestApp::init().with_user().await;
 
     let response = user
         .get::<()>("/api/v1/crates/unknown-crate/following")

--- a/src/tests/krate/publish/audit_action.rs
+++ b/src/tests/krate/publish/audit_action.rs
@@ -6,7 +6,7 @@ async fn publish_records_an_audit_action() {
     use crate::tests::builders::PublishBuilder;
     use crate::tests::util::{RequestHelper, TestApp};
 
-    let (app, anon, _, token) = TestApp::full().with_token();
+    let (app, anon, _, token) = TestApp::full().with_token().await;
 
     let mut conn = app.db_conn();
     assert!(VersionOwnerAction::all(&mut conn).unwrap().is_empty());

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -35,7 +35,7 @@ async fn new_wrong_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_wrong_user() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     // Create the foo_wrong crate with one user

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_wrong_token() {
-    let (app, anon, _, token) = TestApp::full().with_token();
+    let (app, anon, _, token) = TestApp::full().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     // Try to publish without a token

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -42,7 +42,8 @@ async fn new_krate_wrong_user() {
     CrateBuilder::new("foo_wrong", user.as_model().id).expect_build(&mut conn);
 
     // Then try to publish with a different user
-    let another_user = app.db_new_user("another").db_new_token("bar");
+    let another_user = app.db_new_user("another").await;
+    let another_user = another_user.db_new_token("bar");
     let crate_to_publish = PublishBuilder::new("foo_wrong", "2.0.0");
 
     let response = another_user.publish_crate(crate_to_publish).await;

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -43,7 +43,7 @@ async fn new_krate_wrong_user() {
 
     // Then try to publish with a different user
     let another_user = app.db_new_user("another").await;
-    let another_user = another_user.db_new_token("bar");
+    let another_user = another_user.db_new_token("bar").await;
     let crate_to_publish = PublishBuilder::new("foo_wrong", "2.0.0");
 
     let response = another_user.publish_crate(crate_to_publish).await;

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -9,7 +9,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     let mut conn = app.async_db_conn().await;
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -43,7 +43,7 @@ async fn new_krate() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_token() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
     let response = token.publish_crate(crate_to_publish).await;
@@ -64,7 +64,7 @@ async fn new_krate_with_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_weird_version() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_weird", "0.0.0-pre");
     let response = token.publish_crate(crate_to_publish).await;
@@ -85,7 +85,7 @@ async fn new_krate_weird_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_twice() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_twice", "0.99.0");
     token.publish_crate(crate_to_publish).await.good();
@@ -116,7 +116,7 @@ async fn new_krate_twice() {
 // The primary purpose is to verify that the `default_version` we provide is as expected.
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_twice_alt() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish =
         PublishBuilder::new("foo_twice", "2.0.0").description("2.0.0 description");
@@ -145,7 +145,7 @@ async fn new_krate_twice_alt() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_duplicate_version() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database and then we'll try to publish the same version

--- a/src/tests/krate/publish/build_metadata.rs
+++ b/src/tests/krate/publish/build_metadata.rs
@@ -5,7 +5,7 @@ use insta::assert_json_snapshot;
 use serde_json::json;
 
 async fn version_with_build_metadata(v1: &str, v2: &str, expected_error: &str) {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token.publish_crate(PublishBuilder::new("foo", v1)).await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/krate/publish/categories.rs
+++ b/src/tests/krate/publish/categories.rs
@@ -10,7 +10,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn good_categories() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     insert_into(categories::table)
@@ -30,7 +30,7 @@ async fn good_categories() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ignored_categories() {
-    let (_, _, _, token) = TestApp::full().with_token();
+    let (_, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_ignored_cat", "1.0.0").category("bar");
     let response = token.publish_crate(crate_to_publish).await;
@@ -40,7 +40,7 @@ async fn ignored_categories() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn too_many_categories() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(

--- a/src/tests/krate/publish/deleted_crates.rs
+++ b/src/tests/krate/publish/deleted_crates.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recently_deleted_crate_with_same_name() -> anyhow::Result<()> {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     let now = Utc::now();

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -6,7 +6,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(PublishBuilder::new("foo", "1.0.0").dependency(DependencyBuilder::new("🦀")))
@@ -18,7 +18,7 @@ async fn invalid_dependency_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_renamed_dependency() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -35,7 +35,7 @@ async fn new_with_renamed_dependency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_rename() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -54,7 +54,7 @@ async fn invalid_dependency_rename() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_starts_with_digit() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -73,7 +73,7 @@ async fn invalid_dependency_name_starts_with_digit() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_contains_unicode_chars() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -92,7 +92,7 @@ async fn invalid_dependency_name_contains_unicode_chars() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_too_long_dependency_name() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -111,7 +111,7 @@ async fn invalid_too_long_dependency_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_dependency_name() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -130,7 +130,7 @@ async fn empty_dependency_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_underscore_renamed_dependency() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new-krate can depend on it
@@ -149,7 +149,7 @@ async fn new_with_underscore_renamed_dependency() {
 async fn new_krate_with_dependency() {
     use crate::tests::routes::crates::versions::dependencies::Deps;
 
-    let (app, anon, user, token) = TestApp::full().with_token();
+    let (app, anon, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new_dep can depend on it
@@ -180,7 +180,7 @@ async fn new_krate_with_dependency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_broken_dependency_requirement() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new_dep can depend on it
@@ -200,7 +200,7 @@ async fn new_krate_with_broken_dependency_requirement() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reject_new_krate_with_non_exact_dependency() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
@@ -218,7 +218,7 @@ async fn reject_new_krate_with_non_exact_dependency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_allow_empty_alternative_registry_dependency() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
@@ -230,7 +230,7 @@ async fn new_crate_allow_empty_alternative_registry_dependency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reject_new_crate_with_alternative_registry_dependency() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let dependency =
         DependencyBuilder::new("dep").registry("https://server.example/path/to/registry");
@@ -245,7 +245,7 @@ async fn reject_new_crate_with_alternative_registry_dependency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_wildcard_dependency() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that new_wild can depend on it
@@ -263,7 +263,7 @@ async fn new_krate_with_wildcard_dependency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_dependency_missing() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     // Deliberately not inserting this crate in the database to test behavior when a dependency
     // doesn't exist!
@@ -278,7 +278,7 @@ async fn new_krate_dependency_missing() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_sorts_deps() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert crates directly into the database so that two-deps can depend on it
@@ -300,7 +300,7 @@ async fn new_krate_sorts_deps() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_feature_name() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(
@@ -317,7 +317,8 @@ async fn invalid_feature_name() {
 async fn test_dep_limit() {
     let (app, _, user, token) = TestApp::full()
         .with_config(|config| config.max_dependencies = 1)
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/krate/publish/emails.rs
+++ b/src/tests/krate/publish/emails.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_without_any_email_fails() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     delete(emails::table).execute(&mut conn).await.unwrap();
@@ -26,7 +26,7 @@ async fn new_krate_without_any_email_fails() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_unverified_email_fails() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     update(emails::table)

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -6,7 +6,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn features_version_2() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Insert a crate directly into the database so that foo_new can depend on it
@@ -26,7 +26,7 @@ async fn features_version_2() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn feature_name_with_dot() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo.bar", &[]);
     token.publish_crate(crate_to_publish).await.good();
     let crates = app.crates_from_index_head("foo");
@@ -35,7 +35,7 @@ async fn feature_name_with_dot() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn feature_name_start_with_number_and_underscore() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0")
         .feature("0foo1.bar", &[])
         .feature("_foo2.bar", &[]);
@@ -46,7 +46,7 @@ async fn feature_name_start_with_number_and_underscore() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn feature_name_with_unicode_chars() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo.你好世界", &[]);
     token.publish_crate(crate_to_publish).await.good();
     let crates = app.crates_from_index_head("foo");
@@ -55,7 +55,7 @@ async fn feature_name_with_unicode_chars() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_feature_name() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("", &[]);
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -65,7 +65,7 @@ async fn empty_feature_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_feature_name1() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("~foo", &[]);
     let response = token.publish_crate(crate_to_publish).await;
@@ -76,7 +76,7 @@ async fn invalid_feature_name1() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_feature_name2() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("foo", &["!bar"]);
     let response = token.publish_crate(crate_to_publish).await;
@@ -87,7 +87,7 @@ async fn invalid_feature_name2() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_feature_name_start_with_hyphen() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").feature("-foo1.bar", &[]);
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -101,7 +101,8 @@ async fn too_many_features() {
         .with_config(|config| {
             config.max_features = 3;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("one", &[])
@@ -121,7 +122,8 @@ async fn too_many_features_with_custom_limit() {
         .with_config(|config| {
             config.max_features = 3;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.db_conn();
 
@@ -162,7 +164,8 @@ async fn too_many_enabled_features() {
         .with_config(|config| {
             config.max_features = 3;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("default", &["one", "two", "three", "four", "five"]);
@@ -178,7 +181,8 @@ async fn too_many_enabled_features_with_custom_limit() {
         .with_config(|config| {
             config.max_features = 3;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/krate/publish/git.rs
+++ b/src/tests/krate/publish/git.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_git_upload_with_conflicts() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     app.upstream_index().create_empty_commit().unwrap();
 

--- a/src/tests/krate/publish/inheritance.rs
+++ b/src/tests/krate/publish/inheritance.rs
@@ -5,7 +5,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn workspace_inheritance() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(
@@ -19,7 +19,7 @@ async fn workspace_inheritance() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn workspace_inheritance_with_dep() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
         "[package]\nname = \"foo\"\nversion = \"1.0.0\"\n\n[dependencies]\nserde.workspace = true\n",

--- a/src/tests/krate/publish/keywords.rs
+++ b/src/tests/krate/publish/keywords.rs
@@ -6,7 +6,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn good_keywords() {
-    let (_, _, _, token) = TestApp::full().with_token();
+    let (_, _, _, token) = TestApp::full().with_token().await;
     let crate_to_publish = PublishBuilder::new("foo_good_key", "1.0.0")
         .keyword("c++")
         .keyword("crates-io_index")
@@ -21,7 +21,7 @@ async fn good_keywords() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn bad_keywords() {
-    let (_, _, _, token) = TestApp::full().with_token();
+    let (_, _, _, token) = TestApp::full().with_token().await;
     let crate_to_publish =
         PublishBuilder::new("foo_bad_key", "1.0.0").keyword("super-long-keyword-name-oh-no");
     let response = token.publish_crate(crate_to_publish).await;
@@ -41,7 +41,7 @@ async fn bad_keywords() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn too_many_keywords() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let response = token
         .publish_crate(
             PublishBuilder::new("foo", "1.0.0")

--- a/src/tests/krate/publish/links.rs
+++ b/src/tests/krate/publish/links.rs
@@ -5,7 +5,7 @@ use http::StatusCode;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_crate_with_links_field() {
-    let (app, anon, _, token) = TestApp::full().with_token();
+    let (app, anon, _, token) = TestApp::full().with_token().await;
 
     let manifest = r#"
     [package]

--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -8,7 +8,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 async fn boolean_readme() {
     // see https://github.com/rust-lang/crates.io/issues/6847
 
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
@@ -41,7 +41,7 @@ async fn boolean_readme() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn missing_manifest() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(PublishBuilder::new("foo", "1.0.0").no_manifest())
@@ -52,7 +52,7 @@ async fn missing_manifest() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn manifest_casing() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(
@@ -70,7 +70,7 @@ async fn manifest_casing() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_manifests() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(
@@ -92,7 +92,7 @@ async fn multiple_manifests() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_manifest() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(""))
@@ -103,7 +103,7 @@ async fn invalid_manifest() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_manifest_missing_name() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(
@@ -116,7 +116,7 @@ async fn invalid_manifest_missing_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_manifest_missing_version() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(
@@ -129,7 +129,7 @@ async fn invalid_manifest_missing_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_rust_version() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let response =
         token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
@@ -147,7 +147,7 @@ async fn invalid_rust_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_lib_and_bin_crate() {
-    let (_app, _anon, _cookie, token) = TestApp::full().with_token();
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .add_file("foo-1.0.0/src/lib.rs", "pub fn foo() {}")

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -14,7 +14,8 @@ async fn tarball_between_default_axum_limit_and_max_upload_size() {
             config.max_upload_size = max_upload_size;
             config.max_unpack_size = max_upload_size;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let tarball = {
         let mut builder = TarballBuilder::new();
@@ -66,7 +67,8 @@ async fn tarball_bigger_than_max_upload_size() {
             config.max_upload_size = max_upload_size;
             config.max_unpack_size = max_upload_size;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let tarball = {
         // `data` is bigger than `max_upload_size`
@@ -100,7 +102,8 @@ async fn new_krate_gzip_bomb() {
             config.max_upload_size = 3000;
             config.max_unpack_size = 2000;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let body = vec![0; 512 * 1024];
     let crate_to_publish = PublishBuilder::new("foo", "1.1.0").add_file("foo-1.1.0/a", body);
@@ -131,7 +134,7 @@ async fn new_krate_too_big() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_too_big_but_whitelisted() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo_whitelist", user.as_model().id)

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -121,7 +121,8 @@ async fn new_krate_too_big() {
             config.max_upload_size = 3000;
             config.max_unpack_size = 2000;
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let builder =
         PublishBuilder::new("foo_big", "1.0.0").add_file("foo_big-1.0.0/big", vec![b'a'; 2000]);

--- a/src/tests/krate/publish/rate_limit.rs
+++ b/src/tests/krate/publish/rate_limit.rs
@@ -14,7 +14,8 @@ use std::time::Duration;
 async fn publish_new_crate_ratelimit_hit() {
     let (app, anon, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishNew, Duration::from_millis(500), 1)
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.async_db_conn().await;
 
@@ -49,7 +50,8 @@ async fn publish_new_crate_ratelimit_hit() {
 async fn publish_new_crate_ratelimit_expires() {
     let (app, anon, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishNew, Duration::from_millis(500), 1)
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.async_db_conn().await;
 
@@ -92,7 +94,8 @@ async fn publish_new_crate_override_loosens_ratelimit() {
             Duration::from_secs(60 * 60 * 24),
             1,
         )
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.async_db_conn().await;
 
@@ -169,7 +172,8 @@ async fn publish_new_crate_expired_override_ignored() {
             Duration::from_secs(60 * 60 * 24),
             1,
         )
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.async_db_conn().await;
 
@@ -222,7 +226,8 @@ async fn publish_new_crate_expired_override_ignored() {
 async fn publish_new_crate_rate_limit_doesnt_affect_existing_crates() {
     let (_, _, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishNew, Duration::from_secs(60 * 60), 1)
-        .with_token();
+        .with_token()
+        .await;
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
@@ -238,7 +243,8 @@ async fn publish_existing_crate_rate_limited() {
 
     let (app, anon, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::PublishUpdate, RATE_LIMIT, 1)
-        .with_token();
+        .with_token()
+        .await;
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");
@@ -315,7 +321,8 @@ async fn publish_existing_crate_rate_limit_doesnt_affect_new_crates() {
             Duration::from_secs(60 * 60),
             1,
         )
-        .with_token();
+        .with_token()
+        .await;
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("rate_limited1", "1.0.0");

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -5,7 +5,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_readme() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("hello world");
     let response = token.publish_crate(crate_to_publish).await;
@@ -27,7 +27,7 @@ async fn new_krate_with_readme() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_empty_readme() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0").readme("");
     let response = token.publish_crate(crate_to_publish).await;
@@ -48,7 +48,7 @@ async fn new_krate_with_empty_readme() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_readme_and_plus_version() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_readme", "1.0.0+foo").readme("hello world");
     let response = token.publish_crate(crate_to_publish).await;
@@ -70,7 +70,7 @@ async fn new_krate_with_readme_and_plus_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_after_removing_documentation() {
-    let (app, anon, user, token) = TestApp::full().with_token();
+    let (app, anon, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -6,7 +6,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("Foo_similar", user.as_model().id)
@@ -22,7 +22,7 @@ async fn new_crate_similar_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_hyphen() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo_bar_hyphen", user.as_model().id)
@@ -38,7 +38,7 @@ async fn new_crate_similar_name_hyphen() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_underscore() {
-    let (app, _, user, token) = TestApp::full().with_token();
+    let (app, _, user, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo-bar-underscore", user.as_model().id)

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -21,7 +21,7 @@ async fn new_krate_wrong_files() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_tarball_with_hard_links() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let tarball = {
         let mut builder = TarballBuilder::new();
@@ -58,7 +58,7 @@ async fn empty_body() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn json_len_truncated() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token.publish_crate(&[0u8, 0] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -68,7 +68,7 @@ async fn json_len_truncated() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn json_bytes_truncated() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token.publish_crate(&[100u8, 0, 0, 0, 0] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -78,7 +78,7 @@ async fn json_bytes_truncated() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tarball_len_truncated() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8])
@@ -90,7 +90,7 @@ async fn tarball_len_truncated() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn tarball_bytes_truncated() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8])

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -7,7 +7,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_wrong_files() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
 
     let builder = PublishBuilder::new("foo", "1.0.0")
         .add_file("foo-1.0.0/a", "")
@@ -48,7 +48,7 @@ async fn new_krate_tarball_with_hard_links() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_body() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
 
     let response = user.publish_crate(&[] as &[u8]).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/src/tests/krate/publish/timestamps.rs
+++ b/src/tests/krate/publish/timestamps.rs
@@ -8,7 +8,7 @@ async fn uploading_new_version_touches_crate() {
     use diesel::ExpressionMethods;
     use diesel_async::RunQueryDsl;
 
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     let mut conn = app.async_db_conn().await;
 
     let crate_to_publish = PublishBuilder::new("foo_versions_updated_at", "1.0.0");

--- a/src/tests/krate/publish/validation.rs
+++ b/src/tests/krate/publish/validation.rs
@@ -7,7 +7,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_json() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let (_json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
     let body = PublishBuilder::create_publish_body("{}", &tarball);
@@ -20,7 +20,7 @@ async fn empty_json() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_names() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     async fn bad_name(name: &str, client: &impl RequestHelper) {
         let crate_to_publish = PublishBuilder::new(name, "1.0.0");
@@ -46,7 +46,7 @@ async fn invalid_names() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_version() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let (json, tarball) = PublishBuilder::new("foo", "1.0.0").build();
     let new_json = json.replace(r#""vers":"1.0.0""#, r#""vers":"broken""#);
@@ -61,7 +61,7 @@ async fn invalid_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn license_and_description_required() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0")
         .unset_license()
@@ -88,7 +88,7 @@ async fn license_and_description_required() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn long_description() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let description = "a".repeat(2000);
     let crate_to_publish = PublishBuilder::new("foo_metadata", "1.1.0").description(&description);
@@ -102,7 +102,7 @@ async fn long_description() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_license() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(PublishBuilder::new("foo", "1.0.0").license("MIT AND foobar"))
@@ -114,7 +114,7 @@ async fn invalid_license() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_urls() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
 
     let response = token
         .publish_crate(

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 #[tokio::test(flavor = "multi_thread")]
 #[allow(unknown_lints, clippy::bool_assert_comparison)] // for claim::assert_some_eq! with bool
 async fn yank_works_as_intended() {
-    let (app, anon, cookie, token) = TestApp::full().with_token();
+    let (app, anon, cookie, token) = TestApp::full().with_token().await;
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
@@ -81,7 +81,8 @@ fn check_yanked(app: &TestApp, is_yanked: bool) {
 async fn yank_ratelimit_hit() {
     let (app, _, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::YankUnyank, Duration::from_millis(500), 1)
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.async_db_conn().await;
 
@@ -117,7 +118,8 @@ async fn yank_ratelimit_hit() {
 async fn yank_ratelimit_expires() {
     let (app, _, _, token) = TestApp::full()
         .with_rate_limit(LimitedAction::YankUnyank, Duration::from_millis(500), 1)
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.async_db_conn().await;
 
@@ -147,7 +149,7 @@ async fn yank_ratelimit_expires() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn yank_max_version() {
-    let (_, anon, _, token) = TestApp::full().with_token();
+    let (_, anon, _, token) = TestApp::full().with_token().await;
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk_max", "1.0.0");
@@ -201,7 +203,7 @@ async fn yank_max_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_after_yank_max_version() {
-    let (_, anon, _, token) = TestApp::full().with_token();
+    let (_, anon, _, token) = TestApp::full().with_token().await;
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk_max", "1.0.0");
@@ -231,7 +233,7 @@ async fn publish_after_yank_max_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn patch_version_yank_unyank() {
-    let (_, anon, _, token) = TestApp::full().with_token();
+    let (_, anon, _, token) = TestApp::full().with_token().await;
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("patchable", "1.0.0");

--- a/src/tests/middleware/head.rs
+++ b/src/tests/middleware/head.rs
@@ -3,7 +3,7 @@ use http::{Method, StatusCode};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn head_method_works() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let req = anon.request_builder(Method::HEAD, "/api/v1/summary");
     let res = anon.run::<()>(req).await;
@@ -13,7 +13,7 @@ async fn head_method_works() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn head_method_works_for_404() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let req = anon.request_builder(Method::HEAD, "/unknown");
     let res = anon.run::<()>(req).await;

--- a/src/tests/not_found_error.rs
+++ b/src/tests/not_found_error.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn visiting_unknown_route_returns_404() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let response = anon.get::<()>("/does-not-exist").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -13,7 +13,7 @@ async fn visiting_unknown_route_returns_404() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn visiting_unknown_api_route_returns_404() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let response = anon.get::<()>("/api/v1/does-not-exist").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -156,6 +156,7 @@ async fn new_crate_owner() {
     let crate_to_publish = PublishBuilder::new("foo_owner", "2.0.0");
     user2
         .db_new_token("bar_token")
+        .await
         .publish_crate(crate_to_publish)
         .await
         .good();

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -127,7 +127,7 @@ impl MockAnonymousUser {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_owner() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     // Create a crate under one user
@@ -180,7 +180,7 @@ async fn create_and_add_owner(
 /// a user can still remove their own login as an owner
 #[tokio::test(flavor = "multi_thread")]
 async fn owners_can_remove_self() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let username = &user.as_model().gh_login;
 
@@ -213,7 +213,7 @@ async fn owners_can_remove_self() {
 /// Verify consistency when adidng or removing multiple owners in a single request.
 #[tokio::test(flavor = "multi_thread")]
 async fn modify_multiple_owners() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let username = &user.as_model().gh_login;
 
@@ -335,7 +335,7 @@ async fn check_ownership_one_crate() {
 /// when that team is already a crate owner.
 #[tokio::test(flavor = "multi_thread")]
 async fn add_existing_team() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -399,7 +399,7 @@ async fn invitations_are_empty_by_default_v1() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn api_token_cannot_list_invitations_v1() {
-    let (_, _, _, token) = TestApp::init().with_token();
+    let (_, _, _, token) = TestApp::init().with_token().await;
 
     token
         .get("/api/v1/me/crate_owner_invitations")
@@ -409,7 +409,7 @@ async fn api_token_cannot_list_invitations_v1() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_v1() {
-    let (app, _, owner, token) = TestApp::init().with_token();
+    let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
 
@@ -446,7 +446,7 @@ async fn invitations_list_v1() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_does_not_include_expired_invites_v1() {
-    let (app, _, owner, token) = TestApp::init().with_token();
+    let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
 
@@ -493,7 +493,7 @@ async fn invitations_list_does_not_include_expired_invites_v1() {
 /// inserted into the table for the given crate.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_invitation() {
-    let (app, anon, owner, owner_token) = TestApp::init().with_token();
+    let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar");
@@ -526,7 +526,7 @@ async fn test_accept_invitation() {
 /// the invitations table.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decline_invitation() {
-    let (app, anon, owner, owner_token) = TestApp::init().with_token();
+    let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar");
@@ -555,7 +555,7 @@ async fn test_decline_invitation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_invitation_by_mail() {
-    let (app, anon, owner, owner_token) = TestApp::init().with_token();
+    let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     let owner = owner.as_model();
@@ -604,7 +604,7 @@ pub fn expire_invitation(app: &TestApp, crate_id: i32) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_expired_invitation() {
-    let (app, anon, owner, owner_token) = TestApp::init().with_token();
+    let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
     let invited_user = app.db_new_user("demo_user");
@@ -644,7 +644,7 @@ async fn test_accept_expired_invitation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decline_expired_invitation() {
-    let (app, anon, owner, owner_token) = TestApp::init().with_token();
+    let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
     let invited_user = app.db_new_user("demo_user");
@@ -672,7 +672,7 @@ async fn test_decline_expired_invitation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_expired_invitation_by_mail() {
-    let (app, anon, owner, owner_token) = TestApp::init().with_token();
+    let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     let owner = owner.as_model();
@@ -717,7 +717,7 @@ async fn test_accept_expired_invitation_by_mail() {
 async fn inactive_users_dont_get_invitations() {
     use crate::models::NewUser;
 
-    let (app, _, owner, owner_token) = TestApp::init().with_token();
+    let (app, _, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
 
@@ -753,7 +753,7 @@ async fn inactive_users_dont_get_invitations() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn highest_gh_id_is_most_recent_account_we_know_of() {
-    let (app, _, owner, owner_token) = TestApp::init().with_token();
+    let (app, _, owner, owner_token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let owner = owner.as_model();
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -275,7 +275,7 @@ async fn modify_multiple_owners() {
 /// only crates owned by that team.
 #[tokio::test(flavor = "multi_thread")]
 async fn check_ownership_two_crates() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -306,7 +306,7 @@ async fn check_ownership_two_crates() {
 /// EncodableOwner::encodable is expecting
 #[tokio::test(flavor = "multi_thread")]
 async fn check_ownership_one_crate() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -357,7 +357,7 @@ async fn add_existing_team() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn deleted_ownership_isnt_in_owner_user() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -373,7 +373,7 @@ async fn deleted_ownership_isnt_in_owner_user() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     app.db_new_user("bar");
 
     let response = user.get::<()>("/api/v1/crates/unknown/owners").await;
@@ -391,7 +391,7 @@ async fn test_unknown_crate() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_are_empty_by_default_v1() {
-    let (_, _, user) = TestApp::init().with_user();
+    let (_, _, user) = TestApp::init().with_user().await;
 
     let json = user.list_invitations().await;
     assert_eq!(json.crate_owner_invitations.len(), 0);

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -11,7 +11,8 @@ async fn pagination_blocks_ip_from_cidr_block_list() {
             config.max_allowed_page_offset = 1;
             config.page_offset_cidr_blocklist = vec!["127.0.0.1/24".parse::<IpNetwork>().unwrap()];
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
     let user = user.as_model();

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -45,7 +45,8 @@ async fn can_download_crate_in_read_only_mode() {
         .with_config(|config| {
             config.db.primary.read_only_mode = true;
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -11,7 +11,8 @@ async fn can_hit_read_only_endpoints_in_read_only_mode() {
         .with_config(|config| {
             config.db.primary.read_only_mode = true;
         })
-        .empty();
+        .empty()
+        .await;
 
     let response = anon.get::<()>("/api/v1/crates").await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -23,7 +23,8 @@ async fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
         .with_config(|config| {
             config.db.primary.read_only_mode = true;
         })
-        .with_token();
+        .with_token()
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
 
     let url = "/api/v1/categories/foo-bar";

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -43,7 +43,7 @@ async fn update_crate() {
         json.category.crates_cnt as usize
     }
 
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/categories/list.rs
+++ b/src/tests/routes/categories/list.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn index() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.async_db_conn().await;
 
     // List 0 categories if none exist

--- a/src/tests/routes/category_slugs/list.rs
+++ b/src/tests/routes/category_slugs/list.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn category_slugs_returns_all_slugs_in_alphabetical_order() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.async_db_conn().await;
 
     let cats = vec![

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -63,7 +63,7 @@ pub async fn download(client: &impl RequestHelper, name_and_version: &str) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -98,7 +98,7 @@ async fn test_download() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_with_counting_via_cdn() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo", user.as_model().id)
@@ -113,7 +113,7 @@ async fn test_download_with_counting_via_cdn() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_crate_downloads() {
-    let (app, anon, cookie) = TestApp::init().with_user();
+    let (app, anon, cookie) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     let user_id = cookie.as_model().id;
@@ -153,7 +153,7 @@ async fn test_crate_downloads() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_version_downloads() {
-    let (app, anon, cookie) = TestApp::init().with_user();
+    let (app, anon, cookie) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     let user_id = cookie.as_model().id;

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -12,7 +12,7 @@ async fn diesel_not_found_results_in_404() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn disallow_api_token_auth_for_get_crate_following_status() {
-    let (app, _, _, token) = TestApp::init().with_token();
+    let (app, _, _, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let api_token = token.as_model();
 

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -3,7 +3,7 @@ use crate::tests::util::{RequestHelper, TestApp};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn diesel_not_found_results_in_404() {
-    let (_, _, user) = TestApp::init().with_user();
+    let (_, _, user) = TestApp::init().with_user().await;
 
     user.get("/api/v1/crates/foo_following/following")
         .await

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -40,7 +40,7 @@ async fn index() {
 #[tokio::test(flavor = "multi_thread")]
 #[allow(clippy::cognitive_complexity)]
 async fn index_queries() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -201,7 +201,7 @@ async fn index_queries() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn search_includes_crates_where_name_is_stopword() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -218,7 +218,7 @@ async fn search_includes_crates_where_name_is_stopword() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn exact_match_first_on_queries() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -263,7 +263,7 @@ async fn exact_match_first_on_queries() {
 #[tokio::test(flavor = "multi_thread")]
 #[allow(clippy::cognitive_complexity)]
 async fn index_sorting() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -483,7 +483,7 @@ async fn index_sorting() {
 #[tokio::test(flavor = "multi_thread")]
 #[allow(clippy::cognitive_complexity)]
 async fn ignore_exact_match_on_queries_with_sort() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -613,7 +613,7 @@ async fn ignore_exact_match_on_queries_with_sort() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_ids() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -637,7 +637,7 @@ async fn multiple_ids() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn loose_search_order() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -684,7 +684,7 @@ async fn loose_search_order() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn index_include_yanked() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -748,7 +748,7 @@ async fn index_include_yanked() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn yanked_versions_are_not_considered_for_max_version() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -768,7 +768,7 @@ async fn yanked_versions_are_not_considered_for_max_version() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn max_stable_version() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -797,7 +797,7 @@ async fn max_stable_version() {
 /// these numbers do not overlap.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recent_download_count() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -833,7 +833,7 @@ async fn test_recent_download_count() {
 /// for both recent downloads and downloads.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zero_downloads() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -857,7 +857,7 @@ async fn test_zero_downloads() {
 /// categories and keywords is sorted by recent downloads by default.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_default_sort_recent() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -917,7 +917,7 @@ async fn test_default_sort_recent() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn pagination_links_included_if_applicable() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -962,7 +962,7 @@ async fn pagination_links_included_if_applicable() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn seek_based_pagination() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -1011,7 +1011,7 @@ async fn seek_based_pagination() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pages_work_even_with_seek_based_pagination() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -1034,7 +1034,7 @@ async fn test_pages_work_even_with_seek_based_pagination() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_params_with_null_bytes() {
-    let (_app, anon, _cookie) = TestApp::init().with_user();
+    let (_app, anon, _cookie) = TestApp::init().with_user().await;
 
     for name in ["q", "category", "all_keywords", "keyword", "letter"] {
         let response = anon.get::<()>(&format!("/api/v1/crates?{name}=%00")).await;
@@ -1045,7 +1045,7 @@ async fn invalid_params_with_null_bytes() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_seek_parameter() {
-    let (_app, anon, _cookie) = TestApp::init().with_user();
+    let (_app, anon, _cookie) = TestApp::init().with_user().await;
 
     let response = anon.get::<()>("/api/v1/crates?seek=broken").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -1054,7 +1054,7 @@ async fn invalid_seek_parameter() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn pagination_parameters_only_accept_integers() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -1077,7 +1077,7 @@ async fn pagination_parameters_only_accept_integers() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_user_id() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let id = user.as_model().id;
 
@@ -1091,7 +1091,7 @@ async fn crates_by_user_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_user_id_not_including_deleted_owners() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -13,7 +13,7 @@ use std::sync::LazyLock;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn index() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
 
     for json in search_both(&anon, "").await {

--- a/src/tests/routes/crates/new.rs
+++ b/src/tests/routes/crates/new.rs
@@ -5,7 +5,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn daily_limit() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
 
     let max_daily_versions = app.as_inner().config.new_version_rate_limit.unwrap();
     for version in 1..=max_daily_versions {

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -65,8 +65,9 @@ async fn owner_change_via_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_change_owner_token() {
-    let (app, _, _, token) =
-        TestApp::full().with_scoped_token(None, Some(vec![EndpointScope::ChangeOwners]));
+    let (app, _, _, token) = TestApp::full()
+        .with_scoped_token(None, Some(vec![EndpointScope::ChangeOwners]))
+        .await;
 
     let mut conn = app.db_conn();
 
@@ -84,7 +85,9 @@ async fn owner_change_via_change_owner_token() {
 async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let crate_scopes = Some(vec![CrateScope::try_from("foo_crate").unwrap()]);
     let endpoint_scopes = Some(vec![EndpointScope::ChangeOwners]);
-    let (app, _, _, token) = TestApp::full().with_scoped_token(crate_scopes, endpoint_scopes);
+    let (app, _, _, token) = TestApp::full()
+        .with_scoped_token(crate_scopes, endpoint_scopes)
+        .await;
     let mut conn = app.db_conn();
 
     let user2 = app.db_new_user("user-2");
@@ -101,7 +104,9 @@ async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
 async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let crate_scopes = Some(vec![CrateScope::try_from("bar").unwrap()]);
     let endpoint_scopes = Some(vec![EndpointScope::ChangeOwners]);
-    let (app, _, _, token) = TestApp::full().with_scoped_token(crate_scopes, endpoint_scopes);
+    let (app, _, _, token) = TestApp::full()
+        .with_scoped_token(crate_scopes, endpoint_scopes)
+        .await;
     let mut conn = app.db_conn();
 
     let user2 = app.db_new_user("user-2");
@@ -116,8 +121,9 @@ async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_publish_token() {
-    let (app, _, _, token) =
-        TestApp::full().with_scoped_token(None, Some(vec![EndpointScope::PublishUpdate]));
+    let (app, _, _, token) = TestApp::full()
+        .with_scoped_token(None, Some(vec![EndpointScope::PublishUpdate]))
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 // which call the `PUT /crates/:crate_id/owners` route
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cargo_invite_owners() {
-    let (app, _, owner) = TestApp::init().with_user();
+    let (app, _, owner) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     let new_user = app.db_new_user("cilantro");
@@ -35,7 +35,7 @@ async fn test_cargo_invite_owners() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_cookie() {
-    let (app, _, cookie) = TestApp::full().with_user();
+    let (app, _, cookie) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     let user2 = app.db_new_user("user-2");
@@ -139,7 +139,7 @@ async fn owner_change_via_publish_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_without_auth() {
-    let (app, anon, cookie) = TestApp::full().with_user();
+    let (app, anon, cookie) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     let user2 = app.db_new_user("user-2");
@@ -154,7 +154,7 @@ async fn owner_change_without_auth() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_legacy_field() {
-    let (app, _, user1) = TestApp::full().with_user();
+    let (app, _, user1) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo", user1.as_model().id).expect_build(&mut conn);
@@ -170,7 +170,7 @@ async fn test_owner_change_with_legacy_field() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_invalid_json() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     app.db_new_user("bar");
@@ -262,7 +262,7 @@ async fn invite_with_existing_expired_invite() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     app.db_new_user("bar");
 
     let response = user.add_named_owner("unknown", "bar").await;
@@ -272,7 +272,7 @@ async fn test_unknown_crate() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_user() {
-    let (app, _, cookie) = TestApp::full().with_user();
+    let (app, _, cookie) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
@@ -284,7 +284,7 @@ async fn test_unknown_user() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_team() {
-    let (app, _, cookie) = TestApp::full().with_user();
+    let (app, _, cookie) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -50,7 +50,7 @@ async fn owner_change_via_cookie() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_token() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     let user2 = app.db_new_user("user-2");
@@ -197,7 +197,7 @@ async fn test_owner_change_with_invalid_json() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invite_already_invited_user() {
-    let (app, _, _, owner) = TestApp::init().with_token();
+    let (app, _, _, owner) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     app.db_new_user("invited_user");
@@ -225,7 +225,7 @@ async fn invite_already_invited_user() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invite_with_existing_expired_invite() {
-    let (app, _, _, owner) = TestApp::init().with_token();
+    let (app, _, _, owner) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     app.db_new_user("invited_user");
@@ -292,7 +292,7 @@ async fn test_unknown_team() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn max_invites_per_request() {
-    let (app, _, _, owner) = TestApp::init().with_token();
+    let (app, _, _, owner) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(&mut conn);
@@ -314,7 +314,7 @@ async fn max_invites_per_request() {
 /// Assert that emails are only sent if the request succeeds.
 #[tokio::test(flavor = "multi_thread")]
 async fn no_invite_emails_for_txn_rollback() {
-    let (app, _, _, token) = TestApp::init().with_token();
+    let (app, _, _, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("crate_name", token.as_model().user_id).expect_build(&mut conn);

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -11,7 +11,7 @@ async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
-    app.db_new_user("bar");
+    app.db_new_user("bar").await;
     CrateBuilder::new("foo", user.as_model().id).expect_build(&mut conn);
 
     // incomplete input
@@ -42,7 +42,7 @@ async fn test_owner_change_with_invalid_json() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
     let (app, _, user) = TestApp::full().with_user().await;
-    app.db_new_user("bar");
+    app.db_new_user("bar").await;
 
     let response = user.remove_named_owner("unknown", "bar").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -80,7 +80,7 @@ async fn test_remove_uppercase_user() {
     use diesel::RunQueryDsl;
 
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let user2 = app.db_new_user("user2");
+    let user2 = app.db_new_user("user2").await;
     let mut conn = app.db_conn();
 
     let krate = CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -8,7 +8,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_invalid_json() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     app.db_new_user("bar");
@@ -41,7 +41,7 @@ async fn test_owner_change_with_invalid_json() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
-    let (app, _, user) = TestApp::full().with_user();
+    let (app, _, user) = TestApp::full().with_user().await;
     app.db_new_user("bar");
 
     let response = user.remove_named_owner("unknown", "bar").await;
@@ -51,7 +51,7 @@ async fn test_unknown_crate() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_user() {
-    let (app, _, cookie) = TestApp::full().with_user();
+    let (app, _, cookie) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
@@ -63,7 +63,7 @@ async fn test_unknown_user() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_team() {
-    let (app, _, cookie) = TestApp::full().with_user();
+    let (app, _, cookie) = TestApp::full().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
@@ -79,7 +79,7 @@ async fn test_unknown_team() {
 async fn test_remove_uppercase_user() {
     use diesel::RunQueryDsl;
 
-    let (app, _, cookie) = TestApp::full().with_user();
+    let (app, _, cookie) = TestApp::full().with_user().await;
     let user2 = app.db_new_user("user2");
     let mut conn = app.db_conn();
 
@@ -140,7 +140,7 @@ async fn test_remove_uppercase_team() {
             })
         });
 
-    let (app, _, cookie) = TestApp::full().with_github(github_mock).with_user();
+    let (app, _, cookie) = TestApp::full().with_github(github_mock).with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("crate42", cookie.as_model().id).expect_build(&mut conn);

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -103,7 +103,7 @@ async fn show_all_yanked() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_missing() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let response = anon.get::<()>("/api/v1/crates/missing").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -6,7 +6,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -47,7 +47,7 @@ async fn show() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show_minimal() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -75,7 +75,7 @@ async fn show_minimal() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show_all_yanked() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -112,7 +112,7 @@ async fn test_missing() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn version_size() {
-    let (_, _, user) = TestApp::full().with_user();
+    let (_, _, user) = TestApp::full().with_user().await;
 
     let crate_to_publish = PublishBuilder::new("foo_version_size", "1.0.0");
     user.publish_crate(crate_to_publish).await.good();
@@ -145,7 +145,7 @@ async fn version_size() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn block_bad_documentation_url() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -159,7 +159,7 @@ async fn block_bad_documentation_url() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_new_name() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("new", user.as_model().id).expect_build(&mut conn);

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -5,7 +5,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -42,7 +42,7 @@ async fn reverse_dependencies() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -67,7 +67,7 @@ async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -92,7 +92,7 @@ async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn prerelease_versions_not_included_in_reverse_dependencies() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -121,7 +121,7 @@ async fn prerelease_versions_not_included_in_reverse_dependencies() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn yanked_versions_not_included_in_reverse_dependencies() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -163,7 +163,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_includes_published_by_user_when_present() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -202,7 +202,7 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_query_supports_u64_version_number_parts() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -228,7 +228,7 @@ async fn reverse_dependencies_query_supports_u64_version_number_parts() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let response = anon
         .get::<()>("/api/v1/crates/unknown/reverse_dependencies")

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn authors() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -11,7 +11,7 @@ pub struct Deps {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dependencies() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -3,7 +3,7 @@ use crate::tests::util::{RequestHelper, TestApp};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redirects() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo-download", user.as_model().id)
@@ -33,7 +33,7 @@ async fn test_redirects() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn download_with_build_metadata() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -39,7 +39,7 @@ async fn versions() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_crate() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let response = anon.get::<()>("/api/v1/crates/unknown/versions").await;
     assert_eq!(response.status(), StatusCode::NOT_FOUND);

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn versions() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -48,7 +48,7 @@ async fn test_unknown_crate() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sorting() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     let user = user.as_model();
@@ -150,7 +150,7 @@ async fn test_sorting() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_seek_based_pagination_semver_sorting() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -233,7 +233,7 @@ async fn test_seek_based_pagination_semver_sorting() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_seek_based_pagination_date_sorting() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -319,7 +319,7 @@ async fn test_seek_based_pagination_date_sorting() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_seek_parameter() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show_by_crate_name_and_version() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -32,7 +32,7 @@ async fn show_by_crate_name_and_semver_no_published_by() {
     use crate::schema::versions;
     use diesel::{update, RunQueryDsl};
 
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -136,7 +136,7 @@ mod auth {
     const CRATE_VERSION: &str = "1.0.0";
 
     async fn prepare() -> (TestApp, MockAnonymousUser, MockCookieUser) {
-        let (app, anon, cookie) = TestApp::full().with_user();
+        let (app, anon, cookie) = TestApp::full().with_user().await;
 
         let pb = PublishBuilder::new(CRATE_NAME, CRATE_VERSION);
         cookie.publish_crate(pb).await.good();

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -62,7 +62,7 @@ impl<T: RequestHelper> YankRequestHelper for T {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn yank_by_a_non_owner_fails() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
     let another_user = app.db_new_user("bar");
@@ -79,7 +79,7 @@ async fn yank_by_a_non_owner_fails() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn yank_records_an_audit_action() {
-    let (_, anon, _, token) = TestApp::full().with_token();
+    let (_, anon, _, token) = TestApp::full().with_token().await;
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");
@@ -100,7 +100,7 @@ async fn yank_records_an_audit_action() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unyank_records_an_audit_action() {
-    let (_, anon, _, token) = TestApp::full().with_token();
+    let (_, anon, _, token) = TestApp::full().with_token().await;
 
     // Upload a new crate
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -65,7 +65,7 @@ async fn yank_by_a_non_owner_fails() {
     let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.db_conn();
 
-    let another_user = app.db_new_user("bar");
+    let another_user = app.db_new_user("bar").await;
     let another_user = another_user.as_model();
 
     CrateBuilder::new("foo_not", another_user.id)
@@ -369,7 +369,7 @@ mod auth {
         let (app, _, _) = prepare().await;
         let mut conn = app.async_db_conn().await;
 
-        let admin = app.db_new_user("admin");
+        let admin = app.db_new_user("admin").await;
 
         diesel::update(admin.as_model())
             .set(users::is_admin.eq(true))

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -190,7 +190,7 @@ mod auth {
     #[tokio::test(flavor = "multi_thread")]
     async fn token_user() {
         let (app, _, client) = prepare().await;
-        let client = client.db_new_token("test-token");
+        let client = client.db_new_token("test-token").await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -208,8 +208,9 @@ mod auth {
         let expired_at = Utc::now() + Duration::days(7);
 
         let (app, _, client) = prepare().await;
-        let client =
-            client.db_new_scoped_token("test-token", None, None, Some(expired_at.naive_utc()));
+        let client = client
+            .db_new_scoped_token("test-token", None, None, Some(expired_at.naive_utc()))
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -227,8 +228,9 @@ mod auth {
         let expired_at = Utc::now() - Duration::days(7);
 
         let (app, _, client) = prepare().await;
-        let client =
-            client.db_new_scoped_token("test-token", None, None, Some(expired_at.naive_utc()));
+        let client = client
+            .db_new_scoped_token("test-token", None, None, Some(expired_at.naive_utc()))
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -244,8 +246,9 @@ mod auth {
     #[tokio::test(flavor = "multi_thread")]
     async fn token_user_with_correct_endpoint_scope() {
         let (app, _, client) = prepare().await;
-        let client =
-            client.db_new_scoped_token("test-token", None, Some(vec![EndpointScope::Yank]), None);
+        let client = client
+            .db_new_scoped_token("test-token", None, Some(vec![EndpointScope::Yank]), None)
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -261,12 +264,14 @@ mod auth {
     #[tokio::test(flavor = "multi_thread")]
     async fn token_user_with_incorrect_endpoint_scope() {
         let (app, _, client) = prepare().await;
-        let client = client.db_new_scoped_token(
-            "test-token",
-            None,
-            Some(vec![EndpointScope::PublishUpdate]),
-            None,
-        );
+        let client = client
+            .db_new_scoped_token(
+                "test-token",
+                None,
+                Some(vec![EndpointScope::PublishUpdate]),
+                None,
+            )
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -282,12 +287,14 @@ mod auth {
     #[tokio::test(flavor = "multi_thread")]
     async fn token_user_with_correct_crate_scope() {
         let (app, _, client) = prepare().await;
-        let client = client.db_new_scoped_token(
-            "test-token",
-            Some(vec![CrateScope::try_from(CRATE_NAME).unwrap()]),
-            None,
-            None,
-        );
+        let client = client
+            .db_new_scoped_token(
+                "test-token",
+                Some(vec![CrateScope::try_from(CRATE_NAME).unwrap()]),
+                None,
+                None,
+            )
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -304,12 +311,14 @@ mod auth {
     async fn token_user_with_correct_wildcard_crate_scope() {
         let (app, _, client) = prepare().await;
         let wildcard = format!("{}*", CRATE_NAME.chars().next().unwrap());
-        let client = client.db_new_scoped_token(
-            "test-token",
-            Some(vec![CrateScope::try_from(wildcard).unwrap()]),
-            None,
-            None,
-        );
+        let client = client
+            .db_new_scoped_token(
+                "test-token",
+                Some(vec![CrateScope::try_from(wildcard).unwrap()]),
+                None,
+                None,
+            )
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::OK);
@@ -325,12 +334,14 @@ mod auth {
     #[tokio::test(flavor = "multi_thread")]
     async fn token_user_with_incorrect_crate_scope() {
         let (app, _, client) = prepare().await;
-        let client = client.db_new_scoped_token(
-            "test-token",
-            Some(vec![CrateScope::try_from("foo").unwrap()]),
-            None,
-            None,
-        );
+        let client = client
+            .db_new_scoped_token(
+                "test-token",
+                Some(vec![CrateScope::try_from("foo").unwrap()]),
+                None,
+                None,
+            )
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -346,12 +357,14 @@ mod auth {
     #[tokio::test(flavor = "multi_thread")]
     async fn token_user_with_incorrect_wildcard_crate_scope() {
         let (app, _, client) = prepare().await;
-        let client = client.db_new_scoped_token(
-            "test-token",
-            Some(vec![CrateScope::try_from("foo*").unwrap()]),
-            None,
-            None,
-        );
+        let client = client
+            .db_new_scoped_token(
+                "test-token",
+                Some(vec![CrateScope::try_from("foo*").unwrap()]),
+                None,
+                None,
+            )
+            .await;
 
         let response = client.yank(CRATE_NAME, CRATE_VERSION).await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -16,7 +16,7 @@ struct KeywordMeta {
 #[tokio::test(flavor = "multi_thread")]
 async fn index() {
     let url = "/api/v1/keywords";
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
 
     let json: KeywordList = anon.get(url).await.good();

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -11,7 +11,7 @@ struct GoodKeyword {
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
     let url = "/api/v1/keywords/foo";
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
 
     anon.get(url).await.assert_not_found();
@@ -25,7 +25,7 @@ async fn show() {
 #[tokio::test(flavor = "multi_thread")]
 async fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
 
     anon.get(url).await.assert_not_found();

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -38,7 +38,7 @@ async fn uppercase() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn update_crate() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -26,7 +26,7 @@ impl crate::tests::util::MockCookieUser {
 /// were sent in the request should be updated to the corresponding `email_notifications` value.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_update_email_notifications() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     let a = CrateBuilder::new("test_package", user.as_model().id).expect_build(&mut conn);
@@ -107,7 +107,7 @@ async fn test_update_email_notifications() {
 /// owned by them.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_update_email_notifications_not_owned() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     let user_id = diesel::insert_into(users::table)

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -19,7 +19,7 @@ pub struct UserShowPrivateResponse {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn me() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     let response = anon.get::<()>("/api/v1/me").await;
@@ -39,7 +39,7 @@ async fn me() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user_model = user.as_model();
 

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -101,7 +101,7 @@ async fn create_token_multiple_users_have_different_values() {
     let (app, _, user1) = TestApp::init().with_user().await;
     let first: Value = user1.put("/api/v1/me/tokens", NEW_BAR).await.good();
 
-    let user2 = app.db_new_user("bar");
+    let user2 = app.db_new_user("bar").await;
     let second: Value = user2.put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     assert_ne!(first["api_token"]["token"], second["api_token"]["token"]);

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -109,7 +109,7 @@ async fn create_token_multiple_users_have_different_values() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn cannot_create_token_with_token() {
-    let (app, _, _, token) = TestApp::init().with_token();
+    let (app, _, _, token) = TestApp::init().with_token().await;
     let response = token
         .put::<()>(
             "/api/v1/me/tokens",

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -13,7 +13,7 @@ static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_logged_out() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     anon.put("/api/v1/me/tokens", NEW_BAR)
         .await
         .assert_forbidden();

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -21,7 +21,7 @@ async fn create_token_logged_out() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_invalid_request() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let invalid: &[u8] = br#"{ "name": "" }"#;
     let response = user.put::<()>("/api/v1/me/tokens", invalid).await;
     assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
@@ -31,7 +31,7 @@ async fn create_token_invalid_request() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_no_name() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let empty_name: &[u8] = br#"{ "api_token": { "name": "" } }"#;
     let response = user.put::<()>("/api/v1/me/tokens", empty_name).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -41,7 +41,7 @@ async fn create_token_no_name() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_exceeded_tokens_per_user() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let id = user.as_model().id;
 
@@ -57,7 +57,7 @@ async fn create_token_exceeded_tokens_per_user() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_success() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.async_db_conn().await;
 
     let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR).await;
@@ -88,7 +88,7 @@ async fn create_token_success() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_multiple_have_different_values() {
-    let (_, _, user) = TestApp::init().with_user();
+    let (_, _, user) = TestApp::init().with_user().await;
     let first: Value = user.put("/api/v1/me/tokens", NEW_BAR).await.good();
     let second: Value = user.put("/api/v1/me/tokens", NEW_BAR).await.good();
 
@@ -98,7 +98,7 @@ async fn create_token_multiple_have_different_values() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_multiple_users_have_different_values() {
-    let (app, _, user1) = TestApp::init().with_user();
+    let (app, _, user1) = TestApp::init().with_user().await;
     let first: Value = user1.put("/api/v1/me/tokens", NEW_BAR).await.good();
 
     let user2 = app.db_new_user("bar");
@@ -123,7 +123,7 @@ async fn cannot_create_token_with_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_with_scopes() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.async_db_conn().await;
 
     let json = json!({
@@ -173,7 +173,7 @@ async fn create_token_with_scopes() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_with_null_scopes() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.async_db_conn().await;
 
     let json = json!({
@@ -214,7 +214,7 @@ async fn create_token_with_null_scopes() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_with_empty_crate_scope() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
 
     let json = json!({
         "api_token": {
@@ -234,7 +234,7 @@ async fn create_token_with_empty_crate_scope() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_with_invalid_endpoint_scope() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
 
     let json = json!({
         "api_token": {
@@ -254,7 +254,7 @@ async fn create_token_with_invalid_endpoint_scope() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_with_expiry_date() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
 
     let json = json!({
         "api_token": {

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -9,7 +9,7 @@ pub struct RevokedResponse {}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_token_non_existing() {
-    let (_, _, user) = TestApp::init().with_user();
+    let (_, _, user) = TestApp::init().with_user().await;
     let _json: RevokedResponse = user.delete("/api/v1/me/tokens/5").await.good();
 }
 

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -15,7 +15,7 @@ async fn revoke_token_non_existing() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_token_doesnt_revoke_other_users_token() {
-    let (app, _, user1, token) = TestApp::init().with_token();
+    let (app, _, user1, token) = TestApp::init().with_token().await;
     let mut conn = app.async_db_conn().await;
     let user1 = user1.as_model();
     let token = token.as_model();
@@ -50,7 +50,7 @@ async fn revoke_token_doesnt_revoke_other_users_token() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_token_success() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     // List tokens contains the token

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -19,7 +19,7 @@ async fn revoke_token_doesnt_revoke_other_users_token() {
     let mut conn = app.async_db_conn().await;
     let user1 = user1.as_model();
     let token = token.as_model();
-    let user2 = app.db_new_user("baz");
+    let user2 = app.db_new_user("baz").await;
 
     // List tokens for first user contains the token
     let tokens: Vec<ApiToken> = assert_ok!(

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -8,7 +8,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_current_token_success() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     // Ensure that the token currently exists in the database
@@ -50,7 +50,7 @@ async fn revoke_current_token_without_auth() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_current_token_with_cookie_user() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     // Ensure that the token currently exists in the database

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -41,7 +41,7 @@ async fn revoke_current_token_success() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_current_token_without_auth() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let response = anon.delete::<()>("/api/v1/tokens/current").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -26,7 +26,7 @@ async fn show() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show_token_with_scopes() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user_model = user.as_model();
     let id = user_model.id;
@@ -62,7 +62,7 @@ async fn show_with_anonymous_user() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show_other_user_token() {
-    let (app, _, user1) = TestApp::init().with_user();
+    let (app, _, user1) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user2 = app.db_new_user("baz");
     let user2 = user2.as_model();

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -56,7 +56,7 @@ async fn show_token_with_scopes() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_with_anonymous_user() {
     let url = "/api/v1/me/tokens/1";
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     anon.get(url).await.assert_forbidden();
 }
 

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -8,13 +8,13 @@ use insta::assert_json_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn show_token_non_existing() {
     let url = "/api/v1/me/tokens/10086";
-    let (_, _, user, _) = TestApp::init().with_token();
+    let (_, _, user, _) = TestApp::init().with_token().await;
     user.get(url).await.assert_not_found();
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
-    let (_, _, user, token) = TestApp::init().with_token();
+    let (_, _, user, token) = TestApp::init().with_token().await;
     let token = token.as_model();
     let url = format!("/api/v1/me/tokens/{}", token.id);
     let response = user.get::<()>(&url).await;

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -64,7 +64,7 @@ async fn show_with_anonymous_user() {
 async fn show_other_user_token() {
     let (app, _, user1) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
-    let user2 = app.db_new_user("baz");
+    let user2 = app.db_new_user("baz").await;
     let user2 = user2.as_model();
 
     let token = assert_ok!(ApiToken::insert(&mut conn, user2.id, "bar"));

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_logged_out() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     anon.get("/api/v1/me/tokens").await.assert_forbidden();
 }
 

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -21,7 +21,7 @@ async fn list_with_api_token_is_forbidden() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_empty() {
-    let (_, _, user) = TestApp::init().with_user();
+    let (_, _, user) = TestApp::init().with_user().await;
     let response = user.get::<()>("/api/v1/me/tokens").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r#"{"api_tokens":[]}"#);
@@ -29,7 +29,7 @@ async fn list_empty() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_tokens() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let id = user.as_model().id;
 
@@ -70,7 +70,7 @@ async fn list_recently_expired_tokens() {
         assert_some!(response_tokens.iter().find(|token| token["name"] == name));
     }
 
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let id = user.as_model().id;
 
@@ -115,7 +115,7 @@ async fn list_recently_expired_tokens() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_tokens_exclude_revoked() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let id = user.as_model().id;
 

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -15,7 +15,7 @@ async fn list_logged_out() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_with_api_token_is_forbidden() {
-    let (_, _, _, token) = TestApp::init().with_token();
+    let (_, _, _, token) = TestApp::init().with_token().await;
     token.get("/api/v1/me/tokens").await.assert_forbidden();
 }
 

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -11,7 +11,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn api_token_cannot_get_user_updates() {
-    let (_, _, _, token) = TestApp::init().with_token();
+    let (_, _, _, token) = TestApp::init().with_token().await;
     token.get("/api/v1/me/updates").await.assert_forbidden();
 }
 

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -27,7 +27,7 @@ async fn following() {
         more: bool,
     }
 
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user_model = user.as_model();
     let user_id = user_model.id;

--- a/src/tests/routes/metrics.rs
+++ b/src/tests/routes/metrics.rs
@@ -6,7 +6,8 @@ use http::StatusCode;
 async fn metrics_endpoint_works() {
     let (_, anon) = TestApp::init()
         .with_config(|config| config.metrics_authorization_token = Some("foobar".into()))
-        .empty();
+        .empty()
+        .await;
 
     let resp = request_metrics(&anon, "service", Some("foobar")).await;
     assert_eq!(resp.status(), StatusCode::OK);
@@ -22,7 +23,8 @@ async fn metrics_endpoint_works() {
 async fn metrics_endpoint_wrong_auth() {
     let (_, anon) = TestApp::init()
         .with_config(|config| config.metrics_authorization_token = Some("secret".into()))
-        .empty();
+        .empty()
+        .await;
 
     // Wrong secret
 
@@ -51,7 +53,8 @@ async fn metrics_endpoint_wrong_auth() {
 async fn metrics_endpoint_auth_disabled() {
     let (_, anon) = TestApp::init()
         .with_config(|config| config.metrics_authorization_token = None)
-        .empty();
+        .empty()
+        .await;
 
     // Wrong secret
 

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -28,7 +28,7 @@ async fn get_invitations(user: &MockCookieUser, query: &str) -> CrateOwnerInvita
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list() {
-    let (app, _, owner, token) = TestApp::init().with_token();
+    let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
@@ -165,7 +165,7 @@ async fn invitation_list() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_does_not_include_expired_invites() {
-    let (app, _, owner, token) = TestApp::init().with_token();
+    let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("invited_user");
 
@@ -209,7 +209,7 @@ async fn invitations_list_does_not_include_expired_invites() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_paginated() {
-    let (app, _, owner, token) = TestApp::init().with_token();
+    let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("invited_user");
 
@@ -283,7 +283,7 @@ async fn invitations_list_paginated() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list_with_no_filter() {
-    let (_, _, owner, _) = TestApp::init().with_token();
+    let (_, _, owner, _) = TestApp::init().with_token().await;
 
     let resp = owner
         .get::<()>("/api/private/crate_owner_invitations")
@@ -301,7 +301,7 @@ async fn invitation_list_with_no_filter() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list_other_users() {
-    let (app, _, owner, _) = TestApp::init().with_token();
+    let (app, _, owner, _) = TestApp::init().with_token().await;
     let other_user = app.db_new_user("other");
 
     // Retrieving our own invitations work.
@@ -325,7 +325,7 @@ async fn invitation_list_other_users() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list_other_crates() {
-    let (app, _, owner, _) = TestApp::init().with_token();
+    let (app, _, owner, _) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
     let other_user = app.db_new_user("other");
 

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -34,8 +34,8 @@ async fn invitation_list() {
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
     let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
 
-    let user1 = app.db_new_user("user_1");
-    let user2 = app.db_new_user("user_2");
+    let user1 = app.db_new_user("user_1").await;
+    let user2 = app.db_new_user("user_2").await;
     token.add_named_owner("crate_1", "user_1").await.good();
     token.add_named_owner("crate_1", "user_2").await.good();
     token.add_named_owner("crate_2", "user_1").await.good();
@@ -167,7 +167,7 @@ async fn invitation_list() {
 async fn invitations_list_does_not_include_expired_invites() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
-    let user = app.db_new_user("invited_user");
+    let user = app.db_new_user("invited_user").await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
     let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
@@ -211,7 +211,7 @@ async fn invitations_list_does_not_include_expired_invites() {
 async fn invitations_list_paginated() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
-    let user = app.db_new_user("invited_user");
+    let user = app.db_new_user("invited_user").await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
     let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
@@ -302,7 +302,7 @@ async fn invitation_list_with_no_filter() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list_other_users() {
     let (app, _, owner, _) = TestApp::init().with_token().await;
-    let other_user = app.db_new_user("other");
+    let other_user = app.db_new_user("other").await;
 
     // Retrieving our own invitations work.
     let resp = owner
@@ -327,7 +327,7 @@ async fn invitation_list_other_users() {
 async fn invitation_list_other_crates() {
     let (app, _, owner, _) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
-    let other_user = app.db_new_user("other");
+    let other_user = app.db_new_user("other").await;
 
     CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
     CrateBuilder::new("crate_2", other_user.as_model().id).expect_build(&mut conn);

--- a/src/tests/routes/session/authorize.rs
+++ b/src/tests/routes/session/authorize.rs
@@ -4,7 +4,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn access_token_needs_data() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     let response = anon.get::<()>("/api/private/session/authorize").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize query string: missing field `code`"}]}"#);

--- a/src/tests/routes/session/begin.rs
+++ b/src/tests/routes/session/begin.rs
@@ -8,7 +8,7 @@ struct AuthResponse {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn auth_gives_a_token() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     let json: AuthResponse = anon.get("/api/private/session/begin").await.good();
     assert!(json.url.contains(&json.state));
 }

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -27,7 +27,7 @@ async fn summary_doesnt_die() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn summary_new_crates() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 
@@ -146,7 +146,8 @@ async fn excluded_crate_id() {
                 "downloads".into(),
             ];
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
     let user = user.as_model();
@@ -201,7 +202,8 @@ async fn all_yanked() {
                 "downloads".into(),
             ];
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
     let user = user.as_model();

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -21,7 +21,7 @@ struct SummaryResponse {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn summary_doesnt_die() {
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
     anon.get::<SummaryResponse>("/api/v1/summary").await.good();
 }
 

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -11,7 +11,7 @@ pub struct UserShowPublicResponse {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
-    let (app, anon, _) = TestApp::init().with_user();
+    let (app, anon, _) = TestApp::init().with_user().await;
     app.db_new_user("Bar");
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").await.good();

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -24,7 +24,7 @@ async fn show() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show_latest_user_case_insensitively() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
 
     // Please do not delete or modify the setup of this test in order to get it to pass.

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -12,7 +12,7 @@ pub struct UserShowPublicResponse {
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
     let (app, anon, _) = TestApp::init().with_user().await;
-    app.db_new_user("Bar");
+    app.db_new_user("Bar").await;
 
     let json: UserShowPublicResponse = anon.get("/api/v1/users/foo").await.good();
     assert_eq!(json.user.login, "foo");

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -13,7 +13,7 @@ async fn user_total_downloads() {
     use diesel::prelude::*;
     use diesel::{update, QueryDsl, RunQueryDsl};
 
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
     let another_user = app.db_new_user("bar");
@@ -54,7 +54,7 @@ async fn user_total_downloads() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn user_total_downloads_no_crates() {
-    let (_, anon, user) = TestApp::init().with_user();
+    let (_, anon, user) = TestApp::init().with_user().await;
     let user = user.as_model();
     let url = format!("/api/v1/users/{}/stats", user.id);
 

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -16,7 +16,7 @@ async fn user_total_downloads() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
-    let another_user = app.db_new_user("bar");
+    let another_user = app.db_new_user("bar").await;
     let another_user = another_user.as_model();
 
     let krate = CrateBuilder::new("foo_krate1", user.id).expect_build(&mut conn);

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -39,7 +39,7 @@ impl crate::tests::util::MockCookieUser {
 /// their email by adding an empty string.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_empty_email_not_added() {
-    let (_app, _anon, user) = TestApp::init().with_user();
+    let (_app, _anon, user) = TestApp::init().with_user().await;
     let model = user.as_model();
 
     let response = user.update_email_more_control(model.id, Some("")).await;
@@ -49,7 +49,7 @@ async fn test_empty_email_not_added() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ignore_empty() {
-    let (_app, _anon, user) = TestApp::init().with_user();
+    let (_app, _anon, user) = TestApp::init().with_user().await;
     let model = user.as_model();
 
     let url = format!("/api/v1/users/{}", model.id);
@@ -61,7 +61,7 @@ async fn test_ignore_empty() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ignore_nulls() {
-    let (_app, _anon, user) = TestApp::init().with_user();
+    let (_app, _anon, user) = TestApp::init().with_user().await;
     let model = user.as_model();
 
     let url = format!("/api/v1/users/{}", model.id);
@@ -78,7 +78,7 @@ async fn test_ignore_nulls() {
 /// does not match the requested user.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_other_users_cannot_change_my_email() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let another_user = app.db_new_user("not_me");
     let another_user_model = another_user.as_model();
 
@@ -103,7 +103,7 @@ async fn test_other_users_cannot_change_my_email() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_invalid_email_address() {
-    let (_app, _, user) = TestApp::init().with_user();
+    let (_app, _, user) = TestApp::init().with_user().await;
     let model = user.as_model();
 
     let response = user.update_email_more_control(model.id, Some("foo")).await;
@@ -113,7 +113,7 @@ async fn test_invalid_email_address() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_invalid_json() {
-    let (_app, _anon, user) = TestApp::init().with_user();
+    let (_app, _anon, user) = TestApp::init().with_user().await;
     let model = user.as_model();
 
     let url = format!("/api/v1/users/{}", model.id);

--- a/src/tests/routes/users/update.rs
+++ b/src/tests/routes/users/update.rs
@@ -79,7 +79,7 @@ async fn test_ignore_nulls() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_other_users_cannot_change_my_email() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let another_user = app.db_new_user("not_me");
+    let another_user = app.db_new_user("not_me").await;
     let another_user_model = another_user.as_model();
 
     let response = user

--- a/src/tests/routes/users/update/publish_notifications.rs
+++ b/src/tests/routes/users/update/publish_notifications.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unsubscribe_and_resubscribe() {
-    let (app, _anon, cookie, token) = TestApp::full().with_token();
+    let (app, _anon, cookie, token) = TestApp::full().with_token().await;
 
     let user_url = format!("/api/v1/users/{}", cookie.as_model().id);
 

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -7,7 +7,7 @@ use http::{header, Request, StatusCode};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn user_agent_is_required() {
-    let (_app, anon) = TestApp::init().empty();
+    let (_app, anon) = TestApp::init().empty().await;
 
     let req = Request::get("/api/v1/crates").body("").unwrap();
     let resp = anon.run::<()>(req).await;
@@ -99,7 +99,8 @@ async fn block_traffic_via_ip() {
         .with_config(|config| {
             config.blocked_ips = HashSet::from(["127.0.0.1".parse().unwrap()]);
         })
-        .empty();
+        .empty()
+        .await;
 
     let resp = anon.get::<()>("/api/v1/crates").await;
     assert_eq!(resp.status(), StatusCode::FORBIDDEN);

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -25,7 +25,7 @@ async fn user_agent_is_required() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn user_agent_is_not_required_for_download() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(&mut conn);
@@ -42,7 +42,8 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
         .with_config(|config| {
             config.blocked_traffic = vec![("Never-Given".into(), vec!["1".into()])];
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
 
@@ -60,7 +61,8 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         .with_config(|config| {
             config.blocked_traffic = vec![("User-Agent".into(), vec!["1".into(), "2".into()])];
         })
-        .with_user();
+        .with_user()
+        .await;
 
     let mut conn = app.db_conn();
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -83,7 +83,7 @@ async fn add_nonexistent_team() {
 /// Test adding a renamed team
 #[tokio::test(flavor = "multi_thread")]
 async fn add_renamed_team() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-all-teams");
     let token = user.db_new_token("arbitrary token name");
@@ -123,7 +123,7 @@ async fn add_renamed_team() {
 /// Test adding team names with mixed case, when on the team
 #[tokio::test(flavor = "multi_thread")]
 async fn add_team_mixed_case() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-all-teams");
     let token = user.db_new_token("arbitrary token name");
@@ -148,7 +148,7 @@ async fn add_team_mixed_case() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn add_team_as_org_owner() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-org-owner");
     let token = user.db_new_token("arbitrary token name");
@@ -174,7 +174,7 @@ async fn add_team_as_org_owner() {
 /// Test adding team as owner when not on it
 #[tokio::test(flavor = "multi_thread")]
 async fn add_team_as_non_member() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-one-team");
     let token = user.db_new_token("arbitrary token name");
@@ -190,7 +190,7 @@ async fn add_team_as_non_member() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn remove_team_as_named_owner() {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let username = "user-all-teams";
     let user_on_both_teams = app.db_new_user(username);
@@ -225,7 +225,7 @@ async fn remove_team_as_named_owner() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn remove_team_as_team_owner() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -283,7 +283,7 @@ async fn remove_nonexistent_team() {
 /// Test trying to publish a crate we don't own
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_not_owned() {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -305,7 +305,7 @@ async fn publish_not_owned() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_org_owner_owned() {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -328,7 +328,7 @@ async fn publish_org_owner_owned() {
 /// Test trying to publish a krate we do own (but only because of teams)
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_owned() {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -354,7 +354,7 @@ async fn publish_owned() {
 /// Test trying to change owners (when only on an owning team)
 #[tokio::test(flavor = "multi_thread")]
 async fn add_owners_as_org_owner() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -378,7 +378,7 @@ async fn add_owners_as_org_owner() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn add_owners_as_team_owner() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams");
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
@@ -418,7 +418,7 @@ async fn crates_by_team_id() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_team_id_not_including_deleted_owners() {
-    let (app, anon) = TestApp::init().empty();
+    let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-all-teams");
     let user = user.as_model();

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -402,7 +402,7 @@ async fn add_owners_as_team_owner() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_team_id() {
-    let (app, anon, user) = TestApp::init().with_user();
+    let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -85,7 +85,7 @@ async fn add_nonexistent_team() {
 async fn add_renamed_team() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user = app.db_new_user("user-all-teams");
+    let user = app.db_new_user("user-all-teams").await;
     let token = user.db_new_token("arbitrary token name");
     let owner_id = user.as_model().id;
 
@@ -125,7 +125,7 @@ async fn add_renamed_team() {
 async fn add_team_mixed_case() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user = app.db_new_user("user-all-teams");
+    let user = app.db_new_user("user-all-teams").await;
     let token = user.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_mixed_case", user.as_model().id).expect_build(&mut conn);
@@ -150,7 +150,7 @@ async fn add_team_mixed_case() {
 async fn add_team_as_org_owner() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user = app.db_new_user("user-org-owner");
+    let user = app.db_new_user("user-org-owner").await;
     let token = user.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_org_owner", user.as_model().id).expect_build(&mut conn);
@@ -176,7 +176,7 @@ async fn add_team_as_org_owner() {
 async fn add_team_as_non_member() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user = app.db_new_user("user-one-team");
+    let user = app.db_new_user("user-one-team").await;
     let token = user.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_team_non_member", user.as_model().id).expect_build(&mut conn);
@@ -193,7 +193,7 @@ async fn remove_team_as_named_owner() {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let username = "user-all-teams";
-    let user_on_both_teams = app.db_new_user(username);
+    let user_on_both_teams = app.db_new_user(username).await;
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_remove_team", user_on_both_teams.as_model().id).expect_build(&mut conn);
@@ -216,7 +216,7 @@ async fn remove_team_as_named_owner() {
         .await
         .good();
 
-    let user_on_one_team = app.db_new_user("user-one-team");
+    let user_on_one_team = app.db_new_user("user-one-team").await;
     let crate_to_publish = PublishBuilder::new("foo_remove_team", "2.0.0");
     let response = user_on_one_team.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -227,7 +227,7 @@ async fn remove_team_as_named_owner() {
 async fn remove_team_as_team_owner() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user_on_both_teams = app.db_new_user("user-all-teams");
+    let user_on_both_teams = app.db_new_user("user-all-teams").await;
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_remove_team_owner", user_on_both_teams.as_model().id)
@@ -238,7 +238,7 @@ async fn remove_team_as_team_owner() {
         .await
         .good();
 
-    let user_on_one_team = app.db_new_user("user-one-team");
+    let user_on_one_team = app.db_new_user("user-one-team").await;
     let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
 
     let response = token_on_one_team
@@ -247,7 +247,7 @@ async fn remove_team_as_team_owner() {
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"team members don't have permission to modify owners"}]}"#);
 
-    let user_org_owner = app.db_new_user("user-org-owner");
+    let user_org_owner = app.db_new_user("user-org-owner").await;
     let token_org_owner = user_org_owner.db_new_token("arbitrary token name");
     let response = token_org_owner
         .remove_named_owner("foo_remove_team_owner", "github:test-org:all")
@@ -285,7 +285,7 @@ async fn remove_nonexistent_team() {
 async fn publish_not_owned() {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
-    let user_on_both_teams = app.db_new_user("user-all-teams");
+    let user_on_both_teams = app.db_new_user("user-all-teams").await;
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_not_owned", user_on_both_teams.as_model().id).expect_build(&mut conn);
@@ -295,7 +295,7 @@ async fn publish_not_owned() {
         .await
         .good();
 
-    let user_on_one_team = app.db_new_user("user-one-team");
+    let user_on_one_team = app.db_new_user("user-one-team").await;
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned", "2.0.0");
     let response = user_on_one_team.publish_crate(crate_to_publish).await;
@@ -307,7 +307,7 @@ async fn publish_not_owned() {
 async fn publish_org_owner_owned() {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
-    let user_on_both_teams = app.db_new_user("user-all-teams");
+    let user_on_both_teams = app.db_new_user("user-all-teams").await;
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_not_owned", user_on_both_teams.as_model().id).expect_build(&mut conn);
@@ -317,7 +317,7 @@ async fn publish_org_owner_owned() {
         .await
         .good();
 
-    let user_org_owner = app.db_new_user("user-org-owner");
+    let user_org_owner = app.db_new_user("user-org-owner").await;
 
     let crate_to_publish = PublishBuilder::new("foo_not_owned", "2.0.0");
     let response = user_org_owner.publish_crate(crate_to_publish).await;
@@ -330,7 +330,7 @@ async fn publish_org_owner_owned() {
 async fn publish_owned() {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
-    let user_on_both_teams = app.db_new_user("user-all-teams");
+    let user_on_both_teams = app.db_new_user("user-all-teams").await;
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_team_owned", user_on_both_teams.as_model().id).expect_build(&mut conn);
@@ -340,7 +340,7 @@ async fn publish_owned() {
         .await
         .good();
 
-    let user_on_one_team = app.db_new_user("user-one-team");
+    let user_on_one_team = app.db_new_user("user-one-team").await;
 
     let crate_to_publish = PublishBuilder::new("foo_team_owned", "2.0.0");
     user_on_one_team
@@ -356,7 +356,7 @@ async fn publish_owned() {
 async fn add_owners_as_org_owner() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user_on_both_teams = app.db_new_user("user-all-teams");
+    let user_on_both_teams = app.db_new_user("user-all-teams").await;
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_add_owner", user_on_both_teams.as_model().id).expect_build(&mut conn);
@@ -366,7 +366,7 @@ async fn add_owners_as_org_owner() {
         .await
         .good();
 
-    let user_org_owner = app.db_new_user("user-org-owner");
+    let user_org_owner = app.db_new_user("user-org-owner").await;
     let token_org_owner = user_org_owner.db_new_token("arbitrary token name");
 
     let response = token_org_owner
@@ -380,7 +380,7 @@ async fn add_owners_as_org_owner() {
 async fn add_owners_as_team_owner() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user_on_both_teams = app.db_new_user("user-all-teams");
+    let user_on_both_teams = app.db_new_user("user-all-teams").await;
     let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
 
     CrateBuilder::new("foo_add_owner", user_on_both_teams.as_model().id).expect_build(&mut conn);
@@ -390,7 +390,7 @@ async fn add_owners_as_team_owner() {
         .await
         .good();
 
-    let user_on_one_team = app.db_new_user("user-one-team");
+    let user_on_one_team = app.db_new_user("user-one-team").await;
     let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
 
     let response = token_on_one_team
@@ -420,7 +420,7 @@ async fn crates_by_team_id() {
 async fn crates_by_team_id_not_including_deleted_owners() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
-    let user = app.db_new_user("user-all-teams");
+    let user = app.db_new_user("user-all-teams").await;
     let user = user.as_model();
 
     let t = NewTeam::new("github:test-org:core", 1000, 2001, None, None)

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -26,7 +26,7 @@ impl crate::tests::util::MockAnonymousUser {
 /// Test adding team without `github:`
 #[tokio::test(flavor = "multi_thread")]
 async fn not_github() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
 
     let mut conn = app.db_conn();
 
@@ -41,7 +41,7 @@ async fn not_github() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn weird_name() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo_weird_name", user.as_model().id).expect_build(&mut conn);
@@ -56,7 +56,7 @@ async fn weird_name() {
 /// Test adding team without second `:`
 #[tokio::test(flavor = "multi_thread")]
 async fn one_colon() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo_one_colon", user.as_model().id).expect_build(&mut conn);
@@ -68,7 +68,7 @@ async fn one_colon() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn add_nonexistent_team() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo_add_nonexistent", user.as_model().id).expect_build(&mut conn);
@@ -258,7 +258,7 @@ async fn remove_team_as_team_owner() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn remove_nonexistent_team() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo_remove_nonexistent", user.as_model().id).expect_build(&mut conn);

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -86,7 +86,7 @@ async fn add_renamed_team() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-all-teams").await;
-    let token = user.db_new_token("arbitrary token name");
+    let token = user.db_new_token("arbitrary token name").await;
     let owner_id = user.as_model().id;
 
     use crate::schema::teams;
@@ -126,7 +126,7 @@ async fn add_team_mixed_case() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-all-teams").await;
-    let token = user.db_new_token("arbitrary token name");
+    let token = user.db_new_token("arbitrary token name").await;
 
     CrateBuilder::new("foo_mixed_case", user.as_model().id).expect_build(&mut conn);
 
@@ -151,7 +151,7 @@ async fn add_team_as_org_owner() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-org-owner").await;
-    let token = user.db_new_token("arbitrary token name");
+    let token = user.db_new_token("arbitrary token name").await;
 
     CrateBuilder::new("foo_org_owner", user.as_model().id).expect_build(&mut conn);
 
@@ -177,7 +177,7 @@ async fn add_team_as_non_member() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user = app.db_new_user("user-one-team").await;
-    let token = user.db_new_token("arbitrary token name");
+    let token = user.db_new_token("arbitrary token name").await;
 
     CrateBuilder::new("foo_team_non_member", user.as_model().id).expect_build(&mut conn);
 
@@ -194,7 +194,9 @@ async fn remove_team_as_named_owner() {
     let mut conn = app.db_conn();
     let username = "user-all-teams";
     let user_on_both_teams = app.db_new_user(username).await;
-    let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
+    let token_on_both_teams = user_on_both_teams
+        .db_new_token("arbitrary token name")
+        .await;
 
     CrateBuilder::new("foo_remove_team", user_on_both_teams.as_model().id).expect_build(&mut conn);
 
@@ -228,7 +230,9 @@ async fn remove_team_as_team_owner() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams").await;
-    let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
+    let token_on_both_teams = user_on_both_teams
+        .db_new_token("arbitrary token name")
+        .await;
 
     CrateBuilder::new("foo_remove_team_owner", user_on_both_teams.as_model().id)
         .expect_build(&mut conn);
@@ -239,7 +243,7 @@ async fn remove_team_as_team_owner() {
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team").await;
-    let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
+    let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name").await;
 
     let response = token_on_one_team
         .remove_named_owner("foo_remove_team_owner", "github:test-org:all")
@@ -248,7 +252,7 @@ async fn remove_team_as_team_owner() {
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"team members don't have permission to modify owners"}]}"#);
 
     let user_org_owner = app.db_new_user("user-org-owner").await;
-    let token_org_owner = user_org_owner.db_new_token("arbitrary token name");
+    let token_org_owner = user_org_owner.db_new_token("arbitrary token name").await;
     let response = token_org_owner
         .remove_named_owner("foo_remove_team_owner", "github:test-org:all")
         .await;
@@ -286,7 +290,9 @@ async fn publish_not_owned() {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams").await;
-    let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
+    let token_on_both_teams = user_on_both_teams
+        .db_new_token("arbitrary token name")
+        .await;
 
     CrateBuilder::new("foo_not_owned", user_on_both_teams.as_model().id).expect_build(&mut conn);
 
@@ -308,7 +314,9 @@ async fn publish_org_owner_owned() {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams").await;
-    let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
+    let token_on_both_teams = user_on_both_teams
+        .db_new_token("arbitrary token name")
+        .await;
 
     CrateBuilder::new("foo_not_owned", user_on_both_teams.as_model().id).expect_build(&mut conn);
 
@@ -331,7 +339,9 @@ async fn publish_owned() {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams").await;
-    let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
+    let token_on_both_teams = user_on_both_teams
+        .db_new_token("arbitrary token name")
+        .await;
 
     CrateBuilder::new("foo_team_owned", user_on_both_teams.as_model().id).expect_build(&mut conn);
 
@@ -357,7 +367,9 @@ async fn add_owners_as_org_owner() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams").await;
-    let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
+    let token_on_both_teams = user_on_both_teams
+        .db_new_token("arbitrary token name")
+        .await;
 
     CrateBuilder::new("foo_add_owner", user_on_both_teams.as_model().id).expect_build(&mut conn);
 
@@ -367,7 +379,7 @@ async fn add_owners_as_org_owner() {
         .good();
 
     let user_org_owner = app.db_new_user("user-org-owner").await;
-    let token_org_owner = user_org_owner.db_new_token("arbitrary token name");
+    let token_org_owner = user_org_owner.db_new_token("arbitrary token name").await;
 
     let response = token_org_owner
         .add_named_owner("foo_add_owner", "arbitrary_username")
@@ -381,7 +393,9 @@ async fn add_owners_as_team_owner() {
     let (app, _) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
     let user_on_both_teams = app.db_new_user("user-all-teams").await;
-    let token_on_both_teams = user_on_both_teams.db_new_token("arbitrary token name");
+    let token_on_both_teams = user_on_both_teams
+        .db_new_token("arbitrary token name")
+        .await;
 
     CrateBuilder::new("foo_add_owner", user_on_both_teams.as_model().id).expect_build(&mut conn);
 
@@ -391,7 +405,7 @@ async fn add_owners_as_team_owner() {
         .good();
 
     let user_on_one_team = app.db_new_user("user-one-team").await;
-    let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name");
+    let token_on_one_team = user_on_one_team.db_new_token("arbitrary token name").await;
 
     let response = token_on_one_team
         .add_named_owner("foo_add_owner", "arbitrary_username")

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn using_token_updates_last_used_at() {
     let url = "/api/v1/me";
-    let (app, anon, user, token) = TestApp::init().with_token();
+    let (app, anon, user, token) = TestApp::init().with_token().await;
     let mut conn = app.async_db_conn().await;
 
     anon.get(url).await.assert_forbidden();

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -35,7 +35,7 @@ async fn using_token_updates_last_used_at() {
 #[tokio::test(flavor = "multi_thread")]
 async fn old_tokens_give_specific_error_message() {
     let url = "/api/v1/me";
-    let (_, anon) = TestApp::init().empty();
+    let (_, anon) = TestApp::init().empty().await;
 
     let mut request = anon.get_request(url);
     request.header(header::AUTHORIZATION, "oldtoken");

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -77,7 +77,8 @@ async fn fallback_to_replica_returns_user_info() {
     let (app, _, owner) = TestApp::init()
         .with_replica()
         .with_chaos_proxy()
-        .with_user();
+        .with_user()
+        .await;
     app.db_new_user("foo");
     app.primary_db_chaosproxy().break_networking().unwrap();
 
@@ -97,7 +98,8 @@ async fn restored_replica_returns_user_info() {
     let (app, _, owner) = TestApp::init()
         .with_replica()
         .with_chaos_proxy()
-        .with_user();
+        .with_user()
+        .await;
     app.db_new_user("foo");
     app.primary_db_chaosproxy().break_networking().unwrap();
     app.replica_db_chaosproxy().break_networking().unwrap();
@@ -130,7 +132,8 @@ async fn restored_primary_returns_user_info() {
     let (app, _, owner) = TestApp::init()
         .with_replica()
         .with_chaos_proxy()
-        .with_user();
+        .with_user()
+        .await;
     app.db_new_user("foo");
     app.primary_db_chaosproxy().break_networking().unwrap();
     app.replica_db_chaosproxy().break_networking().unwrap();

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -33,7 +33,7 @@ async fn wait_until_healthy(pool: &Pool<AsyncPgConnection>) {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn http_error_with_unhealthy_database() {
-    let (app, anon) = TestApp::init().with_chaos_proxy().empty();
+    let (app, anon) = TestApp::init().with_chaos_proxy().empty().await;
 
     let response = anon.get::<()>("/api/v1/summary").await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -79,7 +79,7 @@ async fn fallback_to_replica_returns_user_info() {
         .with_chaos_proxy()
         .with_user()
         .await;
-    app.db_new_user("foo");
+    app.db_new_user("foo").await;
     app.primary_db_chaosproxy().break_networking().unwrap();
 
     // When the primary database is down, requests are forwarded to the replica database
@@ -100,7 +100,7 @@ async fn restored_replica_returns_user_info() {
         .with_chaos_proxy()
         .with_user()
         .await;
-    app.db_new_user("foo");
+    app.db_new_user("foo").await;
     app.primary_db_chaosproxy().break_networking().unwrap();
     app.replica_db_chaosproxy().break_networking().unwrap();
 
@@ -134,7 +134,7 @@ async fn restored_primary_returns_user_info() {
         .with_chaos_proxy()
         .with_user()
         .await;
-    app.db_new_user("foo");
+    app.db_new_user("foo").await;
     app.primary_db_chaosproxy().break_networking().unwrap();
     app.replica_db_chaosproxy().break_networking().unwrap();
 

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -52,7 +52,7 @@ async fn http_error_with_unhealthy_database() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn download_requests_with_unhealthy_database_succeed() {
-    let (app, anon, _, token) = TestApp::init().with_chaos_proxy().with_token();
+    let (app, anon, _, token) = TestApp::init().with_chaos_proxy().with_token().await;
     let mut conn = app.db_conn();
 
     CrateBuilder::new("foo", token.as_model().user_id)

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -54,7 +54,7 @@ async fn updating_existing_user_doesnt_change_api_token() {
 /// deleting their email when they sign back in.
 #[tokio::test(flavor = "multi_thread")]
 async fn github_without_email_does_not_overwrite_email() {
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::init().empty().await;
     let mut conn = app.async_db_conn().await;
 
     // Simulate logging in via GitHub with an account that has no email.
@@ -161,7 +161,7 @@ async fn test_email_get_and_put() {
 async fn test_confirm_user_email() {
     use crate::schema::emails;
 
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::init().empty().await;
     let mut conn = app.async_db_conn().await;
 
     // Simulate logging in via GitHub. Don't use app.db_new_user because it inserts a verified
@@ -200,7 +200,7 @@ async fn test_existing_user_email() {
     use chrono::NaiveDateTime;
     use diesel::update;
 
-    let (app, _) = TestApp::init().empty();
+    let (app, _) = TestApp::init().empty().await;
     let mut conn = app.async_db_conn().await;
 
     // Simulate logging in via GitHub. Don't use app.db_new_user because it inserts a verified

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -22,7 +22,7 @@ impl crate::tests::util::MockCookieUser {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn updating_existing_user_doesnt_change_api_token() {
-    let (app, _, user, token) = TestApp::init().with_token();
+    let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.async_db_conn().await;
     let gh_id = user.as_model().gh_id;
     let token = token.plaintext();

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -100,7 +100,7 @@ async fn github_without_email_does_not_overwrite_email() {
 async fn github_with_email_does_not_overwrite_email() {
     use crate::schema::emails;
 
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.async_db_conn().await;
 
     let model = user.as_model();
@@ -139,7 +139,7 @@ async fn github_with_email_does_not_overwrite_email() {
 /// that the updated email is sent back to the user (GET /me).
 #[tokio::test(flavor = "multi_thread")]
 async fn test_email_get_and_put() {
-    let (_app, _anon, user) = TestApp::init().with_user();
+    let (_app, _anon, user) = TestApp::init().with_user().await;
 
     let json = user.show_me().await;
     assert_eq!(json.user.email.unwrap(), "foo@example.com");

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -314,13 +314,13 @@ impl MockCookieUser {
     ///
     /// This method updates the database directly
     pub async fn db_new_token(&self, name: &str) -> MockTokenUser {
-        self.db_new_scoped_token(name, None, None, None)
+        self.db_new_scoped_token(name, None, None, None).await
     }
 
     /// Creates a scoped token and wraps it in a helper struct
     ///
     /// This method updates the database directly
-    pub fn db_new_scoped_token(
+    pub async fn db_new_scoped_token(
         &self,
         name: &str,
         crate_scopes: Option<Vec<CrateScope>>,

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -313,7 +313,7 @@ impl MockCookieUser {
     /// Creates a token and wraps it in a helper struct
     ///
     /// This method updates the database directly
-    pub fn db_new_token(&self, name: &str) -> MockTokenUser {
+    pub async fn db_new_token(&self, name: &str) -> MockTokenUser {
         self.db_new_scoped_token(name, None, None, None)
     }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -354,7 +354,7 @@ impl TestAppBuilder {
     pub async fn with_token(self) -> (TestApp, MockAnonymousUser, MockCookieUser, MockTokenUser) {
         let (app, anon) = self.empty().await;
         let user = app.db_new_user("foo").await;
-        let token = user.db_new_token("bar");
+        let token = user.db_new_token("bar").await;
         (app, anon, user, token)
     }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -347,7 +347,7 @@ impl TestAppBuilder {
     }
 
     // Create a `TestApp` with a database including a default user
-    pub fn with_user(self) -> (TestApp, MockAnonymousUser, MockCookieUser) {
+    pub async fn with_user(self) -> (TestApp, MockAnonymousUser, MockCookieUser) {
         let (app, anon) = self.empty();
         let user = app.db_new_user("foo");
         (app, anon, user)

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -354,7 +354,7 @@ impl TestAppBuilder {
     }
 
     /// Create a `TestApp` with a database including a default user and its token
-    pub fn with_token(self) -> (TestApp, MockAnonymousUser, MockCookieUser, MockTokenUser) {
+    pub async fn with_token(self) -> (TestApp, MockAnonymousUser, MockCookieUser, MockTokenUser) {
         let (app, anon) = self.empty();
         let user = app.db_new_user("foo");
         let token = user.db_new_token("bar");

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -20,12 +20,11 @@ use crates_io_test_db::TestDatabase;
 use crates_io_worker::Runner;
 use diesel::r2d2::{ConnectionManager, PooledConnection};
 use diesel::PgConnection;
-use diesel_async::AsyncPgConnection;
+use diesel_async::{AsyncConnection, AsyncPgConnection};
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
 use regex::Regex;
 use std::collections::HashSet;
-use std::ops::DerefMut;
 use std::sync::LazyLock;
 use std::{rc::Rc, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
@@ -119,8 +118,8 @@ impl TestApp {
     }
 
     /// Obtain an async database connection from the primary database pool.
-    pub async fn async_db_conn(&self) -> impl DerefMut<Target = AsyncPgConnection> {
-        let result = self.as_inner().primary_database.get().await;
+    pub async fn async_db_conn(&self) -> AsyncPgConnection {
+        let result = AsyncPgConnection::establish(self.0.test_database.url()).await;
         result.expect("Failed to get database connection")
     }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -365,7 +365,9 @@ impl TestAppBuilder {
     ) -> (TestApp, MockAnonymousUser, MockCookieUser, MockTokenUser) {
         let (app, anon) = self.empty().await;
         let user = app.db_new_user("foo").await;
-        let token = user.db_new_scoped_token("bar", crate_scopes, endpoint_scopes, None);
+        let token = user
+            .db_new_scoped_token("bar", crate_scopes, endpoint_scopes, None)
+            .await;
         (app, anon, user, token)
     }
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -361,7 +361,7 @@ impl TestAppBuilder {
         (app, anon, user, token)
     }
 
-    pub fn with_scoped_token(
+    pub async fn with_scoped_token(
         self,
         crate_scopes: Option<Vec<CrateScope>>,
         endpoint_scopes: Option<Vec<EndpointScope>>,

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -4,7 +4,7 @@ use crate::tests::TestApp;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn record_rerendered_readme_time() {
-    let (app, _, user) = TestApp::init().with_user();
+    let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
     let user = user.as_model();
 

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -9,7 +9,7 @@ use http::StatusCode;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn index_smoke_test() {
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let mut conn = app.async_db_conn().await;
     let upstream = app.upstream_index();
 
@@ -95,7 +95,7 @@ async fn test_config_changes() {
         "api": "https://crates.io"
     }"#;
 
-    let (app, _, _, token) = TestApp::full().with_token();
+    let (app, _, _, token) = TestApp::full().with_token().await;
     let upstream = app.upstream_index();
 
     // Initialize upstream index with a `config.json` file

--- a/src/tests/worker/rss/sync_crate_feed.rs
+++ b/src/tests/worker/rss/sync_crate_feed.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_crate_feed() {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.async_db_conn().await;
 
     create_version(&mut conn, "foo", "0.1.0", "2024-06-20T10:13:54Z").await;

--- a/src/tests/worker/rss/sync_crates_feed.rs
+++ b/src/tests/worker/rss/sync_crates_feed.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_crates_feed() {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.async_db_conn().await;
 
     let description = Some("something something foo");

--- a/src/tests/worker/rss/sync_updates_feed.rs
+++ b/src/tests/worker/rss/sync_updates_feed.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_updates_feed() {
-    let (app, _) = TestApp::full().empty();
+    let (app, _) = TestApp::full().empty().await;
     let mut conn = app.async_db_conn().await;
 
     let d = Some("let's try & break this <item> ]]>");

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -22,7 +22,7 @@ async fn test_sync_admins_job() {
         .with(mockall::predicate::eq("crates_io_admin"))
         .returning(move |_| Ok(mock_response.clone()));
 
-    let (app, _) = TestApp::full().with_team_repo(team_repo).empty();
+    let (app, _) = TestApp::full().with_team_repo(team_repo).empty().await;
     let mut conn = app.async_db_conn().await;
 
     create_user("existing-admin", 1, true, &mut conn)


### PR DESCRIPTION
The creation of users and tokens is currently hard to convert to `diesel-async` because the test suite is using sync fn calls to create them. This PR migrates the fns to async/await, even if internally some of them are not actually using async/await yet. This makes it much easier to port these to `diesel-async` in follow-up pull requests.