### PR TITLE
Improve `/crates` route error handling

### DIFF
--- a/app/routes/crates.js
+++ b/app/routes/crates.js
@@ -2,6 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
 export default class CratesRoute extends Route {
+  @service router;
   @service store;
 
   queryParams = {
@@ -9,7 +10,13 @@ export default class CratesRoute extends Route {
     sort: { refreshModel: true },
   };
 
-  model(params) {
-    return this.store.query('crate', params);
+  async model(params, transition) {
+    try {
+      return await this.store.query('crate', params);
+    } catch (error) {
+      let title = `Failed to load crate list`;
+      let details = error.errors?.[0]?.detail;
+      return this.router.replaceWith('catch-all', { transition, error, title, details, tryAgain: true });
+    }
   }
 }

--- a/app/templates/catch-all.hbs
+++ b/app/templates/catch-all.hbs
@@ -4,6 +4,10 @@
 
     <h1 local-class="title" data-test-title>{{or @model.title "Page not found"}}</h1>
 
+    {{#if @model.details}}
+      <p local-class="details" data-test-details>{{@model.details}}</p>
+    {{/if}}
+
     {{#if @model.loginNeeded}}
       <button
         type="button"


### PR DESCRIPTION
Previously, this route was showing an unhelpful error message. With this change it is using the regular error screen with a "Try again" button and a slightly friendlier error message.

Resolves https://github.com/rust-lang/crates.io/issues/10614