### PR TITLE
Add OpenAPI documentation for `GET /api/v1/crates/{name}/{version}` response payload

### DIFF
--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -349,6 +349,255 @@ expression: response.json()
           "url"
         ],
         "type": "object"
+      },
+      "Version": {
+        "properties": {
+          "audit_actions": {
+            "description": "A list of actions performed on this version.",
+            "items": {
+              "properties": {
+                "action": {
+                  "description": "The action that was performed.",
+                  "example": "publish",
+                  "type": "string"
+                },
+                "time": {
+                  "description": "The date and time the action was performed.",
+                  "example": "2019-12-13T13:46:41Z",
+                  "format": "date-time",
+                  "type": "string"
+                },
+                "user": {
+                  "$ref": "#/components/schemas/User",
+                  "description": "The user who performed the action."
+                }
+              },
+              "required": [
+                "action",
+                "user",
+                "time"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "bin_names": {
+            "description": "The names of the binaries provided by this version, if any.",
+            "example": [],
+            "items": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "checksum": {
+            "description": "The SHA256 checksum of the compressed crate file encoded as a\nhexadecimal string.",
+            "example": "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60",
+            "type": "string"
+          },
+          "crate": {
+            "description": "The name of the crate.",
+            "example": "serde",
+            "type": "string"
+          },
+          "crate_size": {
+            "description": "The size of the compressed crate file in bytes.",
+            "example": 1234,
+            "format": "int32",
+            "type": "integer"
+          },
+          "created_at": {
+            "description": "The date and time this version was created.",
+            "example": "2019-12-13T13:46:41Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "description": {
+            "description": "The description of this version of the crate.",
+            "example": "A generic serialization/deserialization framework",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dl_path": {
+            "description": "The API path to download the crate.",
+            "example": "/api/v1/crates/serde/1.0.0/download",
+            "type": "string"
+          },
+          "documentation": {
+            "description": "The URL to the crate's documentation, if set.",
+            "example": "https://docs.rs/serde",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "downloads": {
+            "description": "The total number of downloads for this version.",
+            "example": 123456,
+            "format": "int32",
+            "type": "integer"
+          },
+          "edition": {
+            "description": "The Rust Edition used to compile this version, if set.",
+            "example": "2021",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "features": {
+            "description": "The features defined by this version.",
+            "type": "object"
+          },
+          "has_lib": {
+            "description": "Whether this version can be used as a library.",
+            "example": true,
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "homepage": {
+            "description": "The URL to the crate's homepage, if set.",
+            "example": "https://serde.rs",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "description": "An opaque identifier for the version.",
+            "example": 42,
+            "format": "int32",
+            "type": "integer"
+          },
+          "lib_links": {
+            "description": "The name of the native library this version links with, if any.",
+            "example": "git2",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "license": {
+            "description": "The license of this version of the crate.",
+            "example": "MIT",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "links": {
+            "$ref": "#/components/schemas/VersionLinks",
+            "description": "Links to other API endpoints related to this version."
+          },
+          "num": {
+            "description": "The version number.",
+            "example": "1.0.0",
+            "type": "string"
+          },
+          "published_by": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/User",
+                "description": "The user who published this version.\n\nThis field may be `null` if the version was published before crates.io\nstarted recording this information."
+              }
+            ]
+          },
+          "readme_path": {
+            "description": "The API path to download the crate's README file as HTML code.",
+            "example": "/api/v1/crates/serde/1.0.0/readme",
+            "type": "string"
+          },
+          "repository": {
+            "description": "The URL to the crate's repository, if set.",
+            "example": "https://github.com/serde-rs/serde",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rust_version": {
+            "description": "The minimum version of the Rust compiler required to compile\nthis version, if set.",
+            "example": "1.31",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "updated_at": {
+            "description": "The date and time this version was last updated (i.e. yanked or unyanked).",
+            "example": "2019-12-13T13:46:41Z",
+            "format": "date-time",
+            "type": "string"
+          },
+          "yank_message": {
+            "description": "The message given when this version was yanked, if any.",
+            "example": "Security vulnerability",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "yanked": {
+            "description": "Whether this version has been yanked.",
+            "example": false,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "crate",
+          "num",
+          "dl_path",
+          "readme_path",
+          "updated_at",
+          "created_at",
+          "downloads",
+          "features",
+          "yanked",
+          "links",
+          "crate_size",
+          "audit_actions",
+          "checksum"
+        ],
+        "type": "object"
+      },
+      "VersionLinks": {
+        "properties": {
+          "authors": {
+            "deprecated": true,
+            "description": "The API path to download this version's authors.",
+            "example": "/api/v1/crates/serde/1.0.0/authors",
+            "type": "string"
+          },
+          "dependencies": {
+            "description": "The API path to download this version's dependencies.",
+            "example": "/api/v1/crates/serde/1.0.0/dependencies",
+            "type": "string"
+          },
+          "version_downloads": {
+            "description": "The API path to download this version's download numbers.",
+            "example": "/api/v1/crates/serde/1.0.0/downloads",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dependencies",
+          "version_downloads",
+          "authors"
+        ],
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -1459,6 +1708,21 @@ expression: response.json()
         ],
         "responses": {
           "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "version": {
+                      "$ref": "#/components/schemas/Version"
+                    }
+                  },
+                  "required": [
+                    "version"
+                  ],
+                  "type": "object"
+                }
+              }
+            },
             "description": "Successful Response"
           }
         },

--- a/src/views.rs
+++ b/src/views.rs
@@ -632,43 +632,129 @@ impl From<User> for EncodablePublicUser {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, utoipa::ToSchema)]
 pub struct EncodableAuditAction {
+    /// The action that was performed.
+    #[schema(example = "publish")]
     pub action: String,
+
+    /// The user who performed the action.
     pub user: EncodablePublicUser,
+
+    /// The date and time the action was performed.
+    #[schema(example = "2019-12-13T13:46:41Z")]
     pub time: DateTime<Utc>,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, utoipa::ToSchema)]
+#[schema(as = Version)]
 pub struct EncodableVersion {
+    /// An opaque identifier for the version.
+    #[schema(example = 42)]
     pub id: i32,
+
+    /// The name of the crate.
     #[serde(rename = "crate")]
+    #[schema(example = "serde")]
     pub krate: String,
+
+    /// The version number.
+    #[schema(example = "1.0.0")]
     pub num: String,
+
+    /// The API path to download the crate.
+    #[schema(example = "/api/v1/crates/serde/1.0.0/download")]
     pub dl_path: String,
+
+    /// The API path to download the crate's README file as HTML code.
+    #[schema(example = "/api/v1/crates/serde/1.0.0/readme")]
     pub readme_path: String,
+
+    /// The date and time this version was last updated (i.e. yanked or unyanked).
+    #[schema(example = "2019-12-13T13:46:41Z")]
     pub updated_at: DateTime<Utc>,
+
+    /// The date and time this version was created.
+    #[schema(example = "2019-12-13T13:46:41Z")]
     pub created_at: DateTime<Utc>,
-    // NOTE: Used by shields.io, altering `downloads` requires a PR with shields.io
+
+    /// The total number of downloads for this version.
+    #[schema(example = 123_456)]
     pub downloads: i32,
+
+    /// The features defined by this version.
+    #[schema(value_type = Object)]
     pub features: serde_json::Value,
+
+    /// Whether this version has been yanked.
+    #[schema(example = false)]
     pub yanked: bool,
+
+    /// The message given when this version was yanked, if any.
+    #[schema(example = "Security vulnerability")]
     pub yank_message: Option<String>,
+
+    /// The name of the native library this version links with, if any.
+    #[schema(example = "git2")]
     pub lib_links: Option<String>,
-    // NOTE: Used by shields.io, altering `license` requires a PR with shields.io
+
+    /// The license of this version of the crate.
+    #[schema(example = "MIT")]
     pub license: Option<String>,
+
+    /// Links to other API endpoints related to this version.
     pub links: EncodableVersionLinks,
+
+    /// The size of the compressed crate file in bytes.
+    #[schema(example = 1_234)]
     pub crate_size: i32,
+
+    /// The user who published this version.
+    ///
+    /// This field may be `null` if the version was published before crates.io
+    /// started recording this information.
     pub published_by: Option<EncodablePublicUser>,
+
+    /// A list of actions performed on this version.
+    #[schema(inline)]
     pub audit_actions: Vec<EncodableAuditAction>,
+
+    /// The SHA256 checksum of the compressed crate file encoded as a
+    /// hexadecimal string.
+    #[schema(example = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60")]
     pub checksum: String,
+
+    /// The minimum version of the Rust compiler required to compile
+    /// this version, if set.
+    #[schema(example = "1.31")]
     pub rust_version: Option<String>,
+
+    /// Whether this version can be used as a library.
+    #[schema(example = true)]
     pub has_lib: Option<bool>,
+
+    /// The names of the binaries provided by this version, if any.
+    #[schema(example = json!([]))]
     pub bin_names: Option<Vec<Option<String>>>,
+
+    /// The Rust Edition used to compile this version, if set.
+    #[schema(example = "2021")]
     pub edition: Option<String>,
+
+    /// The description of this version of the crate.
+    #[schema(example = "A generic serialization/deserialization framework")]
     pub description: Option<String>,
+
+    /// The URL to the crate's homepage, if set.
+    #[schema(example = "https://serde.rs")]
     pub homepage: Option<String>,
+
+    /// The URL to the crate's documentation, if set.
+    #[schema(example = "https://docs.rs/serde")]
     pub documentation: Option<String>,
+
+    /// The URL to the crate's repository, if set.
+    #[schema(example = "https://github.com/serde-rs/serde")]
     pub repository: Option<String>,
 }
 
@@ -747,10 +833,19 @@ impl EncodableVersion {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, utoipa::ToSchema)]
+#[schema(as = VersionLinks)]
 pub struct EncodableVersionLinks {
+    /// The API path to download this version's dependencies.
+    #[schema(example = "/api/v1/crates/serde/1.0.0/dependencies")]
     pub dependencies: String,
+
+    /// The API path to download this version's download numbers.
+    #[schema(example = "/api/v1/crates/serde/1.0.0/downloads")]
     pub version_downloads: String,
+
+    /// The API path to download this version's authors.
+    #[schema(deprecated, example = "/api/v1/crates/serde/1.0.0/authors")]
     pub authors: String,
 }
 


### PR DESCRIPTION
Related:

- #10692
- https://github.com/rust-lang/crates.io/pull/10693
- https://github.com/rust-lang/crates.io/pull/10698
- https://github.com/rust-lang/crates.io/pull/10702
- https://github.com/rust-lang/crates.io/pull/10703
- https://github.com/rust-lang/crates.io/pull/10707
- #10685