### PR TITLE
smoke_test: Check failed publish with large payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,6 +1254,7 @@ dependencies = [
  "bytes",
  "clap",
  "crates_io_index",
+ "rand",
  "reqwest 0.12.9",
  "secrecy",
  "semver",

--- a/crates/crates_io_smoke_test/Cargo.toml
+++ b/crates/crates_io_smoke_test/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "=1.0.93"
 bytes = "=1.9.0"
 clap = { version = "=4.5.21", features = ["derive", "env", "unicode", "wrap_help"] }
 crates_io_index = { path = "../crates_io_index" }
+rand = "=0.8.5"
 reqwest = { version = "=0.12.9", features = ["gzip", "json"] }
 secrecy = "=0.10.3"
 semver = { version = "=1.0.23", features = ["serde"] }


### PR DESCRIPTION
The "invalid authentication" check (see #10104) was actually resulting in a false-positive, since the request payload was small enough to not trigger the Cloudfront bug. This commit adjusts the smoke test to generate a 15 MB dummy file which we then try to publish instead.

Related:

- https://github.com/rust-lang/crates.io/issues/10098
- #10104