### PR TITLE
Use `cargo-machete` to remove unused dependency declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ env:
   CARGO_TERM_COLOR: always
   # renovate: datasource=crate depName=cargo-deny versioning=semver
   CARGO_DENY_VERSION: 0.16.4
+  # renovate: datasource=crate depName=cargo-machete versioning=semver
+  CARGO_MACHETE_VERSION: 0.7.0
   # renovate: datasource=crate depName=grcov versioning=semver
   GRCOV_VERSION: 0.8.20
   # renovate: datasource=npm depName=pnpm
@@ -111,8 +113,18 @@ jobs:
       - run: cargo clippy --all-targets --all-features --workspace
       - run: cargo doc --no-deps --document-private-items
 
+  # to make https://github.com/rust-lang/team/blob/651fb3f9c64c934c9073472765d745a606dd9daf/repos/rust-lang/crates.io.toml#L17 happy until we migrated it…
   backend-cargo-deny:
     name: Backend / cargo-deny
+    runs-on: ubuntu-24.04
+    if: false
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+  backend-deps:
+    name: Backend / dependencies
     runs-on: ubuntu-24.04
     needs: changed-files
     if: github.event_name != 'pull_request' || needs.changed-files.outputs.rust-lockfile == 'true'
@@ -126,6 +138,9 @@ jobs:
 
       - run: cargo install cargo-deny --vers ${CARGO_DENY_VERSION}
       - run: cargo deny check
+
+      - run: cargo install cargo-machete --vers ${CARGO_MACHETE_VERSION}
+      - run: cargo machete
 
   backend-test:
     name: Backend / Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,6 @@ dependencies = [
  "googletest",
  "hex",
  "http 1.2.0",
- "http-body-util",
  "hyper 1.6.0",
  "indexmap",
  "indicatif",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1340,7 +1340,6 @@ dependencies = [
  "anyhow",
  "claims",
  "crates_io_test_db",
- "deadpool-diesel",
  "diesel",
  "diesel-async",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ unescaped_backticks = "warn"
 dbg_macro = "warn"
 todo = "warn"
 
+[package.metadata.cargo-machete]
+ignored = ["krata-tokio-tar"]
+
+[workspace.metadata.cargo-machete]
+ignored = ["krata-tokio-tar"]
+
 [lints]
 workspace = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ flate2 = "=1.0.35"
 futures-util = "=0.3.31"
 hex = "=0.4.3"
 http = "=1.2.0"
-http-body-util = "=0.1.2"
 hyper = { version = "=1.6.0", features = ["client", "http1"] }
 indexmap = { version = "=2.7.1", features = ["serde"] }
 indicatif = "=0.17.11"

--- a/crates/crates_io_worker/Cargo.toml
+++ b/crates/crates_io_worker/Cargo.toml
@@ -9,7 +9,6 @@ workspace = true
 
 [dependencies]
 anyhow = "=1.0.95"
-deadpool-diesel = { version = "=0.6.1", features = ["postgres", "tracing"] }
 diesel = { version = "=2.2.7", features = ["postgres", "serde_json"] }
 diesel-async = { version = "=0.5.2", features = ["async-connection-wrapper", "deadpool", "postgres"] }
 futures-util = "=0.3.31"


### PR DESCRIPTION
This removes two unused dependency declarations and adds `cargo-machete` to our CI pipeline.