### PR TITLE
Add `default_versions.num_versions` column

### DIFF
--- a/crates/crates_io_database/src/schema.rs
+++ b/crates/crates_io_database/src/schema.rs
@@ -408,6 +408,8 @@ diesel::table! {
         crate_id -> Int4,
         /// Reference to the version in the `versions` table.
         version_id -> Int4,
+        /// The total number of versions.
+        num_versions -> Nullable<Int4>,
     }
 }
 

--- a/crates/crates_io_database_dump/src/dump-db.toml
+++ b/crates/crates_io_database_dump/src/dump-db.toml
@@ -105,6 +105,7 @@ dependencies = ["crates", "versions"]
 [default_versions.columns]
 crate_id = "public"
 version_id = "public"
+num_versions = "public"
 
 [deleted_crates]
 dependencies = ["users"]

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@export.sql.snap
@@ -18,7 +18,7 @@ BEGIN ISOLATION LEVEL REPEATABLE READ, READ ONLY;
     \copy (SELECT "crate_id", "created_at", "created_by", "owner_id", "owner_kind" FROM "crate_owners" WHERE NOT deleted) TO 'data/crate_owners.csv' WITH CSV HEADER
 
     \copy "versions" ("bin_names", "categories", "checksum", "crate_id", "crate_size", "created_at", "description", "documentation", "downloads", "edition", "features", "has_lib", "homepage", "id", "keywords", "license", "links", "num", "num_no_build", "published_by", "repository", "rust_version", "updated_at", "yanked") TO 'data/versions.csv' WITH CSV HEADER
-    \copy "default_versions" ("crate_id", "version_id") TO 'data/default_versions.csv' WITH CSV HEADER
+    \copy "default_versions" ("crate_id", "num_versions", "version_id") TO 'data/default_versions.csv' WITH CSV HEADER
     \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") TO 'data/dependencies.csv' WITH CSV HEADER
     \copy "version_downloads" ("date", "downloads", "version_id") TO 'data/version_downloads.csv' WITH CSV HEADER
 COMMIT;

--- a/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
+++ b/crates/crates_io_database_dump/src/snapshots/crates_io_database_dump__tests__sql_scripts@import.sql.snap
@@ -60,7 +60,7 @@ BEGIN;
     \copy "crates_keywords" ("crate_id", "keyword_id") FROM 'data/crates_keywords.csv' WITH CSV HEADER
     \copy "crate_owners" ("crate_id", "created_at", "created_by", "owner_id", "owner_kind") FROM 'data/crate_owners.csv' WITH CSV HEADER
     \copy "versions" ("bin_names", "categories", "checksum", "crate_id", "crate_size", "created_at", "description", "documentation", "downloads", "edition", "features", "has_lib", "homepage", "id", "keywords", "license", "links", "num", "num_no_build", "published_by", "repository", "rust_version", "updated_at", "yanked") FROM 'data/versions.csv' WITH CSV HEADER
-    \copy "default_versions" ("crate_id", "version_id") FROM 'data/default_versions.csv' WITH CSV HEADER
+    \copy "default_versions" ("crate_id", "num_versions", "version_id") FROM 'data/default_versions.csv' WITH CSV HEADER
     \copy "dependencies" ("crate_id", "default_features", "explicit_name", "features", "id", "kind", "optional", "req", "target", "version_id") FROM 'data/dependencies.csv' WITH CSV HEADER
     \copy "version_downloads" ("date", "downloads", "version_id") FROM 'data/version_downloads.csv' WITH CSV HEADER
 

--- a/migrations/2025-02-05-083109_add-num-versions-column/down.sql
+++ b/migrations/2025-02-05-083109_add-num-versions-column/down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE default_versions
+    DROP COLUMN num_versions;
+
+DROP FUNCTION IF EXISTS update_num_versions_from_versions CASCADE;

--- a/migrations/2025-02-05-083109_add-num-versions-column/up.sql
+++ b/migrations/2025-02-05-083109_add-num-versions-column/up.sql
@@ -1,0 +1,27 @@
+ALTER TABLE default_versions
+    ADD COLUMN num_versions INTEGER;
+
+COMMENT ON COLUMN default_versions.num_versions IS 'The total number of versions.';
+
+CREATE OR REPLACE FUNCTION update_num_versions_from_versions() RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO default_versions (crate_id, version_id, num_versions)
+        VALUES (NEW.crate_id, NEW.id, 1)
+        ON CONFLICT (crate_id) DO UPDATE
+        SET num_versions = EXCLUDED.num_versions + 1;
+        RETURN NEW;
+    ELSIF (TG_OP = 'DELETE') THEN
+        UPDATE default_versions
+        SET num_versions = num_versions - 1
+        WHERE crate_id = OLD.crate_id;
+        RETURN OLD;
+    END IF;
+END
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_update_num_versions_from_versions ON versions;
+CREATE TRIGGER trigger_update_num_versions_from_versions
+     AFTER INSERT OR DELETE ON versions
+     FOR EACH ROW
+     EXECUTE PROCEDURE update_num_versions_from_versions();


### PR DESCRIPTION
The total number of versions is one of the blockers for avoiding loading full versions within the application. To address this, we can either send a separate request to retrieve the number, or, as suggested by @Turbo87, store the value in db and include it in the crate response. The latter approach seems more promising, as it eliminates the need for an extra request solely to obtain the total.

To ensure the value is up-to-date and maintain deployment convenience, the implementation will be separated into multiple PRs:

- [x] db: migration and save value
- [ ] expose on the API and leverage in the application
