### PR TITLE
utoipa: Add remaining `Path` params

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -51,6 +51,9 @@ pub async fn list_categories(app: AppState, req: Parts) -> AppResult<ErasedJson>
 #[utoipa::path(
     get,
     path = "/api/v1/categories/{category}",
+    params(
+        ("category" = String, Path, description = "Name of the category"),
+    ),
     tag = "categories",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -287,6 +287,9 @@ struct OwnerInvitation {
 #[utoipa::path(
     put,
     path = "/api/v1/me/crate_owner_invitations/{crate_id}",
+    params(
+        ("crate_id" = i32, Path, description = "ID of the crate"),
+    ),
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -324,6 +327,9 @@ pub async fn handle_crate_owner_invitation(
 #[utoipa::path(
     put,
     path = "/api/v1/me/crate_owner_invitations/accept/{token}",
+    params(
+        ("token" = String, Path, description = "Secret token sent to the user's email address"),
+    ),
     tag = "owners",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -56,6 +56,9 @@ pub async fn list_keywords(
 #[utoipa::path(
     get,
     path = "/api/v1/keywords/{keyword}",
+    params(
+        ("keyword" = String, Path, description = "The keyword to find"),
+    ),
     tag = "keywords",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -12,6 +12,9 @@ use diesel_async::RunQueryDsl;
 #[utoipa::path(
     get,
     path = "/api/v1/teams/{team}",
+    params(
+        ("team" = String, Path, description = "Name of the team", example = "github:rust-lang:crates-io"),
+    ),
     tag = "teams",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -181,6 +181,9 @@ pub async fn create_api_token(
 #[utoipa::path(
     get,
     path = "/api/v1/me/tokens/{id}",
+    params(
+        ("id" = i32, Path, description = "ID of the API token"),
+    ),
     tag = "api_tokens",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -205,6 +208,9 @@ pub async fn find_api_token(
 #[utoipa::path(
     delete,
     path = "/api/v1/me/tokens/{id}",
+    params(
+        ("id" = i32, Path, description = "ID of the API token"),
+    ),
     tag = "api_tokens",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -117,6 +117,9 @@ pub async fn get_authenticated_user_updates(app: AppState, req: Parts) -> AppRes
 #[utoipa::path(
     put,
     path = "/api/v1/confirm/{email_token}",
+    params(
+        ("email_token" = String, Path, description = "Secret verification token sent to the user's email address"),
+    ),
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -16,6 +16,9 @@ use crate::views::EncodablePublicUser;
 #[utoipa::path(
     get,
     path = "/api/v1/users/{user}",
+    params(
+        ("user" = String, Path, description = "Login name of the user"),
+    ),
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]
@@ -41,6 +44,9 @@ pub async fn find_user(state: AppState, Path(user_name): Path<String>) -> AppRes
 #[utoipa::path(
     get,
     path = "/api/v1/users/{id}/stats",
+    params(
+        ("id" = i32, Path, description = "ID of the user"),
+    ),
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/user/resend.rs
+++ b/src/controllers/user/resend.rs
@@ -18,6 +18,9 @@ use http::request::Parts;
 #[utoipa::path(
     put,
     path = "/api/v1/users/{id}/resend",
+    params(
+        ("id" = i32, Path, description = "ID of the user"),
+    ),
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -32,6 +32,9 @@ pub struct User {
 #[utoipa::path(
     put,
     path = "/api/v1/users/{user}",
+    params(
+        ("user" = i32, Path, description = "ID of the user"),
+    ),
     tag = "users",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -95,6 +95,17 @@ snapshot_kind: text
     "/api/v1/categories/{category}": {
       "get": {
         "operationId": "find_category",
+        "parameters": [
+          {
+            "description": "Name of the category",
+            "in": "path",
+            "name": "category",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -123,6 +134,17 @@ snapshot_kind: text
     "/api/v1/confirm/{email_token}": {
       "put": {
         "operationId": "confirm_user_email",
+        "parameters": [
+          {
+            "description": "Secret verification token sent to the user's email address",
+            "in": "path",
+            "name": "email_token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -833,6 +855,17 @@ snapshot_kind: text
     "/api/v1/keywords/{keyword}": {
       "get": {
         "operationId": "find_keyword",
+        "parameters": [
+          {
+            "description": "The keyword to find",
+            "in": "path",
+            "name": "keyword",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -875,6 +908,17 @@ snapshot_kind: text
     "/api/v1/me/crate_owner_invitations/accept/{token}": {
       "put": {
         "operationId": "accept_crate_owner_invitation_with_token",
+        "parameters": [
+          {
+            "description": "Secret token sent to the user's email address",
+            "in": "path",
+            "name": "token",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -889,6 +933,18 @@ snapshot_kind: text
     "/api/v1/me/crate_owner_invitations/{crate_id}": {
       "put": {
         "operationId": "handle_crate_owner_invitation",
+        "parameters": [
+          {
+            "description": "ID of the crate",
+            "in": "path",
+            "name": "crate_id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -945,6 +1001,18 @@ snapshot_kind: text
     "/api/v1/me/tokens/{id}": {
       "delete": {
         "operationId": "revoke_api_token",
+        "parameters": [
+          {
+            "description": "ID of the API token",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -957,6 +1025,18 @@ snapshot_kind: text
       },
       "get": {
         "operationId": "find_api_token",
+        "parameters": [
+          {
+            "description": "ID of the API token",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -1015,6 +1095,18 @@ snapshot_kind: text
     "/api/v1/teams/{team}": {
       "get": {
         "operationId": "find_team",
+        "parameters": [
+          {
+            "description": "Name of the team",
+            "example": "github:rust-lang:crates-io",
+            "in": "path",
+            "name": "team",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -1044,6 +1136,18 @@ snapshot_kind: text
     "/api/v1/users/{id}/resend": {
       "put": {
         "operationId": "resend_email_verification",
+        "parameters": [
+          {
+            "description": "ID of the user",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -1059,6 +1163,18 @@ snapshot_kind: text
       "get": {
         "description": "This currently only returns the total number of downloads for crates owned\nby the user.",
         "operationId": "get_user_stats",
+        "parameters": [
+          {
+            "description": "ID of the user",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -1073,6 +1189,17 @@ snapshot_kind: text
     "/api/v1/users/{user}": {
       "get": {
         "operationId": "find_user",
+        "parameters": [
+          {
+            "description": "Login name of the user",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"
@@ -1086,6 +1213,18 @@ snapshot_kind: text
       "put": {
         "description": "This endpoint allows users to update their email address and publish notifications settings.\n\nThe `id` parameter needs to match the ID of the currently authenticated user.",
         "operationId": "update_user",
+        "parameters": [
+          {
+            "description": "ID of the user",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "format": "int32",
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"


### PR DESCRIPTION
The overhead of adding dedicated `Path` structs for these did not seem worth it compared to https://github.com/rust-lang/crates.io/pull/10208, so I added these `Path` params only to the `utoipa` annotations.

Related:

- https://github.com/rust-lang/crates.io/issues/741
- https://github.com/rust-lang/crates.io/pull/10186
- https://github.com/rust-lang/crates.io/pull/10201
- https://github.com/rust-lang/crates.io/pull/10207
- https://github.com/rust-lang/crates.io/pull/10208