### PR TITLE
crate/delete: tinker with the requirements styling

### DIFF
--- a/app/styles/crate/delete.module.css
+++ b/app/styles/crate/delete.module.css
@@ -55,7 +55,8 @@
 
 .requirements {
     .or {
-        text-align: center;
+        padding-left: 3.5em;
+        padding-bottom: 0.3em;
         font-weight: bold;
         font-variant: small-caps;
     }

--- a/app/styles/crate/delete.module.css
+++ b/app/styles/crate/delete.module.css
@@ -47,10 +47,30 @@
     }
 }
 
+@counter-style sub {
+    system: extends lower-alpha;
+    prefix: '(';
+    suffix: ') ';
+}
+
 .requirements {
-    ul {
-        list-style: none;
-        padding-left: 0;
+    .or {
+        text-align: center;
+        font-weight: bold;
+        font-variant: small-caps;
+    }
+
+    .first {
+        margin-bottom: 0.5em;
+    }
+
+    .second {
+        margin-top: 0.5em;
+    }
+
+    ol ol {
+        list-style-type: sub;
+        padding-left: 1.5em;
     }
 }
 

--- a/app/templates/crate/delete.hbs
+++ b/app/templates/crate/delete.hbs
@@ -20,15 +20,18 @@
 
     <div local-class="requirements">
       <h3>Requirements:</h3>
-      <p>A crate can only be deleted if:</p>
-      <ol>
-        <li>the crate has been published for less than 72 hours, or</li>
+      <p>A crate can only be deleted if either:</p>
+      <ol local-class='first'>
+        <li>the crate has been published for less than 72 hours</li>
+      </ol>
+      <div local-class='or'>or</div>
+      <ol start="2" local-class='second'>
         <li>
-          <ul>
-            <li>the crate only has a single owner, and</li>
-            <li>the crate has been downloaded less than 500 times for each month it has been published, and</li>
+          <ol>
+            <li>the crate only has a single owner, <em>and</em></li>
+            <li>the crate has been downloaded less than 500 times for each month it has been published, <em>and</em></li>
             <li>the crate is not depended upon by any other crate on crates.io.</li>
-          </ul>
+          </ol>
         </li>
       </ol>
     </div>


### PR DESCRIPTION
As discussed at today's team meeting, here is a slight tweak to how the requirements are laid out when deleting a crate.

Before:

![image](https://github.com/user-attachments/assets/93ca0ecd-7ac6-4222-8309-c5af4ce373a9)

After:

![image](https://github.com/user-attachments/assets/e00e1fec-44ad-4538-a595-925625ec1ef3)
