### PR TITLE
models/team: Replace `App` arguments with `GitHubClient`

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -157,7 +157,7 @@ async fn prepare_list(
                 // Only allow crate owners to query pending invitations for their crate.
                 let krate: Crate = Crate::by_name(&crate_name).first(conn).await?;
                 let owners = krate.owners(conn).await?;
-                if user.rights(state, &owners).await? != Rights::Full {
+                if user.rights(&*state.github, &owners).await? != Rights::Full {
                     let detail = "only crate owners can query pending invitations for their crate";
                     return Err(forbidden(detail));
                 }

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -68,7 +68,7 @@ pub async fn delete_crate(
     // Check that the user is an owner of the crate (team owners are not allowed to delete crates)
     let user = auth.user();
     let owners = krate.owners(&mut conn).await?;
-    match user.rights(&app, &owners).await? {
+    match user.rights(&*app.github, &owners).await? {
         Rights::Full => {}
         Rights::Publish => {
             let msg = "team members don't have permission to delete crates";

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -356,7 +356,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         };
 
         let owners = krate.owners(conn).await?;
-        if user.rights(&app, &owners).await? < Rights::Publish {
+        if user.rights(&*app.github, &owners).await? < Rights::Publish {
             return Err(custom(StatusCode::FORBIDDEN, MISSING_RIGHTS_ERROR_MESSAGE));
         }
 

--- a/src/controllers/version/update.rs
+++ b/src/controllers/version/update.rs
@@ -122,7 +122,7 @@ pub async fn perform_version_yank_update(
 
     let yanked = yanked.unwrap_or(version.yanked);
 
-    if user.rights(state, &owners).await? < Rights::Publish {
+    if user.rights(&*state.github, &owners).await? < Rights::Publish {
         if user.is_admin {
             let action = if yanked { "yanking" } else { "unyanking" };
             warn!(


### PR DESCRIPTION
We don't need the full-blown `App` struct. All we need is a way to talk to the GitHub API.