### PR TITLE
Add OpenAPI documentation for `GET /api/v1/users/{id}/stats` response payload

### DIFF
--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -2021,6 +2021,25 @@ expression: response.json()
         ],
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "total_downloads": {
+                      "description": "The total number of downloads for crates owned by the user.",
+                      "example": 123456789,
+                      "format": "int64",
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "total_downloads"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
             "description": "Successful Response"
           }
         },


### PR DESCRIPTION
Related:

- #10692
- https://github.com/rust-lang/crates.io/pull/10693
- https://github.com/rust-lang/crates.io/pull/10698
- #10685