### PR TITLE
ember-data: Address `DEPRECATE_STORE_EXTENDS_EMBER_OBJECT` deprecation

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -67,6 +67,13 @@ module.exports = function (defaults) {
         ],
       },
     },
+
+    emberData: {
+      deprecations: {
+        DEPRECATE_STORE_EXTENDS_EMBER_OBJECT: false,
+      },
+    },
+
     fingerprint: {
       extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg', 'ttf', 'woff', 'woff2'],
     },


### PR DESCRIPTION
We don't need the `Store` to extend `EmberObject` (anymore?), so we can disable the corresponding behavior.