### PR TITLE
Exclude deleted crate owners from admin tool output

### DIFF
--- a/src/bin/crates-admin/delete_crate.rs
+++ b/src/bin/crates-admin/delete_crate.rs
@@ -191,6 +191,7 @@ fn owners_subquery() -> SqlLiteral<Array<Text>> {
             LEFT JOIN teams ON teams.id = crate_owners.owner_id
             LEFT JOIN users ON users.id = crate_owners.owner_id
             WHERE crate_owners.crate_id = crates.id
+            AND crate_owners.deleted = 'f'
         )
     "#)
 }


### PR DESCRIPTION
I just tried to use the admin tool to delete a crate and it LIED TO MY FACE and included the username of a DELETED OWNER in the output. Uuuuunaaaaaaccceptable