### PR TITLE
serializers/crate: Prevent `categories` and `keywords` from being cleared

### DIFF
--- a/e2e/acceptance/crate.spec.ts
+++ b/e2e/acceptance/crate.spec.ts
@@ -270,4 +270,33 @@ test.describe('Acceptance | crate page', { tag: '@acceptance' }, () => {
     await expect(page).toHaveURL('/crates/nanomsg');
     await expect(page.locator('[data-test-keyword]')).toBeVisible();
   });
+
+  test('keywords are shown when navigating from crate to keywords, and then back to crate', async ({ page, msw }) => {
+    loadFixtures(msw.db);
+
+    await page.goto('/crates/nanomsg');
+    await expect(page.locator('[data-test-keyword]')).toBeVisible();
+
+    await page.getByRole('link', { name: '#network', exact: true }).click();
+    await expect(page).toHaveURL('/keywords/network');
+    await page.getByRole('link', { name: 'nanomsg', exact: true }).click();
+
+    await expect(page).toHaveURL('/crates/nanomsg');
+    await expect(page.locator('[data-test-keyword]')).toBeVisible();
+  });
+
+  test('keywords are shown when navigating from crate to searchs, and then back to crate', async ({ page, msw }) => {
+    loadFixtures(msw.db);
+
+    await page.goto('/crates/nanomsg');
+    await expect(page.locator('[data-test-keyword]')).toBeVisible();
+
+    await page.fill('[data-test-search-input]', 'nanomsg');
+    await page.locator('[data-test-search-form]').getByRole('button', { name: 'Submit' }).click();
+    await expect(page).toHaveURL('/search?q=nanomsg');
+    await page.getByRole('link', { name: 'nanomsg', exact: true }).click();
+
+    await expect(page).toHaveURL('/crates/nanomsg');
+    await expect(page.locator('[data-test-keyword]')).toBeVisible();
+  });
 });

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -1,4 +1,4 @@
-import { click, currentRouteName, currentURL, waitFor } from '@ember/test-helpers';
+import { click, currentRouteName, currentURL, fillIn, triggerEvent, waitFor } from '@ember/test-helpers';
 import { module, skip, test } from 'qunit';
 
 import { loadFixtures } from '@crates-io/msw/fixtures.js';
@@ -267,6 +267,35 @@ module('Acceptance | crate page', function (hooks) {
 
     await visit('/search?q=nanomsg');
     await click('[data-test-crate-link]');
+
+    assert.strictEqual(currentURL(), '/crates/nanomsg');
+    assert.dom('[data-test-keyword]').exists();
+  });
+
+  test('keywords are shown when navigating from crate to keywords, and then back to crate', async function (assert) {
+    loadFixtures(this.db);
+
+    await visit('/crates/nanomsg');
+    assert.dom('[data-test-keyword]').exists();
+
+    await click('[data-test-keyword="network"]');
+    assert.strictEqual(currentURL(), '/keywords/network');
+    await click('[href="/crates/nanomsg"]');
+
+    assert.strictEqual(currentURL(), '/crates/nanomsg');
+    assert.dom('[data-test-keyword]').exists();
+  });
+
+  test('keywords are shown when navigating from crate to searchs, and then back to crate', async function (assert) {
+    loadFixtures(this.db);
+
+    await visit('/crates/nanomsg');
+    assert.dom('[data-test-keyword]').exists();
+
+    await fillIn('[data-test-search-input]', 'nanomsg');
+    await triggerEvent('[data-test-search-form]', 'submit');
+    assert.strictEqual(currentURL(), '/search?q=nanomsg');
+    await click('[href="/crates/nanomsg"]');
 
     assert.strictEqual(currentURL(), '/crates/nanomsg');
     assert.dom('[data-test-keyword]').exists();


### PR DESCRIPTION
Previously, if `categories` and `keywords` of `crate` had existing values, they would be cleared from query results if those value returned null. This caused issues when `crate` was peeked from the store. This commit detects null values and ignores the fields instead of updating them.

Fixes #10711 .