### PR TITLE
models/action: Extract `NewVersionOwnerAction` struct

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -24,8 +24,8 @@ use tokio::runtime::Handle;
 use url::Url;
 
 use crate::models::{
-    default_versions::Version as DefaultVersion, insert_version_owner_action, Category, Crate,
-    DependencyKind, Keyword, NewCrate, NewVersion, Rights, VersionAction,
+    default_versions::Version as DefaultVersion, Category, Crate, DependencyKind, Keyword,
+    NewCrate, NewVersion, NewVersionOwnerAction, Rights, VersionAction,
 };
 
 use crate::licenses::parse_license_expr;
@@ -415,13 +415,13 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
                 }
             })?;
 
-            insert_version_owner_action(
-                conn,
-                version.id,
-                user.id,
-                api_token_id,
-                VersionAction::Publish,
-            )?;
+            NewVersionOwnerAction::builder()
+                .version_id(version.id)
+                .user_id(user.id)
+                .maybe_api_token_id(api_token_id)
+                .action(VersionAction::Publish)
+                .build()
+                .insert(conn)?;
 
             // Link this new version to all dependencies
             add_dependencies(conn, &deps, version.id)?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,4 +1,4 @@
-pub use self::action::{insert_version_owner_action, VersionAction, VersionOwnerAction};
+pub use self::action::{NewVersionOwnerAction, VersionAction, VersionOwnerAction};
 pub use self::category::{Category, CrateCategory, NewCategory};
 pub use self::crate_owner_invitation::{CrateOwnerInvitation, NewCrateOwnerInvitationOutcome};
 pub use self::default_versions::{update_default_version, verify_default_version};


### PR DESCRIPTION
This avoids potential bugs from confusing the `version_id: i32` and `user_id: i32` arguments in the `insert_version_owner_action()` fn.