### PR TITLE
CI: Remove broken CodeCov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ env:
   CARGO_DENY_VERSION: 0.16.4
   # renovate: datasource=crate depName=cargo-machete versioning=semver
   CARGO_MACHETE_VERSION: 0.7.0
-  # renovate: datasource=crate depName=grcov versioning=semver
-  GRCOV_VERSION: 0.8.20
   # renovate: datasource=npm depName=pnpm
   PNPM_VERSION: 10.3.0
   # renovate: datasource=docker depName=postgres
@@ -179,16 +177,6 @@ jobs:
 
       - run: cargo build --tests --workspace
       - run: cargo test --workspace
-
-      - run: curl -sL https://github.com/mozilla/grcov/releases/download/v${GRCOV_VERSION}/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar xjf -
-      - run: rustup component add llvm-tools
-      - run: ./grcov . --binary-path ${CARGO_TARGET_DIR}/debug/ -s . -t lcov --branch --ignore-not-existing --ignore "/*" --ignore "${CARGO_TARGET_DIR}/debug/build/**" -o ${CARGO_TARGET_DIR}/coverage.lcov
-
-      - uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # v5.3.1
-        with:
-          files: ${CARGO_TARGET_DIR}/coverage.lcov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   frontend-lint:
     name: Frontend / Lint


### PR DESCRIPTION
This has been silently broken for a while and it's unclear at this point what exactly broke it. Since we rarely look at it and the `grcov` call takes the majority of our CI time, we will remove this for now in the hope that a better alternative will emerge eventually.