### PR TITLE
mirage: Maintains crate version-related handling

### DIFF
--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -174,7 +174,12 @@ export function register(server) {
 
     let num = request.params.version_num;
     let version = schema.versions.findBy({ crateId: crate.id, num });
-    if (!version) return { errors: [{ detail: `crate \`${crate.name}\` does not have a version \`${num}\`` }] };
+    if (!version)
+      return new Response(
+        404,
+        {},
+        { errors: [{ detail: `crate \`${crate.name}\` does not have a version \`${num}\`` }] },
+      );
 
     return { meta: { names: [] }, users: [] };
   });
@@ -186,7 +191,12 @@ export function register(server) {
 
     let num = request.params.version_num;
     let version = schema.versions.findBy({ crateId: crate.id, num });
-    if (!version) return { errors: [{ detail: `crate \`${crate.name}\` does not have a version \`${num}\`` }] };
+    if (!version)
+      return new Response(
+        404,
+        {},
+        { errors: [{ detail: `crate \`${crate.name}\` does not have a version \`${num}\`` }] },
+      );
 
     return schema.dependencies.where({ versionId: version.id });
   });
@@ -196,9 +206,14 @@ export function register(server) {
     let crate = schema.crates.findBy({ name });
     if (!crate) return notFound();
 
-    let versionNum = request.params.version_num;
-    let version = schema.versions.findBy({ crateId: crate.id, num: versionNum });
-    if (!version) return { errors: [{ detail: `crate \`${crate.name}\` does not have a version \`${versionNum}\`` }] };
+    let num = request.params.version_num;
+    let version = schema.versions.findBy({ crateId: crate.id, num });
+    if (!version)
+      return new Response(
+        404,
+        {},
+        { errors: [{ detail: `crate \`${crate.name}\` does not have a version \`${num}\`` }] },
+      );
 
     return schema.versionDownloads.where({ versionId: version.id });
   });

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -167,12 +167,12 @@ export function register(server) {
     return resp;
   });
 
-  server.get('/api/v1/crates/:name/:version_num/authors', (schema, request) => {
+  server.get('/api/v1/crates/:name/:version/authors', (schema, request) => {
     let { name } = request.params;
     let crate = schema.crates.findBy({ name });
     if (!crate) return notFound();
 
-    let num = request.params.version_num;
+    let num = request.params.version;
     let version = schema.versions.findBy({ crateId: crate.id, num });
     if (!version)
       return new Response(
@@ -184,12 +184,12 @@ export function register(server) {
     return { meta: { names: [] }, users: [] };
   });
 
-  server.get('/api/v1/crates/:name/:version_num/dependencies', (schema, request) => {
+  server.get('/api/v1/crates/:name/:version/dependencies', (schema, request) => {
     let { name } = request.params;
     let crate = schema.crates.findBy({ name });
     if (!crate) return notFound();
 
-    let num = request.params.version_num;
+    let num = request.params.version;
     let version = schema.versions.findBy({ crateId: crate.id, num });
     if (!version)
       return new Response(
@@ -201,12 +201,12 @@ export function register(server) {
     return schema.dependencies.where({ versionId: version.id });
   });
 
-  server.get('/api/v1/crates/:name/:version_num/downloads', function (schema, request) {
+  server.get('/api/v1/crates/:name/:version/downloads', function (schema, request) {
     let { name } = request.params;
     let crate = schema.crates.findBy({ name });
     if (!crate) return notFound();
 
-    let num = request.params.version_num;
+    let num = request.params.version;
     let version = schema.versions.findBy({ crateId: crate.id, num });
     if (!version)
       return new Response(
@@ -377,13 +377,13 @@ export function register(server) {
       return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
     }
 
-    const { name, version: versionNum } = request.params;
+    const { name, version: num } = request.params;
     const crate = schema.crates.findBy({ name });
     if (!crate) {
       return notFound();
     }
 
-    const version = schema.versions.findBy({ crateId: crate.id, num: versionNum });
+    const version = schema.versions.findBy({ crateId: crate.id, num });
     if (!version) {
       return notFound();
     }
@@ -403,13 +403,13 @@ export function register(server) {
       return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
     }
 
-    const { name, version: versionNum } = request.params;
+    const { name, version: num } = request.params;
     const crate = schema.crates.findBy({ name });
     if (!crate) {
       return notFound();
     }
 
-    const version = schema.versions.findBy({ crateId: crate.id, num: versionNum });
+    const version = schema.versions.findBy({ crateId: crate.id, num });
     if (!version) {
       return notFound();
     }
@@ -425,13 +425,13 @@ export function register(server) {
       return new Response(403, {}, { errors: [{ detail: 'must be logged in to perform that action' }] });
     }
 
-    const { name, version: versionNum } = request.params;
+    const { name, version: num } = request.params;
     const crate = schema.crates.findBy({ name });
     if (!crate) {
       return notFound();
     }
 
-    const version = schema.versions.findBy({ crateId: crate.id, num: versionNum });
+    const version = schema.versions.findBy({ crateId: crate.id, num });
     if (!version) {
       return notFound();
     }
@@ -442,13 +442,13 @@ export function register(server) {
   });
 
   server.get('/api/v1/crates/:name/:version/readme', (schema, request) => {
-    const { name, version: versionNum } = request.params;
+    const { name, version: num } = request.params;
     const crate = schema.crates.findBy({ name });
     if (!crate) {
       return new Response(403, { 'Content-Type': 'text/html' }, '');
     }
 
-    const version = schema.versions.findBy({ crateId: crate.id, num: versionNum });
+    const version = schema.versions.findBy({ crateId: crate.id, num });
     if (!version || !version.readme) {
       return new Response(403, { 'Content-Type': 'text/html' }, '');
     }

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -354,6 +354,23 @@ export function register(server) {
     return { ok: true, msg: 'owners successfully removed' };
   });
 
+  server.get('/api/v1/crates/:name/:version', function (schema, request) {
+    let { name } = request.params;
+    let crate = schema.crates.findBy({ name });
+    if (!crate) return notFound();
+
+    let num = request.params.version;
+    let version = schema.versions.findBy({ crateId: crate.id, num });
+    if (!version) {
+      return new Response(
+        404,
+        {},
+        { errors: [{ detail: `crate \`${crate.name}\` does not have a version \`${num}\`` }] },
+      );
+    }
+    return this.serialize(version);
+  });
+
   server.patch('/api/v1/crates/:name/:version', function (schema, request) {
     let { user } = getSession(schema);
     if (!user) {

--- a/tests/mirage/crates/versions/authors-test.js
+++ b/tests/mirage/crates/versions/authors-test.js
@@ -15,13 +15,11 @@ module('Mirage | GET /api/v1/crates/:id/:version/authors', function (hooks) {
     assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
   });
 
-  test('returns 200 for unknown versions', async function (assert) {
+  test('returns 404 for unknown versions', async function (assert) {
     this.server.create('crate', { name: 'rand' });
 
     let response = await fetch('/api/v1/crates/rand/1.0.0/authors');
-    // we should probably return 404 for this, but the production API
-    // currently doesn't do this either
-    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.status, 404);
     assert.deepEqual(await response.json(), { errors: [{ detail: 'crate `rand` does not have a version `1.0.0`' }] });
   });
 

--- a/tests/mirage/crates/versions/authors-test.js
+++ b/tests/mirage/crates/versions/authors-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../helpers';
 import setupMirage from '../../../helpers/setup-mirage';
 
-module('Mirage | GET /api/v1/crates/:id/:version/authors', function (hooks) {
+module('Mirage | GET /api/v1/crates/:name/:version/authors', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 

--- a/tests/mirage/crates/versions/dependencies-test.js
+++ b/tests/mirage/crates/versions/dependencies-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../helpers';
 import setupMirage from '../../../helpers/setup-mirage';
 
-module('Mirage | GET /api/v1/crates/:id/:version/dependencies', function (hooks) {
+module('Mirage | GET /api/v1/crates/:name/:version/dependencies', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 

--- a/tests/mirage/crates/versions/dependencies-test.js
+++ b/tests/mirage/crates/versions/dependencies-test.js
@@ -15,13 +15,11 @@ module('Mirage | GET /api/v1/crates/:id/:version/dependencies', function (hooks)
     assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
   });
 
-  test('returns 200 for unknown versions', async function (assert) {
+  test('returns 404 for unknown versions', async function (assert) {
     this.server.create('crate', { name: 'rand' });
 
     let response = await fetch('/api/v1/crates/rand/1.0.0/dependencies');
-    // we should probably return 404 for this, but the production API
-    // currently doesn't do this either
-    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.status, 404);
     assert.deepEqual(await response.json(), { errors: [{ detail: 'crate `rand` does not have a version `1.0.0`' }] });
   });
 

--- a/tests/mirage/crates/versions/downloads-test.js
+++ b/tests/mirage/crates/versions/downloads-test.js
@@ -15,13 +15,11 @@ module('Mirage | GET /api/v1/crates/:id/:version/downloads', function (hooks) {
     assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
   });
 
-  test('returns 200 for unknown versions', async function (assert) {
+  test('returns 404 for unknown versions', async function (assert) {
     this.server.create('crate', { name: 'rand' });
 
     let response = await fetch('/api/v1/crates/rand/1.0.0/downloads');
-    // we should probably return 404 for this, but the production API
-    // currently doesn't do this either
-    assert.strictEqual(response.status, 200);
+    assert.strictEqual(response.status, 404);
     assert.deepEqual(await response.json(), { errors: [{ detail: 'crate `rand` does not have a version `1.0.0`' }] });
   });
 

--- a/tests/mirage/crates/versions/downloads-test.js
+++ b/tests/mirage/crates/versions/downloads-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../helpers';
 import setupMirage from '../../../helpers/setup-mirage';
 
-module('Mirage | GET /api/v1/crates/:id/:version/downloads', function (hooks) {
+module('Mirage | GET /api/v1/crates/:name/:version/downloads', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 

--- a/tests/mirage/crates/versions/get-by-num-test.js
+++ b/tests/mirage/crates/versions/get-by-num-test.js
@@ -1,0 +1,57 @@
+import { module, test } from 'qunit';
+
+import fetch from 'fetch';
+
+import { setupTest } from '../../../helpers';
+import setupMirage from '../../../helpers/setup-mirage';
+
+module('Mirage | GET /api/v1/crates/:name/:version', function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  test('returns 404 for unknown crates', async function (assert) {
+    let response = await fetch('/api/v1/crates/foo/1.0.0-beta.1');
+    assert.strictEqual(response.status, 404);
+    assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+  });
+
+  test('returns 404 for unknown versions', async function (assert) {
+    let crate = this.server.create('crate', { name: 'rand' });
+    this.server.create('version', { crate, num: '1.0.0-alpha.1' });
+    let response = await fetch('/api/v1/crates/rand/1.0.0-beta.1');
+    assert.strictEqual(response.status, 404);
+    assert.deepEqual(await response.json(), {
+      errors: [{ detail: 'crate `rand` does not have a version `1.0.0-beta.1`' }],
+    });
+  });
+
+  test('returns a version object for known version', async function (assert) {
+    let crate = this.server.create('crate', { name: 'rand' });
+    this.server.create('version', { crate, num: '1.0.0-beta.1' });
+
+    let response = await fetch('/api/v1/crates/rand/1.0.0-beta.1');
+    assert.strictEqual(response.status, 200);
+    assert.deepEqual(await response.json(), {
+      version: {
+        crate: 'rand',
+        crate_size: 0,
+        created_at: '2010-06-16T21:30:45Z',
+        dl_path: '/api/v1/crates/rand/1.0.0-beta.1/download',
+        downloads: 0,
+        id: '1',
+        license: 'MIT/Apache-2.0',
+        links: {
+          dependencies: '/api/v1/crates/rand/1.0.0-beta.1/dependencies',
+          version_downloads: '/api/v1/crates/rand/1.0.0-beta.1/downloads',
+        },
+        num: '1.0.0-beta.1',
+        published_by: null,
+        readme_path: '/api/v1/crates/rand/1.0.0-beta.1/readme',
+        rust_version: null,
+        updated_at: '2017-02-24T12:34:56Z',
+        yank_message: null,
+        yanked: false,
+      },
+    });
+  });
+});

--- a/tests/mirage/crates/versions/list-test.js
+++ b/tests/mirage/crates/versions/list-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../helpers';
 import setupMirage from '../../../helpers/setup-mirage';
 
-module('Mirage | GET /api/v1/crates/:id/versions', function (hooks) {
+module('Mirage | GET /api/v1/crates/:name/versions', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 

--- a/tests/mirage/crates/versions/patch-test.js
+++ b/tests/mirage/crates/versions/patch-test.js
@@ -18,7 +18,7 @@ const UNYANK_BODY = JSON.stringify({
   },
 });
 
-module('Mirage | PATCH /api/v1/crates/:crate/:version', function (hooks) {
+module('Mirage | PATCH /api/v1/crates/:name/:version', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 

--- a/tests/mirage/crates/versions/readme-test.js
+++ b/tests/mirage/crates/versions/readme-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../helpers';
 import setupMirage from '../../../helpers/setup-mirage';
 
-module('Mirage | GET /api/v1/crates/:id/:version/readme', function (hooks) {
+module('Mirage | GET /api/v1/crates/:name/:version/readme', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 

--- a/tests/mirage/crates/versions/yank/unyank-test.js
+++ b/tests/mirage/crates/versions/yank/unyank-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../../helpers';
 import setupMirage from '../../../../helpers/setup-mirage';
 
-module('Mirage | PUT /api/v1/crates/:crateId/unyank', function (hooks) {
+module('Mirage | PUT /api/v1/crates/:name/unyank', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 

--- a/tests/mirage/crates/versions/yank/yank-test.js
+++ b/tests/mirage/crates/versions/yank/yank-test.js
@@ -5,7 +5,7 @@ import fetch from 'fetch';
 import { setupTest } from '../../../../helpers';
 import setupMirage from '../../../../helpers/setup-mirage';
 
-module('Mirage | DELETE /api/v1/crates/:crateId/yank', function (hooks) {
+module('Mirage | DELETE /api/v1/crates/:name/yank', function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
 


### PR DESCRIPTION
This PR maintains crate version-related handling by:
- Fixing the not found error status code to 404.
- Adding the missing `GET /api/v1/crates/:name/:version` endpoint.
- Rewording some request parameters or variables for consistency.

Related:
- #7881