### PR TITLE
tests/util: Reduce monomorphization overhead for the `RequestHelper` code

### DIFF
--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -141,26 +141,18 @@ pub trait RequestHelper {
 
     /// Issue a PUT request
     async fn put<T>(&self, path: &str, body: impl Into<Bytes>) -> Response<T> {
-        let body = body.into();
-
-        let mut request = self.request_builder(Method::PUT, path);
-        *request.body_mut() = body;
-        if is_json_body(request.body()) {
-            request.header(header::CONTENT_TYPE, "application/json");
-        }
+        let request = self
+            .request_builder(Method::PUT, path)
+            .with_body(body.into());
 
         self.run(request).await
     }
 
     /// Issue a PATCH request
     async fn patch<T>(&self, path: &str, body: impl Into<Bytes>) -> Response<T> {
-        let body = body.into();
-
-        let mut request = self.request_builder(Method::PATCH, path);
-        *request.body_mut() = body;
-        if is_json_body(request.body()) {
-            request.header(header::CONTENT_TYPE, "application/json");
-        }
+        let request = self
+            .request_builder(Method::PATCH, path)
+            .with_body(body.into());
 
         self.run(request).await
     }
@@ -173,13 +165,9 @@ pub trait RequestHelper {
 
     /// Issue a DELETE request with a body... yes we do it, for crate owner removal
     async fn delete_with_body<T>(&self, path: &str, body: impl Into<Bytes>) -> Response<T> {
-        let body = body.into();
-
-        let mut request = self.request_builder(Method::DELETE, path);
-        *request.body_mut() = body;
-        if is_json_body(request.body()) {
-            request.header(header::CONTENT_TYPE, "application/json");
-        }
+        let request = self
+            .request_builder(Method::DELETE, path)
+            .with_body(body.into());
 
         self.run(request).await
     }
@@ -261,11 +249,6 @@ fn req(method: Method, path: &str) -> MockRequest {
         .header(header::USER_AGENT, "conduit-test")
         .body(Bytes::new())
         .unwrap()
-}
-
-fn is_json_body(body: &Bytes) -> bool {
-    (body.starts_with(b"{") && body.ends_with(b"}"))
-        || (body.starts_with(b"[") && body.ends_with(b"]"))
 }
 
 /// A type that can generate unauthenticated requests

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -105,21 +105,25 @@ fn json<T>(r: &hyper::Response<Bytes>) -> T
 where
     for<'de> T: serde::Deserialize<'de>,
 {
-    let headers = r.headers();
+    fn inner(r: &hyper::Response<Bytes>) -> &Bytes {
+        let headers = r.headers();
 
-    assert_some_eq!(headers.get(header::CONTENT_TYPE), "application/json");
+        assert_some_eq!(headers.get(header::CONTENT_TYPE), "application/json");
 
-    let content_length = assert_some!(
-        r.headers().get(header::CONTENT_LENGTH),
-        "Missing content-length header"
-    );
-    let content_length = assert_ok!(content_length.to_str());
-    let content_length: usize = assert_ok!(content_length.parse());
+        let content_length = assert_some!(
+            r.headers().get(header::CONTENT_LENGTH),
+            "Missing content-length header"
+        );
+        let content_length = assert_ok!(content_length.to_str());
+        let content_length: usize = assert_ok!(content_length.parse());
 
-    let bytes = r.body();
-    assert_that!(*bytes, len(eq(content_length)));
+        let bytes = r.body();
+        assert_that!(*bytes, len(eq(content_length)));
 
-    match serde_json::from_slice(bytes) {
+        bytes
+    }
+
+    match serde_json::from_slice(inner(r)) {
         Ok(t) => t,
         Err(e) => panic!("failed to decode: {e:?}"),
     }

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -51,10 +51,6 @@ impl<T> Response<T> {
         assert_ok!(from_utf8(bytes)).to_string()
     }
 
-    pub fn status(&self) -> StatusCode {
-        self.response.status()
-    }
-
     #[track_caller]
     pub fn assert_redirect_ends_with(&self, target: &str) -> &Self {
         let headers = self.response.headers();


### PR DESCRIPTION
The result of `cargo llvm-lines --lib --profile test` indicated that our `RequestHelper` trait was causing a lot of code generation due to the generic `<T>` parameter.

This PR considerably reduces the amount of copied code, and thus should improve the compile times of our test suite a bit (see https://matklad.github.io/2021/09/04/fast-rust-builds.html#Keeping-an-Eye-on-Instantiations).