### PR TITLE
Use `utoipa` crates to generate and serve basic OpenAPI description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1125,6 +1125,8 @@ dependencies = [
  "typomania",
  "unicode-xid",
  "url",
+ "utoipa",
+ "utoipa-axum",
  "zip",
 ]
 
@@ -5570,6 +5572,42 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514a48569e4e21c86d0b84b5612b5e73c0b2cf09db63260134ba426d4e8ea714"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-axum"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1370cc4a8eee751c4d2a729566d83d1568212320a20581c7c72c2d76ab80ed37"
+dependencies = [
+ "axum",
+ "paste",
+ "tower-layer",
+ "tower-service",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5629efe65599d0ccd5d493688cbf6e03aa7c1da07fe59ff97cf5977ed0637f66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,8 @@ tracing-subscriber = { version = "=0.3.19", features = ["env-filter", "json"] }
 typomania = { version = "=0.1.2", default-features = false }
 url = "=2.5.4"
 unicode-xid = "=0.2.6"
+utoipa = "=5.2.0"
+utoipa-axum = "=0.1.2"
 
 [dev-dependencies]
 bytes = "=1.9.0"

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -24,28 +24,35 @@ use crate::models::krate::ALL_COLUMNS;
 use crate::sql::{array_agg, canon_crate_name, lower};
 use crate::util::RequestUtils;
 
-/// Handles the `GET /crates` route.
-/// Returns a list of crates. Called in a variety of scenarios in the
-/// front end, including:
+/// Returns a list of crates.
+///
+/// Called in a variety of scenarios in the front end, including:
 /// - Alphabetical listing of crates
 /// - List of crates under a specific owner
 /// - Listing a user's followed crates
-///
-/// Notes:
-/// The different use cases this function covers is handled through passing
-/// in parameters in the GET request.
-///
-/// We would like to stop adding functionality in here. It was built like
-/// this to keep the number of database queries low, though given Rust's
-/// low performance overhead, this is a soft goal to have, and can afford
-/// more database transactions if it aids understandability.
-///
-/// All of the edge cases for this function are not currently covered
-/// in testing, and if they fail, it is difficult to determine what
-/// caused the break. In the future, we should look at splitting this
-/// function out to cover the different use cases, and create unit tests
-/// for them.
+#[utoipa::path(
+    get,
+    path = "/api/v1/crates",
+    operation_id = "crates_list",
+    tag = "crates",
+    responses((status = 200, description = "Successful Response")),
+)]
 pub async fn search(app: AppState, req: Parts) -> AppResult<ErasedJson> {
+    // Notes:
+    // The different use cases this function covers is handled through passing
+    // in parameters in the GET request.
+    //
+    // We would like to stop adding functionality in here. It was built like
+    // this to keep the number of database queries low, though given Rust's
+    // low performance overhead, this is a soft goal to have, and can afford
+    // more database transactions if it aids understandability.
+    //
+    // All of the edge cases for this function are not currently covered
+    // in testing, and if they fail, it is difficult to determine what
+    // caused the break. In the future, we should look at splitting this
+    // function out to cover the different use cases, and create unit tests
+    // for them.
+
     let mut conn = app.db_read().await?;
 
     use diesel::sql_types::Float;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ mod licenses;
 pub mod metrics;
 pub mod middleware;
 pub mod models;
+pub mod openapi;
 pub mod rate_limiter;
 mod real_ip;
 mod router;

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,0 +1,30 @@
+use utoipa::OpenApi;
+use utoipa_axum::router::OpenApiRouter;
+
+#[derive(OpenApi)]
+pub struct BaseOpenApi;
+
+impl BaseOpenApi {
+    pub fn router<S>() -> OpenApiRouter<S>
+    where
+        S: Send + Sync + Clone + 'static,
+    {
+        OpenApiRouter::with_openapi(Self::openapi())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::util::{RequestHelper, TestApp};
+    use http::StatusCode;
+    use insta::assert_json_snapshot;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_openapi_snapshot() {
+        let (_app, anon) = TestApp::init().empty().await;
+
+        let response = anon.get::<()>("/api/openapi.json").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_json_snapshot!(response.json());
+    }
+}

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -2,14 +2,20 @@ use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 
 #[derive(OpenApi)]
-#[openapi(info(
-    title = "crates.io",
-    description = "API documentation for the [crates.io](https://crates.io/) package registry",
-    terms_of_service = "https://crates.io/policies",
-    contact(name = "the crates.io team", email = "help@crates.io"),
-    license(),
-    version = "0.0.0",
-))]
+#[openapi(
+    info(
+        title = "crates.io",
+        description = "API documentation for the [crates.io](https://crates.io/) package registry",
+        terms_of_service = "https://crates.io/policies",
+        contact(name = "the crates.io team", email = "help@crates.io"),
+        license(),
+        version = "0.0.0",
+    ),
+    servers(
+        (url = "https://crates.io"),
+        (url = "https://staging.crates.io"),
+    ),
+)]
 pub struct BaseOpenApi;
 
 impl BaseOpenApi {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -2,6 +2,14 @@ use utoipa::OpenApi;
 use utoipa_axum::router::OpenApiRouter;
 
 #[derive(OpenApi)]
+#[openapi(info(
+    title = "crates.io",
+    description = "API documentation for the [crates.io](https://crates.io/) package registry",
+    terms_of_service = "https://crates.io/policies",
+    contact(name = "the crates.io team", email = "help@crates.io"),
+    license(),
+    version = "0.0.0",
+))]
 pub struct BaseOpenApi;
 
 impl BaseOpenApi {

--- a/src/router.rs
+++ b/src/router.rs
@@ -3,6 +3,7 @@ use axum::response::IntoResponse;
 use axum::routing::{delete, get, post, put};
 use axum::{Json, Router};
 use http::{Method, StatusCode};
+use utoipa_axum::routes;
 
 use crate::app::AppState;
 use crate::controllers::user::update_user;
@@ -14,11 +15,14 @@ use crate::Env;
 const MAX_PUBLISH_CONTENT_LENGTH: usize = 128 * 1024 * 1024; // 128 MB
 
 pub fn build_axum_router(state: AppState) -> Router<()> {
-    let (router, openapi) = BaseOpenApi::router().split_for_parts();
+    let (router, openapi) = BaseOpenApi::router()
+        .routes(routes!(
+            // Route used by both `cargo search` and the frontend
+            krate::search::search
+        ))
+        .split_for_parts();
 
     let mut router = router
-        // Route used by both `cargo search` and the frontend
-        .route("/api/v1/crates", get(krate::search::search))
         // Routes used by `cargo`
         .route(
             "/api/v1/crates/new",

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -7,14 +7,15 @@ snapshot_kind: text
   "components": {},
   "info": {
     "contact": {
-      "email": "alex@alexcrichton.com",
-      "name": "Alex Crichton"
+      "email": "help@crates.io",
+      "name": "the crates.io team"
     },
-    "description": "Backend of crates.io",
+    "description": "API documentation for the [crates.io](https://crates.io/) package registry",
     "license": {
-      "name": "MIT OR Apache-2.0"
+      "name": ""
     },
-    "title": "crates_io",
+    "termsOfService": "https://crates.io/policies",
+    "title": "crates.io",
     "version": "0.0.0"
   },
   "openapi": "3.1.0",

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -19,5 +19,13 @@ snapshot_kind: text
     "version": "0.0.0"
   },
   "openapi": "3.1.0",
-  "paths": {}
+  "paths": {},
+  "servers": [
+    {
+      "url": "https://crates.io"
+    },
+    {
+      "url": "https://staging.crates.io"
+    }
+  ]
 }

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1,0 +1,22 @@
+---
+source: src/openapi.rs
+expression: response.json()
+snapshot_kind: text
+---
+{
+  "components": {},
+  "info": {
+    "contact": {
+      "email": "alex@alexcrichton.com",
+      "name": "Alex Crichton"
+    },
+    "description": "Backend of crates.io",
+    "license": {
+      "name": "MIT OR Apache-2.0"
+    },
+    "title": "crates_io",
+    "version": "0.0.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {}
+}

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -19,7 +19,23 @@ snapshot_kind: text
     "version": "0.0.0"
   },
   "openapi": "3.1.0",
-  "paths": {},
+  "paths": {
+    "/api/v1/crates": {
+      "get": {
+        "description": "Called in a variety of scenarios in the front end, including:\n- Alphabetical listing of crates\n- List of crates under a specific owner\n- Listing a user's followed crates",
+        "operationId": "crates_list",
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Returns a list of crates.",
+        "tags": [
+          "crates"
+        ]
+      }
+    }
+  },
   "servers": [
     {
       "url": "https://crates.io"


### PR DESCRIPTION
![Bildschirmfoto 2024-12-11 um 16 47 05](https://github.com/user-attachments/assets/0c02ab7d-bfa1-4a46-807f-06a94a219140)

This PR implements the basic infrastructure to have an **experimental**, best-effort, automatically generated OpenAPI description for the crates.io API. The OpenAPI description will be available at https://crates.io/api/openaip.json, with a viewer available at https://crates.io/api/openaip.

Due to the viewer being on the same domain as the Ember.js frontend, it will automatically share the cookie authentication, which may or may not be a problem. We could alternatively consider serving the viewer from a different subdomain if this turns out to be problematic.

Note that this PR only migrates a single route for now to prove the viability of this approach. The remaining routes can be migrated incrementally.

Related:

- https://github.com/rust-lang/crates.io/issues/741