### PR TITLE
UI: Implement `/crates/:name/delete` route

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -3,6 +3,12 @@ import RESTAdapter from '@ember-data/adapter/rest';
 export default class ApplicationAdapter extends RESTAdapter {
   namespace = 'api/v1';
 
+  isInvalid() {
+    // HTTP 422 errors are causing all sorts of issues within Ember Data,
+    // so we disable their special case handling here, since we don't need/want it.
+    return false;
+  }
+
   handleResponse(status, headers, payload, requestData) {
     if (typeof payload === 'string') {
       try {

--- a/app/controllers/crate/delete.js
+++ b/app/controllers/crate/delete.js
@@ -1,0 +1,32 @@
+import Controller from '@ember/controller';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+import { task } from 'ember-concurrency';
+
+export default class CrateSettingsController extends Controller {
+  @service notifications;
+  @service router;
+
+  @tracked isConfirmed;
+
+  @action toggleConfirmation() {
+    this.isConfirmed = !this.isConfirmed;
+  }
+
+  deleteTask = task(async () => {
+    try {
+      await this.model.destroyRecord();
+      this.notifications.success(`Crate ${this.model.name} has been successfully deleted.`);
+      this.router.transitionTo('index');
+    } catch (error) {
+      let detail = error.errors?.[0]?.detail;
+      if (detail && !detail.startsWith('{')) {
+        this.notifications.error(`Failed to delete crate: ${detail}`);
+      } else {
+        this.notifications.error('Failed to delete crate');
+      }
+    }
+  });
+}

--- a/app/router.js
+++ b/app/router.js
@@ -20,6 +20,7 @@ Router.map(function () {
 
     this.route('owners');
     this.route('settings');
+    this.route('delete');
 
     // Well-known routes
     this.route('docs');

--- a/app/routes/crate/delete.js
+++ b/app/routes/crate/delete.js
@@ -1,0 +1,25 @@
+import { inject as service } from '@ember/service';
+
+import AuthenticatedRoute from '../-authenticated-route';
+
+export default class SettingsRoute extends AuthenticatedRoute {
+  @service router;
+  @service session;
+
+  async afterModel(crate, transition) {
+    let user = this.session.currentUser;
+    let owners = await crate.owner_user;
+    let isOwner = owners.some(owner => owner.id === user.id);
+    if (!isOwner) {
+      this.router.replaceWith('catch-all', {
+        transition,
+        title: 'This page is only accessible by crate owners',
+      });
+    }
+  }
+
+  setupController(controller) {
+    super.setupController(...arguments);
+    controller.set('isConfirmed', false);
+  }
+}

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -18,8 +18,10 @@
     --orange-800: #9a3412;
     --orange-900: #7c2d12;
 
+    --yellow100: hsl(44, 100%, 90%);
     --yellow500: hsl(44, 100%, 60%);
     --yellow700: hsl(44, 67%, 50%);
+    --yellow800: hsl(44, 67%, 20%);
 
     --header-bg-color: light-dark(hsl(115, 31%, 20%), #141413);
 

--- a/app/styles/crate/delete.module.css
+++ b/app/styles/crate/delete.module.css
@@ -1,0 +1,86 @@
+.wrapper {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    place-items: center;
+    margin: var(--space-s);
+}
+
+.content {
+    max-width: 100%;
+    overflow-wrap: break-word;
+}
+
+.title {
+    margin-top: 0;
+}
+
+.warning-block {
+    background: light-dark(var(--yellow100), var(--yellow800));
+    border-color: var(--yellow500);
+    border-left-style: solid;
+    border-left-width: 4px;
+    border-top-right-radius: var(--space-3xs);
+    border-bottom-right-radius: var(--space-3xs);
+    padding: var(--space-xs);
+}
+
+.warning {
+    composes: warning-block;
+    display: flex;
+
+    svg {
+        flex-shrink: 0;
+        width: 1em;
+        height: 1em;
+        color: var(--yellow500);
+    }
+
+    p {
+        margin: 0 0 0 var(--space-xs);
+        text-wrap: pretty;
+    }
+}
+
+.impact, .requirements {
+    li {
+        margin-bottom: var(--space-2xs);
+    }
+}
+
+.requirements {
+    ul {
+        list-style: none;
+        padding-left: 0;
+    }
+}
+
+.confirmation {
+    composes: warning-block;
+    display: block;
+
+    input {
+        margin-right: var(--space-3xs);
+    }
+}
+
+.actions {
+    margin-top: var(--space-m);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.delete-button {
+    composes: red-button from '../shared/buttons.module.css';
+}
+
+.spinner-wrapper {
+    position: relative;
+}
+
+.spinner {
+    position: absolute;
+    --spinner-size: 1.5em;
+    top: calc(-.5 * var(--spinner-size));
+    margin-left: var(--space-xs);
+}

--- a/app/templates/crate/delete.hbs
+++ b/app/templates/crate/delete.hbs
@@ -1,0 +1,64 @@
+<div local-class="wrapper">
+  <div local-class="content">
+    <h1 local-class="title" data-test-title>Delete the {{@model.name}} crate?</h1>
+
+    <p>Are you sure you want to delete the crate "{{@model.name}}"?</p>
+
+    <div local-class="warning">
+      {{svg-jar "triangle-exclamation"}}
+      <p><strong>Important:</strong> This action will permanently delete the crate and its associated versions. Deleting a crate cannot be reversed!</p>
+    </div>
+
+    <div local-class="impact">
+      <h3>Potential Impact:</h3>
+      <ul>
+        <li>Users will no longer be able to download this crate.</li>
+        <li>Any dependencies or projects relying on this crate will be broken.</li>
+        <li>Deleted crates cannot be restored.</li>
+      </ul>
+    </div>
+
+    <div local-class="requirements">
+      <h3>Requirements:</h3>
+      <p>A crate can only be deleted if:</p>
+      <ol>
+        <li>the crate has been published for less than 72 hours, or</li>
+        <li>
+          <ul>
+            <li>the crate only has a single owner, and</li>
+            <li>the crate has been downloaded less than 100 times for each month it has been published, and</li>
+            <li>the crate is not depended upon by any other crate on crates.io.</li>
+          </ul>
+        </li>
+      </ol>
+    </div>
+
+    <label local-class="confirmation">
+      <Input
+        @type="checkbox"
+        @checked={{this.isConfirmed}}
+        disabled={{this.deleteTask.isRunning}}
+        data-test-confirmation-checkbox
+        {{on "change" this.toggleConfirmation}}
+      />
+      I understand that deleting this crate is permanent and cannot be undone.
+    </label>
+
+    <div local-class="actions">
+      <button
+        type="submit"
+        disabled={{or (not this.isConfirmed) this.deleteTask.isRunning}}
+        local-class="delete-button"
+        data-test-delete-button
+        {{on "click" (perform this.deleteTask)}}
+      >
+        Delete this crate
+      </button>
+      {{#if this.deleteTask.isRunning}}
+        <div local-class="spinner-wrapper">
+          <LoadingSpinner local-class="spinner" data-test-spinner />
+        </div>
+      {{/if}}
+    </div>
+  </div>
+</div>

--- a/e2e/routes/crate/delete.spec.ts
+++ b/e2e/routes/crate/delete.spec.ts
@@ -1,0 +1,100 @@
+import { expect, test } from '@/e2e/helper';
+
+test.describe('Route: crate.delete', { tag: '@routes' }, () => {
+  async function prepare({ mirage }) {
+    await mirage.addHook(server => {
+      let user = server.create('user');
+
+      let crate = server.create('crate', { name: 'foo' });
+      server.create('version', { crate });
+      server.create('crate-ownership', { crate, user });
+
+      authenticateAs(user);
+    });
+  }
+
+  test('unauthenticated', async ({ mirage, page }) => {
+    await mirage.addHook(server => {
+      let crate = server.create('crate', { name: 'foo' });
+      server.create('version', { crate });
+    });
+
+    await page.goto('/crates/foo/delete');
+    await expect(page).toHaveURL('/crates/foo/delete');
+    await expect(page.locator('[data-test-title]')).toHaveText('This page requires authentication');
+    await expect(page.locator('[data-test-login]')).toBeVisible();
+  });
+
+  test('not an owner', async ({ mirage, page }) => {
+    await mirage.addHook(server => {
+      let user1 = server.create('user');
+      authenticateAs(user1);
+
+      let user2 = server.create('user');
+      let crate = server.create('crate', { name: 'foo' });
+      server.create('version', { crate });
+      server.create('crate-ownership', { crate, user: user2 });
+    });
+
+    await page.goto('/crates/foo/delete');
+    await expect(page).toHaveURL('/crates/foo/delete');
+    await expect(page.locator('[data-test-title]')).toHaveText('This page is only accessible by crate owners');
+    await expect(page.locator('[data-test-go-back]')).toBeVisible();
+  });
+
+  test('happy path', async ({ mirage, page, percy }) => {
+    await prepare({ mirage });
+
+    await page.goto('/crates/foo/delete');
+    await expect(page).toHaveURL('/crates/foo/delete');
+    await expect(page.locator('[data-test-title]')).toHaveText('Delete the foo crate?');
+    await percy.snapshot();
+
+    await expect(page.locator('[data-test-delete-button]')).toBeDisabled();
+    await page.click('[data-test-confirmation-checkbox]');
+    await expect(page.locator('[data-test-delete-button]')).toBeEnabled();
+    await page.click('[data-test-delete-button]');
+
+    await expect(page).toHaveURL('/');
+
+    let message = 'Crate foo has been successfully deleted.';
+    await expect(page.locator('[data-test-notification-message="success"]')).toHaveText(message);
+
+    let crate = await page.evaluate(() => server.schema.crates.findBy({ name: 'foo' }));
+    expect(crate).toBeNull();
+  });
+
+  test('loading state', async ({ page, mirage }) => {
+    await prepare({ mirage });
+    await mirage.addHook(server => {
+      globalThis.deferred = require('rsvp').defer();
+      server.delete('/api/v1/crates/foo', () => globalThis.deferred.promise);
+    });
+
+    await page.goto('/crates/foo/delete');
+    await page.click('[data-test-confirmation-checkbox]');
+    await page.click('[data-test-delete-button]');
+    await expect(page.locator('[data-test-spinner]')).toBeVisible();
+    await expect(page.locator('[data-test-confirmation-checkbox]')).toBeDisabled();
+    await expect(page.locator('[data-test-delete-button]')).toBeDisabled();
+
+    await page.evaluate(async () => globalThis.deferred.resolve());
+    await expect(page).toHaveURL('/');
+  });
+
+  test('error state', async ({ page, mirage }) => {
+    await prepare({ mirage });
+    await mirage.addHook(server => {
+      let payload = { errors: [{ detail: 'only crates without reverse dependencies can be deleted after 72 hours' }] };
+      server.delete('/api/v1/crates/foo', payload, 422);
+    });
+
+    await page.goto('/crates/foo/delete');
+    await page.click('[data-test-confirmation-checkbox]');
+    await page.click('[data-test-delete-button]');
+    await expect(page).toHaveURL('/crates/foo/delete');
+
+    let message = 'Failed to delete crate: only crates without reverse dependencies can be deleted after 72 hours';
+    await expect(page.locator('[data-test-notification-message="error"]')).toHaveText(message);
+  });
+});

--- a/public/assets/triangle-exclamation.svg
+++ b/public/assets/triangle-exclamation.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <!--!Font Awesome Free 6.7.1 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.-->
+    <path d="M256 32c14.2 0 27.3 7.5 34.5 19.8l216 368c7.3 12.4 7.3 27.7 .2 40.1S486.3 480 472 480L40 480c-14.3 0-27.6-7.7-34.7-20.1s-7-27.8 .2-40.1l216-368C228.7 39.5 241.8 32 256 32zm0 128c-13.3 0-24 10.7-24 24l0 112c0 13.3 10.7 24 24 24s24-10.7 24-24l0-112c0-13.3-10.7-24-24-24zm32 224a32 32 0 1 0 -64 0 32 32 0 1 0 64 0z" fill="currentColor"/>
+</svg>

--- a/tests/routes/crate/delete-test.js
+++ b/tests/routes/crate/delete-test.js
@@ -1,0 +1,108 @@
+import { click, currentURL, waitFor } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { defer } from 'rsvp';
+
+import percySnapshot from '@percy/ember';
+import { Response } from 'miragejs';
+
+import { setupApplicationTest } from 'crates-io/tests/helpers';
+
+import { visit } from '../../helpers/visit-ignoring-abort';
+
+module('Route: crate.delete', function (hooks) {
+  setupApplicationTest(hooks);
+
+  function prepare(context) {
+    let user = context.server.create('user');
+
+    let crate = context.server.create('crate', { name: 'foo' });
+    context.server.create('version', { crate });
+    context.server.create('crate-ownership', { crate, user });
+
+    context.authenticateAs(user);
+
+    return { user };
+  }
+
+  test('unauthenticated', async function (assert) {
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate });
+
+    await visit('/crates/foo/delete');
+    assert.strictEqual(currentURL(), '/crates/foo/delete');
+    assert.dom('[data-test-title]').hasText('This page requires authentication');
+    assert.dom('[data-test-login]').exists();
+  });
+
+  test('not an owner', async function (assert) {
+    let user1 = this.server.create('user');
+    this.authenticateAs(user1);
+
+    let user2 = this.server.create('user');
+    let crate = this.server.create('crate', { name: 'foo' });
+    this.server.create('version', { crate });
+    this.server.create('crate-ownership', { crate, user: user2 });
+
+    await visit('/crates/foo/delete');
+    assert.strictEqual(currentURL(), '/crates/foo/delete');
+    assert.dom('[data-test-title]').hasText('This page is only accessible by crate owners');
+    assert.dom('[data-test-go-back]').exists();
+  });
+
+  test('happy path', async function (assert) {
+    prepare(this);
+
+    await visit('/crates/foo/delete');
+    assert.strictEqual(currentURL(), '/crates/foo/delete');
+    assert.dom('[data-test-title]').hasText('Delete the foo crate?');
+    await percySnapshot(assert);
+
+    assert.dom('[data-test-delete-button]').isDisabled();
+    await click('[data-test-confirmation-checkbox]');
+    assert.dom('[data-test-delete-button]').isEnabled();
+    await click('[data-test-delete-button]');
+
+    assert.strictEqual(currentURL(), '/');
+
+    let message = 'Crate foo has been successfully deleted.';
+    assert.dom('[data-test-notification-message="success"]').hasText(message);
+
+    let crate = this.server.schema.crates.findBy({ name: 'foo' });
+    assert.strictEqual(crate, null);
+  });
+
+  test('loading state', async function (assert) {
+    prepare(this);
+
+    let deferred = defer();
+    this.server.delete('/api/v1/crates/foo', deferred.promise);
+
+    await visit('/crates/foo/delete');
+    await click('[data-test-confirmation-checkbox]');
+    let clickPromise = click('[data-test-delete-button]');
+    await waitFor('[data-test-spinner]');
+    assert.dom('[data-test-confirmation-checkbox]').isDisabled();
+    assert.dom('[data-test-delete-button]').isDisabled();
+
+    deferred.resolve(new Response(204));
+    await clickPromise;
+
+    assert.strictEqual(currentURL(), '/');
+  });
+
+  test('error state', async function (assert) {
+    prepare(this);
+
+    let payload = { errors: [{ detail: 'only crates without reverse dependencies can be deleted after 72 hours' }] };
+    this.server.delete('/api/v1/crates/foo', payload, 422);
+
+    await visit('/crates/foo/delete');
+    await click('[data-test-confirmation-checkbox]');
+    await click('[data-test-delete-button]');
+    assert.strictEqual(currentURL(), '/crates/foo/delete');
+
+    let message = 'Failed to delete crate: only crates without reverse dependencies can be deleted after 72 hours';
+    assert.dom('[data-test-notification-message="error"]').hasText(message);
+  });
+});


### PR DESCRIPTION
This partially implements step 2 of https://github.com/rust-lang/crates.io/issues/9352. The missing piece after this PR is a "Delete" button in the crate settings tab, since the new route is currently only reachable by typing it directly in the URL bar. I opted for this hidden route for now to be able to test it out first before making it more public.

Related: 
- https://github.com/rust-lang/crates.io/issues/9352

### Screenshots

![Screen Shot 2024-12-09 at 15 58 28](https://github.com/user-attachments/assets/3d2bc6a1-6ae1-45dc-9977-59329121d715)
![Screen Shot 2024-12-09 at 15 57 41](https://github.com/user-attachments/assets/59a975de-927c-4970-9165-ea6e554ed74d)

