### PR TITLE
Replace `ember-tooltips` with `floating-ui`

### DIFF
--- a/app/components/crate-header.hbs
+++ b/app/components/crate-header.hbs
@@ -9,10 +9,10 @@
           {{svg-jar "trash"}}
           Yanked
 
-          <EmberTooltip>
+          <Tooltip>
             This crate has been yanked, but it is still available for download for other crates that
             may be depending on it.
-          </EmberTooltip>
+          </Tooltip>
         </span>
       {{/if}}
     {{/if}}

--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -28,7 +28,7 @@
       <span>
         <span>
           All-Time:
-          <EmberTooltip @text="Total number of downloads"/>
+          <Tooltip @text="Total number of downloads"/>
         </span>
         {{ format-num @crate.downloads }}
       </span>
@@ -38,7 +38,7 @@
       <span>
         <span>
           Recent:
-          <EmberTooltip @text="Downloads in the last 90 days"/>
+          <Tooltip @text="Downloads in the last 90 days"/>
         </span>
         {{ format-num @crate.recent_downloads }}
       </span>
@@ -48,11 +48,11 @@
       <span>
         <span>
           Updated:
-          <EmberTooltip @text="The last time the crate was updated" />
+          <Tooltip @text="The last time the crate was updated" />
         </span>
         <time datetime="{{date-format-iso @crate.updated_at}}" data-test-updated-at>
           {{date-format-distance-to-now @crate.updated_at addSuffix=true}}
-          <EmberTooltip @text={{ @crate.updated_at }}/>
+          <Tooltip @text={{ @crate.updated_at }}/>
         </time>
       </span>
     </div>

--- a/app/components/crate-sidebar.hbs
+++ b/app/components/crate-sidebar.hbs
@@ -13,7 +13,7 @@
       {{svg-jar "calendar"}}
       <span>
         {{date-format-distance-to-now @version.created_at addSuffix=true}}
-        <EmberTooltip @text={{date-format @version.created_at 'PPP'}} />
+        <Tooltip @text={{date-format @version.created_at 'PPP'}} />
       </span>
     </time>
 
@@ -120,7 +120,7 @@
         Try on Rust Playground
 
         {{#if this.canHover}}
-          <EmberTooltip
+          <Tooltip
             @text="The top 100 crates are available on the Rust Playground for you to try out directly in your browser." />
         {{/if}}
       </a>

--- a/app/components/crate-sidebar.module.css
+++ b/app/components/crate-sidebar.module.css
@@ -37,7 +37,7 @@
 .date,
 .msrv,
 .edition {
-    [title], :global(.ember-tooltip-target) {
+    > span {
         cursor: help;
     }
 }

--- a/app/components/dependency-list/row.hbs
+++ b/app/components/dependency-list/row.hbs
@@ -36,23 +36,20 @@
 
       {{#if this.featuresDescription}}
         <span local-class="features-label" data-test-features>
-          {{! extra <span> for better tooltip alignment }}
-          <span>
-            {{this.featuresDescription}}
+          {{this.featuresDescription}}
 
-            <EmberTooltip>
-              <ul local-class="feature-list">
+          <Tooltip local-class="tooltip">
+            <ul local-class="feature-list">
+              <li>
+                {{svg-jar (if @dependency.default_features "checkbox" "checkbox-empty")}} default features
+              </li>
+              {{#each @dependency.features as |feature|}}
                 <li>
-                  {{svg-jar (if @dependency.default_features "checkbox" "checkbox-empty")}} default features
+                  {{svg-jar "checkbox"}} {{feature}}
                 </li>
-                {{#each @dependency.features as |feature|}}
-                  <li>
-                    {{svg-jar "checkbox"}} {{feature}}
-                  </li>
-                {{/each}}
-              </ul>
-            </EmberTooltip>
-          </span>
+              {{/each}}
+            </ul>
+          </Tooltip>
         </span>
       {{/if}}
     </div>

--- a/app/components/dependency-list/row.module.css
+++ b/app/components/dependency-list/row.module.css
@@ -31,13 +31,13 @@
         --placeholder-opacity: 0.15;
     }
 
-    [title], :global(.ember-tooltip-target) {
+    [title], .features-label {
         position: relative;
         z-index: 1;
         cursor: help;
     }
 
-    :global(.ember-tooltip) {
+    .tooltip {
         word-break: break-all;
     }
 
@@ -112,7 +112,7 @@
         margin-bottom: -.1em;
     }
 
-    :global(.ember-tooltip) {
+    .tooltip {
         text-transform: none;
         letter-spacing: normal;
     }
@@ -133,7 +133,7 @@
 
 .feature-list {
     padding: 0;
-    margin: 10px 5px;
+    margin: var(--space-2xs) var(--space-3xs);
     list-style: none;
 
     svg {

--- a/app/components/edition.hbs
+++ b/app/components/edition.hbs
@@ -1,7 +1,7 @@
 <span>
   {{@version.edition}} edition
 
-  <EmberTooltip>
+  <Tooltip>
     This crate version does not declare a Minimum Supported Rust Version, but
     does require the {{@version.edition}} Rust Edition.
 
@@ -10,5 +10,5 @@
       but this crate may require features that were added in later versions of
       Rust.
     </div>
-  </EmberTooltip>
+  </Tooltip>
 </span>

--- a/app/components/ember-tooltip.js
+++ b/app/components/ember-tooltip.js
@@ -1,5 +1,0 @@
-import EmberTooltipComponent from 'ember-tooltips/components/ember-tooltip';
-
-export default class extends EmberTooltipComponent {
-  delay = 200;
-}

--- a/app/components/msrv.hbs
+++ b/app/components/msrv.hbs
@@ -1,10 +1,10 @@
 <span>
   v{{@version.msrv}}
 
-  <EmberTooltip>
+  <Tooltip>
     &quot;Minimum Supported Rust Version&quot;
     {{#if @version.edition}}
       <div local-class="edition">requires Rust Edition {{@version.edition}}</div>
     {{/if}}
-  </EmberTooltip>
+  </Tooltip>
 </span>

--- a/app/components/privileged-action.hbs
+++ b/app/components/privileged-action.hbs
@@ -12,9 +12,9 @@
       <fieldset data-test-placeholder-fieldset disabled="disabled">
         {{yield}}
       </fieldset>
-      <EmberTooltip>
+      <Tooltip>
         You must enable admin actions before you can perform this operation.
-      </EmberTooltip>
+      </Tooltip>
     </div>
   {{/if}}
 {{else}}

--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -48,7 +48,7 @@
 
                 {{#each (this.listToParts token.endpoint_scopes) as |part|~}}
                   {{#if (eq part.type "element")}}
-                    <strong>{{part.value}}<EmberTooltip @text={{this.scopeDescription part.value}} /></strong>
+                    <strong>{{part.value}}<Tooltip @text={{this.scopeDescription part.value}} /></strong>
                     {{~else~}}
                     {{part.value}}
                   {{/if}}
@@ -62,7 +62,7 @@
 
                 {{#each (this.listToParts token.crate_scopes) as |part|~}}
                   {{#if (eq part.type "element")}}
-                    <strong>{{part.value}}<EmberTooltip @text={{this.patternDescription part.value}} /></strong>
+                    <strong>{{part.value}}<Tooltip @text={{this.patternDescription part.value}} /></strong>
                     {{~else~}}
                     {{part.value}}
                   {{/if}}

--- a/app/components/tooltip.hbs
+++ b/app/components/tooltip.hbs
@@ -1,0 +1,9 @@
+<div ...attributes local-class="tooltip" {{attach-tooltip hide=this.hide show=this.show side=@side}}>
+  {{#unless this.hidden}}
+    {{#if (has-block)}}
+      {{yield}}
+    {{else}}
+      {{@text}}
+    {{/if}}
+  {{/unless}}
+</div>

--- a/app/components/tooltip.js
+++ b/app/components/tooltip.js
@@ -1,0 +1,15 @@
+import { action } from '@ember/object';
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+
+export default class Tooltip extends Component {
+  @tracked hidden = true;
+
+  @action hide() {
+    this.hidden = true;
+  }
+
+  @action show() {
+    this.hidden = false;
+  }
+}

--- a/app/components/tooltip.module.css
+++ b/app/components/tooltip.module.css
@@ -1,0 +1,22 @@
+.tooltip {
+    display: none;
+    width: max-content;
+    max-width: 300px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background: #3a3c47;
+    color: white;
+    font-family: var(--font-body);
+    font-size: 14px;
+    font-weight: normal;
+    overflow: hidden;
+    text-wrap: auto;
+    padding: var(--space-2xs) var(--space-xs);
+    border-radius: var(--space-3xs);
+    z-index: 2;
+
+    strong {
+        color: unset;
+    }
+}

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -20,9 +20,9 @@
         {{@version.releaseTrack}}
       {{/if}}
 
-      <EmberTooltip @side="right" data-test-release-track-title>
+      <Tooltip @side="right" local-class="tooltip" data-test-release-track-title>
         {{this.releaseTrackTitle}}
-      </EmberTooltip>
+      </Tooltip>
     </div>
 
     <LinkTo
@@ -56,12 +56,12 @@
         {{svg-jar "calendar"}}
         {{date-format-distance-to-now @version.created_at addSuffix=true}}
 
-        <EmberTooltip>
+        <Tooltip local-class="tooltip">
           {{date-format @version.created_at 'PPP'}}
           {{#if @version.isNew}}
             (<span local-class="new">new</span>)
           {{/if}}
-        </EmberTooltip>
+        </Tooltip>
       </time>
     </div>
 
@@ -98,7 +98,7 @@
             {{svg-jar "checkbox"}}
             {{@version.featureList.length}} {{if (eq @version.featureList.length 1) "Feature" "Features"}}
 
-            <EmberTooltip>
+            <Tooltip local-class="tooltip">
               <ul local-class="feature-list">
                 {{#each @version.featureList as |feature|}}
                   <li>
@@ -107,7 +107,7 @@
                   </li>
                 {{/each}}
               </ul>
-            </EmberTooltip>
+            </Tooltip>
           </span>
         {{/if}}
       </div>

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -40,12 +40,15 @@
         --hover-bg-color: light-dark(hsl(0, 92%, 98%), hsl(0, 10%, 11%));
         --fg-color: light-dark(hsl(0, 84%, 32%), hsl(0, 92%, 90%));
     }
+}
 
-    [title], :global(.ember-tooltip-target) {
-        position: relative;
-        z-index: 1;
-        cursor: help;
-    }
+.release-track, .date, .num-features {
+    z-index: 1;
+    cursor: help;
+}
+
+.date, .num-features {
+    position: relative;
 }
 
 .version {
@@ -53,7 +56,7 @@
     grid-template-columns: auto auto;
     place-items: center;
 
-    :global(.ember-tooltip) {
+    .tooltip {
         word-break: break-all;
     }
 
@@ -158,7 +161,7 @@
         margin-bottom: -.1em;
     }
 
-    :global(.ember-tooltip) {
+    .tooltip {
         text-transform: none;
         letter-spacing: normal;
     }
@@ -199,7 +202,7 @@
     }
 }
 
-.date.new, :global(.tooltip) .new {
+.date.new, .tooltip .new {
     color: hsl(39, 98%, 47%);
 }
 
@@ -221,7 +224,7 @@
 
 .feature-list {
     padding: 0;
-    margin: var(--space-xs) var(--space-2xs);
+    margin: var(--space-2xs) var(--space-3xs);
     list-style: none;
 }
 

--- a/app/modifiers/attach-tooltip.js
+++ b/app/modifiers/attach-tooltip.js
@@ -1,0 +1,45 @@
+import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
+import { modifier } from 'ember-modifier';
+
+export default modifier((floatingElement, positional, { hide, show, side = 'top' } = {}) => {
+  let referenceElement = floatingElement.parentElement;
+
+  let cleanup;
+
+  async function update() {
+    let middleware = [offset(5), flip(), shift({ padding: 5 })];
+
+    let { x, y } = await computePosition(referenceElement, floatingElement, {
+      placement: side,
+      middleware,
+    });
+
+    Object.assign(floatingElement.style, {
+      left: `${x}px`,
+      top: `${y}px`,
+    });
+  }
+
+  function showTooltip() {
+    show();
+    floatingElement.style.display = 'block';
+    cleanup = autoUpdate(referenceElement, floatingElement, update);
+  }
+
+  function hideTooltip() {
+    hide();
+    floatingElement.style.display = '';
+    cleanup?.();
+  }
+
+  [
+    ['mouseenter', showTooltip],
+    ['mouseleave', hideTooltip],
+    ['focus', showTooltip],
+    ['blur', hideTooltip],
+  ].forEach(([event, listener]) => {
+    referenceElement.addEventListener(event, listener);
+  });
+
+  return () => cleanup?.();
+});

--- a/app/styles/application.module.css
+++ b/app/styles/application.module.css
@@ -202,8 +202,3 @@ noscript {
     flex-direction: column;
     padding: var(--main-layout-padding);
 }
-
-:global(.ember-tooltip) {
-    max-width: 300px;
-    font-weight: normal;
-}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@sentry/ember": "8.54.0",
     "chart.js": "4.4.7",
     "date-fns": "4.1.0",
+    "@floating-ui/dom": "1.6.13",
     "highlight.js": "11.11.1",
     "macro-decorators": "0.1.2",
     "mermaid": "11.4.1",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "ember-svg-jar": "2.6.0",
     "ember-template-lint": "6.1.0",
     "ember-test-selectors": "7.0.0",
-    "ember-tooltips": "3.6.0",
     "ember-truth-helpers": "4.0.3",
     "ember-web-app": "5.0.1",
     "ember-window-mock": "1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/dom':
+        specifier: 1.6.13
+        version: 1.6.13
       '@juggle/resize-observer':
         specifier: 3.4.0
         version: 3.4.0
@@ -1588,6 +1591,15 @@ packages:
   '@eslint/plugin-kit@0.2.5':
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.6.9':
+    resolution: {integrity: sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==}
+
+  '@floating-ui/dom@1.6.13':
+    resolution: {integrity: sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==}
+
+  '@floating-ui/utils@0.2.9':
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
   '@glimmer/compiler@0.92.4':
     resolution: {integrity: sha512-xoR8F6fsgFqWbPbCfSgJuJ95vaLnXw0SgDCwyl/KMeeaSxpHwJbr8+BfiUl+7ko2A+HzrY5dPXXnGr4ZM+CUXw==}
@@ -10440,6 +10452,17 @@ snapshots:
     dependencies:
       '@eslint/core': 0.10.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.6.9':
+    dependencies:
+      '@floating-ui/utils': 0.2.9
+
+  '@floating-ui/dom@1.6.13':
+    dependencies:
+      '@floating-ui/core': 1.6.9
+      '@floating-ui/utils': 0.2.9
+
+  '@floating-ui/utils@0.2.9': {}
 
   '@glimmer/compiler@0.92.4':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,9 +229,6 @@ importers:
       ember-test-selectors:
         specifier: 7.0.0
         version: 7.0.0
-      ember-tooltips:
-        specifier: 3.6.0
-        version: 3.6.0(webpack@5.97.1)
       ember-truth-helpers:
         specifier: 4.0.3
         version: 4.0.3(ember-source@6.0.1(@glimmer/component@2.0.0)(rsvp@4.8.5)(webpack@5.97.1))
@@ -4592,10 +4589,6 @@ packages:
     resolution: {integrity: sha512-gGJzzBw6CsBB9gfk9/4qw0+iOSvhlqvUe4jIZKDf4waMkgVLtnPdFUWMocfFvUnJS7IitwKB/iTgIctD4RgH7w==}
     engines: {node: 18.* || 20.* || >= 22.*}
 
-  ember-tooltips@3.6.0:
-    resolution: {integrity: sha512-DsqF6vvL3DKWSUHJKuMJ8KSxbE/T+eZAE2xtzAuHRqjl1AYIOkugGBVynGYYP8+2/10NMwk05LYbT1dirAcEBQ==}
-    engines: {node: 12.* || 14.* || >= 16}
-
   ember-tracked-storage-polyfill@1.0.0:
     resolution: {integrity: sha512-eL7lZat68E6P/D7b9UoTB5bB5Oh/0aju0Z7PCMi3aTwhaydRaxloE7TGrTRYU+NdJuyNVZXeGyxFxn2frvd3TA==}
     engines: {node: 12.* || >= 14}
@@ -7047,10 +7040,6 @@ packages:
   points-on-path@0.2.1:
     resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
-  popper.js@1.16.1:
-    resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
-    deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
-
   portfinder@1.0.32:
     resolution: {integrity: sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==}
     engines: {node: '>= 0.12.0'}
@@ -8256,10 +8245,6 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-
-  tooltip.js@1.3.3:
-    resolution: {integrity: sha512-XWWuy/dBdF/F/YpRE955yqBZ4VdLfiTAUdOqoU+wJm6phJlMpEzl/iYHZ+qJswbeT9VG822bNfsETF9wzmoy5A==}
-    deprecated: Tooltip.js is not supported anymore, please migrate to tippy.js
 
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
@@ -14776,23 +14761,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-tooltips@3.6.0(webpack@5.97.1):
-    dependencies:
-      '@embroider/macros': 1.16.10
-      broccoli-file-creator: 2.1.1
-      broccoli-merge-trees: 4.2.0
-      ember-auto-import: 2.10.0(webpack@5.97.1)
-      ember-cli-babel: 7.26.11
-      ember-cli-htmlbars: 5.7.2
-      ember-in-element-polyfill: 1.0.1
-      popper.js: 1.16.1
-      resolve: 1.22.10
-      tooltip.js: 1.3.3
-    transitivePeerDependencies:
-      - '@glint/template'
-      - supports-color
-      - webpack
-
   ember-tracked-storage-polyfill@1.0.0:
     dependencies:
       ember-cli-babel: 7.26.11
@@ -17700,8 +17668,6 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  popper.js@1.16.1: {}
-
   portfinder@1.0.32:
     dependencies:
       async: 2.6.4
@@ -19184,10 +19150,6 @@ snapshots:
       safe-regex: 1.1.0
 
   toidentifier@1.0.1: {}
-
-  tooltip.js@1.3.3:
-    dependencies:
-      popper.js: 1.16.1
 
   toposort@2.0.2: {}
 


### PR DESCRIPTION
https://floating-ui.com is a low-level library to implement e.g. tooltips. This PR replaces the unmaintained `ember-tooltips` addon with a custom `Tooltip` component based on `floating-ui` that works roughly similar. This should hopefully then unblock the `@ember/string` update in #10354.

### Before

![Bildschirmfoto 2025-02-05 um 13 04 55](https://github.com/user-attachments/assets/976b1df8-6d6d-42a8-a7ae-a6811d9c8184)

### After

![Bildschirmfoto 2025-02-05 um 13 04 31](https://github.com/user-attachments/assets/d19328d4-f683-49f8-90b3-47d0179af37f)

yes, we lost the arrow, but does that really matter? 😅 

floating-ui does have an "arrow middleware", but I couldn't make it work properly in combination with `flip()`. since it would require more complexity for IMHO little gain I think it's fine to ship this without arrows.