### PR TITLE
Add minimum version tracking to deleted crates

### DIFF
--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -428,6 +428,8 @@ diesel::table! {
         message -> Nullable<Varchar>,
         /// Date and time when users will be able to create a new crate with the same name
         available_at -> Timestamptz,
+        /// The first version that can be used by a new crate with the same name
+        min_version -> Nullable<Varchar>,
     }
 }
 

--- a/migrations/2024-11-20-031728_add-min-version-to-deleted-crates/down.sql
+++ b/migrations/2024-11-20-031728_add-min-version-to-deleted-crates/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE deleted_crates
+DROP COLUMN min_version;

--- a/migrations/2024-11-20-031728_add-min-version-to-deleted-crates/up.sql
+++ b/migrations/2024-11-20-031728_add-min-version-to-deleted-crates/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE deleted_crates
+ADD COLUMN min_version VARCHAR NULL;
+
+COMMENT ON COLUMN deleted_crates.min_version IS 'The first version that can be used by a new crate with the same name';

--- a/src/controllers/krate/publish/deleted.rs
+++ b/src/controllers/krate/publish/deleted.rs
@@ -1,0 +1,264 @@
+use chrono::{DateTime, SecondsFormat, Utc};
+use diesel_async::AsyncPgConnection;
+use http::StatusCode;
+use semver::Version;
+
+use crate::{
+    schema::deleted_crates,
+    sql::canon_crate_name,
+    util::{
+        diesel::prelude::*,
+        errors::{custom, AppResult},
+    },
+};
+
+/// Checks the given crate name and version against the deleted crates table,
+/// ensuring that the crate version is allowed to be published.
+///
+/// If the crate version cannot be published, a
+/// [`crate::util::errors::BoxedAppError`] will be returned with a user-oriented
+/// message suitable for being returned directly by a controller.
+pub async fn validate(
+    conn: &mut AsyncPgConnection,
+    name: &str,
+    version: &Version,
+) -> AppResult<()> {
+    use diesel_async::RunQueryDsl;
+
+    // Since the same crate may have been deleted multiple times, we need to
+    // calculate the most restrictive set of conditions that the crate version
+    // being published must adhere to; specifically: the latest available_at
+    // time, and the highest min_version.
+    let mut state = State::default();
+
+    // To do this, we need to iterate over all the relevant deleted crates.
+    for (available_at, min_version) in deleted_crates::table
+        .filter(canon_crate_name(deleted_crates::name).eq(canon_crate_name(name)))
+        .select((deleted_crates::available_at, deleted_crates::min_version))
+        .load::<(DateTime<Utc>, Option<String>)>(conn)
+        .await?
+    {
+        state.observe_available_at(available_at);
+
+        // We shouldn't really end up with an invalid semver in the
+        // `min_version` field, so we're going to silently swallow any errors
+        // for now.
+        if let Some(Ok(min_version)) = min_version.map(|v| Version::parse(&v)) {
+            state.observe_min_version(min_version);
+        }
+    }
+
+    // Finally, we can check the given name and version against the built up
+    // state and see if it passes.
+    state.into_result(name, version, Utc::now())
+}
+
+#[derive(Default)]
+#[cfg_attr(test, derive(Clone))]
+struct State {
+    available_at: Option<DateTime<Utc>>,
+    min_version: Option<Version>,
+}
+
+impl State {
+    fn observe_available_at(&mut self, available_at: DateTime<Utc>) {
+        if let Some(current) = self.available_at {
+            self.available_at = Some(std::cmp::max(current, available_at));
+        } else {
+            self.available_at = Some(available_at);
+        }
+    }
+
+    fn observe_min_version(&mut self, min_version: Version) {
+        if let Some(current) = self.min_version.take() {
+            self.min_version = Some(std::cmp::max(current, min_version));
+        } else {
+            self.min_version = Some(min_version);
+        }
+    }
+
+    fn into_result(self, name: &str, version: &Version, now: DateTime<Utc>) -> AppResult<()> {
+        let mut messages = Vec::new();
+
+        if let Some(available_at) = self.available_at {
+            if now < available_at {
+                messages.push(format!(
+                    "Reuse of this name will be available after {}.",
+                    available_at.to_rfc3339_opts(SecondsFormat::Secs, true)
+                ));
+            }
+        }
+
+        if let Some(min_version) = self.min_version {
+            if version < &min_version {
+                messages.push(format!("To avoid conflicts with previously published versions of this crate, the minimum version that can be published is {min_version}."));
+            }
+        }
+
+        if messages.is_empty() {
+            Ok(())
+        } else {
+            Err(custom(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                format!(
+                    "A crate with the name `{name}` was previously deleted.\n\n* {}",
+                    messages.join("\n* "),
+                ),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeDelta;
+    use insta::assert_snapshot;
+
+    use super::*;
+
+    macro_rules! assert_result_status {
+        ($result:expr) => {{
+            let response = $result.unwrap_err().response();
+            assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+            String::from_utf8(
+                axum::body::to_bytes(response.into_body(), usize::MAX)
+                    .await
+                    .unwrap()
+                    .into(),
+            )
+            .unwrap()
+        }};
+    }
+
+    macro_rules! assert_result_failed {
+        ($result:expr) => {{
+            let text = assert_result_status!($result);
+            assert_snapshot!(text);
+        }};
+        ($result:expr, $name:tt) => {{
+            let text = assert_result_status!($result);
+            assert_snapshot!($name, text);
+        }};
+    }
+
+    #[test]
+    fn empty_state() {
+        let state = State::default();
+
+        // Any combination of values should result in Ok, since there are no
+        // deleted crates.
+        for (name, version, now) in [
+            ("foo", "0.0.0", "2024-11-20T01:00:00Z"),
+            ("bar", "1.0.0", "1970-01-01T00:00:00Z"),
+        ] {
+            assert_ok!(state.clone().into_result(
+                name,
+                &Version::parse(version).unwrap(),
+                now.parse().unwrap()
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn available_at_only() {
+        let available_at = "2024-11-20T00:00:00Z".parse().unwrap();
+        let version = Version::parse("0.0.0").unwrap();
+
+        let mut state = State::default();
+        state.observe_available_at(available_at);
+
+        // There should be no error for a crate after available_at.
+        assert_ok!(state.clone().into_result(
+            "foo",
+            &version,
+            available_at + TimeDelta::seconds(60)
+        ));
+
+        // Similarly, a crate actually _at_ available_at should be fine.
+        assert_ok!(state.clone().into_result("foo", &version, available_at));
+
+        // But a crate one second earlier should error.
+        assert_result_failed!(state.into_result(
+            "foo",
+            &version,
+            available_at - TimeDelta::seconds(1)
+        ));
+    }
+
+    #[tokio::test]
+    async fn min_version_only() {
+        let available_at = "2024-11-20T00:00:00Z".parse().unwrap();
+
+        let mut state = State::default();
+        state.observe_available_at(available_at);
+
+        // Test the versions that we expect to pass.
+        for (min_version, publish_version) in [
+            ("0.1.0", "0.1.0"),
+            ("0.1.0", "0.1.1"),
+            ("0.1.0", "0.2.0"),
+            ("0.1.0", "1.0.0"),
+            ("1.0.0", "1.0.0"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0", "2.0.0"),
+        ] {
+            let mut state = state.clone();
+            state.observe_min_version(Version::parse(min_version).unwrap());
+
+            assert_ok!(state.into_result(
+                "foo",
+                &Version::parse(publish_version).unwrap(),
+                available_at
+            ));
+        }
+
+        // Now test the versions that we expect to fail.
+        for (min_version, publish_version) in [("0.1.0", "0.0.0"), ("1.0.0", "0.1.0")] {
+            let mut state = state.clone();
+            state.observe_min_version(Version::parse(min_version).unwrap());
+
+            assert_result_failed!(
+                state.into_result(
+                    "foo",
+                    &Version::parse(publish_version).unwrap(),
+                    available_at,
+                ),
+                publish_version
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_deleted() {
+        // We won't repeat everything from the above here, but let's make sure
+        // the most restrictive available_at and min_version are used when
+        // multiple deleted crates are observed.
+        let mut state = State::default();
+
+        let earlier_available_at = "2024-11-20T00:00:00Z".parse().unwrap();
+        let later_available_at = "2024-11-21T12:00:00Z".parse().unwrap();
+        state.observe_available_at(earlier_available_at);
+        state.observe_available_at(later_available_at);
+        state.observe_available_at(earlier_available_at);
+
+        let first_version = Version::parse("0.1.0").unwrap();
+        let second_version = Version::parse("1.0.0").unwrap();
+        state.observe_min_version(first_version.clone());
+        state.observe_min_version(second_version.clone());
+        state.observe_min_version(first_version.clone());
+
+        assert_ok!(state
+            .clone()
+            .into_result("foo", &second_version, later_available_at));
+
+        // Now the bad cases.
+        for (name, version, now) in [
+            ("min_version", &first_version, later_available_at),
+            ("available_at", &second_version, earlier_available_at),
+            ("both", &first_version, earlier_available_at),
+        ] {
+            assert_result_failed!(state.clone().into_result("foo", version, now), name);
+        }
+    }
+}

--- a/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__0.0.0.snap
+++ b/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__0.0.0.snap
@@ -1,0 +1,5 @@
+---
+source: src/controllers/krate/publish/deleted.rs
+expression: text
+---
+{"errors":[{"detail":"A crate with the name `foo` was previously deleted.\n\n* To avoid conflicts with previously published versions of this crate, the minimum version that can be published is 0.1.0."}]}

--- a/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__0.1.0.snap
+++ b/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__0.1.0.snap
@@ -1,0 +1,5 @@
+---
+source: src/controllers/krate/publish/deleted.rs
+expression: text
+---
+{"errors":[{"detail":"A crate with the name `foo` was previously deleted.\n\n* To avoid conflicts with previously published versions of this crate, the minimum version that can be published is 1.0.0."}]}

--- a/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__available_at.snap
+++ b/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__available_at.snap
@@ -1,0 +1,5 @@
+---
+source: src/controllers/krate/publish/deleted.rs
+expression: text
+---
+{"errors":[{"detail":"A crate with the name `foo` was previously deleted.\n\n* Reuse of this name will be available after 2024-11-21T12:00:00Z."}]}

--- a/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__available_at_only.snap
+++ b/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__available_at_only.snap
@@ -1,0 +1,5 @@
+---
+source: src/controllers/krate/publish/deleted.rs
+expression: text
+---
+{"errors":[{"detail":"A crate with the name `foo` was previously deleted.\n\n* Reuse of this name will be available after 2024-11-20T00:00:00Z."}]}

--- a/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__both.snap
+++ b/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__both.snap
@@ -1,0 +1,5 @@
+---
+source: src/controllers/krate/publish/deleted.rs
+expression: text
+---
+{"errors":[{"detail":"A crate with the name `foo` was previously deleted.\n\n* Reuse of this name will be available after 2024-11-21T12:00:00Z.\n* To avoid conflicts with previously published versions of this crate, the minimum version that can be published is 1.0.0."}]}

--- a/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__min_version.snap
+++ b/src/controllers/krate/publish/snapshots/crates_io__controllers__krate__publish__deleted__tests__min_version.snap
@@ -1,0 +1,5 @@
+---
+source: src/controllers/krate/publish/deleted.rs
+expression: text
+---
+{"errors":[{"detail":"A crate with the name `foo` was previously deleted.\n\n* To avoid conflicts with previously published versions of this crate, the minimum version that can be published is 1.0.0."}]}

--- a/src/models/deleted_crate.rs
+++ b/src/models/deleted_crate.rs
@@ -13,4 +13,5 @@ pub struct NewDeletedCrate<'a> {
     deleted_by: Option<i32>,
     message: Option<&'a str>,
     available_at: &'a DateTime<Utc>,
+    min_version: Option<&'a str>,
 }

--- a/src/tests/krate/publish/deleted_crates.rs
+++ b/src/tests/krate/publish/deleted_crates.rs
@@ -31,8 +31,70 @@ async fn test_recently_deleted_crate_with_same_name() -> anyhow::Result<()> {
 
     let crate_to_publish = PublishBuilder::new("actix-web", "1.0.0");
     let response = token.publish_crate(crate_to_publish).await;
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"A crate with the name `actix_web` was recently deleted. Reuse of this name will be available after 2099-12-25T12:34:56Z."}]}"#);
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"A crate with the name `actix-web` was previously deleted.\n\n* Reuse of this name will be available after 2099-12-25T12:34:56Z."}]}"#);
+    assert_that!(app.stored_files().await, empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_deleted_crate_with_same_name_and_version() -> anyhow::Result<()> {
+    let (app, _, _, token) = TestApp::full().with_token().await;
+    let mut conn = app.async_db_conn().await;
+
+    let now = Utc::now();
+    let created_at = now - Duration::hours(24);
+    let deleted_at = now - Duration::hours(1);
+    let available_at = now - Duration::minutes(30);
+
+    let deleted_crate = NewDeletedCrate::builder("actix_web")
+        .created_at(&created_at)
+        .deleted_at(&deleted_at)
+        .available_at(&available_at)
+        .min_version("2.0.0")
+        .build();
+
+    diesel::insert_into(deleted_crates::table)
+        .values(deleted_crate)
+        .execute(&mut conn)
+        .await?;
+
+    let crate_to_publish = PublishBuilder::new("actix-web", "1.0.0");
+    let response = token.publish_crate(crate_to_publish).await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"A crate with the name `actix-web` was previously deleted.\n\n* To avoid conflicts with previously published versions of this crate, the minimum version that can be published is 2.0.0."}]}"#);
+    assert_that!(app.stored_files().await, empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_recently_deleted_crate_with_same_name_and_version() -> anyhow::Result<()> {
+    let (app, _, _, token) = TestApp::full().with_token().await;
+    let mut conn = app.async_db_conn().await;
+
+    let now = Utc::now();
+    let created_at = now - Duration::hours(24);
+    let deleted_at = now - Duration::hours(1);
+    let available_at = "2099-12-25T12:34:56Z".parse()?;
+
+    let deleted_crate = NewDeletedCrate::builder("actix_web")
+        .created_at(&created_at)
+        .deleted_at(&deleted_at)
+        .available_at(&available_at)
+        .min_version("2.0.0")
+        .build();
+
+    diesel::insert_into(deleted_crates::table)
+        .values(deleted_crate)
+        .execute(&mut conn)
+        .await?;
+
+    let crate_to_publish = PublishBuilder::new("actix-web", "1.0.0");
+    let response = token.publish_crate(crate_to_publish).await;
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"A crate with the name `actix-web` was previously deleted.\n\n* Reuse of this name will be available after 2099-12-25T12:34:56Z.\n* To avoid conflicts with previously published versions of this crate, the minimum version that can be published is 2.0.0."}]}"#);
     assert_that!(app.stored_files().await, empty());
 
     Ok(())


### PR DESCRIPTION
As discussed in #9904 and #9912, this PR:

1. Adds a column to the `deleted_crates` table that indicates the first version that can be used when publishing a new crate version with the same name.
2. Populates that column when `crates-admin delete-crate` is run.
3. Checks that column when publishing a new crate version.

---

Implementation wise, most of the noise here is actually moving the `deleted_crates` publish checks into a sub-module, mostly because the original version I wrote inline in the controller was ugly as hell. Instead, we now get to enjoy a slightly overengineered state machine. I'm open to suggestions.

(Although, on the bright side, if we ever do need [the more complex semver compatibility check](https://github.com/rust-lang/crates.io/pull/9912#issuecomment-2484477233) rather than just checking against a minimum version, having the validation logic separated out already should make that easier to implement.)

I added new integration tests for the controller, but most of the specifics are tested in unit tests in said new sub-module. Redundant? Probably. :shrug:

As for the deletion side of things, we're going to need the same `min_version` population behaviour (specifically the use of `TopVersions`) that I added to `crates-admin` when #9904 lands, but I was struggling a bit to figure out how to integrate that into `models::krate`, since `crates-admin` never actually constructs a `models::krate::Crate` when deleting a crate. I played around with doing a partial build of `NewDeletedCrateBuilder` based on a `Crate`, but the type signatures were driving me slightly bonkers, and it didn't really feel cleaner anyway, so I just did it inline for now.

Honestly, it might be simple enough that it's easiest to just copy/paste/adapt the same general logic into #9904.

---

I have a couple of other, more specific open questions that I'll throw into the inline review after I publish this, but I guess the main question here is whether this feels directionally correct.