### PR TITLE
controllers/krate/delete: Send deletion notification email after successful deletion

### DIFF
--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_new_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_new_crate-2.snap
@@ -1,0 +1,33 @@
+---
+source: src/controllers/krate/delete.rs
+expression: app.emails_snapshot().await
+snapshot_kind: text
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Successfully published foo@1.0.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello foo!
+
+A new version of the package foo (1.0.0) was published by your account (htt=
+ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+If you have questions or security concerns, you can contact us at help@crat=
+es.io. If you would like to stop receiving these security notifications, yo=
+u can disable them in your account settings.
+----------------------------------------
+
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Deleted "foo" crate
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hi foo,
+
+your "foo" crate has been deleted, per your request.
+
+If you did not initiate this deletion, your account may have been compromis=
+ed. Please contact us at help@crates.io.

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_old_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_old_crate-2.snap
@@ -1,0 +1,33 @@
+---
+source: src/controllers/krate/delete.rs
+expression: app.emails_snapshot().await
+snapshot_kind: text
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Successfully published foo@1.0.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello foo!
+
+A new version of the package foo (1.0.0) was published by your account (htt=
+ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+If you have questions or security concerns, you can contact us at help@crat=
+es.io. If you would like to stop receiving these security notifications, yo=
+u can disable them in your account settings.
+----------------------------------------
+
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Deleted "foo" crate
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hi foo,
+
+your "foo" crate has been deleted, per your request.
+
+If you did not initiate this deletion, your account may have been compromis=
+ed. Please contact us at help@crates.io.

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_really_old_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_really_old_crate-2.snap
@@ -1,0 +1,33 @@
+---
+source: src/controllers/krate/delete.rs
+expression: app.emails_snapshot().await
+snapshot_kind: text
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Successfully published foo@1.0.0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hello foo!
+
+A new version of the package foo (1.0.0) was published by your account (htt=
+ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+
+If you have questions or security concerns, you can contact us at help@crat=
+es.io. If you would like to stop receiving these security notifications, yo=
+u can disable them in your account settings.
+----------------------------------------
+
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Deleted "foo" crate
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Hi foo,
+
+your "foo" crate has been deleted, per your request.
+
+If you did not initiate this deletion, your account may have been compromis=
+ed. Please contact us at help@crates.io.


### PR DESCRIPTION
This PR addresses part two of https://github.com/rust-lang/crates.io/issues/9352#issuecomment-2549402681 by sending a notification email to the owner when a crate is getting deleted.