### PR TITLE
Adjust styles for crate row

### DIFF
--- a/app/components/crate-row.hbs
+++ b/app/components/crate-row.hbs
@@ -1,6 +1,6 @@
 <div local-class="crate-row" data-test-crate-row ...attributes>
   <div local-class="description-box">
-    <div>
+    <div local-class="crate-spec">
       {{#let (link "crate" @crate.id) as |l|}}
         <a href={{l.url}} local-class="name" data-test-crate-link {{on "click" l.transitionTo}}>
           {{@crate.name}}

--- a/app/components/crate-row.module.css
+++ b/app/components/crate-row.module.css
@@ -32,17 +32,22 @@
     padding: 0 var(--space-2xs);
     color: var(--main-color);
     cursor: pointer;
-    opacity: 0;
-    transition: var(--transition-medium);
 
-    .crate-row:hover & {
-        opacity: .8;
-        transition: var(--transition-instant);
-    }
+    /* Hover selector for pointer only */
+    /* See: https://github.com/rust-lang/crates.io/issues/10772 */
+    @media (pointer: fine) {
+        opacity: 0;
+        transition: var(--transition-medium);
 
-    .crate-row:hover &:hover, &:focus {
-        opacity: 1;
-        transition: var(--transition-instant);
+        .crate-row:hover & {
+            opacity: .8;
+            transition: var(--transition-instant);
+        }
+
+        .crate-row:hover &:hover, &:focus {
+            opacity: 1;
+            transition: var(--transition-instant);
+        }
     }
 
     svg {

--- a/app/components/crate-row.module.css
+++ b/app/components/crate-row.module.css
@@ -23,13 +23,8 @@
     overflow-wrap: break-word;
 }
 
-.version {
-    margin-left: var(--space-2xs);
-}
-
 .copy-button {
     composes: button-reset from '../styles/shared/buttons.module.css';
-    padding: 0 var(--space-2xs);
     color: var(--main-color);
     cursor: pointer;
 
@@ -51,14 +46,28 @@
     }
 
     svg {
+        vertical-align: top;
         height: 1rem;
         width: 1rem;
     }
 }
 
+.crate-spec {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+
+    & > * {
+        margin-bottom: calc(var(--space-xs) / 2);
+    }
+    & > :not(last-child) {
+        margin-right: var(--space-2xs);
+    }
+}
+
 .description {
     composes: small from '../styles/shared/typography.module.css';
-    margin-top: var(--space-xs);
+    margin-top: calc(var(--space-xs) / 2);
     line-height: 1.5;
 }
 


### PR DESCRIPTION
This enables the hover selector only when a pointer is available to fix #10772. This also adjusts the styles for alignment and spacing, particularly when wrapping is involved.

Fixes #10772 .

Before (Always showing the copy button, without style adjustments):
<img width="400" alt="image" src="https://github.com/user-attachments/assets/83af339c-dab2-445a-96e1-627efb50a3ff" />

After:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/59b424fb-c472-43bc-993c-84df6657c04d" />

