### PR TITLE
Ember: Enable `no-implicit-route-model` feature

### DIFF
--- a/config/optional-features.json
+++ b/config/optional-features.json
@@ -2,5 +2,6 @@
   "application-template-wrapper": false,
   "default-async-observers": true,
   "jquery-integration": false,
-  "template-only-glimmer-components": true
+  "template-only-glimmer-components": true,
+  "no-implicit-route-model": true
 }


### PR DESCRIPTION
Looks like we're not relying on the implicit `model()` hooks anymore, so we might as well disable them.

Extracted from https://github.com/rust-lang/crates.io/pull/10976