### PR TITLE
controllers/version: Remove more `spawn_blocking()` fns

### DIFF
--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -100,10 +100,11 @@ pub async fn show(
 
     let mut conn = state.db_read().await?;
     let (version, krate) = version_and_crate(&mut conn, &crate_name, &version).await?;
+    let published_by = version.published_by(&mut conn).await?;
+
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
-        let published_by = version.published_by(conn)?;
         let actions = VersionOwnerAction::by_version(conn, &version)?;
 
         let version = EncodableVersion::from(version, &krate.name, published_by, actions);
@@ -146,10 +147,11 @@ pub async fn update(
     )
     .await?;
 
+    let published_by = version.published_by(&mut conn).await?;
+
     spawn_blocking(move || {
         let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
 
-        let published_by = version.published_by(conn)?;
         let actions = VersionOwnerAction::by_version(conn, &version)?;
         let updated_version = EncodableVersion::from(version, &krate.name, published_by, actions);
         Ok(json!({ "version": updated_version }))

--- a/src/models/action.rs
+++ b/src/models/action.rs
@@ -57,8 +57,11 @@ impl VersionOwnerAction {
         version_owner_actions::table.load(conn)
     }
 
-    pub fn by_version(conn: &mut impl Conn, version: &Version) -> QueryResult<Vec<(Self, User)>> {
-        use diesel::RunQueryDsl;
+    pub async fn by_version(
+        conn: &mut AsyncPgConnection,
+        version: &Version,
+    ) -> QueryResult<Vec<(Self, User)>> {
+        use diesel_async::RunQueryDsl;
         use version_owner_actions::dsl::version_id;
 
         version_owner_actions::table
@@ -66,6 +69,7 @@ impl VersionOwnerAction {
             .inner_join(users::table)
             .order(version_owner_actions::dsl::id)
             .load(conn)
+            .await
     }
 
     pub fn for_versions(

--- a/src/models/action.rs
+++ b/src/models/action.rs
@@ -114,4 +114,16 @@ impl NewVersionOwnerAction {
             .values(self)
             .get_result(conn)
     }
+
+    pub async fn async_insert(
+        &self,
+        conn: &mut AsyncPgConnection,
+    ) -> QueryResult<VersionOwnerAction> {
+        use diesel_async::RunQueryDsl;
+
+        diesel::insert_into(version_owner_actions::table)
+            .values(self)
+            .get_result(conn)
+            .await
+    }
 }

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -55,11 +55,11 @@ impl Version {
 
     /// Gets the User who ran `cargo publish` for this version, if recorded.
     /// Not for use when you have a group of versions you need the publishers for.
-    pub fn published_by(&self, conn: &mut impl Conn) -> QueryResult<Option<User>> {
-        use diesel::RunQueryDsl;
+    pub async fn published_by(&self, conn: &mut AsyncPgConnection) -> QueryResult<Option<User>> {
+        use diesel_async::RunQueryDsl;
 
         match self.published_by {
-            Some(pb) => users::table.find(pb).first(conn).optional(),
+            Some(pb) => users::table.find(pb).first(conn).await.optional(),
             None => Ok(None),
         }
     }


### PR DESCRIPTION
This pull requests gets rid of more `spawn_blocking()` fns by converting the code to async/await and taking advantage of `diesel-async` queries.