### PR TITLE
models/team: Replace `NewTeam::new()` fn with `Builder` pattern

### DIFF
--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -104,13 +104,11 @@ fn new_user(login: &str) -> NewUser<'_> {
 }
 
 fn new_team(login: &str) -> NewTeam<'_> {
-    NewTeam {
-        org_id: next_gh_id(),
-        github_id: next_gh_id(),
-        login,
-        name: None,
-        avatar: None,
-    }
+    NewTeam::builder()
+        .login(login)
+        .org_id(next_gh_id())
+        .github_id(next_gh_id())
+        .build()
 }
 
 fn add_team_to_crate(

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -95,15 +95,16 @@ async fn add_renamed_team() {
 
     // create team with same ID and different name compared to http mock
     // used for `async_add_named_owner`.await
-    NewTeam::new(
-        "github:test-org:old-core", // different team name
-        1000,                       // same org ID
-        2001,                       // same team id as `core` team
-        None,
-        None,
-    )
-    .create_or_update(&mut conn)
-    .unwrap();
+    let new_team = NewTeam::builder()
+        // different team name
+        .login("github:test-org:old-core")
+        // same org ID
+        .org_id(1000)
+        // same team id as `core` team
+        .github_id(2001)
+        .build();
+
+    new_team.create_or_update(&mut conn).unwrap();
 
     assert_eq!(
         teams::table.count().get_result::<i64>(&mut conn).unwrap(),
@@ -437,9 +438,13 @@ async fn crates_by_team_id_not_including_deleted_owners() {
     let user = app.db_new_user("user-all-teams").await;
     let user = user.as_model();
 
-    let t = NewTeam::new("github:test-org:core", 1000, 2001, None, None)
-        .create_or_update(&mut conn)
-        .unwrap();
+    let new_team = NewTeam::builder()
+        .login("github:test-org:core")
+        .org_id(1000)
+        .github_id(2001)
+        .build();
+
+    let t = new_team.create_or_update(&mut conn).unwrap();
 
     let krate = CrateBuilder::new("foo", user.id).expect_build(&mut conn);
     add_team_to_crate(&t, &krate, user, &mut conn).unwrap();

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -48,16 +48,15 @@ pub mod faker {
     }
 
     pub fn team(conn: &mut PgConnection, org: &str, team: &str) -> anyhow::Result<Owner> {
-        Ok(Owner::Team(
-            NewTeam::new(
-                &format!("github:{org}:{team}"),
-                next_gh_id(),
-                next_gh_id(),
-                Some(team),
-                None,
-            )
-            .create_or_update(conn)?,
-        ))
+        let login = format!("github:{org}:{team}");
+        let team = NewTeam::builder()
+            .login(&login)
+            .org_id(next_gh_id())
+            .github_id(next_gh_id())
+            .name(team)
+            .build();
+
+        Ok(Owner::Team(team.create_or_update(conn)?))
     }
 
     pub fn user(conn: &mut PgConnection, login: &str) -> QueryResult<User> {


### PR DESCRIPTION
Having two `i32` arguments in the `new()` fn was a bit dangerous and could easily lead to someone unintentionally swapping the values. This commit changes the `NewTeam` construction to use the builder pattern with named fns instead to avoid the potential confusion.