### PR TITLE
ember-data: Fix `ember-data:deprecate-array-like` warning

### DIFF
--- a/app/controllers/categories.js
+++ b/app/controllers/categories.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../utils/pagination';
 
 export default class CategoriesController extends Controller {
@@ -11,11 +9,13 @@ export default class CategoriesController extends Controller {
   @tracked per_page = 100;
   @tracked sort = 'alpha';
 
-  @reads('model.meta.total') totalItems;
-
   @pagination() pagination;
 
   get currentSortBy() {
     return this.sort === 'crates' ? '# Crates' : 'Alphabetical';
+  }
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
   }
 }

--- a/app/controllers/category/index.js
+++ b/app/controllers/category/index.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../../utils/pagination';
 
 export default class CategoryIndexController extends Controller {
@@ -10,8 +8,6 @@ export default class CategoryIndexController extends Controller {
   @tracked page = '1';
   @tracked per_page = 10;
   @tracked sort = 'recent-downloads';
-
-  @reads('model.meta.total') totalItems;
 
   @pagination() pagination;
 
@@ -29,5 +25,9 @@ export default class CategoryIndexController extends Controller {
     } else {
       return 'Recent Downloads';
     }
+  }
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
   }
 }

--- a/app/controllers/crate/reverse-dependencies.js
+++ b/app/controllers/crate/reverse-dependencies.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../../utils/pagination';
 
 export default class ReverseDependenciesController extends Controller {
@@ -11,7 +9,9 @@ export default class ReverseDependenciesController extends Controller {
   @tracked per_page = 10;
   @tracked crate = null;
 
-  @reads('model.meta.total') totalItems;
-
   @pagination() pagination;
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
+  }
 }

--- a/app/controllers/crates.js
+++ b/app/controllers/crates.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../utils/pagination';
 
 export default class CratesController extends Controller {
@@ -11,7 +9,6 @@ export default class CratesController extends Controller {
   @tracked per_page = 50;
   @tracked sort = 'recent-downloads';
 
-  @reads('model.meta.total') totalItems;
   @pagination() pagination;
 
   get currentSortBy() {
@@ -26,5 +23,9 @@ export default class CratesController extends Controller {
     } else {
       return 'Alphabetical';
     }
+  }
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
   }
 }

--- a/app/controllers/keyword.js
+++ b/app/controllers/keyword.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../utils/pagination';
 
 export default class KeywordIndexController extends Controller {
@@ -10,8 +8,6 @@ export default class KeywordIndexController extends Controller {
   @tracked page = '1';
   @tracked per_page = 10;
   @tracked sort = 'recent-downloads';
-
-  @reads('model.crates.meta.total') totalItems;
 
   @pagination() pagination;
 
@@ -27,5 +23,9 @@ export default class KeywordIndexController extends Controller {
     } else {
       return 'Recent Downloads';
     }
+  }
+
+  get totalItems() {
+    return this.model.crates.meta.total ?? 0;
   }
 }

--- a/app/controllers/keywords.js
+++ b/app/controllers/keywords.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../utils/pagination';
 
 export default class KeywordsController extends Controller {
@@ -11,11 +9,13 @@ export default class KeywordsController extends Controller {
   @tracked per_page = 10;
   @tracked sort = 'crates';
 
-  @reads('model.meta.total') totalItems;
-
   @pagination() pagination;
 
   get currentSortBy() {
     return this.sort === 'crates' ? '# Crates' : 'Alphabetical';
+  }
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
   }
 }

--- a/app/controllers/me/crates.js
+++ b/app/controllers/me/crates.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../../utils/pagination';
 
 // TODO: reduce duplicatoin with controllers/crates
@@ -12,8 +10,6 @@ export default class MeCratesController extends Controller {
   @tracked page = '1';
   @tracked per_page = 10;
   @tracked sort = 'alpha';
-
-  @reads('model.meta.total') totalItems;
 
   @pagination() pagination;
 
@@ -29,5 +25,9 @@ export default class MeCratesController extends Controller {
     } else {
       return 'Alphabetical';
     }
+  }
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
   }
 }

--- a/app/controllers/me/following.js
+++ b/app/controllers/me/following.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../../utils/pagination';
 
 // TODO: reduce duplicatoin with controllers/me/crates
@@ -13,11 +11,13 @@ export default class FollowingController extends Controller {
   @tracked per_page = 10;
   @tracked sort = 'alpha';
 
-  @reads('model.meta.total') totalItems;
-
   @pagination() pagination;
 
   get currentSortBy() {
     return this.sort === 'downloads' ? 'Downloads' : 'Alphabetical';
+  }
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
   }
 }

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -29,8 +29,6 @@ export default class SearchController extends Controller {
     return !this.dataTask.lastComplete && this.dataTask.isRunning;
   }
 
-  @reads('model.meta.total') totalItems;
-
   @pagination() pagination;
 
   get pageTitle() {
@@ -75,4 +73,8 @@ export default class SearchController extends Controller {
 
     return await this.store.query('crate', searchOptions);
   });
+
+  get totalItems() {
+    return this.model.meta.total ?? 0;
+  }
 }

--- a/app/controllers/team.js
+++ b/app/controllers/team.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../utils/pagination';
 
 export default class TeamController extends Controller {
@@ -10,8 +8,6 @@ export default class TeamController extends Controller {
   @tracked page = '1';
   @tracked per_page = 10;
   @tracked sort = 'alpha';
-
-  @reads('model.crates.meta.total') totalItems;
 
   @pagination() pagination;
 
@@ -27,5 +23,9 @@ export default class TeamController extends Controller {
     } else {
       return 'Alphabetical';
     }
+  }
+
+  get totalItems() {
+    return this.model.crates.meta.total ?? 0;
   }
 }

--- a/app/controllers/user.js
+++ b/app/controllers/user.js
@@ -1,8 +1,6 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 
-import { reads } from 'macro-decorators';
-
 import { pagination } from '../utils/pagination';
 
 // TODO: reduce duplication with controllers/crates
@@ -12,8 +10,6 @@ export default class UserController extends Controller {
   @tracked page = '1';
   @tracked per_page = 10;
   @tracked sort = 'alpha';
-
-  @reads('model.crates.meta.total') totalItems;
 
   @pagination() pagination;
 
@@ -29,5 +25,9 @@ export default class UserController extends Controller {
     } else {
       return 'Alphabetical';
     }
+  }
+
+  get totalItems() {
+    return this.model.crates.meta.total ?? 0;
   }
 }


### PR DESCRIPTION
Since the underlying implementation of `@reads` uses `.get()`, which introduces deprecation warnings `deprecation id: ember-data:deprecate-array-like`, this commit fixes the warning by rewriting the `@reads('some.deep.path')` to equivalent `@cached get function ()`.

This should hopefully resolve some deprecation warnings similar to the following:
```log
{"type":"warn","text":"DEPRECATION: The EmberObject get method on the class RecordArray is deprecated. Use dot-notation javascript get/set access instead. [deprecation id: ember-data:deprecate-array-like] This will be removed in ember-data 5.0.\n        at logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:712:308)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at raiseOnDeprecation (http://localhost:7357/assets/vendor.js:715:210)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at eval (webpack://crates-io/../../.pnpm/@ember+test-helpers@4.0.4_@babel+core@7.26.0_ember-source@6.0.1_@glimmer+component@2.0.0_rsvp@4.8.5_webpack@5.97.1_/node_modules/@ember/test-helpers/dist/setup-context-Cx9HkMuO.js?:560:8)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at invoke (http://localhost:7357/assets/vendor.js:667:501)\n        at deprecate (http://localhost:7357/assets/vendor.js:772:442)\n        at deprecate$1 (http://localhost:7357/assets/vendor.js:968:335)"}
```