### PR TITLE
controllers/krate/owners: Convert remaining endpoints to async/await

### DIFF
--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -60,14 +60,15 @@ impl User {
             .await
     }
 
-    pub fn owning(krate: &Crate, conn: &mut impl Conn) -> QueryResult<Vec<Owner>> {
-        use diesel::RunQueryDsl;
+    pub async fn owning(krate: &Crate, conn: &mut AsyncPgConnection) -> QueryResult<Vec<Owner>> {
+        use diesel_async::RunQueryDsl;
 
         let users = CrateOwner::by_owner_kind(OwnerKind::User)
             .inner_join(users::table)
             .select(User::as_select())
             .filter(crate_owners::crate_id.eq(krate.id))
-            .load(conn)?
+            .load(conn)
+            .await?
             .into_iter()
             .map(Owner::User);
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -384,14 +384,16 @@ async fn add_existing_team() {
 #[tokio::test(flavor = "multi_thread")]
 async fn deleted_ownership_isnt_in_owner_user() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
         .expect_build(&mut async_conn)
         .await;
-    krate.owner_remove(&mut conn, &user.gh_login).unwrap();
+    krate
+        .owner_remove(&mut async_conn, &user.gh_login)
+        .await
+        .unwrap();
 
     let json: UserResponse = anon
         .get("/api/v1/crates/foo_my_packages/owner_user")

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -1175,14 +1175,13 @@ async fn crates_by_user_id() {
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_user_id_not_including_deleted_owners() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
         .expect_build(&mut async_conn)
         .await;
-    krate.owner_remove(&mut conn, "foo").unwrap();
+    krate.owner_remove(&mut async_conn, "foo").await.unwrap();
 
     for response in search_both_by_user_id(&anon, user.id).await {
         assert_eq!(response.crates.len(), 0);

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -42,14 +42,16 @@ async fn me() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
     let user_model = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user_model.id)
         .expect_build(&mut async_conn)
         .await;
-    krate.owner_remove(&mut conn, &user_model.gh_login).unwrap();
+    krate
+        .owner_remove(&mut async_conn, &user_model.gh_login)
+        .await
+        .unwrap();
 
     let json = user.show_me().await;
     assert_eq!(json.owned_crates.len(), 0);

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -52,7 +52,8 @@ async fn user_total_downloads() {
         .execute(&mut conn)
         .unwrap();
     no_longer_my_krate
-        .owner_remove(&mut conn, &user.gh_login)
+        .owner_remove(&mut async_conn, &user.gh_login)
+        .await
         .unwrap();
 
     let url = format!("/api/v1/users/{}/stats", user.id);

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -477,7 +477,6 @@ async fn crates_by_team_id() {
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_team_id_not_including_deleted_owners() {
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
     let user = app.db_new_user("user-all-teams").await;
     let user = user.as_model();
@@ -499,7 +498,7 @@ async fn crates_by_team_id_not_including_deleted_owners() {
     add_team_to_crate(&t, &krate, user, &mut async_conn)
         .await
         .unwrap();
-    krate.owner_remove(&mut conn, &t.login).unwrap();
+    krate.owner_remove(&mut async_conn, &t.login).await.unwrap();
 
     let json = anon.search(&format!("team_id={}", t.id)).await;
     assert_eq!(json.crates.len(), 0);


### PR DESCRIPTION
These were the last two API endpoints that were still using synchronous database operations. With this PR the two endpoints are now using `diesel-async` queries as well, allowing us to start the cleanup process of removing all of the duplicate sync functions.

Here is what GitHub Copilot has to say about the PR: 😅 


----

This pull request includes several changes to the `src/controllers/krate/owners.rs`, `src/models/crate_owner_invitation.rs`, `src/models/krate.rs`, `src/models/owner.rs`, `src/models/team.rs`, and `src/models/user.rs` files to transition from synchronous to asynchronous database operations using `diesel_async`.

Key changes include:

### Transition to Asynchronous Database Operations:
* [`src/controllers/krate/owners.rs`](diffhunk://#diff-b941ec2990765da236d673c85bff680d222ced1060e2ae5f5c1e360b159b9a82L65-L83): Replaced synchronous `diesel::RunQueryDsl` with `diesel_async::RunQueryDsl` and removed `spawn_blocking` in favor of direct async calls. 
* [`src/models/crate_owner_invitation.rs`](diffhunk://#diff-e0d19143c429befcaf714d59ae72ea057849e06c1724a377c34094a5e9562a0aL2-L10): Updated the `create` method and related transaction logic to use async/await patterns.
* [`src/models/krate.rs`](diffhunk://#diff-c35a05c74a461d5bcd476b6c88f9f4f225f89de3c8bc53221f480505233ea142L418-R434): Modified `owner_add` and `owner_remove` methods to be asynchronous.
* [`src/models/owner.rs`](diffhunk://#diff-3b3ff9b0f44f41d5e324caf5cfc4bec4d54c07aa2d317028e121d9f0e1edea69L1-L10): Converted `find_or_create_by_login` to an async function. 
* [`src/models/team.rs`](diffhunk://#diff-917c4ed60c2be4713bf166ab939c5733b8aec88968f1c281598c120b4a598aa9L10): Updated `create_or_update` and `create_or_update_github_team` methods to use async/await.
* [`src/models/user.rs`](diffhunk://#diff-7813c175daf4c5f5bc376f0d0ac222aeae163f68b365eba515c9a2f87093644bL63-R71): Made the `owning` method asynchronous.