### PR TITLE
utoipa: Rename route handler fns to remove `operation_id` attributes

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -16,11 +16,10 @@ use http::request::Parts;
 #[utoipa::path(
     get,
     path = "/api/v1/categories",
-    operation_id = "list_categories",
     tag = "categories",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn index(app: AppState, req: Parts) -> AppResult<ErasedJson> {
+pub async fn list_categories(app: AppState, req: Parts) -> AppResult<ErasedJson> {
     // FIXME: There are 69 categories, 47 top level. This isn't going to
     // grow by an OoM. We need a limit for /summary, but we don't need
     // to paginate this.
@@ -52,11 +51,10 @@ pub async fn index(app: AppState, req: Parts) -> AppResult<ErasedJson> {
 #[utoipa::path(
     get,
     path = "/api/v1/categories/{category}",
-    operation_id = "get_category",
     tag = "categories",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show(state: AppState, Path(slug): Path<String>) -> AppResult<ErasedJson> {
+pub async fn find_category(state: AppState, Path(slug): Path<String>) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
     let cat: Category = Category::by_slug(&slug).first(&mut conn).await?;
@@ -92,11 +90,10 @@ pub async fn show(state: AppState, Path(slug): Path<String>) -> AppResult<Erased
 #[utoipa::path(
     get,
     path = "/api/v1/category_slugs",
-    operation_id = "list_category_slugs",
     tag = "categories",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn slugs(state: AppState) -> AppResult<ErasedJson> {
+pub async fn list_category_slugs(state: AppState) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
     let slugs: Vec<Slug> = categories::table

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -27,11 +27,13 @@ use std::collections::{HashMap, HashSet};
 #[utoipa::path(
     get,
     path = "/api/v1/me/crate_owner_invitations",
-    operation_id = "list_crate_owner_invitations_for_user",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn list(app: AppState, req: Parts) -> AppResult<ErasedJson> {
+pub async fn list_crate_owner_invitations_for_user(
+    app: AppState,
+    req: Parts,
+) -> AppResult<ErasedJson> {
     let mut conn = app.db_read().await?;
     let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
 
@@ -72,11 +74,13 @@ pub async fn list(app: AppState, req: Parts) -> AppResult<ErasedJson> {
 #[utoipa::path(
     get,
     path = "/api/private/crate_owner_invitations",
-    operation_id = "list_crate_owner_invitations",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn private_list(app: AppState, req: Parts) -> AppResult<Json<PrivateListResponse>> {
+pub async fn list_crate_owner_invitations(
+    app: AppState,
+    req: Parts,
+) -> AppResult<Json<PrivateListResponse>> {
     let mut conn = app.db_read().await?;
     let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
 
@@ -283,11 +287,13 @@ struct OwnerInvitation {
 #[utoipa::path(
     put,
     path = "/api/v1/me/crate_owner_invitations/{crate_id}",
-    operation_id = "handle_crate_owner_invitation",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<ErasedJson> {
+pub async fn handle_crate_owner_invitation(
+    state: AppState,
+    req: BytesRequest,
+) -> AppResult<ErasedJson> {
     let (parts, body) = req.0.into_parts();
 
     let crate_invite: OwnerInvitation =
@@ -318,11 +324,10 @@ pub async fn handle_invite(state: AppState, req: BytesRequest) -> AppResult<Eras
 #[utoipa::path(
     put,
     path = "/api/v1/me/crate_owner_invitations/accept/{token}",
-    operation_id = "accept_crate_owner_invitation_with_token",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn handle_invite_with_token(
+pub async fn accept_crate_owner_invitation_with_token(
     state: AppState,
     Path(token): Path<String>,
 ) -> AppResult<ErasedJson> {

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -19,11 +19,14 @@ pub struct IndexQuery {
 #[utoipa::path(
     get,
     path = "/api/v1/keywords",
-    operation_id = "list_keywords",
     tag = "keywords",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppResult<ErasedJson> {
+pub async fn list_keywords(
+    state: AppState,
+    qp: Query<IndexQuery>,
+    req: Parts,
+) -> AppResult<ErasedJson> {
     use crate::schema::keywords;
 
     let mut query = keywords::table.into_boxed();
@@ -53,11 +56,10 @@ pub async fn index(state: AppState, qp: Query<IndexQuery>, req: Parts) -> AppRes
 #[utoipa::path(
     get,
     path = "/api/v1/keywords/{keyword}",
-    operation_id = "get_keyword",
     tag = "keywords",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show(Path(name): Path<String>, state: AppState) -> AppResult<ErasedJson> {
+pub async fn find_keyword(Path(name): Path<String>, state: AppState) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
     let kw = Keyword::find_by_keyword(&mut conn, &name).await?;
 

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -30,11 +30,10 @@ const AVAILABLE_AFTER: TimeDelta = TimeDelta::hours(24);
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}",
-    operation_id = "delete_crate",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn delete(
+pub async fn delete_crate(
     Path(name): Path<String>,
     parts: Parts,
     app: AppState,

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -23,12 +23,14 @@ use std::cmp;
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/downloads",
-    operation_id = "get_crate_downloads",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
 
-pub async fn downloads(state: AppState, Path(crate_name): Path<String>) -> AppResult<ErasedJson> {
+pub async fn get_crate_downloads(
+    state: AppState,
+    Path(crate_name): Path<String>,
+) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
     use diesel::dsl::*;

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -33,11 +33,10 @@ async fn follow_target(
 #[utoipa::path(
     put,
     path = "/api/v1/crates/{name}/follow",
-    operation_id = "follow_crate",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn follow(
+pub async fn follow_crate(
     app: AppState,
     Path(crate_name): Path<String>,
     req: Parts,
@@ -58,11 +57,10 @@ pub async fn follow(
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}/follow",
-    operation_id = "unfollow_crate",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn unfollow(
+pub async fn unfollow_crate(
     app: AppState,
     Path(crate_name): Path<String>,
     req: Parts,
@@ -79,11 +77,10 @@ pub async fn unfollow(
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/following",
-    operation_id = "get_following_crate",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn following(
+pub async fn get_following_crate(
     app: AppState,
     Path(crate_name): Path<String>,
     req: Parts,

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -33,23 +33,25 @@ use std::str::FromStr;
 #[utoipa::path(
     get,
     path = "/api/v1/crates/new",
-    operation_id = "crates_show_new",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show_new(app: AppState, req: Parts) -> AppResult<ErasedJson> {
-    show(app, Path("new".to_string()), req).await
+pub async fn find_new_crate(app: AppState, req: Parts) -> AppResult<ErasedJson> {
+    find_crate(app, Path("new".to_string()), req).await
 }
 
 /// Get crate metadata.
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}",
-    operation_id = "get_crate",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show(app: AppState, Path(name): Path<String>, req: Parts) -> AppResult<ErasedJson> {
+pub async fn find_crate(
+    app: AppState,
+    Path(name): Path<String>,
+    req: Parts,
+) -> AppResult<ErasedJson> {
     let mut conn = app.db_read().await?;
 
     let include = req
@@ -248,11 +250,10 @@ impl FromStr for ShowIncludeMode {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/readme",
-    operation_id = "get_version_readme",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn readme(
+pub async fn get_version_readme(
     app: AppState,
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,
@@ -269,11 +270,10 @@ pub async fn readme(
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/reverse_dependencies",
-    operation_id = "list_reverse_dependencies",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn reverse_dependencies(
+pub async fn list_reverse_dependencies(
     app: AppState,
     Path(name): Path<String>,
     req: Parts,

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -21,11 +21,10 @@ use secrecy::{ExposeSecret, SecretString};
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/owners",
-    operation_id = "list_owners",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResult<ErasedJson> {
+pub async fn list_owners(state: AppState, Path(crate_name): Path<String>) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
     let krate: Crate = Crate::by_name(&crate_name)
@@ -48,11 +47,13 @@ pub async fn owners(state: AppState, Path(crate_name): Path<String>) -> AppResul
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/owner_team",
-    operation_id = "get_team_owners",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn owner_team(state: AppState, Path(crate_name): Path<String>) -> AppResult<ErasedJson> {
+pub async fn get_team_owners(
+    state: AppState,
+    Path(crate_name): Path<String>,
+) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
     let krate: Crate = Crate::by_name(&crate_name)
         .first(&mut conn)
@@ -73,11 +74,13 @@ pub async fn owner_team(state: AppState, Path(crate_name): Path<String>) -> AppR
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/owner_user",
-    operation_id = "get_user_owners",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn owner_user(state: AppState, Path(crate_name): Path<String>) -> AppResult<ErasedJson> {
+pub async fn get_user_owners(
+    state: AppState,
+    Path(crate_name): Path<String>,
+) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
     let krate: Crate = Crate::by_name(&crate_name)
@@ -99,7 +102,6 @@ pub async fn owner_user(state: AppState, Path(crate_name): Path<String>) -> AppR
 #[utoipa::path(
     put,
     path = "/api/v1/crates/{name}/owners",
-    operation_id = "add_owners",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -116,7 +118,6 @@ pub async fn add_owners(
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}/owners",
-    operation_id = "delete_owners",
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -56,7 +56,6 @@ const MAX_DESCRIPTION_LENGTH: usize = 1000;
 #[utoipa::path(
     put,
     path = "/api/v1/crates/new",
-    operation_id = "publish",
     tag = "publish",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -33,11 +33,10 @@ use crate::util::RequestUtils;
 #[utoipa::path(
     get,
     path = "/api/v1/crates",
-    operation_id = "crates_list",
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn search(app: AppState, req: Parts) -> AppResult<ErasedJson> {
+pub async fn list_crates(app: AppState, req: Parts) -> AppResult<ErasedJson> {
     // Notes:
     // The different use cases this function covers is handled through passing
     // in parameters in the GET request.

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -24,11 +24,10 @@ use crate::views::EncodableVersion;
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/versions",
-    operation_id = "list_crate_versions",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn versions(
+pub async fn list_versions(
     state: AppState,
     Path(crate_name): Path<String>,
     req: Parts,

--- a/src/controllers/site_metadata.rs
+++ b/src/controllers/site_metadata.rs
@@ -9,11 +9,10 @@ use axum_extra::json;
 #[utoipa::path(
     get,
     path = "/api/v1/site_metadata",
-    operation_id = "get_site_metadata",
     tag = "other",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show_deployed_sha(state: AppState) -> impl IntoResponse {
+pub async fn get_site_metadata(state: AppState) -> impl IntoResponse {
     let read_only = state.config.db.are_all_read_only();
 
     let deployed_sha =

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -19,11 +19,10 @@ use std::future::Future;
 #[utoipa::path(
     get,
     path = "/api/v1/summary",
-    operation_id = "get_summary",
     tag = "other",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn summary(state: AppState) -> AppResult<ErasedJson> {
+pub async fn get_summary(state: AppState) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
     let config = &state.config;

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -12,11 +12,10 @@ use diesel_async::RunQueryDsl;
 #[utoipa::path(
     get,
     path = "/api/v1/teams/{team}",
-    operation_id = "get_team",
     tag = "teams",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show_team(state: AppState, Path(name): Path<String>) -> AppResult<ErasedJson> {
+pub async fn find_team(state: AppState, Path(name): Path<String>) -> AppResult<ErasedJson> {
     use crate::schema::teams::dsl::{login, teams};
 
     let mut conn = state.db_read().await?;

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -39,11 +39,10 @@ impl GetParams {
 #[utoipa::path(
     get,
     path = "/api/v1/me/tokens",
-    operation_id = "list_api_tokens",
     tag = "api_tokens",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn list(
+pub async fn list_api_tokens(
     app: AppState,
     Query(params): Query<GetParams>,
     req: Parts,
@@ -87,11 +86,10 @@ pub struct NewApiTokenRequest {
 #[utoipa::path(
     put,
     path = "/api/v1/me/tokens",
-    operation_id = "create_api_token",
     tag = "api_tokens",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn new(
+pub async fn create_api_token(
     app: AppState,
     parts: Parts,
     Json(new): Json<NewApiTokenRequest>,
@@ -183,11 +181,14 @@ pub async fn new(
 #[utoipa::path(
     get,
     path = "/api/v1/me/tokens/{id}",
-    operation_id = "get_api_token",
     tag = "api_tokens",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<ErasedJson> {
+pub async fn find_api_token(
+    app: AppState,
+    Path(id): Path<i32>,
+    req: Parts,
+) -> AppResult<ErasedJson> {
     let mut conn = app.db_write().await?;
     let auth = AuthCheck::default().check(&req, &mut conn).await?;
     let user = auth.user();
@@ -204,11 +205,14 @@ pub async fn show(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<E
 #[utoipa::path(
     delete,
     path = "/api/v1/me/tokens/{id}",
-    operation_id = "revoke_api_token",
     tag = "api_tokens",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult<ErasedJson> {
+pub async fn revoke_api_token(
+    app: AppState,
+    Path(id): Path<i32>,
+    req: Parts,
+) -> AppResult<ErasedJson> {
     let mut conn = app.db_write().await?;
     let auth = AuthCheck::default().check(&req, &mut conn).await?;
     let user = auth.user();
@@ -227,11 +231,10 @@ pub async fn revoke(app: AppState, Path(id): Path<i32>, req: Parts) -> AppResult
 #[utoipa::path(
     delete,
     path = "/api/v1/tokens/current",
-    operation_id = "revoke_current_api_token",
     tag = "api_tokens",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn revoke_current(app: AppState, req: Parts) -> AppResult<Response> {
+pub async fn revoke_current_api_token(app: AppState, req: Parts) -> AppResult<Response> {
     let mut conn = app.db_write().await?;
     let auth = AuthCheck::default().check(&req, &mut conn).await?;
     let api_token_id = auth

--- a/src/controllers/user.rs
+++ b/src/controllers/user.rs
@@ -4,5 +4,5 @@ pub mod resend;
 pub mod session;
 pub mod update;
 
-pub use resend::regenerate_token_and_send;
+pub use resend::resend_email_verification;
 pub use update::update_user;

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -23,11 +23,10 @@ use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCra
 #[utoipa::path(
     get,
     path = "/api/v1/me",
-    operation_id = "get_authenticated_user",
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
+pub async fn get_authenticated_user(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
     let mut conn = app.db_read_prefer_primary().await?;
     let user_id = AuthCheck::only_cookie()
         .check(&req, &mut conn)
@@ -73,11 +72,10 @@ pub async fn me(app: AppState, req: Parts) -> AppResult<Json<EncodableMe>> {
 #[utoipa::path(
     get,
     path = "/api/v1/me/updates",
-    operation_id = "get_authenticated_user_updates",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn updates(app: AppState, req: Parts) -> AppResult<ErasedJson> {
+pub async fn get_authenticated_user_updates(app: AppState, req: Parts) -> AppResult<ErasedJson> {
     let mut conn = app.db_read_prefer_primary().await?;
     let auth = AuthCheck::only_cookie().check(&req, &mut conn).await?;
 
@@ -119,7 +117,6 @@ pub async fn updates(app: AppState, req: Parts) -> AppResult<ErasedJson> {
 #[utoipa::path(
     put,
     path = "/api/v1/confirm/{email_token}",
-    operation_id = "confirm_user_email",
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -147,7 +144,6 @@ pub async fn confirm_user_email(state: AppState, Path(token): Path<String>) -> A
 #[utoipa::path(
     put,
     path = "/api/v1/me/email_notifications",
-    operation_id = "update_email_notifications",
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -16,11 +16,10 @@ use crate::views::EncodablePublicUser;
 #[utoipa::path(
     get,
     path = "/api/v1/users/{user}",
-    operation_id = "get_user",
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show(state: AppState, Path(user_name): Path<String>) -> AppResult<ErasedJson> {
+pub async fn find_user(state: AppState, Path(user_name): Path<String>) -> AppResult<ErasedJson> {
     let mut conn = state.db_read_prefer_primary().await?;
 
     use crate::schema::users::dsl::{gh_login, id, users};
@@ -42,11 +41,10 @@ pub async fn show(state: AppState, Path(user_name): Path<String>) -> AppResult<E
 #[utoipa::path(
     get,
     path = "/api/v1/users/{id}/stats",
-    operation_id = "get_user_stats",
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn stats(state: AppState, Path(user_id): Path<i32>) -> AppResult<ErasedJson> {
+pub async fn get_user_stats(state: AppState, Path(user_id): Path<i32>) -> AppResult<ErasedJson> {
     let mut conn = state.db_read_prefer_primary().await?;
 
     use diesel::dsl::sum;

--- a/src/controllers/user/resend.rs
+++ b/src/controllers/user/resend.rs
@@ -18,11 +18,10 @@ use http::request::Parts;
 #[utoipa::path(
     put,
     path = "/api/v1/users/{id}/resend",
-    operation_id = "resend_email_verification",
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn regenerate_token_and_send(
+pub async fn resend_email_verification(
     state: AppState,
     Path(param_user_id): Path<i32>,
     req: Parts,

--- a/src/controllers/user/session.rs
+++ b/src/controllers/user/session.rs
@@ -37,11 +37,10 @@ use crates_io_github::GithubUser;
 #[utoipa::path(
     get,
     path = "/api/private/session/begin",
-    operation_id = "begin_session",
     tag = "session",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn begin(app: AppState, session: SessionExtension) -> ErasedJson {
+pub async fn begin_session(app: AppState, session: SessionExtension) -> ErasedJson {
     let (url, state) = app
         .github_oauth
         .authorize_url(oauth2::CsrfToken::new_random)
@@ -91,11 +90,10 @@ pub struct AuthorizeQuery {
 #[utoipa::path(
     get,
     path = "/api/private/session/authorize",
-    operation_id = "authorize_session",
     tag = "session",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn authorize(
+pub async fn authorize_session(
     query: AuthorizeQuery,
     app: AppState,
     session: SessionExtension,
@@ -130,7 +128,7 @@ pub async fn authorize(
     // Log in by setting a cookie and the middleware authentication
     session.insert("user_id".to_string(), user.id.to_string());
 
-    super::me::me(app, req).await
+    super::me::get_authenticated_user(app, req).await
 }
 
 async fn save_user_to_database(
@@ -175,11 +173,10 @@ async fn find_user_by_gh_id(conn: &mut AsyncPgConnection, gh_id: i32) -> QueryRe
 #[utoipa::path(
     delete,
     path = "/api/private/session",
-    operation_id = "end_session",
     tag = "session",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn logout(session: SessionExtension) -> Json<bool> {
+pub async fn end_session(session: SessionExtension) -> Json<bool> {
     session.remove("user_id");
     Json(true)
 }

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -32,7 +32,6 @@ pub struct User {
 #[utoipa::path(
     put,
     path = "/api/v1/users/{user}",
-    operation_id = "update_user",
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -24,11 +24,10 @@ use http::request::Parts;
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/download",
-    operation_id = "download_version",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn download(
+pub async fn download_version(
     app: AppState,
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,
@@ -48,11 +47,10 @@ pub async fn download(
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/downloads",
-    operation_id = "get_version_downloads",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn downloads(
+pub async fn get_version_downloads(
     app: AppState,
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -50,11 +50,10 @@ pub struct VersionUpdateRequest {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/dependencies",
-    operation_id = "get_version_dependencies",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn dependencies(
+pub async fn get_version_dependencies(
     state: AppState,
     Path((crate_name, version)): Path<(String, String)>,
 ) -> AppResult<ErasedJson> {
@@ -85,12 +84,11 @@ pub async fn dependencies(
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/authors",
-    operation_id = "get_version_authors",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
 #[deprecated]
-pub async fn authors() -> ErasedJson {
+pub async fn get_version_authors() -> ErasedJson {
     json!({
         "users": [],
         "meta": { "names": [] },
@@ -101,11 +99,10 @@ pub async fn authors() -> ErasedJson {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}",
-    operation_id = "get_version",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn show(
+pub async fn find_version(
     state: AppState,
     Path((crate_name, version)): Path<(String, String)>,
 ) -> AppResult<ErasedJson> {
@@ -128,11 +125,10 @@ pub async fn show(
 #[utoipa::path(
     patch,
     path = "/api/v1/crates/{name}/{version}",
-    operation_id = "update_version",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn update(
+pub async fn update_version(
     state: AppState,
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -24,11 +24,10 @@ use http::request::Parts;
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}/{version}/yank",
-    operation_id = "yank_version",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn yank(
+pub async fn yank_version(
     app: AppState,
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,
@@ -40,11 +39,10 @@ pub async fn yank(
 #[utoipa::path(
     put,
     path = "/api/v1/crates/{name}/{version}/unyank",
-    operation_id = "unyank_version",
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn unyank(
+pub async fn unyank_version(
     app: AppState,
     Path((crate_name, version)): Path<(String, String)>,
     req: Parts,

--- a/src/router.rs
+++ b/src/router.rs
@@ -14,57 +14,77 @@ use crate::Env;
 pub fn build_axum_router(state: AppState) -> Router<()> {
     let (router, openapi) = BaseOpenApi::router()
         // Route used by both `cargo search` and the frontend
-        .routes(routes!(krate::search::search))
+        .routes(routes!(krate::search::list_crates))
         // Routes used by `cargo`
-        .routes(routes!(krate::publish::publish, krate::metadata::show_new))
         .routes(routes!(
-            krate::owners::owners,
+            krate::publish::publish,
+            krate::metadata::find_new_crate
+        ))
+        .routes(routes!(
+            krate::owners::list_owners,
             krate::owners::add_owners,
             krate::owners::remove_owners
         ))
-        .routes(routes!(version::yank::yank))
-        .routes(routes!(version::yank::unyank))
-        .routes(routes!(version::downloads::download))
+        .routes(routes!(version::yank::yank_version))
+        .routes(routes!(version::yank::unyank_version))
+        .routes(routes!(version::downloads::download_version))
         // Routes used by the frontend
-        .routes(routes!(krate::metadata::show, krate::delete::delete))
-        .routes(routes!(version::metadata::show, version::metadata::update))
-        .routes(routes!(krate::metadata::readme))
-        .routes(routes!(version::metadata::dependencies))
-        .routes(routes!(version::downloads::downloads))
-        .routes(routes!(version::metadata::authors))
-        .routes(routes!(krate::downloads::downloads))
-        .routes(routes!(krate::versions::versions))
-        .routes(routes!(krate::follow::follow, krate::follow::unfollow))
-        .routes(routes!(krate::follow::following))
-        .routes(routes!(krate::owners::owner_team))
-        .routes(routes!(krate::owners::owner_user))
-        .routes(routes!(krate::metadata::reverse_dependencies))
-        .routes(routes!(keyword::index))
-        .routes(routes!(keyword::show))
-        .routes(routes!(category::index))
-        .routes(routes!(category::show))
-        .routes(routes!(category::slugs))
-        .routes(routes!(user::other::show, user::update::update_user))
-        .routes(routes!(user::other::stats))
-        .routes(routes!(team::show_team))
-        .routes(routes!(user::me::me))
-        .routes(routes!(user::me::updates))
-        .routes(routes!(token::list, token::new))
-        .routes(routes!(token::show, token::revoke))
-        .routes(routes!(token::revoke_current))
-        .routes(routes!(crate_owner_invitation::list))
-        .routes(routes!(crate_owner_invitation::private_list))
-        .routes(routes!(crate_owner_invitation::handle_invite))
-        .routes(routes!(crate_owner_invitation::handle_invite_with_token))
+        .routes(routes!(
+            krate::metadata::find_crate,
+            krate::delete::delete_crate
+        ))
+        .routes(routes!(
+            version::metadata::find_version,
+            version::metadata::update_version
+        ))
+        .routes(routes!(krate::metadata::get_version_readme))
+        .routes(routes!(version::metadata::get_version_dependencies))
+        .routes(routes!(version::downloads::get_version_downloads))
+        .routes(routes!(version::metadata::get_version_authors))
+        .routes(routes!(krate::downloads::get_crate_downloads))
+        .routes(routes!(krate::versions::list_versions))
+        .routes(routes!(
+            krate::follow::follow_crate,
+            krate::follow::unfollow_crate
+        ))
+        .routes(routes!(krate::follow::get_following_crate))
+        .routes(routes!(krate::owners::get_team_owners))
+        .routes(routes!(krate::owners::get_user_owners))
+        .routes(routes!(krate::metadata::list_reverse_dependencies))
+        .routes(routes!(keyword::list_keywords))
+        .routes(routes!(keyword::find_keyword))
+        .routes(routes!(category::list_categories))
+        .routes(routes!(category::find_category))
+        .routes(routes!(category::list_category_slugs))
+        .routes(routes!(user::other::find_user, user::update::update_user))
+        .routes(routes!(user::other::get_user_stats))
+        .routes(routes!(team::find_team))
+        .routes(routes!(user::me::get_authenticated_user))
+        .routes(routes!(user::me::get_authenticated_user_updates))
+        .routes(routes!(token::list_api_tokens, token::create_api_token))
+        .routes(routes!(token::find_api_token, token::revoke_api_token))
+        .routes(routes!(token::revoke_current_api_token))
+        .routes(routes!(
+            crate_owner_invitation::list_crate_owner_invitations_for_user
+        ))
+        .routes(routes!(
+            crate_owner_invitation::list_crate_owner_invitations
+        ))
+        .routes(routes!(
+            crate_owner_invitation::handle_crate_owner_invitation
+        ))
+        .routes(routes!(
+            crate_owner_invitation::accept_crate_owner_invitation_with_token
+        ))
         .routes(routes!(user::me::update_email_notifications))
-        .routes(routes!(summary::summary))
+        .routes(routes!(summary::get_summary))
         .routes(routes!(user::me::confirm_user_email))
-        .routes(routes!(user::resend::regenerate_token_and_send))
-        .routes(routes!(site_metadata::show_deployed_sha))
+        .routes(routes!(user::resend::resend_email_verification))
+        .routes(routes!(site_metadata::get_site_metadata))
         // Session management
-        .routes(routes!(user::session::begin))
-        .routes(routes!(user::session::authorize))
-        .routes(routes!(user::session::logout))
+        .routes(routes!(user::session::begin_session))
+        .routes(routes!(user::session::authorize_session))
+        .routes(routes!(user::session::end_session))
         .split_for_parts();
 
     let mut router = router

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -94,7 +94,7 @@ snapshot_kind: text
     },
     "/api/v1/categories/{category}": {
       "get": {
-        "operationId": "get_category",
+        "operationId": "find_category",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -137,7 +137,7 @@ snapshot_kind: text
     "/api/v1/crates": {
       "get": {
         "description": "Called in a variety of scenarios in the front end, including:\n- Alphabetical listing of crates\n- List of crates under a specific owner\n- Listing a user's followed crates",
-        "operationId": "crates_list",
+        "operationId": "list_crates",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -152,7 +152,7 @@ snapshot_kind: text
     "/api/v1/crates/new": {
       "get": {
         "description": "This endpoint works around a small limitation in `axum` and is delegating\nto the `GET /api/v1/crates/{name}` endpoint internally.",
-        "operationId": "crates_show_new",
+        "operationId": "find_new_crate",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -192,7 +192,7 @@ snapshot_kind: text
         ]
       },
       "get": {
-        "operationId": "get_crate",
+        "operationId": "find_crate",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -289,7 +289,7 @@ snapshot_kind: text
     },
     "/api/v1/crates/{name}/owners": {
       "delete": {
-        "operationId": "delete_owners",
+        "operationId": "remove_owners",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -341,7 +341,7 @@ snapshot_kind: text
     },
     "/api/v1/crates/{name}/versions": {
       "get": {
-        "operationId": "list_crate_versions",
+        "operationId": "list_versions",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -355,7 +355,7 @@ snapshot_kind: text
     },
     "/api/v1/crates/{name}/{version}": {
       "get": {
-        "operationId": "get_version",
+        "operationId": "find_version",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -500,7 +500,7 @@ snapshot_kind: text
     },
     "/api/v1/keywords/{keyword}": {
       "get": {
-        "operationId": "get_keyword",
+        "operationId": "find_keyword",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -624,7 +624,7 @@ snapshot_kind: text
         ]
       },
       "get": {
-        "operationId": "get_api_token",
+        "operationId": "find_api_token",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -682,7 +682,7 @@ snapshot_kind: text
     },
     "/api/v1/teams/{team}": {
       "get": {
-        "operationId": "get_team",
+        "operationId": "find_team",
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -740,7 +740,7 @@ snapshot_kind: text
     },
     "/api/v1/users/{user}": {
       "get": {
-        "operationId": "get_user",
+        "operationId": "find_user",
         "responses": {
           "200": {
             "description": "Successful Response"


### PR DESCRIPTION
... and unify some of the differing naming patterns.

The goal of this was to save a couple of code lines, but it turns out that with longer and unique names rustfmt negates those line savings again. Still worth it for DRY reasons 😅 