### PR TITLE
controllers/krate/delete: prevent any crates with rdeps from deletion

### DIFF
--- a/app/templates/crate/delete.hbs
+++ b/app/templates/crate/delete.hbs
@@ -20,7 +20,16 @@
 
     <div local-class="requirements">
       <h3>Requirements:</h3>
-      <p>A crate can only be deleted if either:</p>
+      <p>
+        A crate can only be deleted if it is not depended upon by any other crate on crates.io. (This is a temporary
+        restriction due to
+        <a
+          href='https://github.com/rust-lang/crates.io/issues/10538'
+          target='_blank'
+          rel='noopener noreferrer'
+        >#10538</a>.)
+      </p>
+      <p>Additionally, a crate can only be deleted if either:</p>
       <ol local-class='first'>
         <li>the crate has been published for less than 72 hours</li>
       </ol>
@@ -29,8 +38,7 @@
         <li>
           <ol>
             <li>the crate only has a single owner, <em>and</em></li>
-            <li>the crate has been downloaded less than 500 times for each month it has been published, <em>and</em></li>
-            <li>the crate is not depended upon by any other crate on crates.io.</li>
+            <li>the crate has been downloaded less than 500 times for each month it has been published.</li>
           </ol>
         </li>
       </ol>


### PR DESCRIPTION
Temporary hack while we discuss #10538 further.

Here's what this now looks like on the deletion page:

![image](https://github.com/user-attachments/assets/2ce9ee90-4da8-4f10-baca-e0b64fc56772)

Feel free to bikeshed exactly what we include in there. (Do we need the GitHub issue?)

This should be a straightforward revert depending on what we decide.