### PR TITLE
typosquat/test_util: Migrate `user()` fn to `diesel-async`

### DIFF
--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -1,4 +1,5 @@
-use diesel::{prelude::*, PgConnection};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
 
 use crate::tests::util::github::next_gh_id;
 use crate::{
@@ -40,11 +41,12 @@ pub mod faker {
         Ok(team.async_create_or_update(conn).await?)
     }
 
-    pub fn user(conn: &mut PgConnection, login: &str) -> QueryResult<User> {
+    pub async fn user(conn: &mut AsyncPgConnection, login: &str) -> QueryResult<User> {
         let user = NewUser::new(next_gh_id(), login, None, None, "token");
 
         diesel::insert_into(users::table)
             .values(user)
             .get_result(conn)
+            .await
     }
 }

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -130,12 +130,11 @@ mod tests {
     async fn integration() -> anyhow::Result<()> {
         let emails = Emails::new_in_memory();
         let test_db = TestDatabase::new();
-        let mut conn = test_db.connect();
-        let mut async_conn = test_db.async_connect().await;
+        let mut conn = test_db.async_connect().await;
 
         // Set up a user and a popular crate to match against.
-        let user = faker::user(&mut conn, "a")?;
-        faker::crate_and_version(&mut async_conn, "my-crate", "It's awesome", &user, 100).await?;
+        let user = faker::user(&mut conn, "a").await?;
+        faker::crate_and_version(&mut conn, "my-crate", "It's awesome", &user, 100).await?;
 
         // Prime the cache so it only includes the crate we just created.
         let mut async_conn = test_db.async_connect().await;
@@ -143,7 +142,7 @@ mod tests {
         let cache = Arc::new(cache);
 
         // Now we'll create new crates: one problematic, one not so.
-        let other_user = faker::user(&mut conn, "b")?;
+        let other_user = faker::user(&mut async_conn, "b").await?;
         let angel = faker::crate_and_version(
             &mut async_conn,
             "innocent-crate",


### PR DESCRIPTION
This was one of the last `TestDatabase::connect()` users. We should soon be able to remove it.