### PR TITLE
List crate features so they're readable

### DIFF
--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -94,21 +94,15 @@
         {{/if}}
 
         {{#if @version.featureList}}
-          <span local-class="num-features" data-test-feature-list>
-            {{svg-jar "checkbox"}}
-            {{@version.featureList.length}} {{if (eq @version.featureList.length 1) "Feature" "Features"}}
-
-            <Tooltip local-class="tooltip">
-              <ul local-class="feature-list">
-                {{#each @version.featureList as |feature|}}
-                  <li>
-                    {{svg-jar (if feature.isDefault "checkbox" "checkbox-empty")}}
-                    {{feature.name}}
-                  </li>
-                {{/each}}
-              </ul>
-            </Tooltip>
-          </span>
+            <button
+              type="button"
+              local-class="features-button"
+              {{on "click" this.toggleDropdown}}
+            >
+              <span local-class="num-features" data-test-feature-list>
+                {{svg-jar "checkbox"}}
+                {{@version.featureList.length}} {{if (eq @version.featureList.length 1) "Feature" "Features"}}</span>
+            </button>
         {{/if}}
       </div>
     {{/if}}
@@ -118,3 +112,24 @@
     <YankButton @version={{@version}} local-class="yank-button" />
   </PrivilegedAction>
 </div>
+
+{{#if this.featuresOpen}}
+  <div
+    local-class="
+    row
+    features-panel
+    {{if @version.isHighestOfReleaseTrack "latest"}}
+    {{if @version.yanked "yanked"}}
+    {{if @version.isPrerelease "prerelease"}}
+    {{if this.focused "focused"}}
+  ">
+    <ul local-class="feature-list">
+      {{#each @version.featureList as |feature|}}
+        <li>
+          {{svg-jar (if feature.isDefault "checkbox" "checkbox-empty")}}
+          {{feature.name}}
+        </li>
+      {{/each}}
+    </ul>
+  </div>
+{{/if}}

--- a/app/components/version-list/row.js
+++ b/app/components/version-list/row.js
@@ -10,6 +10,7 @@ export default class VersionRow extends Component {
   @service session;
 
   @tracked focused = false;
+  @tracked featuresOpen = false;
 
   get releaseTrackTitle() {
     let { version } = this.args;
@@ -54,5 +55,9 @@ export default class VersionRow extends Component {
 
   @action setFocused(value) {
     this.focused = value;
+  }
+
+  @action toggleDropdown() {
+    this.featuresOpen = !this.featuresOpen;
   }
 }

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -222,10 +222,43 @@
     text-transform: none;
 }
 
+.features-button {
+    text-align: center;
+    padding-top: var(--space-4xs);
+    position: relative;
+    cursor: help;
+    svg {
+        height: 1em;
+        width: auto;
+        margin-right: var(--space-4xs);
+        margin-bottom: -.2em;
+    }
+}
+
+.features-panel {
+    margin-top: var(--space-2xs);
+    letter-spacing: .7px;
+    font-size: 13px;
+    svg {
+        height: 1em;
+        width: auto;
+        margin-right: var(--space-4xs);
+        margin-bottom: -.1em;
+    }
+}
+
 .feature-list {
     padding: 0;
     margin: var(--space-2xs) var(--space-3xs);
     list-style: none;
+    user-select: text;
+
+    li {
+        padding: var(--space-4xs);
+    }
+    li svg {
+        vertical-align: middle;
+    }
 }
 
 .yank-button {


### PR DESCRIPTION
fixes #465 

Just a UI update to move the version feature list to a separate togglable panel.
Currently you can only view them on hover. Which isn't readable with long lists and doesn't allow you to easily select what you wanna see.
Before: 
![image](https://github.com/user-attachments/assets/089f83c9-d1b3-4af5-942a-e63fb0d74415)

After:
![image](https://github.com/user-attachments/assets/31400e49-e725-4e77-8ede-8b0547eaf7d0)
![image](https://github.com/user-attachments/assets/c226d0f8-82b6-4eec-89e1-2c243d44063a)
![image](https://github.com/user-attachments/assets/8c458afb-b565-40c6-a440-52f42cb8e827)

Thoughts, suggestions, improvements, etc. appreciated!