### PR TITLE
Simplify `releaseTrackSet` using `release_tracks` meta

### DIFF
--- a/app/adapters/crate.js
+++ b/app/adapters/crate.js
@@ -5,6 +5,34 @@ const BULK_REQUEST_GROUP_SIZE = 10;
 export default class CrateAdapter extends ApplicationAdapter {
   coalesceFindRequests = true;
 
+  async findHasMany(store, snapshot, url, relationship) {
+    if (relationship.key === 'versions') {
+      let { adapterOptions } = snapshot;
+      let data;
+      if (adapterOptions?.withReleaseTracks === true) {
+        data = { include: 'release_tracks' };
+      }
+      return this.ajax(url, 'GET', { data }).then(resp => {
+        let crate = store.peekRecord('crate', snapshot.id);
+        if (resp.meta) {
+          let payload = {
+            crate: {
+              id: snapshot.id,
+              versions_meta: {
+                ...crate.versions_meta,
+                ...resp.meta,
+              },
+            },
+          };
+          store.pushPayload(payload);
+        }
+        return resp;
+      });
+    }
+
+    return super.findHasMany(store, snapshot, url, relationship);
+  }
+
   findRecord(store, type, id, snapshot) {
     let { include } = snapshot;
     // This ensures `crate.versions` are always fetched from another request.

--- a/app/adapters/crate.js
+++ b/app/adapters/crate.js
@@ -5,6 +5,15 @@ const BULK_REQUEST_GROUP_SIZE = 10;
 export default class CrateAdapter extends ApplicationAdapter {
   coalesceFindRequests = true;
 
+  findRecord(store, type, id, snapshot) {
+    let { include } = snapshot;
+    // This ensures `crate.versions` are always fetched from another request.
+    if (include === undefined) {
+      snapshot.include = 'keywords,categories,badges,downloads';
+    }
+    return super.findRecord(store, type, id, snapshot);
+  }
+
   groupRecordsForFindMany(store, snapshots) {
     let result = [];
     for (let i = 0; i < snapshots.length; i += BULK_REQUEST_GROUP_SIZE) {

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -22,6 +22,22 @@ export default class Crate extends Model {
   @attr max_version;
   @attr max_stable_version;
   @attr newest_version;
+  /**
+   * @typedef {Object} VersionsMeta
+   * @property {number} total
+   * @property {string | null} next_page
+   * @property {Object.<string, ReleaseTrackDetails>} release_tracks
+   *
+   * @typedef {Object} ReleaseTrackDetails
+   * @property {string} highest
+   **/
+  /**
+   * This isn't an attribute in the crate response.
+   * It's actually the `meta` attribute that belongs to `versions`
+   * and needs to be assigned to `crate` manually.
+   * @type {VersionsMeta | null}
+   **/
+  @attr versions_meta;
 
   @attr description;
   @attr homepage;

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -83,16 +83,17 @@ export default class Crate extends Model {
     return Object.fromEntries(versions.slice().map(v => [v.id, v]));
   }
 
+  /**
+   * @type {Set<string>}
+   **/
   @cached get releaseTrackSet() {
-    let map = new Map();
-    let { versionsObj: versions, versionIdsBySemver } = this;
-    for (let id of versionIdsBySemver) {
-      let { releaseTrack, isPrerelease, yanked } = versions[id];
-      if (releaseTrack && !isPrerelease && !yanked && !map.has(releaseTrack)) {
-        map.set(releaseTrack, id);
-      }
-    }
-    return new Set(map.values());
+    let { release_tracks } = this.versions_meta ?? {};
+    assert(
+      '`loadVersionsTask.perform({ withReleaseTracks: true })` must be called before calling `releaseTrackSet`',
+      release_tracks != null,
+    );
+    let nums = Object.values(release_tracks ?? {}).map(it => it.highest) ?? [];
+    return new Set(nums);
   }
 
   hasOwnerUser(userId) {

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -146,9 +146,18 @@ export default class Crate extends Model {
     return [...(teams ?? []), ...(users ?? [])];
   });
 
-  loadVersionsTask = task(async ({ reload = false } = {}) => {
+  /**
+   * @param {Object} [Options]
+   * @param {bool} [Options.reload]
+   * @param {bool} [Options.withReleaseTracks] - default: true if it has not yet been loaded else false
+   **/
+  loadVersionsTask = task(async ({ reload = false, withReleaseTracks } = {}) => {
     let versionsRef = this.hasMany('versions');
-    let fut = reload === true ? versionsRef.reload() : versionsRef.load();
+    let opts = { adapterOptions: { withReleaseTracks } };
+    if (opts.adapterOptions.withReleaseTracks == null) {
+      opts.adapterOptions.withReleaseTracks = this?.versions_meta?.release_tracks == null;
+    }
+    let fut = reload === true ? versionsRef.reload(opts) : versionsRef.load(opts);
     return (await fut) ?? [];
   });
 }

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -130,8 +130,10 @@ export default class Crate extends Model {
     return [...(teams ?? []), ...(users ?? [])];
   });
 
-  loadVersionsTask = task(async () => {
-    return (await this.versions) ?? [];
+  loadVersionsTask = task(async ({ reload = false } = {}) => {
+    let versionsRef = this.hasMany('versions');
+    let fut = reload === true ? versionsRef.reload() : versionsRef.load();
+    return (await fut) ?? [];
   });
 }
 

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -106,7 +106,7 @@ export default class Version extends Model {
       return false;
     }
 
-    return this.crate?.releaseTrackSet.has(this.id);
+    return this.crate?.releaseTrackSet.has(this.num);
   }
 
   get featureList() {

--- a/app/routes/crate/dependencies.js
+++ b/app/routes/crate/dependencies.js
@@ -6,7 +6,7 @@ export default class VersionRoute extends Route {
 
   async model() {
     let crate = this.modelFor('crate');
-    let versions = await crate.get('versions');
+    let versions = await crate.loadVersionsTask.perform();
 
     let { default_version } = crate;
     let version = versions.find(version => version.num === default_version) ?? versions.lastObject;

--- a/app/routes/crate/range.js
+++ b/app/routes/crate/range.js
@@ -15,7 +15,7 @@ export default class VersionRoute extends Route {
     let crate = this.modelFor('crate');
 
     try {
-      let versions = await crate.hasMany('versions').load();
+      let versions = await crate.loadVersionsTask.perform();
       let allVersionNums = versions.map(it => it.num);
       let unyankedVersionNums = versions.filter(it => !it.yanked).map(it => it.num);
 

--- a/app/routes/crate/version-dependencies.js
+++ b/app/routes/crate/version-dependencies.js
@@ -9,7 +9,7 @@ export default class VersionRoute extends Route {
 
     let versions;
     try {
-      versions = await crate.get('versions');
+      versions = await crate.loadVersionsTask.perform();
     } catch (error) {
       let title = `${crate.name}: Failed to load version data`;
       return this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -16,7 +16,7 @@ export default class VersionRoute extends Route {
 
     let versions;
     try {
-      versions = await crate.get('versions');
+      versions = await crate.loadVersionsTask.perform();
     } catch (error) {
       let title = `${crate.name}: Failed to load version data`;
       return this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });

--- a/e2e/acceptance/crate-dependencies.spec.ts
+++ b/e2e/acceptance/crate-dependencies.spec.ts
@@ -76,16 +76,17 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
     });
 
     await ember.addHook(async owner => {
-      // Load `crate` and then explicitly unload the side-loaded `versions`.
+      // Load `crate` and ensure all `versions` are not loaded.
       let store = owner.lookup('service:store');
       let crateRecord = await store.findRecord('crate', 'foo');
-      let versions = crateRecord.hasMany('versions').value();
-      versions.forEach(record => record.unloadRecord());
+      let versionsRef = crateRecord.hasMany('versions');
+      globalThis.version_ids = versionsRef.ids();
     });
 
     await page.goto('/crates/foo/1.0.0/dependencies');
 
     await expect(page).toHaveURL('/crates/foo/1.0.0/dependencies');
+    await page.waitForFunction(() => globalThis.version_ids?.length === 0);
     await expect(page.locator('[data-test-404-page]')).toBeVisible();
     await expect(page.locator('[data-test-title]')).toHaveText('foo: Failed to load version data');
     await expect(page.locator('[data-test-go-back]')).toHaveCount(0);

--- a/e2e/acceptance/versions.spec.ts
+++ b/e2e/acceptance/versions.spec.ts
@@ -13,6 +13,7 @@ test.describe('Acceptance | crate versions page', { tag: '@acceptance' }, () => 
     await page.goto('/crates/nanomsg/versions');
     await expect(page).toHaveURL('/crates/nanomsg/versions');
 
+    await expect(page.locator('[data-test-version]')).toHaveCount(4);
     let versions = await page.locator('[data-test-version]').evaluateAll(el => el.map(it => it.dataset.testVersion));
     expect(versions).toEqual(['0.2.1', '0.3.0', '0.2.0', '0.1.0']);
 

--- a/e2e/routes/crate/range.spec.ts
+++ b/e2e/routes/crate/range.spec.ts
@@ -128,15 +128,16 @@ test.describe('Route | crate.range', { tag: '@routes' }, () => {
     });
 
     await ember.addHook(async owner => {
-      // Load `crate` and then explicitly unload the side-loaded `versions`.
+      // Load `crate` and ensure all `versions` are not loaded.
       let store = owner.lookup('service:store');
       let crateRecord = await store.findRecord('crate', 'foo');
-      let versions = crateRecord.hasMany('versions').value();
-      versions.forEach(record => record.unloadRecord());
+      let versionsRef = crateRecord.hasMany('versions');
+      globalThis.version_ids = versionsRef.ids();
     });
 
     await page.goto('/crates/foo/range/^3');
     await expect(page).toHaveURL('/crates/foo/range/%5E3');
+    await page.waitForFunction(() => globalThis.version_ids?.length === 0);
     await expect(page.locator('[data-test-404-page]')).toBeVisible();
     await expect(page.locator('[data-test-title]')).toHaveText('foo: Failed to load version data');
     await expect(page.locator('[data-test-go-back]')).toHaveCount(0);

--- a/mirage/route-handlers/-utils.js
+++ b/mirage/route-handlers/-utils.js
@@ -1,4 +1,6 @@
 import { Response } from 'miragejs';
+import semverParse from 'semver/functions/parse';
+import semverSort from 'semver/functions/rsort';
 
 export function notFound() {
   return new Response(
@@ -30,4 +32,18 @@ export function compareIsoDates(a, b) {
   let aDate = new Date(a);
   let bDate = new Date(b);
   return aDate < bDate ? -1 : aDate > bDate ? 1 : 0;
+}
+
+export function releaseTracks(versions) {
+  let versionNums = versions.models.filter(it => !it.yanked).map(it => it.num);
+  semverSort(versionNums, { loose: true });
+  let tracks = {};
+  for (let num of versionNums) {
+    let semver = semverParse(num, { loose: true });
+    if (!semver || semver.prerelease.length !== 0) continue;
+    let name = semver.major == 0 ? `0.${semver.minor}` : `${semver.major}`;
+    if (name in tracks) continue;
+    tracks[name] = { highest: num };
+  }
+  return tracks;
 }

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -58,12 +58,15 @@ export function register(server) {
     let { name } = request.params;
     let crate = schema.crates.findBy({ name });
     if (!crate) return notFound();
-
+    let serialized = this.serialize(crate);
     return {
-      ...this.serialize(crate),
-      ...this.serialize(crate.categories),
-      ...this.serialize(crate.keywords),
-      ...this.serialize(crate.versions.sort((a, b) => Number(b.id) - Number(a.id))),
+      categories: null,
+      keywords: null,
+      versions: null,
+      ...serialized,
+      ...(serialized.crate.categories && this.serialize(crate.categories)),
+      ...(serialized.crate.keywords && this.serialize(crate.keywords)),
+      ...(serialized.crate.versions && this.serialize(crate.versions.sort((a, b) => Number(b.id) - Number(a.id)))),
     };
   });
 

--- a/mirage/serializers/crate.js
+++ b/mirage/serializers/crate.js
@@ -6,7 +6,15 @@ import semverSort from 'semver/functions/rsort';
 import { compareIsoDates } from '../route-handlers/-utils';
 import BaseSerializer from './application';
 
+const VALID_INCLUDE_MODEL = new Set(['versions', 'keywords', 'categories' /*, 'badges', 'downloads' */]);
+
 export default BaseSerializer.extend({
+  include(request) {
+    let include = request.queryParams.include;
+    return include == null || include === 'full'
+      ? VALID_INCLUDE_MODEL.values()
+      : include.split(',').filter(it => VALID_INCLUDE_MODEL.has(it));
+  },
   attrs: [
     'badges',
     'categories',
@@ -38,19 +46,20 @@ export default BaseSerializer.extend({
 
   getHashForResource() {
     let [hash, addToIncludes] = BaseSerializer.prototype.getHashForResource.apply(this, arguments);
+    let includes = [...this.include(this.request)];
 
     if (Array.isArray(hash)) {
       for (let resource of hash) {
-        this._adjust(resource);
+        this._adjust(resource, includes);
       }
     } else {
-      this._adjust(hash);
+      this._adjust(hash, includes);
     }
 
     return [hash, addToIncludes];
   },
 
-  _adjust(hash) {
+  _adjust(hash, includes) {
     let versions = this.schema.versions.where({ crateId: hash.id });
     assert(`crate \`${hash.name}\` has no associated versions`, versions.length !== 0);
 
@@ -63,24 +72,31 @@ export default BaseSerializer.extend({
       versionNums[0];
     hash.yanked = versionsByNum[hash.default_version]?.yanked ?? false;
 
-    versions = versions.filter(it => !it.yanked);
-    versionNums = versionNums.filter(it => !versionsByNum[it].yanked);
-    hash.max_version = versionNums[0] ?? '0.0.0';
-    hash.max_stable_version = versionNums.find(it => !prerelease(it, { loose: true })) ?? null;
+    if (includes.includes('versions')) {
+      versions = versions.filter(it => !it.yanked);
+      versionNums = versionNums.filter(it => !versionsByNum[it].yanked);
+      hash.max_version = versionNums[0] ?? '0.0.0';
+      hash.max_stable_version = versionNums.find(it => !prerelease(it, { loose: true })) ?? null;
 
-    let newestVersions = versions.models.sort((a, b) => compareIsoDates(b.updated_at, a.updated_at));
-    hash.newest_version = newestVersions[0]?.num ?? '0.0.0';
+      let newestVersions = versions.models.sort((a, b) => compareIsoDates(b.updated_at, a.updated_at));
+      hash.newest_version = newestVersions[0]?.num ?? '0.0.0';
+
+      hash.versions = hash.version_ids;
+    } else {
+      hash.max_version = '0.0.0';
+      hash.newest_version = '0.0.0';
+      hash.max_stable_version = null;
+      hash.versions = null;
+    }
+    delete hash.version_ids;
 
     hash.id = hash.name;
 
-    hash.categories = hash.category_ids;
+    hash.categories = includes.includes('categories') ? hash.category_ids : null;
     delete hash.category_ids;
 
-    hash.keywords = hash.keyword_ids;
+    hash.keywords = includes.includes('keywords') ? hash.keyword_ids : null;
     delete hash.keyword_ids;
-
-    hash.versions = hash.version_ids;
-    delete hash.version_ids;
 
     delete hash.team_owner_ids;
     delete hash.user_owner_ids;

--- a/tests/acceptance/crate-dependencies-test.js
+++ b/tests/acceptance/crate-dependencies-test.js
@@ -78,11 +78,11 @@ module('Acceptance | crate dependencies page', function (hooks) {
 
     this.server.get('/api/v1/crates/:crate_name/versions', {}, 500);
 
-    // Load `crate` and then explicitly unload the side-loaded `versions`.
+    // Load `crate` and ensure all `versions` are not loaded.
     let store = this.owner.lookup('service:store');
     let crateRecord = await store.findRecord('crate', 'foo');
-    let versions = crateRecord.hasMany('versions').value();
-    versions.forEach(record => record.unloadRecord());
+    let versionsRef = crateRecord.hasMany('versions');
+    assert.deepEqual(versionsRef.ids(), []);
 
     await visit('/crates/foo/1.0.0/dependencies');
     assert.strictEqual(currentURL(), '/crates/foo/1.0.0/dependencies');

--- a/tests/adapters/crate-test.js
+++ b/tests/adapters/crate-test.js
@@ -22,4 +22,21 @@ module('Adapter | crate', function (hooks) {
     assert.strictEqual(foo?.name, 'foo');
     assert.strictEqual(bar?.name, 'bar');
   });
+
+  test('findRecord requests do not include versions by default', async function (assert) {
+    let _foo = this.server.create('crate', { name: 'foo' });
+    let version = this.server.create('version', { crate: _foo });
+
+    let store = this.owner.lookup('service:store');
+
+    let foo = await store.findRecord('crate', 'foo');
+    assert.strictEqual(foo?.name, 'foo');
+
+    // versions should not be loaded yet
+    let versionsRef = foo.hasMany('versions');
+    assert.deepEqual(versionsRef.ids(), []);
+
+    await versionsRef.load();
+    assert.deepEqual(versionsRef.ids(), [version.id]);
+  });
 });

--- a/tests/mirage/crates/versions/list-test.js
+++ b/tests/mirage/crates/versions/list-test.js
@@ -22,6 +22,7 @@ module('Mirage | GET /api/v1/crates/:id/versions', function (hooks) {
     assert.strictEqual(response.status, 200);
     assert.deepEqual(await response.json(), {
       versions: [],
+      meta: { total: 0, next_page: null },
     });
   });
 
@@ -103,6 +104,32 @@ module('Mirage | GET /api/v1/crates/:id/versions', function (hooks) {
           yank_message: null,
         },
       ],
+      meta: { total: 3, next_page: null },
+    });
+  });
+
+  test('include `release_tracks` meta', async function (assert) {
+    let user = this.server.create('user');
+    let crate = this.server.create('crate', { name: 'rand' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.1.0', publishedBy: user });
+    this.server.create('version', { crate, num: '1.2.0', rust_version: '1.69' });
+
+    let req = await fetch('/api/v1/crates/rand/versions');
+    let expected = await req.json();
+
+    let response = await fetch('/api/v1/crates/rand/versions?include=release_tracks');
+    assert.strictEqual(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      ...expected,
+      meta: {
+        ...expected.meta,
+        release_tracks: {
+          1: {
+            highest: '1.2.0',
+          },
+        },
+      },
     });
   });
 });

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -229,7 +229,7 @@ module('Model | Version', function (hooks) {
       this.server.create('version', { crate, num: '0.4.2' });
       this.server.create('version', { crate, num: '0.4.3', yanked: true });
       crateRecord = await this.store.findRecord('crate', crate.name, { reload: true });
-      versions = (await crateRecord.loadVersionsTask.perform({ reload: true })).slice();
+      versions = (await crateRecord.loadVersionsTask.perform({ reload: true, withReleaseTracks: true })).slice();
 
       assert.deepEqual(
         versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -229,7 +229,7 @@ module('Model | Version', function (hooks) {
       this.server.create('version', { crate, num: '0.4.2' });
       this.server.create('version', { crate, num: '0.4.3', yanked: true });
       crateRecord = await this.store.findRecord('crate', crate.name, { reload: true });
-      versions = (await crateRecord.loadVersionsTask.perform()).slice();
+      versions = (await crateRecord.loadVersionsTask.perform({ reload: true })).slice();
 
       assert.deepEqual(
         versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -119,11 +119,11 @@ module('Route | crate.range', function (hooks) {
 
     this.server.get('/api/v1/crates/:crate_name/versions', {}, 500);
 
-    // Load `crate` and then explicitly unload the side-loaded `versions`.
+    // Load `crate` and ensure all `versions` are not loaded.
     let store = this.owner.lookup('service:store');
     let crateRecord = await store.findRecord('crate', 'foo');
-    let versions = crateRecord.hasMany('versions').value();
-    versions.forEach(record => record.unloadRecord());
+    let versionsRef = crateRecord.hasMany('versions');
+    assert.deepEqual(versionsRef.ids(), []);
 
     await visit('/crates/foo/range/^3');
     assert.strictEqual(currentURL(), '/crates/foo/range/%5E3');


### PR DESCRIPTION
This is a follow-up PR to #10214 that simplifies `releaseTrackSet` using `release_tracks` meta. As part of this transition, we also ensure that `versions` are loaded from a separate request. In other words, we ask the `crate` API to *not* include the `versions` data by default.

This is also part of eliminating the need for versions to be sorted again within the app. Therefore, the next step would be to leverage sorted data from endpoint without recalculating it within the app.