### PR TITLE
cargo-deny: Ignore `ring` maintenance advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -68,7 +68,9 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+    # "ring is unmaintained" – we are aware, but there is not much we can do
+    # about it on our side for now :-/
+    "RUSTSEC-2025-0007",
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
As the code comment says, we are aware, but there is not much we can do about it from our side at the moment.