### PR TITLE
models/user: Change `gh_access_token` field to `SecretString`

### DIFF
--- a/src/models/team.rs
+++ b/src/models/team.rs
@@ -7,6 +7,7 @@ use crate::util::errors::{bad_request, custom, AppResult};
 
 use crates_io_github::{GitHubClient, GitHubError};
 use oauth2::AccessToken;
+use secrecy::ExposeSecret;
 
 use crate::models::{Crate, CrateOwner, Owner, OwnerKind, User};
 use crate::schema::{crate_owners, teams};
@@ -125,7 +126,7 @@ impl Team {
             )));
         }
 
-        let token = AccessToken::new(req_user.gh_access_token.clone());
+        let token = AccessToken::new(req_user.gh_access_token.expose_secret().to_string());
         let team = gh_client.team_by_name(org_name, team_name, &token).await
             .map_err(|_| {
                 bad_request(format_args!(
@@ -211,7 +212,7 @@ async fn is_gh_org_owner(
     org_id: i32,
     user: &User,
 ) -> AppResult<bool> {
-    let token = AccessToken::new(user.gh_access_token.clone());
+    let token = AccessToken::new(user.gh_access_token.expose_secret().to_string());
     match gh_client
         .org_membership(org_id, &user.gh_login, &token)
         .await
@@ -231,7 +232,7 @@ async fn team_with_gh_id_contains_user(
     // GET /organizations/:org_id/team/:team_id/memberships/:username
     // check that "state": "active"
 
-    let token = AccessToken::new(user.gh_access_token.clone());
+    let token = AccessToken::new(user.gh_access_token.expose_secret().to_string());
     let membership = match gh_client
         .team_membership(github_org_id, github_team_id, &user.gh_login, &token)
         .await

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -14,7 +14,7 @@ use crates_io_diesel_helpers::lower;
 use crates_io_github::GitHubClient;
 
 /// The model representing a row in the `users` database table.
-#[derive(Clone, Debug, PartialEq, Eq, Queryable, Identifiable, AsChangeset, Selectable)]
+#[derive(Clone, Debug, Queryable, Identifiable, AsChangeset, Selectable)]
 pub struct User {
     pub id: i32,
     pub gh_access_token: String,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -5,6 +5,7 @@ use diesel::prelude::*;
 use diesel::sql_types::Integer;
 use diesel::upsert::excluded;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use secrecy::SecretString;
 
 use crate::util::errors::AppResult;
 
@@ -17,7 +18,8 @@ use crates_io_github::GitHubClient;
 #[derive(Clone, Debug, Queryable, Identifiable, Selectable)]
 pub struct User {
     pub id: i32,
-    pub gh_access_token: String,
+    #[diesel(deserialize_as = String)]
+    pub gh_access_token: SecretString,
     pub gh_login: String,
     pub name: Option<String>,
     pub gh_avatar: Option<String>,

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -14,7 +14,7 @@ use crates_io_diesel_helpers::lower;
 use crates_io_github::GitHubClient;
 
 /// The model representing a row in the `users` database table.
-#[derive(Clone, Debug, Queryable, Identifiable, AsChangeset, Selectable)]
+#[derive(Clone, Debug, Queryable, Identifiable, Selectable)]
 pub struct User {
     pub id: i32,
     pub gh_access_token: String,

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -44,7 +44,7 @@ async fn updating_existing_user_doesnt_change_api_token() -> anyhow::Result<()> 
     let user = assert_ok!(User::find(&mut conn, api_token.user_id).await);
 
     assert_eq!(user.gh_login, "bar");
-    assert_eq!(user.gh_access_token, "bar_token");
+    assert_eq!(user.gh_access_token.expose_secret(), "bar_token");
 
     Ok(())
 }


### PR DESCRIPTION
The struct has a `Debug` implementation, so we should be using `SecretString` to redact it from the output and avoid other accidental leakages.