### PR TITLE
app: Migrate the overlooked `versions.length` to `num_versions`

### DIFF
--- a/app/templates/crate/version.hbs
+++ b/app/templates/crate/version.hbs
@@ -74,7 +74,7 @@
     <div local-class='stat'>
       <span local-class="num">
         {{svg-jar "crate"}}
-        <span local-class="num__align">{{ this.crate.versions.length }}</span>
+        <span local-class="num__align">{{ this.crate.num_versions }}</span>
       </span>
       <span local-class="stat-description">Versions published</span>
     </div>


### PR DESCRIPTION
Missed a replacement spot in #10581 🙈 