### PR TITLE
models/krate: Remove `PaginationOptions` dependency

### DIFF
--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -30,9 +30,9 @@ pub async fn list_reverse_dependencies(
 
     let krate = path.load_crate(&mut conn).await?;
 
-    let (rev_deps, total) = krate
-        .reverse_dependencies(&mut conn, pagination_options)
-        .await?;
+    let offset = pagination_options.offset().unwrap_or_default();
+    let limit = pagination_options.per_page;
+    let (rev_deps, total) = krate.reverse_dependencies(&mut conn, offset, limit).await?;
 
     let rev_deps: Vec<_> = rev_deps
         .into_iter()

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -9,7 +9,6 @@ use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use secrecy::SecretString;
 use thiserror::Error;
 
-use crate::controllers::helpers::pagination::*;
 use crate::models::helpers::with_count::*;
 use crate::models::version::TopVersions;
 use crate::models::{
@@ -491,17 +490,17 @@ impl Crate {
     pub(crate) async fn reverse_dependencies(
         &self,
         conn: &mut AsyncPgConnection,
-        options: PaginationOptions,
+        offset: i64,
+        limit: i64,
     ) -> QueryResult<(Vec<ReverseDependency>, i64)> {
         use diesel::sql_query;
         use diesel::sql_types::{BigInt, Integer};
 
-        let offset = options.offset().unwrap_or_default();
         let rows: Vec<WithCount<ReverseDependency>> =
             sql_query(include_str!("krate_reverse_dependencies.sql"))
                 .bind::<Integer, _>(self.id)
                 .bind::<BigInt, _>(offset)
-                .bind::<BigInt, _>(options.per_page)
+                .bind::<BigInt, _>(limit)
                 .load(conn)
                 .await?;
 


### PR DESCRIPTION
This dependency on the `PaginationOptions` struct makes it hard to eventually extract our database model code into a dedicated crate. Since we only need the offset and limit for this query we can just pass it in directly and move the dependency into the controller that is already using `PaginationOptions` anyway.