### PR TITLE
mirage: Add `include=default_version` support for `GET /api/v1/crates/:id`

### DIFF
--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -59,6 +59,8 @@ export function register(server) {
     let crate = schema.crates.findBy({ name });
     if (!crate) return notFound();
     let serialized = this.serialize(crate);
+    let includes = request.queryParams?.include ?? '';
+    let includeDefaultVersion = includes.includes('default_version') && !includes.includes('versions');
     return {
       categories: null,
       keywords: null,
@@ -67,6 +69,12 @@ export function register(server) {
       ...(serialized.crate.categories && this.serialize(crate.categories)),
       ...(serialized.crate.keywords && this.serialize(crate.keywords)),
       ...(serialized.crate.versions && this.serialize(crate.versions.sort((a, b) => Number(b.id) - Number(a.id)))),
+      // `default_version` share the same key `versions`
+      ...(includeDefaultVersion && {
+        versions: [serialized.crate.default_version].map(
+          num => this.serialize(schema.versions.findBy({ num })).version,
+        ),
+      }),
     };
   });
 

--- a/mirage/serializers/crate.js
+++ b/mirage/serializers/crate.js
@@ -6,7 +6,13 @@ import semverSort from 'semver/functions/rsort';
 import { compareIsoDates } from '../route-handlers/-utils';
 import BaseSerializer from './application';
 
-const VALID_INCLUDE_MODEL = new Set(['versions', 'keywords', 'categories' /*, 'badges', 'downloads' */]);
+const VALID_INCLUDE_MODEL = new Set([
+  'versions',
+  'default_version',
+  'keywords',
+  'categories',
+  /*, 'badges', 'downloads' */
+]);
 
 export default BaseSerializer.extend({
   include(request) {


### PR DESCRIPTION
Related:
- #10288 