### PR TITLE
Docker: Remove deprecated `version` attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 x-backend: &backend
   build:
     context: .

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -558,7 +558,6 @@ For example, in order to specify a set of Github OAuth Client credentials, a
 `docker-compose.override.yml` file might look like this:
 
 ```yaml
-version: '3'
 services:
   backend:
     environment:


### PR DESCRIPTION
You can find these warnings when you run docker-compose:
```sh
❯ docker-compose up -d
WARN[0000] /Volumes/t7/code/crates.io/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
WARN[0000] /Volumes/t7/code/crates.io/docker-compose.override.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

See more at: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete