### PR TITLE
settings/api-tokens: Fix `margin-top` for buttons

### DIFF
--- a/app/components/settings/api-tokens.module.css
+++ b/app/components/settings/api-tokens.module.css
@@ -206,7 +206,10 @@
         .actions > * {
             flex-grow: 1;
             width: 100%;
-            margin-top: var(--space-xs);
+
+            & + * {
+                margin-top: var(--space-xs);
+            }
         }
 
         .new-token {


### PR DESCRIPTION
The top-most button should not have a dedicated top margin...