### PR TITLE
tests/builders: Migrate to async/await

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -171,7 +171,7 @@ mod tests {
 
         let fooo = CrateBuilder::new("foo", user_id)
             .version(VersionBuilder::new("0.1.0"))
-            .async_expect_build(&mut conn)
+            .expect_build(&mut conn)
             .await;
 
         let metadata = index_metadata(&fooo, &mut conn).await.unwrap();
@@ -190,7 +190,7 @@ mod tests {
                     .dependency(&fooo, None),
             )
             .version(VersionBuilder::new("1.0.1").checksum("0123456789abcdef"))
-            .async_expect_build(&mut conn)
+            .expect_build(&mut conn)
             .await;
 
         let metadata = index_metadata(&bar, &mut conn).await.unwrap();

--- a/src/index.rs
+++ b/src/index.rs
@@ -145,8 +145,7 @@ mod tests {
     #[tokio::test]
     async fn test_index_metadata() {
         let test_db = TestDatabase::new();
-        let mut conn = test_db.connect();
-        let mut async_conn = test_db.async_connect().await;
+        let mut conn = test_db.async_connect().await;
 
         let user_id = diesel::insert_into(users::table)
             .values((
@@ -156,7 +155,7 @@ mod tests {
                 users::gh_access_token.eq("some random token"),
             ))
             .returning(users::id)
-            .get_result::<i32>(&mut async_conn)
+            .get_result::<i32>(&mut conn)
             .await
             .unwrap();
 
@@ -172,9 +171,10 @@ mod tests {
 
         let fooo = CrateBuilder::new("foo", user_id)
             .version(VersionBuilder::new("0.1.0"))
-            .expect_build(&mut conn);
+            .async_expect_build(&mut conn)
+            .await;
 
-        let metadata = index_metadata(&fooo, &mut async_conn).await.unwrap();
+        let metadata = index_metadata(&fooo, &mut conn).await.unwrap();
         assert_json_snapshot!(metadata);
 
         let bar = CrateBuilder::new("bar", user_id)
@@ -190,9 +190,10 @@ mod tests {
                     .dependency(&fooo, None),
             )
             .version(VersionBuilder::new("1.0.1").checksum("0123456789abcdef"))
-            .expect_build(&mut conn);
+            .async_expect_build(&mut conn)
+            .await;
 
-        let metadata = index_metadata(&bar, &mut async_conn).await.unwrap();
+        let metadata = index_metadata(&bar, &mut conn).await.unwrap();
         assert_json_snapshot!(metadata);
     }
 }

--- a/src/models/keyword.rs
+++ b/src/models/keyword.rs
@@ -38,6 +38,31 @@ impl Keyword {
             .await
     }
 
+    pub async fn async_find_or_create_all(
+        conn: &mut AsyncPgConnection,
+        names: &[&str],
+    ) -> QueryResult<Vec<Keyword>> {
+        use diesel_async::RunQueryDsl;
+
+        let lowercase_names: Vec<_> = names.iter().map(|s| s.to_lowercase()).collect();
+
+        let new_keywords: Vec<_> = lowercase_names
+            .iter()
+            .map(|s| keywords::keyword.eq(s))
+            .collect();
+
+        diesel::insert_into(keywords::table)
+            .values(&new_keywords)
+            .on_conflict_do_nothing()
+            .execute(conn)
+            .await?;
+
+        keywords::table
+            .filter(keywords::keyword.eq_any(&lowercase_names))
+            .load(conn)
+            .await
+    }
+
     pub fn find_or_create_all(conn: &mut impl Conn, names: &[&str]) -> QueryResult<Vec<Keyword>> {
         use diesel::RunQueryDsl;
 
@@ -99,23 +124,27 @@ mod tests {
     use super::*;
     use crates_io_test_db::TestDatabase;
 
-    #[test]
-    fn dont_associate_with_non_lowercased_keywords() {
-        use diesel::RunQueryDsl;
+    #[tokio::test]
+    #[allow(clippy::iter_next_slice)]
+    async fn dont_associate_with_non_lowercased_keywords() {
+        use diesel_async::RunQueryDsl;
 
         let test_db = TestDatabase::new();
-        let conn = &mut test_db.connect();
+        let mut conn = test_db.async_connect().await;
 
         // The code should be preventing lowercased keywords from existing,
         // but if one happens to sneak in there, don't associate crates with it.
 
         diesel::insert_into(keywords::table)
             .values(keywords::keyword.eq("NO"))
-            .execute(conn)
+            .execute(&mut conn)
+            .await
             .unwrap();
 
-        let associated = Keyword::find_or_create_all(conn, &["no"]).unwrap();
+        let associated = Keyword::async_find_or_create_all(&mut conn, &["no"])
+            .await
+            .unwrap();
         assert_eq!(associated.len(), 1);
-        assert_eq!(associated.first().unwrap().keyword, "no");
+        assert_eq!(associated.iter().next().unwrap().keyword, "no");
     }
 }

--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -47,6 +47,19 @@ pub struct NewTeam<'a> {
 }
 
 impl<'a> NewTeam<'a> {
+    pub async fn async_create_or_update(&self, conn: &mut AsyncPgConnection) -> QueryResult<Team> {
+        use diesel::insert_into;
+        use diesel_async::RunQueryDsl;
+
+        insert_into(teams::table)
+            .values(self)
+            .on_conflict(teams::github_id)
+            .do_update()
+            .set(self)
+            .get_result(conn)
+            .await
+    }
+
     pub fn create_or_update(&self, conn: &mut impl Conn) -> QueryResult<Team> {
         use diesel::insert_into;
         use diesel::RunQueryDsl;

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -11,11 +11,12 @@ async fn test_non_blocked_download_route() {
         .with_user()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let status = anon
         .get::<()>("/api/v1/crates/foo/1.0.0/download")
@@ -36,11 +37,12 @@ async fn test_blocked_download_route() {
         .with_user()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let status = anon
         .get::<()>("/api/v1/crates/foo/1.0.0/download")

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -15,7 +15,7 @@ async fn test_non_blocked_download_route() {
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let status = anon
@@ -41,7 +41,7 @@ async fn test_blocked_download_route() {
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let status = anon

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -141,7 +141,7 @@ impl<'a> CrateBuilder<'a> {
         let mut last_version_id = 0;
         for version_builder in self.versions {
             last_version_id = version_builder
-                .async_build(krate.id, self.owner_id, connection)
+                .build(krate.id, self.owner_id, connection)
                 .await?
                 .id;
         }

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -4,12 +4,12 @@ use crate::{
     util::errors::AppResult,
 };
 
-use crate::models::update_default_version;
-use crate::schema::crate_downloads;
-use chrono::NaiveDateTime;
-use diesel::prelude::*;
-
 use super::VersionBuilder;
+use crate::models::{async_update_default_version, update_default_version};
+use crate::schema::crate_downloads;
+use crate::util::diesel::prelude::*;
+use chrono::NaiveDateTime;
+use diesel_async::AsyncPgConnection;
 
 /// A builder to create crate records for the purpose of inserting directly into the database.
 /// If you want to test logic that happens as part of a publish request, use `PublishBuilder`
@@ -118,8 +118,72 @@ impl<'a> CrateBuilder<'a> {
         self
     }
 
-    pub fn build(mut self, connection: &mut PgConnection) -> AppResult<Crate> {
+    pub async fn async_build(mut self, connection: &mut AsyncPgConnection) -> AppResult<Crate> {
         use diesel::{insert_into, select, update};
+        use diesel_async::RunQueryDsl;
+
+        let mut krate = self.krate.async_create(connection, self.owner_id).await?;
+
+        // Since we are using `NewCrate`, we can't set all the
+        // crate properties in a single DB call.
+
+        if let Some(downloads) = self.downloads {
+            update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate.id)))
+                .set(crate_downloads::downloads.eq(downloads as i64))
+                .execute(connection)
+                .await?;
+        }
+
+        if self.versions.is_empty() {
+            self.versions.push(VersionBuilder::new("0.99.0"));
+        }
+
+        let mut last_version_id = 0;
+        for version_builder in self.versions {
+            last_version_id = version_builder
+                .async_build(krate.id, self.owner_id, connection)
+                .await?
+                .id;
+        }
+
+        if let Some(downloads) = self.recent_downloads {
+            insert_into(version_downloads::table)
+                .values((
+                    version_downloads::version_id.eq(last_version_id),
+                    version_downloads::downloads.eq(downloads),
+                ))
+                .execute(connection)
+                .await?;
+
+            define_sql_function!(fn refresh_recent_crate_downloads());
+            select(refresh_recent_crate_downloads())
+                .execute(connection)
+                .await?;
+        }
+
+        if !self.categories.is_empty() {
+            Category::async_update_crate(connection, krate.id, &self.categories).await?;
+        }
+
+        if !self.keywords.is_empty() {
+            Keyword::async_update_crate(connection, krate.id, &self.keywords).await?;
+        }
+
+        if let Some(updated_at) = self.updated_at {
+            krate = update(&krate)
+                .set(crates::updated_at.eq(updated_at))
+                .returning(Crate::as_returning())
+                .get_result(connection)
+                .await?;
+        }
+
+        async_update_default_version(krate.id, connection).await?;
+
+        Ok(krate)
+    }
+
+    pub fn build(mut self, connection: &mut PgConnection) -> AppResult<Crate> {
+        use diesel::{insert_into, select, update, RunQueryDsl};
 
         let mut krate = self.krate.create(connection, self.owner_id)?;
 
@@ -173,6 +237,18 @@ impl<'a> CrateBuilder<'a> {
         update_default_version(krate.id, connection)?;
 
         Ok(krate)
+    }
+
+    /// Consumes the builder and creates the crate record in the database.
+    ///
+    /// # Panics
+    ///
+    /// Panics (and fails the test) if any part of inserting the crate record fails.
+    pub async fn async_expect_build(self, connection: &mut AsyncPgConnection) -> Crate {
+        let name = self.krate.name;
+        self.async_build(connection).await.unwrap_or_else(|e| {
+            panic!("Unable to create crate {name}: {e:?}");
+        })
     }
 
     /// Consumes the builder and creates the crate record in the database.

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -91,7 +91,7 @@ impl VersionBuilder {
         self
     }
 
-    pub async fn async_build(
+    pub async fn build(
         self,
         crate_id: i32,
         published_by: i32,
@@ -142,83 +142,19 @@ impl VersionBuilder {
         Ok(vers)
     }
 
-    pub fn build(
-        self,
-        crate_id: i32,
-        published_by: i32,
-        connection: &mut PgConnection,
-    ) -> AppResult<Version> {
-        use diesel::{insert_into, RunQueryDsl};
-
-        let version = self.num.to_string();
-
-        let new_version = NewVersion::builder(crate_id, &version)
-            .features(serde_json::to_value(&self.features)?)
-            .maybe_license(self.license.as_deref())
-            .size(self.size)
-            .published_by(published_by)
-            .checksum(&self.checksum)
-            .maybe_links(self.links.as_deref())
-            .maybe_rust_version(self.rust_version.as_deref())
-            .yanked(self.yanked)
-            .maybe_created_at(self.created_at.as_ref())
-            .build();
-
-        let vers = new_version.save(connection, "someone@example.com")?;
-
-        let new_deps = self
-            .dependencies
-            .into_iter()
-            .map(|(crate_id, target)| {
-                (
-                    dependencies::version_id.eq(vers.id),
-                    dependencies::req.eq(">= 0"),
-                    dependencies::crate_id.eq(crate_id),
-                    dependencies::target.eq(target),
-                    dependencies::optional.eq(false),
-                    dependencies::default_features.eq(false),
-                    dependencies::features.eq(Vec::<String>::new()),
-                )
-            })
-            .collect::<Vec<_>>();
-        insert_into(dependencies::table)
-            .values(&new_deps)
-            .execute(connection)?;
-
-        Ok(vers)
-    }
-
     /// Consumes the builder and creates the version record in the database.
     ///
     /// # Panics
     ///
     /// Panics (and fails the test) if any part of inserting the version record fails.
-    pub async fn async_expect_build(
+    pub async fn expect_build(
         self,
         crate_id: i32,
         published_by: i32,
         connection: &mut AsyncPgConnection,
     ) -> Version {
-        self.async_build(crate_id, published_by, connection)
-            .await
-            .unwrap_or_else(|e| {
-                panic!("Unable to create version: {e:?}");
-            })
-    }
-
-    /// Consumes the builder and creates the version record in the database.
-    ///
-    /// # Panics
-    ///
-    /// Panics (and fails the test) if any part of inserting the version record fails.
-    #[track_caller]
-    pub fn expect_build(
-        self,
-        crate_id: i32,
-        published_by: i32,
-        connection: &mut PgConnection,
-    ) -> Version {
         self.build(crate_id, published_by, connection)
+            .await
             .unwrap_or_else(|e| {
                 panic!("Unable to create version: {e:?}");
             })

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -16,11 +16,13 @@ static PATH_DATE_RE: LazyLock<Regex> =
 #[tokio::test(flavor = "multi_thread")]
 async fn test_dump_db_job() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("test-crate", token.as_model().user_id).expect_build(&mut conn);
+    CrateBuilder::new("test-crate", token.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
-    DumpDb.enqueue(&mut conn).unwrap();
+    DumpDb.async_enqueue(&mut conn).await.unwrap();
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -19,7 +19,7 @@ async fn test_dump_db_job() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("test-crate", token.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     DumpDb.async_enqueue(&mut conn).await.unwrap();

--- a/src/tests/issues/issue1205.rs
+++ b/src/tests/issues/issue1205.rs
@@ -18,7 +18,7 @@ async fn test_issue_1205() -> anyhow::Result<()> {
     let mut async_conn = app.async_db_conn().await;
 
     let krate = CrateBuilder::new(CRATE_NAME, user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = user

--- a/src/tests/issues/issue1205.rs
+++ b/src/tests/issues/issue1205.rs
@@ -15,8 +15,11 @@ async fn test_issue_1205() -> anyhow::Result<()> {
         .await;
 
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
 
-    let krate = CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(&mut conn);
+    let krate = CrateBuilder::new(CRATE_NAME, user.as_model().id)
+        .async_expect_build(&mut async_conn)
+        .await;
 
     let response = user
         .add_named_owner(CRATE_NAME, "github:rustaudio:owners")

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -20,7 +20,7 @@ async fn test_issue_2736() -> anyhow::Result<()> {
     let someone_else = app.db_new_user("someone_else").await;
 
     let krate = CrateBuilder::new("crate1", someone_else.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     diesel::insert_into(crate_owners::table)

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -11,6 +11,7 @@ use insta::assert_snapshot;
 async fn test_issue_2736() -> anyhow::Result<()> {
     let (app, _) = TestApp::full().empty().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
 
     // - A user had a GitHub account named, let's say, `foo`
     let foo1 = app.db_new_user("foo").await;
@@ -18,7 +19,9 @@ async fn test_issue_2736() -> anyhow::Result<()> {
     // - Another user `someone_else` added them as an owner of a crate
     let someone_else = app.db_new_user("someone_else").await;
 
-    let krate = CrateBuilder::new("crate1", someone_else.as_model().id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("crate1", someone_else.as_model().id)
+        .async_expect_build(&mut async_conn)
+        .await;
 
     diesel::insert_into(crate_owners::table)
         .values(CrateOwner {

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -37,7 +37,7 @@ async fn test_unauthenticated_requests() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new(CRATE_NAME, user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -67,7 +67,7 @@ async fn test_following() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new(CRATE_NAME, user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Check that initially we are not following the crate yet.
@@ -126,10 +126,10 @@ async fn test_api_token_auth() {
     let api_token = token.as_model();
 
     CrateBuilder::new(CRATE_TO_FOLLOW, api_token.user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new(CRATE_NOT_TO_FOLLOW, api_token.user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     follow(CRATE_TO_FOLLOW, &token).await;

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -34,9 +34,11 @@ async fn test_unauthenticated_requests() {
     const CRATE_NAME: &str = "foo";
 
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new(CRATE_NAME, user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get::<()>(&format!("/api/v1/crates/{CRATE_NAME}/following"))
@@ -62,9 +64,11 @@ async fn test_following() {
     const CRATE_NAME: &str = "foo_following";
 
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new(CRATE_NAME, user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new(CRATE_NAME, user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Check that initially we are not following the crate yet.
     assert_is_following(CRATE_NAME, false, &user).await;
@@ -118,11 +122,15 @@ async fn test_api_token_auth() {
     const CRATE_NOT_TO_FOLLOW: &str = "another_crate";
 
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let api_token = token.as_model();
 
-    CrateBuilder::new(CRATE_TO_FOLLOW, api_token.user_id).expect_build(&mut conn);
-    CrateBuilder::new(CRATE_NOT_TO_FOLLOW, api_token.user_id).expect_build(&mut conn);
+    CrateBuilder::new(CRATE_TO_FOLLOW, api_token.user_id)
+        .async_expect_build(&mut conn)
+        .await;
+    CrateBuilder::new(CRATE_NOT_TO_FOLLOW, api_token.user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     follow(CRATE_TO_FOLLOW, &token).await;
 

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -40,7 +40,7 @@ async fn new_krate_wrong_user() {
 
     // Create the foo_wrong crate with one user
     CrateBuilder::new("foo_wrong", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Then try to publish with a different user

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -36,10 +36,12 @@ async fn new_wrong_token() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_wrong_user() {
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Create the foo_wrong crate with one user
-    CrateBuilder::new("foo_wrong", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo_wrong", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Then try to publish with a different user
     let another_user = app.db_new_user("another").await;

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -146,12 +146,13 @@ async fn new_krate_twice_alt() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_duplicate_version() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database and then we'll try to publish the same version
     CrateBuilder::new("foo_dupe", user.as_model().id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let crate_to_publish = PublishBuilder::new("foo_dupe", "1.0.0");
     let response = token.publish_crate(crate_to_publish).await;

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -151,7 +151,7 @@ async fn new_krate_duplicate_version() {
     // Insert a crate directly into the database and then we'll try to publish the same version
     CrateBuilder::new("foo_dupe", user.as_model().id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let crate_to_publish = PublishBuilder::new("foo_dupe", "1.0.0");

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -23,7 +23,7 @@ async fn new_with_renamed_dependency() {
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dependency = DependencyBuilder::new("package-name").rename("my-name");
@@ -42,7 +42,7 @@ async fn invalid_dependency_rename() {
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token
@@ -63,7 +63,7 @@ async fn invalid_dependency_name_starts_with_digit() {
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token
@@ -84,7 +84,7 @@ async fn invalid_dependency_name_contains_unicode_chars() {
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token
@@ -105,7 +105,7 @@ async fn invalid_too_long_dependency_name() {
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token
@@ -126,7 +126,7 @@ async fn empty_dependency_name() {
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token
@@ -147,7 +147,7 @@ async fn new_with_underscore_renamed_dependency() {
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dependency = DependencyBuilder::new("package-name").rename("_my-name");
@@ -171,7 +171,7 @@ async fn new_krate_with_dependency() {
     // name != canon_crate_name(name) and is a regression test for
     // https://github.com/rust-lang/crates.io/issues/651
     CrateBuilder::new("foo-dep", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dependency = DependencyBuilder::new("foo-dep").version_req("1.0.0");
@@ -204,7 +204,7 @@ async fn new_krate_with_broken_dependency_requirement() {
     // name != canon_crate_name(name) and is a regression test for
     // https://github.com/rust-lang/crates.io/issues/651
     CrateBuilder::new("foo-dep", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dependency = DependencyBuilder::new("foo-dep").version_req("broken");
@@ -222,7 +222,7 @@ async fn reject_new_krate_with_non_exact_dependency() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo-dep", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Use non-exact name for the dependency
@@ -242,7 +242,7 @@ async fn new_crate_allow_empty_alternative_registry_dependency() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo-dep", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dependency = DependencyBuilder::new("foo-dep").registry("");
@@ -272,7 +272,7 @@ async fn new_krate_with_wildcard_dependency() {
 
     // Insert a crate directly into the database so that new_wild can depend on it
     CrateBuilder::new("foo_wild", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dependency = DependencyBuilder::new("foo_wild").version_req("*");
@@ -307,10 +307,10 @@ async fn new_krate_sorts_deps() {
 
     // Insert crates directly into the database so that two-deps can depend on it
     CrateBuilder::new("dep-a", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("dep-b", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dep_a = DependencyBuilder::new("dep-a");
@@ -351,10 +351,10 @@ async fn test_dep_limit() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("dep-a", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("dep-b", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0")

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -19,10 +19,12 @@ async fn invalid_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
-    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("package-name", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dependency = DependencyBuilder::new("package-name").rename("my-name");
 
@@ -36,10 +38,12 @@ async fn new_with_renamed_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_rename() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
-    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("package-name", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token
         .publish_crate(
@@ -55,10 +59,12 @@ async fn invalid_dependency_rename() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_starts_with_digit() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
-    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("package-name", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token
         .publish_crate(
@@ -74,10 +80,12 @@ async fn invalid_dependency_name_starts_with_digit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_contains_unicode_chars() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
-    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("package-name", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token
         .publish_crate(
@@ -93,10 +101,12 @@ async fn invalid_dependency_name_contains_unicode_chars() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_too_long_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
-    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("package-name", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token
         .publish_crate(
@@ -112,10 +122,12 @@ async fn invalid_too_long_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
-    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("package-name", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token
         .publish_crate(
@@ -131,10 +143,12 @@ async fn empty_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_underscore_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
-    CrateBuilder::new("package-name", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("package-name", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dependency = DependencyBuilder::new("package-name").rename("_my-name");
 
@@ -150,13 +164,15 @@ async fn new_krate_with_dependency() {
     use crate::tests::routes::crates::versions::dependencies::Deps;
 
     let (app, anon, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new_dep can depend on it
     // The name choice of `foo-dep` is important! It has the property of
     // name != canon_crate_name(name) and is a regression test for
     // https://github.com/rust-lang/crates.io/issues/651
-    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo-dep", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dependency = DependencyBuilder::new("foo-dep").version_req("1.0.0");
 
@@ -181,13 +197,15 @@ async fn new_krate_with_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_broken_dependency_requirement() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new_dep can depend on it
     // The name choice of `foo-dep` is important! It has the property of
     // name != canon_crate_name(name) and is a regression test for
     // https://github.com/rust-lang/crates.io/issues/651
-    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo-dep", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dependency = DependencyBuilder::new("foo-dep").version_req("broken");
 
@@ -201,9 +219,11 @@ async fn new_krate_with_broken_dependency_requirement() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reject_new_krate_with_non_exact_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo-dep", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Use non-exact name for the dependency
     let dependency = DependencyBuilder::new("foo_dep");
@@ -219,9 +239,11 @@ async fn reject_new_krate_with_non_exact_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_allow_empty_alternative_registry_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("foo-dep", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo-dep", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dependency = DependencyBuilder::new("foo-dep").registry("");
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0").dependency(dependency);
@@ -246,10 +268,12 @@ async fn reject_new_crate_with_alternative_registry_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_wildcard_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that new_wild can depend on it
-    CrateBuilder::new("foo_wild", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo_wild", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dependency = DependencyBuilder::new("foo_wild").version_req("*");
 
@@ -279,11 +303,15 @@ async fn new_krate_dependency_missing() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_sorts_deps() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert crates directly into the database so that two-deps can depend on it
-    CrateBuilder::new("dep-a", user.as_model().id).expect_build(&mut conn);
-    CrateBuilder::new("dep-b", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("dep-a", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
+    CrateBuilder::new("dep-b", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dep_a = DependencyBuilder::new("dep-a");
     let dep_b = DependencyBuilder::new("dep-b");
@@ -320,10 +348,14 @@ async fn test_dep_limit() {
         .with_token()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("dep-a", user.as_model().id).expect_build(&mut conn);
-    CrateBuilder::new("dep-b", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("dep-a", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
+    CrateBuilder::new("dep-b", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0")
         .dependency(DependencyBuilder::new("dep-a"))

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -7,10 +7,12 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn features_version_2() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     // Insert a crate directly into the database so that foo_new can depend on it
-    CrateBuilder::new("bar", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("bar", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let dependency = DependencyBuilder::new("bar");
 
@@ -125,11 +127,12 @@ async fn too_many_features_with_custom_limit() {
         .with_token()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .max_features(4)
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("one", &[])
@@ -184,11 +187,12 @@ async fn too_many_enabled_features_with_custom_limit() {
         .with_token()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .max_features(4)
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
         .feature("default", &["one", "two", "three", "four", "five"]);

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -11,7 +11,7 @@ async fn features_version_2() {
 
     // Insert a crate directly into the database so that foo_new can depend on it
     CrateBuilder::new("bar", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let dependency = DependencyBuilder::new("bar");
@@ -131,7 +131,7 @@ async fn too_many_features_with_custom_limit() {
 
     CrateBuilder::new("foo", user.as_model().id)
         .max_features(4)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")
@@ -191,7 +191,7 @@ async fn too_many_enabled_features_with_custom_limit() {
 
     CrateBuilder::new("foo", user.as_model().id)
         .max_features(4)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let publish_builder = PublishBuilder::new("foo", "1.0.0")

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -136,11 +136,12 @@ async fn new_krate_too_big() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_too_big_but_whitelisted() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_whitelist", user.as_model().id)
         .max_upload_size(2_000_000)
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let crate_to_publish = PublishBuilder::new("foo_whitelist", "1.1.0")
         .add_file("foo_whitelist-1.1.0/big", vec![b'a'; 2000]);

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -140,7 +140,7 @@ async fn new_krate_too_big_but_whitelisted() {
 
     CrateBuilder::new("foo_whitelist", user.as_model().id)
         .max_upload_size(2_000_000)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let crate_to_publish = PublishBuilder::new("foo_whitelist", "1.1.0")

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -77,7 +77,7 @@ async fn publish_after_removing_documentation() {
     // 1. Start with a crate with no documentation
     CrateBuilder::new("docscrate", user.id)
         .version("0.2.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Verify that crates start without any documentation so the next assertion can *prove*

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -71,13 +71,14 @@ async fn new_krate_with_readme_and_plus_version() {
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_after_removing_documentation() {
     let (app, anon, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     // 1. Start with a crate with no documentation
     CrateBuilder::new("docscrate", user.id)
         .version("0.2.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     // Verify that crates start without any documentation so the next assertion can *prove*
     // that it was the one that added the documentation

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -7,11 +7,12 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("Foo_similar", user.as_model().id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let crate_to_publish = PublishBuilder::new("foo_similar", "1.1.0");
     let response = token.publish_crate(crate_to_publish).await;
@@ -23,11 +24,12 @@ async fn new_crate_similar_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_hyphen() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_bar_hyphen", user.as_model().id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen", "1.1.0");
     let response = token.publish_crate(crate_to_publish).await;
@@ -39,11 +41,12 @@ async fn new_crate_similar_name_hyphen() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_underscore() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo-bar-underscore", user.as_model().id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore", "1.1.0");
     let response = token.publish_crate(crate_to_publish).await;

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -11,7 +11,7 @@ async fn new_crate_similar_name() {
 
     CrateBuilder::new("Foo_similar", user.as_model().id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let crate_to_publish = PublishBuilder::new("foo_similar", "1.1.0");
@@ -28,7 +28,7 @@ async fn new_crate_similar_name_hyphen() {
 
     CrateBuilder::new("foo_bar_hyphen", user.as_model().id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let crate_to_publish = PublishBuilder::new("foo-bar-hyphen", "1.1.0");
@@ -45,7 +45,7 @@ async fn new_crate_similar_name_underscore() {
 
     CrateBuilder::new("foo-bar-underscore", user.as_model().id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let crate_to_publish = PublishBuilder::new("foo_bar_underscore", "1.1.0");

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -282,7 +282,10 @@ async fn check_ownership_two_crates() {
     let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    let team = new_team("team_foo").create_or_update(&mut conn).unwrap();
+    let team = new_team("team_foo")
+        .async_create_or_update(&mut async_conn)
+        .await
+        .unwrap();
     let krate_owned_by_team = CrateBuilder::new("foo", user.id).expect_build(&mut conn);
     add_team_to_crate(&team, &krate_owned_by_team, user, &mut async_conn)
         .await
@@ -317,7 +320,8 @@ async fn check_ownership_one_crate() {
     let user = user.as_model();
 
     let team = new_team("github:test_org:team_sloth")
-        .create_or_update(&mut conn)
+        .async_create_or_update(&mut async_conn)
+        .await
         .unwrap();
     let krate = CrateBuilder::new("best_crate", user.id).expect_build(&mut conn);
     add_team_to_crate(&team, &krate, user, &mut async_conn)
@@ -349,7 +353,8 @@ async fn add_existing_team() {
     let user = user.as_model();
 
     let t = new_team("github:test_org:bananas")
-        .create_or_update(&mut conn)
+        .async_create_or_update(&mut async_conn)
+        .await
         .unwrap();
     let krate = CrateBuilder::new("best_crate", user.id).expect_build(&mut conn);
     add_team_to_crate(&t, &krate, user, &mut async_conn)

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -183,10 +183,12 @@ async fn create_and_add_owner(
 #[tokio::test(flavor = "multi_thread")]
 async fn owners_can_remove_self() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let username = &user.as_model().gh_login;
 
-    let krate = CrateBuilder::new("owners_selfremove", user.as_model().id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("owners_selfremove", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Deleting yourself when you're the only owner isn't allowed.
     let response = token
@@ -217,9 +219,12 @@ async fn owners_can_remove_self() {
 async fn modify_multiple_owners() {
     let (app, _, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let username = &user.as_model().gh_login;
 
-    let krate = CrateBuilder::new("owners_multiple", user.as_model().id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("owners_multiple", user.as_model().id)
+        .async_expect_build(&mut async_conn)
+        .await;
 
     let user2 = create_and_add_owner(&app, &token, "user2", &krate).await;
     let user3 = create_and_add_owner(&app, &token, "user3", &krate).await;
@@ -278,22 +283,25 @@ async fn modify_multiple_owners() {
 #[tokio::test(flavor = "multi_thread")]
 async fn check_ownership_two_crates() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let team = new_team("team_foo")
-        .async_create_or_update(&mut async_conn)
+        .async_create_or_update(&mut conn)
         .await
         .unwrap();
-    let krate_owned_by_team = CrateBuilder::new("foo", user.id).expect_build(&mut conn);
-    add_team_to_crate(&team, &krate_owned_by_team, user, &mut async_conn)
+    let krate_owned_by_team = CrateBuilder::new("foo", user.id)
+        .async_expect_build(&mut conn)
+        .await;
+    add_team_to_crate(&team, &krate_owned_by_team, user, &mut conn)
         .await
         .unwrap();
 
     let user2 = app.db_new_user("user_bar").await;
     let user2 = user2.as_model();
-    let krate_not_owned_by_team = CrateBuilder::new("bar", user2.id).expect_build(&mut conn);
+    let krate_not_owned_by_team = CrateBuilder::new("bar", user2.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let json = anon.search(&format!("user_id={}", user2.id)).await;
     assert_eq!(json.crates[0].name, krate_not_owned_by_team.name);
@@ -315,16 +323,17 @@ async fn check_ownership_two_crates() {
 #[tokio::test(flavor = "multi_thread")]
 async fn check_ownership_one_crate() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let team = new_team("github:test_org:team_sloth")
-        .async_create_or_update(&mut async_conn)
+        .async_create_or_update(&mut conn)
         .await
         .unwrap();
-    let krate = CrateBuilder::new("best_crate", user.id).expect_build(&mut conn);
-    add_team_to_crate(&team, &krate, user, &mut async_conn)
+    let krate = CrateBuilder::new("best_crate", user.id)
+        .async_expect_build(&mut conn)
+        .await;
+    add_team_to_crate(&team, &krate, user, &mut conn)
         .await
         .unwrap();
 
@@ -348,16 +357,17 @@ async fn check_ownership_one_crate() {
 #[tokio::test(flavor = "multi_thread")]
 async fn add_existing_team() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let t = new_team("github:test_org:bananas")
-        .async_create_or_update(&mut async_conn)
+        .async_create_or_update(&mut conn)
         .await
         .unwrap();
-    let krate = CrateBuilder::new("best_crate", user.id).expect_build(&mut conn);
-    add_team_to_crate(&t, &krate, user, &mut async_conn)
+    let krate = CrateBuilder::new("best_crate", user.id)
+        .async_expect_build(&mut conn)
+        .await;
+    add_team_to_crate(&t, &krate, user, &mut conn)
         .await
         .unwrap();
 
@@ -375,9 +385,12 @@ async fn add_existing_team() {
 async fn deleted_ownership_isnt_in_owner_user() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    let krate = CrateBuilder::new("foo_my_packages", user.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_my_packages", user.id)
+        .async_expect_build(&mut async_conn)
+        .await;
     krate.owner_remove(&mut conn, &user.gh_login).unwrap();
 
     let json: UserResponse = anon
@@ -426,10 +439,12 @@ async fn api_token_cannot_list_invitations_v1() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_v1() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let owner = owner.as_model();
 
-    let krate = CrateBuilder::new("invited_crate", owner.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("invited_crate", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let user = app.db_new_user("invited_user").await;
     token
@@ -463,13 +478,17 @@ async fn invitations_list_v1() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_does_not_include_expired_invites_v1() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let owner = owner.as_model();
 
     let user = app.db_new_user("invited_user").await;
 
-    let krate1 = CrateBuilder::new("invited_crate_1", owner.id).expect_build(&mut conn);
-    let krate2 = CrateBuilder::new("invited_crate_2", owner.id).expect_build(&mut conn);
+    let krate1 = CrateBuilder::new("invited_crate_1", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
+    let krate2 = CrateBuilder::new("invited_crate_2", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
     token
         .add_named_owner("invited_crate_1", "invited_user")
         .await
@@ -510,11 +529,13 @@ async fn invitations_list_does_not_include_expired_invites_v1() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar").await;
 
-    let krate = CrateBuilder::new("accept_invitation", owner.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("accept_invitation", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Invite a new owner
     owner_token
@@ -543,11 +564,13 @@ async fn test_accept_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decline_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar").await;
 
-    let krate = CrateBuilder::new("decline_invitation", owner.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("decline_invitation", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Invite a new owner
     owner_token
@@ -572,12 +595,14 @@ async fn test_decline_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_invitation_by_mail() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar").await;
 
-    CrateBuilder::new("accept_invitation", owner.id).expect_build(&mut conn);
+    CrateBuilder::new("accept_invitation", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Invite a new owner
     owner_token
@@ -622,11 +647,13 @@ pub async fn expire_invitation(app: &TestApp, crate_id: i32) {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_expired_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("demo_user").await;
 
-    let krate = CrateBuilder::new("demo_crate", owner.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("demo_crate", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Invite a new user
     owner_token
@@ -662,11 +689,13 @@ async fn test_accept_expired_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decline_expired_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("demo_user").await;
 
-    let krate = CrateBuilder::new("demo_crate", owner.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("demo_crate", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Invite a new user
     owner_token
@@ -690,11 +719,13 @@ async fn test_decline_expired_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_expired_invitation_by_mail() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let owner = owner.as_model();
     let _invited_user = app.db_new_user("demo_user").await;
-    let krate = CrateBuilder::new("demo_crate", owner.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("demo_crate", owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Invite a new owner
     owner_token
@@ -756,8 +787,9 @@ async fn inactive_users_dont_get_invitations() {
         .await
         .unwrap();
 
-    let mut conn = app.db_conn();
-    CrateBuilder::new(krate_name, owner.id).expect_build(&mut conn);
+    CrateBuilder::new(krate_name, owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let invited_user = app.db_new_user(invited_gh_login).await;
 
@@ -773,7 +805,7 @@ async fn inactive_users_dont_get_invitations() {
 #[tokio::test(flavor = "multi_thread")]
 async fn highest_gh_id_is_most_recent_account_we_know_of() {
     let (app, _, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let owner = owner.as_model();
 
     // An inactive user with a lower gh_id and an active user with a higher gh_id both exist
@@ -785,7 +817,9 @@ async fn highest_gh_id_is_most_recent_account_we_know_of() {
 
     let invited_user = app.db_new_user(invited_gh_login).await;
 
-    CrateBuilder::new(krate_name, owner.id).expect_build(&mut conn);
+    CrateBuilder::new(krate_name, owner.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     owner_token
         .add_named_owner(krate_name, "user_bar")

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -187,7 +187,7 @@ async fn owners_can_remove_self() {
     let username = &user.as_model().gh_login;
 
     let krate = CrateBuilder::new("owners_selfremove", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Deleting yourself when you're the only owner isn't allowed.
@@ -223,7 +223,7 @@ async fn modify_multiple_owners() {
     let username = &user.as_model().gh_login;
 
     let krate = CrateBuilder::new("owners_multiple", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let user2 = create_and_add_owner(&app, &token, "user2", &krate).await;
@@ -291,7 +291,7 @@ async fn check_ownership_two_crates() {
         .await
         .unwrap();
     let krate_owned_by_team = CrateBuilder::new("foo", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     add_team_to_crate(&team, &krate_owned_by_team, user, &mut conn)
         .await
@@ -300,7 +300,7 @@ async fn check_ownership_two_crates() {
     let user2 = app.db_new_user("user_bar").await;
     let user2 = user2.as_model();
     let krate_not_owned_by_team = CrateBuilder::new("bar", user2.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let json = anon.search(&format!("user_id={}", user2.id)).await;
@@ -331,7 +331,7 @@ async fn check_ownership_one_crate() {
         .await
         .unwrap();
     let krate = CrateBuilder::new("best_crate", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     add_team_to_crate(&team, &krate, user, &mut conn)
         .await
@@ -365,7 +365,7 @@ async fn add_existing_team() {
         .await
         .unwrap();
     let krate = CrateBuilder::new("best_crate", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     add_team_to_crate(&t, &krate, user, &mut conn)
         .await
@@ -389,7 +389,7 @@ async fn deleted_ownership_isnt_in_owner_user() {
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     krate.owner_remove(&mut conn, &user.gh_login).unwrap();
 
@@ -443,7 +443,7 @@ async fn invitations_list_v1() {
     let owner = owner.as_model();
 
     let krate = CrateBuilder::new("invited_crate", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let user = app.db_new_user("invited_user").await;
@@ -484,10 +484,10 @@ async fn invitations_list_does_not_include_expired_invites_v1() {
     let user = app.db_new_user("invited_user").await;
 
     let krate1 = CrateBuilder::new("invited_crate_1", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let krate2 = CrateBuilder::new("invited_crate_2", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     token
         .add_named_owner("invited_crate_1", "invited_user")
@@ -534,7 +534,7 @@ async fn test_accept_invitation() {
     let invited_user = app.db_new_user("user_bar").await;
 
     let krate = CrateBuilder::new("accept_invitation", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Invite a new owner
@@ -569,7 +569,7 @@ async fn test_decline_invitation() {
     let invited_user = app.db_new_user("user_bar").await;
 
     let krate = CrateBuilder::new("decline_invitation", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Invite a new owner
@@ -601,7 +601,7 @@ async fn test_accept_invitation_by_mail() {
     let invited_user = app.db_new_user("user_bar").await;
 
     CrateBuilder::new("accept_invitation", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Invite a new owner
@@ -652,7 +652,7 @@ async fn test_accept_expired_invitation() {
     let invited_user = app.db_new_user("demo_user").await;
 
     let krate = CrateBuilder::new("demo_crate", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Invite a new user
@@ -694,7 +694,7 @@ async fn test_decline_expired_invitation() {
     let invited_user = app.db_new_user("demo_user").await;
 
     let krate = CrateBuilder::new("demo_crate", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Invite a new user
@@ -724,7 +724,7 @@ async fn test_accept_expired_invitation_by_mail() {
     let owner = owner.as_model();
     let _invited_user = app.db_new_user("demo_user").await;
     let krate = CrateBuilder::new("demo_crate", owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Invite a new owner
@@ -788,7 +788,7 @@ async fn inactive_users_dont_get_invitations() {
         .unwrap();
 
     CrateBuilder::new(krate_name, owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let invited_user = app.db_new_user(invited_gh_login).await;
@@ -818,7 +818,7 @@ async fn highest_gh_id_is_most_recent_account_we_know_of() {
     let invited_user = app.db_new_user(invited_gh_login).await;
 
     CrateBuilder::new(krate_name, owner.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     owner_token

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -18,13 +18,13 @@ async fn pagination_blocks_ip_from_cidr_block_list() {
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_2", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_3", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -14,12 +14,18 @@ async fn pagination_blocks_ip_from_cidr_block_list() {
         .with_user()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    CrateBuilder::new("pagination_links_1", user.id).expect_build(&mut conn);
-    CrateBuilder::new("pagination_links_2", user.id).expect_build(&mut conn);
-    CrateBuilder::new("pagination_links_3", user.id).expect_build(&mut conn);
+    CrateBuilder::new("pagination_links_1", user.id)
+        .async_expect_build(&mut conn)
+        .await;
+    CrateBuilder::new("pagination_links_2", user.id)
+        .async_expect_build(&mut conn)
+        .await;
+    CrateBuilder::new("pagination_links_3", user.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get_with_query::<()>("/api/v1/crates", "page=2&per_page=1")

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -31,7 +31,7 @@ async fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
 
     CrateBuilder::new("foo_yank_read_only", user.as_model().id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token
@@ -55,7 +55,7 @@ async fn can_download_crate_in_read_only_mode() {
 
     CrateBuilder::new("foo_download_read_only", user.as_model().id)
         .version("1.0.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = anon

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -27,11 +27,12 @@ async fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
         .with_token()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_yank_read_only", user.as_model().id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token
         .delete::<()>("/api/v1/crates/foo_yank_read_only/1.0.0/yank")
@@ -50,10 +51,12 @@ async fn can_download_crate_in_read_only_mode() {
         .await;
 
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_download_read_only", user.as_model().id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/foo_download_read_only/1.0.0/download")

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -57,7 +57,9 @@ async fn update_crate() {
         .values(cats)
         .execute(&mut conn));
 
-    let krate = CrateBuilder::new("foo_crate", user.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", user.id)
+        .async_expect_build(&mut async_conn)
+        .await;
 
     // Updating with no categories has no effect
     Category::async_update_crate(&mut async_conn, krate.id, &[])

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -45,6 +45,7 @@ async fn update_crate() {
 
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let cats = vec![
@@ -59,38 +60,52 @@ async fn update_crate() {
     let krate = CrateBuilder::new("foo_crate", user.id).expect_build(&mut conn);
 
     // Updating with no categories has no effect
-    Category::update_crate(&mut conn, krate.id, &[]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &[])
+        .await
+        .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Happy path adding one category
-    Category::update_crate(&mut conn, krate.id, &["cat1"]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &["cat1"])
+        .await
+        .unwrap();
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Replacing one category with another
-    Category::update_crate(&mut conn, krate.id, &["category-2"]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &["category-2"])
+        .await
+        .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing one category
-    Category::update_crate(&mut conn, krate.id, &[]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &[])
+        .await
+        .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Adding 2 categories
-    Category::update_crate(&mut conn, krate.id, &["cat1", "category-2"]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &["cat1", "category-2"])
+        .await
+        .unwrap();
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing all categories
-    Category::update_crate(&mut conn, krate.id, &[]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &[])
+        .await
+        .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Attempting to add one valid category and one invalid category
     let invalid_categories =
-        Category::update_crate(&mut conn, krate.id, &["cat1", "catnope"]).unwrap();
+        Category::async_update_crate(&mut async_conn, krate.id, &["cat1", "catnope"])
+            .await
+            .unwrap();
     assert_eq!(invalid_categories, vec!["catnope"]);
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 0);
@@ -102,7 +117,9 @@ async fn update_crate() {
     assert_eq!(json.meta.total, 2);
 
     // Attempting to add a category by display text; must use slug
-    Category::update_crate(&mut conn, krate.id, &["Category 2"]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &["Category 2"])
+        .await
+        .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
@@ -111,7 +128,9 @@ async fn update_crate() {
         .values(new_category("cat1::bar", "cat1::bar", "bar crates"))
         .execute(&mut conn));
 
-    Category::update_crate(&mut conn, krate.id, &["cat1", "cat1::bar"]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &["cat1", "cat1::bar"])
+        .await
+        .unwrap();
 
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "cat1::bar").await, 1);

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -58,7 +58,7 @@ async fn update_crate() {
         .execute(&mut conn));
 
     let krate = CrateBuilder::new("foo_crate", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Updating with no categories has no effect

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -65,11 +65,13 @@ pub async fn download(client: &impl RequestHelper, name_and_version: &str) {
 async fn test_download() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_download", user.id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     // TODO: test the with_json code path
     download(&anon, "foo_download/1.0.0").await;
@@ -99,11 +101,12 @@ async fn test_download() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_download_with_counting_via_cdn() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     download(&anon, "foo/1.0.0").await;
 
@@ -115,12 +118,14 @@ async fn test_download_with_counting_via_cdn() {
 async fn test_crate_downloads() {
     let (app, anon, cookie) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
 
     let user_id = cookie.as_model().id;
     CrateBuilder::new("foo", user_id)
         .version("1.0.0")
         .version("1.1.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     download(&anon, "foo/1.0.0").await;
     download(&anon, "foo/1.0.0").await;
@@ -155,12 +160,14 @@ async fn test_crate_downloads() {
 async fn test_version_downloads() {
     let (app, anon, cookie) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
 
     let user_id = cookie.as_model().id;
     CrateBuilder::new("foo", user_id)
         .version("1.0.0")
         .version("1.1.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     download(&anon, "foo/1.0.0").await;
     download(&anon, "foo/1.0.0").await;

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -70,7 +70,7 @@ async fn test_download() {
 
     CrateBuilder::new("foo_download", user.id)
         .version(VersionBuilder::new("1.0.0"))
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // TODO: test the with_json code path
@@ -105,7 +105,7 @@ async fn test_download_with_counting_via_cdn() {
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     download(&anon, "foo/1.0.0").await;
@@ -124,7 +124,7 @@ async fn test_crate_downloads() {
     CrateBuilder::new("foo", user_id)
         .version("1.0.0")
         .version("1.1.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     download(&anon, "foo/1.0.0").await;
@@ -166,7 +166,7 @@ async fn test_version_downloads() {
     CrateBuilder::new("foo", user_id)
         .version("1.0.0")
         .version("1.1.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     download(&anon, "foo/1.0.0").await;

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -13,12 +13,14 @@ async fn diesel_not_found_results_in_404() {
 #[tokio::test(flavor = "multi_thread")]
 async fn disallow_api_token_auth_for_get_crate_following_status() {
     let (app, _, _, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let api_token = token.as_model();
 
     let a_crate = "a_crate";
 
-    CrateBuilder::new(a_crate, api_token.user_id).expect_build(&mut conn);
+    CrateBuilder::new(a_crate, api_token.user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Token auth on GET for get following status is disallowed
     token

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -19,7 +19,7 @@ async fn disallow_api_token_auth_for_get_crate_following_status() {
     let a_crate = "a_crate";
 
     CrateBuilder::new(a_crate, api_token.user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Token auth on GET for get following status is disallowed

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -42,6 +42,7 @@ async fn index() {
 async fn index_queries() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_index_queries", user.id)
@@ -165,8 +166,12 @@ async fn index_queries() {
         .execute(&mut conn)
         .unwrap();
 
-    Category::update_crate(&mut conn, krate.id, &["cat1"]).unwrap();
-    Category::update_crate(&mut conn, krate2.id, &["cat1::bar"]).unwrap();
+    Category::async_update_crate(&mut async_conn, krate.id, &["cat1"])
+        .await
+        .unwrap();
+    Category::async_update_crate(&mut async_conn, krate2.id, &["cat1::bar"])
+        .await
+        .unwrap();
 
     for cl in search_both(&anon, "category=cat1").await {
         assert_eq!(cl.crates.len(), 2);
@@ -859,6 +864,7 @@ async fn test_zero_downloads() {
 async fn test_default_sort_recent() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     // More than 90 days ago
@@ -896,8 +902,12 @@ async fn test_default_sort_recent() {
         .execute(&mut conn)
         .unwrap();
 
-    Category::update_crate(&mut conn, green_crate.id, &["animal"]).unwrap();
-    Category::update_crate(&mut conn, potato_crate.id, &["animal"]).unwrap();
+    Category::async_update_crate(&mut async_conn, green_crate.id, &["animal"])
+        .await
+        .unwrap();
+    Category::async_update_crate(&mut async_conn, potato_crate.id, &["animal"])
+        .await
+        .unwrap();
 
     // test that index for categories is sorted by recent_downloads
     // by default

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -29,7 +29,7 @@ async fn index() {
         .unwrap();
 
     let krate = CrateBuilder::new("fooindex", user_id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     for json in search_both(&anon, "").await {
@@ -52,23 +52,23 @@ async fn index_queries() {
         .readme("readme")
         .description("description")
         .keyword("kw1")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let krate2 = CrateBuilder::new("BAR_INDEX_QUERIES", user.id)
         .keyword("KW1")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     CrateBuilder::new("foo", user.id)
         .keyword("kw3")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     CrateBuilder::new("two-keywords", user.id)
         .keyword("kw1")
         .keyword("kw3")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     for json in search_both(&anon, "q=baz").await {
@@ -218,11 +218,11 @@ async fn search_includes_crates_where_name_is_stopword() {
     let user = user.as_model();
 
     CrateBuilder::new("which", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("should_be_excluded", user.id)
         .readme("crate which does things")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "q=which").await {
@@ -239,22 +239,22 @@ async fn exact_match_first_on_queries() {
 
     CrateBuilder::new("foo_exact", user.id)
         .description("bar_exact baz_exact")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("bar-exact", user.id)
         .description("foo_exact baz_exact foo-exact baz_exact")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("baz_exact", user.id)
         .description("foo-exact bar_exact foo-exact bar_exact foo_exact bar_exact")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("other_exact", user.id)
         .description("other_exact")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "q=foo-exact").await {
@@ -294,27 +294,27 @@ async fn index_sorting() {
         .description("bar_sort baz_sort const")
         .downloads(50)
         .recent_downloads(50)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let krate2 = CrateBuilder::new("bar_sort", user.id)
         .description("foo_sort baz_sort foo_sort baz_sort const")
         .downloads(3333)
         .recent_downloads(0)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let krate3 = CrateBuilder::new("baz_sort", user.id)
         .description("foo_sort bar_sort foo_sort bar_sort foo_sort bar_sort const")
         .downloads(100_000)
         .recent_downloads(50)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let krate4 = CrateBuilder::new("other_sort", user.id)
         .description("other_sort const")
         .downloads(100_000)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Set the created at column for each crate
@@ -516,27 +516,27 @@ async fn ignore_exact_match_on_queries_with_sort() {
         .description("bar_sort baz_sort const")
         .downloads(50)
         .recent_downloads(50)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let krate2 = CrateBuilder::new("bar_sort", user.id)
         .description("foo_sort baz_sort foo_sort baz_sort const")
         .downloads(3333)
         .recent_downloads(0)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let krate3 = CrateBuilder::new("baz_sort", user.id)
         .description("foo_sort bar_sort foo_sort bar_sort foo_sort bar_sort const")
         .downloads(100_000)
         .recent_downloads(10)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let krate4 = CrateBuilder::new("other_sort", user.id)
         .description("other_sort const")
         .downloads(999_999)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Set the created at column for each crate
@@ -647,16 +647,16 @@ async fn multiple_ids() {
     let user = user.as_model();
 
     CrateBuilder::new("foo", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("bar", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("baz", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("other", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(
@@ -683,28 +683,28 @@ async fn loose_search_order() {
         .readme("readme")
         .description("description")
         .keyword("kw1")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     // temp_udp should match second because of _
     let two = CrateBuilder::new("temp_utp", user.id)
         .readme("readme")
         .description("description")
         .keyword("kw1")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     // evalrs should match 3rd because of readme
     let three = CrateBuilder::new("evalrs", user.id)
         .readme("evalrs_temp evalrs_temp evalrs_temp")
         .description("description")
         .keyword("kw1")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     // tempfile should appear 4th
     let four = CrateBuilder::new("tempfile", user.id)
         .readme("readme")
         .description("description")
         .keyword("kw1")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let ordered = vec![one, two, three, four];
@@ -732,25 +732,25 @@ async fn index_include_yanked() {
     CrateBuilder::new("unyanked", user.id)
         .version(VersionBuilder::new("1.0.0"))
         .version(VersionBuilder::new("2.0.0"))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("newest_yanked", user.id)
         .version(VersionBuilder::new("1.0.0"))
         .version(VersionBuilder::new("2.0.0").yanked(true))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("oldest_yanked", user.id)
         .version(VersionBuilder::new("1.0.0").yanked(true))
         .version(VersionBuilder::new("2.0.0"))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("all_yanked", user.id)
         .version(VersionBuilder::new("1.0.0").yanked(true))
         .version(VersionBuilder::new("2.0.0").yanked(true))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Include fully yanked (all versions were yanked) crates
@@ -801,7 +801,7 @@ async fn yanked_versions_are_not_considered_for_max_version() {
         .description("foo")
         .version("1.0.0")
         .version(VersionBuilder::new("1.1.0").yanked(true))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "q=foo").await {
@@ -825,7 +825,7 @@ async fn max_stable_version() {
         .version(VersionBuilder::new("1.1.0").yanked(true))
         .version("2.0.0-beta.1")
         .version("0.3.1")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "q=foo").await {
@@ -853,14 +853,14 @@ async fn test_recent_download_count() {
         .description("For fetching")
         .downloads(10)
         .recent_downloads(0)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("sweet_potato_snack", user.id)
         .description("For when better than usual")
         .downloads(5)
         .recent_downloads(2)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "sort=recent-downloads").await {
@@ -891,7 +891,7 @@ async fn test_zero_downloads() {
         .description("For fetching")
         .downloads(0)
         .recent_downloads(0)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "sort=recent-downloads").await {
@@ -918,7 +918,7 @@ async fn test_default_sort_recent() {
         .keyword("dog")
         .downloads(10)
         .recent_downloads(10)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let potato_crate = CrateBuilder::new("sweet_potato_snack", user.id)
@@ -926,7 +926,7 @@ async fn test_default_sort_recent() {
         .keyword("dog")
         .downloads(20)
         .recent_downloads(0)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // test that index for keywords is sorted by recent_downloads
@@ -979,13 +979,13 @@ async fn pagination_links_included_if_applicable() {
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_2", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_3", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // This uses a filter (`page=n`) to disable seek-based pagination, as seek-based pagination
@@ -1030,13 +1030,13 @@ async fn seek_based_pagination() {
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_2", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_3", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let mut url = Some("?per_page=1".to_string());
@@ -1085,13 +1085,13 @@ async fn test_pages_work_even_with_seek_based_pagination() {
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_2", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_3", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // The next_page returned by the request is seek-based
@@ -1134,13 +1134,13 @@ async fn pagination_parameters_only_accept_integers() {
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_2", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("pagination_links_3", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -1163,7 +1163,7 @@ async fn crates_by_user_id() {
     let id = user.as_model().id;
 
     CrateBuilder::new("foo_my_packages", id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     for response in search_both_by_user_id(&user, id).await {
@@ -1180,7 +1180,7 @@ async fn crates_by_user_id_not_including_deleted_owners() {
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     krate.owner_remove(&mut conn, "foo").unwrap();
 

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -11,10 +11,12 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cargo_invite_owners() {
     let (app, _, owner) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let new_user = app.db_new_user("cilantro").await;
-    CrateBuilder::new("guacamole", owner.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("guacamole", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let json = owner
         .add_named_owner("guacamole", &new_user.as_model().gh_login)
@@ -36,12 +38,14 @@ async fn test_cargo_invite_owners() {
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_cookie() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
 
-    let krate = CrateBuilder::new("foo_crate", cookie.as_model().id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", cookie.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = cookie.add_named_owner(&krate.name, &user2.gh_login).await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -51,12 +55,14 @@ async fn owner_change_via_cookie() {
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_token() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
 
-    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -69,12 +75,14 @@ async fn owner_change_via_change_owner_token() {
         .with_scoped_token(None, Some(vec![EndpointScope::ChangeOwners]))
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
 
-    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -88,12 +96,14 @@ async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let (app, _, _, token) = TestApp::full()
         .with_scoped_token(crate_scopes, endpoint_scopes)
         .await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
 
-    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -107,12 +117,14 @@ async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let (app, _, _, token) = TestApp::full()
         .with_scoped_token(crate_scopes, endpoint_scopes)
         .await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
 
-    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -125,12 +137,14 @@ async fn owner_change_via_publish_token() {
         .with_scoped_token(None, Some(vec![EndpointScope::PublishUpdate]))
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
 
-    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -140,12 +154,14 @@ async fn owner_change_via_publish_token() {
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_without_auth() {
     let (app, anon, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
 
-    let krate = CrateBuilder::new("foo_crate", cookie.as_model().id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_crate", cookie.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon.add_named_owner(&krate.name, &user2.gh_login).await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -155,9 +171,11 @@ async fn owner_change_without_auth() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_legacy_field() {
     let (app, _, user1) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("foo", user1.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo", user1.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
     app.db_new_user("user2").await;
 
     let input = r#"{"users": ["user2"]}"#;
@@ -171,10 +189,12 @@ async fn test_owner_change_with_legacy_field() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     app.db_new_user("bar").await;
-    CrateBuilder::new("foo", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
@@ -204,10 +224,12 @@ async fn test_owner_change_with_invalid_json() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invite_already_invited_user() {
     let (app, _, _, owner) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     app.db_new_user("invited_user").await;
-    CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(&mut conn);
+    CrateBuilder::new("crate_name", owner.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Ensure no emails were sent up to this point
     assert_eq!(app.emails().await.len(), 0);
@@ -232,10 +254,12 @@ async fn invite_already_invited_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invite_with_existing_expired_invite() {
     let (app, _, _, owner) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     app.db_new_user("invited_user").await;
-    let krate = CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("crate_name", owner.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Ensure no emails were sent up to this point
     assert_eq!(app.emails().await.len(), 0);
@@ -273,9 +297,11 @@ async fn test_unknown_crate() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_user() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo", cookie.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = cookie.add_named_owner("foo", "unknown").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -285,9 +311,11 @@ async fn test_unknown_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_team() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo", cookie.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = cookie
         .add_named_owner("foo", "github:unknown:unknown")
@@ -299,9 +327,11 @@ async fn test_unknown_team() {
 #[tokio::test(flavor = "multi_thread")]
 async fn max_invites_per_request() {
     let (app, _, _, owner) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("crate_name", owner.as_model().user_id).expect_build(&mut conn);
+    CrateBuilder::new("crate_name", owner.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let usernames = (0..11)
         .map(|i| format!("user_{i}"))
@@ -321,9 +351,11 @@ async fn max_invites_per_request() {
 #[tokio::test(flavor = "multi_thread")]
 async fn no_invite_emails_for_txn_rollback() {
     let (app, _, _, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("crate_name", token.as_model().user_id).expect_build(&mut conn);
+    CrateBuilder::new("crate_name", token.as_model().user_id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let mut usernames = (0..9).map(|i| format!("user_{i}")).collect::<Vec<String>>();
 

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -15,7 +15,7 @@ async fn test_cargo_invite_owners() {
 
     let new_user = app.db_new_user("cilantro").await;
     CrateBuilder::new("guacamole", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let json = owner
@@ -44,7 +44,7 @@ async fn owner_change_via_cookie() {
     let user2 = user2.as_model();
 
     let krate = CrateBuilder::new("foo_crate", cookie.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = cookie.add_named_owner(&krate.name, &user2.gh_login).await;
@@ -61,7 +61,7 @@ async fn owner_change_via_token() {
     let user2 = user2.as_model();
 
     let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
@@ -81,7 +81,7 @@ async fn owner_change_via_change_owner_token() {
     let user2 = user2.as_model();
 
     let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
@@ -102,7 +102,7 @@ async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let user2 = user2.as_model();
 
     let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
@@ -123,7 +123,7 @@ async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let user2 = user2.as_model();
 
     let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
@@ -143,7 +143,7 @@ async fn owner_change_via_publish_token() {
     let user2 = user2.as_model();
 
     let krate = CrateBuilder::new("foo_crate", token.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token.add_named_owner(&krate.name, &user2.gh_login).await;
@@ -160,7 +160,7 @@ async fn owner_change_without_auth() {
     let user2 = user2.as_model();
 
     let krate = CrateBuilder::new("foo_crate", cookie.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon.add_named_owner(&krate.name, &user2.gh_login).await;
@@ -174,7 +174,7 @@ async fn test_owner_change_with_legacy_field() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", user1.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     app.db_new_user("user2").await;
 
@@ -193,7 +193,7 @@ async fn test_owner_change_with_invalid_json() {
 
     app.db_new_user("bar").await;
     CrateBuilder::new("foo", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // incomplete input
@@ -228,7 +228,7 @@ async fn invite_already_invited_user() {
 
     app.db_new_user("invited_user").await;
     CrateBuilder::new("crate_name", owner.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Ensure no emails were sent up to this point
@@ -258,7 +258,7 @@ async fn invite_with_existing_expired_invite() {
 
     app.db_new_user("invited_user").await;
     let krate = CrateBuilder::new("crate_name", owner.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Ensure no emails were sent up to this point
@@ -300,7 +300,7 @@ async fn test_unknown_user() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = cookie.add_named_owner("foo", "unknown").await;
@@ -314,7 +314,7 @@ async fn test_unknown_team() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = cookie
@@ -330,7 +330,7 @@ async fn max_invites_per_request() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("crate_name", owner.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let usernames = (0..11)
@@ -354,7 +354,7 @@ async fn no_invite_emails_for_txn_rollback() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("crate_name", token.as_model().user_id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let mut usernames = (0..9).map(|i| format!("user_{i}")).collect::<Vec<String>>();

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -13,7 +13,7 @@ async fn test_owner_change_with_invalid_json() {
 
     app.db_new_user("bar").await;
     CrateBuilder::new("foo", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // incomplete input
@@ -57,7 +57,7 @@ async fn test_unknown_user() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = cookie.remove_named_owner("foo", "unknown").await;
@@ -71,7 +71,7 @@ async fn test_unknown_team() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = cookie
@@ -91,7 +91,7 @@ async fn test_remove_uppercase_user() {
     let mut async_conn = app.async_db_conn().await;
 
     let krate = CrateBuilder::new("foo", cookie.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     diesel::insert_into(crate_owners::table)
@@ -153,7 +153,7 @@ async fn test_remove_uppercase_team() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("crate42", cookie.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = cookie.add_named_owner("crate42", "github:org:team").await;

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -9,10 +9,12 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     app.db_new_user("bar").await;
-    CrateBuilder::new("foo", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // incomplete input
     let input = r#"{"owners": ["foo", }"#;
@@ -52,9 +54,11 @@ async fn test_unknown_crate() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_user() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo", cookie.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = cookie.remove_named_owner("foo", "unknown").await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
@@ -64,9 +68,11 @@ async fn test_unknown_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_team() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo", cookie.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = cookie
         .remove_named_owner("foo", "github:unknown:unknown")
@@ -82,8 +88,11 @@ async fn test_remove_uppercase_user() {
     let (app, _, cookie) = TestApp::full().with_user().await;
     let user2 = app.db_new_user("user2").await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
 
-    let krate = CrateBuilder::new("foo", cookie.as_model().id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo", cookie.as_model().id)
+        .async_expect_build(&mut async_conn)
+        .await;
 
     diesel::insert_into(crate_owners::table)
         .values(CrateOwner {
@@ -141,9 +150,11 @@ async fn test_remove_uppercase_team() {
         });
 
     let (app, _, cookie) = TestApp::full().with_github(github_mock).with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("crate42", cookie.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("crate42", cookie.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = cookie.add_named_owner("crate42", "github:org:team").await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -8,6 +8,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 async fn show() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     use crate::schema::versions;
@@ -23,7 +24,8 @@ async fn show() {
         .keyword("kw1")
         .downloads(20)
         .recent_downloads(10)
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     // Make version 1.0.0 mimic a version published before we started recording who published
     // versions
@@ -48,7 +50,7 @@ async fn show() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_minimal() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_show_minimal", user.id)
@@ -61,7 +63,8 @@ async fn show_minimal() {
         .keyword("kw1")
         .downloads(20)
         .recent_downloads(10)
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/foo_show_minimal?include=")
@@ -76,7 +79,7 @@ async fn show_minimal() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_all_yanked() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_show", user.id)
@@ -88,7 +91,8 @@ async fn show_all_yanked() {
         .keyword("kw1")
         .downloads(20)
         .recent_downloads(10)
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon.get::<()>("/api/v1/crates/foo_show").await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -146,12 +150,13 @@ async fn version_size() {
 #[tokio::test(flavor = "multi_thread")]
 async fn block_bad_documentation_url() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_bad_doc_url", user.id)
         .documentation("http://rust-ci.org/foo/foo_bad_doc_url/doc/foo_bad_doc_url/")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let json = anon.show_crate("foo_bad_doc_url").await;
     assert_eq!(json.krate.documentation, None);
@@ -160,9 +165,11 @@ async fn block_bad_documentation_url() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_new_name() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("new", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("new", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon.get::<()>("/api/v1/crates/new?include=").await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -24,7 +24,7 @@ async fn show() {
         .keyword("kw1")
         .downloads(20)
         .recent_downloads(10)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Make version 1.0.0 mimic a version published before we started recording who published
@@ -63,7 +63,7 @@ async fn show_minimal() {
         .keyword("kw1")
         .downloads(20)
         .recent_downloads(10)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -91,7 +91,7 @@ async fn show_all_yanked() {
         .keyword("kw1")
         .downloads(20)
         .recent_downloads(10)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon.get::<()>("/api/v1/crates/foo_show").await;
@@ -155,7 +155,7 @@ async fn block_bad_documentation_url() {
 
     CrateBuilder::new("foo_bad_doc_url", user.id)
         .documentation("http://rust-ci.org/foo/foo_bad_doc_url/doc/foo_bad_doc_url/")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let json = anon.show_crate("foo_bad_doc_url").await;
@@ -168,7 +168,7 @@ async fn test_new_name() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("new", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon.get::<()>("/api/v1/crates/new?include=").await;

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -10,7 +10,7 @@ async fn reverse_dependencies() {
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("c2", user.id)
@@ -20,7 +20,7 @@ async fn reverse_dependencies() {
                 .dependency(&c1, None)
                 .dependency(&c1, Some("foo")),
         )
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -51,13 +51,13 @@ async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.1.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("c2", user.id)
         .version("1.0.0")
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -78,13 +78,13 @@ async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("c2", user.id)
         .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
         .version("2.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -105,18 +105,18 @@ async fn prerelease_versions_not_included_in_reverse_dependencies() {
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("c2", user.id)
         .version("1.1.0-pre")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("c3", user.id)
         .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
         .version("1.1.0-pre")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -138,13 +138,13 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     CrateBuilder::new("c2", user.id)
         .version("1.0.0")
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = anon
@@ -186,11 +186,11 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     CrateBuilder::new("c2", user.id)
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Make c2's version (and,incidentally, c1's, but that doesn't matter) mimic a version
@@ -204,7 +204,7 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
     // c3's version will have the published by info recorded
     CrateBuilder::new("c3", user.id)
         .version(VersionBuilder::new("3.0.0").dependency(&c1, None))
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = anon
@@ -226,14 +226,14 @@ async fn reverse_dependencies_query_supports_u64_version_number_parts() {
     let large_but_valid_version_number = format!("1.0.{}", u64::MAX);
 
     let c1 = CrateBuilder::new("c1", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // The crate that depends on c1...
     CrateBuilder::new("c2", user.id)
         // ...has a patch version at the limits of what the semver crate supports
         .version(VersionBuilder::new(&large_but_valid_version_number).dependency(&c1, None))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -6,10 +6,12 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    let c1 = CrateBuilder::new("c1", user.id).expect_build(&mut conn);
+    let c1 = CrateBuilder::new("c1", user.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     CrateBuilder::new("c2", user.id)
         .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
@@ -18,7 +20,8 @@ async fn reverse_dependencies() {
                 .dependency(&c1, None)
                 .dependency(&c1, Some("foo")),
         )
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -43,17 +46,19 @@ async fn reverse_dependencies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.1.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     CrateBuilder::new("c2", user.id)
         .version("1.0.0")
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -68,17 +73,19 @@ async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     CrateBuilder::new("c2", user.id)
         .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
         .version("2.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -93,21 +100,24 @@ async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
 #[tokio::test(flavor = "multi_thread")]
 async fn prerelease_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     CrateBuilder::new("c2", user.id)
         .version("1.1.0-pre")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     CrateBuilder::new("c3", user.id)
         .version(VersionBuilder::new("1.0.0").dependency(&c1, None))
         .version("1.1.0-pre")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -123,16 +133,19 @@ async fn prerelease_versions_not_included_in_reverse_dependencies() {
 async fn yanked_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     CrateBuilder::new("c2", user.id)
         .version("1.0.0")
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -165,6 +178,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
 async fn reverse_dependencies_includes_published_by_user_when_present() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     use crate::schema::versions;
@@ -172,10 +186,12 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
     CrateBuilder::new("c2", user.id)
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     // Make c2's version (and,incidentally, c1's, but that doesn't matter) mimic a version
     // published before we started recording who published versions
@@ -188,7 +204,8 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
     // c3's version will have the published by info recorded
     CrateBuilder::new("c3", user.id)
         .version(VersionBuilder::new("3.0.0").dependency(&c1, None))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")
@@ -203,18 +220,21 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_query_supports_u64_version_number_parts() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let large_but_valid_version_number = format!("1.0.{}", u64::MAX);
 
-    let c1 = CrateBuilder::new("c1", user.id).expect_build(&mut conn);
+    let c1 = CrateBuilder::new("c1", user.id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // The crate that depends on c1...
     CrateBuilder::new("c2", user.id)
         // ...has a patch version at the limits of what the semver crate supports
         .version(VersionBuilder::new(&large_but_valid_version_number).dependency(&c1, None))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = anon
         .get::<()>("/api/v1/crates/c1/reverse_dependencies")

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -6,12 +6,13 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn authors() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_authors", user.id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let json: Value = anon
         .get("/api/v1/crates/foo_authors/1.0.0/authors")

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -11,7 +11,7 @@ async fn authors() {
 
     CrateBuilder::new("foo_authors", user.id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let json: Value = anon

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -13,13 +13,15 @@ pub struct Deps {
 async fn dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("foo_deps", user.id).expect_build(&mut conn);
     let c2 = CrateBuilder::new("bar_deps", user.id).expect_build(&mut conn);
     VersionBuilder::new("1.0.0")
         .dependency(&c2, None)
-        .expect_build(c1.id, user.id, &mut conn);
+        .async_expect_build(c1.id, user.id, &mut async_conn)
+        .await;
 
     let deps: Deps = anon
         .get("/api/v1/crates/foo_deps/1.0.0/dependencies")

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -23,7 +23,7 @@ async fn dependencies() {
         .await;
     VersionBuilder::new("1.0.0")
         .dependency(&c2, None)
-        .async_expect_build(c1.id, user.id, &mut conn)
+        .expect_build(c1.id, user.id, &mut conn)
         .await;
 
     let deps: Deps = anon

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -12,15 +12,18 @@ pub struct Deps {
 #[tokio::test(flavor = "multi_thread")]
 async fn dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    let c1 = CrateBuilder::new("foo_deps", user.id).expect_build(&mut conn);
-    let c2 = CrateBuilder::new("bar_deps", user.id).expect_build(&mut conn);
+    let c1 = CrateBuilder::new("foo_deps", user.id)
+        .async_expect_build(&mut conn)
+        .await;
+    let c2 = CrateBuilder::new("bar_deps", user.id)
+        .async_expect_build(&mut conn)
+        .await;
     VersionBuilder::new("1.0.0")
         .dependency(&c2, None)
-        .async_expect_build(c1.id, user.id, &mut async_conn)
+        .async_expect_build(c1.id, user.id, &mut conn)
         .await;
 
     let deps: Deps = anon

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -16,10 +16,10 @@ async fn dependencies() {
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("foo_deps", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let c2 = CrateBuilder::new("bar_deps", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     VersionBuilder::new("1.0.0")
         .dependency(&c2, None)

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -4,11 +4,12 @@ use crate::tests::util::{RequestHelper, TestApp};
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redirects() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo-download", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     // Any redirect to an existing crate and version works correctly.
     anon.get::<()>("/api/v1/crates/foo-download/1.0.0/download")
@@ -34,12 +35,13 @@ async fn test_redirects() {
 #[tokio::test(flavor = "multi_thread")]
 async fn download_with_build_metadata() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo", user.id)
         .version(VersionBuilder::new("1.0.0+bar"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     anon.get::<()>("/api/v1/crates/foo/1.0.0+bar/download")
         .await

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -8,7 +8,7 @@ async fn test_redirects() {
 
     CrateBuilder::new("foo-download", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Any redirect to an existing crate and version works correctly.
@@ -40,7 +40,7 @@ async fn download_with_build_metadata() {
 
     CrateBuilder::new("foo", user.id)
         .version(VersionBuilder::new("1.0.0+bar"))
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     anon.get::<()>("/api/v1/crates/foo/1.0.0+bar/download")

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -19,7 +19,7 @@ async fn versions() {
         .version("0.5.1")
         .version(VersionBuilder::new("1.0.0").rust_version("1.64"))
         .version("0.5.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Make version 1.0.0 mimic a version published before we started recording who published
@@ -71,7 +71,7 @@ async fn test_sorting() {
     for version in versions {
         builder = builder.version(version);
     }
-    builder.async_expect_build(&mut async_conn).await;
+    builder.expect_build(&mut async_conn).await;
     // Make version 1.0.0-beta.2 and 1.0.0-alpha.beta mimic versions created at same time,
     // but 1.0.0-alpha.beta owns larger id number
     let versions_aliased = diesel::alias!(versions as versions_aliased);
@@ -90,7 +90,7 @@ async fn test_sorting() {
     // An additional crate to guarantee the accuracy of the response dataset and its total
     CrateBuilder::new("bar_versions", user.id)
         .version("0.0.1")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let expects = [
@@ -163,7 +163,7 @@ async fn test_seek_based_pagination_semver_sorting() {
         .version(VersionBuilder::new("0.5.1").yanked(true))
         .version(VersionBuilder::new("1.0.0").rust_version("1.64"))
         .version("0.5.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Make version 1.0.0 mimic a version published before we started recording who published
@@ -248,7 +248,7 @@ async fn test_seek_based_pagination_date_sorting() {
         .version(VersionBuilder::new("0.5.1").yanked(true))
         .version(VersionBuilder::new("1.0.0").rust_version("1.64"))
         .version("0.5.0")
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Make version 1.0.0 mimic a version published before we started recording who published
@@ -332,7 +332,7 @@ async fn invalid_seek_parameter() {
     let user = user.as_model();
 
     CrateBuilder::new("foo_versions", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let url = "/api/v1/crates/foo_versions/versions";

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -8,6 +8,7 @@ use serde_json::Value;
 async fn show_by_crate_name_and_version() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_vers_show", user.id).expect_build(&mut conn);
@@ -15,7 +16,8 @@ async fn show_by_crate_name_and_version() {
         .size(1234)
         .checksum("c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4")
         .rust_version("1.64")
-        .expect_build(krate.id, user.id, &mut conn);
+        .async_expect_build(krate.id, user.id, &mut async_conn)
+        .await;
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
     let json: Value = anon.get(url).await.good();
@@ -34,10 +36,13 @@ async fn show_by_crate_name_and_semver_no_published_by() {
 
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_vers_show_no_pb", user.id).expect_build(&mut conn);
-    let version = VersionBuilder::new("1.0.0").expect_build(krate.id, user.id, &mut conn);
+    let version = VersionBuilder::new("1.0.0")
+        .async_expect_build(krate.id, user.id, &mut async_conn)
+        .await;
 
     // Mimic a version published before we started recording who published versions
     let none: Option<i32> = None;

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -17,7 +17,7 @@ async fn show_by_crate_name_and_version() {
         .size(1234)
         .checksum("c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4")
         .rust_version("1.64")
-        .async_expect_build(krate.id, user.id, &mut conn)
+        .expect_build(krate.id, user.id, &mut conn)
         .await;
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
@@ -44,7 +44,7 @@ async fn show_by_crate_name_and_semver_no_published_by() {
         .expect_build(&mut async_conn)
         .await;
     let version = VersionBuilder::new("1.0.0")
-        .async_expect_build(krate.id, user.id, &mut async_conn)
+        .expect_build(krate.id, user.id, &mut async_conn)
         .await;
 
     // Mimic a version published before we started recording who published versions

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -11,7 +11,7 @@ async fn show_by_crate_name_and_version() {
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_vers_show", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let v = VersionBuilder::new("2.0.0")
         .size(1234)
@@ -41,7 +41,7 @@ async fn show_by_crate_name_and_semver_no_published_by() {
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_vers_show_no_pb", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     let version = VersionBuilder::new("1.0.0")
         .async_expect_build(krate.id, user.id, &mut async_conn)

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -7,16 +7,17 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn show_by_crate_name_and_version() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    let krate = CrateBuilder::new("foo_vers_show", user.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_vers_show", user.id)
+        .async_expect_build(&mut conn)
+        .await;
     let v = VersionBuilder::new("2.0.0")
         .size(1234)
         .checksum("c241cd77c3723ccf1aa453f169ee60c0a888344da504bee0142adb859092acb4")
         .rust_version("1.64")
-        .async_expect_build(krate.id, user.id, &mut async_conn)
+        .async_expect_build(krate.id, user.id, &mut conn)
         .await;
 
     let url = "/api/v1/crates/foo_vers_show/2.0.0";
@@ -39,7 +40,9 @@ async fn show_by_crate_name_and_semver_no_published_by() {
     let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    let krate = CrateBuilder::new("foo_vers_show_no_pb", user.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_vers_show_no_pb", user.id)
+        .async_expect_build(&mut async_conn)
+        .await;
     let version = VersionBuilder::new("1.0.0")
         .async_expect_build(krate.id, user.id, &mut async_conn)
         .await;

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -63,14 +63,15 @@ impl<T: RequestHelper> YankRequestHelper for T {
 #[tokio::test(flavor = "multi_thread")]
 async fn yank_by_a_non_owner_fails() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let another_user = app.db_new_user("bar").await;
     let another_user = another_user.as_model();
 
     CrateBuilder::new("foo_not", another_user.id)
         .version("1.0.0")
-        .expect_build(&mut conn);
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = token.yank("foo_not", "1.0.0").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -70,7 +70,7 @@ async fn yank_by_a_non_owner_fails() {
 
     CrateBuilder::new("foo_not", another_user.id)
         .version("1.0.0")
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = token.yank("foo_not", "1.0.0").await;

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -17,13 +17,15 @@ struct KeywordMeta {
 async fn index() {
     let url = "/api/v1/keywords";
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let json: KeywordList = anon.get(url).await.good();
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
 
-    Keyword::find_or_create_all(&mut conn, &["foo"]).unwrap();
+    Keyword::async_find_or_create_all(&mut conn, &["foo"])
+        .await
+        .unwrap();
 
     let json: KeywordList = anon.get(url).await.good();
     assert_eq!(json.keywords.len(), 1);

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -57,27 +57,39 @@ async fn update_crate() {
         .unwrap();
     let krate = CrateBuilder::new("fookey", user.id).expect_build(&mut conn);
 
-    Keyword::update_crate(&mut conn, krate.id, &[]).unwrap();
+    Keyword::async_update_crate(&mut async_conn, krate.id, &[])
+        .await
+        .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::update_crate(&mut conn, krate.id, &["kw1"]).unwrap();
+    Keyword::async_update_crate(&mut async_conn, krate.id, &["kw1"])
+        .await
+        .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 1);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::update_crate(&mut conn, krate.id, &["kw2"]).unwrap();
+    Keyword::async_update_crate(&mut async_conn, krate.id, &["kw2"])
+        .await
+        .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 1);
 
-    Keyword::update_crate(&mut conn, krate.id, &[]).unwrap();
+    Keyword::async_update_crate(&mut async_conn, krate.id, &[])
+        .await
+        .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::update_crate(&mut conn, krate.id, &["kw1", "kw2"]).unwrap();
+    Keyword::async_update_crate(&mut async_conn, krate.id, &["kw1", "kw2"])
+        .await
+        .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 1);
     assert_eq!(cnt("kw2", &anon).await, 1);
 
-    Keyword::update_crate(&mut conn, krate.id, &[]).unwrap();
+    Keyword::async_update_crate(&mut async_conn, krate.id, &[])
+        .await
+        .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 }

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -12,11 +12,13 @@ struct GoodKeyword {
 async fn show() {
     let url = "/api/v1/keywords/foo";
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     anon.get(url).await.assert_not_found();
 
-    Keyword::find_or_create_all(&mut conn, &["foo"]).unwrap();
+    Keyword::async_find_or_create_all(&mut conn, &["foo"])
+        .await
+        .unwrap();
 
     let json: GoodKeyword = anon.get(url).await.good();
     assert_eq!(json.keyword.keyword.as_str(), "foo");
@@ -26,11 +28,13 @@ async fn show() {
 async fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     anon.get(url).await.assert_not_found();
 
-    Keyword::find_or_create_all(&mut conn, &["UPPER"]).unwrap();
+    Keyword::async_find_or_create_all(&mut conn, &["UPPER"])
+        .await
+        .unwrap();
 
     let json: GoodKeyword = anon.get(url).await.good();
     assert_eq!(json.keyword.keyword.as_str(), "upper");
@@ -40,6 +44,7 @@ async fn uppercase() {
 async fn update_crate() {
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     async fn cnt(kw: &str, client: &impl RequestHelper) -> usize {
@@ -47,7 +52,9 @@ async fn update_crate() {
         json.keyword.crates_cnt as usize
     }
 
-    Keyword::find_or_create_all(&mut conn, &["kw1", "kw2"]).unwrap();
+    Keyword::async_find_or_create_all(&mut async_conn, &["kw1", "kw2"])
+        .await
+        .unwrap();
     let krate = CrateBuilder::new("fookey", user.id).expect_build(&mut conn);
 
     Keyword::update_crate(&mut conn, krate.id, &[]).unwrap();

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -55,7 +55,7 @@ async fn update_crate() {
         .await
         .unwrap();
     let krate = CrateBuilder::new("fookey", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     Keyword::async_update_crate(&mut conn, krate.id, &[])

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -30,10 +30,10 @@ async fn test_update_email_notifications() {
     let mut conn = app.async_db_conn().await;
 
     let a = CrateBuilder::new("test_package", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let b = CrateBuilder::new("another_package", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Update crate_a: email_notifications = false
@@ -122,7 +122,7 @@ async fn test_update_email_notifications_not_owned() {
         .unwrap();
 
     let not_my_crate = CrateBuilder::new("test_package", user_id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     user.update_email_notifications(vec![EmailNotificationsUpdate {

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -27,10 +27,14 @@ impl crate::tests::util::MockCookieUser {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_update_email_notifications() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    let a = CrateBuilder::new("test_package", user.as_model().id).expect_build(&mut conn);
-    let b = CrateBuilder::new("another_package", user.as_model().id).expect_build(&mut conn);
+    let a = CrateBuilder::new("test_package", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
+    let b = CrateBuilder::new("another_package", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Update crate_a: email_notifications = false
     // crate_a should be false, crate_b should be true
@@ -109,6 +113,7 @@ async fn test_update_email_notifications() {
 async fn test_update_email_notifications_not_owned() {
     let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
 
     let user_id = diesel::insert_into(users::table)
         .values(new_user("arbitrary_username"))
@@ -116,7 +121,9 @@ async fn test_update_email_notifications_not_owned() {
         .get_result(&mut conn)
         .unwrap();
 
-    let not_my_crate = CrateBuilder::new("test_package", user_id).expect_build(&mut conn);
+    let not_my_crate = CrateBuilder::new("test_package", user_id)
+        .async_expect_build(&mut async_conn)
+        .await;
 
     user.update_email_notifications(vec![EmailNotificationsUpdate {
         id: not_my_crate.id,

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -31,7 +31,7 @@ async fn me() {
     assert_json_snapshot!(response.json());
 
     CrateBuilder::new("foo_my_packages", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = user.get::<()>("/api/v1/me").await;
@@ -47,7 +47,7 @@ async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
     let user_model = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user_model.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     krate.owner_remove(&mut conn, &user_model.gh_login).unwrap();
 

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -20,7 +20,7 @@ pub struct UserShowPrivateResponse {
 #[tokio::test(flavor = "multi_thread")]
 async fn me() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     let response = anon.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -30,7 +30,9 @@ async fn me() {
     assert_eq!(response.status(), StatusCode::OK);
     assert_json_snapshot!(response.json());
 
-    CrateBuilder::new("foo_my_packages", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("foo_my_packages", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let response = user.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -41,9 +43,12 @@ async fn me() {
 async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
     let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user_model = user.as_model();
 
-    let krate = CrateBuilder::new("foo_my_packages", user_model.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_my_packages", user_model.id)
+        .async_expect_build(&mut async_conn)
+        .await;
     krate.owner_remove(&mut conn, &user_model.gh_login).unwrap();
 
     let json = user.show_me().await;

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -29,12 +29,14 @@ async fn following() {
 
     let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user_model = user.as_model();
     let user_id = user_model.id;
 
     CrateBuilder::new("foo_fighters", user_id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     // Make foo_fighters's version mimic a version published before we started recording who
     // published versions
@@ -46,7 +48,8 @@ async fn following() {
 
     CrateBuilder::new("bar_fighters", user_id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut conn);
+        .async_expect_build(&mut async_conn)
+        .await;
 
     let r: R = user.get("/api/v1/me/updates").await.good();
     assert_that!(r.versions, empty());

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -35,7 +35,7 @@ async fn following() {
 
     CrateBuilder::new("foo_fighters", user_id)
         .version(VersionBuilder::new("1.0.0"))
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // Make foo_fighters's version mimic a version published before we started recording who
@@ -48,7 +48,7 @@ async fn following() {
 
     CrateBuilder::new("bar_fighters", user_id)
         .version(VersionBuilder::new("1.0.0"))
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let r: R = user.get("/api/v1/me/updates").await.good();

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -32,10 +32,10 @@ async fn invitation_list() {
     let mut conn = app.async_db_conn().await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let user1 = app.db_new_user("user_1").await;
@@ -174,10 +174,10 @@ async fn invitations_list_does_not_include_expired_invites() {
     let user = app.db_new_user("invited_user").await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     token
@@ -222,10 +222,10 @@ async fn invitations_list_paginated() {
     let user = app.db_new_user("invited_user").await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     token
@@ -342,10 +342,10 @@ async fn invitation_list_other_crates() {
     let other_user = app.db_new_user("other").await;
 
     CrateBuilder::new("crate_1", owner.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("crate_2", other_user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     // Retrieving our own invitations work.

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -29,10 +29,14 @@ async fn get_invitations(user: &MockCookieUser, query: &str) -> CrateOwnerInvita
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
-    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
+    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
+    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let user1 = app.db_new_user("user_1").await;
     let user2 = app.db_new_user("user_2").await;
@@ -166,11 +170,15 @@ async fn invitation_list() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_does_not_include_expired_invites() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = app.db_new_user("invited_user").await;
 
-    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
-    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
+    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
+    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     token
         .add_named_owner("crate_1", "invited_user")
@@ -210,11 +218,15 @@ async fn invitations_list_does_not_include_expired_invites() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_paginated() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let user = app.db_new_user("invited_user").await;
 
-    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
-    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id).expect_build(&mut conn);
+    let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
+    let crate2 = CrateBuilder::new("crate_2", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     token
         .add_named_owner("crate_1", "invited_user")
@@ -326,11 +338,15 @@ async fn invitation_list_other_users() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list_other_crates() {
     let (app, _, owner, _) = TestApp::init().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
     let other_user = app.db_new_user("other").await;
 
-    CrateBuilder::new("crate_1", owner.as_model().id).expect_build(&mut conn);
-    CrateBuilder::new("crate_2", other_user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("crate_1", owner.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
+    CrateBuilder::new("crate_2", other_user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     // Retrieving our own invitations work.
     let resp = owner

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -51,7 +51,7 @@ async fn summary_new_crates() {
                 .category("cat1")
                 .downloads(20)
                 .recent_downloads(10)
-                .async_expect_build(conn)
+                .expect_build(conn)
                 .await;
 
             CrateBuilder::new("most_recent_downloads", user.id)
@@ -61,7 +61,7 @@ async fn summary_new_crates() {
                 .category("cat1")
                 .downloads(5000)
                 .recent_downloads(50)
-                .async_expect_build(conn)
+                .expect_build(conn)
                 .await;
 
             CrateBuilder::new("just_updated", user.id)
@@ -70,7 +70,7 @@ async fn summary_new_crates() {
                 .version(VersionBuilder::new("0.1.2"))
                 // update 'just_updated' krate. Others won't appear because updated_at == created_at.
                 .updated_at(now_)
-                .async_expect_build(conn)
+                .expect_build(conn)
                 .await;
 
             CrateBuilder::new("just_updated_patch", user.id)
@@ -80,7 +80,7 @@ async fn summary_new_crates() {
                 // Add a patch version be newer than the other versions, including the higher one.
                 .version(VersionBuilder::new("0.1.1").created_at(now_plus_two))
                 .updated_at(now_plus_two)
-                .async_expect_build(conn)
+                .expect_build(conn)
                 .await;
 
             CrateBuilder::new("with_downloads", user.id)
@@ -88,7 +88,7 @@ async fn summary_new_crates() {
                 .version(VersionBuilder::new("0.3.1").yanked(true))
                 .keyword("popular")
                 .downloads(1000)
-                .async_expect_build(conn)
+                .expect_build(conn)
                 .await;
 
             // set total_downloads global value for `num_downloads` prop
@@ -174,7 +174,7 @@ async fn excluded_crate_id() {
         .category("cat1")
         .downloads(20)
         .recent_downloads(10)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("most_recent_downloads", user.id)
@@ -183,7 +183,7 @@ async fn excluded_crate_id() {
         .category("cat1")
         .downloads(5000)
         .recent_downloads(50)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let json: SummaryResponse = anon.get("/api/v1/summary").await.good();
@@ -232,7 +232,7 @@ async fn all_yanked() {
         .category("cat1")
         .downloads(20)
         .recent_downloads(10)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("most_recent_downloads", user.id)
@@ -241,7 +241,7 @@ async fn all_yanked() {
         .category("cat1")
         .downloads(5000)
         .recent_downloads(50)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let json: SummaryResponse = anon.get("/api/v1/summary").await.good();

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -15,29 +15,38 @@ async fn user_total_downloads() {
 
     let (app, anon, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
     let another_user = app.db_new_user("bar").await;
     let another_user = another_user.as_model();
 
-    let krate = CrateBuilder::new("foo_krate1", user.id).expect_build(&mut conn);
+    let krate = CrateBuilder::new("foo_krate1", user.id)
+        .async_expect_build(&mut async_conn)
+        .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate.id)))
         .set(crate_downloads::downloads.eq(10))
         .execute(&mut conn)
         .unwrap();
 
-    let krate2 = CrateBuilder::new("foo_krate2", user.id).expect_build(&mut conn);
+    let krate2 = CrateBuilder::new("foo_krate2", user.id)
+        .async_expect_build(&mut async_conn)
+        .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate2.id)))
         .set(crate_downloads::downloads.eq(20))
         .execute(&mut conn)
         .unwrap();
 
-    let another_krate = CrateBuilder::new("bar_krate1", another_user.id).expect_build(&mut conn);
+    let another_krate = CrateBuilder::new("bar_krate1", another_user.id)
+        .async_expect_build(&mut async_conn)
+        .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(another_krate.id)))
         .set(crate_downloads::downloads.eq(2))
         .execute(&mut conn)
         .unwrap();
 
-    let no_longer_my_krate = CrateBuilder::new("nacho", user.id).expect_build(&mut conn);
+    let no_longer_my_krate = CrateBuilder::new("nacho", user.id)
+        .async_expect_build(&mut async_conn)
+        .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(no_longer_my_krate.id)))
         .set(crate_downloads::downloads.eq(5))
         .execute(&mut conn)

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -21,7 +21,7 @@ async fn user_total_downloads() {
     let another_user = another_user.as_model();
 
     let krate = CrateBuilder::new("foo_krate1", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate.id)))
         .set(crate_downloads::downloads.eq(10))
@@ -29,7 +29,7 @@ async fn user_total_downloads() {
         .unwrap();
 
     let krate2 = CrateBuilder::new("foo_krate2", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate2.id)))
         .set(crate_downloads::downloads.eq(20))
@@ -37,7 +37,7 @@ async fn user_total_downloads() {
         .unwrap();
 
     let another_krate = CrateBuilder::new("bar_krate1", another_user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(another_krate.id)))
         .set(crate_downloads::downloads.eq(2))
@@ -45,7 +45,7 @@ async fn user_total_downloads() {
         .unwrap();
 
     let no_longer_my_krate = CrateBuilder::new("nacho", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(no_longer_my_krate.id)))
         .set(crate_downloads::downloads.eq(5))

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -26,9 +26,11 @@ async fn user_agent_is_required() {
 #[tokio::test(flavor = "multi_thread")]
 async fn user_agent_is_not_required_for_download() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("dl_no_ua", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
@@ -45,9 +47,11 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
         .with_user()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("dl_no_ua", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
     let req = Request::get(uri).body("").unwrap();
@@ -64,9 +68,11 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         .with_user()
         .await;
 
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
-    CrateBuilder::new("dl_no_ua", user.as_model().id).expect_build(&mut conn);
+    CrateBuilder::new("dl_no_ua", user.as_model().id)
+        .async_expect_build(&mut conn)
+        .await;
 
     let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")
         // A request with a header value we want to block isn't allowed

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -29,7 +29,7 @@ async fn user_agent_is_not_required_for_download() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("dl_no_ua", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
@@ -50,7 +50,7 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("dl_no_ua", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let uri = "/api/v1/crates/dl_no_ua/0.99.0/download";
@@ -71,7 +71,7 @@ async fn block_traffic_via_arbitrary_header_and_value() {
     let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("dl_no_ua", user.as_model().id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
 
     let req = Request::get("/api/v1/crates/dl_no_ua/0.99.0/download")

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -31,7 +31,7 @@ async fn not_github() {
     let mut async_conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_not_github", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = token
@@ -47,7 +47,7 @@ async fn weird_name() {
     let mut async_conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_weird_name", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = token
@@ -64,7 +64,7 @@ async fn one_colon() {
     let mut async_conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_one_colon", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = token.add_named_owner("foo_one_colon", "github:foo").await;
@@ -78,7 +78,7 @@ async fn add_nonexistent_team() {
     let mut async_conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_add_nonexistent", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = token
@@ -101,7 +101,7 @@ async fn add_renamed_team() {
     use crate::schema::teams;
 
     CrateBuilder::new("foo_renamed_team", owner_id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     // create team with same ID and different name compared to http mock
@@ -145,7 +145,7 @@ async fn add_team_mixed_case() {
     let token = user.db_new_token("arbitrary token name").await;
 
     CrateBuilder::new("foo_mixed_case", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token
@@ -173,7 +173,7 @@ async fn add_team_as_org_owner() {
     let token = user.db_new_token("arbitrary token name").await;
 
     CrateBuilder::new("foo_org_owner", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token
@@ -201,7 +201,7 @@ async fn add_team_as_non_member() {
     let token = user.db_new_token("arbitrary token name").await;
 
     CrateBuilder::new("foo_team_non_member", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     let response = token
@@ -222,7 +222,7 @@ async fn remove_team_as_named_owner() {
         .await;
 
     CrateBuilder::new("foo_remove_team", user_on_both_teams.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token_on_both_teams
@@ -260,7 +260,7 @@ async fn remove_team_as_team_owner() {
         .await;
 
     CrateBuilder::new("foo_remove_team_owner", user_on_both_teams.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token_on_both_teams
@@ -293,7 +293,7 @@ async fn remove_nonexistent_team() {
     let mut async_conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_remove_nonexistent", user.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     insert_into(teams::table)
         .values((
@@ -324,7 +324,7 @@ async fn publish_not_owned() {
         .await;
 
     CrateBuilder::new("foo_not_owned", user_on_both_teams.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token_on_both_teams
@@ -350,7 +350,7 @@ async fn publish_org_owner_owned() {
         .await;
 
     CrateBuilder::new("foo_not_owned", user_on_both_teams.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token_on_both_teams
@@ -377,7 +377,7 @@ async fn publish_owned() {
         .await;
 
     CrateBuilder::new("foo_team_owned", user_on_both_teams.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token_on_both_teams
@@ -407,7 +407,7 @@ async fn add_owners_as_org_owner() {
         .await;
 
     CrateBuilder::new("foo_add_owner", user_on_both_teams.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token_on_both_teams
@@ -435,7 +435,7 @@ async fn add_owners_as_team_owner() {
         .await;
 
     CrateBuilder::new("foo_add_owner", user_on_both_teams.as_model().id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
 
     token_on_both_teams
@@ -464,7 +464,7 @@ async fn crates_by_team_id() {
         .await
         .unwrap();
     let krate = CrateBuilder::new("foo", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     add_team_to_crate(&t, &krate, user, &mut async_conn)
         .await
@@ -494,7 +494,7 @@ async fn crates_by_team_id_not_including_deleted_owners() {
         .unwrap();
 
     let krate = CrateBuilder::new("foo", user.id)
-        .async_expect_build(&mut async_conn)
+        .expect_build(&mut async_conn)
         .await;
     add_team_to_crate(&t, &krate, user, &mut async_conn)
         .await

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -85,6 +85,7 @@ async fn add_nonexistent_team() {
 async fn add_renamed_team() {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = app.db_new_user("user-all-teams").await;
     let token = user.db_new_token("arbitrary token name").await;
     let owner_id = user.as_model().id;
@@ -104,7 +105,10 @@ async fn add_renamed_team() {
         .github_id(2001)
         .build();
 
-    new_team.create_or_update(&mut conn).unwrap();
+    new_team
+        .async_create_or_update(&mut async_conn)
+        .await
+        .unwrap();
 
     assert_eq!(
         teams::table.count().get_result::<i64>(&mut conn).unwrap(),
@@ -423,7 +427,8 @@ async fn crates_by_team_id() {
     let user = user.as_model();
 
     let t = new_team("github:test-org:team")
-        .create_or_update(&mut conn)
+        .async_create_or_update(&mut async_conn)
+        .await
         .unwrap();
     let krate = CrateBuilder::new("foo", user.id).expect_build(&mut conn);
     add_team_to_crate(&t, &krate, user, &mut async_conn)
@@ -448,7 +453,10 @@ async fn crates_by_team_id_not_including_deleted_owners() {
         .github_id(2001)
         .build();
 
-    let t = new_team.create_or_update(&mut conn).unwrap();
+    let t = new_team
+        .async_create_or_update(&mut async_conn)
+        .await
+        .unwrap();
 
     let krate = CrateBuilder::new("foo", user.id).expect_build(&mut conn);
     add_team_to_crate(&t, &krate, user, &mut async_conn)

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -53,11 +53,12 @@ async fn http_error_with_unhealthy_database() {
 #[tokio::test(flavor = "multi_thread")]
 async fn download_requests_with_unhealthy_database_succeed() {
     let (app, anon, _, token) = TestApp::init().with_chaos_proxy().with_token().await;
-    let mut conn = app.db_conn();
+    let mut conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo", token.as_model().user_id)
         .version("1.0.0")
-        .build(&mut conn)
+        .async_build(&mut conn)
+        .await
         .unwrap();
 
     app.primary_db_chaosproxy().break_networking().unwrap();

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -57,7 +57,7 @@ async fn download_requests_with_unhealthy_database_succeed() {
 
     CrateBuilder::new("foo", token.as_model().user_id)
         .version("1.0.0")
-        .async_build(&mut conn)
+        .build(&mut conn)
         .await
         .unwrap();
 

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -5,13 +5,14 @@ use crate::tests::TestApp;
 #[tokio::test(flavor = "multi_thread")]
 async fn record_rerendered_readme_time() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.async_db_conn().await;
     let user = user.as_model();
 
-    let c = CrateBuilder::new("foo_authors", user.id).expect_build(&mut conn);
+    let c = CrateBuilder::new("foo_authors", user.id)
+        .async_expect_build(&mut conn)
+        .await;
     let version = VersionBuilder::new("1.0.0")
-        .async_expect_build(c.id, user.id, &mut async_conn)
+        .async_expect_build(c.id, user.id, &mut conn)
         .await;
 
     let mut conn = app.async_db_conn().await;

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -9,7 +9,7 @@ async fn record_rerendered_readme_time() {
     let user = user.as_model();
 
     let c = CrateBuilder::new("foo_authors", user.id)
-        .async_expect_build(&mut conn)
+        .expect_build(&mut conn)
         .await;
     let version = VersionBuilder::new("1.0.0")
         .async_expect_build(c.id, user.id, &mut conn)

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -6,10 +6,13 @@ use crate::tests::TestApp;
 async fn record_rerendered_readme_time() {
     let (app, _, user) = TestApp::init().with_user().await;
     let mut conn = app.db_conn();
+    let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let c = CrateBuilder::new("foo_authors", user.id).expect_build(&mut conn);
-    let version = VersionBuilder::new("1.0.0").expect_build(c.id, user.id, &mut conn);
+    let version = VersionBuilder::new("1.0.0")
+        .async_expect_build(c.id, user.id, &mut async_conn)
+        .await;
 
     let mut conn = app.async_db_conn().await;
     Version::record_readme_rendering(version.id, &mut conn)

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -12,7 +12,7 @@ async fn record_rerendered_readme_time() {
         .expect_build(&mut conn)
         .await;
     let version = VersionBuilder::new("1.0.0")
-        .async_expect_build(c.id, user.id, &mut conn)
+        .expect_build(c.id, user.id, &mut conn)
         .await;
 
     let mut conn = app.async_db_conn().await;

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -190,9 +190,11 @@ mod tests {
         let user_b = faker::user(&mut conn, "b")?;
 
         // Set up three crates with various ownership schemes.
-        let _top_a = faker::crate_and_version(&mut conn, "a", "Hello", &user_a, 2)?;
-        let top_b = faker::crate_and_version(&mut conn, "b", "Yes, this is dog", &user_b, 1)?;
-        let not_top_c = faker::crate_and_version(&mut conn, "c", "Unpopular", &user_a, 0)?;
+        let _top_a = faker::crate_and_version(&mut async_conn, "a", "Hello", &user_a, 2).await?;
+        let top_b =
+            faker::crate_and_version(&mut async_conn, "b", "Yes, this is dog", &user_b, 1).await?;
+        let not_top_c =
+            faker::crate_and_version(&mut async_conn, "c", "Unpopular", &user_a, 0).await?;
 
         // Let's set up a team that owns both b and c, but not a.
         let not_the_a_team = faker::team(&mut async_conn, "org", "team").await?;

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -195,7 +195,7 @@ mod tests {
         let not_top_c = faker::crate_and_version(&mut conn, "c", "Unpopular", &user_a, 0)?;
 
         // Let's set up a team that owns both b and c, but not a.
-        let not_the_a_team = faker::team(&mut conn, "org", "team")?;
+        let not_the_a_team = faker::team(&mut async_conn, "org", "team").await?;
         add_team_to_crate(&not_the_a_team, &top_b, &user_b, &mut async_conn).await?;
         add_team_to_crate(&not_the_a_team, &not_top_c, &user_b, &mut async_conn).await?;
 

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -23,7 +23,7 @@ pub mod faker {
             .description(description)
             .downloads(downloads)
             .version("1.0.0")
-            .async_build(conn)
+            .build(conn)
             .await
             .map_err(|err| anyhow!(err.to_string()))
     }

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -12,8 +12,8 @@ pub mod faker {
     use anyhow::anyhow;
     use diesel_async::AsyncPgConnection;
 
-    pub fn crate_and_version(
-        conn: &mut PgConnection,
+    pub async fn crate_and_version(
+        conn: &mut AsyncPgConnection,
         name: &str,
         description: &str,
         user: &User,
@@ -23,7 +23,8 @@ pub mod faker {
             .description(description)
             .downloads(downloads)
             .version("1.0.0")
-            .build(conn)
+            .async_build(conn)
+            .await
             .map_err(|err| anyhow!(err.to_string()))
     }
 

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -10,6 +10,7 @@ pub mod faker {
     use super::*;
     use crate::tests::builders::CrateBuilder;
     use anyhow::anyhow;
+    use diesel_async::AsyncPgConnection;
 
     pub fn crate_and_version(
         conn: &mut PgConnection,
@@ -26,7 +27,7 @@ pub mod faker {
             .map_err(|err| anyhow!(err.to_string()))
     }
 
-    pub fn team(conn: &mut PgConnection, org: &str, team: &str) -> anyhow::Result<Team> {
+    pub async fn team(conn: &mut AsyncPgConnection, org: &str, team: &str) -> anyhow::Result<Team> {
         let login = format!("github:{org}:{team}");
         let team = NewTeam::builder()
             .login(&login)
@@ -35,7 +36,7 @@ pub mod faker {
             .name(team)
             .build();
 
-        Ok(team.create_or_update(conn)?)
+        Ok(team.async_create_or_update(conn).await?)
     }
 
     pub fn user(conn: &mut PgConnection, login: &str) -> QueryResult<User> {


### PR DESCRIPTION
This PR has gotten a bit big... I'm sorry 🙈 

This PR gets rid of more sync database connection usage by converting the `CrateBuilder` and `VersionBuilder` to using async functions instead of the sync counterparts. Some duplication was necessary for now until the publish endpoint has been migrated...