### PR TITLE
database: Add `categories` and `keywords` columns to the `versions` table

### DIFF
--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -1021,6 +1021,10 @@ diesel::table! {
         documentation -> Nullable<Text>,
         /// Value of the `repository` field in the `Cargo.toml` file of this version.
         repository -> Nullable<Text>,
+        /// The list of `categories` in the `Cargo.toml` file of this version.
+        categories -> Array<Nullable<Text>>,
+        /// The list of `keywords` in the `Cargo.toml` file of this version.
+        keywords -> Array<Nullable<Text>>,
     }
 }
 

--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -251,6 +251,8 @@ description = "public"
 homepage = "public"
 documentation = "public"
 repository = "public"
+categories = "public"
+keywords = "public"
 
 [versions_published_by.columns]
 version_id = "private"

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
@@ -18,7 +18,7 @@ BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
     \copy "crates_keywords" ("crate_id", "keyword_id") TO 'data/crates_keywords.csv' WITH CSV HEADER
     \copy (SELECT "crate_id", "created_at", "created_by", "owner_id", "owner_kind" FROM "crate_owners" WHERE NOT deleted) TO 'data/crate_owners.csv' WITH CSV HEADER
 
-    \copy "versions" ("bin_names", "checksum", "crate_id", "crate_size", "created_at", "description", "documentation", "downloads", "edition", "features", "has_lib", "homepage", "id", "license", "links", "num", "published_by", "repository", "rust_version", "updated_at", "yanked") TO 'data/versions.csv' WITH CSV HEADER
+    \copy "versions" ("bin_names", "categories", "checksum", "crate_id", "crate_size", "created_at", "description", "documentation", "downloads", "edition", "features", "has_lib", "homepage", "id", "keywords", "license", "links", "num", "published_by", "repository", "rust_version", "updated_at", "yanked") TO 'data/versions.csv' WITH CSV HEADER
     \copy "default_versions" ("crate_id", "version_id") TO 'data/default_versions.csv' WITH CSV HEADER
     \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") TO 'data/dependencies.csv' WITH CSV HEADER
     \copy "version_downloads" ("date", "downloads", "version_id") TO 'data/version_downloads.csv' WITH CSV HEADER

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -60,7 +60,7 @@ BEGIN;
     \copy "crates_categories" ("category_id", "crate_id") FROM 'data/crates_categories.csv' WITH CSV HEADER
     \copy "crates_keywords" ("crate_id", "keyword_id") FROM 'data/crates_keywords.csv' WITH CSV HEADER
     \copy "crate_owners" ("crate_id", "created_at", "created_by", "owner_id", "owner_kind") FROM 'data/crate_owners.csv' WITH CSV HEADER
-    \copy "versions" ("bin_names", "checksum", "crate_id", "crate_size", "created_at", "description", "documentation", "downloads", "edition", "features", "has_lib", "homepage", "id", "license", "links", "num", "published_by", "repository", "rust_version", "updated_at", "yanked") FROM 'data/versions.csv' WITH CSV HEADER
+    \copy "versions" ("bin_names", "categories", "checksum", "crate_id", "crate_size", "created_at", "description", "documentation", "downloads", "edition", "features", "has_lib", "homepage", "id", "keywords", "license", "links", "num", "published_by", "repository", "rust_version", "updated_at", "yanked") FROM 'data/versions.csv' WITH CSV HEADER
     \copy "default_versions" ("crate_id", "version_id") FROM 'data/default_versions.csv' WITH CSV HEADER
     \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") FROM 'data/dependencies.csv' WITH CSV HEADER
     \copy "version_downloads" ("date", "downloads", "version_id") FROM 'data/version_downloads.csv' WITH CSV HEADER

--- a/migrations/2024-11-26-155931_add-cats-and-keys-to-version/down.sql
+++ b/migrations/2024-11-26-155931_add-cats-and-keys-to-version/down.sql
@@ -1,0 +1,3 @@
+alter table versions
+    drop column categories,
+    drop column keywords;

--- a/migrations/2024-11-26-155931_add-cats-and-keys-to-version/up.sql
+++ b/migrations/2024-11-26-155931_add-cats-and-keys-to-version/up.sql
@@ -1,0 +1,6 @@
+alter table versions
+    add column categories text[] default array[]::text[] not null,
+    add column keywords text[] default array[]::text[] not null;
+
+comment on column versions.categories is 'The list of `categories` in the `Cargo.toml` file of this version.';
+comment on column versions.keywords is 'The list of `keywords` in the `Cargo.toml` file of this version.';

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -393,6 +393,8 @@ pub async fn publish(app: AppState, req: BytesRequest) -> AppResult<Json<GoodCra
             .maybe_homepage(homepage.as_deref())
             .maybe_documentation(documentation.as_deref())
             .maybe_repository(repository.as_deref())
+            .categories(&categories)
+            .keywords(&keywords)
             .build();
 
         let version = new_version.save(conn, &verified_email_address).await.map_err(|error| {

--- a/src/models/version.rs
+++ b/src/models/version.rs
@@ -102,6 +102,8 @@ pub struct NewVersion<'a> {
     homepage: Option<&'a str>,
     documentation: Option<&'a str>,
     repository: Option<&'a str>,
+    categories: Option<&'a [&'a str]>,
+    keywords: Option<&'a [&'a str]>,
 }
 
 impl NewVersion<'_> {


### PR DESCRIPTION
Similar to https://github.com/rust-lang/crates.io/pull/9998, this PR adds two new columns to the `versions` database table: `categories` and `keywords`

These columns are filled with the corresponding values from the `Cargo.toml` file when new crates/versions are published.

Compared to the per-crate categories and keywords, these are not saved in dedicated `crates_categories` and `crates_keywords` tables, but just as a regular Postgres array column. The reason for this is that we don't need to find versions by category or keyword. We only need the data to set the new crate categories/keywords when the "default version" of a crate changes (will be implemented in a follow-up PR, once the data is backfilled in the database).

Related:

- https://github.com/rust-lang/crates.io/issues/953
- https://github.com/rust-lang/crates.io/discussions/7560
- https://github.com/rust-lang/crates.io/pull/9998