### PR TITLE
Improving the readability of search test cases

### DIFF
--- a/src/tests/routes/crates/list.rs
+++ b/src/tests/routes/crates/list.rs
@@ -308,7 +308,7 @@ async fn index_sorting() -> anyhow::Result<()> {
         .await;
 
     let krate3 = CrateBuilder::new("baz_sort", user.id)
-        .description("foo_sort bar_sort foo_sort bar_sort foo_sort bar_sort const")
+        .description("foo_sort bar_sort foo_sort bar_sort bar_sort const")
         .downloads(100_000)
         .recent_downloads(50)
         .expect_build(&mut conn)


### PR DESCRIPTION
This PR rewrites our test cases for `alpha` and `relevance` sorting to be more dumb, explicit and easier to follow for better readability. Aside from that, previously, we seem not to cover the cases with the same rank for `relevance` sorting, which are also covered in this PR.