### PR TITLE
Extract `QueryParams` structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ tracing-subscriber = { version = "=0.3.19", features = ["env-filter", "json"] }
 typomania = { version = "=0.1.2", default-features = false }
 url = "=2.5.4"
 unicode-xid = "=0.2.6"
-utoipa = "=5.2.0"
+utoipa = { version = "=5.2.0", features = ["chrono"] }
 utoipa-axum = "=0.1.2"
 
 [dev-dependencies]

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -7,6 +7,7 @@ use crate::util::errors::{bad_request, AppResult};
 use crate::util::HeaderMapExt;
 use std::num::NonZeroU32;
 
+use axum::extract::FromRequestParts;
 use base64::{engine::general_purpose, Engine};
 use diesel::pg::Pg;
 use diesel::prelude::*;
@@ -55,7 +56,8 @@ impl PaginationOptions {
     }
 }
 
-#[derive(Debug, Deserialize, utoipa::IntoParams)]
+#[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
+#[from_request(via(axum::extract::Query))]
 #[into_params(parameter_in = Query)]
 pub struct PaginationQueryParams {
     /// The page number to request.
@@ -63,11 +65,11 @@ pub struct PaginationQueryParams {
     /// This parameter is mutually exclusive with `seek` and not supported for
     /// all requests.
     #[param(value_type = Option<u32>, minimum = 1)]
-    page: Option<NonZeroU32>,
+    pub page: Option<NonZeroU32>,
 
     /// The number of items to request per page.
     #[param(value_type = Option<u32>, minimum = 1)]
-    per_page: Option<NonZeroU32>,
+    pub per_page: Option<NonZeroU32>,
 
     /// The seek key to request.
     ///
@@ -76,7 +78,7 @@ pub struct PaginationQueryParams {
     ///
     /// The seek key can usually be found in the `meta.next_page` field of
     /// paginated responses.
-    seek: Option<String>,
+    pub seek: Option<String>,
 }
 
 pub(crate) struct PaginationOptionsBuilder {

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -81,6 +81,60 @@ snapshot_kind: text
     "/api/v1/categories": {
       "get": {
         "operationId": "list_categories",
+        "parameters": [
+          {
+            "description": "The sort order of the categories.\n\nValid values: `alpha`, and `crates`.\n\nDefaults to `alpha`.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The page number to request.\n\nThis parameter is mutually exclusive with `seek` and not supported for\nall requests.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The number of items to request per page.",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The seek key to request.\n\nThis parameter is mutually exclusive with `page` and not supported for\nall requests.\n\nThe seek key can usually be found in the `meta.next_page` field of\npaginated responses.",
+            "in": "query",
+            "name": "seek",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -830,6 +830,70 @@ snapshot_kind: text
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Additional data to include in the response.\n\nValid values: `release_tracks`.\n\nDefaults to no additional data.\n\nThis parameter expects a comma-separated list of values.",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The sort order of the versions.\n\nValid values: `date`, and `semver`.\n\nDefaults to `semver`.",
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The page number to request.\n\nThis parameter is mutually exclusive with `seek` and not supported for\nall requests.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The number of items to request per page.",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The seek key to request.\n\nThis parameter is mutually exclusive with `page` and not supported for\nall requests.\n\nThe seek key can usually be found in the `meta.next_page` field of\npaginated responses.",
+            "in": "query",
+            "name": "seek",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         ],
         "responses": {

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -23,6 +23,73 @@ snapshot_kind: text
     "/api/private/crate_owner_invitations": {
       "get": {
         "operationId": "list_crate_owner_invitations",
+        "parameters": [
+          {
+            "description": "Filter crate owner invitations by crate name.\n\nOnly crate owners can query pending invitations for their crate.",
+            "in": "query",
+            "name": "crate_name",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The ID of the user who was invited to be a crate owner.\n\nThis parameter needs to match the authenticated user's ID.",
+            "in": "query",
+            "name": "invitee_id",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The page number to request.\n\nThis parameter is mutually exclusive with `seek` and not supported for\nall requests.",
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The number of items to request per page.",
+            "in": "query",
+            "name": "per_page",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 1,
+              "type": [
+                "integer",
+                "null"
+              ]
+            }
+          },
+          {
+            "description": "The seek key to request.\n\nThis parameter is mutually exclusive with `page` and not supported for\nall requests.\n\nThe seek key can usually be found in the `meta.next_page` field of\npaginated responses.",
+            "in": "query",
+            "name": "seek",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response"

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1044,6 +1044,20 @@ snapshot_kind: text
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Only return download counts before this date.",
+            "example": "2024-06-28",
+            "in": "query",
+            "name": "before_date",
+            "required": false,
+            "schema": {
+              "format": "date",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         ],
         "responses": {

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -560,6 +560,18 @@ snapshot_kind: text
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "description": "Additional data to include in the response.\n\nValid values: `versions`, `keywords`, `categories`, `badges`,\n`downloads`, or `full`.\n\nDefaults to `full` for backwards compatibility.\n\nThis parameter expects a comma-separated list of values.",
+            "in": "query",
+            "name": "include",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
           }
         ],
         "responses": {

--- a/src/util/request_helpers.rs
+++ b/src/util/request_helpers.rs
@@ -27,18 +27,11 @@ pub fn redirect(url: String) -> Response {
 }
 
 pub trait RequestUtils {
-    fn query(&self) -> IndexMap<String, String>;
     fn wants_json(&self) -> bool;
     fn query_with_params(&self, params: IndexMap<String, String>) -> String;
 }
 
 impl<T: RequestPartsExt> RequestUtils for T {
-    fn query(&self) -> IndexMap<String, String> {
-        url::form_urlencoded::parse(self.uri().query().unwrap_or("").as_bytes())
-            .into_owned()
-            .collect()
-    }
-
     fn wants_json(&self) -> bool {
         self.headers()
             .get_all(header::ACCEPT)


### PR DESCRIPTION
This PR extracts a bunch of `FooQueryParams` structs to simplify our query parameter handling and better document our supported query parameters. These structs implement `axum::FromRequestParts` and `utoipa::IntoParams` so they should be easy to use and essentially self-documenting wrt our OpenAPI description.

Related:

- https://github.com/rust-lang/crates.io/issues/741
- https://github.com/rust-lang/crates.io/pull/10186
- https://github.com/rust-lang/crates.io/pull/10201
- https://github.com/rust-lang/crates.io/pull/10207
- https://github.com/rust-lang/crates.io/pull/10208
- https://github.com/rust-lang/crates.io/pull/10233