### PR TITLE
cdn_logs: Use `README.md` as module documentation

### DIFF
--- a/crates/crates_io_cdn_logs/src/lib.rs
+++ b/crates/crates_io_cdn_logs/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = include_str!("../README.md")]
+
 pub mod cloudfront;
 mod compression;
 mod download_map;


### PR DESCRIPTION
We don't use docs.rs, but this might help people that use `cargo doc` locally, or that have IDE support for these things.