### PR TITLE
tests/util/test_app: Remove obsolete db_conn() fn

### DIFF
--- a/src/tests/account_lock.rs
+++ b/src/tests/account_lock.rs
@@ -11,7 +11,7 @@ async fn lock_account(app: &TestApp, user_id: i32, until: Option<NaiveDateTime>)
     use diesel::prelude::*;
     use diesel_async::RunQueryDsl;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     diesel::update(users::table)
         .set((

--- a/src/tests/blocked_routes.rs
+++ b/src/tests/blocked_routes.rs
@@ -11,7 +11,7 @@ async fn test_non_blocked_download_route() {
         .with_user()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
@@ -37,7 +37,7 @@ async fn test_blocked_download_route() {
         .with_user()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -16,7 +16,7 @@ static PATH_DATE_RE: LazyLock<Regex> =
 #[tokio::test(flavor = "multi_thread")]
 async fn test_dump_db_job() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("test-crate", token.as_model().user_id)
         .expect_build(&mut conn)

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -45,7 +45,7 @@ async fn github_secret_alert_revokes_token() {
         .with_github(github_mock())
         .with_token()
         .await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Ensure no emails were sent up to this point
     assert_eq!(app.emails().await.len(), 0);
@@ -106,7 +106,7 @@ async fn github_secret_alert_for_revoked_token() {
         .with_github(github_mock())
         .with_token()
         .await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Ensure no emails were sent up to this point
     assert_eq!(app.emails().await.len(), 0);
@@ -170,7 +170,7 @@ async fn github_secret_alert_for_unknown_token() {
         .with_github(github_mock())
         .with_token()
         .await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Ensure no emails were sent up to this point
     assert_eq!(app.emails().await.len(), 0);

--- a/src/tests/issues/issue1205.rs
+++ b/src/tests/issues/issue1205.rs
@@ -14,10 +14,10 @@ async fn test_issue_1205() -> anyhow::Result<()> {
         .with_token()
         .await;
 
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let krate = CrateBuilder::new(CRATE_NAME, user.as_model().id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = user
@@ -26,7 +26,7 @@ async fn test_issue_1205() -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r#"{"msg":"team github:rustaudio:owners has been added as an owner of crate deepspeech-sys","ok":true}"#);
 
-    let owners = krate.async_owners(&mut async_conn).await?;
+    let owners = krate.async_owners(&mut conn).await?;
     assert_eq!(owners.len(), 2);
     assert_eq!(owners[0].login(), "foo");
     assert_eq!(owners[1].login(), "github:rustaudio:owners");
@@ -37,7 +37,7 @@ async fn test_issue_1205() -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r#"{"msg":"team github:rustaudio:cratesio-push has been added as an owner of crate deepspeech-sys","ok":true}"#);
 
-    let owners = krate.async_owners(&mut async_conn).await?;
+    let owners = krate.async_owners(&mut conn).await?;
     assert_eq!(owners.len(), 2);
     assert_eq!(owners[0].login(), "foo");
     assert_eq!(owners[1].login(), "github:rustaudio:cratesio-push");

--- a/src/tests/issues/issue1205.rs
+++ b/src/tests/issues/issue1205.rs
@@ -14,7 +14,6 @@ async fn test_issue_1205() -> anyhow::Result<()> {
         .with_token()
         .await;
 
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
 
     let krate = CrateBuilder::new(CRATE_NAME, user.as_model().id)
@@ -27,7 +26,7 @@ async fn test_issue_1205() -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r#"{"msg":"team github:rustaudio:owners has been added as an owner of crate deepspeech-sys","ok":true}"#);
 
-    let owners = krate.owners(&mut conn)?;
+    let owners = krate.async_owners(&mut async_conn).await?;
     assert_eq!(owners.len(), 2);
     assert_eq!(owners[0].login(), "foo");
     assert_eq!(owners[1].login(), "github:rustaudio:owners");
@@ -38,7 +37,7 @@ async fn test_issue_1205() -> anyhow::Result<()> {
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r#"{"msg":"team github:rustaudio:cratesio-push has been added as an owner of crate deepspeech-sys","ok":true}"#);
 
-    let owners = krate.owners(&mut conn)?;
+    let owners = krate.async_owners(&mut async_conn).await?;
     assert_eq!(owners.len(), 2);
     assert_eq!(owners[0].login(), "foo");
     assert_eq!(owners[1].login(), "github:rustaudio:cratesio-push");

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -34,7 +34,7 @@ async fn test_unauthenticated_requests() {
     const CRATE_NAME: &str = "foo";
 
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new(CRATE_NAME, user.as_model().id)
         .expect_build(&mut conn)
@@ -64,7 +64,7 @@ async fn test_following() {
     const CRATE_NAME: &str = "foo_following";
 
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new(CRATE_NAME, user.as_model().id)
         .expect_build(&mut conn)
@@ -122,7 +122,7 @@ async fn test_api_token_auth() {
     const CRATE_NOT_TO_FOLLOW: &str = "another_crate";
 
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let api_token = token.as_model();
 
     CrateBuilder::new(CRATE_TO_FOLLOW, api_token.user_id)

--- a/src/tests/krate/publish/audit_action.rs
+++ b/src/tests/krate/publish/audit_action.rs
@@ -8,7 +8,7 @@ async fn publish_records_an_audit_action() {
 
     let (app, anon, _, token) = TestApp::full().with_token().await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     assert!(VersionOwnerAction::all(&mut conn).await.unwrap().is_empty());
 
     // Upload a new crate, putting it in the git index

--- a/src/tests/krate/publish/auth.rs
+++ b/src/tests/krate/publish/auth.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn new_wrong_token() {
     let (app, anon, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Try to publish without a token
     let crate_to_publish = PublishBuilder::new("foo", "1.0.0");
@@ -36,7 +36,7 @@ async fn new_wrong_token() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_wrong_user() {
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Create the foo_wrong crate with one user
     CrateBuilder::new("foo_wrong", user.as_model().id)

--- a/src/tests/krate/publish/basics.rs
+++ b/src/tests/krate/publish/basics.rs
@@ -10,7 +10,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate() {
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let crate_to_publish = PublishBuilder::new("foo_new", "1.0.0");
     let response = user.publish_crate(crate_to_publish).await;
@@ -146,7 +146,7 @@ async fn new_krate_twice_alt() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_duplicate_version() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database and then we'll try to publish the same version
     CrateBuilder::new("foo_dupe", user.as_model().id)

--- a/src/tests/krate/publish/categories.rs
+++ b/src/tests/krate/publish/categories.rs
@@ -11,7 +11,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn good_categories() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     insert_into(categories::table)
         .values(new_category("Category 1", "cat1", "Category 1 crates"))

--- a/src/tests/krate/publish/deleted_crates.rs
+++ b/src/tests/krate/publish/deleted_crates.rs
@@ -11,7 +11,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recently_deleted_crate_with_same_name() -> anyhow::Result<()> {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let now = Utc::now();
     let created_at = now - Duration::hours(24);

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -19,7 +19,7 @@ async fn invalid_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
@@ -38,7 +38,7 @@ async fn new_with_renamed_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_rename() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
@@ -59,7 +59,7 @@ async fn invalid_dependency_rename() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_starts_with_digit() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
@@ -80,7 +80,7 @@ async fn invalid_dependency_name_starts_with_digit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_dependency_name_contains_unicode_chars() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
@@ -101,7 +101,7 @@ async fn invalid_dependency_name_contains_unicode_chars() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invalid_too_long_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
@@ -122,7 +122,7 @@ async fn invalid_too_long_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn empty_dependency_name() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
@@ -143,7 +143,7 @@ async fn empty_dependency_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_with_underscore_renamed_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new-krate can depend on it
     CrateBuilder::new("package-name", user.as_model().id)
@@ -164,7 +164,7 @@ async fn new_krate_with_dependency() {
     use crate::tests::routes::crates::versions::dependencies::Deps;
 
     let (app, anon, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new_dep can depend on it
     // The name choice of `foo-dep` is important! It has the property of
@@ -197,7 +197,7 @@ async fn new_krate_with_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_broken_dependency_requirement() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new_dep can depend on it
     // The name choice of `foo-dep` is important! It has the property of
@@ -219,7 +219,7 @@ async fn new_krate_with_broken_dependency_requirement() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reject_new_krate_with_non_exact_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo-dep", user.as_model().id)
         .expect_build(&mut conn)
@@ -239,7 +239,7 @@ async fn reject_new_krate_with_non_exact_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_allow_empty_alternative_registry_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo-dep", user.as_model().id)
         .expect_build(&mut conn)
@@ -268,7 +268,7 @@ async fn reject_new_crate_with_alternative_registry_dependency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_wildcard_dependency() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that new_wild can depend on it
     CrateBuilder::new("foo_wild", user.as_model().id)
@@ -303,7 +303,7 @@ async fn new_krate_dependency_missing() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_sorts_deps() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert crates directly into the database so that two-deps can depend on it
     CrateBuilder::new("dep-a", user.as_model().id)
@@ -348,7 +348,7 @@ async fn test_dep_limit() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("dep-a", user.as_model().id)
         .expect_build(&mut conn)

--- a/src/tests/krate/publish/emails.rs
+++ b/src/tests/krate/publish/emails.rs
@@ -11,7 +11,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_without_any_email_fails() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     delete(emails::table).execute(&mut conn).await.unwrap();
 
@@ -27,7 +27,7 @@ async fn new_krate_without_any_email_fails() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_with_unverified_email_fails() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     update(emails::table)
         .set((emails::verified.eq(false),))

--- a/src/tests/krate/publish/features.rs
+++ b/src/tests/krate/publish/features.rs
@@ -7,7 +7,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn features_version_2() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Insert a crate directly into the database so that foo_new can depend on it
     CrateBuilder::new("bar", user.as_model().id)
@@ -127,7 +127,7 @@ async fn too_many_features_with_custom_limit() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .max_features(4)
@@ -187,7 +187,7 @@ async fn too_many_enabled_features_with_custom_limit() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", user.as_model().id)
         .max_features(4)

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -136,7 +136,7 @@ async fn new_krate_too_big() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_krate_too_big_but_whitelisted() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo_whitelist", user.as_model().id)
         .max_upload_size(2_000_000)

--- a/src/tests/krate/publish/rate_limit.rs
+++ b/src/tests/krate/publish/rate_limit.rs
@@ -17,7 +17,7 @@ async fn publish_new_crate_ratelimit_hit() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Set up the database so it'll think we've massively ratelimited ourselves
 
@@ -53,7 +53,7 @@ async fn publish_new_crate_ratelimit_expires() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Set up the database so it'll think we've massively ratelimited ourselves
 
@@ -97,7 +97,7 @@ async fn publish_new_crate_override_loosens_ratelimit() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Add an override so our user gets *2* new tokens (expires, y'know, sometime)
     diesel::insert_into(publish_rate_overrides::table)
@@ -175,7 +175,7 @@ async fn publish_new_crate_expired_override_ignored() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Add an override so our user gets *2* new tokens (expires, y'know, sometime)
     let just_now = Utc::now().naive_utc() - Duration::from_secs(1);

--- a/src/tests/krate/publish/readme.rs
+++ b/src/tests/krate/publish/readme.rs
@@ -71,7 +71,7 @@ async fn new_krate_with_readme_and_plus_version() {
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_after_removing_documentation() {
     let (app, anon, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     // 1. Start with a crate with no documentation

--- a/src/tests/krate/publish/similar_names.rs
+++ b/src/tests/krate/publish/similar_names.rs
@@ -7,7 +7,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("Foo_similar", user.as_model().id)
         .version("1.0.0")
@@ -24,7 +24,7 @@ async fn new_crate_similar_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_hyphen() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo_bar_hyphen", user.as_model().id)
         .version("1.0.0")
@@ -41,7 +41,7 @@ async fn new_crate_similar_name_hyphen() {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_similar_name_underscore() {
     let (app, _, user, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo-bar-underscore", user.as_model().id)
         .version("1.0.0")

--- a/src/tests/krate/publish/timestamps.rs
+++ b/src/tests/krate/publish/timestamps.rs
@@ -9,7 +9,7 @@ async fn uploading_new_version_touches_crate() {
     use diesel_async::RunQueryDsl;
 
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let crate_to_publish = PublishBuilder::new("foo_versions_updated_at", "1.0.0");
     user.publish_crate(crate_to_publish).await.good();

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -84,7 +84,7 @@ async fn yank_ratelimit_hit() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Set up the database so it'll think we've massively rate-limited ourselves.
 
@@ -121,7 +121,7 @@ async fn yank_ratelimit_expires() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Set up the database so it'll think we've massively ratelimited ourselves
 

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -129,7 +129,7 @@ impl MockAnonymousUser {
 #[tokio::test(flavor = "multi_thread")]
 async fn new_crate_owner() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Create a crate under one user
     let crate_to_publish = PublishBuilder::new("foo_owner", "1.0.0");
@@ -183,7 +183,7 @@ async fn create_and_add_owner(
 #[tokio::test(flavor = "multi_thread")]
 async fn owners_can_remove_self() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let username = &user.as_model().gh_login;
 
     let krate = CrateBuilder::new("owners_selfremove", user.as_model().id)
@@ -218,11 +218,11 @@ async fn owners_can_remove_self() {
 #[tokio::test(flavor = "multi_thread")]
 async fn modify_multiple_owners() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let username = &user.as_model().gh_login;
 
     let krate = CrateBuilder::new("owners_multiple", user.as_model().id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let user2 = create_and_add_owner(&app, &token, "user2", &krate).await;
@@ -236,7 +236,7 @@ async fn modify_multiple_owners() {
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"cannot remove all individual owners of a crate. Team member don't have permission to modify owners, so at least one individual owner is required."}]}"#);
-    assert_eq!(krate.async_owners(&mut async_conn).await.unwrap().len(), 3);
+    assert_eq!(krate.async_owners(&mut conn).await.unwrap().len(), 3);
 
     // Deleting two owners at once is allowed.
     let response = token
@@ -244,7 +244,7 @@ async fn modify_multiple_owners() {
         .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_snapshot!(response.text(), @r#"{"msg":"owners successfully removed","ok":true}"#);
-    assert_eq!(krate.async_owners(&mut async_conn).await.unwrap().len(), 1);
+    assert_eq!(krate.async_owners(&mut conn).await.unwrap().len(), 1);
 
     // Adding multiple users fails if one of them already is an owner.
     let response = token
@@ -252,7 +252,7 @@ async fn modify_multiple_owners() {
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"`foo` is already an owner"}]}"#);
-    assert_eq!(krate.async_owners(&mut async_conn).await.unwrap().len(), 1);
+    assert_eq!(krate.async_owners(&mut conn).await.unwrap().len(), 1);
 
     // Adding multiple users at once succeeds.
     let response = token
@@ -270,7 +270,7 @@ async fn modify_multiple_owners() {
         .accept_ownership_invitation(&krate.name, krate.id)
         .await;
 
-    assert_eq!(krate.async_owners(&mut async_conn).await.unwrap().len(), 3);
+    assert_eq!(krate.async_owners(&mut conn).await.unwrap().len(), 3);
 }
 
 /// Testing the crate ownership between two crates and one team.
@@ -282,7 +282,7 @@ async fn modify_multiple_owners() {
 #[tokio::test(flavor = "multi_thread")]
 async fn check_ownership_two_crates() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let team = new_team("team_foo")
@@ -322,7 +322,7 @@ async fn check_ownership_two_crates() {
 #[tokio::test(flavor = "multi_thread")]
 async fn check_ownership_one_crate() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let team = new_team("github:test_org:team_sloth")
@@ -356,7 +356,7 @@ async fn check_ownership_one_crate() {
 #[tokio::test(flavor = "multi_thread")]
 async fn add_existing_team() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let t = new_team("github:test_org:bananas")
@@ -383,16 +383,13 @@ async fn add_existing_team() {
 #[tokio::test(flavor = "multi_thread")]
 async fn deleted_ownership_isnt_in_owner_user() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
-    krate
-        .owner_remove(&mut async_conn, &user.gh_login)
-        .await
-        .unwrap();
+    krate.owner_remove(&mut conn, &user.gh_login).await.unwrap();
 
     let json: UserResponse = anon
         .get("/api/v1/crates/foo_my_packages/owner_user")
@@ -440,7 +437,7 @@ async fn api_token_cannot_list_invitations_v1() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_v1() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
 
     let krate = CrateBuilder::new("invited_crate", owner.id)
@@ -479,7 +476,7 @@ async fn invitations_list_v1() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_does_not_include_expired_invites_v1() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
 
     let user = app.db_new_user("invited_user").await;
@@ -530,7 +527,7 @@ async fn invitations_list_does_not_include_expired_invites_v1() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar").await;
 
@@ -565,7 +562,7 @@ async fn test_accept_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decline_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar").await;
 
@@ -596,7 +593,7 @@ async fn test_decline_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_invitation_by_mail() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let owner = owner.as_model();
     let invited_user = app.db_new_user("user_bar").await;
@@ -632,7 +629,7 @@ async fn test_accept_invitation_by_mail() {
 pub async fn expire_invitation(app: &TestApp, crate_id: i32) {
     use crate::schema::crate_owner_invitations;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let expiration = app.as_inner().config.ownership_invitations_expiration_days as i64;
     let created_at = (Utc::now() - Duration::days(expiration)).naive_utc();
@@ -648,7 +645,7 @@ pub async fn expire_invitation(app: &TestApp, crate_id: i32) {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_expired_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("demo_user").await;
 
@@ -690,7 +687,7 @@ async fn test_accept_expired_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_decline_expired_invitation() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
     let invited_user = app.db_new_user("demo_user").await;
 
@@ -720,7 +717,7 @@ async fn test_decline_expired_invitation() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_accept_expired_invitation_by_mail() {
     let (app, anon, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let owner = owner.as_model();
     let _invited_user = app.db_new_user("demo_user").await;
@@ -767,7 +764,7 @@ async fn inactive_users_dont_get_invitations() {
     use crate::models::NewUser;
 
     let (app, _, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
 
     // An inactive user with gh_id -1 and an active user with a non-negative gh_id both exist
@@ -806,7 +803,7 @@ async fn inactive_users_dont_get_invitations() {
 #[tokio::test(flavor = "multi_thread")]
 async fn highest_gh_id_is_most_recent_account_we_know_of() {
     let (app, _, owner, owner_token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let owner = owner.as_model();
 
     // An inactive user with a lower gh_id and an active user with a higher gh_id both exist

--- a/src/tests/pagination.rs
+++ b/src/tests/pagination.rs
@@ -14,7 +14,7 @@ async fn pagination_blocks_ip_from_cidr_block_list() {
         .with_user()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -2,6 +2,7 @@ use crate::tests::builders::CrateBuilder;
 use crate::tests::{RequestHelper, TestApp};
 
 use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use http::StatusCode;
 use insta::assert_json_snapshot;
 
@@ -50,7 +51,6 @@ async fn can_download_crate_in_read_only_mode() {
         .with_user()
         .await;
 
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
 
     CrateBuilder::new("foo_download_read_only", user.as_model().id)
@@ -70,6 +70,7 @@ async fn can_download_crate_in_read_only_mode() {
 
     let dl_count: Result<Option<i64>, _> = version_downloads::table
         .select(sum(version_downloads::downloads))
-        .get_result(&mut conn);
+        .get_result(&mut async_conn)
+        .await;
     assert_ok_eq!(dl_count, None);
 }

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -28,7 +28,7 @@ async fn cannot_hit_endpoint_which_writes_db_in_read_only_mode() {
         .with_token()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo_yank_read_only", user.as_model().id)
         .version("1.0.0")
@@ -51,11 +51,11 @@ async fn can_download_crate_in_read_only_mode() {
         .with_user()
         .await;
 
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo_download_read_only", user.as_model().id)
         .version("1.0.0")
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -70,7 +70,7 @@ async fn can_download_crate_in_read_only_mode() {
 
     let dl_count: Result<Option<i64>, _> = version_downloads::table
         .select(sum(version_downloads::downloads))
-        .get_result(&mut async_conn)
+        .get_result(&mut conn)
         .await;
     assert_ok_eq!(dl_count, None);
 }

--- a/src/tests/routes/categories/list.rs
+++ b/src/tests/routes/categories/list.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn index() {
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // List 0 categories if none exist
     let json: Value = anon.get("/api/v1/categories").await.good();

--- a/src/tests/routes/category_slugs/list.rs
+++ b/src/tests/routes/category_slugs/list.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn category_slugs_returns_all_slugs_in_alphabetical_order() {
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let cats = vec![
         new_category("Foo", "foo", "For crates that foo"),

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -13,7 +13,7 @@ async fn diesel_not_found_results_in_404() {
 #[tokio::test(flavor = "multi_thread")]
 async fn disallow_api_token_auth_for_get_crate_following_status() {
     let (app, _, _, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let api_token = token.as_model();
 
     let a_crate = "a_crate";

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -15,7 +15,7 @@ use std::sync::LazyLock;
 #[tokio::test(flavor = "multi_thread")]
 async fn index() {
     let (app, anon) = TestApp::init().empty().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     for json in search_both(&anon, "").await {
         assert_eq!(json.crates.len(), 0);
@@ -25,12 +25,12 @@ async fn index() {
     let user_id = insert_into(users::table)
         .values(new_user("foo"))
         .returning(users::id)
-        .get_result(&mut async_conn)
+        .get_result(&mut conn)
         .await
         .unwrap();
 
     let krate = CrateBuilder::new("fooindex", user_id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "").await {
@@ -45,30 +45,30 @@ async fn index() {
 #[allow(clippy::cognitive_complexity)]
 async fn index_queries() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_index_queries", user.id)
         .readme("readme")
         .description("description")
         .keyword("kw1")
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let krate2 = CrateBuilder::new("BAR_INDEX_QUERIES", user.id)
         .keyword("KW1")
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("foo", user.id)
         .keyword("kw3")
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("two-keywords", user.id)
         .keyword("kw1")
         .keyword("kw3")
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     for json in search_both(&anon, "q=baz").await {
@@ -170,14 +170,14 @@ async fn index_queries() {
 
     insert_into(categories::table)
         .values(cats)
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
-    Category::update_crate(&mut async_conn, krate.id, &["cat1"])
+    Category::update_crate(&mut conn, krate.id, &["cat1"])
         .await
         .unwrap();
-    Category::update_crate(&mut async_conn, krate2.id, &["cat1::bar"])
+    Category::update_crate(&mut conn, krate2.id, &["cat1::bar"])
         .await
         .unwrap();
 
@@ -215,7 +215,7 @@ async fn index_queries() {
 #[tokio::test(flavor = "multi_thread")]
 async fn search_includes_crates_where_name_is_stopword() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("which", user.id)
@@ -235,7 +235,7 @@ async fn search_includes_crates_where_name_is_stopword() {
 #[tokio::test(flavor = "multi_thread")]
 async fn exact_match_first_on_queries() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_exact", user.id)
@@ -284,7 +284,7 @@ async fn exact_match_first_on_queries() {
 #[allow(clippy::cognitive_complexity)]
 async fn index_sorting() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     // To test that the unique ordering of seed-based pagination is correct, we need to
@@ -294,60 +294,60 @@ async fn index_sorting() {
         .description("bar_sort baz_sort const")
         .downloads(50)
         .recent_downloads(50)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let krate2 = CrateBuilder::new("bar_sort", user.id)
         .description("foo_sort baz_sort foo_sort baz_sort const")
         .downloads(3333)
         .recent_downloads(0)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let krate3 = CrateBuilder::new("baz_sort", user.id)
         .description("foo_sort bar_sort foo_sort bar_sort foo_sort bar_sort const")
         .downloads(100_000)
         .recent_downloads(50)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let krate4 = CrateBuilder::new("other_sort", user.id)
         .description("other_sort const")
         .downloads(100_000)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     // Set the created at column for each crate
     update(&krate1)
         .set(crates::created_at.eq(now - 4.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate2)
         .set(crates::created_at.eq(now - 1.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(crates::table.filter(crates::id.eq_any(vec![krate3.id, krate4.id])))
         .set(crates::created_at.eq(now - 3.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
     // Set the updated at column for each crate
     update(&krate1)
         .set(crates::updated_at.eq(now - 3.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(crates::table.filter(crates::id.eq_any(vec![krate2.id, krate3.id])))
         .set(crates::updated_at.eq(now - 5.days()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate4)
         .set(crates::updated_at.eq(now))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
@@ -514,77 +514,77 @@ async fn index_sorting() {
 #[allow(clippy::cognitive_complexity)]
 async fn ignore_exact_match_on_queries_with_sort() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let krate1 = CrateBuilder::new("foo_sort", user.id)
         .description("bar_sort baz_sort const")
         .downloads(50)
         .recent_downloads(50)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let krate2 = CrateBuilder::new("bar_sort", user.id)
         .description("foo_sort baz_sort foo_sort baz_sort const")
         .downloads(3333)
         .recent_downloads(0)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let krate3 = CrateBuilder::new("baz_sort", user.id)
         .description("foo_sort bar_sort foo_sort bar_sort foo_sort bar_sort const")
         .downloads(100_000)
         .recent_downloads(10)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let krate4 = CrateBuilder::new("other_sort", user.id)
         .description("other_sort const")
         .downloads(999_999)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     // Set the created at column for each crate
     update(&krate1)
         .set(crates::created_at.eq(now - 4.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate2)
         .set(crates::created_at.eq(now - 1.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate3)
         .set(crates::created_at.eq(now - 2.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate4)
         .set(crates::created_at.eq(now - 3.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
     // Set the updated at column for each crate
     update(&krate1)
         .set(crates::updated_at.eq(now - 3.weeks()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate2)
         .set(crates::updated_at.eq(now - 5.days()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate3)
         .set(crates::updated_at.eq(now - 10.seconds()))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     update(&krate4)
         .set(crates::updated_at.eq(now))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
@@ -656,7 +656,7 @@ async fn ignore_exact_match_on_queries_with_sort() {
 #[tokio::test(flavor = "multi_thread")]
 async fn multiple_ids() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo", user.id)
@@ -688,7 +688,7 @@ async fn multiple_ids() {
 #[tokio::test(flavor = "multi_thread")]
 async fn loose_search_order() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     // exact match should be first
@@ -739,7 +739,7 @@ async fn loose_search_order() {
 #[tokio::test(flavor = "multi_thread")]
 async fn index_include_yanked() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("unyanked", user.id)
@@ -807,7 +807,7 @@ async fn index_include_yanked() {
 #[tokio::test(flavor = "multi_thread")]
 async fn yanked_versions_are_not_considered_for_max_version() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_yanked_version", user.id)
@@ -828,7 +828,7 @@ async fn yanked_versions_are_not_considered_for_max_version() {
 #[tokio::test(flavor = "multi_thread")]
 async fn max_stable_version() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo", user.id)
@@ -858,7 +858,7 @@ async fn max_stable_version() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_recent_download_count() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     // More than 90 days ago
@@ -896,7 +896,7 @@ async fn test_recent_download_count() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zero_downloads() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     // More than 90 days ago
@@ -921,7 +921,7 @@ async fn test_zero_downloads() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_default_sort_recent() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     // More than 90 days ago
@@ -930,7 +930,7 @@ async fn test_default_sort_recent() {
         .keyword("dog")
         .downloads(10)
         .recent_downloads(10)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let potato_crate = CrateBuilder::new("sweet_potato_snack", user.id)
@@ -938,7 +938,7 @@ async fn test_default_sort_recent() {
         .keyword("dog")
         .downloads(20)
         .recent_downloads(0)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     // test that index for keywords is sorted by recent_downloads
@@ -958,14 +958,14 @@ async fn test_default_sort_recent() {
 
     insert_into(categories::table)
         .values(new_category("Animal", "animal", "animal crates"))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
-    Category::update_crate(&mut async_conn, green_crate.id, &["animal"])
+    Category::update_crate(&mut conn, green_crate.id, &["animal"])
         .await
         .unwrap();
-    Category::update_crate(&mut async_conn, potato_crate.id, &["animal"])
+    Category::update_crate(&mut conn, potato_crate.id, &["animal"])
         .await
         .unwrap();
 
@@ -988,7 +988,7 @@ async fn test_default_sort_recent() {
 #[tokio::test(flavor = "multi_thread")]
 async fn pagination_links_included_if_applicable() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
@@ -1039,7 +1039,7 @@ async fn pagination_links_included_if_applicable() {
 #[tokio::test(flavor = "multi_thread")]
 async fn seek_based_pagination() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
@@ -1094,7 +1094,7 @@ async fn seek_based_pagination() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pages_work_even_with_seek_based_pagination() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
@@ -1143,7 +1143,7 @@ async fn invalid_seek_parameter() {
 #[tokio::test(flavor = "multi_thread")]
 async fn pagination_parameters_only_accept_integers() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("pagination_links_1", user.id)
@@ -1172,7 +1172,7 @@ async fn pagination_parameters_only_accept_integers() {
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_user_id() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let id = user.as_model().id;
 
     CrateBuilder::new("foo_my_packages", id)
@@ -1188,13 +1188,13 @@ async fn crates_by_user_id() {
 #[tokio::test(flavor = "multi_thread")]
 async fn crates_by_user_id_not_including_deleted_owners() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
-    krate.owner_remove(&mut async_conn, "foo").await.unwrap();
+    krate.owner_remove(&mut conn, "foo").await.unwrap();
 
     for response in search_both_by_user_id(&anon, user.id).await {
         assert_eq!(response.crates.len(), 0);

--- a/src/tests/routes/crates/owners/add.rs
+++ b/src/tests/routes/crates/owners/add.rs
@@ -11,7 +11,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cargo_invite_owners() {
     let (app, _, owner) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let new_user = app.db_new_user("cilantro").await;
     CrateBuilder::new("guacamole", owner.as_model().id)
@@ -38,7 +38,7 @@ async fn test_cargo_invite_owners() {
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_cookie() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
@@ -55,7 +55,7 @@ async fn owner_change_via_cookie() {
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_via_token() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
@@ -75,7 +75,7 @@ async fn owner_change_via_change_owner_token() {
         .with_scoped_token(None, Some(vec![EndpointScope::ChangeOwners]))
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
@@ -96,7 +96,7 @@ async fn owner_change_via_change_owner_token_with_matching_crate_scope() {
     let (app, _, _, token) = TestApp::full()
         .with_scoped_token(crate_scopes, endpoint_scopes)
         .await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
@@ -117,7 +117,7 @@ async fn owner_change_via_change_owner_token_with_wrong_crate_scope() {
     let (app, _, _, token) = TestApp::full()
         .with_scoped_token(crate_scopes, endpoint_scopes)
         .await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
@@ -137,7 +137,7 @@ async fn owner_change_via_publish_token() {
         .with_scoped_token(None, Some(vec![EndpointScope::PublishUpdate]))
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
@@ -154,7 +154,7 @@ async fn owner_change_via_publish_token() {
 #[tokio::test(flavor = "multi_thread")]
 async fn owner_change_without_auth() {
     let (app, anon, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let user2 = app.db_new_user("user-2").await;
     let user2 = user2.as_model();
@@ -171,7 +171,7 @@ async fn owner_change_without_auth() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_legacy_field() {
     let (app, _, user1) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", user1.as_model().id)
         .expect_build(&mut conn)
@@ -189,7 +189,7 @@ async fn test_owner_change_with_legacy_field() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     app.db_new_user("bar").await;
     CrateBuilder::new("foo", user.as_model().id)
@@ -224,7 +224,7 @@ async fn test_owner_change_with_invalid_json() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invite_already_invited_user() {
     let (app, _, _, owner) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     app.db_new_user("invited_user").await;
     CrateBuilder::new("crate_name", owner.as_model().user_id)
@@ -254,7 +254,7 @@ async fn invite_already_invited_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invite_with_existing_expired_invite() {
     let (app, _, _, owner) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     app.db_new_user("invited_user").await;
     let krate = CrateBuilder::new("crate_name", owner.as_model().user_id)
@@ -297,7 +297,7 @@ async fn test_unknown_crate() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_user() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
         .expect_build(&mut conn)
@@ -311,7 +311,7 @@ async fn test_unknown_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_team() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
         .expect_build(&mut conn)
@@ -327,7 +327,7 @@ async fn test_unknown_team() {
 #[tokio::test(flavor = "multi_thread")]
 async fn max_invites_per_request() {
     let (app, _, _, owner) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("crate_name", owner.as_model().user_id)
         .expect_build(&mut conn)
@@ -351,7 +351,7 @@ async fn max_invites_per_request() {
 #[tokio::test(flavor = "multi_thread")]
 async fn no_invite_emails_for_txn_rollback() {
     let (app, _, _, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("crate_name", token.as_model().user_id)
         .expect_build(&mut conn)

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -83,11 +83,10 @@ async fn test_unknown_team() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_remove_uppercase_user() {
-    use diesel::RunQueryDsl;
+    use diesel_async::RunQueryDsl;
 
     let (app, _, cookie) = TestApp::full().with_user().await;
     let user2 = app.db_new_user("user2").await;
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
 
     let krate = CrateBuilder::new("foo", cookie.as_model().id)
@@ -102,7 +101,8 @@ async fn test_remove_uppercase_user() {
             owner_kind: OwnerKind::User,
             email_notifications: true,
         })
-        .execute(&mut conn)
+        .execute(&mut async_conn)
+        .await
         .unwrap();
 
     let response = cookie.remove_named_owner("foo", "USER2").await;

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_owner_change_with_invalid_json() {
     let (app, _, user) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     app.db_new_user("bar").await;
     CrateBuilder::new("foo", user.as_model().id)
@@ -54,7 +54,7 @@ async fn test_unknown_crate() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_user() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
         .expect_build(&mut conn)
@@ -68,7 +68,7 @@ async fn test_unknown_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_team() {
     let (app, _, cookie) = TestApp::full().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", cookie.as_model().id)
         .expect_build(&mut conn)
@@ -87,10 +87,10 @@ async fn test_remove_uppercase_user() {
 
     let (app, _, cookie) = TestApp::full().with_user().await;
     let user2 = app.db_new_user("user2").await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let krate = CrateBuilder::new("foo", cookie.as_model().id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     diesel::insert_into(crate_owners::table)
@@ -101,7 +101,7 @@ async fn test_remove_uppercase_user() {
             owner_kind: OwnerKind::User,
             email_notifications: true,
         })
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
@@ -150,7 +150,7 @@ async fn test_remove_uppercase_team() {
         });
 
     let (app, _, cookie) = TestApp::full().with_github(github_mock).with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("crate42", cookie.as_model().id)
         .expect_build(&mut conn)

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -1,13 +1,12 @@
 use crate::tests::builders::{CrateBuilder, PublishBuilder, VersionBuilder};
 use crate::tests::util::{RequestHelper, TestApp};
-use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
     let user = user.as_model();
 
@@ -33,7 +32,8 @@ async fn show() {
     update(versions::table)
         .filter(versions::num.eq("1.0.0"))
         .set(versions::published_by.eq(none))
-        .execute(&mut conn)
+        .execute(&mut async_conn)
+        .await
         .unwrap();
 
     let response = anon.get::<()>("/api/v1/crates/foo_show").await;

--- a/src/tests/routes/crates/read.rs
+++ b/src/tests/routes/crates/read.rs
@@ -7,7 +7,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn show() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     use crate::schema::versions;
@@ -23,7 +23,7 @@ async fn show() {
         .keyword("kw1")
         .downloads(20)
         .recent_downloads(10)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     // Make version 1.0.0 mimic a version published before we started recording who published
@@ -32,7 +32,7 @@ async fn show() {
     update(versions::table)
         .filter(versions::num.eq("1.0.0"))
         .set(versions::published_by.eq(none))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
@@ -50,7 +50,7 @@ async fn show() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_minimal() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_show_minimal", user.id)
@@ -79,7 +79,7 @@ async fn show_minimal() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_all_yanked() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_show", user.id)
@@ -150,7 +150,7 @@ async fn version_size() {
 #[tokio::test(flavor = "multi_thread")]
 async fn block_bad_documentation_url() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_bad_doc_url", user.id)
@@ -165,7 +165,7 @@ async fn block_bad_documentation_url() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_new_name() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("new", user.as_model().id)
         .expect_build(&mut conn)

--- a/src/tests/routes/crates/reverse_dependencies.rs
+++ b/src/tests/routes/crates/reverse_dependencies.rs
@@ -6,7 +6,7 @@ use insta::{assert_json_snapshot, assert_snapshot};
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
@@ -46,7 +46,7 @@ async fn reverse_dependencies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
@@ -73,7 +73,7 @@ async fn reverse_dependencies_when_old_version_doesnt_depend_but_new_does() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
@@ -100,7 +100,7 @@ async fn reverse_dependencies_when_old_version_depended_but_new_doesnt() {
 #[tokio::test(flavor = "multi_thread")]
 async fn prerelease_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
@@ -132,18 +132,18 @@ async fn prerelease_versions_not_included_in_reverse_dependencies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn yanked_versions_not_included_in_reverse_dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     CrateBuilder::new("c2", user.id)
         .version("1.0.0")
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -161,7 +161,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
 
     diesel::update(versions::table.filter(versions::num.eq("2.0.0")))
         .set(versions::yanked.eq(true))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
@@ -178,7 +178,7 @@ async fn yanked_versions_not_included_in_reverse_dependencies() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_includes_published_by_user_when_present() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     use crate::schema::versions;
@@ -187,11 +187,11 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 
     let c1 = CrateBuilder::new("c1", user.id)
         .version("1.0.0")
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
     CrateBuilder::new("c2", user.id)
         .version(VersionBuilder::new("2.0.0").dependency(&c1, None))
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     // Make c2's version (and,incidentally, c1's, but that doesn't matter) mimic a version
@@ -199,14 +199,14 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
     let none: Option<i32> = None;
     update(versions::table)
         .set(versions::published_by.eq(none))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
     // c3's version will have the published by info recorded
     CrateBuilder::new("c3", user.id)
         .version(VersionBuilder::new("3.0.0").dependency(&c1, None))
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let response = anon
@@ -222,7 +222,7 @@ async fn reverse_dependencies_includes_published_by_user_when_present() {
 #[tokio::test(flavor = "multi_thread")]
 async fn reverse_dependencies_query_supports_u64_version_number_parts() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let large_but_valid_version_number = format!("1.0.{}", u64::MAX);

--- a/src/tests/routes/crates/versions/authors.rs
+++ b/src/tests/routes/crates/versions/authors.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn authors() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo_authors", user.id)

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -12,7 +12,7 @@ pub struct Deps {
 #[tokio::test(flavor = "multi_thread")]
 async fn dependencies() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let c1 = CrateBuilder::new("foo_deps", user.id)

--- a/src/tests/routes/crates/versions/download.rs
+++ b/src/tests/routes/crates/versions/download.rs
@@ -4,7 +4,7 @@ use crate::tests::util::{RequestHelper, TestApp};
 #[tokio::test(flavor = "multi_thread")]
 async fn test_redirects() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo-download", user.as_model().id)
         .version(VersionBuilder::new("1.0.0"))
@@ -35,7 +35,7 @@ async fn test_redirects() {
 #[tokio::test(flavor = "multi_thread")]
 async fn download_with_build_metadata() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("foo", user.id)

--- a/src/tests/routes/crates/versions/read.rs
+++ b/src/tests/routes/crates/versions/read.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 #[tokio::test(flavor = "multi_thread")]
 async fn show_by_crate_name_and_version() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_vers_show", user.id)
@@ -37,21 +37,21 @@ async fn show_by_crate_name_and_semver_no_published_by() {
     use diesel::update;
 
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let krate = CrateBuilder::new("foo_vers_show_no_pb", user.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
     let version = VersionBuilder::new("1.0.0")
-        .expect_build(krate.id, user.id, &mut async_conn)
+        .expect_build(krate.id, user.id, &mut conn)
         .await;
 
     // Mimic a version published before we started recording who published versions
     let none: Option<i32> = None;
     update(versions::table)
         .set(versions::published_by.eq(none))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 

--- a/src/tests/routes/crates/versions/yank_unyank.rs
+++ b/src/tests/routes/crates/versions/yank_unyank.rs
@@ -63,7 +63,7 @@ impl<T: RequestHelper> YankRequestHelper for T {
 #[tokio::test(flavor = "multi_thread")]
 async fn yank_by_a_non_owner_fails() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let another_user = app.db_new_user("bar").await;
     let another_user = another_user.as_model();
@@ -146,7 +146,7 @@ mod auth {
     }
 
     async fn is_yanked(app: &TestApp) -> bool {
-        let mut conn = app.async_db_conn().await;
+        let mut conn = app.db_conn().await;
 
         versions::table
             .inner_join(crates::table)
@@ -381,7 +381,7 @@ mod auth {
     #[tokio::test(flavor = "multi_thread")]
     async fn admin() {
         let (app, _, _) = prepare().await;
-        let mut conn = app.async_db_conn().await;
+        let mut conn = app.db_conn().await;
 
         let admin = app.db_new_user("admin").await;
 

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -17,7 +17,7 @@ struct KeywordMeta {
 async fn index() {
     let url = "/api/v1/keywords";
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let json: KeywordList = anon.get(url).await.good();
     assert_eq!(json.keywords.len(), 0);

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -12,7 +12,7 @@ struct GoodKeyword {
 async fn show() {
     let url = "/api/v1/keywords/foo";
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     anon.get(url).await.assert_not_found();
 
@@ -28,7 +28,7 @@ async fn show() {
 async fn uppercase() {
     let url = "/api/v1/keywords/UPPER";
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     anon.get(url).await.assert_not_found();
 
@@ -43,7 +43,7 @@ async fn uppercase() {
 #[tokio::test(flavor = "multi_thread")]
 async fn update_crate() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     async fn cnt(kw: &str, client: &impl RequestHelper) -> usize {

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -20,7 +20,7 @@ pub struct UserShowPrivateResponse {
 #[tokio::test(flavor = "multi_thread")]
 async fn me() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let response = anon.get::<()>("/api/v1/me").await;
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
@@ -42,14 +42,14 @@ async fn me() {
 #[tokio::test(flavor = "multi_thread")]
 async fn test_user_owned_crates_doesnt_include_deleted_ownership() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user_model = user.as_model();
 
     let krate = CrateBuilder::new("foo_my_packages", user_model.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
     krate
-        .owner_remove(&mut async_conn, &user_model.gh_login)
+        .owner_remove(&mut conn, &user_model.gh_login)
         .await
         .unwrap();
 

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -42,7 +42,7 @@ async fn create_token_no_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_exceeded_tokens_per_user() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let id = user.as_model().id;
 
     for i in 0..1000 {
@@ -58,7 +58,7 @@ async fn create_token_exceeded_tokens_per_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_success() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR).await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -124,7 +124,7 @@ async fn cannot_create_token_with_token() {
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_with_scopes() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let json = json!({
         "api_token": {
@@ -174,7 +174,7 @@ async fn create_token_with_scopes() {
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_with_null_scopes() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let json = json!({
         "api_token": {

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -16,7 +16,7 @@ async fn revoke_token_non_existing() {
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_token_doesnt_revoke_other_users_token() {
     let (app, _, user1, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user1 = user1.as_model();
     let token = token.as_model();
     let user2 = app.db_new_user("baz").await;
@@ -51,7 +51,7 @@ async fn revoke_token_doesnt_revoke_other_users_token() {
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_token_success() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // List tokens contains the token
     let tokens: Vec<ApiToken> = assert_ok!(

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -9,7 +9,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_current_token_success() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Ensure that the token currently exists in the database
 
@@ -51,7 +51,7 @@ async fn revoke_current_token_without_auth() {
 #[tokio::test(flavor = "multi_thread")]
 async fn revoke_current_token_with_cookie_user() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Ensure that the token currently exists in the database
 

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -27,7 +27,7 @@ async fn show() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_token_with_scopes() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user_model = user.as_model();
     let id = user_model.id;
 
@@ -66,7 +66,7 @@ async fn show_with_anonymous_user() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_other_user_token() {
     let (app, _, user1) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user2 = app.db_new_user("baz").await;
     let user2 = user2.as_model();
 

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -30,7 +30,7 @@ async fn list_empty() {
 #[tokio::test(flavor = "multi_thread")]
 async fn list_tokens() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let id = user.as_model().id;
 
     assert_ok!(ApiToken::insert(&mut conn, id, "bar").await);
@@ -77,7 +77,7 @@ async fn list_recently_expired_tokens() {
     }
 
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let id = user.as_model().id;
 
     assert_ok!(ApiToken::insert(&mut conn, id, "bar").await);
@@ -128,7 +128,7 @@ async fn list_recently_expired_tokens() {
 #[tokio::test(flavor = "multi_thread")]
 async fn list_tokens_exclude_revoked() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let id = user.as_model().id;
 
     let token1 = assert_ok!(ApiToken::insert(&mut conn, id, "bar").await);

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -29,13 +29,13 @@ async fn following() {
     }
 
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user_model = user.as_model();
     let user_id = user_model.id;
 
     CrateBuilder::new("foo_fighters", user_id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     // Make foo_fighters's version mimic a version published before we started recording who
@@ -43,13 +43,13 @@ async fn following() {
     let none: Option<i32> = None;
     update(versions::table)
         .set(versions::published_by.eq(none))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
     CrateBuilder::new("bar_fighters", user_id)
         .version(VersionBuilder::new("1.0.0"))
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
 
     let r: R = user.get("/api/v1/me/updates").await.good();

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -5,6 +5,7 @@ use crate::tests::OkBool;
 use crate::views::EncodableVersion;
 use diesel::prelude::*;
 use diesel::update;
+use diesel_async::RunQueryDsl;
 use googletest::prelude::*;
 use http::StatusCode;
 use insta::assert_snapshot;
@@ -28,7 +29,6 @@ async fn following() {
     }
 
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.db_conn();
     let mut async_conn = app.async_db_conn().await;
     let user_model = user.as_model();
     let user_id = user_model.id;
@@ -43,7 +43,8 @@ async fn following() {
     let none: Option<i32> = None;
     update(versions::table)
         .set(versions::published_by.eq(none))
-        .execute(&mut conn)
+        .execute(&mut async_conn)
+        .await
         .unwrap();
 
     CrateBuilder::new("bar_fighters", user_id)

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -29,7 +29,7 @@ async fn get_invitations(user: &MockCookieUser, query: &str) -> CrateOwnerInvita
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
         .expect_build(&mut conn)
@@ -170,7 +170,7 @@ async fn invitation_list() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_does_not_include_expired_invites() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = app.db_new_user("invited_user").await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
@@ -218,7 +218,7 @@ async fn invitations_list_does_not_include_expired_invites() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitations_list_paginated() {
     let (app, _, owner, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = app.db_new_user("invited_user").await;
 
     let crate1 = CrateBuilder::new("crate_1", owner.as_model().id)
@@ -338,7 +338,7 @@ async fn invitation_list_other_users() {
 #[tokio::test(flavor = "multi_thread")]
 async fn invitation_list_other_crates() {
     let (app, _, owner, _) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let other_user = app.db_new_user("other").await;
 
     CrateBuilder::new("crate_1", owner.as_model().id)

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -30,7 +30,7 @@ async fn summary_doesnt_die() {
 #[tokio::test(flavor = "multi_thread")]
 async fn summary_new_crates() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     conn.transaction(|conn| {
@@ -163,7 +163,7 @@ async fn excluded_crate_id() {
         .with_user()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("some_downloads", user.id)
@@ -221,7 +221,7 @@ async fn all_yanked() {
         .with_user()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     CrateBuilder::new("some_downloads", user.id)

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -25,7 +25,7 @@ async fn show() {
 #[tokio::test(flavor = "multi_thread")]
 async fn show_latest_user_case_insensitively() {
     let (app, anon) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Please do not delete or modify the setup of this test in order to get it to pass.
     // This setup mimics how GitHub works. If someone abandons a GitHub account, the username is

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -15,48 +15,48 @@ async fn user_total_downloads() {
     use diesel_async::RunQueryDsl;
 
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut async_conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
     let another_user = app.db_new_user("bar").await;
     let another_user = another_user.as_model();
 
     let krate = CrateBuilder::new("foo_krate1", user.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate.id)))
         .set(crate_downloads::downloads.eq(10))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
     let krate2 = CrateBuilder::new("foo_krate2", user.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(krate2.id)))
         .set(crate_downloads::downloads.eq(20))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
     let another_krate = CrateBuilder::new("bar_krate1", another_user.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(another_krate.id)))
         .set(crate_downloads::downloads.eq(2))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
 
     let no_longer_my_krate = CrateBuilder::new("nacho", user.id)
-        .expect_build(&mut async_conn)
+        .expect_build(&mut conn)
         .await;
     update(crate_downloads::table.filter(crate_downloads::crate_id.eq(no_longer_my_krate.id)))
         .set(crate_downloads::downloads.eq(5))
-        .execute(&mut async_conn)
+        .execute(&mut conn)
         .await
         .unwrap();
     no_longer_my_krate
-        .owner_remove(&mut async_conn, &user.gh_login)
+        .owner_remove(&mut conn, &user.gh_login)
         .await
         .unwrap();
 

--- a/src/tests/server.rs
+++ b/src/tests/server.rs
@@ -26,7 +26,7 @@ async fn user_agent_is_required() {
 #[tokio::test(flavor = "multi_thread")]
 async fn user_agent_is_not_required_for_download() {
     let (app, anon, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("dl_no_ua", user.as_model().id)
         .expect_build(&mut conn)
@@ -47,7 +47,7 @@ async fn blocked_traffic_doesnt_panic_if_checked_header_is_not_present() {
         .with_user()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("dl_no_ua", user.as_model().id)
         .expect_build(&mut conn)
@@ -68,7 +68,7 @@ async fn block_traffic_via_arbitrary_header_and_value() {
         .with_user()
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("dl_no_ua", user.as_model().id)
         .expect_build(&mut conn)

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 async fn using_token_updates_last_used_at() {
     let url = "/api/v1/me";
     let (app, anon, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     anon.get(url).await.assert_forbidden();
     user.get::<EncodableMe>(url).await.good();

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -53,7 +53,7 @@ async fn http_error_with_unhealthy_database() {
 #[tokio::test(flavor = "multi_thread")]
 async fn download_requests_with_unhealthy_database_succeed() {
     let (app, anon, _, token) = TestApp::init().with_chaos_proxy().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     CrateBuilder::new("foo", token.as_model().user_id)
         .version("1.0.0")

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -23,7 +23,7 @@ impl crate::tests::util::MockCookieUser {
 #[tokio::test(flavor = "multi_thread")]
 async fn updating_existing_user_doesnt_change_api_token() {
     let (app, _, user, token) = TestApp::init().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let gh_id = user.as_model().gh_id;
     let token = token.plaintext();
 
@@ -55,7 +55,7 @@ async fn updating_existing_user_doesnt_change_api_token() {
 #[tokio::test(flavor = "multi_thread")]
 async fn github_without_email_does_not_overwrite_email() {
     let (app, _) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Simulate logging in via GitHub with an account that has no email.
     // Because faking GitHub is terrible, call what GithubUser::save_to_database does directly.
@@ -101,7 +101,7 @@ async fn github_with_email_does_not_overwrite_email() {
     use crate::schema::emails;
 
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let model = user.as_model();
 
@@ -162,7 +162,7 @@ async fn test_confirm_user_email() {
     use crate::schema::emails;
 
     let (app, _) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Simulate logging in via GitHub. Don't use app.db_new_user because it inserts a verified
     // email directly into the database and we want to test the verification flow here.
@@ -201,7 +201,7 @@ async fn test_existing_user_email() {
     use diesel::update;
 
     let (app, _) = TestApp::init().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     // Simulate logging in via GitHub. Don't use app.db_new_user because it inserts a verified
     // email directly into the database and we want to test the verification flow here.

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -327,7 +327,7 @@ impl MockCookieUser {
         endpoint_scopes: Option<Vec<EndpointScope>>,
         expired_at: Option<NaiveDateTime>,
     ) -> MockTokenUser {
-        let mut conn = self.app().async_db_conn().await;
+        let mut conn = self.app().db_conn().await;
 
         let token = ApiToken::insert_with_scopes(
             &mut conn,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -111,7 +111,7 @@ impl TestApp {
     }
 
     /// Obtain an async database connection from the primary database pool.
-    pub async fn async_db_conn(&self) -> AsyncPgConnection {
+    pub async fn db_conn(&self) -> AsyncPgConnection {
         self.0.test_database.async_connect().await
     }
 
@@ -124,7 +124,7 @@ impl TestApp {
         use diesel::prelude::*;
         use diesel_async::RunQueryDsl;
 
-        let mut conn = self.async_db_conn().await;
+        let mut conn = self.db_conn().await;
 
         let email = format!("{username}@example.com");
 

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -18,8 +18,6 @@ use crates_io_index::{Credentials, RepositoryConfig};
 use crates_io_team_repo::MockTeamRepo;
 use crates_io_test_db::TestDatabase;
 use crates_io_worker::Runner;
-use diesel::r2d2::{ConnectionManager, PooledConnection};
-use diesel::PgConnection;
 use diesel_async::AsyncPgConnection;
 use futures_util::TryStreamExt;
 use oauth2::{ClientId, ClientSecret};
@@ -110,11 +108,6 @@ impl TestApp {
     /// Initialize a full application, with a proxy, index, and background worker
     pub fn full() -> TestAppBuilder {
         Self::init().with_git_index().with_job_runner()
-    }
-
-    /// Obtain a database connection.
-    pub fn db_conn(&self) -> PooledConnection<ConnectionManager<PgConnection>> {
-        self.0.test_database.connect()
     }
 
     /// Obtain an async database connection from the primary database pool.

--- a/src/tests/version.rs
+++ b/src/tests/version.rs
@@ -5,7 +5,7 @@ use crate::tests::TestApp;
 #[tokio::test(flavor = "multi_thread")]
 async fn record_rerendered_readme_time() {
     let (app, _, user) = TestApp::init().with_user().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let user = user.as_model();
 
     let c = CrateBuilder::new("foo_authors", user.id)
@@ -15,7 +15,7 @@ async fn record_rerendered_readme_time() {
         .expect_build(c.id, user.id, &mut conn)
         .await;
 
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     Version::record_readme_rendering(version.id, &mut conn)
         .await
         .unwrap();

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -10,7 +10,7 @@ use http::StatusCode;
 #[tokio::test(flavor = "multi_thread")]
 async fn index_smoke_test() {
     let (app, _, _, token) = TestApp::full().with_token().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
     let upstream = app.upstream_index();
 
     // Add a new crate

--- a/src/tests/worker/rss/sync_crate_feed.rs
+++ b/src/tests/worker/rss/sync_crate_feed.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_crate_feed() {
     let (app, _) = TestApp::full().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     create_version(&mut conn, "foo", "0.1.0", "2024-06-20T10:13:54Z").await;
     create_version(&mut conn, "foo", "0.1.1", "2024-06-20T12:45:12Z").await;

--- a/src/tests/worker/rss/sync_crates_feed.rs
+++ b/src/tests/worker/rss/sync_crates_feed.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_crates_feed() {
     let (app, _) = TestApp::full().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let description = Some("something something foo");
     create_crate(&mut conn, "foo", description, "2024-06-20T10:13:54Z").await;

--- a/src/tests/worker/rss/sync_updates_feed.rs
+++ b/src/tests/worker/rss/sync_updates_feed.rs
@@ -10,7 +10,7 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sync_updates_feed() {
     let (app, _) = TestApp::full().empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     let d = Some("let's try & break this <item> ]]>");
 

--- a/src/tests/worker/sync_admins.rs
+++ b/src/tests/worker/sync_admins.rs
@@ -23,7 +23,7 @@ async fn test_sync_admins_job() {
         .returning(move |_| Ok(mock_response.clone()));
 
     let (app, _) = TestApp::full().with_team_repo(team_repo).empty().await;
-    let mut conn = app.async_db_conn().await;
+    let mut conn = app.db_conn().await;
 
     create_user("existing-admin", 1, true, &mut conn)
         .await


### PR DESCRIPTION
None of our tests strictly need a sync database connection anymore, and those that were still using one are migrated by this commit to use an async one instead. 🎉 