### PR TITLE
Replace `require('@ember/service')` with service property

### DIFF
--- a/app/services/testing.js
+++ b/app/services/testing.js
@@ -2,6 +2,8 @@ import { setTesting } from '@ember/debug';
 import Service from '@ember/service';
 
 export default class extends Service {
+  Service = Service;
+
   setTesting(value) {
     // This indirection is needed for playwright to be able to use the `setTesting()` fn of `@ember/debug`.
     setTesting(value);

--- a/e2e/routes/support.spec.ts
+++ b/e2e/routes/support.spec.ts
@@ -27,7 +27,7 @@ test.describe('Route | support', { tag: '@routes' }, () => {
 
   test('LinkTo support must overwirte query', async ({ page, ember }) => {
     await ember.addHook(async owner => {
-      const Service = require('@ember/service').default;
+      const { Service } = owner.lookup('service:testing');
       // query params of LinkTo support's in footer will not be cleared
       class MockService extends Service {
         paramsFor() {


### PR DESCRIPTION
`require()` is no longer available starting with Ember.js v6.1.0. This should unblock https://github.com/rust-lang/crates.io/pull/10269.