### PR TITLE
markdown: Add tasklist test cases

### DIFF
--- a/crates/crates_io_markdown/lib.rs
+++ b/crates/crates_io_markdown/lib.rs
@@ -670,4 +670,20 @@ There can also be some text in between!
         </picture>
         "#);
     }
+
+    #[test]
+    fn nested_checkbox_lists() {
+        let text = r#"
+- [ ] `c`
+- [ ] [link](https://crates.io)
+- [ ] [link](#anchor)
+        "#;
+        assert_snapshot!(markdown_to_html(text, None, ""), @r##"
+        <ul>
+        <li><input type="checkbox" disabled=""> <code>c</code></li>
+        <li><input type="checkbox" disabled=""> <a href="https://crates.io" rel="nofollow noopener noreferrer">link</a></li>
+        <li><input type="checkbox" disabled=""> <a href="#anchor" rel="nofollow noopener noreferrer">link</a></li>
+        </ul>
+        "##);
+    }
 }


### PR DESCRIPTION
The test are currently failing, which indicates a bug. From my understanding, the test should pass.

As per this URLO thread: https://users.rust-lang.org/t/missing-list-item-names-in-the-readme-on-crates-io/127558

You can see the bug live in action at
https://crates.io/crates/Yoda/0.11.5