### PR TITLE
Replace `krata-tokio-tar` with `astral-tokio-tar`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65152cbda42e8ab5ecff69e8811e8333d69188c7d5c41e3eedb8d127e3f23b27"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.0",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,7 +731,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.11.0",
@@ -731,12 +747,6 @@ dependencies = [
  "syn",
  "which",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1148,6 +1158,7 @@ name = "crates_io"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "astral-tokio-tar",
  "async-compression",
  "async-trait",
  "aws-credential-types",
@@ -1200,7 +1211,6 @@ dependencies = [
  "insta",
  "ipnetwork",
  "json-subscriber",
- "krata-tokio-tar",
  "lettre",
  "minijinja",
  "mockall",
@@ -1426,6 +1436,7 @@ name = "crates_io_tarball"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "astral-tokio-tar",
  "async-compression",
  "cargo-manifest",
  "claims",
@@ -1434,7 +1445,6 @@ dependencies = [
  "futures-util",
  "indicatif",
  "insta",
- "krata-tokio-tar",
  "rayon",
  "serde",
  "serde_json",
@@ -1825,7 +1835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470eb10efc8646313634c99bb1593f402a6434cbd86e266770c6e39219adb86a"
 dependencies = [
  "bigdecimal",
- "bitflags 2.8.0",
+ "bitflags",
  "byteorder",
  "chrono",
  "diesel_derives",
@@ -2341,7 +2351,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "libc",
  "libgit2-sys",
  "log",
@@ -3085,22 +3095,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "krata-tokio-tar"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8bd5fee9b96acb5fc36b401896d601e6fdcce52b0e651ce24a3b21fb524e79f"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "portable-atomic",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3183,9 +3177,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3653,7 +3647,7 @@ version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3750,7 +3744,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.8",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4292,20 +4286,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4479,7 +4464,7 @@ version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4492,7 +4477,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f8dcd64f141950290e45c99f7710ede1b600297c91818bb30b3667c0f45dc0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.2",
@@ -4698,7 +4683,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -4711,7 +4696,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -5188,7 +5173,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5562,7 +5547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "async-compression",
- "bitflags 2.8.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -6091,7 +6076,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
 dependencies = [
- "redox_syscall 0.5.8",
+ "redox_syscall",
  "wasite",
  "web-sys",
 ]
@@ -6406,7 +6391,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,10 +27,10 @@ dbg_macro = "warn"
 todo = "warn"
 
 [package.metadata.cargo-machete]
-ignored = ["krata-tokio-tar"]
+ignored = ["astral-tokio-tar"]
 
 [workspace.metadata.cargo-machete]
-ignored = ["krata-tokio-tar"]
+ignored = ["astral-tokio-tar"]
 
 [lints]
 workspace = true
@@ -48,6 +48,7 @@ doctest = true
 
 [dependencies]
 anyhow = "=1.0.97"
+astral-tokio-tar = "=0.5.1"
 async-compression = { version = "=0.4.21", default-features = false, features = ["gzip", "tokio"] }
 async-trait = "=0.1.88"
 aws-credential-types = { version = "=1.2.2", features = ["hardcoded-credentials"] }
@@ -95,7 +96,6 @@ indexmap = { version = "=2.8.0", features = ["serde"] }
 indicatif = "=0.17.11"
 ipnetwork = "=0.21.1"
 json-subscriber = "=0.2.4"
-krata-tokio-tar = "=0.4.2"
 lettre = { version = "=0.11.15", default-features = false, features = ["file-transport", "smtp-transport", "hostname", "builder", "tokio1", "tokio1-native-tls"] }
 minijinja = { version = "=2.8.0", features = ["loader"] }
 mockall = "=0.13.1"

--- a/crates/crates_io_tarball/Cargo.toml
+++ b/crates/crates_io_tarball/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 builder = ["dep:flate2", "dep:tar"]
 
 [dependencies]
+astral-tokio-tar = "=0.5.1"
 cargo-manifest = "=0.19.1"
 flate2 = { version = "=1.1.0", optional = true }
 serde = { version = "=1.0.219", features = ["derive"] }
@@ -20,7 +21,6 @@ thiserror = "=2.0.12"
 tracing = "=0.1.41"
 tokio = { version = "=1.44.1", features = ["io-util", "macros", "rt-multi-thread"] }
 async-compression = { version = "=0.4.21", default-features = false, features = ["gzip", "tokio"] }
-krata-tokio-tar = "=0.4.2"
 futures-util = "=0.3.31"
 
 [dev-dependencies]


### PR DESCRIPTION
Astral recently published `astral-tokio-tar`, which is a fork of `krata-tokio-tar` that preserves permissions and is actively maintained. I don't see any reason not to switch to it.