### PR TITLE
tests/util: Adjust helper methods to work for JSON arrays too

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -258,7 +258,8 @@ fn req(method: Method, path: &str) -> MockRequest {
 }
 
 fn is_json_body(body: &Bytes) -> bool {
-    body.starts_with(b"{") && body.ends_with(b"}")
+    (body.starts_with(b"{") && body.ends_with(b"}"))
+        || (body.starts_with(b"[") && body.ends_with(b"]"))
 }
 
 /// A type that can generate unauthenticated requests


### PR DESCRIPTION
The axum `Json` extractor expects a `Content-Type: application/json` header, but in our test utilities we currently only add that when we detect that the request body contains a JSON object. This PR adjusts the code to also work for JSON arrays.

(This is in preparation for the next PR that uses the `Json` extractor with a `Vec` 😉)