### PR TITLE
Fix low contrast of "Load More" on dashboard

### DIFF
--- a/app/styles/dashboard.module.css
+++ b/app/styles/dashboard.module.css
@@ -133,7 +133,7 @@
         outline: 0;
         border: 0;
         background-color: light-dark(#dbd9cf, #202023);
-        color: white;
+        color: light-dark(#525252, #f9f7ec);
 
         &:hover, &:focus {
             background-color: light-dark(#c5c2b2, #26262b);


### PR DESCRIPTION
This fixes the low color contrast of the "Load More" button on dashboard, especially in light mode.

Light (before)
<img width="600" alt="image" src="https://github.com/user-attachments/assets/62c4b629-0aaa-49ef-b981-7fc6f4149b21" />

Light (after)
<img width="602" alt="image" src="https://github.com/user-attachments/assets/ec514bca-67c1-4a1a-b372-a05f2c1d90fc" />

Dark (before)
<img width="602" alt="image" src="https://github.com/user-attachments/assets/72660d02-3235-4baa-a6bf-0be00dcbb47e" />

Dark (after)
<img width="603" alt="image" src="https://github.com/user-attachments/assets/10f60f34-56f2-4747-97a4-735574b21926" />
