### PR TITLE
Show Rust Edition requirement if set

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -22,7 +22,13 @@
         {{svg-jar "rust"}}
         <span>
           v{{@version.msrv}}
-          <EmberTooltip @text="Minimum Supported Rust Version" />
+
+          <EmberTooltip>
+            &quot;Minimum Supported Rust Version&quot;
+            {{#if @version.edition}}
+              <div local-class="edition">requires Rust Edition {{@version.edition}}</div>
+            {{/if}}
+          </EmberTooltip>
         </span>
       </div>
     {{/if}}

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -40,6 +40,10 @@
     }
 }
 
+.edition {
+    margin-top: var(--space-2xs);
+}
+
 .license {
     a {
         color: var(--main-color);

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -71,6 +71,13 @@
           <span local-class="msrv">
             {{svg-jar "rust"}}
             v{{@version.msrv}}
+
+            <EmberTooltip>
+              &quot;Minimum Supported Rust Version&quot;
+              {{#if @version.edition}}
+                <div local-class="edition">requires Rust Edition {{@version.edition}}</div>
+              {{/if}}
+            </EmberTooltip>
           </span>
         {{/if}}
 

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -46,16 +46,16 @@
         z-index: 1;
         cursor: help;
     }
-
-    :global(.ember-tooltip) {
-        word-break: break-all;
-    }
 }
 
 .version {
     display: grid;
     grid-template-columns: auto auto;
     place-items: center;
+
+    :global(.ember-tooltip) {
+        word-break: break-all;
+    }
 
     @media only screen and (max-width: 550px) {
         grid-template-columns: auto;

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -212,6 +212,10 @@
     }
 }
 
+.edition {
+    margin-top: var(--space-2xs);
+}
+
 .bytes {
     font-variant-numeric: tabular-nums;
     text-transform: none;

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -29,6 +29,12 @@ export default class Version extends Model {
    */
   @attr rust_version;
 
+  /**
+   * The Rust edition required to compile this crate version.
+   * @type {string | null}
+   */
+  @attr edition;
+
   /** @type {boolean | null} */
   @attr has_lib;
   /** @type {string[] | null} */
@@ -46,8 +52,14 @@ export default class Version extends Model {
 
   get msrv() {
     let rustVersion = this.rust_version;
-    // add `.0` suffix if the `rust-version` field only has two version components
-    return /^[^.]+\.[^.]+$/.test(rustVersion) ? `${rustVersion}.0` : rustVersion;
+    if (rustVersion) {
+      // add `.0` suffix if the `rust-version` field only has two version components
+      return /^[^.]+\.[^.]+$/.test(rustVersion) ? `${rustVersion}.0` : rustVersion;
+    } else if (this.edition === '2018') {
+      return '1.31.0';
+    } else if (this.edition === '2021') {
+      return '1.56.0';
+    }
   }
 
   get isNew() {

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -202,5 +202,6 @@ noscript {
 }
 
 :global(.ember-tooltip) {
+    max-width: 300px;
     font-weight: normal;
 }


### PR DESCRIPTION
This PR adjusts the MSRV tooltip to also show the required Rust Edition:

![Bildschirmfoto 2024-11-19 um 09 36 00](https://github.com/user-attachments/assets/0ab73e78-32e8-4622-a000-ce784fbbcadc)

![Bildschirmfoto 2024-11-19 um 09 36 20](https://github.com/user-attachments/assets/0aa6c3f0-ebd6-4ed7-aecb-5bc5153e7a9e)

Resolves https://github.com/rust-lang/crates.io/issues/1541

Related:

- https://github.com/rust-lang/crates.io/issues/1541
- https://github.com/rust-lang/crates.io/pull/9932
- https://github.com/rust-lang/crates.io/pull/9996
