### PR TITLE
controllers/krate/publish: Validate JSON metadata before reading tarball

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-postgres",
+ "tokio-util",
  "toml",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ tempfile = "=3.14.0"
 thiserror = "=2.0.3"
 tokio = { version = "=1.41.1", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros", "process"]}
 tokio-postgres = "=0.7.12"
+tokio-util = "=0.7.12"
 toml = "=0.8.19"
 tower = "=0.5.1"
 tower-http = { version = "=0.6.2", features = ["add-extension", "fs", "catch-panic", "timeout", "compression-full"] }

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -1,5 +1,6 @@
 use crate::tests::builders::PublishBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
+use bytes::{BufMut, BytesMut};
 use crates_io_tarball::TarballBuilder;
 use googletest::prelude::*;
 use http::StatusCode;
@@ -80,9 +81,16 @@ async fn json_bytes_truncated() {
 async fn tarball_len_truncated() {
     let (app, _, _, token) = TestApp::full().with_token().await;
 
-    let response = token
-        .publish_crate(&[2, 0, 0, 0, b'{', b'}', 0, 0] as &[u8])
-        .await;
+    let json = br#"{ "name": "foo", "vers": "1.0.0" }"#;
+
+    let mut bytes = BytesMut::new();
+    bytes.put_u32_le(json.len() as u32);
+    bytes.put_slice(json);
+    bytes.put_u8(0);
+    bytes.put_u8(0);
+
+    let response = token.publish_crate(bytes.freeze()).await;
+
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid tarball length"}]}"#);
     assert_that!(app.stored_files().await, empty());
@@ -92,9 +100,15 @@ async fn tarball_len_truncated() {
 async fn tarball_bytes_truncated() {
     let (app, _, _, token) = TestApp::full().with_token().await;
 
-    let response = token
-        .publish_crate(&[2, 0, 0, 0, b'{', b'}', 100, 0, 0, 0, 0] as &[u8])
-        .await;
+    let json = br#"{ "name": "foo", "vers": "1.0.0" }"#;
+
+    let mut bytes = BytesMut::new();
+    bytes.put_u32_le(json.len() as u32);
+    bytes.put_slice(json);
+    bytes.put_u32_le(100);
+    bytes.put_u8(0);
+
+    let response = token.publish_crate(bytes.freeze()).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid tarball length for remaining payload: 100"}]}"#);
     assert_that!(app.stored_files().await, empty());


### PR DESCRIPTION
Previously, the `BytesRequest` allocated memory for the full tarball (and the JSON metadata blob) before even validating that the `name` and `vers` fields of the JSON metadata correspond to a crate and version that the user has publish access too. This commit changes the code to first read the JSON metadata from the request body stream, validate it, and then read the tarball bytes afterwards.

Unfortunately, this means that we still buffer the full tarball in memory, but since we only want to upload the tarball to S3 once we validated the content of the tarball, this is somewhat hard to fix. Ideas are welcome! 😉 