### PR TITLE
Remove unused sync fns

### DIFF
--- a/crates/crates_io_worker/src/background_job.rs
+++ b/crates/crates_io_worker/src/background_job.rs
@@ -1,11 +1,9 @@
 use crate::errors::EnqueueError;
 use crate::schema::background_jobs;
-use diesel::connection::LoadConnection;
 use diesel::dsl::{exists, not};
-use diesel::pg::Pg;
 use diesel::sql_types::{Int2, Jsonb, Text};
 use diesel::{ExpressionMethods, IntoSql, OptionalExtension, QueryDsl};
-use diesel_async::AsyncPgConnection;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
@@ -40,85 +38,28 @@ pub trait BackgroundJob: Serialize + DeserializeOwned + Send + Sync + 'static {
     /// Execute the task. This method should define its logic.
     fn run(&self, ctx: Self::Context) -> impl Future<Output = anyhow::Result<()>> + Send;
 
-    #[instrument(name = "swirl.enqueue", skip(self, conn), fields(message = Self::JOB_NAME))]
-    fn enqueue(
-        &self,
-        conn: &mut impl LoadConnection<Backend = Pg>,
-    ) -> Result<Option<i64>, EnqueueError> {
-        let data = serde_json::to_value(self)?;
-        let priority = Self::PRIORITY;
-
-        if Self::DEDUPLICATED {
-            Ok(enqueue_deduplicated(conn, Self::JOB_NAME, &data, priority)?)
-        } else {
-            Ok(Some(enqueue_simple(conn, Self::JOB_NAME, &data, priority)?))
-        }
-    }
-
     #[allow(async_fn_in_trait)]
     #[instrument(name = "swirl.enqueue", skip(self, conn), fields(message = Self::JOB_NAME))]
-    async fn async_enqueue(
-        &self,
-        conn: &mut AsyncPgConnection,
-    ) -> Result<Option<i64>, EnqueueError> {
+    async fn enqueue(&self, conn: &mut AsyncPgConnection) -> Result<Option<i64>, EnqueueError> {
         let data = serde_json::to_value(self)?;
         let priority = Self::PRIORITY;
 
         if Self::DEDUPLICATED {
-            Ok(async_enqueue_deduplicated(conn, Self::JOB_NAME, &data, priority).await?)
+            Ok(enqueue_deduplicated(conn, Self::JOB_NAME, &data, priority).await?)
         } else {
             Ok(Some(
-                async_enqueue_simple(conn, Self::JOB_NAME, &data, priority).await?,
+                enqueue_simple(conn, Self::JOB_NAME, &data, priority).await?,
             ))
         }
     }
 }
 
-fn enqueue_deduplicated(
-    conn: &mut impl LoadConnection<Backend = Pg>,
-    job_type: &str,
-    data: &Value,
-    priority: i16,
-) -> Result<Option<i64>, EnqueueError> {
-    use diesel::RunQueryDsl;
-
-    let similar_jobs = background_jobs::table
-        .select(background_jobs::id)
-        .filter(background_jobs::job_type.eq(job_type))
-        .filter(background_jobs::data.eq(data))
-        .filter(background_jobs::priority.eq(priority))
-        .for_update()
-        .skip_locked();
-
-    let deduplicated_select = diesel::select((
-        job_type.into_sql::<Text>(),
-        data.into_sql::<Jsonb>(),
-        priority.into_sql::<Int2>(),
-    ))
-    .filter(not(exists(similar_jobs)));
-
-    let id = diesel::insert_into(background_jobs::table)
-        .values(deduplicated_select)
-        .into_columns((
-            background_jobs::job_type,
-            background_jobs::data,
-            background_jobs::priority,
-        ))
-        .returning(background_jobs::id)
-        .get_result::<i64>(conn)
-        .optional()?;
-
-    Ok(id)
-}
-
-async fn async_enqueue_deduplicated(
+async fn enqueue_deduplicated(
     conn: &mut AsyncPgConnection,
     job_type: &str,
     data: &Value,
     priority: i16,
 ) -> Result<Option<i64>, EnqueueError> {
-    use diesel_async::RunQueryDsl;
-
     let similar_jobs = background_jobs::table
         .select(background_jobs::id)
         .filter(background_jobs::job_type.eq(job_type))
@@ -149,34 +90,12 @@ async fn async_enqueue_deduplicated(
     Ok(id)
 }
 
-fn enqueue_simple(
-    conn: &mut impl LoadConnection<Backend = Pg>,
-    job_type: &str,
-    data: &Value,
-    priority: i16,
-) -> Result<i64, EnqueueError> {
-    use diesel::RunQueryDsl;
-
-    let id = diesel::insert_into(background_jobs::table)
-        .values((
-            background_jobs::job_type.eq(job_type),
-            background_jobs::data.eq(data),
-            background_jobs::priority.eq(priority),
-        ))
-        .returning(background_jobs::id)
-        .get_result(conn)?;
-
-    Ok(id)
-}
-
-async fn async_enqueue_simple(
+async fn enqueue_simple(
     conn: &mut AsyncPgConnection,
     job_type: &str,
     data: &Value,
     priority: i16,
 ) -> Result<i64, EnqueueError> {
-    use diesel_async::RunQueryDsl;
-
     let id = diesel::insert_into(background_jobs::table)
         .values((
             background_jobs::job_type.eq(job_type),

--- a/src/bin/crates-admin/delete_crate.rs
+++ b/src/bin/crates-admin/delete_crate.rs
@@ -109,18 +109,18 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
 
         info!("{name}: Enqueuing index sync jobs…");
         let job = jobs::SyncToGitIndex::new(name);
-        if let Err(error) = job.async_enqueue(&mut conn).await {
+        if let Err(error) = job.enqueue(&mut conn).await {
             warn!("{name}: Failed to enqueue SyncToGitIndex job: {error}");
         }
 
         let job = jobs::SyncToSparseIndex::new(name);
-        if let Err(error) = job.async_enqueue(&mut conn).await {
+        if let Err(error) = job.enqueue(&mut conn).await {
             warn!("{name}: Failed to enqueue SyncToSparseIndex job: {error}");
         }
 
         info!("{name}: Enqueuing DeleteCrateFromStorage job…");
         let job = jobs::DeleteCrateFromStorage::new(name.into());
-        if let Err(error) = job.async_enqueue(&mut conn).await {
+        if let Err(error) = job.enqueue(&mut conn).await {
             warn!("{name}: Failed to enqueue DeleteCrateFromStorage job: {error}");
         }
     }

--- a/src/bin/crates-admin/delete_version.rs
+++ b/src/bin/crates-admin/delete_version.rs
@@ -96,11 +96,11 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
 
     info!(%crate_name, "Enqueuing index sync jobs");
     let job = jobs::SyncToGitIndex::new(crate_name);
-    if let Err(error) = job.async_enqueue(&mut conn).await {
+    if let Err(error) = job.enqueue(&mut conn).await {
         warn!(%crate_name, ?error, "Failed to enqueue SyncToGitIndex job");
     }
     let job = jobs::SyncToSparseIndex::new(crate_name);
-    if let Err(error) = job.async_enqueue(&mut conn).await {
+    if let Err(error) = job.enqueue(&mut conn).await {
         warn!(%crate_name, ?error, "Failed to enqueue SyncToSparseIndex job");
     }
 

--- a/src/bin/crates-admin/enqueue_job.rs
+++ b/src/bin/crates-admin/enqueue_job.rs
@@ -60,12 +60,12 @@ pub async fn run(command: Command) -> Result<()> {
             before
                 .map(jobs::ArchiveVersionDownloads::before)
                 .unwrap_or_default()
-                .async_enqueue(&mut conn)
+                .enqueue(&mut conn)
                 .await?;
         }
         Command::IndexVersionDownloadsArchive => {
             jobs::IndexVersionDownloadsArchive
-                .async_enqueue(&mut conn)
+                .enqueue(&mut conn)
                 .await?;
         }
         Command::UpdateDownloads => {
@@ -81,16 +81,14 @@ pub async fn run(command: Command) -> Result<()> {
                     jobs::UpdateDownloads::JOB_NAME
                 );
             } else {
-                jobs::UpdateDownloads.async_enqueue(&mut conn).await?;
+                jobs::UpdateDownloads.enqueue(&mut conn).await?;
             }
         }
         Command::CleanProcessedLogFiles => {
-            jobs::CleanProcessedLogFiles
-                .async_enqueue(&mut conn)
-                .await?;
+            jobs::CleanProcessedLogFiles.enqueue(&mut conn).await?;
         }
         Command::DumpDb => {
-            jobs::DumpDb.async_enqueue(&mut conn).await?;
+            jobs::DumpDb.enqueue(&mut conn).await?;
         }
         Command::SyncAdmins { force } => {
             if !force {
@@ -112,20 +110,20 @@ pub async fn run(command: Command) -> Result<()> {
                 }
             }
 
-            jobs::SyncAdmins.async_enqueue(&mut conn).await?;
+            jobs::SyncAdmins.enqueue(&mut conn).await?;
         }
         Command::DailyDbMaintenance => {
-            jobs::DailyDbMaintenance.async_enqueue(&mut conn).await?;
+            jobs::DailyDbMaintenance.enqueue(&mut conn).await?;
         }
         Command::ProcessCdnLogQueue(job) => {
-            job.async_enqueue(&mut conn).await?;
+            job.enqueue(&mut conn).await?;
         }
         Command::SquashIndex => {
-            jobs::SquashIndex.async_enqueue(&mut conn).await?;
+            jobs::SquashIndex.enqueue(&mut conn).await?;
         }
         Command::NormalizeIndex { dry_run } => {
             jobs::NormalizeIndex::new(dry_run)
-                .async_enqueue(&mut conn)
+                .enqueue(&mut conn)
                 .await?;
         }
         Command::CheckTyposquat { name } => {
@@ -142,30 +140,26 @@ pub async fn run(command: Command) -> Result<()> {
                 );
             }
 
-            jobs::CheckTyposquat::new(&name)
-                .async_enqueue(&mut conn)
-                .await?;
+            jobs::CheckTyposquat::new(&name).enqueue(&mut conn).await?;
         }
         Command::SendTokenExpiryNotifications => {
             jobs::SendTokenExpiryNotifications
-                .async_enqueue(&mut conn)
+                .enqueue(&mut conn)
                 .await?;
         }
         Command::SyncCratesFeed => {
-            jobs::rss::SyncCratesFeed.async_enqueue(&mut conn).await?;
+            jobs::rss::SyncCratesFeed.enqueue(&mut conn).await?;
         }
         Command::SyncToGitIndex { name } => {
-            jobs::SyncToGitIndex::new(name)
-                .async_enqueue(&mut conn)
-                .await?;
+            jobs::SyncToGitIndex::new(name).enqueue(&mut conn).await?;
         }
         Command::SyncToSparseIndex { name } => {
             jobs::SyncToSparseIndex::new(name)
-                .async_enqueue(&mut conn)
+                .enqueue(&mut conn)
                 .await?;
         }
         Command::SyncUpdatesFeed => {
-            jobs::rss::SyncUpdatesFeed.async_enqueue(&mut conn).await?;
+            jobs::rss::SyncUpdatesFeed.enqueue(&mut conn).await?;
         }
     };
 

--- a/src/bin/crates-admin/yank_version.rs
+++ b/src/bin/crates-admin/yank_version.rs
@@ -66,15 +66,11 @@ async fn yank(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()> {
         .execute(conn)
         .await?;
 
-    SyncToGitIndex::new(&krate.name).async_enqueue(conn).await?;
+    SyncToGitIndex::new(&krate.name).enqueue(conn).await?;
 
-    SyncToSparseIndex::new(&krate.name)
-        .async_enqueue(conn)
-        .await?;
+    SyncToSparseIndex::new(&krate.name).enqueue(conn).await?;
 
-    UpdateDefaultVersion::new(krate.id)
-        .async_enqueue(conn)
-        .await?;
+    UpdateDefaultVersion::new(krate.id).enqueue(conn).await?;
 
     Ok(())
 }

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -74,7 +74,7 @@ pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppRes
             .iter()
             .map(|(v, _)| v)
             .collect::<Vec<_>>();
-        let actions = VersionOwnerAction::async_for_versions(&mut conn, &versions).await?;
+        let actions = VersionOwnerAction::for_versions(&mut conn, &versions).await?;
         Some(
             versions_and_publishers
                 .into_iter()
@@ -284,7 +284,7 @@ pub async fn reverse_dependencies(
         .map(|(v, ..)| v)
         .collect::<Vec<_>>();
 
-    let actions = VersionOwnerAction::async_for_versions(&mut conn, &versions).await?;
+    let actions = VersionOwnerAction::for_versions(&mut conn, &versions).await?;
 
     let versions = versions_and_publishers
         .into_iter()

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -122,7 +122,7 @@ pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppRes
     };
 
     let top_versions = if include.versions {
-        Some(krate.async_top_versions(&mut conn).await?)
+        Some(krate.top_versions(&mut conn).await?)
     } else {
         None
     };

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -473,7 +473,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
 
         // Update all categories for this crate, collecting any invalid categories
         // in order to be able to return an error to the user.
-        let unknown_categories = Category::async_update_crate(conn, krate.id, &categories).await?;
+        let unknown_categories = Category::update_crate(conn, krate.id, &categories).await?;
         if !unknown_categories.is_empty() {
             let unknown_categories = unknown_categories.join(", ");
             let domain = &app.config.domain_name;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -469,7 +469,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
         }
 
         // Update all keywords for this crate
-        Keyword::async_update_crate(conn, krate.id, &keywords).await?;
+        Keyword::update_crate(conn, krate.id, &keywords).await?;
 
         // Update all categories for this crate, collecting any invalid categories
         // in order to be able to return an error to the user.

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -415,7 +415,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             .maybe_api_token_id(api_token_id)
             .action(VersionAction::Publish)
             .build()
-            .async_insert(conn)
+            .insert(conn)
             .await?;
 
         // Link this new version to all dependencies

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -344,7 +344,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
 
         // To avoid race conditions, we try to insert
         // first so we know whether to add an owner
-        let krate = match persist.async_create(conn, user.id).await.optional()? {
+        let krate = match persist.create(conn, user.id).await.optional()? {
             Some(krate) => krate,
             None => persist.update(conn).await?,
         };
@@ -480,7 +480,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             return Err(bad_request(format!("The following category slugs are not currently supported on crates.io: {}\n\nSee https://{}/category_slugs for a list of supported slugs.", unknown_categories, domain)));
         }
 
-        let top_versions = krate.async_top_versions(conn).await?;
+        let top_versions = krate.top_versions(conn).await?;
 
         let downloads: i64 = crate_downloads::table.select(crate_downloads::downloads)
             .filter(crate_downloads::crate_id.eq(krate.id))

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -400,7 +400,7 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             .maybe_edition(edition)
             .build();
 
-        let version = new_version.async_save(conn, &verified_email_address).await.map_err(|error| {
+        let version = new_version.save(conn, &verified_email_address).await.map_err(|error| {
             use diesel::result::{Error, DatabaseErrorKind};
             match error {
                 Error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) =>

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -67,7 +67,7 @@ pub async fn versions(
         .iter()
         .map(|(v, _)| v)
         .collect::<Vec<_>>();
-    let actions = VersionOwnerAction::async_for_versions(&mut conn, &versions).await?;
+    let actions = VersionOwnerAction::for_versions(&mut conn, &versions).await?;
     let versions = versions_and_publishers
         .data
         .into_iter()

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -83,7 +83,7 @@ pub async fn updates(app: AppState, req: Parts) -> AppResult<ErasedJson> {
 
     let more = data.next_page_params().is_some();
     let versions = data.iter().map(|(v, ..)| v).collect::<Vec<_>>();
-    let actions = VersionOwnerAction::async_for_versions(&mut conn, &versions).await?;
+    let actions = VersionOwnerAction::for_versions(&mut conn, &versions).await?;
     let data = data
         .into_iter()
         .zip(actions)

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -243,13 +243,9 @@ pub async fn perform_version_yank_update(
         .async_insert(conn)
         .await?;
 
-    SyncToGitIndex::new(&krate.name).async_enqueue(conn).await?;
-    SyncToSparseIndex::new(&krate.name)
-        .async_enqueue(conn)
-        .await?;
-    UpdateDefaultVersion::new(krate.id)
-        .async_enqueue(conn)
-        .await?;
+    SyncToGitIndex::new(&krate.name).enqueue(conn).await?;
+    SyncToSparseIndex::new(&krate.name).enqueue(conn).await?;
+    UpdateDefaultVersion::new(krate.id).enqueue(conn).await?;
 
     Ok(())
 }

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -240,7 +240,7 @@ pub async fn perform_version_yank_update(
         .maybe_api_token_id(api_token_id)
         .action(action)
         .build()
-        .async_insert(conn)
+        .insert(conn)
         .await?;
 
     SyncToGitIndex::new(&krate.name).enqueue(conn).await?;

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -126,11 +126,7 @@ impl<'a> NewCrate<'a> {
             .await
     }
 
-    pub async fn create(
-        &self,
-        conn: &mut AsyncPgConnection,
-        user_id: i32,
-    ) -> QueryResult<Crate> {
+    pub async fn create(&self, conn: &mut AsyncPgConnection, user_id: i32) -> QueryResult<Crate> {
         use diesel_async::RunQueryDsl;
 
         conn.transaction(|conn| {
@@ -356,10 +352,7 @@ impl Crate {
     /// Return both the newest (most recently updated) and
     /// highest version (in semver order) for the current crate,
     /// where all top versions are not yanked.
-    pub async fn top_versions(
-        &self,
-        conn: &mut AsyncPgConnection,
-    ) -> QueryResult<TopVersions> {
+    pub async fn top_versions(&self, conn: &mut AsyncPgConnection) -> QueryResult<TopVersions> {
         use diesel_async::RunQueryDsl;
 
         Ok(TopVersions::from_date_version_pairs(

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -126,7 +126,7 @@ impl<'a> NewCrate<'a> {
             .await
     }
 
-    pub async fn async_create(
+    pub async fn create(
         &self,
         conn: &mut AsyncPgConnection,
         user_id: i32,
@@ -160,32 +160,6 @@ impl<'a> NewCrate<'a> {
             .scope_boxed()
         })
         .await
-    }
-
-    pub fn create(&self, conn: &mut impl Conn, user_id: i32) -> QueryResult<Crate> {
-        use diesel::RunQueryDsl;
-
-        conn.transaction(|conn| {
-            let krate: Crate = diesel::insert_into(crates::table)
-                .values(self)
-                .on_conflict_do_nothing()
-                .returning(Crate::as_returning())
-                .get_result(conn)?;
-
-            let owner = CrateOwner {
-                crate_id: krate.id,
-                owner_id: user_id,
-                created_by: user_id,
-                owner_kind: OwnerKind::User,
-                email_notifications: true,
-            };
-
-            diesel::insert_into(crate_owners::table)
-                .values(&owner)
-                .execute(conn)?;
-
-            Ok(krate)
-        })
     }
 }
 
@@ -382,7 +356,7 @@ impl Crate {
     /// Return both the newest (most recently updated) and
     /// highest version (in semver order) for the current crate,
     /// where all top versions are not yanked.
-    pub async fn async_top_versions(
+    pub async fn top_versions(
         &self,
         conn: &mut AsyncPgConnection,
     ) -> QueryResult<TopVersions> {
@@ -394,20 +368,6 @@ impl Crate {
                 .select((versions::created_at, versions::num))
                 .load(conn)
                 .await?,
-        ))
-    }
-
-    /// Return both the newest (most recently updated) and
-    /// highest version (in semver order) for the current crate,
-    /// where all top versions are not yanked.
-    pub fn top_versions(&self, conn: &mut impl Conn) -> QueryResult<TopVersions> {
-        use diesel::RunQueryDsl;
-
-        Ok(TopVersions::from_date_version_pairs(
-            Version::belonging_to(self)
-                .filter(versions::yanked.eq(false))
-                .select((versions::created_at, versions::num))
-                .load(conn)?,
         ))
     }
 

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -166,7 +166,7 @@ impl<'a> CrateBuilder<'a> {
         }
 
         if !self.keywords.is_empty() {
-            Keyword::async_update_crate(connection, krate.id, &self.keywords).await?;
+            Keyword::update_crate(connection, krate.id, &self.keywords).await?;
         }
 
         if let Some(updated_at) = self.updated_at {

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -162,7 +162,7 @@ impl<'a> CrateBuilder<'a> {
         }
 
         if !self.categories.is_empty() {
-            Category::async_update_crate(connection, krate.id, &self.categories).await?;
+            Category::update_crate(connection, krate.id, &self.categories).await?;
         }
 
         if !self.keywords.is_empty() {

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -122,7 +122,7 @@ impl<'a> CrateBuilder<'a> {
         use diesel::{insert_into, select, update};
         use diesel_async::RunQueryDsl;
 
-        let mut krate = self.krate.async_create(connection, self.owner_id).await?;
+        let mut krate = self.krate.create(connection, self.owner_id).await?;
 
         // Since we are using `NewCrate`, we can't set all the
         // crate properties in a single DB call.

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -114,9 +114,7 @@ impl VersionBuilder {
             .maybe_created_at(self.created_at.as_ref())
             .build();
 
-        let vers = new_version
-            .async_save(connection, "someone@example.com")
-            .await?;
+        let vers = new_version.save(connection, "someone@example.com").await?;
 
         let new_deps = self
             .dependencies

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -22,7 +22,7 @@ async fn test_dump_db_job() {
         .expect_build(&mut conn)
         .await;
 
-    DumpDb.async_enqueue(&mut conn).await.unwrap();
+    DumpDb.enqueue(&mut conn).await.unwrap();
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/krate/publish/audit_action.rs
+++ b/src/tests/krate/publish/audit_action.rs
@@ -8,8 +8,8 @@ async fn publish_records_an_audit_action() {
 
     let (app, anon, _, token) = TestApp::full().with_token().await;
 
-    let mut conn = app.db_conn();
-    assert!(VersionOwnerAction::all(&mut conn).unwrap().is_empty());
+    let mut conn = app.async_db_conn().await;
+    assert!(VersionOwnerAction::all(&mut conn).await.unwrap().is_empty());
 
     // Upload a new crate, putting it in the git index
     let crate_to_publish = PublishBuilder::new("fyk", "1.0.0");

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -62,42 +62,42 @@ async fn update_crate() {
         .await;
 
     // Updating with no categories has no effect
-    Category::async_update_crate(&mut async_conn, krate.id, &[])
+    Category::update_crate(&mut async_conn, krate.id, &[])
         .await
         .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Happy path adding one category
-    Category::async_update_crate(&mut async_conn, krate.id, &["cat1"])
+    Category::update_crate(&mut async_conn, krate.id, &["cat1"])
         .await
         .unwrap();
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Replacing one category with another
-    Category::async_update_crate(&mut async_conn, krate.id, &["category-2"])
+    Category::update_crate(&mut async_conn, krate.id, &["category-2"])
         .await
         .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing one category
-    Category::async_update_crate(&mut async_conn, krate.id, &[])
+    Category::update_crate(&mut async_conn, krate.id, &[])
         .await
         .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
     assert_eq!(count(&anon, "category-2").await, 0);
 
     // Adding 2 categories
-    Category::async_update_crate(&mut async_conn, krate.id, &["cat1", "category-2"])
+    Category::update_crate(&mut async_conn, krate.id, &["cat1", "category-2"])
         .await
         .unwrap();
     assert_eq!(count(&anon, "cat1").await, 1);
     assert_eq!(count(&anon, "category-2").await, 1);
 
     // Removing all categories
-    Category::async_update_crate(&mut async_conn, krate.id, &[])
+    Category::update_crate(&mut async_conn, krate.id, &[])
         .await
         .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
@@ -105,7 +105,7 @@ async fn update_crate() {
 
     // Attempting to add one valid category and one invalid category
     let invalid_categories =
-        Category::async_update_crate(&mut async_conn, krate.id, &["cat1", "catnope"])
+        Category::update_crate(&mut async_conn, krate.id, &["cat1", "catnope"])
             .await
             .unwrap();
     assert_eq!(invalid_categories, vec!["catnope"]);
@@ -119,7 +119,7 @@ async fn update_crate() {
     assert_eq!(json.meta.total, 2);
 
     // Attempting to add a category by display text; must use slug
-    Category::async_update_crate(&mut async_conn, krate.id, &["Category 2"])
+    Category::update_crate(&mut async_conn, krate.id, &["Category 2"])
         .await
         .unwrap();
     assert_eq!(count(&anon, "cat1").await, 0);
@@ -130,7 +130,7 @@ async fn update_crate() {
         .values(new_category("cat1::bar", "cat1::bar", "bar crates"))
         .execute(&mut conn));
 
-    Category::async_update_crate(&mut async_conn, krate.id, &["cat1", "cat1::bar"])
+    Category::update_crate(&mut async_conn, krate.id, &["cat1", "cat1::bar"])
         .await
         .unwrap();
 

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -173,10 +173,10 @@ async fn index_queries() {
         .execute(&mut conn)
         .unwrap();
 
-    Category::async_update_crate(&mut async_conn, krate.id, &["cat1"])
+    Category::update_crate(&mut async_conn, krate.id, &["cat1"])
         .await
         .unwrap();
-    Category::async_update_crate(&mut async_conn, krate2.id, &["cat1::bar"])
+    Category::update_crate(&mut async_conn, krate2.id, &["cat1::bar"])
         .await
         .unwrap();
 
@@ -949,10 +949,10 @@ async fn test_default_sort_recent() {
         .execute(&mut conn)
         .unwrap();
 
-    Category::async_update_crate(&mut async_conn, green_crate.id, &["animal"])
+    Category::update_crate(&mut async_conn, green_crate.id, &["animal"])
         .await
         .unwrap();
-    Category::async_update_crate(&mut async_conn, potato_crate.id, &["animal"])
+    Category::update_crate(&mut async_conn, potato_crate.id, &["animal"])
         .await
         .unwrap();
 

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -23,7 +23,7 @@ async fn index() {
     assert_eq!(json.keywords.len(), 0);
     assert_eq!(json.meta.total, 0);
 
-    Keyword::async_find_or_create_all(&mut conn, &["foo"])
+    Keyword::find_or_create_all(&mut conn, &["foo"])
         .await
         .unwrap();
 

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -16,7 +16,7 @@ async fn show() {
 
     anon.get(url).await.assert_not_found();
 
-    Keyword::async_find_or_create_all(&mut conn, &["foo"])
+    Keyword::find_or_create_all(&mut conn, &["foo"])
         .await
         .unwrap();
 
@@ -32,7 +32,7 @@ async fn uppercase() {
 
     anon.get(url).await.assert_not_found();
 
-    Keyword::async_find_or_create_all(&mut conn, &["UPPER"])
+    Keyword::find_or_create_all(&mut conn, &["UPPER"])
         .await
         .unwrap();
 
@@ -51,44 +51,44 @@ async fn update_crate() {
         json.keyword.crates_cnt as usize
     }
 
-    Keyword::async_find_or_create_all(&mut conn, &["kw1", "kw2"])
+    Keyword::find_or_create_all(&mut conn, &["kw1", "kw2"])
         .await
         .unwrap();
     let krate = CrateBuilder::new("fookey", user.id)
         .expect_build(&mut conn)
         .await;
 
-    Keyword::async_update_crate(&mut conn, krate.id, &[])
+    Keyword::update_crate(&mut conn, krate.id, &[])
         .await
         .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::async_update_crate(&mut conn, krate.id, &["kw1"])
+    Keyword::update_crate(&mut conn, krate.id, &["kw1"])
         .await
         .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 1);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::async_update_crate(&mut conn, krate.id, &["kw2"])
+    Keyword::update_crate(&mut conn, krate.id, &["kw2"])
         .await
         .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 1);
 
-    Keyword::async_update_crate(&mut conn, krate.id, &[])
+    Keyword::update_crate(&mut conn, krate.id, &[])
         .await
         .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);
     assert_eq!(cnt("kw2", &anon).await, 0);
 
-    Keyword::async_update_crate(&mut conn, krate.id, &["kw1", "kw2"])
+    Keyword::update_crate(&mut conn, krate.id, &["kw1", "kw2"])
         .await
         .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 1);
     assert_eq!(cnt("kw2", &anon).await, 1);
 
-    Keyword::async_update_crate(&mut conn, krate.id, &[])
+    Keyword::update_crate(&mut conn, krate.id, &[])
         .await
         .unwrap();
     assert_eq!(cnt("kw1", &anon).await, 0);

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -57,14 +57,10 @@ async fn index_smoke_test() {
             .await
     );
 
-    assert_ok!(
-        jobs::SyncToGitIndex::new("serde")
-            .async_enqueue(&mut conn)
-            .await
-    );
+    assert_ok!(jobs::SyncToGitIndex::new("serde").enqueue(&mut conn).await);
     assert_ok!(
         jobs::SyncToSparseIndex::new("serde")
-            .async_enqueue(&mut conn)
+            .enqueue(&mut conn)
             .await
     );
 

--- a/src/tests/worker/rss/sync_crate_feed.rs
+++ b/src/tests/worker/rss/sync_crate_feed.rs
@@ -20,7 +20,7 @@ async fn test_sync_crate_feed() {
     create_version(&mut conn, "foo", "1.2.0", "2024-06-22T15:57:19Z").await;
 
     let job = jobs::rss::SyncCrateFeed::new("foo".to_string());
-    job.async_enqueue(&mut conn).await.unwrap();
+    job.enqueue(&mut conn).await.unwrap();
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/worker/rss/sync_crates_feed.rs
+++ b/src/tests/worker/rss/sync_crates_feed.rs
@@ -19,10 +19,7 @@ async fn test_sync_crates_feed() {
     create_crate(&mut conn, "baz", description, "2024-06-21T17:01:33Z").await;
     create_crate(&mut conn, "quux", None, "2024-06-21T17:03:45Z").await;
 
-    jobs::rss::SyncCratesFeed
-        .async_enqueue(&mut conn)
-        .await
-        .unwrap();
+    jobs::rss::SyncCratesFeed.enqueue(&mut conn).await.unwrap();
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/worker/rss/sync_updates_feed.rs
+++ b/src/tests/worker/rss/sync_updates_feed.rs
@@ -21,10 +21,7 @@ async fn test_sync_updates_feed() {
     create_version(&mut conn, "foo", "1.1.0", None, "2024-06-22T08:30:01Z").await;
     create_version(&mut conn, "foo", "1.2.0", None, "2024-06-22T15:57:19Z").await;
 
-    jobs::rss::SyncUpdatesFeed
-        .async_enqueue(&mut conn)
-        .await
-        .unwrap();
+    jobs::rss::SyncUpdatesFeed.enqueue(&mut conn).await.unwrap();
 
     app.run_pending_background_jobs().await;
 

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -40,7 +40,7 @@ async fn test_sync_admins_job() {
     let expected_admins = vec![("existing-admin".into(), 1), ("obsolete-admin".into(), 2)];
     assert_eq!(admins, expected_admins);
 
-    SyncAdmins.async_enqueue(&mut conn).await.unwrap();
+    SyncAdmins.enqueue(&mut conn).await.unwrap();
     app.run_pending_background_jobs().await;
 
     let admins = get_admins(&mut conn).await.unwrap();
@@ -51,7 +51,7 @@ async fn test_sync_admins_job() {
 
     // Run the job again to verify that no new emails are sent
     // for `new-admin-without-account`.
-    SyncAdmins.async_enqueue(&mut conn).await.unwrap();
+    SyncAdmins.enqueue(&mut conn).await.unwrap();
     app.run_pending_background_jobs().await;
 
     assert_eq!(app.emails().await.len(), 2);

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -69,7 +69,7 @@ impl BackgroundJob for ArchiveVersionDownloads {
 
         // Queue up the job to regenerate the archive index.
         IndexVersionDownloadsArchive
-            .async_enqueue(&mut conn)
+            .enqueue(&mut conn)
             .await
             .context("Failed to enqueue IndexVersionDownloadsArchive job")?;
 

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -209,7 +209,7 @@ async fn enqueue_jobs(
         let path = &job.path;
 
         info!("Enqueuing processing job… ({path})");
-        job.async_enqueue(conn)
+        job.enqueue(conn)
             .await
             .context("Failed to enqueue processing job")?;
 

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -124,7 +124,7 @@ mod tests {
             name: "foo",
             ..Default::default()
         }
-        .async_create(conn, user_id)
+        .create(conn, user_id)
         .await
         .unwrap();
 

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -133,10 +133,7 @@ mod tests {
             .checksum("0000000000000000000000000000000000000000000000000000000000000000")
             .build();
 
-        let version = version
-            .async_save(conn, "someone@example.com")
-            .await
-            .unwrap();
+        let version = version.save(conn, "someone@example.com").await.unwrap();
         (krate, version)
     }
 


### PR DESCRIPTION
Now that we are using async database connections (almost) everywhere we can remove a lot of the code duplication that was introduced to enable the migration. At the same time we are dropping the `async_` prefixes from these function, since they are not needed anymore and just clutter the code.