### PR TITLE
tests/acceptance/support-test: Fix QUnit warning

### DIFF
--- a/tests/acceptance/support-test.js
+++ b/tests/acceptance/support-test.js
@@ -45,7 +45,7 @@ module('Acceptance | support', function (hooks) {
     );
   });
 
-  module('reporting a crate from support page', function () {
+  module('reporting a crate from support page', function (hooks) {
     setupWindowMock(hooks);
 
     async function prepare(context, assert) {
@@ -191,7 +191,7 @@ test detail
     });
   });
 
-  module('reporting a crate from crate page', function () {
+  module('reporting a crate from crate page', function (hooks) {
     setupWindowMock(hooks);
 
     async function prepare(context, assert) {


### PR DESCRIPTION
This PR add missing parameter `hooks` to fix warnings
```json
{"type":"warn","text":"The `beforeEach` hook was called inside the wrong module (`Acceptance | support > reporting a crate from support page`). Instead, use hooks provided by the callback to the containing module (`Acceptance | support`). This will become an error in QUnit 3.0."}
{"type":"warn","text":"The `afterEach` hook was called inside the wrong module (`Acceptance | support > reporting a crate from support page`). Instead, use hooks provided by the callback to the containing module (`Acceptance | support`). This will become an error in QUnit 3.0."}
{"type":"warn","text":"The `beforeEach` hook was called inside the wrong module (`Acceptance | support > reporting a crate from crate page`). Instead, use hooks provided by the callback to the containing module (`Acceptance | support`). This will become an error in QUnit 3.0."}
{"type":"warn","text":"The `afterEach` hook was called inside the wrong module (`Acceptance | support > reporting a crate from crate page`). Instead, use hooks provided by the callback to the containing module (`Acceptance | support`). This will become an error in QUnit 3.0."}
```