### PR TITLE
Add `security` category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -547,6 +547,12 @@ description = """
 Crates for processing biological sequences, including alignment, assembly, and annotation.\
 """
 
+[security]
+name = "Security"
+description = """
+Crates related to cybersecurity, penetration testing, code review, vulnerability research, and reverse engineering.\
+"""
+
 [simulation]
 name = "Simulation"
 description = """


### PR DESCRIPTION
I'm proposing to add a new `security` category for binary and library crates related to cybersecurity, penetration testing, code review, vulnerability research, and reverse engineering.

Some examples of crates that would fit in this category:
* [binarly-io/idalib](https://github.com/binarly-io/idalib) [[idalib](https://crates.io/crates/idalib)] - Rust bindings for the IDA SDK, enabling the development of standalone analysis tools using IDA v9.0’s idalib
* [0xdea/augur](https://github.com/0xdea/augur) [[augur](https://crates.io/crates/augur)] - Reverse engineering assistant that extracts strings and related pseudo-code from a binary file
* [0xdea/haruspex](https://github.com/0xdea/haruspex) [[haruspex](https://crates.io/crates/haruspex)] - Vulnerability research assistant that extracts pseudo-code from the IDA Hex-Rays decompiler
* [0xdea/rhabdomancer](https://github.com/0xdea/rhabdomancer) [[rhabdomancer](https://crates.io/crates/rhabdomancer)] - Vulnerability research assistant that locates all calls to potentially insecure API functions in a binary file
* [entropic-security/xgadget](https://github.com/entropic-security/xgadget) [[xgadget](https://crates.io/crates/xgadget)] - Fast, parallel, cross-variant ROP/JOP gadget search
* [AFLplusplus/LibAFL](https://github.com/AFLplusplus/LibAFL) [[libafl](https://crates.io/crates/libafl)] - Advanced Fuzzing Library - Slot your Fuzzer together in Rust! Scales across cores and machines. For Windows, Android, MacOS, Linux, no_std, etc.
* [frida-rust](https://github.com/frida/frida-rust) [[frida](https://crates.io/crates/frida)] - Rust bindings for [Frida](http://www.frida.re/).
* [objdiff](https://github.com/encounter/objdiff) [[objdiff](https://crates.io/crates/objdiff-core)] - A local diffing tool for decompilation projects
* [epi052/feroxbuster](https://github.com/epi052/feroxbuster) [[feroxbuster](https://crates.io/crates/feroxbuster)] - A simple, fast, recursive content discovery tool.
* [arp-scan-rs](https://github.com/kongbytes/arp-scan-rs) [[arp-scan](https://crates.io/crates/arp-scan)] - A minimalistic ARP scan tool for fast local network scans
* [kpcyrd/rshijack](https://github.com/kpcyrd/rshijack) [[rshijack](https://crates.io/crates/rshijack)] - A TCP connection hijacker; rewrite of shijack
* [kpcyrd/sn0int](https://github.com/kpcyrd/sn0int) [[sn0int](https://crates.io/crates/sn0int)] - A semi-automatic OSINT framework and package manager
* [kpcyrd/sniffglue](https://github.com/kpcyrd/sniffglue) [[sniffglue](https://crates.io/crates/sniffglue)] - A secure multithreaded packet sniffer
* [ripasso](https://github.com/cortex/ripasso/) [[ripasso](https://crates.io/crates/ripasso)] - A password manager, filesystem compatible with pass
* [rustscan](https://github.com/bee-san/RustScan) [[rustscan](https://crates.io/crates/rustscan)] - Make Nmap faster with this port scanning tool

Most of these (and other) crates aren't really a good fit for any other currently available categories, in my opinion. For this reason, many of them are currently in the very generic `command-line utilities` category or they aren't assigned to any category.

Thanks for considering this!