### PR TITLE
Replace `require('@ember/debug')` with service function call

### DIFF
--- a/app/services/testing.js
+++ b/app/services/testing.js
@@ -1,0 +1,9 @@
+import { setTesting } from '@ember/debug';
+import Service from '@ember/service';
+
+export default class extends Service {
+  setTesting(value) {
+    // This indirection is needed for playwright to be able to use the `setTesting()` fn of `@ember/debug`.
+    setTesting(value);
+  }
+}

--- a/e2e/fixtures/ember.ts
+++ b/e2e/fixtures/ember.ts
@@ -47,7 +47,7 @@ export class EmberPage {
           `${event}`,
           async ({ detail: { owner } }: CustomEvent<{ owner: _Ember.ApplicationInstance }>) => {
             if (testing) {
-              require('@ember/debug').setTesting(true);
+              owner.lookup('service:testing').setTesting(true);
             }
             window[Symbol.for(`${ownerKey}`)] = owner;
           },


### PR DESCRIPTION
`require()` is no longer available starting with Ember.js v6.1.0. This should help to unblock https://github.com/rust-lang/crates.io/pull/10269.