### PR TITLE
Merge `EncodableCategoryWithSubcategories` into `EncodableCategory`

### DIFF
--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -3,7 +3,7 @@ use crate::app::AppState;
 use crate::models::Category;
 use crate::schema::categories;
 use crate::util::errors::AppResult;
-use crate::views::{EncodableCategory, EncodableCategoryWithSubcategories};
+use crate::views::EncodableCategory;
 use axum::extract::{FromRequestParts, Path, Query};
 use axum_extra::json;
 use axum_extra::response::ErasedJson;
@@ -89,19 +89,11 @@ pub async fn find_category(state: AppState, Path(slug): Path<String>) -> AppResu
         .map(Category::into)
         .collect();
 
-    let cat = EncodableCategory::from(cat);
-    let cat_with_subcats = EncodableCategoryWithSubcategories {
-        id: cat.id,
-        category: cat.category,
-        slug: cat.slug,
-        description: cat.description,
-        created_at: cat.created_at,
-        crates_cnt: cat.crates_cnt,
-        subcategories: subcats,
-        parent_categories: parents,
-    };
+    let mut category = EncodableCategory::from(cat);
+    category.subcategories = Some(subcats);
+    category.parent_categories = Some(parents);
 
-    Ok(json!({ "category": cat_with_subcats }))
+    Ok(json!({ "category": category }))
 }
 
 /// List all available category slugs.

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,8 +1,8 @@
 use crate::models::{Crate, CrateOwner, NewCategory, NewTeam, NewUser, Team, User};
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::{
-    EncodableCategory, EncodableCategoryWithSubcategories, EncodableCrate, EncodableKeyword,
-    EncodableOwner, EncodableVersion, GoodCrate,
+    EncodableCategory, EncodableCrate, EncodableKeyword, EncodableOwner, EncodableVersion,
+    GoodCrate,
 };
 
 use crate::tests::util::github::next_gh_id;
@@ -67,7 +67,7 @@ pub struct OwnersResponse {
 }
 #[derive(Deserialize)]
 pub struct CategoryResponse {
-    category: EncodableCategoryWithSubcategories,
+    category: EncodableCategory,
 }
 #[derive(Deserialize)]
 pub struct CategoryListResponse {

--- a/src/views.rs
+++ b/src/views.rs
@@ -18,6 +18,12 @@ pub struct EncodableCategory {
     pub description: String,
     pub created_at: DateTime<Utc>,
     pub crates_cnt: i32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subcategories: Option<Vec<EncodableCategory>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_categories: Option<Vec<EncodableCategory>>,
 }
 
 impl From<Category> for EncodableCategory {
@@ -37,20 +43,10 @@ impl From<Category> for EncodableCategory {
             created_at,
             crates_cnt,
             category: category.rsplit("::").collect::<Vec<_>>()[0].to_string(),
+            subcategories: None,
+            parent_categories: None,
         }
     }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct EncodableCategoryWithSubcategories {
-    pub id: String,
-    pub category: String,
-    pub slug: String,
-    pub description: String,
-    pub created_at: DateTime<Utc>,
-    pub crates_cnt: i32,
-    pub subcategories: Vec<EncodableCategory>,
-    pub parent_categories: Vec<EncodableCategory>,
 }
 
 /// The serialization format for the `CrateOwnerInvitation` model.
@@ -701,26 +697,8 @@ mod tests {
                 .and_hms_opt(14, 23, 11)
                 .unwrap()
                 .and_utc(),
-        };
-        let json = serde_json::to_string(&cat).unwrap();
-        assert_some!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11Z""#));
-    }
-
-    #[test]
-    fn category_with_sub_dates_serializes_to_rfc3339() {
-        let cat = EncodableCategoryWithSubcategories {
-            id: "".to_string(),
-            category: "".to_string(),
-            slug: "".to_string(),
-            description: "".to_string(),
-            crates_cnt: 1,
-            created_at: NaiveDate::from_ymd_opt(2017, 1, 6)
-                .unwrap()
-                .and_hms_opt(14, 23, 11)
-                .unwrap()
-                .and_utc(),
-            subcategories: vec![],
-            parent_categories: vec![],
+            subcategories: None,
+            parent_categories: None,
         };
         let json = serde_json::to_string(&cat).unwrap();
         assert_some!(json.as_str().find(r#""created_at":"2017-01-06T14:23:11Z""#));


### PR DESCRIPTION
`#[serde(skip_serializing_if = "Option::is_none")]` allows us to use the same struct for both cases which removes the unnecessary duplication between the two structs.