### PR TITLE
utoipa: Add pagination query params to `list_crates()` documentation

### DIFF
--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -22,7 +22,7 @@ use crate::schema::*;
 use crate::util::errors::{bad_request, AppResult};
 use crate::views::EncodableCrate;
 
-use crate::controllers::helpers::pagination::{Page, PaginationOptions};
+use crate::controllers::helpers::pagination::{Page, PaginationOptions, PaginationQueryParams};
 use crate::models::krate::ALL_COLUMNS;
 use crate::sql::{array_agg, canon_crate_name, lower};
 use crate::util::string_excl_null::StringExclNull;
@@ -37,7 +37,7 @@ use crate::util::RequestUtils;
 #[utoipa::path(
     get,
     path = "/api/v1/crates",
-    params(ListQueryParams),
+    params(ListQueryParams, PaginationQueryParams),
     tag = "crates",
     responses((status = 200, description = "Successful Response")),
 )]

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -322,6 +322,46 @@ snapshot_kind: text
               },
               "type": "array"
             }
+          },
+          {
+            "description": "The page number to request.\n\nThis parameter is mutually exclusive with `seek` and not supported for\nall requests.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The number of items to request per page.",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The seek key to request.\n\nThis parameter is mutually exclusive with `page` and not supported for\nall requests.\n\nThe seek key can usually be found in the `meta.next_page` field of\npaginated responses.",
+            "in": "query",
+            "name": "seek",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
I guess the title speaks for itself...? 😅 


Related:

- https://github.com/rust-lang/crates.io/issues/741
- https://github.com/rust-lang/crates.io/pull/10186
- https://github.com/rust-lang/crates.io/pull/10201
- https://github.com/rust-lang/crates.io/pull/10207
- https://github.com/rust-lang/crates.io/pull/10208