### PR TITLE
Fix flaky tests

### DIFF
--- a/tests/acceptance/support-test.js
+++ b/tests/acceptance/support-test.js
@@ -1,4 +1,4 @@
-import { click, currentURL, fillIn, findAll } from '@ember/test-helpers';
+import { click, currentURL, fillIn, findAll, waitFor } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 
 import percySnapshot from '@percy/ember';
@@ -205,6 +205,8 @@ test detail
       };
 
       await visit('/crates/nanomsg');
+      assert.strictEqual(currentURL(), '/crates/nanomsg');
+      await waitFor('[data-test-id="link-crate-report"]');
       await click('[data-test-id="link-crate-report"]');
       assert.strictEqual(currentURL(), '/support?crate=nanomsg&inquire=crate-violation');
       assert.dom('[data-test-id="crate-input"]').hasValue('nanomsg');


### PR DESCRIPTION
Attempting to fix the following flaky tests:

https://github.com/rust-lang/crates.io/actions/runs/13632195641/job/38102274110?pr=10740#step:6:239
```
not ok 156 Chrome 133.0 - [147 ms] - Exam Partition 1 - Acceptance | support > reporting a crate from crate page: valid form without detail
    ---
        stack: >
            Error: Element not found when calling `click('[data-test-id="link-crate-report"]')`.
                at eval (webpack://crates-io/../../.pnpm/@ember+test-helpers@5.1.0_@babel+core@7.26.9_ember-source@6.0.1_@glimmer+component@2.0.0_rsvp@4.8.5_webpack@5.98.0_/node_modules/@ember/test-helpers/dist/dom/click.js?:107:13)
                at async prepare (webpack://crates-io/./tests/acceptance/support-test.js?:3035:7)
                at async Object.eval (webpack://crates-io/./tests/acceptance/support-test.js?:3091:7)
        message: >
            Promise rejected during "valid form without detail": Element not found when calling `click('[data-test-id="link-crate-report"]')`.
        negative: >
            false
        browser log: |
    ...
```
and
https://github.com/rust-lang/crates.io/actions/runs/13632195641/job/38102274110?pr=10740#step:6:254
```
not ok 159 Chrome 133.0 - [90 ms] - Exam Partition 1 - Acceptance | support > reporting a crate from crate page: valid form with required detail
    ---
        stack: >
            Error: Element not found when calling `click('[data-test-id="link-crate-report"]')`.
                at eval (webpack://crates-io/../../.pnpm/@ember+test-helpers@5.1.0_@babel+core@7.26.9_ember-source@6.0.1_@glimmer+component@2.0.0_rsvp@4.8.5_webpack@5.98.0_/node_modules/@ember/test-helpers/dist/dom/click.js?:107:13)
                at async prepare (webpack://crates-io/./tests/acceptance/support-test.js?:3035:7)
                at async Object.eval (webpack://crates-io/./tests/acceptance/support-test.js?:3132:7)
        message: >
            Promise rejected during "valid form with required detail": Element not found when calling `click('[data-test-id="link-crate-report"]')`.
        negative: >
            false
        browser log: |
    ...
```