### PR TITLE
CI: Remove obsolete `backend-cargo-deny` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,16 +113,6 @@ jobs:
       - run: cargo clippy --all-targets --all-features --workspace
       - run: cargo doc --no-deps --document-private-items
 
-  # to make https://github.com/rust-lang/team/blob/651fb3f9c64c934c9073472765d745a606dd9daf/repos/rust-lang/crates.io.toml#L17 happy until we migrated it…
-  backend-cargo-deny:
-    name: Backend / cargo-deny
-    runs-on: ubuntu-24.04
-    if: false
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-
   backend-deps:
     name: Backend / dependencies
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This is no longer needed due to https://github.com/rust-lang/team/pull/1664 being accepted and merged.