### PR TITLE
Fix pagination field generation for duplicate keys

### DIFF
--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -664,12 +664,8 @@ async fn multiple_ids() -> anyhow::Result<()> {
         .expect_build(&mut conn)
         .await;
 
-    for json in search_both(
-        &anon,
-        "ids%5B%5D=foo&ids%5B%5D=bar&ids%5B%5D=baz&ids%5B%5D=baz&ids%5B%5D=unknown",
-    )
-    .await
-    {
+    let query = "ids[]=foo&ids[]=bar&ids[]=baz&ids[]=baz&ids[]=unknown";
+    for json in search_both(&anon, query).await {
         assert_eq!(json.meta.total, 3);
         assert_eq!(json.crates[0].name, "bar");
         assert_eq!(json.crates[1].name, "baz");

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -672,6 +672,13 @@ async fn multiple_ids() -> anyhow::Result<()> {
         assert_eq!(json.crates[2].name, "foo");
     }
 
+    let response = anon.search(&format!("{query}&per_page=1&page=2")).await;
+    assert_snapshot!(response.meta.prev_page.unwrap(), @"?ids%5B%5D=unknown&per_page=1&page=1");
+    assert_snapshot!(response.meta.next_page.unwrap(), @"?ids%5B%5D=unknown&per_page=1&page=3");
+
+    let response = anon.search(&format!("{query}&per_page=1")).await;
+    assert_snapshot!(response.meta.next_page.unwrap(), @"?ids%5B%5D=unknown&per_page=1&seek=Mg");
+
     Ok(())
 }
 

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -673,11 +673,11 @@ async fn multiple_ids() -> anyhow::Result<()> {
     }
 
     let response = anon.search(&format!("{query}&per_page=1&page=2")).await;
-    assert_snapshot!(response.meta.prev_page.unwrap(), @"?ids%5B%5D=unknown&per_page=1&page=1");
-    assert_snapshot!(response.meta.next_page.unwrap(), @"?ids%5B%5D=unknown&per_page=1&page=3");
+    assert_snapshot!(response.meta.prev_page.unwrap(), @"?ids%5B%5D=foo&ids%5B%5D=bar&ids%5B%5D=baz&ids%5B%5D=baz&ids%5B%5D=unknown&per_page=1&page=1");
+    assert_snapshot!(response.meta.next_page.unwrap(), @"?ids%5B%5D=foo&ids%5B%5D=bar&ids%5B%5D=baz&ids%5B%5D=baz&ids%5B%5D=unknown&per_page=1&page=3");
 
     let response = anon.search(&format!("{query}&per_page=1")).await;
-    assert_snapshot!(response.meta.next_page.unwrap(), @"?ids%5B%5D=unknown&per_page=1&seek=Mg");
+    assert_snapshot!(response.meta.next_page.unwrap(), @"?ids%5B%5D=foo&ids%5B%5D=bar&ids%5B%5D=baz&ids%5B%5D=baz&ids%5B%5D=unknown&per_page=1&seek=Mg");
 
     Ok(())
 }
@@ -1016,21 +1016,21 @@ async fn pagination_links_included_if_applicable() -> anyhow::Result<()> {
     let page4 = anon.search("letter=p&page=4&per_page=1").await;
 
     assert_eq!(
-        Some("?letter=p&page=2&per_page=1".to_string()),
+        Some("?letter=p&per_page=1&page=2".to_string()),
         page1.meta.next_page
     );
     assert_eq!(None, page1.meta.prev_page);
     assert_eq!(
-        Some("?letter=p&page=3&per_page=1".to_string()),
+        Some("?letter=p&per_page=1&page=3".to_string()),
         page2.meta.next_page
     );
     assert_eq!(
-        Some("?letter=p&page=1&per_page=1".to_string()),
+        Some("?letter=p&per_page=1&page=1".to_string()),
         page2.meta.prev_page
     );
     assert_eq!(None, page4.meta.next_page);
     assert_eq!(
-        Some("?letter=p&page=2&per_page=1".to_string()),
+        Some("?letter=p&per_page=1&page=2".to_string()),
         page3.meta.prev_page
     );
     assert!([page1.meta.total, page2.meta.total, page3.meta.total]

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -47,8 +47,15 @@ impl<T: RequestPartsExt> RequestUtils for T {
     }
 
     fn query_with_params(&self, new_params: IndexMap<String, String>) -> String {
-        let mut params = self.query();
+        let query_bytes = self.uri().query().unwrap_or("").as_bytes();
+
+        let mut params = url::form_urlencoded::parse(query_bytes)
+            .into_owned()
+            .filter(|(key, _)| !new_params.contains_key(key))
+            .collect::<Vec<_>>();
+
         params.extend(new_params);
+
         let query_string = url::form_urlencoded::Serializer::new(String::new())
             .extend_pairs(params)
             .finish();


### PR DESCRIPTION
Our search endpoint supports having multiple `ids[]` query parameters defined, but the way we generate our pagination fields only considered the last such query parameter until now. This PR fixes the code to include all query parameters instead.