### PR TITLE
Add support for `message` query parameter when deleting crates

### DIFF
--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -492,6 +492,14 @@ expression: response.json()
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "in": "query",
+            "name": "message",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR adds support for `DELETE /api/v1/crates/foo?message=hello%20world` requests, to set the corresponding `message` column in the `deleted_crates` database table.

In a follow-up PR I'm planning to add a (required?) input field to the crate deletion UI, which sets the query parameter accordingly.