### PR TITLE
CI: Fix `changed-files` action usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
+          # This is needed to get the commit history for the changed-files action
+          # (see https://github.com/tj-actions/changed-files/blob/v46.0.5/README.md#usage-)
+          fetch-depth: 0
 
       - uses: tj-actions/changed-files@6cb76d07bee4c9772c6882c06c37837bf82a04d3 # v46.0.4
         id: changed-files-non-js


### PR DESCRIPTION
Unfortunately this action needs to perform `git fetch` operations in some cases, which apparently requires `persist-credentials` to be `true`.