### PR TITLE
models/default_versions: Remove sync fns

### DIFF
--- a/src/bin/crates-admin/default_versions.rs
+++ b/src/bin/crates-admin/default_versions.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use crates_io::models::{async_update_default_version, async_verify_default_version};
+use crates_io::models::{update_default_version, verify_default_version};
 use crates_io::{db, schema::crates};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -33,8 +33,8 @@ pub async fn run(command: Command) -> anyhow::Result<()> {
 
     for crate_id in crate_ids.into_iter().progress_with(pb.clone()) {
         let result = match command {
-            Command::Update => async_update_default_version(crate_id, &mut conn).await,
-            Command::Verify => async_verify_default_version(crate_id, &mut conn).await,
+            Command::Update => update_default_version(crate_id, &mut conn).await,
+            Command::Verify => verify_default_version(crate_id, &mut conn).await,
         };
 
         if let Err(error) = result {

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -1,14 +1,14 @@
 use crate::dialoguer;
 use anyhow::Context;
-use crates_io::models::update_default_version;
+use crates_io::models::async_update_default_version;
 use crates_io::schema::crates;
 use crates_io::storage::Storage;
-use crates_io::tasks::spawn_blocking;
 use crates_io::worker::jobs;
 use crates_io::{db, schema::versions};
 use crates_io_worker::BackgroundJob;
-use diesel::{Connection, ExpressionMethods, QueryDsl};
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncConnection, RunQueryDsl};
 
 #[derive(clap::Parser, Debug)]
 #[command(
@@ -36,17 +36,12 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
 
     let store = Storage::from_environment();
 
-    let crate_id: i32 = {
-        use diesel_async::RunQueryDsl;
-
-        crates::table
-            .select(crates::id)
-            .filter(crates::name.eq(&opts.crate_name))
-            .first(&mut conn)
-            .await
-            .context("Failed to look up crate id from the database")
-    }?;
-
+    let crate_id: i32 = crates::table
+        .select(crates::id)
+        .filter(crates::name.eq(&opts.crate_name))
+        .first(&mut conn)
+        .await
+        .context("Failed to look up crate id from the database")?;
     {
         let crate_name = &opts.crate_name;
 
@@ -64,56 +59,50 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         }
     }
 
-    let opts = spawn_blocking(move || {
-        use diesel::RunQueryDsl;
-
-        let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-
+    let opts = conn.transaction(|conn| async move {
         let crate_name = &opts.crate_name;
 
-        conn.transaction(|conn| {
-            info!(%crate_name, %crate_id, versions = ?opts.versions, "Deleting versions from the database");
-            let result = diesel::delete(
-                versions::table
-                    .filter(versions::crate_id.eq(crate_id))
-                    .filter(versions::num.eq_any(&opts.versions)),
-            )
-            .execute(conn);
+        info!(%crate_name, %crate_id, versions = ?opts.versions, "Deleting versions from the database");
+        let result = diesel::delete(
+            versions::table
+                .filter(versions::crate_id.eq(crate_id))
+                .filter(versions::num.eq_any(&opts.versions)),
+        )
+        .execute(conn).await;
 
-            match result {
-                Ok(num_deleted) if num_deleted == opts.versions.len() => {}
-                Ok(num_deleted) => {
-                    warn!(
-                        %crate_name,
-                        "Deleted only {num_deleted} of {num_expected} versions from the database",
-                        num_expected = opts.versions.len()
-                    );
-                }
-                Err(error) => {
-                    warn!(%crate_name, ?error, "Failed to delete versions from the database")
-                }
+        match result {
+            Ok(num_deleted) if num_deleted == opts.versions.len() => {}
+            Ok(num_deleted) => {
+                warn!(
+                    %crate_name,
+                    "Deleted only {num_deleted} of {num_expected} versions from the database",
+                    num_expected = opts.versions.len()
+                );
             }
-
-            info!(%crate_name, %crate_id, "Updating default version in the database");
-            if let Err(error) = update_default_version(crate_id, conn) {
-                warn!(%crate_name, %crate_id, ?error, "Failed to update default version");
+            Err(error) => {
+                warn!(%crate_name, ?error, "Failed to delete versions from the database")
             }
-
-            Ok::<_, anyhow::Error>(())
-        })?;
-
-        info!(%crate_name, "Enqueuing index sync jobs");
-        if let Err(error) = jobs::SyncToGitIndex::new(crate_name).enqueue(conn) {
-            warn!(%crate_name, ?error, "Failed to enqueue SyncToGitIndex job");
         }
-        if let Err(error) = jobs::SyncToSparseIndex::new(crate_name).enqueue(conn) {
-            warn!(%crate_name, ?error, "Failed to enqueue SyncToSparseIndex job");
+
+        info!(%crate_name, %crate_id, "Updating default version in the database");
+        if let Err(error) = async_update_default_version(crate_id, conn).await {
+            warn!(%crate_name, %crate_id, ?error, "Failed to update default version");
         }
 
         Ok::<_, anyhow::Error>(opts)
-    }).await??;
+    }.scope_boxed()).await?;
 
     let crate_name = &opts.crate_name;
+
+    info!(%crate_name, "Enqueuing index sync jobs");
+    let job = jobs::SyncToGitIndex::new(crate_name);
+    if let Err(error) = job.async_enqueue(&mut conn).await {
+        warn!(%crate_name, ?error, "Failed to enqueue SyncToGitIndex job");
+    }
+    let job = jobs::SyncToSparseIndex::new(crate_name);
+    if let Err(error) = job.async_enqueue(&mut conn).await {
+        warn!(%crate_name, ?error, "Failed to enqueue SyncToSparseIndex job");
+    }
 
     for version in &opts.versions {
         debug!(%crate_name, %version, "Deleting crate file from S3");

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -1,6 +1,6 @@
 use crate::dialoguer;
 use anyhow::Context;
-use crates_io::models::async_update_default_version;
+use crates_io::models::update_default_version;
 use crates_io::schema::crates;
 use crates_io::storage::Storage;
 use crates_io::worker::jobs;
@@ -85,7 +85,7 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
         }
 
         info!(%crate_name, %crate_id, "Updating default version in the database");
-        if let Err(error) = async_update_default_version(crate_id, conn).await {
+        if let Err(error) = update_default_version(crate_id, conn).await {
             warn!(%crate_name, %crate_id, ?error, "Failed to update default version");
         }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,10 +1,7 @@
 pub use self::action::{NewVersionOwnerAction, VersionAction, VersionOwnerAction};
 pub use self::category::{Category, CrateCategory, NewCategory};
 pub use self::crate_owner_invitation::{CrateOwnerInvitation, NewCrateOwnerInvitationOutcome};
-pub use self::default_versions::{
-    async_update_default_version, async_verify_default_version, update_default_version,
-    verify_default_version,
-};
+pub use self::default_versions::{update_default_version, verify_default_version};
 pub use self::deleted_crate::NewDeletedCrate;
 pub use self::dependency::{Dependency, DependencyKind, ReverseDependency};
 pub use self::download::VersionDownload;

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 use super::VersionBuilder;
-use crate::models::async_update_default_version;
+use crate::models::update_default_version;
 use crate::schema::crate_downloads;
 use crate::util::diesel::prelude::*;
 use chrono::NaiveDateTime;
@@ -177,7 +177,7 @@ impl<'a> CrateBuilder<'a> {
                 .await?;
         }
 
-        async_update_default_version(krate.id, connection).await?;
+        update_default_version(krate.id, connection).await?;
 
         Ok(krate)
     }

--- a/src/worker/jobs/update_default_version.rs
+++ b/src/worker/jobs/update_default_version.rs
@@ -1,4 +1,4 @@
-use crate::models::async_update_default_version;
+use crate::models::update_default_version;
 use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
 use std::sync::Arc;
@@ -26,7 +26,7 @@ impl BackgroundJob for UpdateDefaultVersion {
 
         info!("Updating default version for crate {crate_id}");
         let mut conn = ctx.deadpool.get().await?;
-        async_update_default_version(crate_id, &mut conn).await?;
+        update_default_version(crate_id, &mut conn).await?;
 
         Ok(())
     }

--- a/src/worker/jobs/update_default_version.rs
+++ b/src/worker/jobs/update_default_version.rs
@@ -1,8 +1,6 @@
-use crate::models::update_default_version;
-use crate::tasks::spawn_blocking;
+use crate::models::async_update_default_version;
 use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
-use diesel_async::async_connection_wrapper::AsyncConnectionWrapper;
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize)]
@@ -27,12 +25,9 @@ impl BackgroundJob for UpdateDefaultVersion {
         let crate_id = self.crate_id;
 
         info!("Updating default version for crate {crate_id}");
-        let conn = ctx.deadpool.get().await?;
-        spawn_blocking(move || {
-            let conn: &mut AsyncConnectionWrapper<_> = &mut conn.into();
-            update_default_version(crate_id, conn)?;
-            Ok(())
-        })
-        .await?
+        let mut conn = ctx.deadpool.get().await?;
+        async_update_default_version(crate_id, &mut conn).await?;
+
+        Ok(())
     }
 }


### PR DESCRIPTION
This PR first migrates the remaining code paths to use the async variants of the fns in the `models/default_versions` module, and then removes the now-unused sync functions, while also renaming the async variants and dropping the `async_` prefix.

- ... as promised in https://github.com/rust-lang/crates.io/pull/10036