### PR TITLE
Add multiple `nums[]` parameters support for `GET /api/v1/crates/:name/versions`

### DIFF
--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -153,7 +153,12 @@ export function register(server) {
     let crate = schema.crates.findBy({ name });
     if (!crate) return notFound();
 
-    let versions = crate.versions.sort((a, b) => compareIsoDates(b.created_at, a.created_at));
+    let versions = crate.versions;
+    let { nums } = request.queryParams;
+    if (nums) {
+      versions = versions.filter(version => nums.includes(version.num));
+    }
+    versions = versions.sort((a, b) => compareIsoDates(b.created_at, a.created_at));
     let total = versions.length;
     let include = request.queryParams?.include ?? '';
     let release_tracks = include.split(',').includes('release_tracks') && releaseTracks(crate.versions);

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -856,6 +856,19 @@ expression: response.json()
             }
           },
           {
+            "description": "If set, only versions with the specified semver strings are returned.",
+            "in": "query",
+            "name": "nums[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "description": "A string that does not contain null bytes (`\\0`).",
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
             "description": "The page number to request.\n\nThis parameter is mutually exclusive with `seek` and not supported for\nall requests.",
             "in": "query",
             "name": "page",

--- a/tests/mirage/crates/versions/list-test.js
+++ b/tests/mirage/crates/versions/list-test.js
@@ -108,6 +108,21 @@ module('Mirage | GET /api/v1/crates/:name/versions', function (hooks) {
     });
   });
 
+  test('supports multiple `ids[]` parameters', async function (assert) {
+    let user = this.server.create('user');
+    let crate = this.server.create('crate', { name: 'rand' });
+    this.server.create('version', { crate, num: '1.0.0' });
+    this.server.create('version', { crate, num: '1.1.0', publishedBy: user });
+    this.server.create('version', { crate, num: '1.2.0', rust_version: '1.69' });
+    let response = await fetch('/api/v1/crates/rand/versions?nums[]=1.0.0&nums[]=1.2.0');
+    assert.strictEqual(response.status, 200);
+    let json = await response.json();
+    assert.deepEqual(
+      json.versions.map(v => v.num),
+      ['1.0.0', '1.2.0'],
+    );
+  });
+
   test('include `release_tracks` meta', async function (assert) {
     let user = this.server.create('user');
     let crate = this.server.create('crate', { name: 'rand' });


### PR DESCRIPTION
This allows us to return specified versions by filtering with the `ids[]` parameter.