### PR TITLE
Include `default_version` by default

### DIFF
--- a/app/adapters/crate.js
+++ b/app/adapters/crate.js
@@ -49,7 +49,7 @@ export default class CrateAdapter extends ApplicationAdapter {
 function setDefaultInclude(query) {
   if (query.include === undefined) {
     // This ensures `crate.versions` are always fetched from another request.
-    query.include = 'keywords,categories,downloads';
+    query.include = 'keywords,categories,downloads,default_version';
   }
 
   return query;

--- a/app/adapters/version.js
+++ b/app/adapters/version.js
@@ -6,4 +6,14 @@ export default class VersionAdapter extends ApplicationAdapter {
     let num = snapshot.record.num;
     return `/${this.namespace}/crates/${crateName}/${num}`;
   }
+
+  urlForQueryRecord(query) {
+    let { name, num } = query ?? {};
+    let baseUrl = this.buildURL('crate', name);
+    let url = `${baseUrl}/${num}`;
+    // The following used to remove them from URL's query string.
+    delete query.name;
+    delete query.num;
+    return url;
+  }
 }

--- a/app/models/crate.js
+++ b/app/models/crate.js
@@ -67,6 +67,14 @@ export default class Crate extends Model {
     return Object.fromEntries(versions.slice().map(v => [v.id, v]));
   }
 
+  /** @return {Map<string, import("../models/version").default>} */
+  @cached
+  get loadedVersionsByNum() {
+    let versionsRef = this.hasMany('versions');
+    let values = versionsRef.value();
+    return new Map(values?.map(ref => [ref.num, ref]));
+  }
+
   @cached get releaseTrackSet() {
     let map = new Map();
     let { versionsObj: versions, versionIdsBySemver } = this;

--- a/app/routes/crate/dependencies.js
+++ b/app/routes/crate/dependencies.js
@@ -6,11 +6,8 @@ export default class VersionRoute extends Route {
 
   async model() {
     let crate = this.modelFor('crate');
-    let versions = await crate.loadVersionsTask.perform();
-
     let { default_version } = crate;
-    let version = versions.find(version => version.num === default_version) ?? versions.lastObject;
 
-    this.router.replaceWith('crate.version-dependencies', crate, version.num);
+    this.router.replaceWith('crate.version-dependencies', crate, default_version);
   }
 }

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -1,22 +1,26 @@
+import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 
 import { didCancel } from 'ember-concurrency';
-import semverSort from 'semver/functions/rsort';
 
 import { AjaxError } from '../../utils/ajax';
 
 export default class VersionRoute extends Route {
   @service router;
   @service sentry;
+  @service store;
 
   async model(params, transition) {
     let crate = this.modelFor('crate');
 
-    let versions;
+    // TODO: Resolved version without waiting for versions to be resolved
+    // The main blocker for this right now is that we have a "belongsTo" relationship between
+    // `version-download` and `version` in sync mode. This requires us to wait for `versions` to
+    // exist before `version-download` can be created.
     try {
-      versions = await crate.loadVersionsTask.perform();
+      await crate.loadVersionsTask.perform();
     } catch (error) {
       let title = `${crate.name}: Failed to load version data`;
       return this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });
@@ -24,21 +28,25 @@ export default class VersionRoute extends Route {
 
     let version;
     let requestedVersion = params.version_num;
-    if (requestedVersion) {
-      version = versions.find(version => version.num === requestedVersion);
-      if (!version) {
-        let title = `${crate.name}: Version ${requestedVersion} not found`;
+    let num = requestedVersion || crate.default_version;
+
+    try {
+      version =
+        crate.loadedVersionsByNum.get(num) ??
+        (await crate.store.queryRecord('version', {
+          name: crate.id,
+          num,
+        }));
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        let title =
+          requestedVersion == null
+            ? `${crate.name}: Failed to find default version`
+            : `${crate.name}: Version ${requestedVersion} not found`;
         return this.router.replaceWith('catch-all', { transition, title });
-      }
-    } else {
-      let { default_version } = crate;
-      version = versions.find(version => version.num === default_version);
-
-      if (!version) {
-        let versionNums = versions.map(it => it.num);
-        semverSort(versionNums, { loose: true });
-
-        version = versions.find(version => version.num === versionNums[0]);
+      } else {
+        let title = `${crate.name}: Failed to load version data`;
+        return this.router.replaceWith('catch-all', { transition, error, title, tryAgain: true });
       }
     }
 

--- a/e2e/acceptance/crate-dependencies.spec.ts
+++ b/e2e/acceptance/crate-dependencies.spec.ts
@@ -62,20 +62,6 @@ test.describe('Acceptance | crate dependencies page', { tag: '@acceptance' }, ()
     await expect(page.locator('[data-test-try-again]')).toHaveCount(0);
   });
 
-  test('shows an error page if versions fail to load', async ({ page, msw, ember }) => {
-    let crate = msw.db.crate.create({ name: 'foo' });
-    msw.db.version.create({ crate, num: '2.0.0' });
-    await msw.worker.use(http.get('/api/v1/crates/:crate_name/versions', () => HttpResponse.json({}, { status: 500 })));
-
-    await page.goto('/crates/foo/1.0.0/dependencies');
-
-    await expect(page).toHaveURL('/crates/foo/1.0.0/dependencies');
-    await expect(page.locator('[data-test-404-page]')).toBeVisible();
-    await expect(page.locator('[data-test-title]')).toHaveText('foo: Failed to load version data');
-    await expect(page.locator('[data-test-go-back]')).toHaveCount(0);
-    await expect(page.locator('[data-test-try-again]')).toBeVisible();
-  });
-
   test('shows error message if loading of dependencies fails', async ({ page, msw }) => {
     let crate = msw.db.crate.create({ name: 'foo' });
     msw.db.version.create({ crate, num: '1.0.0' });

--- a/tests/acceptance/crate-dependencies-test.js
+++ b/tests/acceptance/crate-dependencies-test.js
@@ -74,20 +74,6 @@ module('Acceptance | crate dependencies page', function (hooks) {
     assert.dom('[data-test-try-again]').doesNotExist();
   });
 
-  test('shows an error page if versions fail to load', async function (assert) {
-    let crate = this.db.crate.create({ name: 'foo' });
-    this.db.version.create({ crate, num: '2.0.0' });
-
-    this.worker.use(http.get('/api/v1/crates/:crate_name/versions', () => HttpResponse.json({}, { status: 500 })));
-
-    await visit('/crates/foo/1.0.0/dependencies');
-    assert.strictEqual(currentURL(), '/crates/foo/1.0.0/dependencies');
-    assert.dom('[data-test-404-page]').exists();
-    assert.dom('[data-test-title]').hasText('foo: Failed to load version data');
-    assert.dom('[data-test-go-back]').doesNotExist();
-    assert.dom('[data-test-try-again]').exists();
-  });
-
   test('shows error message if loading of dependencies fails', async function (assert) {
     let crate = this.db.crate.create({ name: 'foo' });
     this.db.version.create({ crate, num: '1.0.0' });


### PR DESCRIPTION
This PR would ensure that `default_version` is included in the `crate` response by default. This eliminates the need to wait for the `versions` request to complete when `default_version` is the only version required. This also decouples requested version handling from versions. 

Related:
- #10288 
- #10296 