### PR TITLE
mirage: Add seek pagination support for `GET /api/v1/crates/:name/versions`

### DIFF
--- a/mirage/route-handlers/-utils.js
+++ b/mirage/route-handlers/-utils.js
@@ -47,3 +47,5 @@ export function releaseTracks(versions) {
   }
   return tracks;
 }
+
+export { default as compareSemvers } from 'semver/functions/compare-loose';

--- a/mirage/route-handlers/crates.js
+++ b/mirage/route-handlers/crates.js
@@ -1,7 +1,7 @@
 import { Response } from 'miragejs';
 
 import { getSession } from '../utils/session';
-import { compareIsoDates, compareStrings, notFound, pageParams, releaseTracks } from './-utils';
+import { compareIsoDates, compareSemvers, compareStrings, notFound, pageParams, releaseTracks } from './-utils';
 
 function toCanonicalName(name) {
   return name.toLowerCase().replace(/-/g, '_');
@@ -159,11 +159,14 @@ export function register(server) {
     if (!crate) return notFound();
 
     let versions = crate.versions;
-    let { nums } = request.queryParams;
+    let { nums, sort } = request.queryParams;
     if (nums) {
       versions = versions.filter(version => nums.includes(version.num));
     }
-    versions = versions.sort((a, b) => compareIsoDates(b.created_at, a.created_at));
+    versions =
+      sort == 'date'
+        ? versions.sort((a, b) => compareIsoDates(b.created_at, a.created_at))
+        : versions.sort((a, b) => compareSemvers(b.num, a.num));
     let total = versions.length;
     let include = request.queryParams?.include ?? '';
     let release_tracks = include.split(',').includes('release_tracks') && releaseTracks(crate.versions);

--- a/tests/components/version-list-row-test.js
+++ b/tests/components/version-list-row-test.js
@@ -75,17 +75,17 @@ module('Component | VersionList::Row', function (hooks) {
     let crateRecord = await store.findRecord('crate', crate.name);
     let versions = (await crateRecord.loadVersionsTask.perform()).slice();
     await crateRecord.loadOwnerUserTask.perform();
-    this.firstVersion = versions[0];
-    this.secondVersion = versions[1];
-    this.thirdVersion = versions[2];
+    this.firstVersion = versions.find(it => it.num == '0.3.0');
+    this.secondVersion = versions.find(it => it.num == '0.2.0');
+    this.thirdVersion = versions.find(it => it.num == '0.1.0');
 
     await render(hbs`<VersionList::Row @version={{this.firstVersion}} />`);
-    assert.dom('[data-test-feature-list]').doesNotExist();
+    assert.dom('[data-test-feature-list]').hasText('2 Features');
 
     await render(hbs`<VersionList::Row @version={{this.secondVersion}} />`);
     assert.dom('[data-test-feature-list]').hasText('1 Feature');
 
     await render(hbs`<VersionList::Row @version={{this.thirdVersion}} />`);
-    assert.dom('[data-test-feature-list]').hasText('2 Features');
+    assert.dom('[data-test-feature-list]').doesNotExist();
   });
 });

--- a/tests/mirage/crates/versions/list-test.js
+++ b/tests/mirage/crates/versions/list-test.js
@@ -38,21 +38,21 @@ module('Mirage | GET /api/v1/crates/:name/versions', function (hooks) {
     assert.deepEqual(await response.json(), {
       versions: [
         {
-          id: '1',
+          id: '3',
           crate: 'rand',
-          crate_size: 0,
+          crate_size: 325_926,
           created_at: '2010-06-16T21:30:45Z',
-          dl_path: '/api/v1/crates/rand/1.0.0/download',
-          downloads: 0,
-          license: 'MIT/Apache-2.0',
+          dl_path: '/api/v1/crates/rand/1.2.0/download',
+          downloads: 7404,
+          license: 'Apache-2.0',
           links: {
-            dependencies: '/api/v1/crates/rand/1.0.0/dependencies',
-            version_downloads: '/api/v1/crates/rand/1.0.0/downloads',
+            dependencies: '/api/v1/crates/rand/1.2.0/dependencies',
+            version_downloads: '/api/v1/crates/rand/1.2.0/downloads',
           },
-          num: '1.0.0',
+          num: '1.2.0',
           published_by: null,
-          readme_path: '/api/v1/crates/rand/1.0.0/readme',
-          rust_version: null,
+          readme_path: '/api/v1/crates/rand/1.2.0/readme',
+          rust_version: '1.69',
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
           yank_message: null,
@@ -84,21 +84,21 @@ module('Mirage | GET /api/v1/crates/:name/versions', function (hooks) {
           yank_message: null,
         },
         {
-          id: '3',
+          id: '1',
           crate: 'rand',
-          crate_size: 325_926,
+          crate_size: 0,
           created_at: '2010-06-16T21:30:45Z',
-          dl_path: '/api/v1/crates/rand/1.2.0/download',
-          downloads: 7404,
-          license: 'Apache-2.0',
+          dl_path: '/api/v1/crates/rand/1.0.0/download',
+          downloads: 0,
+          license: 'MIT/Apache-2.0',
           links: {
-            dependencies: '/api/v1/crates/rand/1.2.0/dependencies',
-            version_downloads: '/api/v1/crates/rand/1.2.0/downloads',
+            dependencies: '/api/v1/crates/rand/1.0.0/dependencies',
+            version_downloads: '/api/v1/crates/rand/1.0.0/downloads',
           },
-          num: '1.2.0',
+          num: '1.0.0',
           published_by: null,
-          readme_path: '/api/v1/crates/rand/1.2.0/readme',
-          rust_version: '1.69',
+          readme_path: '/api/v1/crates/rand/1.0.0/readme',
+          rust_version: null,
           updated_at: '2017-02-24T12:34:56Z',
           yanked: false,
           yank_message: null,
@@ -106,6 +106,45 @@ module('Mirage | GET /api/v1/crates/:name/versions', function (hooks) {
       ],
       meta: { total: 3, next_page: null },
     });
+  });
+
+  test('supports `sort` parameters', async function (assert) {
+    let user = this.server.create('user');
+    let crate = this.server.create('crate', { name: 'rand' });
+    this.server.create('version', { crate, num: '1.0.0', created_at: '2010-06-16T21:30:45Z' });
+    this.server.create('version', { crate, num: '1.2.0', rust_version: '1.69', created_at: '2010-06-16T21:30:46Z' });
+    this.server.create('version', { crate, num: '1.1.0', publishedBy: user, created_at: '2010-06-16T21:30:47Z' });
+
+    // sort by `semver` by default
+    {
+      let response = await fetch('/api/v1/crates/rand/versions');
+      assert.strictEqual(response.status, 200);
+      let json = await response.json();
+      assert.deepEqual(
+        json.versions.map(it => it.num),
+        ['1.2.0', '1.1.0', '1.0.0'],
+      );
+    }
+
+    {
+      let response = await fetch('/api/v1/crates/rand/versions?sort=semver');
+      assert.strictEqual(response.status, 200);
+      let json = await response.json();
+      assert.deepEqual(
+        json.versions.map(it => it.num),
+        ['1.2.0', '1.1.0', '1.0.0'],
+      );
+    }
+
+    {
+      let response = await fetch('/api/v1/crates/rand/versions?sort=date');
+      assert.strictEqual(response.status, 200);
+      let json = await response.json();
+      assert.deepEqual(
+        json.versions.map(it => it.num),
+        ['1.1.0', '1.2.0', '1.0.0'],
+      );
+    }
   });
 
   test('supports multiple `ids[]` parameters', async function (assert) {
@@ -119,7 +158,7 @@ module('Mirage | GET /api/v1/crates/:name/versions', function (hooks) {
     let json = await response.json();
     assert.deepEqual(
       json.versions.map(v => v.num),
-      ['1.0.0', '1.2.0'],
+      ['1.2.0', '1.0.0'],
     );
   });
 

--- a/tests/models/version-test.js
+++ b/tests/models/version-test.js
@@ -153,8 +153,8 @@ module('Model | Version', function (hooks) {
         '0.3.3',
         '0.3.2',
         '0.3.1',
-        '0.3.0-alpha.01',
         '0.3.0',
+        '0.3.0-alpha.01',
         '0.2.1',
         '0.2.0',
         '0.1.2',
@@ -181,8 +181,8 @@ module('Model | Version', function (hooks) {
           { num: '0.3.3', isHighestOfReleaseTrack: false },
           { num: '0.3.2', isHighestOfReleaseTrack: false },
           { num: '0.3.1', isHighestOfReleaseTrack: false },
-          { num: '0.3.0-alpha.01', isHighestOfReleaseTrack: false },
           { num: '0.3.0', isHighestOfReleaseTrack: false },
+          { num: '0.3.0-alpha.01', isHighestOfReleaseTrack: false },
           { num: '0.2.1', isHighestOfReleaseTrack: true },
           { num: '0.2.0', isHighestOfReleaseTrack: false },
           { num: '0.1.2', isHighestOfReleaseTrack: true },
@@ -203,9 +203,9 @@ module('Model | Version', function (hooks) {
       assert.deepEqual(
         versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
         [
-          { num: '0.4.0', isHighestOfReleaseTrack: false },
-          { num: '0.4.1', isHighestOfReleaseTrack: true },
           { num: '0.4.2', isHighestOfReleaseTrack: false },
+          { num: '0.4.1', isHighestOfReleaseTrack: true },
+          { num: '0.4.0', isHighestOfReleaseTrack: false },
         ],
       );
     });
@@ -221,8 +221,8 @@ module('Model | Version', function (hooks) {
       assert.deepEqual(
         versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
         [
-          { num: '0.4.0', isHighestOfReleaseTrack: false },
           { num: '0.4.1', isHighestOfReleaseTrack: true },
+          { num: '0.4.0', isHighestOfReleaseTrack: false },
         ],
       );
 
@@ -234,10 +234,10 @@ module('Model | Version', function (hooks) {
       assert.deepEqual(
         versions.map(it => ({ num: it.num, isHighestOfReleaseTrack: it.isHighestOfReleaseTrack })),
         [
-          { num: '0.4.0', isHighestOfReleaseTrack: false },
-          { num: '0.4.1', isHighestOfReleaseTrack: false },
-          { num: '0.4.2', isHighestOfReleaseTrack: true },
           { num: '0.4.3', isHighestOfReleaseTrack: false },
+          { num: '0.4.2', isHighestOfReleaseTrack: true },
+          { num: '0.4.1', isHighestOfReleaseTrack: false },
+          { num: '0.4.0', isHighestOfReleaseTrack: false },
         ],
       );
     });


### PR DESCRIPTION
This would also aligns more closely with our backend, which sorts by `semver` by default.