### PR TITLE
Extract `NewCrateOwnerInvitation` struct

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,8 @@
 pub use self::action::{NewVersionOwnerAction, VersionAction, VersionOwnerAction};
 pub use self::category::{Category, CrateCategory, NewCategory};
-pub use self::crate_owner_invitation::{CrateOwnerInvitation, NewCrateOwnerInvitationOutcome};
+pub use self::crate_owner_invitation::{
+    CrateOwnerInvitation, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome,
+};
 pub use self::default_versions::{update_default_version, verify_default_version};
 pub use self::deleted_crate::NewDeletedCrate;
 pub use self::dependency::{Dependency, DependencyKind, ReverseDependency};

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -13,8 +13,8 @@ use crate::controllers::helpers::pagination::*;
 use crate::models::helpers::with_count::*;
 use crate::models::version::TopVersions;
 use crate::models::{
-    CrateOwner, CrateOwnerInvitation, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome,
-    Owner, OwnerKind, ReverseDependency, User, Version,
+    CrateOwner, NewCrateOwnerInvitation, NewCrateOwnerInvitationOutcome, Owner, OwnerKind,
+    ReverseDependency, User, Version,
 };
 use crate::schema::*;
 use crate::util::errors::{bad_request, version_not_found, AppResult};
@@ -407,7 +407,8 @@ impl Crate {
                     crate_id: self.id,
                 };
 
-                let creation_ret = CrateOwnerInvitation::create(&invite, conn, &app.config)
+                let creation_ret = invite
+                    .create(conn, &app.config)
                     .await
                     .map_err(BoxedAppError::from)?;
 


### PR DESCRIPTION
This avoids the "three `i32` arguments in a function call" issue and is more consistent with the rest of the codebase that uses similar patterns.