### PR TITLE
controllers/helpers/pagination: Read query parameters via `axum::Query` extractor

### DIFF
--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -526,6 +526,7 @@ pub(crate) use seek;
 mod tests {
     use super::*;
     use http::{Method, Request, StatusCode};
+    use insta::assert_snapshot;
 
     #[test]
     fn no_pagination_param() {
@@ -536,17 +537,12 @@ mod tests {
 
     #[test]
     fn page_param_parsing() {
-        let assert_error =
-            |query, msg| assert_pagination_error(PaginationOptions::builder(), query, msg);
+        let error = |query| pagination_error(PaginationOptions::builder(), query);
 
-        let expected = "Failed to deserialize query string: cannot parse integer from empty string";
-        assert_error("page=", expected);
-        let expected = "Failed to deserialize query string: invalid digit found in string";
-        assert_error("page=not_a_number", expected);
-        let expected = "Failed to deserialize query string: invalid digit found in string";
-        assert_error("page=1.0", expected);
-        let expected = "Failed to deserialize query string: invalid value: integer `0`, expected a nonzero u32";
-        assert_error("page=0", expected);
+        assert_snapshot!(error("page="), @"Failed to deserialize query string: cannot parse integer from empty string");
+        assert_snapshot!(error("page=not_a_number"), @"Failed to deserialize query string: invalid digit found in string");
+        assert_snapshot!(error("page=1.0"), @"Failed to deserialize query string: invalid digit found in string");
+        assert_snapshot!(error("page=0"), @"Failed to deserialize query string: invalid value: integer `0`, expected a nonzero u32");
 
         let pagination = PaginationOptions::builder()
             .gather(&mock("page=5"))
@@ -556,18 +552,13 @@ mod tests {
 
     #[test]
     fn per_page_param_parsing() {
-        let assert_error =
-            |query, msg| assert_pagination_error(PaginationOptions::builder(), query, msg);
+        let error = |query| pagination_error(PaginationOptions::builder(), query);
 
-        let expected = "Failed to deserialize query string: cannot parse integer from empty string";
-        assert_error("per_page=", expected);
-        let expected = "Failed to deserialize query string: invalid digit found in string";
-        assert_error("per_page=not_a_number", expected);
-        let expected = "Failed to deserialize query string: invalid digit found in string";
-        assert_error("per_page=1.0", expected);
-        assert_error("per_page=101", "cannot request more than 100 items");
-        let expected = "Failed to deserialize query string: invalid value: integer `0`, expected a nonzero u32";
-        assert_error("per_page=0", expected);
+        assert_snapshot!(error("per_page="), @"Failed to deserialize query string: cannot parse integer from empty string");
+        assert_snapshot!(error("per_page=not_a_number"), @"Failed to deserialize query string: invalid digit found in string");
+        assert_snapshot!(error("per_page=1.0"), @"Failed to deserialize query string: invalid digit found in string");
+        assert_snapshot!(error("per_page=101"), @"cannot request more than 100 items");
+        assert_snapshot!(error("per_page=0"), @"Failed to deserialize query string: invalid value: integer `0`, expected a nonzero u32");
 
         let pagination = PaginationOptions::builder()
             .gather(&mock("per_page=5"))
@@ -577,11 +568,8 @@ mod tests {
 
     #[test]
     fn seek_param_parsing() {
-        assert_pagination_error(
-            PaginationOptions::builder(),
-            "seek=OTg",
-            "?seek= is not supported for this request",
-        );
+        let error = pagination_error(PaginationOptions::builder(), "seek=OTg");
+        assert_snapshot!(error, @"?seek= is not supported for this request");
 
         let pagination = PaginationOptions::builder()
             .enable_seek(true)
@@ -600,25 +588,20 @@ mod tests {
 
     #[test]
     fn both_page_and_seek() {
-        assert_pagination_error(
-            PaginationOptions::builder(),
-            "page=1&seek=OTg",
-            "providing both ?page= and ?seek= is unsupported",
-        );
-        assert_pagination_error(
+        let error = pagination_error(PaginationOptions::builder(), "page=1&seek=OTg");
+        assert_snapshot!(error, @"providing both ?page= and ?seek= is unsupported");
+
+        let error = pagination_error(
             PaginationOptions::builder().enable_seek(true),
             "page=1&seek=OTg",
-            "providing both ?page= and ?seek= is unsupported",
         );
+        assert_snapshot!(error, @"providing both ?page= and ?seek= is unsupported");
     }
 
     #[test]
     fn disabled_pages() {
-        assert_pagination_error(
-            PaginationOptions::builder().enable_pages(false),
-            "page=1",
-            "?page= is not supported for this request",
-        );
+        let error = pagination_error(PaginationOptions::builder().enable_pages(false), "page=1");
+        assert_snapshot!(error, @"?page= is not supported for this request");
     }
 
     #[test]
@@ -751,11 +734,12 @@ mod tests {
             .0
     }
 
-    fn assert_pagination_error(options: PaginationOptionsBuilder, query: &str, message: &str) {
+    fn pagination_error(options: PaginationOptionsBuilder, query: &str) -> String {
         let error = options.gather(&mock(query)).unwrap_err();
-        assert_eq!(error.to_string(), message);
 
         let response = error.response();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        error.to_string()
     }
 }

--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -1172,13 +1172,13 @@ async fn pagination_parameters_only_accept_integers() {
         .get_with_query::<()>("/api/v1/crates", "page=1&per_page=100%22%EF%BC%8Cexception")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid digit found in string"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize query string: invalid digit found in string"}]}"#);
 
     let response = anon
         .get_with_query::<()>("/api/v1/crates", "page=100%22%EF%BC%8Cexception&per_page=1")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"invalid digit found in string"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize query string: invalid digit found in string"}]}"#);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -103,5 +103,5 @@ async fn following() {
         .get_with_query::<()>("/api/v1/me/updates", "page=0")
         .await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"page indexing starts from 1, page 0 is invalid"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Failed to deserialize query string: invalid value: integer `0`, expected a nonzero u32"}]}"#);
 }


### PR DESCRIPTION
This avoids allocating a bunch of `String` instances for all the keys and values in the query string when all we need is three optional fields, of which two are just integers. This PR also uses `NonZeroU32` for the `page` and `per_page` parameters, since we were throwing errors for values below 1 anyway.

Admittedly the error messages aren't perfect, since they don't include the field name of the value that couldn't be parsed, but that is something that can be improved centrally in the `Query` extractor or the underlying serde deserializer.