### PR TITLE
Add a basic user admin backend

### DIFF
--- a/src/controllers/user.rs
+++ b/src/controllers/user.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod email_notifications;
 pub mod email_verification;
 pub mod me;

--- a/src/controllers/user/admin.rs
+++ b/src/controllers/user/admin.rs
@@ -1,12 +1,14 @@
 use axum::{extract::Path, Json};
+use chrono::NaiveDateTime;
 use crates_io_database::schema::{emails, users};
 use diesel::{pg::Pg, prelude::*};
-use diesel_async::{AsyncConnection, RunQueryDsl};
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
 use http::request::Parts;
+use utoipa::ToSchema;
 
 use crate::{
     app::AppState, auth::AuthCheck, models::User, sql::lower, util::errors::AppResult,
-    views::EncodableAdminUser,
+    util::rfc3339, views::EncodableAdminUser,
 };
 
 /// Find user by login, returning the admin's view of the user.
@@ -38,6 +40,66 @@ pub async fn get(
     )
     .await
     .map(Json)
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct LockRequest {
+    /// The reason for locking the account. This is visible to the user.
+    reason: String,
+
+    /// When to lock the account until. If omitted, the lock will be indefinite.
+    #[serde(default, with = "rfc3339::option")]
+    until: Option<NaiveDateTime>,
+}
+
+/// Lock the given user.
+///
+/// Only site admins can use this endpoint.
+#[utoipa::path(
+    put,
+    path = "/api/v1/users/{user}/lock",
+    params(
+        ("user" = String, Path, description = "Login name of the user"),
+    ),
+    request_body = LockRequest,
+    tags = ["admin", "users"],
+    responses((status = 200, description = "Successful Response")),
+)]
+pub async fn lock(
+    state: AppState,
+    Path(user_name): Path<String>,
+    req: Parts,
+    Json(LockRequest { reason, until }): Json<LockRequest>,
+) -> AppResult<Json<EncodableAdminUser>> {
+    let mut conn = state.db_read_prefer_primary().await?;
+    AuthCheck::only_cookie()
+        .require_admin()
+        .check(&req, &mut conn)
+        .await?;
+
+    // In theory, we could cook up a complicated update query that returns
+    // everything we need to build an `EncodableAdminUser`, but that feels hard.
+    // Instead, let's use a small transaction to get the same effect.
+    let user = conn
+        .transaction(|conn| {
+            async move {
+                let id = diesel::update(users::table)
+                    .filter(lower(users::gh_login).eq(lower(user_name)))
+                    .set((
+                        users::account_lock_reason.eq(reason),
+                        users::account_lock_until.eq(until),
+                    ))
+                    .returning(users::id)
+                    .get_result::<i32>(conn)
+                    .await?;
+
+                get_user(|query| query.filter(users::id.eq(id)), conn).await
+            }
+            .scope_boxed()
+        })
+        .await?;
+
+    Ok(Json(user))
 }
 
 /// A helper to get an [`EncodableAdminUser`] based on whatever filter predicate

--- a/src/controllers/user/admin.rs
+++ b/src/controllers/user/admin.rs
@@ -1,0 +1,75 @@
+use axum::{extract::Path, Json};
+use crates_io_database::schema::{emails, users};
+use diesel::{pg::Pg, prelude::*};
+use diesel_async::{AsyncConnection, RunQueryDsl};
+use http::request::Parts;
+
+use crate::{
+    app::AppState, auth::AuthCheck, models::User, sql::lower, util::errors::AppResult,
+    views::EncodableAdminUser,
+};
+
+/// Find user by login, returning the admin's view of the user.
+///
+/// Only site admins can use this endpoint.
+#[utoipa::path(
+    get,
+    path = "/api/v1/users/{user}/admin",
+    params(
+        ("user" = String, Path, description = "Login name of the user"),
+    ),
+    tags = ["admin", "users"],
+    responses((status = 200, description = "Successful Response")),
+)]
+pub async fn get(
+    state: AppState,
+    Path(user_name): Path<String>,
+    req: Parts,
+) -> AppResult<Json<EncodableAdminUser>> {
+    let mut conn = state.db_read_prefer_primary().await?;
+    AuthCheck::only_cookie()
+        .require_admin()
+        .check(&req, &mut conn)
+        .await?;
+
+    get_user(
+        |query| query.filter(lower(users::gh_login).eq(lower(user_name))),
+        &mut conn,
+    )
+    .await
+    .map(Json)
+}
+
+/// A helper to get an [`EncodableAdminUser`] based on whatever filter predicate
+/// is provided in the callback.
+///
+/// It would be ill advised to do anything in `filter` other than calling
+/// [`QueryDsl::filter`] on the given query, but I'm not the boss of you.
+async fn get_user<Conn, F>(filter: F, conn: &mut Conn) -> AppResult<EncodableAdminUser>
+where
+    Conn: AsyncConnection<Backend = Pg>,
+    F: FnOnce(users::BoxedQuery<'_, Pg>) -> users::BoxedQuery<'_, Pg>,
+{
+    let query = filter(users::table.into_boxed());
+
+    let (user, verified, email, verification_sent): (User, Option<bool>, Option<String>, bool) =
+        query
+            .left_join(emails::table)
+            .select((
+                User::as_select(),
+                emails::verified.nullable(),
+                emails::email.nullable(),
+                emails::token_generated_at.nullable().is_not_null(),
+            ))
+            .first(conn)
+            .await?;
+
+    let verified = verified.unwrap_or(false);
+    let verification_sent = verified || verification_sent;
+    Ok(EncodableAdminUser::from(
+        user,
+        email,
+        verified,
+        verification_sent,
+    ))
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,7 +62,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .routes(routes!(user::me::get_authenticated_user))
         .routes(routes!(user::me::get_authenticated_user_updates))
         .routes(routes!(user::admin::get))
-        .routes(routes!(user::admin::lock))
+        .routes(routes!(user::admin::lock, user::admin::unlock))
         .routes(routes!(token::list_api_tokens, token::create_api_token))
         .routes(routes!(token::find_api_token, token::revoke_api_token))
         .routes(routes!(token::revoke_current_api_token))

--- a/src/router.rs
+++ b/src/router.rs
@@ -62,6 +62,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .routes(routes!(user::me::get_authenticated_user))
         .routes(routes!(user::me::get_authenticated_user_updates))
         .routes(routes!(user::admin::get))
+        .routes(routes!(user::admin::lock))
         .routes(routes!(token::list_api_tokens, token::create_api_token))
         .routes(routes!(token::find_api_token, token::revoke_api_token))
         .routes(routes!(token::revoke_current_api_token))

--- a/src/router.rs
+++ b/src/router.rs
@@ -61,6 +61,7 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
         .routes(routes!(team::find_team))
         .routes(routes!(user::me::get_authenticated_user))
         .routes(routes!(user::me::get_authenticated_user_updates))
+        .routes(routes!(user::admin::get))
         .routes(routes!(token::list_api_tokens, token::create_api_token))
         .routes(routes!(token::find_api_token, token::revoke_api_token))
         .routes(routes!(token::revoke_current_api_token))

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -3,7 +3,30 @@ source: src/openapi.rs
 expression: response.json()
 ---
 {
-  "components": {},
+  "components": {
+    "schemas": {
+      "LockRequest": {
+        "properties": {
+          "reason": {
+            "description": "The reason for locking the account. This is visible to the user.",
+            "type": "string"
+          },
+          "until": {
+            "description": "When to lock the account until. If omitted, the lock will be indefinite.",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "reason"
+        ],
+        "type": "object"
+      }
+    }
+  },
   "info": {
     "contact": {
       "email": "help@crates.io",
@@ -1671,6 +1694,43 @@ expression: response.json()
           }
         },
         "summary": "Find user by login, returning the admin's view of the user.",
+        "tags": [
+          "admin",
+          "users"
+        ]
+      }
+    },
+    "/api/v1/users/{user}/lock": {
+      "put": {
+        "description": "Only site admins can use this endpoint.",
+        "operationId": "lock",
+        "parameters": [
+          {
+            "description": "Login name of the user",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LockRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Lock the given user.",
         "tags": [
           "admin",
           "users"

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1,7 +1,6 @@
 ---
 source: src/openapi.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "components": {},
@@ -1647,6 +1646,33 @@ snapshot_kind: text
         },
         "summary": "Update user settings.",
         "tags": [
+          "users"
+        ]
+      }
+    },
+    "/api/v1/users/{user}/admin": {
+      "get": {
+        "description": "Only site admins can use this endpoint.",
+        "operationId": "get",
+        "parameters": [
+          {
+            "description": "Login name of the user",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Find user by login, returning the admin's view of the user.",
+        "tags": [
+          "admin",
           "users"
         ]
       }

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1701,6 +1701,31 @@ expression: response.json()
       }
     },
     "/api/v1/users/{user}/lock": {
+      "delete": {
+        "description": "Only site admins can use this endpoint.",
+        "operationId": "unlock",
+        "parameters": [
+          {
+            "description": "Login name of the user",
+            "in": "path",
+            "name": "user",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Unlock the given user.",
+        "tags": [
+          "admin",
+          "users"
+        ]
+      },
       "put": {
         "description": "Only site admins can use this endpoint.",
         "operationId": "lock",

--- a/src/tests/routes/users/admin.rs
+++ b/src/tests/routes/users/admin.rs
@@ -1,7 +1,12 @@
+use chrono::DateTime;
 use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
+use serde_json::json;
 
-use crate::tests::util::{RequestHelper, TestApp};
+use crate::{
+    models::User,
+    tests::util::{RequestHelper, TestApp},
+};
 
 mod get {
     use super::*;
@@ -42,4 +47,125 @@ mod get {
         assert_eq!(response.status(), StatusCode::OK);
         assert_json_snapshot!("admin-found", response.json());
     }
+}
+
+mod lock {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn lock() {
+        let (app, anon, user) = TestApp::init().with_user().await;
+        let admin = app.db_new_admin_user("admin").await;
+
+        // Because axum will validate and deserialise the body before any auth
+        // check occurs, we actually need to provide a valid body for all the
+        // auth related test cases.
+        let body = serde_json::to_string(&json!({
+            "reason": "l33t h4x0r",
+            "until": "2045-01-01T01:02:03Z",
+        }))
+        .unwrap();
+
+        // Anonymous users should be forbidden.
+        let response = anon.put::<()>("/api/v1/users/foo/lock", body.clone()).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("anonymous-found", response.text());
+
+        let response = anon.put::<()>("/api/v1/users/bar/lock", body.clone()).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("anonymous-not-found", response.text());
+
+        // Regular users should also be forbidden, even if they're locking
+        // themself.
+        let response = user.put::<()>("/api/v1/users/foo/lock", body.clone()).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("non-admin-found", response.text());
+
+        let response = user.put::<()>("/api/v1/users/bar/lock", body.clone()).await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("non-admin-not-found", response.text());
+
+        // Admin users are allowed, but still can't manifest users who don't
+        // exist.
+        let response = admin
+            .put::<()>("/api/v1/users/bar/lock", body.clone())
+            .await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_snapshot!("admin-not-found", response.text());
+
+        // Admin users who provide invalid request bodies should be denied.
+        let response = admin
+            .put::<()>("/api/v1/users/bar/lock", b"invalid JSON" as &[u8])
+            .await;
+        assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_snapshot!("admin-invalid-json", response.text());
+
+        let response = admin
+            .put::<()>("/api/v1/users/bar/lock", br#"{"valid": "json"}"# as &[u8])
+            .await;
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_snapshot!("admin-malformed-json", response.text());
+
+        // Admin users are allowed, and should be able to lock the user.
+        assert_none!(&user.as_model().account_lock_reason);
+        assert_none!(&user.as_model().account_lock_until);
+
+        let response = admin.put::<()>("/api/v1/users/foo/lock", body).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_json_snapshot!("admin-found", response.json());
+
+        // Get the user again and validate that they are now locked.
+        let mut conn = app.db_conn().await;
+        let locked_user = User::find(&mut conn, user.as_model().id).await.unwrap();
+        assert_user_is_locked(&locked_user, "l33t h4x0r", "2045-01-01T01:02:03Z");
+
+        // Re-locking a locked user should update their lock reason and
+        // expiration time.
+        let body = serde_json::to_string(&json!({
+            "reason": "less l33t",
+            "until": "2035-01-01T01:02:03Z",
+        }))
+        .unwrap();
+
+        let response = admin.put::<()>("/api/v1/users/foo/lock", body).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_json_snapshot!("admin-relock-shorter", response.json());
+
+        // Get the user again and validate that they are now locked for less
+        // time.
+        let mut conn = app.db_conn().await;
+        let locked_user = User::find(&mut conn, user.as_model().id).await.unwrap();
+        assert_user_is_locked(&locked_user, "less l33t", "2035-01-01T01:02:03Z");
+
+        // Finally, not including an until time at all should lock the account
+        // forever. (Insert evil laughter here.)
+        let body = serde_json::to_string(&json!({
+            "reason": "less l33t",
+        }))
+        .unwrap();
+
+        let response = admin.put::<()>("/api/v1/users/foo/lock", body).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_json_snapshot!("admin-lock-forever", response.json());
+
+        // Get the user again and validate that they are now locked forever.
+        let mut conn = app.db_conn().await;
+        let locked_user = User::find(&mut conn, user.as_model().id).await.unwrap();
+        assert_user_is_locked_indefinitely(&locked_user, "less l33t");
+    }
+}
+
+#[track_caller]
+fn assert_user_is_locked(user: &User, reason: &str, until: &str) {
+    assert_eq!(user.account_lock_reason.as_deref(), Some(reason));
+    assert_eq!(
+        user.account_lock_until,
+        Some(DateTime::parse_from_rfc3339(until).unwrap().naive_utc())
+    );
+}
+
+#[track_caller]
+fn assert_user_is_locked_indefinitely(user: &User, reason: &str) {
+    assert_eq!(user.account_lock_reason.as_deref(), Some(reason));
+    assert_none!(user.account_lock_until);
 }

--- a/src/tests/routes/users/admin.rs
+++ b/src/tests/routes/users/admin.rs
@@ -1,0 +1,45 @@
+use http::StatusCode;
+use insta::{assert_json_snapshot, assert_snapshot};
+
+use crate::tests::util::{RequestHelper, TestApp};
+
+mod get {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get() {
+        let (app, anon, user) = TestApp::init().with_user().await;
+        let admin = app.db_new_admin_user("admin").await;
+
+        // Anonymous users should be forbidden.
+        let response = anon.get::<()>("/api/v1/users/foo/admin").await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("anonymous-found", response.text());
+
+        let response = anon.get::<()>("/api/v1/users/bar/admin").await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("anonymous-not-found", response.text());
+
+        // Regular users should also be forbidden, even if they're requesting
+        // themself.
+        let response = user.get::<()>("/api/v1/users/foo/admin").await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("non-admin-found", response.text());
+
+        let response = user.get::<()>("/api/v1/users/bar/admin").await;
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert_snapshot!("non-admin-not-found", response.text());
+
+        // Admin users are allowed, but still can't manifest users who don't
+        // exist.
+        let response = admin.get::<()>("/api/v1/users/bar/admin").await;
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_snapshot!("admin-not-found", response.text());
+
+        // Admin users are allowed, and should get an admin's eye view of the
+        // requested user.
+        let response = admin.get::<()>("/api/v1/users/foo/admin").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_json_snapshot!("admin-found", response.json());
+    }
+}

--- a/src/tests/routes/users/mod.rs
+++ b/src/tests/routes/users/mod.rs
@@ -1,3 +1,4 @@
+mod admin;
 mod read;
 mod stats;
 pub mod update;

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__admin-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__admin-found.snap
@@ -1,0 +1,17 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.json()
+---
+{
+  "avatar": null,
+  "email": "foo@example.com",
+  "email_verification_sent": true,
+  "email_verified": true,
+  "id": 1,
+  "is_admin": false,
+  "lock": null,
+  "login": "foo",
+  "name": null,
+  "publish_notifications": true,
+  "url": "https://github.com/foo"
+}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__admin-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__admin-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"Not Found"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__anonymous-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__anonymous-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action requires authentication"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__anonymous-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__anonymous-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action requires authentication"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__non-admin-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__non-admin-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action can only be performed by a site admin"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__non-admin-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__get__non-admin-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action can only be performed by a site admin"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-found.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.json()
+---
+{
+  "avatar": null,
+  "email": "foo@example.com",
+  "email_verification_sent": true,
+  "email_verified": true,
+  "id": 1,
+  "is_admin": false,
+  "lock": {
+    "reason": "l33t h4x0r",
+    "until": "2045-01-01T01:02:03+00:00"
+  },
+  "login": "foo",
+  "name": null,
+  "publish_notifications": true,
+  "url": "https://github.com/foo"
+}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-invalid-json.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-invalid-json.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"Expected request with `Content-Type: application/json`"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-lock-forever.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-lock-forever.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.json()
+---
+{
+  "avatar": null,
+  "email": "foo@example.com",
+  "email_verification_sent": true,
+  "email_verified": true,
+  "id": 1,
+  "is_admin": false,
+  "lock": {
+    "reason": "less l33t",
+    "until": null
+  },
+  "login": "foo",
+  "name": null,
+  "publish_notifications": true,
+  "url": "https://github.com/foo"
+}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-malformed-json.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-malformed-json.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"Failed to deserialize the JSON body into the target type: missing field `reason` at line 1 column 17"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"Not Found"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-relock-shorter.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__admin-relock-shorter.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.json()
+---
+{
+  "avatar": null,
+  "email": "foo@example.com",
+  "email_verification_sent": true,
+  "email_verified": true,
+  "id": 1,
+  "is_admin": false,
+  "lock": {
+    "reason": "less l33t",
+    "until": "2035-01-01T01:02:03+00:00"
+  },
+  "login": "foo",
+  "name": null,
+  "publish_notifications": true,
+  "url": "https://github.com/foo"
+}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__anonymous-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__anonymous-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action requires authentication"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__anonymous-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__anonymous-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action requires authentication"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__non-admin-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__non-admin-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action can only be performed by a site admin"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__non-admin-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__lock__non-admin-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action can only be performed by a site admin"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__admin-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__admin-found.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.json()
+---
+{
+  "avatar": null,
+  "email": "foo@example.com",
+  "email_verification_sent": true,
+  "email_verified": true,
+  "id": 1,
+  "is_admin": false,
+  "lock": {
+    "reason": "naughty naughty",
+    "until": "[datetime]"
+  },
+  "login": "foo",
+  "name": null,
+  "publish_notifications": true,
+  "url": "https://github.com/foo"
+}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__admin-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__admin-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"Not Found"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__admin-reunlock.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__admin-reunlock.snap
@@ -1,0 +1,20 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.json()
+---
+{
+  "avatar": null,
+  "email": "foo@example.com",
+  "email_verification_sent": true,
+  "email_verified": true,
+  "id": 1,
+  "is_admin": false,
+  "lock": {
+    "reason": "naughty naughty",
+    "until": "[datetime]"
+  },
+  "login": "foo",
+  "name": null,
+  "publish_notifications": true,
+  "url": "https://github.com/foo"
+}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__anonymous-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__anonymous-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action requires authentication"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__anonymous-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__anonymous-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"this action requires authentication"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__non-admin-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__non-admin-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"This account is locked until 2050-01-01 at 01:02:03 UTC. Reason: naughty naughty"}]}

--- a/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__non-admin-not-found.snap
+++ b/src/tests/routes/users/snapshots/crates_io__tests__routes__users__admin__unlock__non-admin-not-found.snap
@@ -1,0 +1,5 @@
+---
+source: src/tests/routes/users/admin.rs
+expression: response.text()
+---
+{"errors":[{"detail":"This account is locked until 2050-01-01 at 01:02:03 UTC. Reason: naughty naughty"}]}

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -150,6 +150,23 @@ impl TestApp {
         }
     }
 
+    pub async fn db_new_admin_user(&self, username: &str) -> MockCookieUser {
+        use diesel::prelude::*;
+        use diesel_async::RunQueryDsl;
+
+        let MockCookieUser { app, user } = self.db_new_user(username).await;
+
+        let mut conn = self.db_conn().await;
+        let user = diesel::update(users::table)
+            .filter(users::id.eq(user.id))
+            .set(users::is_admin.eq(true))
+            .get_result::<User>(&mut conn)
+            .await
+            .unwrap();
+
+        MockCookieUser { app, user }
+    }
+
     /// Obtain a reference to the upstream repository ("the index")
     pub fn upstream_index(&self) -> &UpstreamIndex {
         assert_some!(self.0.index.as_ref())


### PR DESCRIPTION
This PR adds three new routes, all of them admin only:

* `GET /api/v1/users/:user_id/admin`: returns an extended version of `EncodablePrivateUser` with information on whether the account is locked
* `PUT /api/v1/users/:user_id/lock`: locks the given account
* `DELETE /api/v1/users/:user_id/unlock`: unlocks the given account

The only part I expect to be slightly controversial here is the first one: in theory, we could extend the existing `GET /api/v1/users/:user_id` route to return the extra fields only to admins. But, practically, it feels cleaner and less error prone to add a new route that is entirely its own thing, although it reuses existing view and model infrastructure as much as it can.

Unsurprisingly, this will be followed by some frontend PRs.

## Notes for reviewers

This is probably best reviewed commit-by-commit. (I thought about splitting it into three or four PRs, but I think that's just increasing the review overhead, honestly.)

I will also note — slightly defensively — that the actual _functional_ diff is only 247 lines; the remainder is the update to the OpenAPI snapshot, integration tests for the new controllers, and snapshots related to those tests.