### PR TITLE
components: don't infer MSRV based on edition

### DIFF
--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -17,19 +17,15 @@
       </span>
     </time>
 
-    {{#if @version.msrv}}
+    {{#if @version.rust_version}}
       <div local-class="msrv" data-test-msrv>
         {{svg-jar "rust"}}
-        <span>
-          v{{@version.msrv}}
-
-          <EmberTooltip>
-            &quot;Minimum Supported Rust Version&quot;
-            {{#if @version.edition}}
-              <div local-class="edition">requires Rust Edition {{@version.edition}}</div>
-            {{/if}}
-          </EmberTooltip>
-        </span>
+        <Msrv @version={{@version}} />
+      </div>
+    {{else if @version.edition}}
+      <div local-class="edition" data-test-edition>
+        {{svg-jar "rust"}}
+        <Edition @version={{@version}} />
       </div>
     {{/if}}
 

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -20,6 +20,7 @@
 
 .date,
 .msrv,
+.edition,
 .license,
 .bytes {
     display: flex;
@@ -34,14 +35,11 @@
 }
 
 .date,
-.msrv {
+.msrv,
+.edition {
     [title], :global(.ember-tooltip-target) {
         cursor: help;
     }
-}
-
-.edition {
-    margin-top: var(--space-2xs);
 }
 
 .license {

--- a/app/components/edition.hbs
+++ b/app/components/edition.hbs
@@ -1,0 +1,14 @@
+<span>
+  {{@version.edition}} edition
+
+  <EmberTooltip>
+    This crate version does not declare a Minimum Supported Rust Version, but
+    does require the {{@version.edition}} Rust Edition.
+
+    <div local-class="edition-msrv">
+      {{@version.editionMsrv}} was the first version of Rust in this edition,
+      but this crate may require features that were added in later versions of
+      Rust.
+    </div>
+  </EmberTooltip>
+</span>

--- a/app/components/edition.module.css
+++ b/app/components/edition.module.css
@@ -1,0 +1,3 @@
+.edition-msrv {
+    margin-top: var(--space-2xs);
+}

--- a/app/components/msrv.hbs
+++ b/app/components/msrv.hbs
@@ -1,0 +1,10 @@
+<span>
+  v{{@version.msrv}}
+
+  <EmberTooltip>
+    &quot;Minimum Supported Rust Version&quot;
+    {{#if @version.edition}}
+      <div local-class="edition">requires Rust Edition {{@version.edition}}</div>
+    {{/if}}
+  </EmberTooltip>
+</span>

--- a/app/components/msrv.module.css
+++ b/app/components/msrv.module.css
@@ -1,0 +1,3 @@
+.edition {
+    margin-top: var(--space-2xs);
+}

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -67,17 +67,15 @@
 
     {{#if (or @version.crate_size @version.license @version.featureList)}}
       <div local-class="metadata-row">
-        {{#if @version.msrv}}
+        {{#if @version.rust_version}}
           <span local-class="msrv">
             {{svg-jar "rust"}}
-            v{{@version.msrv}}
-
-            <EmberTooltip>
-              &quot;Minimum Supported Rust Version&quot;
-              {{#if @version.edition}}
-                <div local-class="edition">requires Rust Edition {{@version.edition}}</div>
-              {{/if}}
-            </EmberTooltip>
+            <Msrv @version={{@version}} />
+          </span>
+        {{else if @version.edition}}
+          <span local-class="edition">
+            {{svg-jar "rust"}}
+            <Edition @version={{@version}} />
           </span>
         {{/if}}
 

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -205,15 +205,13 @@
 
 .msrv {
     text-transform: initial;
+}
 
+.msrv, .edition {
     svg {
         /* this makes the text look a little more aligned with the icon... 🤷 */
         margin-bottom: -0.15em;
     }
-}
-
-.edition {
-    margin-top: var(--space-2xs);
 }
 
 .bytes {

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -50,17 +50,21 @@ export default class Version extends Model {
     return this.belongsTo('crate').id();
   }
 
-  get msrv() {
-    let rustVersion = this.rust_version;
-    if (rustVersion) {
-      // add `.0` suffix if the `rust-version` field only has two version components
-      return /^[^.]+\.[^.]+$/.test(rustVersion) ? `${rustVersion}.0` : rustVersion;
-    } else if (this.edition === '2018') {
+  get editionMsrv() {
+    if (this.edition === '2018') {
       return '1.31.0';
     } else if (this.edition === '2021') {
       return '1.56.0';
     } else if (this.edition === '2024') {
       return '1.85.0';
+    }
+  }
+
+  get msrv() {
+    let rustVersion = this.rust_version;
+    if (rustVersion) {
+      // add `.0` suffix if the `rust-version` field only has two version components
+      return /^[^.]+\.[^.]+$/.test(rustVersion) ? `${rustVersion}.0` : rustVersion;
     }
   }
 

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -32,6 +32,26 @@ module('Model | Version', function (hooks) {
     assert.false(versions[0].isNew);
   });
 
+  test('editionMsrv', async function (assert) {
+    let version = await this.store.createRecord('version');
+    assert.strictEqual(version.editionMsrv, undefined);
+
+    version.edition = '2015';
+    assert.strictEqual(version.editionMsrv, undefined);
+
+    version.edition = '2018';
+    assert.strictEqual(version.editionMsrv, '1.31.0');
+
+    version.edition = '2021';
+    assert.strictEqual(version.editionMsrv, '1.56.0');
+
+    version.edition = '2024';
+    assert.strictEqual(version.editionMsrv, '1.85.0');
+
+    version.edition = '2027';
+    assert.strictEqual(version.editionMsrv, undefined);
+  });
+
   test('msrv', async function (assert) {
     let version = await this.store.createRecord('version');
     assert.strictEqual(version.msrv, undefined);


### PR DESCRIPTION
I assume we'll want to bikeshed the tooltip wording here. I don't know if showing the minimum edition version is actually useful, honestly, but I included it for now for discussion purposes.

Visually, this feels like it works out OK:

|Edition|MSRV|
|-------|-----|
|![image](https://github.com/user-attachments/assets/3c899291-e9c0-4d0d-ad9e-78e99fb67ba1)|![image](https://github.com/user-attachments/assets/c1ea7efa-d8ee-44ba-82b3-9d465ca21e73)|
|![edition](https://github.com/user-attachments/assets/3b8e325c-d62d-4570-8055-76e529791738)|![msrv](https://github.com/user-attachments/assets/32567c24-25e8-4bed-998d-7761783b0121)|

I toyed with using small caps for the "edition" label on the versions list, but it looked weird with the uppercase "features", so I dropped it.

---

In #9996, we started showing the MSRV based on the edition for crate versions that declare an edition but not a `rust-version` in their manifest. This isn't strictly correct: a crate may require features added later in an edition than in the first Rust version that defined that edition, and showing this as an MSRV implies a level of support that the crate author may not have intended.

So, we shouldn't show an MSRV if one isn't declared, but we _can_ show the edition if one of those is defined. Let's do that.

Fixes #10103.