### PR TITLE
Update `rss` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4102,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "rss"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "554a62b3dd5450fcbb0435b3db809f9dd3c6e9f5726172408f7ad3b57ed59057"
+checksum = "531af70fce504d369cf42ac0a9645f5a62a8ea9265de71cfa25087e9f6080c7c"
 dependencies = [
  "atom_syndication",
  "quick-xml 0.37.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ postgres-native-tls = "=0.5.0"
 prometheus = { version = "=0.13.4", default-features = false }
 rand = "=0.8.5"
 reqwest = { version = "=0.12.9", features = ["gzip", "json"] }
-rss = { version = "=2.0.10", default-features = false, features = ["atom"] }
+rss = { version = "=2.0.11", default-features = false, features = ["atom"] }
 secrecy = "=0.10.3"
 semver = { version = "=1.0.23", features = ["serde"] }
 sentry = { version = "=0.34.0", features = ["tracing", "tower", "tower-axum-matched-path", "tower-http"] }

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -125,10 +125,6 @@ impl NewCrate {
             permalink: true,
         };
 
-        let description = self
-            .description
-            .map(|d| d.replace("]]>", "]]]]><![CDATA[>"));
-
         let name_extension = rss::extension::Extension {
             name: "crates:name".into(),
             value: Some(self.name),
@@ -144,7 +140,7 @@ impl NewCrate {
             guid: Some(guid),
             title: Some(title),
             link: Some(link),
-            description,
+            description: self.description,
             pub_date: Some(pub_date),
             extensions,
             ..Default::default()

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -132,10 +132,6 @@ impl VersionUpdate {
             permalink: true,
         };
 
-        let description = self
-            .description
-            .map(|d| d.replace("]]>", "]]]]><![CDATA[>"));
-
         let name_extension = rss::extension::Extension {
             name: "crates:name".into(),
             value: Some(self.name),
@@ -160,7 +156,7 @@ impl VersionUpdate {
             guid: Some(guid),
             title: Some(title),
             link: Some(link),
-            description,
+            description: self.description,
             pub_date: Some(pub_date),
             extensions,
             ..Default::default()


### PR DESCRIPTION
This update fixes the escaping of `]]>` in `CDATA`, which means we can remove our current workaround :)