### PR TITLE
Return errors if metadata name or version do not match manifest

### DIFF
--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -171,6 +171,22 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
     // we only accept manifests with a `package` section and without
     // inheritance.
     let package = tarball_info.manifest.package.unwrap();
+    if package.name != metadata.name {
+        let message = format!(
+            "metadata name `{}` does not match manifest name `{}`",
+            metadata.name, package.name
+        );
+        return Err(bad_request(message));
+    }
+
+    let manifest_version = package.version.map(|it| it.as_local().unwrap()).unwrap();
+    if manifest_version != metadata.vers {
+        let message = format!(
+            "metadata version `{}` does not match manifest version `{manifest_version}`",
+            metadata.vers
+        );
+        return Err(bad_request(message));
+    }
 
     let description = package.description.map(|it| it.as_local().unwrap());
     let mut license = package.license.map(|it| it.as_local().unwrap());

--- a/src/tests/krate/publish/manifest.rs
+++ b/src/tests/krate/publish/manifest.rs
@@ -128,6 +128,30 @@ async fn invalid_manifest_missing_version() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn name_mismatch() {
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
+
+    let response =
+        token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+            "[package]\nname = \"bar\"\nversion = \"1.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\n",
+        )).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"metadata name `foo` does not match manifest name `bar`"}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_mismatch() {
+    let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
+
+    let response =
+        token.publish_crate(PublishBuilder::new("foo", "1.0.0").custom_manifest(
+            "[package]\nname = \"foo\"\nversion = \"2.0.0\"\ndescription = \"description\"\nlicense = \"MIT\"\n",
+        )).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"metadata version `1.0.0` does not match manifest version `2.0.0`"}]}"#);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn invalid_rust_version() {
     let (_app, _anon, _cookie, token) = TestApp::full().with_token().await;
 


### PR DESCRIPTION
We currently get the package name and version in three places in a publish request: the JSON metadata blob, the path prefix inside the crate tarball, and the `Cargo.toml` manifest inside the crate tarball. Up until now we were primarily relying on the JSON metadata and verifying the path prefixes. Apparently we were not checking the content of the `Cargo.toml` manifest though.

This PR fixes the issue by explicitly checking the manifest fields too and returning errors in case of a mismatch.