### PR TITLE
Simplify nested imports

### DIFF
--- a/src/bin/crates-admin/render_readmes.rs
+++ b/src/bin/crates-admin/render_readmes.rs
@@ -1,9 +1,7 @@
 use anyhow::{anyhow, Context};
-use crates_io::{
-    db,
-    models::Version,
-    schema::{crates, readme_renderings, versions},
-};
+use crates_io::db;
+use crates_io::models::Version;
+use crates_io::schema::{crates, readme_renderings, versions};
 use futures_util::{StreamExt, TryStreamExt};
 use std::path::{Path, PathBuf};
 use std::{future, sync::Arc};

--- a/src/bin/crates-admin/transfer_crates.rs
+++ b/src/bin/crates-admin/transfer_crates.rs
@@ -1,9 +1,7 @@
 use crate::dialoguer;
-use crates_io::{
-    db,
-    models::{Crate, OwnerKind, User},
-    schema::{crate_owners, crates, users},
-};
+use crates_io::db;
+use crates_io::models::{Crate, OwnerKind, User};
+use crates_io::schema::{crate_owners, crates, users};
 
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};

--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -1,12 +1,8 @@
-use crate::{
-    models::{Category, Crate, Keyword, NewCrate},
-    schema::{crates, version_downloads},
-    util::errors::AppResult,
-};
+use crate::models::{update_default_version, Category, Crate, Keyword, NewCrate};
+use crate::schema::{crate_downloads, crates, version_downloads};
+use crate::util::errors::AppResult;
 
 use super::VersionBuilder;
-use crate::models::update_default_version;
-use crate::schema::crate_downloads;
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -1,8 +1,6 @@
-use crate::{
-    models::{Crate, NewVersion, Version},
-    schema::dependencies,
-    util::errors::AppResult,
-};
+use crate::models::{Crate, NewVersion, Version};
+use crate::schema::dependencies;
+use crate::util::errors::AppResult;
 use std::collections::BTreeMap;
 
 use chrono::NaiveDateTime;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,11 +1,9 @@
+use crate::models::{Crate, CrateOwner, NewCategory, NewTeam, NewUser, OwnerKind, Team, User};
+use crate::schema::crate_owners;
 use crate::tests::util::{RequestHelper, TestApp};
-use crate::{
-    models::{Crate, CrateOwner, NewCategory, NewTeam, NewUser, OwnerKind, Team, User},
-    schema::crate_owners,
-    views::{
-        EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
-        EncodableOwner, EncodableVersion, GoodCrate,
-    },
+use crate::views::{
+    EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
+    EncodableOwner, EncodableVersion, GoodCrate,
 };
 
 use crate::tests::util::github::next_gh_id;

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -1,15 +1,11 @@
-use crate::tests::{
-    add_team_to_crate,
-    builders::{CrateBuilder, PublishBuilder},
-    new_team,
-    util::{MockAnonymousUser, MockCookieUser, MockTokenUser, RequestHelper, Response},
-    TestApp,
+use crate::models::Crate;
+use crate::tests::builders::{CrateBuilder, PublishBuilder};
+use crate::tests::util::{
+    MockAnonymousUser, MockCookieUser, MockTokenUser, RequestHelper, Response,
 };
-use crate::{
-    models::Crate,
-    views::{
-        EncodableCrateOwnerInvitationV1, EncodableOwner, EncodablePublicUser, InvitationResponse,
-    },
+use crate::tests::{add_team_to_crate, new_team, TestApp};
+use crate::views::{
+    EncodableCrateOwnerInvitationV1, EncodableOwner, EncodablePublicUser, InvitationResponse,
 };
 
 use crate::schema::users;

--- a/src/tests/team.rs
+++ b/src/tests/team.rs
@@ -1,12 +1,7 @@
-use crate::tests::{
-    add_team_to_crate,
-    builders::{CrateBuilder, PublishBuilder},
-    new_team, OwnerTeamsResponse, RequestHelper, TestApp,
-};
-use crate::{
-    models::{Crate, NewTeam},
-    schema::teams,
-};
+use crate::models::{Crate, NewTeam};
+use crate::schema::teams;
+use crate::tests::builders::{CrateBuilder, PublishBuilder};
+use crate::tests::{add_team_to_crate, new_team, OwnerTeamsResponse, RequestHelper, TestApp};
 
 use diesel::*;
 use diesel_async::RunQueryDsl;

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -1,9 +1,6 @@
 use crate::models::{ApiToken, Email, NewUser, User};
-use crate::tests::{
-    new_user,
-    util::{MockCookieUser, RequestHelper},
-    TestApp,
-};
+use crate::tests::util::{MockCookieUser, RequestHelper};
+use crate::tests::{new_user, TestApp};
 use crate::util::token::HashedToken;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;

--- a/src/tests/util/chaosproxy.rs
+++ b/src/tests/util/chaosproxy.rs
@@ -1,14 +1,10 @@
 use anyhow::{anyhow, Context};
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{
-        tcp::{OwnedReadHalf, OwnedWriteHalf},
-        TcpListener, TcpStream,
-    },
-    sync::broadcast::Sender,
-};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast::Sender;
 use tracing::{debug, error};
 use url::Url;
 

--- a/src/tests/util/matchers.rs
+++ b/src/tests/util/matchers.rs
@@ -1,7 +1,5 @@
-use googletest::{
-    description::Description,
-    matcher::{Matcher, MatcherBase, MatcherResult},
-};
+use googletest::description::Description;
+use googletest::matcher::{Matcher, MatcherBase, MatcherResult};
 use http::StatusCode;
 
 pub fn is_success() -> SuccessMatcher {

--- a/src/typosquat/cache.rs
+++ b/src/typosquat/cache.rs
@@ -1,10 +1,8 @@
 use diesel_async::AsyncPgConnection;
 use std::sync::Arc;
 use thiserror::Error;
-use typomania::{
-    checks::{Bitflips, Omitted, SwappedWords, Typos},
-    Harness,
-};
+use typomania::checks::{Bitflips, Omitted, SwappedWords, Typos};
+use typomania::Harness;
 
 use super::{checks::Affixes, config, database::TopCrates};
 

--- a/src/typosquat/checks.rs
+++ b/src/typosquat/checks.rs
@@ -1,7 +1,5 @@
-use typomania::{
-    checks::{Check, Squat},
-    Corpus, Package,
-};
+use typomania::checks::{Check, Squat};
+use typomania::{Corpus, Package};
 
 /// A typomania check that checks if commonly used prefixes or suffixes have been added to or
 /// removed from a package name.

--- a/src/typosquat/database.rs
+++ b/src/typosquat/database.rs
@@ -1,9 +1,10 @@
 //! Types that bridge the crates.io database and typomania.
 
-use std::{
-    borrow::Borrow,
-    collections::{BTreeMap, HashMap, HashSet},
-};
+use crate::models;
+use crate::schema::{crate_downloads, crate_owners};
+
+use std::borrow::Borrow;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
@@ -20,11 +21,6 @@ pub struct TopCrates {
 impl TopCrates {
     /// Retrieves the `num` top crates from the database.
     pub async fn new(conn: &mut AsyncPgConnection, num: i64) -> QueryResult<Self> {
-        use crate::{
-            models,
-            schema::{crate_downloads, crate_owners},
-        };
-
         // We have to build up a data structure that contains the top crates, their owners in some
         // form that is easily compared, and that can be indexed by the crate name.
         //

--- a/src/typosquat/test_util.rs
+++ b/src/typosquat/test_util.rs
@@ -1,11 +1,9 @@
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 
+use crate::models::{Crate, NewTeam, NewUser, Team, User};
+use crate::schema::users;
 use crate::tests::util::github::next_gh_id;
-use crate::{
-    models::{Crate, NewTeam, NewUser, Team, User},
-    schema::users,
-};
 
 pub mod faker {
     use super::*;

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -5,11 +5,9 @@ use diesel_async::AsyncPgConnection;
 use typomania::Package;
 
 use crate::email::Email;
-use crate::{
-    typosquat::{Cache, Crate},
-    worker::Environment,
-    Emails,
-};
+use crate::typosquat::{Cache, Crate};
+use crate::worker::Environment;
+use crate::Emails;
 
 /// A job to check the name of a newly published crate against the most popular crates to see if
 /// the new crate might be typosquatting an existing, popular crate.


### PR DESCRIPTION
I wish rustfmt / cargo clippy would lint for such things but unfortunately the corresponding rules are not stable yet... anyway, this saves a couple of lines and makes it easier for IDEs to auto-import things without duplicating imports.