### PR TITLE
Adjust loading spinner color

### DIFF
--- a/app/components/follow-button.hbs
+++ b/app/components/follow-button.hbs
@@ -11,7 +11,7 @@
   {{on "click" (perform this.toggleFollowTask)}}
 >
   {{#if (or this.followStateTask.isRunning this.toggleFollowTask.isRunning)}}
-    <LoadingSpinner data-test-spinner />
+    <LoadingSpinner @theme="light" data-test-spinner />
   {{else}}
     {{#if this.following}}
       Unfollow

--- a/app/components/loading-spinner.hbs
+++ b/app/components/loading-spinner.hbs
@@ -1,5 +1,5 @@
 <div
-  local-class="spinner"
+  local-class="spinner {{if (eq @theme 'light') 'light'}}"
   ...attributes
 >
   <span local-class="message">Loading…</span>

--- a/app/components/loading-spinner.module.css
+++ b/app/components/loading-spinner.module.css
@@ -7,6 +7,10 @@
     height: var(--spinner-size);
     width: var(--spinner-size);
 
+    &.light {
+        --spinner-bg-color: rgba(0, 0, 0, .2);
+    }
+
     &:after {
         content: " ";
         display: block;

--- a/app/components/loading-spinner.module.css
+++ b/app/components/loading-spinner.module.css
@@ -1,6 +1,6 @@
 .spinner {
-    --spinner-color: black;
-    --spinner-bg-color: rgba(0, 0, 0, .2);
+    --spinner-color: currentcolor;
+    --spinner-bg-color: var(--gray-border);
     --spinner-size: 16px;
 
     display: inline-block;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -51,7 +51,7 @@
   >
     Try Again
     {{#if this.dataTask.isRunning}}
-      <LoadingSpinner local-class="spinner" data-test-spinner />
+      <LoadingSpinner @theme="light" local-class="spinner" data-test-spinner />
     {{/if}}
   </button>
 {{else}}

--- a/app/templates/settings/tokens/new.hbs
+++ b/app/templates/settings/tokens/new.hbs
@@ -182,7 +182,7 @@
       Generate Token
 
       {{#if this.saveTokenTask.isRunning}}
-        <LoadingSpinner local-class="spinner" data-test-spinner />
+        <LoadingSpinner @theme="light" local-class="spinner" data-test-spinner />
       {{/if}}
     </button>
 


### PR DESCRIPTION
This adjusts the spinner color to follow the color mode, and ensures certain buttons' loading spinners remain dark, especially those with backgrounds that do not follow the color mode.

Before:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/61533d8a-7533-48ce-bd66-bee0f4a3ba1f" />
<img width="393" alt="image" src="https://github.com/user-attachments/assets/320c04c4-da79-4ebf-8488-294c371ad4d6" />


After:
<img width="385" alt="image" src="https://github.com/user-attachments/assets/580b6910-9b46-4371-80c8-479e280e1436" />
<img width="390" alt="image" src="https://github.com/user-attachments/assets/4e4baa42-30be-48f9-ae6e-a835efe9c2d3" />


Before:
<img width="196" alt="image" src="https://github.com/user-attachments/assets/4422a6c0-7baa-4e91-9b4b-f307746ad75f" />
<img width="201" alt="image" src="https://github.com/user-attachments/assets/c86aacc1-6184-4361-be20-6f952be8e66f" />



After:
<img width="206" alt="image" src="https://github.com/user-attachments/assets/b8441ee7-ab75-4932-9c83-838fb9321d51" />
<img width="207" alt="image" src="https://github.com/user-attachments/assets/81556ece-27c9-49d8-9f61-52b3ef780ff0" />

