### PR TITLE
Derive `bon::Builder` for `CrateOwner` struct and add `insert()` fn

### DIFF
--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -4,7 +4,7 @@ use crate::controllers::krate::CratePath;
 use crate::models::krate::OwnerRemoveError;
 use crate::models::{
     krate::NewOwnerInvite, token::EndpointScope, CrateOwner, NewCrateOwnerInvitation,
-    NewCrateOwnerInvitationOutcome, OwnerKind,
+    NewCrateOwnerInvitationOutcome,
 };
 use crate::models::{Crate, Owner, Rights, Team, User};
 use crate::util::errors::{bad_request, crate_not_found, custom, AppResult, BoxedAppError};
@@ -342,14 +342,14 @@ async fn add_team_owner(
 
     // Teams are added as owners immediately, since the above call ensures
     // the user is a team member.
+    let crate_owner = CrateOwner::builder()
+        .crate_id(krate.id)
+        .team_id(team.id)
+        .created_by(req_user.id)
+        .build();
+
     diesel::insert_into(crate_owners::table)
-        .values(&CrateOwner {
-            crate_id: krate.id,
-            owner_id: team.id,
-            created_by: req_user.id,
-            owner_kind: OwnerKind::Team,
-            email_notifications: true,
-        })
+        .values(&crate_owner)
         .on_conflict(crate_owners::table.primary_key())
         .do_update()
         .set(crate_owners::deleted.eq(false))

--- a/src/models/crate_owner_invitation.rs
+++ b/src/models/crate_owner_invitation.rs
@@ -5,7 +5,7 @@ use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use secrecy::SecretString;
 
 use crate::models::CrateOwner;
-use crate::schema::{crate_owner_invitations, crate_owners, crates};
+use crate::schema::{crate_owner_invitations, crates};
 
 #[derive(Debug)]
 pub enum NewCrateOwnerInvitationOutcome {
@@ -101,13 +101,7 @@ impl CrateOwnerInvitation {
 
         conn.transaction(|conn| {
             async move {
-                diesel::insert_into(crate_owners::table)
-                    .values(CrateOwner::from_invite(&self))
-                    .on_conflict(crate_owners::table.primary_key())
-                    .do_update()
-                    .set(crate_owners::deleted.eq(false))
-                    .execute(conn)
-                    .await?;
+                CrateOwner::from_invite(&self).insert(conn).await?;
 
                 diesel::delete(&self).execute(conn).await?;
 

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -128,13 +128,11 @@ impl NewCrate<'_> {
                     .get_result(conn)
                     .await?;
 
-                let owner = CrateOwner {
-                    crate_id: krate.id,
-                    owner_id: user_id,
-                    created_by: user_id,
-                    owner_kind: OwnerKind::User,
-                    email_notifications: true,
-                };
+                let owner = CrateOwner::builder()
+                    .crate_id(krate.id)
+                    .user_id(user_id)
+                    .created_by(user_id)
+                    .build();
 
                 diesel::insert_into(crate_owners::table)
                     .values(&owner)

--- a/src/models/krate.rs
+++ b/src/models/krate.rs
@@ -128,15 +128,12 @@ impl NewCrate<'_> {
                     .get_result(conn)
                     .await?;
 
-                let owner = CrateOwner::builder()
+                CrateOwner::builder()
                     .crate_id(krate.id)
                     .user_id(user_id)
                     .created_by(user_id)
-                    .build();
-
-                diesel::insert_into(crate_owners::table)
-                    .values(&owner)
-                    .execute(conn)
+                    .build()
+                    .insert(conn)
                     .await?;
 
                 Ok(krate)

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -1,4 +1,4 @@
-use crate::models::{CrateOwner, OwnerKind};
+use crate::models::CrateOwner;
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
 use crates_io_database::schema::{crate_owners, users};
@@ -23,14 +23,14 @@ async fn test_issue_2736() -> anyhow::Result<()> {
         .expect_build(&mut conn)
         .await;
 
+    let owner = CrateOwner::builder()
+        .crate_id(krate.id)
+        .user_id(foo1.as_model().id)
+        .created_by(someone_else.as_model().id)
+        .build();
+
     diesel::insert_into(crate_owners::table)
-        .values(CrateOwner {
-            crate_id: krate.id,
-            owner_id: foo1.as_model().id,
-            created_by: someone_else.as_model().id,
-            owner_kind: OwnerKind::User,
-            email_notifications: true,
-        })
+        .values(owner)
         .execute(&mut conn)
         .await?;
 

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -1,7 +1,7 @@
 use crate::models::CrateOwner;
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
-use crates_io_database::schema::{crate_owners, users};
+use crates_io_database::schema::users;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
@@ -23,15 +23,12 @@ async fn test_issue_2736() -> anyhow::Result<()> {
         .expect_build(&mut conn)
         .await;
 
-    let owner = CrateOwner::builder()
+    CrateOwner::builder()
         .crate_id(krate.id)
         .user_id(foo1.as_model().id)
         .created_by(someone_else.as_model().id)
-        .build();
-
-    diesel::insert_into(crate_owners::table)
-        .values(owner)
-        .execute(&mut conn)
+        .build()
+        .insert(&mut conn)
         .await?;
 
     // - `foo` deleted their GitHub account (but crates.io has no real knowledge of this)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,4 @@
 use crate::models::{Crate, CrateOwner, NewCategory, NewTeam, NewUser, Team, User};
-use crate::schema::crate_owners;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::{
     EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
@@ -8,7 +7,7 @@ use crate::views::{
 
 use crate::tests::util::github::next_gh_id;
 use diesel::prelude::*;
-use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use diesel_async::AsyncPgConnection;
 
 mod account_lock;
 mod authentication;
@@ -114,21 +113,13 @@ pub async fn add_team_to_crate(
     u: &User,
     conn: &mut AsyncPgConnection,
 ) -> QueryResult<()> {
-    let crate_owner = CrateOwner::builder()
+    CrateOwner::builder()
         .crate_id(krate.id)
         .team_id(t.id)
         .created_by(u.id)
-        .build();
-
-    diesel::insert_into(crate_owners::table)
-        .values(&crate_owner)
-        .on_conflict(crate_owners::table.primary_key())
-        .do_update()
-        .set(crate_owners::deleted.eq(false))
-        .execute(conn)
-        .await?;
-
-    Ok(())
+        .build()
+        .insert(conn)
+        .await
 }
 
 fn new_category<'a>(category: &'a str, slug: &'a str, description: &'a str) -> NewCategory<'a> {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,4 +1,4 @@
-use crate::models::{Crate, CrateOwner, NewCategory, NewTeam, NewUser, OwnerKind, Team, User};
+use crate::models::{Crate, CrateOwner, NewCategory, NewTeam, NewUser, Team, User};
 use crate::schema::crate_owners;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::{
@@ -114,13 +114,11 @@ pub async fn add_team_to_crate(
     u: &User,
     conn: &mut AsyncPgConnection,
 ) -> QueryResult<()> {
-    let crate_owner = CrateOwner {
-        crate_id: krate.id,
-        owner_id: t.id,
-        created_by: u.id,
-        owner_kind: OwnerKind::Team,
-        email_notifications: true,
-    };
+    let crate_owner = CrateOwner::builder()
+        .crate_id(krate.id)
+        .team_id(t.id)
+        .created_by(u.id)
+        .build();
 
     diesel::insert_into(crate_owners::table)
         .values(&crate_owner)

--- a/src/tests/routes/crates/owners/remove.rs
+++ b/src/tests/routes/crates/owners/remove.rs
@@ -1,4 +1,4 @@
-use crate::models::{CrateOwner, OwnerKind};
+use crate::models::CrateOwner;
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
 use crates_io_database::schema::crate_owners;
@@ -93,14 +93,14 @@ async fn test_remove_uppercase_user() {
         .expect_build(&mut conn)
         .await;
 
+    let owner = CrateOwner::builder()
+        .crate_id(krate.id)
+        .user_id(user2.as_model().id)
+        .created_by(cookie.as_model().id)
+        .build();
+
     diesel::insert_into(crate_owners::table)
-        .values(CrateOwner {
-            crate_id: krate.id,
-            owner_id: user2.as_model().id,
-            created_by: cookie.as_model().id,
-            owner_kind: OwnerKind::User,
-            email_notifications: true,
-        })
+        .values(owner)
         .execute(&mut conn)
         .await
         .unwrap();


### PR DESCRIPTION
This simplifies the usage of the `CrateOwner` struct. It also makes it slightly safer to use, since the `user_id()` and `team_id()` fns on the builder avoid potential mismatches.