### PR TITLE
Extract `CratePath` and `CrateVersionPath` structs

### DIFF
--- a/src/controllers/krate.rs
+++ b/src/controllers/krate.rs
@@ -1,4 +1,9 @@
+use crate::models::Crate;
+use crate::util::errors::{crate_not_found, AppResult};
 use axum::extract::{FromRequestParts, Path};
+use crates_io_database::schema::crates;
+use diesel::{OptionalExtension, QueryDsl};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
 pub mod delete;
 pub mod downloads;
@@ -14,4 +19,31 @@ pub mod versions;
 pub struct CratePath {
     /// Name of the crate
     pub name: String,
+}
+
+impl CratePath {
+    pub async fn load_crate(&self, conn: &mut AsyncPgConnection) -> AppResult<Crate> {
+        load_crate(conn, &self.name).await
+    }
+
+    pub async fn load_crate_id(&self, conn: &mut AsyncPgConnection) -> AppResult<i32> {
+        load_crate_id(conn, &self.name).await
+    }
+}
+
+pub async fn load_crate(conn: &mut AsyncPgConnection, name: &str) -> AppResult<Crate> {
+    Crate::by_name(name)
+        .first(conn)
+        .await
+        .optional()?
+        .ok_or_else(|| crate_not_found(name))
+}
+
+pub async fn load_crate_id(conn: &mut AsyncPgConnection, name: &str) -> AppResult<i32> {
+    Crate::by_name(name)
+        .select(crates::id)
+        .first(conn)
+        .await
+        .optional()?
+        .ok_or_else(|| crate_not_found(name))
 }

--- a/src/controllers/krate.rs
+++ b/src/controllers/krate.rs
@@ -4,6 +4,7 @@ use axum::extract::{FromRequestParts, Path};
 use crates_io_database::schema::crates;
 use diesel::{OptionalExtension, QueryDsl};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use utoipa::IntoParams;
 
 pub mod delete;
 pub mod downloads;
@@ -14,7 +15,8 @@ pub mod publish;
 pub mod search;
 pub mod versions;
 
-#[derive(Deserialize, FromRequestParts)]
+#[derive(Deserialize, FromRequestParts, IntoParams)]
+#[into_params(parameter_in = Path)]
 #[from_request(via(Path))]
 pub struct CratePath {
     /// Name of the crate

--- a/src/controllers/krate.rs
+++ b/src/controllers/krate.rs
@@ -1,3 +1,5 @@
+use axum::extract::{FromRequestParts, Path};
+
 pub mod delete;
 pub mod downloads;
 pub mod follow;
@@ -6,3 +8,10 @@ pub mod owners;
 pub mod publish;
 pub mod search;
 pub mod versions;
+
+#[derive(Deserialize, FromRequestParts)]
+#[from_request(via(Path))]
+pub struct CratePath {
+    /// Name of the crate
+    pub name: String,
+}

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -30,6 +30,7 @@ const AVAILABLE_AFTER: TimeDelta = TimeDelta::hours(24);
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}",
+    params(CratePath),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -1,10 +1,10 @@
 use crate::app::AppState;
 use crate::auth::AuthCheck;
+use crate::controllers::krate::CratePath;
 use crate::models::{Crate, NewDeletedCrate, Rights};
 use crate::schema::{crate_downloads, crates, dependencies};
 use crate::util::errors::{crate_not_found, custom, AppResult, BoxedAppError};
 use crate::worker::jobs;
-use axum::extract::Path;
 use bigdecimal::ToPrimitive;
 use chrono::{TimeDelta, Utc};
 use crates_io_database::schema::deleted_crates;
@@ -33,19 +33,15 @@ const AVAILABLE_AFTER: TimeDelta = TimeDelta::hours(24);
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn delete_crate(
-    Path(name): Path<String>,
-    parts: Parts,
-    app: AppState,
-) -> AppResult<StatusCode> {
+pub async fn delete_crate(path: CratePath, parts: Parts, app: AppState) -> AppResult<StatusCode> {
     let mut conn = app.db_write().await?;
 
     // Check that the user is authenticated
     let auth = AuthCheck::only_cookie().check(&parts, &mut conn).await?;
 
     // Check that the crate exists
-    let krate = find_crate(&mut conn, &name).await?;
-    let krate = krate.ok_or_else(|| crate_not_found(&name))?;
+    let krate = find_crate(&mut conn, &path.name).await?;
+    let krate = krate.ok_or_else(|| crate_not_found(&path.name))?;
 
     // Check that the user is an owner of the crate (team owners are not allowed to delete crates)
     let user = auth.user();
@@ -106,7 +102,7 @@ pub async fn delete_crate(
 
             let git_index_job = jobs::SyncToGitIndex::new(&krate.name);
             let sparse_index_job = jobs::SyncToSparseIndex::new(&krate.name);
-            let delete_from_storage_job = jobs::DeleteCrateFromStorage::new(name);
+            let delete_from_storage_job = jobs::DeleteCrateFromStorage::new(path.name);
 
             tokio::try_join!(
                 git_index_job.enqueue(conn),

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -5,10 +5,10 @@
 
 use crate::app::AppState;
 use crate::controllers::krate::CratePath;
-use crate::models::{Crate, Version, VersionDownload};
-use crate::schema::{crates, version_downloads, versions};
+use crate::models::{Version, VersionDownload};
+use crate::schema::{version_downloads, versions};
 use crate::sql::to_char;
-use crate::util::errors::{crate_not_found, AppResult};
+use crate::util::errors::AppResult;
 use crate::views::EncodableVersionDownload;
 use axum_extra::json;
 use axum_extra::response::ErasedJson;
@@ -33,12 +33,7 @@ pub async fn get_crate_downloads(state: AppState, path: CratePath) -> AppResult<
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 
-    let crate_id: i32 = Crate::by_name(&path.name)
-        .select(crates::id)
-        .first(&mut conn)
-        .await
-        .optional()?
-        .ok_or_else(|| crate_not_found(&path.name))?;
+    let crate_id: i32 = path.load_crate_id(&mut conn).await?;
 
     let mut versions: Vec<Version> = versions::table
         .filter(versions::crate_id.eq(crate_id))

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -23,6 +23,7 @@ use std::cmp;
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/downloads",
+    params(CratePath),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -4,12 +4,12 @@
 //! download counts are located in `version::downloads`.
 
 use crate::app::AppState;
+use crate::controllers::krate::CratePath;
 use crate::models::{Crate, Version, VersionDownload};
 use crate::schema::{crates, version_downloads, versions};
 use crate::sql::to_char;
 use crate::util::errors::{crate_not_found, AppResult};
 use crate::views::EncodableVersionDownload;
-use axum::extract::Path;
 use axum_extra::json;
 use axum_extra::response::ErasedJson;
 use diesel::prelude::*;
@@ -27,21 +27,18 @@ use std::cmp;
     responses((status = 200, description = "Successful Response")),
 )]
 
-pub async fn get_crate_downloads(
-    state: AppState,
-    Path(crate_name): Path<String>,
-) -> AppResult<ErasedJson> {
+pub async fn get_crate_downloads(state: AppState, path: CratePath) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
     use diesel::dsl::*;
     use diesel::sql_types::BigInt;
 
-    let crate_id: i32 = Crate::by_name(&crate_name)
+    let crate_id: i32 = Crate::by_name(&path.name)
         .select(crates::id)
         .first(&mut conn)
         .await
         .optional()?
-        .ok_or_else(|| crate_not_found(&crate_name))?;
+        .ok_or_else(|| crate_not_found(&path.name))?;
 
     let mut versions: Vec<Version> = versions::table
         .filter(versions::crate_id.eq(crate_id))

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -33,6 +33,7 @@ async fn follow_target(
 #[utoipa::path(
     put,
     path = "/api/v1/crates/{name}/follow",
+    params(CratePath),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -53,6 +54,7 @@ pub async fn follow_crate(app: AppState, path: CratePath, req: Parts) -> AppResu
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}/follow",
+    params(CratePath),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -69,6 +71,7 @@ pub async fn unfollow_crate(app: AppState, path: CratePath, req: Parts) -> AppRe
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/following",
+    params(CratePath),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -6,6 +6,8 @@
 
 use crate::app::AppState;
 use crate::controllers::helpers::pagination::PaginationOptions;
+use crate::controllers::krate::CratePath;
+use crate::controllers::version::CrateVersionPath;
 use crate::models::{
     Category, Crate, CrateCategory, CrateKeyword, CrateName, Keyword, RecentCrateDownloads, User,
     Version, VersionOwnerAction,
@@ -16,7 +18,6 @@ use crate::util::{redirect, RequestUtils};
 use crate::views::{
     EncodableCategory, EncodableCrate, EncodableDependency, EncodableKeyword, EncodableVersion,
 };
-use axum::extract::Path;
 use axum::response::{IntoResponse, Response};
 use axum_extra::json;
 use axum_extra::response::ErasedJson;
@@ -37,7 +38,8 @@ use std::str::FromStr;
     responses((status = 200, description = "Successful Response")),
 )]
 pub async fn find_new_crate(app: AppState, req: Parts) -> AppResult<ErasedJson> {
-    find_crate(app, Path("new".to_string()), req).await
+    let name = "new".to_string();
+    find_crate(app, CratePath { name }, req).await
 }
 
 /// Get crate metadata.
@@ -47,11 +49,7 @@ pub async fn find_new_crate(app: AppState, req: Parts) -> AppResult<ErasedJson> 
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn find_crate(
-    app: AppState,
-    Path(name): Path<String>,
-    req: Parts,
-) -> AppResult<ErasedJson> {
+pub async fn find_crate(app: AppState, path: CratePath, req: Parts) -> AppResult<ErasedJson> {
     let mut conn = app.db_read().await?;
 
     let include = req
@@ -62,7 +60,7 @@ pub async fn find_crate(
         .unwrap_or_default();
 
     let (krate, downloads, default_version, yanked): (Crate, i64, Option<String>, Option<bool>) =
-        Crate::by_name(&name)
+        Crate::by_name(&path.name)
             .inner_join(crate_downloads::table)
             .left_join(default_versions::table)
             .left_join(versions::table.on(default_versions::version_id.eq(versions::id)))
@@ -75,7 +73,7 @@ pub async fn find_crate(
             .first(&mut conn)
             .await
             .optional()?
-            .ok_or_else(|| crate_not_found(&name))?;
+            .ok_or_else(|| crate_not_found(&path.name))?;
 
     let versions_publishers_and_audit_actions = if include.versions {
         let mut versions_and_publishers: Vec<(Version, Option<User>)> =
@@ -253,12 +251,8 @@ impl FromStr for ShowIncludeMode {
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn get_version_readme(
-    app: AppState,
-    Path((crate_name, version)): Path<(String, String)>,
-    req: Parts,
-) -> Response {
-    let redirect_url = app.storage.readme_location(&crate_name, &version);
+pub async fn get_version_readme(app: AppState, path: CrateVersionPath, req: Parts) -> Response {
+    let redirect_url = app.storage.readme_location(&path.name, &path.version);
     if req.wants_json() {
         json!({ "url": redirect_url }).into_response()
     } else {
@@ -275,18 +269,18 @@ pub async fn get_version_readme(
 )]
 pub async fn list_reverse_dependencies(
     app: AppState,
-    Path(name): Path<String>,
+    path: CratePath,
     req: Parts,
 ) -> AppResult<ErasedJson> {
     let mut conn = app.db_read().await?;
 
     let pagination_options = PaginationOptions::builder().gather(&req)?;
 
-    let krate: Crate = Crate::by_name(&name)
+    let krate: Crate = Crate::by_name(&path.name)
         .first(&mut conn)
         .await
         .optional()?
-        .ok_or_else(|| crate_not_found(&name))?;
+        .ok_or_else(|| crate_not_found(&path.name))?;
 
     let (rev_deps, total) = krate
         .reverse_dependencies(&mut conn, pagination_options)

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -46,6 +46,7 @@ pub async fn find_new_crate(app: AppState, req: Parts) -> AppResult<ErasedJson> 
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}",
+    params(CratePath),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -248,6 +249,7 @@ impl FromStr for ShowIncludeMode {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/readme",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -264,6 +266,7 @@ pub async fn get_version_readme(app: AppState, path: CrateVersionPath, req: Part
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/reverse_dependencies",
+    params(CratePath),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -276,11 +276,7 @@ pub async fn list_reverse_dependencies(
 
     let pagination_options = PaginationOptions::builder().gather(&req)?;
 
-    let krate: Crate = Crate::by_name(&path.name)
-        .first(&mut conn)
-        .await
-        .optional()?
-        .ok_or_else(|| crate_not_found(&path.name))?;
+    let krate = path.load_crate(&mut conn).await?;
 
     let (rev_deps, total) = krate
         .reverse_dependencies(&mut conn, pagination_options)

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -21,6 +21,7 @@ use secrecy::{ExposeSecret, SecretString};
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/owners",
+    params(CratePath),
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -43,6 +44,7 @@ pub async fn list_owners(state: AppState, path: CratePath) -> AppResult<ErasedJs
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/owner_team",
+    params(CratePath),
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -63,6 +65,7 @@ pub async fn get_team_owners(state: AppState, path: CratePath) -> AppResult<Eras
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/owner_user",
+    params(CratePath),
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -84,6 +87,7 @@ pub async fn get_user_owners(state: AppState, path: CratePath) -> AppResult<Eras
 #[utoipa::path(
     put,
     path = "/api/v1/crates/{name}/owners",
+    params(CratePath),
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -100,6 +104,7 @@ pub async fn add_owners(
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}/owners",
+    params(CratePath),
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -27,11 +27,7 @@ use secrecy::{ExposeSecret, SecretString};
 pub async fn list_owners(state: AppState, path: CratePath) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
-    let krate: Crate = Crate::by_name(&path.name)
-        .first(&mut conn)
-        .await
-        .optional()?
-        .ok_or_else(|| crate_not_found(&path.name))?;
+    let krate = path.load_crate(&mut conn).await?;
 
     let owners = krate
         .owners(&mut conn)
@@ -52,11 +48,7 @@ pub async fn list_owners(state: AppState, path: CratePath) -> AppResult<ErasedJs
 )]
 pub async fn get_team_owners(state: AppState, path: CratePath) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
-    let krate: Crate = Crate::by_name(&path.name)
-        .first(&mut conn)
-        .await
-        .optional()?
-        .ok_or_else(|| crate_not_found(&path.name))?;
+    let krate = path.load_crate(&mut conn).await?;
 
     let owners = Team::owning(&krate, &mut conn)
         .await?
@@ -77,11 +69,7 @@ pub async fn get_team_owners(state: AppState, path: CratePath) -> AppResult<Eras
 pub async fn get_user_owners(state: AppState, path: CratePath) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
-    let krate: Crate = Crate::by_name(&path.name)
-        .first(&mut conn)
-        .await
-        .optional()?
-        .ok_or_else(|| crate_not_found(&path.name))?;
+    let krate = path.load_crate(&mut conn).await?;
 
     let owners = User::owning(&krate, &mut conn)
         .await?

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -24,6 +24,7 @@ use crate::views::EncodableVersion;
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/versions",
+    params(CratePath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -1,6 +1,5 @@
 //! Endpoint for versions of a crate
 
-use axum::extract::Path;
 use axum_extra::json;
 use axum_extra::response::ErasedJson;
 use diesel::dsl::not;
@@ -14,6 +13,7 @@ use std::str::FromStr;
 
 use crate::app::AppState;
 use crate::controllers::helpers::pagination::{encode_seek, Page, PaginationOptions};
+use crate::controllers::krate::CratePath;
 use crate::models::{Crate, User, Version, VersionOwnerAction};
 use crate::schema::{crates, users, versions};
 use crate::util::errors::{bad_request, crate_not_found, AppResult, BoxedAppError};
@@ -27,19 +27,15 @@ use crate::views::EncodableVersion;
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
-pub async fn list_versions(
-    state: AppState,
-    Path(crate_name): Path<String>,
-    req: Parts,
-) -> AppResult<ErasedJson> {
+pub async fn list_versions(state: AppState, path: CratePath, req: Parts) -> AppResult<ErasedJson> {
     let mut conn = state.db_read().await?;
 
-    let crate_id: i32 = Crate::by_name(&crate_name)
+    let crate_id: i32 = Crate::by_name(&path.name)
         .select(crates::id)
         .first(&mut conn)
         .await
         .optional()?
-        .ok_or_else(|| crate_not_found(&crate_name))?;
+        .ok_or_else(|| crate_not_found(&path.name))?;
 
     let mut pagination = None;
     let params = req.query();
@@ -78,7 +74,7 @@ pub async fn list_versions(
         .data
         .into_iter()
         .zip(actions)
-        .map(|((v, pb), aas)| EncodableVersion::from(v, &crate_name, pb, aas))
+        .map(|((v, pb), aas)| EncodableVersion::from(v, &path.name, pb, aas))
         .collect::<Vec<_>>();
 
     Ok(match pagination {

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -4,16 +4,19 @@ pub mod yank;
 
 use axum::extract::{FromRequestParts, Path};
 use diesel_async::AsyncPgConnection;
+use utoipa::IntoParams;
 
 use crate::models::{Crate, Version};
 use crate::util::errors::{crate_not_found, AppResult};
 
-#[derive(Deserialize, FromRequestParts)]
+#[derive(Deserialize, FromRequestParts, IntoParams)]
+#[into_params(parameter_in = Path)]
 #[from_request(via(Path))]
 pub struct CrateVersionPath {
     /// Name of the crate
     pub name: String,
     /// Version number
+    #[param(example = "1.0.0")]
     pub version: String,
 }
 

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -18,6 +18,10 @@ pub struct CrateVersionPath {
 }
 
 impl CrateVersionPath {
+    pub async fn load_version(&self, conn: &mut AsyncPgConnection) -> AppResult<Version> {
+        Ok(self.load_version_and_crate(conn).await?.0)
+    }
+
     pub async fn load_version_and_crate(
         &self,
         conn: &mut AsyncPgConnection,

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -17,6 +17,15 @@ pub struct CrateVersionPath {
     pub version: String,
 }
 
+impl CrateVersionPath {
+    pub async fn load_version_and_crate(
+        &self,
+        conn: &mut AsyncPgConnection,
+    ) -> AppResult<(Version, Crate)> {
+        version_and_crate(conn, &self.name, &self.version).await
+    }
+}
+
 async fn version_and_crate(
     conn: &mut AsyncPgConnection,
     crate_name: &str,

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -2,10 +2,20 @@ pub mod downloads;
 pub mod metadata;
 pub mod yank;
 
+use axum::extract::{FromRequestParts, Path};
 use diesel_async::AsyncPgConnection;
 
 use crate::models::{Crate, Version};
 use crate::util::errors::{crate_not_found, AppResult};
+
+#[derive(Deserialize, FromRequestParts)]
+#[from_request(via(Path))]
+pub struct CrateVersionPath {
+    /// Name of the crate
+    pub name: String,
+    /// Version number
+    pub version: String,
+}
 
 async fn version_and_crate(
     conn: &mut AsyncPgConnection,

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -23,6 +23,7 @@ use http::request::Parts;
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/download",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -46,6 +47,7 @@ pub async fn download_version(
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/downloads",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -59,7 +59,7 @@ pub async fn get_version_downloads(
     }
 
     let mut conn = app.db_read().await?;
-    let (version, _) = path.load_version_and_crate(&mut conn).await?;
+    let version = path.load_version(&mut conn).await?;
 
     let cutoff_end_date = req
         .query()

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -2,7 +2,7 @@
 //!
 //! Crate level functionality is located in `krate::downloads`.
 
-use super::{version_and_crate, CrateVersionPath};
+use super::CrateVersionPath;
 use crate::app::AppState;
 use crate::models::VersionDownload;
 use crate::schema::*;
@@ -59,7 +59,7 @@ pub async fn get_version_downloads(
     }
 
     let mut conn = app.db_read().await?;
-    let (version, _) = version_and_crate(&mut conn, &path.name, &path.version).await?;
+    let (version, _) = path.load_version_and_crate(&mut conn).await?;
 
     let cutoff_end_date = req
         .query()

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -6,7 +6,7 @@ use super::CrateVersionPath;
 use crate::app::AppState;
 use crate::models::VersionDownload;
 use crate::schema::*;
-use crate::util::errors::{version_not_found, AppResult};
+use crate::util::errors::AppResult;
 use crate::util::{redirect, RequestUtils};
 use crate::views::EncodableVersionDownload;
 use axum::response::{IntoResponse, Response};
@@ -56,10 +56,6 @@ pub async fn get_version_downloads(
     path: CrateVersionPath,
     req: Parts,
 ) -> AppResult<ErasedJson> {
-    if semver::Version::parse(&path.version).is_err() {
-        return Err(version_not_found(&path.name, &path.version));
-    }
-
     let mut conn = app.db_read().await?;
     let version = path.load_version(&mut conn).await?;
 

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -2,14 +2,13 @@
 //!
 //! Crate level functionality is located in `krate::downloads`.
 
-use super::version_and_crate;
+use super::{version_and_crate, CrateVersionPath};
 use crate::app::AppState;
 use crate::models::VersionDownload;
 use crate::schema::*;
 use crate::util::errors::{version_not_found, AppResult};
 use crate::util::{redirect, RequestUtils};
 use crate::views::EncodableVersionDownload;
-use axum::extract::Path;
 use axum::response::{IntoResponse, Response};
 use axum_extra::json;
 use axum_extra::response::ErasedJson;
@@ -29,11 +28,11 @@ use http::request::Parts;
 )]
 pub async fn download_version(
     app: AppState,
-    Path((crate_name, version)): Path<(String, String)>,
+    path: CrateVersionPath,
     req: Parts,
 ) -> AppResult<Response> {
     let wants_json = req.wants_json();
-    let redirect_url = app.storage.crate_location(&crate_name, &version);
+    let redirect_url = app.storage.crate_location(&path.name, &path.version);
     if wants_json {
         Ok(json!({ "url": redirect_url }).into_response())
     } else {
@@ -52,15 +51,15 @@ pub async fn download_version(
 )]
 pub async fn get_version_downloads(
     app: AppState,
-    Path((crate_name, version)): Path<(String, String)>,
+    path: CrateVersionPath,
     req: Parts,
 ) -> AppResult<ErasedJson> {
-    if semver::Version::parse(&version).is_err() {
-        return Err(version_not_found(&crate_name, &version));
+    if semver::Version::parse(&path.version).is_err() {
+        return Err(version_not_found(&path.name, &path.version));
     }
 
     let mut conn = app.db_read().await?;
-    let (version, _) = version_and_crate(&mut conn, &crate_name, &version).await?;
+    let (version, _) = version_and_crate(&mut conn, &path.name, &path.version).await?;
 
     let cutoff_end_date = req
         .query()

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -61,7 +61,7 @@ pub async fn get_version_dependencies(
     }
 
     let mut conn = state.db_read().await?;
-    let (version, _) = path.load_version_and_crate(&mut conn).await?;
+    let version = path.load_version(&mut conn).await?;
 
     let deps = Dependency::belonging_to(&version)
         .inner_join(crates::table)

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -49,6 +49,7 @@ pub struct VersionUpdateRequest {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/dependencies",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -83,6 +84,7 @@ pub async fn get_version_dependencies(
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}/authors",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -98,6 +100,7 @@ pub async fn get_version_authors() -> ErasedJson {
 #[utoipa::path(
     get,
     path = "/api/v1/crates/{name}/{version}",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -121,6 +124,7 @@ pub async fn find_version(state: AppState, path: CrateVersionPath) -> AppResult<
 #[utoipa::path(
     patch,
     path = "/api/v1/crates/{name}/{version}",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -1,7 +1,7 @@
 //! Endpoints for yanking and unyanking specific versions of crates
 
 use super::metadata::{authenticate, perform_version_yank_update};
-use super::{version_and_crate, CrateVersionPath};
+use super::CrateVersionPath;
 use crate::app::AppState;
 use crate::controllers::helpers::ok_true;
 use crate::rate_limiter::LimitedAction;
@@ -64,7 +64,7 @@ async fn modify_yank(
     }
 
     let mut conn = state.db_write().await?;
-    let (mut version, krate) = version_and_crate(&mut conn, &path.name, &path.version).await?;
+    let (mut version, krate) = path.load_version_and_crate(&mut conn).await?;
     let auth = authenticate(&req, &mut conn, &krate.name).await?;
 
     state

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -23,6 +23,7 @@ use http::request::Parts;
 #[utoipa::path(
     delete,
     path = "/api/v1/crates/{name}/{version}/yank",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -38,6 +39,7 @@ pub async fn yank_version(
 #[utoipa::path(
     put,
     path = "/api/v1/crates/{name}/{version}/unyank",
+    params(CrateVersionPath),
     tag = "versions",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/version/yank.rs
+++ b/src/controllers/version/yank.rs
@@ -5,7 +5,7 @@ use super::CrateVersionPath;
 use crate::app::AppState;
 use crate::controllers::helpers::ok_true;
 use crate::rate_limiter::LimitedAction;
-use crate::util::errors::{version_not_found, AppResult};
+use crate::util::errors::AppResult;
 use axum::response::Response;
 use http::request::Parts;
 
@@ -60,10 +60,6 @@ async fn modify_yank(
 ) -> AppResult<Response> {
     // FIXME: Should reject bad requests before authentication, but can't due to
     // lifetime issues with `req`.
-
-    if semver::Version::parse(&path.version).is_err() {
-        return Err(version_not_found(&path.name, &path.version));
-    }
 
     let mut conn = state.db_write().await?;
     let (mut version, krate) = path.load_version_and_crate(&mut conn).await?;

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -181,6 +181,17 @@ snapshot_kind: text
       "delete": {
         "description": "The crate is immediately deleted from the database, and with a small delay\nfrom the git and sparse index, and the crate file storage.\n\nThe crate can only be deleted by the owner of the crate, and only if the\ncrate has been published for less than 72 hours, or if the crate has a\nsingle owner, has been downloaded less than 100 times for each month it has\nbeen published, and is not depended upon by any other crate on crates.io.",
         "operationId": "delete_crate",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -193,6 +204,17 @@ snapshot_kind: text
       },
       "get": {
         "operationId": "find_crate",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -208,6 +230,17 @@ snapshot_kind: text
       "get": {
         "description": "This includes the per-day downloads for the last 90 days and for the\nlatest 5 versions plus the sum of the rest.",
         "operationId": "get_crate_downloads",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -222,6 +255,17 @@ snapshot_kind: text
     "/api/v1/crates/{name}/follow": {
       "delete": {
         "operationId": "unfollow_crate",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -234,6 +278,17 @@ snapshot_kind: text
       },
       "put": {
         "operationId": "follow_crate",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -248,6 +303,17 @@ snapshot_kind: text
     "/api/v1/crates/{name}/following": {
       "get": {
         "operationId": "get_following_crate",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -262,6 +328,17 @@ snapshot_kind: text
     "/api/v1/crates/{name}/owner_team": {
       "get": {
         "operationId": "get_team_owners",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -276,6 +353,17 @@ snapshot_kind: text
     "/api/v1/crates/{name}/owner_user": {
       "get": {
         "operationId": "get_user_owners",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -290,6 +378,17 @@ snapshot_kind: text
     "/api/v1/crates/{name}/owners": {
       "delete": {
         "operationId": "remove_owners",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -302,6 +401,17 @@ snapshot_kind: text
       },
       "get": {
         "operationId": "list_owners",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -314,6 +424,17 @@ snapshot_kind: text
       },
       "put": {
         "operationId": "add_owners",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -328,6 +449,17 @@ snapshot_kind: text
     "/api/v1/crates/{name}/reverse_dependencies": {
       "get": {
         "operationId": "list_reverse_dependencies",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -342,6 +474,17 @@ snapshot_kind: text
     "/api/v1/crates/{name}/versions": {
       "get": {
         "operationId": "list_versions",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -356,6 +499,27 @@ snapshot_kind: text
     "/api/v1/crates/{name}/{version}": {
       "get": {
         "operationId": "find_version",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -369,6 +533,27 @@ snapshot_kind: text
       "patch": {
         "description": "This endpoint allows updating the `yanked` state of a version, including a yank message.",
         "operationId": "update_version",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -385,6 +570,27 @@ snapshot_kind: text
         "deprecated": true,
         "description": "This endpoint was deprecated by [RFC #3052](https://github.com/rust-lang/rfcs/pull/3052)\nand returns an empty list for backwards compatibility reasons.",
         "operationId": "get_version_authors",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -400,6 +606,27 @@ snapshot_kind: text
       "get": {
         "description": "This information can also be obtained directly from the index.\n\nIn addition to returning cached data from the index, this returns\nfields for `id`, `version_id`, and `downloads` (which appears to always\nbe 0)",
         "operationId": "get_version_dependencies",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -415,6 +642,27 @@ snapshot_kind: text
       "get": {
         "description": "This returns a URL to the location where the crate is stored.",
         "operationId": "download_version",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -430,6 +678,27 @@ snapshot_kind: text
       "get": {
         "description": "This includes the per-day downloads for the last 90 days.",
         "operationId": "get_version_downloads",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -444,6 +713,27 @@ snapshot_kind: text
     "/api/v1/crates/{name}/{version}/readme": {
       "get": {
         "operationId": "get_version_readme",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -458,6 +748,27 @@ snapshot_kind: text
     "/api/v1/crates/{name}/{version}/unyank": {
       "put": {
         "operationId": "unyank_version",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -473,6 +784,27 @@ snapshot_kind: text
       "delete": {
         "description": "This does not delete a crate version, it makes the crate\nversion accessible only to crates that already have a\n`Cargo.lock` containing this version.\n\nNotes:\n\nVersion deletion is not implemented to avoid breaking builds,\nand the goal of yanking a crate is to prevent crates\nbeginning to depend on the yanked crate version.",
         "operationId": "yank_version",
+        "parameters": [
+          {
+            "description": "Name of the crate",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Version number",
+            "example": "1.0.0",
+            "in": "path",
+            "name": "version",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -209,9 +209,9 @@ async fn test_version_downloads() {
     let response = anon
         .get::<()>("/api/v1/crates/foo/invalid-version/downloads")
         .await;
-    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_snapshot!(
         response.text(),
-        @r#"{"errors":[{"detail":"crate `foo` does not have a version `invalid-version`"}]}"#
+        @r#"{"errors":[{"detail":"Invalid URL: unexpected character 'i' while parsing major version number"}]}"#
     );
 }


### PR DESCRIPTION
These structs can be used as `axum` extractors for the corresponding `Path` patterns. At the same time, they implement `utoipa::IntoParams`, which allows them to be used in `#[utoipa::path(params(CratePath), ...)` form, which adds them to the generated OpenAPI description.

Related:

- https://github.com/rust-lang/crates.io/issues/741
- https://github.com/rust-lang/crates.io/pull/10186
- https://github.com/rust-lang/crates.io/pull/10201
- https://github.com/rust-lang/crates.io/pull/10207