### PR TITLE
openapi: Remove unnecessary `schema` declaration

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -40,11 +40,6 @@ other clients).
         license(name = "MIT OR Apache-2.0", url = "https://github.com/rust-lang/crates.io/blob/main/README.md#%EF%B8%8F-license"),
         version = "0.0.0",
     ),
-    components(
-        schemas(
-            crate::views::EncodableKeyword,
-        ),
-    ),
     modifiers(&SecurityAddon),
     servers(
         (url = "https://crates.io"),


### PR DESCRIPTION
Looks like this is being picked up automatically :)