### PR TITLE
controllers/krate/search: Read query parameters via axum extractor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "multer",
  "pin-project-lite",
  "serde",
+ "serde_html_form",
  "serde_json",
  "tower",
  "tower-layer",
@@ -4572,6 +4573,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de514ef58196f1fc96dcaef80fe6170a1ce6215df9687a93fe8300e773fefc5"
+dependencies = [
+ "form_urlencoded",
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ aws-ip-ranges = "=0.954.0"
 aws-sdk-cloudfront = "=1.55.0"
 aws-sdk-sqs = "=1.50.0"
 axum = { version = "=0.7.9", features = ["macros", "matched-path"] }
-axum-extra = { version = "=0.9.6", features = ["cookie-signed", "erased-json", "typed-header"] }
+axum-extra = { version = "=0.9.6", features = ["cookie-signed", "erased-json", "query", "typed-header"] }
 base64 = "=0.22.1"
 bigdecimal = { version = "=0.4.7", features = ["serde"] }
 bon = "=3.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ chrono = { version = "=0.4.39", default-features = false, features = ["serde"] }
 clap = { version = "=4.5.23", features = ["derive", "env", "unicode", "wrap_help"] }
 cookie = { version = "=0.18.1", features = ["secure"] }
 deadpool-diesel = { version = "=0.6.1", features = ["postgres", "tracing"] }
-derive_more = { version = "=1.0.0", features = ["deref", "deref_mut"] }
+derive_more = { version = "=1.0.0", features = ["deref", "deref_mut", "display"] }
 dialoguer = "=0.11.0"
 diesel = { version = "=2.2.6", features = ["postgres", "serde_json", "chrono", "numeric"] }
 diesel-async = { version = "=0.5.2", features = ["async-connection-wrapper", "deadpool", "postgres"] }

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -160,6 +160,170 @@ snapshot_kind: text
       "get": {
         "description": "Called in a variety of scenarios in the front end, including:\n- Alphabetical listing of crates\n- List of crates under a specific owner\n- Listing a user's followed crates",
         "operationId": "list_crates",
+        "parameters": [
+          {
+            "description": "The sort order of the crates.\n\nValid values: `alphabetical`, `relevance`, `downloads`,\n`recent-downloads`, `recent-updates`, `new`.\n\nDefaults to `relevance` if `q` is set, otherwise `alphabetical`.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "A search query string.",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "description": "A string that does not contain null bytes (`\\0`).",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "description": "Set to `yes` to include yanked crates.",
+            "example": "yes",
+            "in": "query",
+            "name": "include_yanked",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "If set, only return crates that belong to this category, or one\nof its subcategories.",
+            "in": "query",
+            "name": "category",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "description": "A string that does not contain null bytes (`\\0`).",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "description": "If set, only return crates matching all the given keywords.\n\nThis parameter expects a space-separated list of keywords.",
+            "in": "query",
+            "name": "all_keywords",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "description": "A string that does not contain null bytes (`\\0`).",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "description": "If set, only return crates matching the given keyword\n(ignored if `all_keywords` is set).",
+            "in": "query",
+            "name": "keyword",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "description": "A string that does not contain null bytes (`\\0`).",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "description": "If set, only return crates with names that start with the given letter\n(ignored if `all_keywords` or `keyword` are set).",
+            "in": "query",
+            "name": "letter",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "description": "A string that does not contain null bytes (`\\0`).",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          {
+            "description": "If set, only crates owned by the given crates.io user ID are returned\n(ignored if `all_keywords`, `keyword`, or `letter` are set).",
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "If set, only crates owned by the given crates.io team ID are returned\n(ignored if `all_keywords`, `keyword`, `letter`, or `user_id` are set).",
+            "in": "query",
+            "name": "team_id",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "If set, only crates owned by users the current user follows are returned\n(ignored if `all_keywords`, `keyword`, `letter`, `user_id`,\nor `team_id` are set).\n\nThe exact value of this parameter is ignored, but it must not be empty.",
+            "example": "yes",
+            "in": "query",
+            "name": "following",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "If set, only crates with the specified names are returned (ignored\nif `all_keywords`, `keyword`, `letter`, `user_id`, `team_id`,\nor `following` are set).",
+            "in": "query",
+            "name": "ids[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "description": "A string that does not contain null bytes (`\\0`).",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -76,6 +76,8 @@ async fn test_following() {
     // Follow the crate and check that we are now following it.
     follow(CRATE_NAME, &user).await;
     assert_is_following(CRATE_NAME, true, &user).await;
+    assert_that!(user.search("").await.crates, len(eq(1)));
+    assert_that!(user.search("following").await.crates, len(eq(1)));
     assert_that!(user.search("following=1").await.crates, len(eq(1)));
 
     // Follow the crate again and check that we are still following it
@@ -86,6 +88,8 @@ async fn test_following() {
     // Unfollow the crate and check that we are not following it anymore.
     unfollow(CRATE_NAME, &user).await;
     assert_is_following(CRATE_NAME, false, &user).await;
+    assert_that!(user.search("").await.crates, len(eq(1)));
+    assert_that!(user.search("following").await.crates, empty());
     assert_that!(user.search("following=1").await.crates, empty());
 
     // Unfollow the crate again and check that this call is also idempotent.

--- a/src/tests/krate/following.rs
+++ b/src/tests/krate/following.rs
@@ -89,7 +89,8 @@ async fn test_following() {
     unfollow(CRATE_NAME, &user).await;
     assert_is_following(CRATE_NAME, false, &user).await;
     assert_that!(user.search("").await.crates, len(eq(1)));
-    assert_that!(user.search("following").await.crates, empty());
+    // see https://github.com/jplatte/serde_html_form/issues/13
+    assert_that!(user.search("following").await.crates, len(eq(1)));
     assert_that!(user.search("following=1").await.crates, empty());
 
     // Unfollow the crate again and check that this call is also idempotent.

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-2.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-2.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 {
   "errors": [
     {
-      "detail": "parameter category cannot contain a null byte"
+      "detail": "Failed to deserialize query string: string contains null byte"
     }
   ]
 }

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-3.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-3.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 {
   "errors": [
     {
-      "detail": "parameter all_keywords cannot contain a null byte"
+      "detail": "Failed to deserialize query string: string contains null byte"
     }
   ]
 }

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-4.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-4.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 {
   "errors": [
     {
-      "detail": "parameter keyword cannot contain a null byte"
+      "detail": "Failed to deserialize query string: string contains null byte"
     }
   ]
 }

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-5.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-5.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 {
   "errors": [
     {
-      "detail": "parameter letter cannot contain a null byte"
+      "detail": "Failed to deserialize query string: string contains null byte"
     }
   ]
 }

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes.snap
@@ -6,7 +6,7 @@ snapshot_kind: text
 {
   "errors": [
     {
-      "detail": "parameter q cannot contain a null byte"
+      "detail": "Failed to deserialize query string: string contains null byte"
     }
   ]
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,5 +8,6 @@ pub mod errors;
 mod io_util;
 mod request_helpers;
 pub mod rfc3339;
+pub mod string_excl_null;
 pub mod token;
 pub mod tracing;

--- a/src/util/string_excl_null.rs
+++ b/src/util/string_excl_null.rs
@@ -1,0 +1,24 @@
+use derive_more::{Deref, Display};
+use serde::Deserialize;
+
+/// A string that does not contain null bytes (`\0`).
+#[derive(Clone, Debug, Display, Deref, Deserialize, utoipa::ToSchema)]
+#[serde(try_from = "String")]
+pub struct StringExclNull(String);
+
+/// Error indicating that a string contained a null byte.
+#[derive(Debug, thiserror::Error)]
+#[error("string contains null byte")]
+pub struct StringExclNullError;
+
+impl TryFrom<String> for StringExclNull {
+    type Error = StringExclNullError;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if s.contains('\0') {
+            Err(StringExclNullError)
+        } else {
+            Ok(Self(s))
+        }
+    }
+}


### PR DESCRIPTION
This allows us to automatically derive OpenAPI descriptions and avoids unnecessary memory allocations from query parameters we do not care about in this endpoint.

Small caveat: the `serde_html_form` crate currently deserializes `foo=` as `None` instead of `Some("")` (see https://github.com/jplatte/serde_html_form/issues/13), which is technically a behavior change for our API. According to our logs, our frontend UI appears to be the only user of the `following` query parameter though, and that one uses `following=1`. So while this is theoretically a breaking change, I don't think in practice it's a hard blocker.