### PR TITLE
Use `Version::as_select()` to allow skipping columns

### DIFF
--- a/src/bin/crates-admin/yank_version.rs
+++ b/src/bin/crates-admin/yank_version.rs
@@ -42,6 +42,7 @@ async fn yank(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()> {
 
     let v: Version = Version::belonging_to(&krate)
         .filter(versions::num.eq(&version))
+        .select(Version::as_select())
         .first(conn)
         .await?;
 

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -32,6 +32,7 @@ pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppRe
 
     let mut versions: Vec<Version> = versions::table
         .filter(versions::crate_id.eq(crate_id))
+        .select(Version::as_select())
         .load(&mut conn)
         .await?;
 

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -216,6 +216,7 @@ pub async fn search(app: AppState, req: Parts) -> AppResult<ErasedJson> {
     let span = info_span!("db.query", message = "SELECT ... FROM versions");
     let versions: Vec<Version> = Version::belonging_to(&crates)
         .filter(versions::yanked.eq(false))
+        .select(Version::as_select())
         .load(&mut conn)
         .instrument(span)
         .await?;

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -40,6 +40,7 @@ pub async fn summary(state: AppState) -> AppResult<ErasedJson> {
         let krates = data.iter().map(|(c, ..)| c).collect::<Vec<_>>();
         let versions: Vec<Version> = Version::belonging_to(&krates)
             .filter(versions::yanked.eq(false))
+            .select(Version::as_select())
             .load(conn)
             .await?;
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -59,7 +59,10 @@ pub async fn index_metadata(
     krate: &Crate,
     conn: &mut AsyncPgConnection,
 ) -> QueryResult<Vec<crates_io_index::Crate>> {
-    let mut versions: Vec<Version> = Version::belonging_to(krate).load(conn).await?;
+    let mut versions: Vec<Version> = Version::belonging_to(krate)
+        .select(Version::as_select())
+        .load(conn)
+        .await?;
 
     // We sort by `created_at` by default, but since tests run within a
     // single database transaction the versions will all have the same

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -207,6 +207,7 @@ impl Crate {
     ) -> AppResult<Version> {
         Version::belonging_to(self)
             .filter(versions::num.eq(version))
+            .select(Version::as_select())
             .first(conn)
             .await
             .optional()?

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -32,7 +32,6 @@ pub struct Version {
     pub has_lib: Option<bool>,
     pub bin_names: Option<Vec<Option<String>>>,
     pub yank_message: Option<String>,
-    pub num_no_build: String,
     pub edition: Option<String>,
     pub description: Option<String>,
     pub homepage: Option<String>,

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -117,6 +117,7 @@ impl NewVersion<'_> {
             async move {
                 let version: Version = insert_into(versions::table)
                     .values(self)
+                    .returning(Version::as_returning())
                     .get_result(conn)
                     .await?;
 

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -286,6 +286,7 @@ mod tests {
 
         let version_before: Version = versions::table
             .find(version.id)
+            .select(Version::as_select())
             .first(&mut conn)
             .await
             .unwrap();
@@ -299,6 +300,7 @@ mod tests {
 
         let version2: Version = versions::table
             .find(version.id)
+            .select(Version::as_select())
             .first(&mut conn)
             .await
             .unwrap();
@@ -324,6 +326,7 @@ mod tests {
 
         let version3: Version = versions::table
             .find(version.id)
+            .select(Version::as_select())
             .first(&mut conn)
             .await
             .unwrap();


### PR DESCRIPTION
This allows us to remove the unused `num_no_build` field of the struct, which means that we have to transfer less bytes from the database to the API server for the queries that result in one or many `Version` structs.