### PR TITLE
styles/buttons: Fix font color in disabled state

### DIFF
--- a/app/styles/shared/buttons.module.css
+++ b/app/styles/shared/buttons.module.css
@@ -54,7 +54,7 @@
 
     &[disabled] {
         background: linear-gradient(to bottom, var(--bg-color-top-light) 0%, var(--bg-color-bottom-light) 100%);
-        color: var(--disabled-text-color);
+        color: var(--disabled-text-color) !important;
     }
 }
 


### PR DESCRIPTION
9bbea928ba2c66247fa64e6474f371ac3d57d48c introduced an `important!` marker, but missed that this was somewhat incompatible with the disabled state. This commit fixes it by also using `important!` for the disabled state. Clearly not a good long-term strategy, but good enough for now... If someone want to contribute a better fix, I'm open to it 😉 