### PR TITLE
app/routes/crate/settings: hide the settings page for non-owners

### DIFF
--- a/app/routes/crate/settings.js
+++ b/app/routes/crate/settings.js
@@ -1,6 +1,23 @@
+import { inject as service } from '@ember/service';
+
 import AuthenticatedRoute from '../-authenticated-route';
 
 export default class SettingsRoute extends AuthenticatedRoute {
+  @service router;
+  @service session;
+
+  async afterModel(crate, transition) {
+    let user = this.session.currentUser;
+    let owners = await crate.owner_user;
+    let isOwner = owners.some(owner => owner.id === user.id);
+    if (!isOwner) {
+      this.router.replaceWith('catch-all', {
+        transition,
+        title: 'This page is only accessible by crate owners',
+      });
+    }
+  }
+
   setupController(controller) {
     super.setupController(...arguments);
     let crate = this.modelFor('crate');

--- a/tests/routes/crate/settings-test.js
+++ b/tests/routes/crate/settings-test.js
@@ -1,0 +1,56 @@
+import { currentURL } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'crates-io/tests/helpers';
+
+import { visit } from '../../helpers/visit-ignoring-abort';
+
+module('Route | crate.settings', hooks => {
+  setupApplicationTest(hooks, { msw: true });
+
+  function prepare(context) {
+    const user = context.db.user.create();
+
+    const crate = context.db.crate.create({ name: 'foo' });
+    context.db.version.create({ crate });
+    context.db.crateOwnership.create({ crate, user });
+
+    return { crate, user };
+  }
+
+  test('unauthenticated', async function (assert) {
+    const crate = this.db.crate.create({ name: 'foo' });
+    this.db.version.create({ crate });
+
+    await visit('/crates/foo/settings');
+    assert.strictEqual(currentURL(), '/crates/foo/settings');
+    assert.dom('[data-test-title]').hasText('This page requires authentication');
+    assert.dom('[data-test-login]').exists();
+  });
+
+  test('not an owner', async function (assert) {
+    const { crate } = prepare(this);
+
+    const otherUser = this.db.user.create();
+    this.authenticateAs(otherUser);
+
+    await visit(`/crates/${crate.name}/settings`);
+    assert.strictEqual(currentURL(), `/crates/${crate.name}/settings`);
+    assert.dom('[data-test-title]').hasText('This page is only accessible by crate owners');
+    assert.dom('[data-test-go-back]').exists();
+  });
+
+  test('happy path', async function (assert) {
+    const { crate, user } = prepare(this);
+    this.authenticateAs(user);
+
+    await visit(`/crates/${crate.name}/settings`);
+    assert.strictEqual(currentURL(), `/crates/${crate.name}/settings`);
+    // This is the Add Owner button.
+    assert.dom('[data-test-save-button]').exists();
+    assert.dom('[data-test-owners]').exists();
+    assert.dom(`[data-test-owner-user="${user.login}"]`).exists();
+    assert.dom('[data-test-remove-owner-button]').exists();
+    assert.dom('[data-test-delete-button]').exists();
+  });
+});


### PR DESCRIPTION
@technetos pinged me via DM on this just in case it was a security issue. It wasn't, since the backend controllers all have appropriate permission checks, but there's no reason for us to even show this page to someone who doesn't own a crate.

I implemented some quick regression tests for the authentication side of the frontend controller based on the delete crate tests, but not a full set of tests for the page. It's Sunday night.