### PR TITLE
Make regenerate button visible for expired tokens

### DIFF
--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -112,15 +112,15 @@
         {{/if}}
 
         <div local-class="actions">
+          <LinkTo
+            @route="settings.tokens.new"
+            @query={{hash from=token.id}}
+            local-class="regenerate-button"
+            data-test-regenerate-token-button
+          >
+            Regenerate
+          </LinkTo>
           {{#unless token.isExpired}}
-            <LinkTo
-              @route="settings.tokens.new"
-              @query={{hash from=token.id}}
-              local-class="regenerate-button"
-              data-test-regenerate-token-button
-            >
-              Regenerate
-            </LinkTo>
             <button
               type="button"
               local-class="revoke-button"


### PR DESCRIPTION
The issue was reported by @fasterthanlime on https://hachyderm.io/@fasterthanlime/114199813804811002 and it was introduced by accident in https://github.com/rust-lang/crates.io/pull/9122. I moved the button outside the if statement and it seems to work!

![Screenshot From 2025-03-21 23-22-55](https://github.com/user-attachments/assets/26c3f4a8-ed70-4ec5-9fac-be87cf9bf891)

Clicking on `Regenerate` redirects to the token creation as expected.