### PR TITLE
deps: update to `cargo-manifest` 0.18.0 for real

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,8 @@ dependencies = [
 [[package]]
 name = "cargo-manifest"
 version = "0.17.0"
-source = "git+https://github.com/LawnGnome/cargo-manifest?rev=5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9#5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2ce2075c35e4b492b93e3d5dd1dd3670de553f15045595daef8164ed9a3751"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,12 +767,12 @@ dependencies = [
 
 [[package]]
 name = "cargo-manifest"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2ce2075c35e4b492b93e3d5dd1dd3670de553f15045595daef8164ed9a3751"
+checksum = "2e7713fa8974fe547c44fcf043d0d910fff5fd95673d40b77a769495657789fb"
 dependencies = [
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.10",
  "toml",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,10 +53,7 @@ axum-extra = { version = "=0.10.0", features = ["erased-json", "query", "typed-h
 base64 = "=0.22.1"
 bigdecimal = { version = "=0.4.7", features = ["serde"] }
 bon = "=3.3.2"
-# Temporarily use cargo-manifest 0.17.0 + the commit to fix
-# https://github.com/LukeMathWalker/cargo-manifest/issues/63 cherry picked on
-# top to unblock resolver v3 support.
-cargo-manifest = { git = "https://github.com/LawnGnome/cargo-manifest", rev = "5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9" }
+cargo-manifest = "=0.17.0"
 colored = "=3.0.0"
 crates_io_cdn_logs = { path = "crates/crates_io_cdn_logs" }
 crates_io_database = { path = "crates/crates_io_database" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ axum-extra = { version = "=0.10.0", features = ["erased-json", "query", "typed-h
 base64 = "=0.22.1"
 bigdecimal = { version = "=0.4.7", features = ["serde"] }
 bon = "=3.3.2"
-cargo-manifest = "=0.17.0"
+cargo-manifest = "=0.18.0"
 colored = "=3.0.0"
 crates_io_cdn_logs = { path = "crates/crates_io_cdn_logs" }
 crates_io_database = { path = "crates/crates_io_database" }

--- a/crates/crates_io_tarball/Cargo.toml
+++ b/crates/crates_io_tarball/Cargo.toml
@@ -11,10 +11,7 @@ workspace = true
 builder = ["dep:flate2", "dep:tar"]
 
 [dependencies]
-# Temporarily use cargo-manifest 0.17.0 + the commit to fix
-# https://github.com/LukeMathWalker/cargo-manifest/issues/63 cherry picked on
-# top to unblock resolver v3 support.
-cargo-manifest = { git = "https://github.com/LawnGnome/cargo-manifest", rev = "5c256c6c3c2507438c501ecfa5c39b4ab5ccf5a9" }
+cargo-manifest = "=0.17.0"
 flate2 = { version = "=1.0.35", optional = true }
 serde = { version = "=1.0.217", features = ["derive"] }
 serde_json = "=1.0.135"

--- a/crates/crates_io_tarball/Cargo.toml
+++ b/crates/crates_io_tarball/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 builder = ["dep:flate2", "dep:tar"]
 
 [dependencies]
-cargo-manifest = "=0.17.0"
+cargo-manifest = "=0.18.0"
 flate2 = { version = "=1.0.35", optional = true }
 serde = { version = "=1.0.217", features = ["derive"] }
 serde_json = "=1.0.135"


### PR DESCRIPTION
This includes the fix for https://github.com/LukeMathWalker/cargo-manifest/issues/63 that necessitated the earlier change to pin to a specific commit in my fork of `cargo-manifest`.