### PR TITLE
models/token: Extract `NewApiToken` struct

### DIFF
--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -7,6 +7,7 @@ use crate::app::AppState;
 use crate::auth::AuthCheck;
 use crate::models::token::{CrateScope, EndpointScope};
 use crate::util::errors::{bad_request, AppResult};
+use crate::util::token::PlainToken;
 use axum::extract::{Path, Query};
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -148,15 +149,16 @@ pub async fn create_api_token(
 
     let recipient = user.email(&mut conn).await?;
 
-    let api_token = ApiToken::insert_with_scopes(
-        &mut conn,
-        user.id,
-        &new.api_token.name,
-        crate_scopes,
-        endpoint_scopes,
-        new.api_token.expired_at,
-    )
-    .await?;
+    let plaintext = PlainToken::generate();
+
+    let new_token = crate::models::token::NewApiToken::builder()
+        .user_id(user.id)
+        .name(&new.api_token.name)
+        .token(plaintext.hashed())
+        .maybe_crate_scopes(crate_scopes)
+        .maybe_endpoint_scopes(endpoint_scopes)
+        .maybe_expired_at(new.api_token.expired_at)
+        .build();
 
     if let Some(recipient) = recipient {
         let email = NewTokenEmail {
@@ -174,9 +176,20 @@ pub async fn create_api_token(
         }
     }
 
-    let api_token = EncodableApiTokenWithToken::from(api_token);
+    let created_token = CreatedApiToken {
+        plaintext,
+        model: new_token.insert(&mut conn).await?,
+    };
+
+    let api_token = EncodableApiTokenWithToken::from(created_token);
 
     Ok(json!({ "api_token": api_token }))
+}
+
+#[derive(Debug)]
+pub struct CreatedApiToken {
+    pub model: ApiToken,
+    pub plaintext: PlainToken,
 }
 
 /// Find API token by id.

--- a/src/models.rs
+++ b/src/models.rs
@@ -14,7 +14,7 @@ pub use self::krate::{Crate, CrateName, NewCrate, RecentCrateDownloads};
 pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::rights::Rights;
 pub use self::team::{NewTeam, Team};
-pub use self::token::{ApiToken, CreatedApiToken};
+pub use self::token::ApiToken;
 pub use self::user::{NewUser, User};
 pub use self::version::{NewVersion, TopVersions, Version};
 

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -61,15 +61,6 @@ pub struct ApiToken {
 }
 
 impl ApiToken {
-    /// Generates a new named API token for a user
-    pub async fn insert(
-        conn: &mut AsyncPgConnection,
-        user_id: i32,
-        name: &str,
-    ) -> QueryResult<CreatedApiToken> {
-        Self::insert_with_scopes(conn, user_id, name, None, None, None).await
-    }
-
     pub async fn insert_with_scopes(
         conn: &mut AsyncPgConnection,
         user_id: i32,

--- a/src/models/token.rs
+++ b/src/models/token.rs
@@ -61,31 +61,6 @@ pub struct ApiToken {
 }
 
 impl ApiToken {
-    pub async fn insert_with_scopes(
-        conn: &mut AsyncPgConnection,
-        user_id: i32,
-        name: &str,
-        crate_scopes: Option<Vec<CrateScope>>,
-        endpoint_scopes: Option<Vec<EndpointScope>>,
-        expired_at: Option<NaiveDateTime>,
-    ) -> QueryResult<CreatedApiToken> {
-        let token = PlainToken::generate();
-
-        let new_token = NewApiToken::builder()
-            .user_id(user_id)
-            .name(name)
-            .token(token.hashed())
-            .maybe_crate_scopes(crate_scopes)
-            .maybe_endpoint_scopes(endpoint_scopes)
-            .maybe_expired_at(expired_at)
-            .build();
-
-        Ok(CreatedApiToken {
-            plaintext: token,
-            model: new_token.insert(conn).await?,
-        })
-    }
-
     pub async fn find_by_api_token(
         conn: &mut AsyncPgConnection,
         token: &HashedToken,
@@ -118,12 +93,6 @@ impl ApiToken {
         };
         token
     }
-}
-
-#[derive(Debug)]
-pub struct CreatedApiToken {
-    pub model: ApiToken,
-    pub plaintext: PlainToken,
 }
 
 #[cfg(test)]

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -1,4 +1,4 @@
-use crate::models::token::{CrateScope, EndpointScope};
+use crate::models::token::{CrateScope, EndpointScope, NewApiToken};
 use crate::models::ApiToken;
 use crate::tests::util::insta::{self, assert_json_snapshot};
 use crate::tests::util::{RequestHelper, TestApp};
@@ -46,7 +46,9 @@ async fn create_token_exceeded_tokens_per_user() {
     let id = user.as_model().id;
 
     for i in 0..1000 {
-        assert_ok!(ApiToken::insert(&mut conn, id, &format!("token {i}")).await);
+        let name = format!("token {i}");
+        let new_token = NewApiToken::builder().name(name).user_id(id).build();
+        assert_ok!(new_token.insert(&mut conn).await);
     }
 
     let response = user.put::<()>("/api/v1/me/tokens", NEW_BAR).await;

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,7 +1,5 @@
 use chrono::NaiveDateTime;
-use secrecy::ExposeSecret;
 
-use crate::controllers::token::CreatedApiToken;
 use crate::external_urls::remove_blocked_urls;
 use crate::models::{
     ApiToken, Category, Crate, CrateOwnerInvitation, Dependency, DependencyKind, Keyword, Owner,
@@ -443,15 +441,6 @@ pub struct EncodableApiTokenWithToken {
     pub token: ApiToken,
     #[serde(rename = "token")]
     pub plaintext: String,
-}
-
-impl From<CreatedApiToken> for EncodableApiTokenWithToken {
-    fn from(token: CreatedApiToken) -> Self {
-        EncodableApiTokenWithToken {
-            token: token.model,
-            plaintext: token.plaintext.expose_secret().to_string(),
-        }
-    }
 }
 
 #[derive(Deserialize, Serialize, Debug)]

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,11 +1,11 @@
 use chrono::NaiveDateTime;
 use secrecy::ExposeSecret;
 
+use crate::controllers::token::CreatedApiToken;
 use crate::external_urls::remove_blocked_urls;
 use crate::models::{
-    ApiToken, Category, Crate, CrateOwnerInvitation, CreatedApiToken, Dependency, DependencyKind,
-    Keyword, Owner, ReverseDependency, Team, TopVersions, User, Version, VersionDownload,
-    VersionOwnerAction,
+    ApiToken, Category, Crate, CrateOwnerInvitation, Dependency, DependencyKind, Keyword, Owner,
+    ReverseDependency, Team, TopVersions, User, Version, VersionDownload, VersionOwnerAction,
 };
 use crate::util::rfc3339;
 use crates_io_github as github;


### PR DESCRIPTION
This simplifies the code for creating new API tokens a little bit by using the builder pattern for the new struct, instead of a list of function parameters that does not really scale.