### PR TITLE
embroider: Remove obsolete `packageRules` config

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -78,22 +78,5 @@ module.exports = function (defaults) {
         },
       },
     },
-    packageRules: [
-      // see https://github.com/embroider-build/embroider/issues/1322
-      {
-        package: '@ember-data/store',
-        addonModules: {
-          '-private.js': {
-            dependsOnModules: [],
-          },
-          '-private/system/core-store.js': {
-            dependsOnModules: [],
-          },
-          '-private/system/model/internal-model.js': {
-            dependsOnModules: [],
-          },
-        },
-      },
-    ],
   });
 };


### PR DESCRIPTION
Now that we use Ember Data 5, we don't appear to need this anymore.