### PR TITLE
deps: patch `cargo-manifest` to support resolver 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,8 +768,7 @@ dependencies = [
 [[package]]
 name = "cargo-manifest"
 version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2ce2075c35e4b492b93e3d5dd1dd3670de553f15045595daef8164ed9a3751"
+source = "git+https://github.com/LawnGnome/cargo-manifest?rev=5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9#5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,10 @@ axum-extra = { version = "=0.10.0", features = ["erased-json", "query", "typed-h
 base64 = "=0.22.1"
 bigdecimal = { version = "=0.4.7", features = ["serde"] }
 bon = "=3.3.2"
-cargo-manifest = "=0.17.0"
+# Temporarily use cargo-manifest 0.17.0 + the commit to fix
+# https://github.com/LukeMathWalker/cargo-manifest/issues/63 cherry picked on
+# top to unblock resolver v3 support.
+cargo-manifest = { git = "https://github.com/LawnGnome/cargo-manifest", rev = "5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9" }
 colored = "=3.0.0"
 crates_io_cdn_logs = { path = "crates/crates_io_cdn_logs" }
 crates_io_database = { path = "crates/crates_io_database" }

--- a/crates/crates_io_tarball/Cargo.toml
+++ b/crates/crates_io_tarball/Cargo.toml
@@ -11,7 +11,10 @@ workspace = true
 builder = ["dep:flate2", "dep:tar"]
 
 [dependencies]
-cargo-manifest = "=0.17.0"
+# Temporarily use cargo-manifest 0.17.0 + the commit to fix
+# https://github.com/LukeMathWalker/cargo-manifest/issues/63 cherry picked on
+# top to unblock resolver v3 support.
+cargo-manifest = { git = "https://github.com/LawnGnome/cargo-manifest", rev = "5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9" }
 flate2 = { version = "=1.0.35", optional = true }
 serde = { version = "=1.0.217", features = ["derive"] }
 serde_json = "=1.0.135"


### PR DESCRIPTION
This should be reverted and replaced with an actual package upgrade once `cargo-manifest` has a release that includes a fix for https://github.com/LukeMathWalker/cargo-manifest/issues/63.

Fixes #10361.