### PR TITLE
mirage: Replace `assert()` from `@ember/debug` with conditional `throw`

### DIFF
--- a/mirage/serializers/crate.js
+++ b/mirage/serializers/crate.js
@@ -1,5 +1,3 @@
-import { assert } from '@ember/debug';
-
 import prerelease from 'semver/functions/prerelease';
 import semverSort from 'semver/functions/rsort';
 
@@ -67,7 +65,9 @@ export default BaseSerializer.extend({
 
   _adjust(hash, includes) {
     let versions = this.schema.versions.where({ crateId: hash.id });
-    assert(`crate \`${hash.name}\` has no associated versions`, versions.length !== 0);
+    if (versions.length === 0) {
+      throw new Error(`crate \`${hash.name}\` has no associated versions`);
+    }
 
     let versionsByNum = Object.fromEntries(versions.models.map(it => [it.num, it]));
     let versionNums = Object.keys(versionsByNum);


### PR DESCRIPTION
The `@ember/debug` import makes it harder to use the mirage code outside of an Ember.js context. This commit replaces the import with an `if + throw` combination. The main advantage of `assert()` is that it is compiled out of production code, but since the mirage code is not shipped to production anyway, this advantage doesn't actually apply here.

/cc @eth3lbert 

Related:

- https://github.com/rust-lang/crates.io/pull/10357