### PR TITLE
Inline `Maximums` struct

### DIFF
--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -41,7 +41,7 @@ pub struct Server {
     pub session_key: cookie::Key,
     pub gh_client_id: ClientId,
     pub gh_client_secret: ClientSecret,
-    pub max_upload_size: u64,
+    pub max_upload_size: u32,
     pub max_unpack_size: u64,
     pub max_dependencies: usize,
     pub max_features: usize,

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -147,8 +147,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
 
     let max_upload_size = existing_crate
         .as_ref()
-        .and_then(|c| c.max_upload_size)
-        .and_then(|m| u32::try_from(m).ok())
+        .and_then(|c| c.max_upload_size())
         .unwrap_or(app.config.max_upload_size);
 
     let tarball_bytes = read_tarball_bytes(&mut reader, max_upload_size).await?;

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -152,7 +152,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         app.config.max_unpack_size,
     );
 
-    let tarball_bytes = read_tarball_bytes(&mut reader, maximums.max_upload_size as u32).await?;
+    let tarball_bytes = read_tarball_bytes(&mut reader, maximums.max_upload_size).await?;
     let content_length = tarball_bytes.len() as u64;
 
     let pkg_name = format!("{}-{}", &*metadata.name, &version_string);

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -52,7 +52,7 @@ pub struct Crate {
     pub homepage: Option<String>,
     pub documentation: Option<String>,
     pub repository: Option<String>,
-    pub max_upload_size: Option<i32>,
+    max_upload_size: Option<i32>,
     pub max_features: Option<i16>,
 }
 
@@ -156,6 +156,11 @@ impl<'a> NewCrate<'a> {
 }
 
 impl Crate {
+    pub fn max_upload_size(&self) -> Option<u32> {
+        self.max_upload_size
+            .and_then(|size| u32::try_from(size).ok())
+    }
+
     /// SQL filter based on whether the crate's name loosely matches the given
     /// string.
     ///

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -12,7 +12,7 @@ async fn tarball_between_default_axum_limit_and_max_upload_size() {
     let (app, _, _, token) = TestApp::full()
         .with_config(|config| {
             config.max_upload_size = max_upload_size;
-            config.max_unpack_size = max_upload_size;
+            config.max_unpack_size = max_upload_size as u64;
         })
         .with_token()
         .await;
@@ -65,7 +65,7 @@ async fn tarball_bigger_than_max_upload_size() {
     let (app, _, _, token) = TestApp::full()
         .with_config(|config| {
             config.max_upload_size = max_upload_size;
-            config.max_unpack_size = max_upload_size;
+            config.max_unpack_size = max_upload_size as u64;
         })
         .with_token()
         .await;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,3 @@
-use std::cmp;
-
 pub use self::bytes_request::BytesRequest;
 pub use self::io_util::{read_fill, read_le_u32};
 pub use self::request_helpers::*;
@@ -12,25 +10,3 @@ mod request_helpers;
 pub mod rfc3339;
 pub mod token;
 pub mod tracing;
-
-#[derive(Debug, Copy, Clone)]
-pub struct Maximums {
-    pub max_upload_size: u32,
-    pub max_unpack_size: u64,
-}
-
-impl Maximums {
-    pub fn new(
-        krate_max_upload: Option<i32>,
-        app_max_upload: u32,
-        app_max_unpack: u64,
-    ) -> Maximums {
-        let krate_max_upload = krate_max_upload.and_then(|m| u32::try_from(m).ok());
-        let max_upload_size = krate_max_upload.unwrap_or(app_max_upload);
-        let max_unpack_size = cmp::max(app_max_unpack, max_upload_size as u64);
-        Maximums {
-            max_upload_size,
-            max_unpack_size,
-        }
-    }
-}

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,18 +15,19 @@ pub mod tracing;
 
 #[derive(Debug, Copy, Clone)]
 pub struct Maximums {
-    pub max_upload_size: u64,
+    pub max_upload_size: u32,
     pub max_unpack_size: u64,
 }
 
 impl Maximums {
     pub fn new(
         krate_max_upload: Option<i32>,
-        app_max_upload: u64,
+        app_max_upload: u32,
         app_max_unpack: u64,
     ) -> Maximums {
-        let max_upload_size = krate_max_upload.map(|m| m as u64).unwrap_or(app_max_upload);
-        let max_unpack_size = cmp::max(app_max_unpack, max_upload_size);
+        let krate_max_upload = krate_max_upload.and_then(|m| u32::try_from(m).ok());
+        let max_upload_size = krate_max_upload.unwrap_or(app_max_upload);
+        let max_unpack_size = cmp::max(app_max_unpack, max_upload_size as u64);
         Maximums {
             max_upload_size,
             max_unpack_size,


### PR DESCRIPTION
Encoding this calculation in a `struct` does not seems to have much value since the calculation is only performed in the publish endpoint. Inlining the struct reduces unnecessary complexity and save a couple of lines :)