### PR TITLE
controllers/version: Load required data only

### DIFF
--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -15,7 +15,6 @@ use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use utoipa::IntoParams;
 
-use crate::controllers::krate::load_crate;
 use crate::models::{Crate, Version};
 use crate::schema::{crates, versions};
 use crate::util::errors::{AppResult, crate_not_found, version_not_found};
@@ -34,13 +33,7 @@ pub struct CrateVersionPath {
 
 impl CrateVersionPath {
     pub async fn load_version(&self, mut conn: &AsyncPgConnection) -> AppResult<Version> {
-        let (_, version) = crates::table
-            .left_join(
-                versions::table.on(crates::id
-                    .eq(versions::crate_id)
-                    .and(versions::num.eq(&self.version))),
-            )
-            .filter(canon_crate_name(crates::name).eq(&self.name))
+        let (_, version) = Self::base_query(&self.name, &self.version)
             .select((crates::id, Option::<Version>::as_select()))
             .first::<(i32, _)>(&mut conn)
             .await
@@ -52,24 +45,28 @@ impl CrateVersionPath {
 
     pub async fn load_version_and_crate(
         &self,
-        conn: &AsyncPgConnection,
+        mut conn: &AsyncPgConnection,
     ) -> AppResult<(Version, Crate)> {
-        version_and_crate(conn, &self.name, &self.version).await
+        let (krate, version) = Self::base_query(&self.name, &self.version)
+            .select(<(Crate, Option<Version>)>::as_select())
+            .first(&mut conn)
+            .await
+            .optional()?
+            .ok_or_else(|| crate_not_found(&self.name))?;
+        let version = version.ok_or_else(|| version_not_found(&self.name, &self.version))?;
+        Ok((version, krate))
     }
-}
 
-async fn version_and_crate(
-    conn: &AsyncPgConnection,
-    crate_name: &str,
-    semver: &str,
-) -> AppResult<(Version, Crate)> {
-    let krate = load_crate(conn, crate_name).await?;
-    let version = krate
-        .find_version(conn, semver)
-        .await?
-        .ok_or_else(|| version_not_found(crate_name, semver))?;
-
-    Ok((version, krate))
+    #[diesel::dsl::auto_type(no_type_alias)]
+    fn base_query<'a>(crate_name: &'a str, semver: &'a str) -> _ {
+        crates::table
+            .left_join(
+                versions::table.on(crates::id
+                    .eq(versions::crate_id)
+                    .and(versions::num.eq(semver))),
+            )
+            .filter(canon_crate_name(crates::name).eq(canon_crate_name(crate_name)))
+    }
 }
 
 fn deserialize_version<'de, D: Deserializer<'de>>(deserializer: D) -> Result<String, D::Error> {

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -8,14 +8,17 @@ pub mod update;
 pub mod yank;
 
 use axum::extract::{FromRequestParts, Path};
-use diesel_async::AsyncPgConnection;
+use crates_io_diesel_helpers::canon_crate_name;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer};
 use utoipa::IntoParams;
 
 use crate::controllers::krate::load_crate;
 use crate::models::{Crate, Version};
-use crate::util::errors::{AppResult, version_not_found};
+use crate::schema::{crates, versions};
+use crate::util::errors::{AppResult, crate_not_found, version_not_found};
 
 #[derive(Deserialize, FromRequestParts, IntoParams)]
 #[into_params(parameter_in = Path)]
@@ -30,8 +33,21 @@ pub struct CrateVersionPath {
 }
 
 impl CrateVersionPath {
-    pub async fn load_version(&self, conn: &AsyncPgConnection) -> AppResult<Version> {
-        Ok(self.load_version_and_crate(conn).await?.0)
+    pub async fn load_version(&self, mut conn: &AsyncPgConnection) -> AppResult<Version> {
+        let (_, version) = crates::table
+            .left_join(
+                versions::table.on(crates::id
+                    .eq(versions::crate_id)
+                    .and(versions::num.eq(&self.version))),
+            )
+            .filter(canon_crate_name(crates::name).eq(&self.name))
+            .select((crates::id, Option::<Version>::as_select()))
+            .first::<(i32, _)>(&mut conn)
+            .await
+            .optional()?
+            .ok_or_else(|| crate_not_found(&self.name))?;
+        let version = version.ok_or_else(|| version_not_found(&self.name, &self.version))?;
+        Ok(version)
     }
 
     pub async fn load_version_and_crate(

--- a/src/controllers/version.rs
+++ b/src/controllers/version.rs
@@ -33,28 +33,26 @@ pub struct CrateVersionPath {
 
 impl CrateVersionPath {
     pub async fn load_version(&self, mut conn: &AsyncPgConnection) -> AppResult<Version> {
-        let (_, version) = Self::base_query(&self.name, &self.version)
+        let row = Self::base_query(&self.name, &self.version)
             .select((crates::id, Option::<Version>::as_select()))
             .first::<(i32, _)>(&mut conn)
             .await
-            .optional()?
-            .ok_or_else(|| crate_not_found(&self.name))?;
-        let version = version.ok_or_else(|| version_not_found(&self.name, &self.version))?;
-        Ok(version)
+            .optional()?;
+
+        self.gather(row).map(|r| r.0)
     }
 
     pub async fn load_version_and_crate(
         &self,
         mut conn: &AsyncPgConnection,
     ) -> AppResult<(Version, Crate)> {
-        let (krate, version) = Self::base_query(&self.name, &self.version)
+        let row = Self::base_query(&self.name, &self.version)
             .select(<(Crate, Option<Version>)>::as_select())
             .first(&mut conn)
             .await
-            .optional()?
-            .ok_or_else(|| crate_not_found(&self.name))?;
-        let version = version.ok_or_else(|| version_not_found(&self.name, &self.version))?;
-        Ok((version, krate))
+            .optional()?;
+
+        self.gather(row)
     }
 
     #[diesel::dsl::auto_type(no_type_alias)]
@@ -66,6 +64,12 @@ impl CrateVersionPath {
                     .and(versions::num.eq(semver))),
             )
             .filter(canon_crate_name(crates::name).eq(canon_crate_name(crate_name)))
+    }
+
+    fn gather<C, V>(&self, row: Option<(C, Option<V>)>) -> AppResult<(V, C)> {
+        let (krate_or_id, version) = row.ok_or_else(|| crate_not_found(&self.name))?;
+        let version = version.ok_or_else(|| version_not_found(&self.name, &self.version))?;
+        Ok((version, krate_or_id))
     }
 }
 


### PR DESCRIPTION
This PR primarily addresses three things:

- Avoiding loading the entire `Crate` when only the `Version` is needed.
- Loading the required data in a single query based on the request, reusing the same or similar queries as much as possible.
- Adding a helper function to handle `not found` scenarios.

First, I assume that in most cases, the given inputs are valid, then it would be great to load them in a single query.

Second, since most endpoints do not require all columns from `Crate` and `Version`, it would be nice to load only the necessary columns to reduce data loading.

Third, when only `Version` is required, it would be ideal to load only the ID of `Crate` to determine its existence.

I also want to thank @weiznich for talking with me during the all-hands to sketch out how to implement this properly using Diesel without overcomplicating things. I hope this aligns with what you suggested!