### PR TITLE
tests/api-token: Add action button visibility assertions

### DIFF
--- a/app/components/settings/api-tokens.hbs
+++ b/app/components/settings/api-tokens.hbs
@@ -112,15 +112,15 @@
         {{/if}}
 
         <div local-class="actions">
+          <LinkTo
+            @route="settings.tokens.new"
+            @query={{hash from=token.id}}
+            local-class="regenerate-button"
+            data-test-regenerate-token-button
+          >
+            Regenerate
+          </LinkTo>
           {{#unless token.isExpired}}
-            <LinkTo
-              @route="settings.tokens.new"
-              @query={{hash from=token.id}}
-              local-class="regenerate-button"
-              data-test-regenerate-token-button
-            >
-              Regenerate
-            </LinkTo>
             <button
               type="button"
               local-class="revoke-button"

--- a/e2e/acceptance/api-token.spec.ts
+++ b/e2e/acceptance/api-token.spec.ts
@@ -9,6 +9,14 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
       email: 'john@doe.com',
       avatar: 'https://avatars2.githubusercontent.com/u/1234567?v=4',
     });
+
+    msw.db.apiToken.create({
+      user,
+      name: 'foo',
+      createdAt: '2017-08-01T12:34:56',
+      lastUsedAt: '2017-11-02T01:45:14',
+    });
+
     msw.db.apiToken.create({
       user,
       name: 'BAR',
@@ -23,12 +31,6 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
       createdAt: '2017-08-01T12:34:56',
       lastUsedAt: '2017-11-02T01:45:14',
       expiredAt: '2017-11-19T17:59:22',
-    });
-    msw.db.apiToken.create({
-      user,
-      name: 'foo',
-      createdAt: '2017-08-01T12:34:56',
-      lastUsedAt: '2017-11-02T01:45:14',
     });
 
     await msw.authenticateAs(user);
@@ -88,6 +90,15 @@ test.describe('Acceptance | api-tokens', { tag: '@acceptance' }, () => {
     await page.goto('/settings/tokens');
     await expect(page).toHaveURL('/settings/tokens');
     await expect(page.locator('[data-test-api-token]')).toHaveCount(3);
+
+    await expect(page.locator('[data-test-api-token="1"] [data-test-regenerate-token-button]')).toBeVisible();
+    await expect(page.locator('[data-test-api-token="1"] [data-test-revoke-token-button]')).toBeVisible();
+
+    await expect(page.locator('[data-test-api-token="2"] [data-test-regenerate-token-button]')).toBeVisible();
+    await expect(page.locator('[data-test-api-token="2"] [data-test-revoke-token-button]')).toBeVisible();
+
+    await expect(page.locator('[data-test-api-token="3"] [data-test-regenerate-token-button]')).toBeVisible();
+    await expect(page.locator('[data-test-api-token="3"] [data-test-revoke-token-button]')).not.toBeVisible();
 
     await page.click('[data-test-api-token="1"] [data-test-regenerate-token-button]');
     await expect(page).toHaveURL('/settings/tokens/new?from=1');

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -106,6 +106,15 @@ module('Acceptance | api-tokens', function (hooks) {
     assert.strictEqual(currentURL(), '/settings/tokens');
     assert.dom('[data-test-api-token]').exists({ count: 3 });
 
+    assert.dom('[data-test-api-token="1"] [data-test-regenerate-token-button]').exists();
+    assert.dom('[data-test-api-token="1"] [data-test-revoke-token-button]').exists();
+
+    assert.dom('[data-test-api-token="2"] [data-test-regenerate-token-button]').exists();
+    assert.dom('[data-test-api-token="2"] [data-test-revoke-token-button]').exists();
+
+    assert.dom('[data-test-api-token="3"] [data-test-regenerate-token-button]').exists();
+    assert.dom('[data-test-api-token="3"] [data-test-revoke-token-button]').doesNotExist();
+
     await click('[data-test-api-token="1"] [data-test-regenerate-token-button]');
     assert.strictEqual(currentURL(), '/settings/tokens/new?from=1');
   });


### PR DESCRIPTION
This PR contains https://github.com/rust-lang/crates.io/pull/10868 plus another commit that adds a couple of regression assertions for the button visibilities. It looks like GitHub currently rejects my attempts to push to the other PR branch for some reason so I had to open another PR for it 🤷‍♂️ 

/cc @seqre 