### PR TITLE
Implement dynamic OpenGraph image url support for crate pages

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -86,3 +86,15 @@ export GH_CLIENT_SECRET=
 # Credentials for connecting to the Sentry error reporting service.
 # export SENTRY_DSN_API=
 export SENTRY_ENV_API=local
+
+# If set the server serves the frontend `index.html` for all
+# non-API requests using the Jinja template at the given path.
+# Setting this parameter requires setting
+# INDEX_HTML_TEMPLATE_PATH as well.
+export INDEX_HTML_TEMPLATE_PATH=dist/index.html
+
+# Base URL for the service from which the OpenGraph images
+# for crates are loaded. Required if
+# INDEX_HTML_TEMPLATE_PATH is set. Make sure the URL ends
+# with a `/`.
+export OG_IMAGE_BASE_URL="http://localhost:3000/og/"

--- a/.env.sample
+++ b/.env.sample
@@ -87,14 +87,7 @@ export GH_CLIENT_SECRET=
 # export SENTRY_DSN_API=
 export SENTRY_ENV_API=local
 
-# If set the server serves the frontend `index.html` for all
-# non-API requests using the Jinja template at the given path.
-# Setting this parameter requires setting
-# INDEX_HTML_TEMPLATE_PATH as well.
-export INDEX_HTML_TEMPLATE_PATH=dist/index.html
-
 # Base URL for the service from which the OpenGraph images
-# for crates are loaded. Required if
-# INDEX_HTML_TEMPLATE_PATH is set. Make sure the URL ends
+# for crates are loaded. Make sure the URL ends
 # with a `/`.
 export OG_IMAGE_BASE_URL="http://localhost:3000/og/"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,6 +210,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +962,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1103,7 @@ dependencies = [
  "lettre",
  "minijinja",
  "mockall",
+ "moka",
  "native-tls",
  "oauth2",
  "object_store",
@@ -1396,6 +1417,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1899,6 +1929,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2138,19 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2341,7 +2405,7 @@ checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
+ "windows 0.52.0",
 ]
 
 [[package]]
@@ -2570,7 +2634,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -3030,6 +3094,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,6 +3164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "migrations_internals"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3212,8 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff7b8df5e85e30b87c2b0b3f58ba3a87b68e133738bf512a7713769326dbca9"
 dependencies = [
+ "memo-map",
+ "self_cell",
  "serde",
 ]
 
@@ -3182,6 +3267,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "event-listener",
+ "futures-util",
+ "loom",
+ "parking_lot",
+ "portable-atomic",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror 1.0.69",
+ "uuid",
 ]
 
 [[package]]
@@ -3438,6 +3545,12 @@ dependencies = [
  "primeorder",
  "sha2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4335,6 +4448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4408,6 +4527,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
 
 [[package]]
 name = "semver"
@@ -4904,6 +5029,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tar"
@@ -5818,7 +5949,17 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core",
+ "windows-core 0.52.0",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets",
 ]
 
@@ -5829,6 +5970,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,9 @@ ipnetwork = "=0.21.1"
 json-subscriber = "=0.2.4"
 krata-tokio-tar = "=0.4.2"
 lettre = { version = "=0.11.12", default-features = false, features = ["file-transport", "smtp-transport", "hostname", "builder", "tokio1", "tokio1-native-tls"] }
-minijinja = "=2.7.0"
+minijinja = { version = "=2.7.0", features = ["loader"] }
 mockall = "=0.13.1"
+moka = { version = "=0.12.10", default-features = false, features = ["future"] }
 native-tls = "=0.2.13"
 oauth2 = "=5.0.0"
 object_store = { version = "=0.11.2", features = ["aws"] }

--- a/app/index.html
+++ b/app/index.html
@@ -23,7 +23,7 @@
 
     <meta name="google" content="notranslate" />
 
-    <meta property="og:image" content="https://crates.io/assets/og-image.png">
+    <meta property="og:image" content="{{og_image_url}}">
     <meta name="twitter:card" content="summary_large_image">
   </head>
   <body>

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -77,10 +77,9 @@ pub fn apply_axum_middleware(state: AppState, router: Router<()>) -> Router {
         .layer(conditional_layer(config.serve_dist, || {
             from_fn(static_or_continue::serve_dist)
         }))
-        .layer(conditional_layer(
-            config.index_html_template_path.is_some(),
-            || from_fn_with_state(state.clone(), ember_html::serve_html),
-        ))
+        .layer(conditional_layer(config.serve_html, || {
+            from_fn_with_state(state.clone(), ember_html::serve_html)
+        }))
         .layer(AddExtensionLayer::new(state.clone()));
 
     router

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -77,9 +77,10 @@ pub fn apply_axum_middleware(state: AppState, router: Router<()>) -> Router {
         .layer(conditional_layer(config.serve_dist, || {
             from_fn(static_or_continue::serve_dist)
         }))
-        .layer(conditional_layer(config.serve_html, || {
-            from_fn_with_state(state.clone(), ember_html::serve_html)
-        }))
+        .layer(conditional_layer(
+            config.index_html_template_path.is_some(),
+            || from_fn_with_state(state.clone(), ember_html::serve_html),
+        ))
         .layer(AddExtensionLayer::new(state.clone()));
 
     router

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -27,7 +27,7 @@ const PATH_PREFIX_CRATES: &str = "/crates/";
 
 /// The [`Shared`] allows for multiple tasks to wait on a single future, [`BoxFuture`] allows
 /// us to name the type in the declaration of static variables, and the [`Arc`] ensures
-/// the [`minijinja::Environment`] doensn't get cloned each request.
+/// the [`minijinja::Environment`] doesn't get cloned each request.
 type TemplateEnvFut = Shared<BoxFuture<'static, Arc<minijinja::Environment<'static>>>>;
 type TemplateCache = moka::future::Cache<Cow<'static, str>, String>;
 
@@ -86,7 +86,7 @@ pub async fn serve_html(state: AppState, request: Request, next: Next) -> Respon
         let render_result = html_cache
             .entry_by_ref(&og_image_url)
             .or_try_insert_with::<_, minijinja::Error>(async {
-                // `LazyLock::deref` blocks as long as its intializer is running in another thread.
+                // `LazyLock::deref` blocks as long as its initializer is running in another thread.
                 // Note that this won't take long, as the constructed Futures are not awaited
                 // during initialization.
                 let template_env = &*TEMPLATE_ENV;

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -17,7 +17,6 @@ use axum::response::{IntoResponse, Response};
 use futures_util::future::{BoxFuture, Shared};
 use futures_util::FutureExt;
 use http::{header, HeaderMap, HeaderValue, Method, StatusCode};
-use minijinja::{context, Environment};
 use url::Url;
 
 use crate::app::AppState;
@@ -39,7 +38,7 @@ async fn init_template_env() -> Arc<minijinja::Environment<'static>> {
         .await
         .expect("Error loading dist/index.html template. Is the frontend package built yet?");
 
-    let mut env = Environment::empty();
+    let mut env = minijinja::Environment::empty();
     env.add_template_owned(INDEX_TEMPLATE_NAME, template_j2)
         .expect("Error loading template");
     Arc::new(env)
@@ -94,7 +93,7 @@ pub async fn serve_html(state: AppState, request: Request, next: Next) -> Respon
                 let html = env
                     .get_template(INDEX_TEMPLATE_NAME)
                     .unwrap()
-                    .render(context! { og_image_url})
+                    .render(minijinja::context! { og_image_url})
                     .expect("Error rendering index");
 
                 html

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -114,11 +114,10 @@ pub async fn serve_html(state: AppState, request: Request, next: Next) -> Respon
 /// prefix, and returning the firsts path segment from the result.
 /// Returns `None` if the path was not prefixed with [`PATH_PREFIX_CRATES`].
 fn extract_crate_name(path: &str) -> Option<&str> {
-    path.strip_prefix(PATH_PREFIX_CRATES).and_then(|suffix| {
-        let len = suffix.find('/').unwrap_or(suffix.len());
-        let krate = &suffix[..len];
-        krate.is_empty().not().then_some(krate)
-    })
+    let suffix = path.strip_prefix(PATH_PREFIX_CRATES)?;
+    let len = suffix.find('/').unwrap_or(suffix.len());
+    let krate = &suffix[..len];
+    krate.is_empty().not().then_some(krate)
 }
 
 /// Come up with an Open Graph image URL. In case a crate page is requested,

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -7,16 +7,57 @@
 //! For now, there is an additional check to see if the `Accept` header contains "html". This is
 //! likely to be removed in the future.
 
+use std::borrow::Cow;
+use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
-use http::{header, StatusCode};
-use tower::ServiceExt;
-use tower_http::services::ServeFile;
+use futures_util::future::{BoxFuture, Shared};
+use futures_util::FutureExt;
+use http::{header, HeaderMap, HeaderValue, Method, StatusCode};
+use minijinja::{context, Environment};
 
-pub async fn serve_html(request: Request, next: Next) -> Response {
+use crate::app::AppState;
+
+const OG_IMAGE_FALLBACK_URL: &str = "https://crates.io/assets/og-image.png";
+const INDEX_TEMPLATE_NAME: &str = "index_html";
+const PATH_PREFIX_CRATES: &str = "/crates/";
+
+/// The [`Shared`] allows for multiple tasks to wait on a single future, [`BoxFuture`] allows
+/// us to name the type in the declaration of static variables, and the [`Arc`] ensures
+/// the [`minijinja::Environment`] doensn't get cloned each request.
+type TemplateEnvFut = Shared<BoxFuture<'static, Arc<minijinja::Environment<'static>>>>;
+type TemplateCache = moka::future::Cache<Cow<'static, str>, String>;
+
+/// Initialize [`minijinja::Environment`] given the path to the index.html file. This should
+/// only be done once as it will load said file from persistent storage.
+async fn init_template_env(
+    index_html_template_path: impl AsRef<Path>,
+) -> Arc<minijinja::Environment<'static>> {
+    let template_j2 = tokio::fs::read_to_string(index_html_template_path.as_ref())
+        .await
+        .expect("Error loading index.html template. Is the frontend package built yet?");
+
+    let mut env = Environment::empty();
+    env.add_template_owned(INDEX_TEMPLATE_NAME, template_j2)
+        .expect("Error loading template");
+    Arc::new(env)
+}
+
+/// Initialize the [`moka::future::Cache`] used to cache the rendered HTML.
+fn init_html_cache(max_capacity: u64) -> TemplateCache {
+    moka::future::CacheBuilder::new(max_capacity)
+        .name("rendered_index_html")
+        .build()
+}
+
+pub async fn serve_html(state: AppState, request: Request, next: Next) -> Response {
+    static TEMPLATE_ENV: OnceLock<TemplateEnvFut> = OnceLock::new();
+    static RENDERED_HTML_CACHE: OnceLock<TemplateCache> = OnceLock::new();
+
     let path = &request.uri().path();
-
     // The "/git/" prefix is only used in development (when within a docker container)
     if path.starts_with("/api/") || path.starts_with("/git/") {
         next.run(request).await
@@ -26,11 +67,63 @@ pub async fn serve_html(request: Request, next: Next) -> Response {
         .iter()
         .any(|val| val.to_str().unwrap_or_default().contains("html"))
     {
+        if !matches!(*request.method(), Method::HEAD | Method::GET) {
+            let headers =
+                HeaderMap::from_iter([(header::ALLOW, HeaderValue::from_static("GET,HEAD"))]);
+            return (StatusCode::METHOD_NOT_ALLOWED, headers).into_response();
+        }
+
+        // Come up with an Open Graph image URL. In case a crate page is requested,
+        // we use the crate's name and the OG image base URL from config to
+        // generate one, otherwise we use the fallback image.
+        let og_image_url = 'og: {
+            if let Some(suffix) = path.strip_prefix(PATH_PREFIX_CRATES) {
+                let len = suffix.find('/').unwrap_or(suffix.len());
+                let krate = &suffix[..len];
+
+                // `state.config.og_image_base_url` will always be `Some` as that's required
+                // if `state.config.index_html_template_path` is `Some`, and otherwise this
+                // middleware won't be executed; see `crate::middleware::apply_axum_middleware`.
+                if let Ok(og_img_url) = state.config.og_image_base_url.as_ref().unwrap().join(krate)
+                {
+                    break 'og Cow::from(og_img_url.to_string());
+                }
+            }
+            OG_IMAGE_FALLBACK_URL.into()
+        };
+
+        // Fetch the HTML from cache given `og_image_url` as key or render it
+        let html = RENDERED_HTML_CACHE
+            .get_or_init(|| init_html_cache(state.config.html_render_cache_max_capacity))
+            .get_with_by_ref(&og_image_url, async {
+                // `OnceLock::get_or_init` blocks as long as its intializer is running in another thread.
+                // Note that this won't take long, as the constructed Futures are not awaited
+                // during initialization.
+                let template_env = TEMPLATE_ENV.get_or_init(|| {
+                    // At this point we can safely assume `state.config.index_html_template_path` is `Some`,
+                    // as this middleware won't be executed otherwise; see `crate::middleware::apply_axum_middleware`.
+                    init_template_env(state.config.index_html_template_path.clone().unwrap())
+                        .boxed()
+                        .shared()
+                });
+
+                // Render the HTML given the OG image URL
+                let env = template_env.clone().await;
+                let html = env
+                    .get_template(INDEX_TEMPLATE_NAME)
+                    .unwrap()
+                    .render(context! { og_image_url})
+                    .expect("Error rendering index");
+
+                html
+            })
+            .await;
+
         // Serve static Ember page to bootstrap the frontend
-        ServeFile::new("dist/index.html")
-            .oneshot(request)
-            .await
-            .map(|response| response.map(axum::body::Body::new))
+        Response::builder()
+            .header(header::CONTENT_TYPE, "text/html")
+            .header(header::CONTENT_LENGTH, html.len())
+            .body(axum::body::Body::new(html))
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
     } else {
         // Return a 404 to crawlers that don't send `Accept: text/hml`.

--- a/src/middleware/ember_html.rs
+++ b/src/middleware/ember_html.rs
@@ -129,10 +129,8 @@ fn generate_og_image_url(path: &str, og_image_base_url: &Option<Url>) -> Cow<'st
     };
 
     if let Some(krate) = extract_crate_name(path) {
-        if let Ok(og_img_url) = og_image_base_url
-            .join(krate)
-            .map(|url_without_extrrension| format!("{url_without_extrrension}.png"))
-        {
+        let filename = format!("{krate}.png");
+        if let Ok(og_img_url) = og_image_base_url.join(&filename) {
             return og_img_url.into();
         }
     }

--- a/src/middleware/static_or_continue.rs
+++ b/src/middleware/static_or_continue.rs
@@ -18,7 +18,10 @@ pub async fn serve_dist(request: Request, next: Next) -> Response {
 }
 
 async fn serve<P: AsRef<Path>>(path: P, request: Request, next: Next) -> Response {
-    if request.method() == Method::GET || request.method() == Method::HEAD {
+    // index.html is a Jinja template, which is to be rendered by `ember_html::serve_html`.
+    if matches!(*request.method(), Method::GET | Method::HEAD)
+        && !matches!(request.uri().path().as_bytes(), b"/" | b"/index.html")
+    {
         let mut static_req = Request::new(());
         *static_req.method_mut() = request.method().clone();
         *static_req.uri_mut() = request.uri().clone();

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -481,7 +481,7 @@ fn simple_config() -> config::Server {
 
         // The frontend code is not needed for the backend tests.
         serve_dist: false,
-        index_html_template_path: None,
+        serve_html: false,
         og_image_base_url: None,
         html_render_cache_max_capacity: 1024,
         content_security_policy: None,

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -481,7 +481,9 @@ fn simple_config() -> config::Server {
 
         // The frontend code is not needed for the backend tests.
         serve_dist: false,
-        serve_html: false,
+        index_html_template_path: None,
+        og_image_base_url: None,
+        html_render_cache_max_capacity: 1024,
         content_security_policy: None,
     }
 }


### PR DESCRIPTION
Related discussion: https://github.com/rust-lang/crates.io/discussions/9928

I replaced `tower_http::services::ServeFile` with a manually built response, and attempted to mimic its behavior. Furthermore, I replaced the hard coded open graph image url from `app/index.html` with a Jinja2 variable called `og_image_url`. I imagine this file is served from a bucket or the like in production, so upon deployment that variable should be replaced with the original fallback URL.

The base URL of the OG images is configurable, and should work with either a local or public instance of [`og-loc`](https://github.com/mainmatter/og-loc), or, as suggested in the related discussion, a file in a bucket.

Is this going in the right direction?

To do:

- [x] cache rendered HTML with [`moka`](https://docs.rs/moka/latest/moka/)