### PR TITLE
crate-header: Fix deprecation warnings

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -24,9 +24,9 @@
     </div>
   {{/if}}
 
-  {{#if @crate.keywords}}
+  {{#if this.keywords}}
     <ul local-class="keywords">
-      {{#each @crate.keywords as |keyword|}}
+      {{#each this.keywords as |keyword|}}
         <li>
           <LinkTo @route="keyword" @model={{keyword.id}} data-test-keyword={{keyword.id}}>
             <span local-class="hash">#</span>{{keyword.id}}

--- a/app/components/crate-header.js
+++ b/app/components/crate-header.js
@@ -1,10 +1,27 @@
 import { inject as service } from '@ember/service';
 import Component from '@glimmer/component';
 
+import { task } from 'ember-concurrency';
+import { alias } from 'macro-decorators';
+
 export default class CrateHeader extends Component {
   @service session;
+
+  @alias('loadKeywordsTask.last.value') keywords;
+
+  constructor() {
+    super(...arguments);
+
+    this.loadKeywordsTask.perform().catch(() => {
+      // ignore all errors and just don't display keywords if the request fails
+    });
+  }
 
   get isOwner() {
     return this.args.crate.owner_user.findBy('id', this.session.currentUser?.id);
   }
+
+  loadKeywordsTask = task(async () => {
+    return (await this.args.crate?.keywords) ?? [];
+  });
 }

--- a/app/components/crate-header.js
+++ b/app/components/crate-header.js
@@ -8,6 +8,7 @@ export default class CrateHeader extends Component {
   @service session;
 
   @alias('loadKeywordsTask.last.value') keywords;
+  @alias('loadOwnerUserTask.last.value') ownerUser;
 
   constructor() {
     super(...arguments);
@@ -15,13 +16,22 @@ export default class CrateHeader extends Component {
     this.loadKeywordsTask.perform().catch(() => {
       // ignore all errors and just don't display keywords if the request fails
     });
+    this.loadOwnerUserTask.perform().catch(() => {
+      // ignore all errors and just don't display settings if the request fails
+    });
   }
 
   get isOwner() {
-    return this.args.crate.owner_user.findBy('id', this.session.currentUser?.id);
+    let ownerUser = this.ownerUser ?? [];
+    let currentUserId = this.session.currentUser?.id;
+    return ownerUser.some(({ id }) => id === currentUserId);
   }
 
   loadKeywordsTask = task(async () => {
     return (await this.args.crate?.keywords) ?? [];
+  });
+
+  loadOwnerUserTask = task(async () => {
+    return (await this.args.crate?.owner_user) ?? [];
   });
 }


### PR DESCRIPTION
This PR addresses deprecation warnings by explicitly loading async values (`crate.keywords`, `crate.owner_user`) using tasks.

This should hopefully resolve some deprecation warnings similar to the following:
```
{"type":"warn","text":"DEPRECATION: Do not use A() on an EmberData PromiseManyArray [deprecation id: ember-data:no-a-with-array-like] This will be removed in ember-data 5.0.\n        at logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:712:308)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at raiseOnDeprecation (http://localhost:7357/assets/vendor.js:715:210)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at eval (webpack://crates-io/../../.pnpm/@ember+test-helpers@4.0.4_@babel+core@7.26.0_ember-source@6.0.1_@glimmer+component@2.0.0_rsvp@4.8.5_webpack@5.97.1_/node_modules/@ember/test-helpers/dist/setup-context-Cx9HkMuO.js?:560:8)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at invoke (http://localhost:7357/assets/vendor.js:667:501)\n        at deprecate (http://localhost:7357/assets/vendor.js:772:442)\n        at deprecate$1 (http://localhost:7357/assets/vendor.js:968:335)"}
{"type":"warn","text":"DEPRECATION: The findBy method on ember-data's PromiseManyArray is deprecated. await the promise and work with the ManyArray directly. [deprecation id: ember-data:deprecate-promise-many-array-behaviors] This will be removed in ember-data 5.0.\n        at logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:712:308)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at raiseOnDeprecation (http://localhost:7357/assets/vendor.js:715:210)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at eval (webpack://crates-io/../../.pnpm/@ember+test-helpers@4.0.4_@babel+core@7.26.0_ember-source@6.0.1_@glimmer+component@2.0.0_rsvp@4.8.5_webpack@5.97.1_/node_modules/@ember/test-helpers/dist/setup-context-Cx9HkMuO.js?:560:8)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at invoke (http://localhost:7357/assets/vendor.js:667:501)\n        at deprecate (http://localhost:7357/assets/vendor.js:772:442)\n        at deprecate$1 (http://localhost:7357/assets/vendor.js:968:335)"}
{"type":"warn","text":"DEPRECATION: The `findBy` method on the class ManyArray is deprecated. Use the native array method `find` instead. [deprecation id: ember-data:deprecate-array-like] This will be removed in ember-data 5.0.\n        at logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:712:308)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at raiseOnDeprecation (http://localhost:7357/assets/vendor.js:715:210)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at eval (webpack://crates-io/../../.pnpm/@ember+test-helpers@4.0.4_@babel+core@7.26.0_ember-source@6.0.1_@glimmer+component@2.0.0_rsvp@4.8.5_webpack@5.97.1_/node_modules/@ember/test-helpers/dist/setup-context-Cx9HkMuO.js?:560:8)\n        at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:667:339)\n        at invoke (http://localhost:7357/assets/vendor.js:667:501)\n        at deprecate (http://localhost:7357/assets/vendor.js:772:442)\n        at deprecate$1 (http://localhost:7357/assets/vendor.js:968:335)"}
```