### PR TITLE
crates_io_database: Fix `utoipa` dependency declaration

### DIFF
--- a/crates/crates_io_database/Cargo.toml
+++ b/crates/crates_io_database/Cargo.toml
@@ -25,7 +25,7 @@ sha2 = "=0.10.8"
 thiserror = "=2.0.12"
 tracing = "=0.1.41"
 unicode-xid = "=0.2.6"
-utoipa = "=5.3.1"
+utoipa = { version = "=5.3.1", features = ["chrono"] }
 
 [dev-dependencies]
 claims = "=0.8.0"


### PR DESCRIPTION
Looks like the `ApiToken` struct needs the `chrono` feature too... 🙈 