### PR TITLE
Raise crate deletion download limit

### DIFF
--- a/app/templates/crate/delete.hbs
+++ b/app/templates/crate/delete.hbs
@@ -26,7 +26,7 @@
         <li>
           <ul>
             <li>the crate only has a single owner, and</li>
-            <li>the crate has been downloaded less than 100 times for each month it has been published, and</li>
+            <li>the crate has been downloaded less than 500 times for each month it has been published, and</li>
             <li>the crate is not depended upon by any other crate on crates.io.</li>
           </ul>
         </li>

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -15,7 +15,7 @@ use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use http::request::Parts;
 use http::StatusCode;
 
-const DOWNLOADS_PER_MONTH_LIMIT: u64 = 100;
+const DOWNLOADS_PER_MONTH_LIMIT: u64 = 500;
 const AVAILABLE_AFTER: TimeDelta = TimeDelta::hours(24);
 
 /// Delete a crate.
@@ -25,7 +25,7 @@ const AVAILABLE_AFTER: TimeDelta = TimeDelta::hours(24);
 ///
 /// The crate can only be deleted by the owner of the crate, and only if the
 /// crate has been published for less than 72 hours, or if the crate has a
-/// single owner, has been downloaded less than 100 times for each month it has
+/// single owner, has been downloaded less than 500 times for each month it has
 /// been published, and is not depended upon by any other crate on crates.io.
 #[utoipa::path(
     delete,
@@ -384,7 +384,7 @@ mod tests {
 
         let response = delete_crate(&user, "foo").await;
         assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
-        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"only crates with less than 100 downloads per month can be deleted after 72 hours"}]}"#);
+        assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"only crates with less than 500 downloads per month can be deleted after 72 hours"}]}"#);
 
         assert_crate_exists(&anon, "foo", true).await;
 

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -440,7 +440,7 @@ snapshot_kind: text
     },
     "/api/v1/crates/{name}": {
       "delete": {
-        "description": "The crate is immediately deleted from the database, and with a small delay\nfrom the git and sparse index, and the crate file storage.\n\nThe crate can only be deleted by the owner of the crate, and only if the\ncrate has been published for less than 72 hours, or if the crate has a\nsingle owner, has been downloaded less than 100 times for each month it has\nbeen published, and is not depended upon by any other crate on crates.io.",
+        "description": "The crate is immediately deleted from the database, and with a small delay\nfrom the git and sparse index, and the crate file storage.\n\nThe crate can only be deleted by the owner of the crate, and only if the\ncrate has been published for less than 72 hours, or if the crate has a\nsingle owner, has been downloaded less than 500 times for each month it has\nbeen published, and is not depended upon by any other crate on crates.io.",
         "operationId": "delete_crate",
         "parameters": [
           {


### PR DESCRIPTION
As discussed in the last crates.io team meeting the current limit of just 100 downloads per month was too conservative. This commit raises the limit to 500 downloads per month to make self-service deletions a bit more viable in practice.