### PR TITLE
Remove `msw` option from `setupApplicationTest()` fn

### DIFF
--- a/tests/acceptance/404-test.js
+++ b/tests/acceptance/404-test.js
@@ -6,7 +6,7 @@ import percySnapshot from '@percy/ember';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | 404', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('/unknown-route shows a 404 page', async function (assert) {
     await visit('/unknown-route');

--- a/tests/acceptance/api-token-test.js
+++ b/tests/acceptance/api-token-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | api-tokens', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let user = context.db.user.create({

--- a/tests/acceptance/categories-test.js
+++ b/tests/acceptance/categories-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import axeConfig from '../axe-config';
 
 module('Acceptance | categories', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('listing categories', async function (assert) {
     this.owner.lookup('service:intl').locale = 'en';

--- a/tests/acceptance/crate-deletion-test.js
+++ b/tests/acceptance/crate-deletion-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | crate deletion', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('happy path', async function (assert) {
     let user = this.db.user.create();

--- a/tests/acceptance/crate-dependencies-test.js
+++ b/tests/acceptance/crate-dependencies-test.js
@@ -13,7 +13,7 @@ import axeConfig from '../axe-config';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | crate dependencies page', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('shows the lists of dependencies', async function (assert) {
     loadFixtures(this.db);

--- a/tests/acceptance/crate-following-test.js
+++ b/tests/acceptance/crate-following-test.js
@@ -8,7 +8,7 @@ import { http, HttpResponse } from 'msw';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | Crate following', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context, { loggedIn = true, following = false } = {}) {
     let { db } = context;

--- a/tests/acceptance/crate-navtabs-test.js
+++ b/tests/acceptance/crate-navtabs-test.js
@@ -10,7 +10,7 @@ const TAB_REV_DEPS = '[data-test-rev-deps-tab] a';
 const TAB_SETTINGS = '[data-test-settings-tab] a';
 
 module('Acceptance | crate navigation tabs', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('basic navigation between tabs works as expected', async function (assert) {
     let crate = this.db.crate.create({ name: 'nanomsg' });

--- a/tests/acceptance/crate-test.js
+++ b/tests/acceptance/crate-test.js
@@ -13,7 +13,7 @@ import axeConfig from '../axe-config';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | crate page', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('visiting a crate page from the front page', async function (assert) {
     let crate = this.db.crate.create({ name: 'nanomsg', newest_version: '0.6.1' });

--- a/tests/acceptance/crates-test.js
+++ b/tests/acceptance/crates-test.js
@@ -13,7 +13,7 @@ import axeConfig from '../axe-config';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | crates page', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   // should match the default set in the crates controller
   const per_page = 50;

--- a/tests/acceptance/dashboard-test.js
+++ b/tests/acceptance/dashboard-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | Dashboard', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('shows "page requires authentication" error when not logged in', async function (assert) {
     await visit('/dashboard');

--- a/tests/acceptance/dev-mode-test.js
+++ b/tests/acceptance/dev-mode-test.js
@@ -11,7 +11,7 @@ if (s.has('devmode')) {
    * @link http://localhost:4200/tests/?notrycatch&devmode&filter=Development%20Mode
    */
   module('Development Mode', function (hooks) {
-    setupApplicationTest(hooks, { msw: true });
+    setupApplicationTest(hooks);
 
     test('authenticated', async function () {
       let user = this.db.user.create();

--- a/tests/acceptance/email-change-test.js
+++ b/tests/acceptance/email-change-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | Email Change', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('happy path', async function (assert) {
     let user = this.db.user.create({ email: 'old@email.com' });

--- a/tests/acceptance/email-confirmation-test.js
+++ b/tests/acceptance/email-confirmation-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | Email Confirmation', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('unauthenticated happy path', async function (assert) {
     let user = this.db.user.create({ emailVerificationToken: 'badc0ffee' });

--- a/tests/acceptance/front-page-test.js
+++ b/tests/acceptance/front-page-test.js
@@ -14,7 +14,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import axeConfig from '../axe-config';
 
 module('Acceptance | front page', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('visiting /', async function (assert) {
     this.owner.lookup('service:intl').locale = 'en';

--- a/tests/acceptance/invites-test.js
+++ b/tests/acceptance/invites-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | /me/pending-invites', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let inviter = context.db.user.create({ name: 'janed' });

--- a/tests/acceptance/keyword-test.js
+++ b/tests/acceptance/keyword-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import axeConfig from '../axe-config';
 
 module('Acceptance | keywords', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('keyword/:keyword_id index default sort is recent-downloads', async function (assert) {
     this.db.keyword.create({ keyword: 'network' });

--- a/tests/acceptance/login-test.js
+++ b/tests/acceptance/login-test.js
@@ -10,7 +10,7 @@ import { http, HttpResponse } from 'msw';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | Login', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
   setupWindowMock(hooks);
 
   test('successful login', async function (assert) {

--- a/tests/acceptance/logout-test.js
+++ b/tests/acceptance/logout-test.js
@@ -7,7 +7,7 @@ import { setupWindowMock } from 'ember-window-mock/test-support';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | Logout', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
   setupWindowMock(hooks);
 
   test('successful logout', async function (assert) {

--- a/tests/acceptance/publish-notifications-test.js
+++ b/tests/acceptance/publish-notifications-test.js
@@ -8,7 +8,7 @@ import { http, HttpResponse } from 'msw';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | publish notifications', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('unsubscribe and resubscribe', async function (assert) {
     let user = this.db.user.create();

--- a/tests/acceptance/read-only-mode-test.js
+++ b/tests/acceptance/read-only-mode-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { AjaxError } from '../../utils/ajax';
 
 module('Acceptance | Read-only Mode', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('notification is not shown for read-write mode', async function (assert) {
     await visit('/');

--- a/tests/acceptance/readme-rendering-test.js
+++ b/tests/acceptance/readme-rendering-test.js
@@ -92,7 +92,7 @@ graph TD;
 `;
 
 module('Acceptance | README rendering', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('it works', async function (assert) {
     let crate = this.db.crate.create({ name: 'serde' });

--- a/tests/acceptance/reverse-dependencies-test.js
+++ b/tests/acceptance/reverse-dependencies-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | /crates/:crate_id/reverse_dependencies', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare({ db }) {
     let foo = db.crate.create({ name: 'foo' });

--- a/tests/acceptance/search-test.js
+++ b/tests/acceptance/search-test.js
@@ -15,7 +15,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import axeConfig from '../axe-config';
 
 module('Acceptance | search', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('searching for "rust"', async function (assert) {
     loadFixtures(this.db);

--- a/tests/acceptance/settings/add-owner-test.js
+++ b/tests/acceptance/settings/add-owner-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | Settings | Add Owner', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let { db } = context;

--- a/tests/acceptance/settings/remove-owner-test.js
+++ b/tests/acceptance/settings/remove-owner-test.js
@@ -6,7 +6,7 @@ import { http, HttpResponse } from 'msw';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | Settings | Remove Owner', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let { db } = context;

--- a/tests/acceptance/settings/settings-test.js
+++ b/tests/acceptance/settings/settings-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import axeConfig from '../../axe-config';
 
 module('Acceptance | Settings', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let { db } = context;

--- a/tests/acceptance/sudo-test.js
+++ b/tests/acceptance/sudo-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | sudo', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context, isAdmin) {
     const user = context.db.user.create({

--- a/tests/acceptance/support-test.js
+++ b/tests/acceptance/support-test.js
@@ -12,7 +12,7 @@ import axeConfig from '../axe-config';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | support', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('shows an inquire list', async function (assert) {
     await visit('/support');

--- a/tests/acceptance/team-page-test.js
+++ b/tests/acceptance/team-page-test.js
@@ -10,7 +10,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import axeConfig from '../axe-config';
 
 module('Acceptance | team page', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('has team organization display', async function (assert) {
     loadFixtures(this.db);

--- a/tests/acceptance/token-invites-test.js
+++ b/tests/acceptance/token-invites-test.js
@@ -9,7 +9,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Acceptance | /accept-invite/:token', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('visiting to /accept-invite shows 404 page', async function (assert) {
     await visit('/accept-invite');

--- a/tests/acceptance/user-page-test.js
+++ b/tests/acceptance/user-page-test.js
@@ -10,7 +10,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import axeConfig from '../axe-config';
 
 module('Acceptance | user page', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('has user display', async function (assert) {
     loadFixtures(this.db);

--- a/tests/acceptance/versions-test.js
+++ b/tests/acceptance/versions-test.js
@@ -6,7 +6,7 @@ import percySnapshot from '@percy/ember';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Acceptance | crate versions page', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('show versions sorted by date', async function (assert) {
     let crate = this.db.crate.create({ name: 'nanomsg' });

--- a/tests/bugs/2329-test.js
+++ b/tests/bugs/2329-test.js
@@ -10,7 +10,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Bug #2329', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
   setupWindowMock(hooks);
 
   test('is fixed', async function (assert) {

--- a/tests/bugs/4506-test.js
+++ b/tests/bugs/4506-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Bug #4506', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let { db } = context;

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -7,14 +7,9 @@ export { setupTest, setupRenderingTest } from 'ember-qunit';
 
 // see http://emberjs.github.io/rfcs/0637-customizable-test-setups.html
 export function setupApplicationTest(hooks, options = {}) {
-  let { msw } = options;
-
   upstreamSetupApplicationTest(hooks, options);
 
-  if (msw) {
-    setupMSW(hooks);
-  }
-
+  setupMSW(hooks);
   setupSentryMock(hooks);
   setupAppTestDataAttr(hooks);
 }

--- a/tests/routes/category-test.js
+++ b/tests/routes/category-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Route | category', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test("shows an error message if the category can't be found", async function (assert) {
     await visit('/categories/foo');

--- a/tests/routes/crate/delete-test.js
+++ b/tests/routes/crate/delete-test.js
@@ -11,7 +11,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../../helpers/visit-ignoring-abort';
 
 module('Route: crate.delete', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let user = context.db.user.create();

--- a/tests/routes/crate/range-test.js
+++ b/tests/routes/crate/range-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../../helpers/visit-ignoring-abort';
 
 module('Route | crate.range', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('happy path', async function (assert) {
     let crate = this.db.crate.create({ name: 'foo' });

--- a/tests/routes/crate/settings-test.js
+++ b/tests/routes/crate/settings-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../../helpers/visit-ignoring-abort';
 
 module('Route | crate.settings', hooks => {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     const user = context.db.user.create();

--- a/tests/routes/crate/version/crate-links-test.js
+++ b/tests/routes/crate/version/crate-links-test.js
@@ -4,7 +4,7 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Route | crate.version | crate links', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('shows all external crate links', async function (assert) {
     let crate = this.db.crate.create({

--- a/tests/routes/crate/version/docs-link-test.js
+++ b/tests/routes/crate/version/docs-link-test.js
@@ -6,7 +6,7 @@ import { http, HttpResponse } from 'msw';
 import { setupApplicationTest } from 'crates-io/tests/helpers';
 
 module('Route | crate.version | docs link', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('shows regular documentation link', async function (assert) {
     let crate = this.db.crate.create({ name: 'foo', documentation: 'https://foo.io/docs' });

--- a/tests/routes/crate/version/model-test.js
+++ b/tests/routes/crate/version/model-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../../../helpers/visit-ignoring-abort';
 
 module('Route | crate.version | model() hook', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   module('with explicit version number in the URL', function () {
     test('shows yanked versions', async function (assert) {

--- a/tests/routes/keyword-test.js
+++ b/tests/routes/keyword-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Route | keyword', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('shows an empty list if the keyword does not exist on the server', async function (assert) {
     await visit('/keywords/foo');

--- a/tests/routes/settings/tokens/index-test.js
+++ b/tests/routes/settings/tokens/index-test.js
@@ -6,7 +6,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../../../helpers/visit-ignoring-abort';
 
 module('/settings/tokens', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let user = context.db.user.create({

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -10,7 +10,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../../../helpers/visit-ignoring-abort';
 
 module('/settings/tokens/new', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   function prepare(context) {
     let user = context.db.user.create({

--- a/tests/routes/support-test.js
+++ b/tests/routes/support-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Route | support', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test('should not retain query params when exiting and then returning', async function (assert) {
     await visit('/support?inquire=crate-violation');

--- a/tests/routes/team-test.js
+++ b/tests/routes/team-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Route | team', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test("shows an error message if the user can't be found", async function (assert) {
     await visit('/teams/foo');

--- a/tests/routes/user-test.js
+++ b/tests/routes/user-test.js
@@ -8,7 +8,7 @@ import { setupApplicationTest } from 'crates-io/tests/helpers';
 import { visit } from '../helpers/visit-ignoring-abort';
 
 module('Route | user', function (hooks) {
-  setupApplicationTest(hooks, { msw: true });
+  setupApplicationTest(hooks);
 
   test("shows an error message if the user can't be found", async function (assert) {
     await visit('/users/foo');


### PR DESCRIPTION
This is no longer needed since we're not running MSW and Mirage in parallel anymore.