### PR TITLE
Derive `Deref` for more structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ chrono = { version = "=0.4.39", default-features = false, features = ["serde"] }
 clap = { version = "=4.5.23", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.18.1", features = ["secure"] }
 deadpool-diesel = { version = "=0.6.1", features = ["postgres", "tracing"] }
-derive_more = { version = "=1.0.0", features = ["deref"] }
+derive_more = { version = "=1.0.0", features = ["deref", "deref_mut"] }
 dialoguer = "=0.11.0"
 diesel = { version = "=2.2.6", features = ["postgres", "serde_json", "chrono", "numeric"] }
 diesel-async = { version = "=0.5.2", features = ["async-connection-wrapper", "deadpool", "postgres"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,6 @@
 
 use crate::config;
 use crate::db::{connection_url, make_manager_config, ConnectionConfig};
-use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::email::Emails;
@@ -12,6 +11,7 @@ use crate::storage::Storage;
 use axum::extract::{FromRef, FromRequestParts, State};
 use crates_io_github::GitHubClient;
 use deadpool_diesel::Runtime;
+use derive_more::Deref;
 use diesel_async::pooled_connection::deadpool::Pool as DeadpoolPool;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::AsyncPgConnection;
@@ -206,18 +206,9 @@ impl App {
     }
 }
 
-#[derive(Clone, FromRequestParts)]
+#[derive(Clone, FromRequestParts, Deref)]
 #[from_request(via(State))]
 pub struct AppState(pub Arc<App>);
-
-// deref so you can still access the inner fields easily
-impl Deref for AppState {
-    type Target = App;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
 
 impl FromRef<AppState> for cookie::Key {
     fn from_ref(app: &AppState) -> Self {

--- a/src/middleware/session.rs
+++ b/src/middleware/session.rs
@@ -6,15 +6,15 @@ use axum_extra::extract::SignedCookieJar;
 use base64::{engine::general_purpose, Engine};
 use cookie::time::Duration;
 use cookie::{Cookie, SameSite};
+use derive_more::Deref;
 use parking_lot::RwLock;
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::sync::Arc;
 
 static COOKIE_NAME: &str = "cargo_session";
 static MAX_AGE_DAYS: i64 = 90;
 
-#[derive(Clone, FromRequestParts)]
+#[derive(Clone, FromRequestParts, Deref)]
 #[from_request(via(Extension))]
 pub struct SessionExtension(Arc<RwLock<Session>>);
 
@@ -38,14 +38,6 @@ impl SessionExtension {
         let mut session = self.write();
         session.dirty = true;
         session.data.remove(key)
-    }
-}
-
-impl Deref for SessionExtension {
-    type Target = RwLock<Session>;
-
-    fn deref(&self) -> &Self::Target {
-        self.0.as_ref()
     }
 }
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -3,25 +3,19 @@ use bytes::Bytes;
 use googletest::prelude::*;
 use serde_json::Value;
 use std::marker::PhantomData;
-use std::ops::Deref;
 use std::str::from_utf8;
 
 use crate::rate_limiter::LimitedAction;
+use derive_more::Deref;
 use http::{header, StatusCode};
 
 /// A type providing helper methods for working with responses
+#[derive(Deref)]
 #[must_use]
 pub struct Response<T> {
+    #[deref]
     response: hyper::Response<Bytes>,
     return_type: PhantomData<T>,
-}
-
-impl Deref for Response<()> {
-    type Target = hyper::Response<Bytes>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.response
-    }
 }
 
 impl<T> Response<T>

--- a/src/util/bytes_request.rs
+++ b/src/util/bytes_request.rs
@@ -3,27 +3,13 @@ use axum::body::Bytes;
 use axum::extract::{FromRequest, Request};
 use axum::response::{IntoResponse, Response};
 use axum::{async_trait, Extension, RequestExt};
+use derive_more::{Deref, DerefMut};
 use http::StatusCode;
 use http_body_util::{BodyExt, LengthLimitError};
 use std::error::Error;
-use std::ops::{Deref, DerefMut};
 
-#[derive(Debug)]
+#[derive(Debug, Deref, DerefMut)]
 pub struct BytesRequest(pub Request<Bytes>);
-
-impl Deref for BytesRequest {
-    type Target = Request<Bytes>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for BytesRequest {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 #[async_trait]
 impl<S> FromRequest<S> for BytesRequest


### PR DESCRIPTION
There is no need for us to implement this trait manually if we can just derive it :)