### PR TITLE
e2e/acceptance/readme-rendering: Fix test flakyness

### DIFF
--- a/e2e/acceptance/readme-rendering.spec.ts
+++ b/e2e/acceptance/readme-rendering.spec.ts
@@ -100,6 +100,7 @@ test.describe('Acceptance | README rendering', { tag: '@acceptance' }, () => {
     await expect(readme.locator('ul > li')).toHaveCount(7);
     await expect(readme.locator('pre > code.language-rust.hljs')).toHaveCount(2);
     await expect(readme.locator('pre > code.language-mermaid svg')).toBeVisible();
+    await expect(readme.locator('pre > code.language-mermaid')).toHaveAttribute('data-processed', 'true');
 
     await percy.snapshot();
   });


### PR DESCRIPTION
According to
https://github.com/mermaid-js/mermaid/blob/bc2cc61240987ac956c69e262c93971cd254f00a/packages/mermaid/src/mermaid.ts#L160-L164, when mermaid finishes processing a node, it will set the `data-processed` to true.