### PR TITLE
db: Fix incorrect Upsert for `num_versions`

### DIFF
--- a/migrations/2025-02-11-163554_fix-num-versions-trigger/down.sql
+++ b/migrations/2025-02-11-163554_fix-num-versions-trigger/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS update_num_versions_from_versions CASCADE;

--- a/migrations/2025-02-11-163554_fix-num-versions-trigger/up.sql
+++ b/migrations/2025-02-11-163554_fix-num-versions-trigger/up.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE FUNCTION update_num_versions_from_versions() RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'INSERT') THEN
+        INSERT INTO default_versions (crate_id, version_id, num_versions)
+        VALUES (NEW.crate_id, NEW.id, 1)
+        ON CONFLICT (crate_id) DO UPDATE
+        SET num_versions = default_versions.num_versions + 1;
+        RETURN NEW;
+    ELSIF (TG_OP = 'DELETE') THEN
+        UPDATE default_versions
+        SET num_versions = num_versions - 1
+        WHERE crate_id = OLD.crate_id;
+        RETURN OLD;
+    END IF;
+END
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
Per https://github.com/rust-lang/crates.io/pull/10519/files#r1951118907. 🤦‍♂️ 🙈 

This fixes the misused `EXCLUDED` which would cause the `num_versions` to remain at 2 during conflicts.