### PR TITLE
insta: Remove obsolete `snapshot_kind` declaration from snapshots

### DIFF
--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_database_dump/src/lib.rs
 expression: content
-snapshot_kind: text
 ---
 BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
 

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_database_dump/src/lib.rs
 expression: content
-snapshot_kind: text
 ---
 BEGIN;
     -- Disable triggers on each table.

--- a/crates/crates_io_index/snapshots/crates_io_index__features__tests__split_features_clap.snap
+++ b/crates/crates_io_index/snapshots/crates_io_index__features__tests__split_features_clap.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_index/features.rs
 expression: split_features(features)
-snapshot_kind: text
 ---
 (
     {

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__app.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__app.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: tarball_info.manifest.bin
-snapshot_kind: text
 ---
 [
     Product {

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: lib
-snapshot_kind: text
 ---
 Product {
     path: Some(

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-2.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-2.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: tarball_info.manifest.bin
-snapshot_kind: text
 ---
 [
     Product {

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-3.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example-3.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: tarball_info.manifest.example
-snapshot_kind: text
 ---
 [
     Product {

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
 expression: lib
-snapshot_kind: text
 ---
 Product {
     path: Some(

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_new_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_new_crate-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/controllers/krate/delete.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_old_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_old_crate-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/controllers/krate/delete.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_really_old_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_really_old_crate-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/controllers/krate/delete.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/controllers/user/snapshots/crates_io__controllers__user__email_verification__tests__happy_path-2.snap
+++ b/src/controllers/user/snapshots/crates_io__controllers__user__email_verification__tests__happy_path-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/controllers/user/email_verification.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/snapshots/crates_io__index__tests__index_metadata-2.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/index.rs
 expression: metadata
-snapshot_kind: text
 ---
 [
   {

--- a/src/snapshots/crates_io__index__tests__index_metadata.snap
+++ b/src/snapshots/crates_io__index__tests__index_metadata.snap
@@ -1,7 +1,6 @@
 ---
 source: src/index.rs
 expression: metadata
-snapshot_kind: text
 ---
 [
   {

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1,7 +1,6 @@
 ---
 source: src/openapi.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "components": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-4.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-4.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_twice_alt.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_weird_version.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate_with_token.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/basics.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_1.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__build_metadata__version_with_build_metadata@build_metadata_3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/build_metadata.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__categories__good_categories.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/categories.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__dep_limit-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_sorts_deps.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_sorts_deps.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_with_dependency.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_krate_with_dependency.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_renamed_dependency.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_renamed_dependency.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_underscore_renamed_dependency.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__dependencies__new_with_underscore_renamed_dependency.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/dependencies.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__edition__edition_is_saved-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__edition__edition_is_saved-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/edition.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__edition__edition_is_saved.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__edition__edition_is_saved.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/edition.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_start_with_number_and_underscore.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_start_with_number_and_underscore.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_dot.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_dot.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_unicode_chars.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__feature_name_with_unicode_chars.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__features_version_2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__features__features_version_2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/features.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__keywords__good_keywords.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/keywords.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/links.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/links.rs
 expression: crates
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__links__crate_with_links_field.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/links.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__boolean_readme.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__manifest__lib_and_bin_crate.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/manifest.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__max_size__tarball_between_default_axum_limit_and_max_upload_size.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/max_size.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_empty_readme.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/readme.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/readme.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__readme__new_krate_with_readme_and_plus_version.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/readme.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "crate": {

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-10.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-10.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-3.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-4.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-4.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-5.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-5.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-6.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-6.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-7.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-7.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-8.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-8.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-9.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name-9.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__validation__bad_name.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/publish/validation.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-2.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-3.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-4.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-4.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-5.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-5.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-6.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank-6.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank.snap
+++ b/src/tests/krate/snapshots/crates_io__tests__krate__yanking__patch_version_yank_unyank.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/krate/yanking.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__get__show.snap
+++ b/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__get__show.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/categories/get.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "category": {

--- a/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index-2.snap
+++ b/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/categories/list.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "categories": [

--- a/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index.snap
+++ b/src/tests/routes/categories/snapshots/crates_io__tests__routes__categories__list__index.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/categories/list.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "categories": [],

--- a/src/tests/routes/category_slugs/snapshots/crates_io__tests__routes__category_slugs__list__category_slugs_returns_all_slugs_in_alphabetical_order.snap
+++ b/src/tests/routes/category_slugs/snapshots/crates_io__tests__routes__category_slugs__list__category_slugs_returns_all_slugs_in_alphabetical_order.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/category_slugs/list.rs
 expression: response
-snapshot_kind: text
 ---
 {
   "category_slugs": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__crate_downloads.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__crate_downloads.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/downloads.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "meta": {

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__version_downloads.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__downloads__version_downloads.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/downloads.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version_downloads": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-2.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-3.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-4.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-4.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-5.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes-5.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__list__invalid_params_with_null_bytes.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/list.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__include_default_version.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__include_default_version.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "categories": null,

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__new_name.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "categories": null,

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "categories": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_all_yanked.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_all_yanked.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "categories": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__read__show_minimal.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/read.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "categories": null,

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__prerelease_versions_not_included_in_reverse_dependencies.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_includes_published_by_user_when_present.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_query_supports_u64_version_number_parts.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_depended_but_new_doesnt.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_depended_but_new_doesnt.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__reverse_dependencies_when_old_version_doesnt_depend_but_new_does.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [],

--- a/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
+++ b/src/tests/routes/crates/snapshots/crates_io__tests__routes__crates__reverse_dependencies__yanked_versions_not_included_in_reverse_dependencies.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/reverse_dependencies.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "dependencies": [

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__authors__authors.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__authors__authors.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/versions/authors.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "meta": {

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__list__versions.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__list__versions.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/versions/list.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "meta": {

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_semver_no_published_by.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/versions/read.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_version.snap
+++ b/src/tests/routes/crates/versions/snapshots/crates_io__tests__routes__crates__versions__read__show_by_crate_name_and_version.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/crates/versions/read.rs
 expression: json
-snapshot_kind: text
 ---
 {
   "version": {

--- a/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-2.snap
+++ b/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/get.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "owned_crates": [],

--- a/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-3.snap
+++ b/src/tests/routes/me/snapshots/crates_io__tests__routes__me__get__me-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/get.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "owned_crates": [

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/create.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/get.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show_token_with_scopes.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__get__show_token_with_scopes.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/get.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "api_token": {

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__list__list_tokens.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__list__list_tokens.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/me/tokens/list.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "api_tokens": [

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-3.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-4.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-4.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-6.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-6.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/routes/users/update/publish_notifications.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_revoked_token.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_revoked_token.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: response.json()
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_unknown_token.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_unknown_token.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: response.json()
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token-2.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/github_secret_scanning.rs
 expression: response.json()
-snapshot_kind: text
 ---
 [
   {

--- a/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners-6.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners-6.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: user2@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: user2@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__owners__new_crate_owner-2.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__new_crate_owner-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__new_crate_owner.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/owners.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: foo@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/snapshots/crates_io__tests__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
+++ b/src/tests/snapshots/crates_io__tests__read_only_mode__cannot_hit_endpoint_which_writes_db_in_read_only_mode.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/read_only_mode.rs
 expression: response.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__block_traffic_via_arbitrary_header_and_value.snap
+++ b/src/tests/snapshots/crates_io__tests__server__block_traffic_via_arbitrary_header_and_value.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__block_traffic_via_ip.snap
+++ b/src/tests/snapshots/crates_io__tests__server__block_traffic_via_ip.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__user_agent_is_required-2.snap
+++ b/src/tests/snapshots/crates_io__tests__server__user_agent_is_required-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__server__user_agent_is_required.snap
+++ b/src/tests/snapshots/crates_io__tests__server__user_agent_is_required.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/server.rs
 expression: resp.json()
-snapshot_kind: text
 ---
 {
   "errors": [

--- a/src/tests/snapshots/crates_io__tests__team__publish_owned.snap
+++ b/src/tests/snapshots/crates_io__tests__team__publish_owned.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/team.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: user-all-teams@example.com
 From: crates.io <noreply@crates.io>

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crate_feed__sync_crate_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crate_feed__sync_crate_feed-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/worker/rss/sync_crate_feed.rs
 expression: content
-snapshot_kind: text
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:crates="https://crates.io/">

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_crates_feed__sync_crates_feed-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/worker/rss/sync_crates_feed.rs
 expression: content
-snapshot_kind: text
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:crates="https://crates.io/">

--- a/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_updates_feed__sync_updates_feed-2.snap
+++ b/src/tests/worker/rss/snapshots/crates_io__tests__worker__rss__sync_updates_feed__sync_updates_feed-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/worker/rss/sync_updates_feed.rs
 expression: content
-snapshot_kind: text
 ---
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:crates="https://crates.io/">

--- a/src/tests/worker/snapshots/crates_io__tests__worker__sync_admins__sync_admins_job.snap
+++ b/src/tests/worker/snapshots/crates_io__tests__worker__sync_admins__sync_admins_job.snap
@@ -1,7 +1,6 @@
 ---
 source: src/tests/worker/sync_admins.rs
 expression: app.emails_snapshot().await
-snapshot_kind: text
 ---
 To: existing-admin@crates.io
 From: crates.io <noreply@crates.io>

--- a/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-2.snap
+++ b/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/downloads/queue/message.rs
 expression: event
-snapshot_kind: text
 ---
 Message {
     records: [

--- a/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-3.snap
+++ b/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/downloads/queue/message.rs
 expression: event
-snapshot_kind: text
 ---
 Message {
     records: [

--- a/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse.snap
+++ b/src/worker/jobs/downloads/queue/snapshots/crates_io__worker__jobs__downloads__queue__message__tests__parse.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/downloads/queue/message.rs
 expression: event
-snapshot_kind: text
 ---
 Message {
     records: [],

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
-snapshot_kind: text
 ---
 <!DOCTYPE HTML>
 <html>

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html_empty.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_html_empty.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
-snapshot_kind: text
 ---
 <!DOCTYPE HTML>
 <html>

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json.snap
@@ -1,6 +1,5 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
-snapshot_kind: text
 ---
 [{"name":"2024-08-01.csv","size":138},{"name":"2024-07-31.csv","size":123},{"name":"2024-07-30.csv","size":124},{"name":"2024-07-29.csv","size":234}]

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json_empty.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__generate_json_empty.snap
@@ -1,6 +1,5 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: "std::str::from_utf8(&index)?"
-snapshot_kind: text
 ---
 [{"name":"2024-08-01.csv","size":138},{"name":"2024-07-31.csv","size":123},{"name":"2024-07-30.csv","size":124},{"name":"2024-07-29.csv","size":234}]

--- a/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__template_context.snap
+++ b/src/worker/jobs/index_version_downloads_archive/snapshots/crates_io__worker__jobs__index_version_downloads_archive__tests__template_context.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/index_version_downloads_archive/mod.rs
 expression: files.to_html()?
-snapshot_kind: text
 ---
 <!DOCTYPE HTML>
 <html>

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crate_feed__tests__load_version_updates-2.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crate_feed__tests__load_version_updates-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_crate_feed.rs
 expression: "updates.iter().map(|u| &u.version).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "1.2.10",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crate_feed__tests__load_version_updates-3.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crate_feed__tests__load_version_updates-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_crate_feed.rs
 expression: "updates.iter().map(|u| &u.version).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "1.3.20",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crate_feed__tests__load_version_updates.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crate_feed__tests__load_version_updates.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_crate_feed.rs
 expression: "updates.iter().map(|u| &u.version).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "1.2.0",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-2.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_crates_feed.rs
 expression: "new_crates.iter().map(|u| &u.name).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "crate-50",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-3.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_crates_feed.rs
 expression: "new_crates.iter().map(|u| &u.name).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "other-crate-60",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_crates_feed__tests__load_version_updates.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_crates_feed.rs
 expression: "new_crates.iter().map(|u| &u.name).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "qux",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_updates_feed__tests__load_version_updates-2.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_updates_feed__tests__load_version_updates-2.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_updates_feed.rs
 expression: "updates.iter().map(|u| &u.version).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "1.2.100",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_updates_feed__tests__load_version_updates-3.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_updates_feed__tests__load_version_updates-3.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_updates_feed.rs
 expression: "updates.iter().map(|u| &u.version).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "1.3.110",

--- a/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_updates_feed__tests__load_version_updates.snap
+++ b/src/worker/jobs/rss/snapshots/crates_io__worker__jobs__rss__sync_updates_feed__tests__load_version_updates.snap
@@ -1,7 +1,6 @@
 ---
 source: src/worker/jobs/rss/sync_updates_feed.rs
 expression: "updates.iter().map(|u| &u.version).collect::<Vec<_>>()"
-snapshot_kind: text
 ---
 [
     "1.2.0",


### PR DESCRIPTION
see https://github.com/mitsuhiko/insta/blob/HEAD/CHANGELOG.md#1420