### PR TITLE
smoke_test: Add "publish with invalid authentication" check

### DIFF
--- a/crates/crates_io_smoke_test/src/main.rs
+++ b/crates/crates_io_smoke_test/src/main.rs
@@ -86,6 +86,7 @@ async fn main() -> anyhow::Result<()> {
             .context("Failed to run `cargo package`")?;
 
         info!("Skipping publish step");
+        new_version = old_version;
     } else {
         info!("Publishing to staging.crates.io…");
         cargo::publish(&project_path, &options.token)


### PR DESCRIPTION
This should check a) if publishing without valid authentication fails and b) if HTTP error codes and messages are successfully received and shown by cargo.

Related:

- https://github.com/rust-lang/crates.io/issues/10098