### PR TITLE
Add OpenAPI documentation for keyword API responses

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -40,6 +40,11 @@ other clients).
         license(name = "MIT OR Apache-2.0", url = "https://github.com/rust-lang/crates.io/blob/main/README.md#%EF%B8%8F-license"),
         version = "0.0.0",
     ),
+    components(
+        schemas(
+            crate::views::EncodableKeyword,
+        ),
+    ),
     modifiers(&SecurityAddon),
     servers(
         (url = "https://crates.io"),

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -4,6 +4,41 @@ expression: response.json()
 ---
 {
   "components": {
+    "schemas": {
+      "Keyword": {
+        "properties": {
+          "crates_cnt": {
+            "description": "The total number of crates that have this keyword.",
+            "example": 42,
+            "format": "int32",
+            "type": "integer"
+          },
+          "created_at": {
+            "description": "The date and time this keyword was created.",
+            "example": "2017-01-06T14:23:11Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "id": {
+            "description": "An opaque identifier for the keyword.",
+            "example": "http",
+            "type": "string"
+          },
+          "keyword": {
+            "description": "The keyword itself.",
+            "example": "http",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "keyword",
+          "created_at",
+          "crates_cnt"
+        ],
+        "type": "object"
+      }
+    },
     "securitySchemes": {
       "api_token": {
         "description": "The API token is used to authenticate requests from cargo and other clients.",

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1366,6 +1366,40 @@ expression: response.json()
         ],
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "keywords": {
+                      "description": "The list of keywords.",
+                      "items": {
+                        "$ref": "#/components/schemas/Keyword"
+                      },
+                      "type": "array"
+                    },
+                    "meta": {
+                      "properties": {
+                        "total": {
+                          "description": "The total number of keywords.",
+                          "example": 123,
+                          "format": "int64",
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "total"
+                      ],
+                      "type": "object"
+                    }
+                  },
+                  "required": [
+                    "keywords",
+                    "meta"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
             "description": "Successful Response"
           }
         },

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1425,6 +1425,21 @@ expression: response.json()
         ],
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "keyword": {
+                      "$ref": "#/components/schemas/Keyword"
+                    }
+                  },
+                  "required": [
+                    "keyword"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
             "description": "Successful Response"
           }
         },

--- a/src/views.rs
+++ b/src/views.rs
@@ -158,11 +158,23 @@ impl From<VersionDownload> for EncodableVersionDownload {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, utoipa::ToSchema)]
+#[schema(as = Keyword)]
 pub struct EncodableKeyword {
+    /// An opaque identifier for the keyword.
+    #[schema(example = "http")]
     pub id: String,
+
+    /// The keyword itself.
+    #[schema(example = "http")]
     pub keyword: String,
+
+    /// The date and time this keyword was created.
+    #[schema(example = "2017-01-06T14:23:11Z")]
     pub created_at: DateTime<Utc>,
+
+    /// The total number of crates that have this keyword.
+    #[schema(example = 42)]
     pub crates_cnt: i32,
 }
 


### PR DESCRIPTION
This PR adjusts our codebase to derive `ToSchema` for a couple of structs related to our keywords API and then attaches them to the generated OpenAPI documentation:

![Bildschirmfoto 2025-02-25 um 14 44 40](https://github.com/user-attachments/assets/e30a9f5e-bc1e-485a-8af7-f69e270cfdf2)
