### PR TITLE
Ember: Simplify `@service` decorator imports

### DIFF
--- a/app/components/color-scheme-menu.js
+++ b/app/components/color-scheme-menu.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Header extends Component {

--- a/app/components/copy-button.js
+++ b/app/components/copy-button.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { restartableTask } from 'ember-concurrency';

--- a/app/components/crate-header.js
+++ b/app/components/crate-header.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { task } from 'ember-concurrency';

--- a/app/components/crate-sidebar.js
+++ b/app/components/crate-sidebar.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { didCancel } from 'ember-concurrency';

--- a/app/components/dependency-list/row.js
+++ b/app/components/dependency-list/row.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/app/components/download-graph.js
+++ b/app/components/download-graph.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 import Component from '@glimmer/component';
 

--- a/app/components/email-input.js
+++ b/app/components/email-input.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/app/components/follow-button.js
+++ b/app/components/follow-button.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/app/components/footer.js
+++ b/app/components/footer.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Footer extends Component {

--- a/app/components/header.js
+++ b/app/components/header.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 // Six hours.

--- a/app/components/pending-owner-invite-row.js
+++ b/app/components/pending-owner-invite-row.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/app/components/privileged-action.js
+++ b/app/components/privileged-action.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 /**

--- a/app/components/progress-bar.js
+++ b/app/components/progress-bar.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class extends Component {

--- a/app/components/rendered-html.js
+++ b/app/components/rendered-html.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class extends Component {

--- a/app/components/rev-dep-row.js
+++ b/app/components/rev-dep-row.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/app/components/search-form.js
+++ b/app/components/search-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 export default class Header extends Component {

--- a/app/components/settings/api-tokens.js
+++ b/app/components/settings/api-tokens.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 
 import { task } from 'ember-concurrency';

--- a/app/components/support/crate-report-form.js
+++ b/app/components/support/crate-report-form.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 

--- a/app/components/version-list/row.js
+++ b/app/components/version-list/row.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ApplicationController extends Controller {
   @service colorScheme;

--- a/app/controllers/catch-all.js
+++ b/app/controllers/catch-all.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CatchAllController extends Controller {
   @service router;

--- a/app/controllers/crate/delete.js
+++ b/app/controllers/crate/delete.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';

--- a/app/controllers/crate/settings.js
+++ b/app/controllers/crate/settings.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
 

--- a/app/controllers/crate/version.js
+++ b/app/controllers/crate/version.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';

--- a/app/controllers/crate/versions.js
+++ b/app/controllers/crate/versions.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { didCancel, dropTask } from 'ember-concurrency';

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -1,6 +1,6 @@
 import { A } from '@ember/array';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { task } from 'ember-concurrency';
 import { alias } from 'macro-decorators';

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { dropTask } from 'ember-concurrency';
 import { reads } from 'macro-decorators';

--- a/app/controllers/search.js
+++ b/app/controllers/search.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { restartableTask } from 'ember-concurrency';

--- a/app/controllers/settings/tokens/new.js
+++ b/app/controllers/settings/tokens/new.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { task } from 'ember-concurrency';

--- a/app/helpers/format-num.js
+++ b/app/helpers/format-num.js
@@ -1,5 +1,5 @@
 import Helper from '@ember/component/helper';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class FormatNumHelper extends Helper {
   @service intl;

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -1,5 +1,5 @@
 import Model, { attr } from '@ember-data/model';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 
 import { apiAction } from '@mainmatter/ember-api-actions';

--- a/app/modifiers/render-mermaids.js
+++ b/app/modifiers/render-mermaids.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 
 import Modifier from 'ember-modifier';

--- a/app/routes/-authenticated-route.js
+++ b/app/routes/-authenticated-route.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AuthenticatedRoute extends Route {
   @service router;

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Ember from 'ember';
 
 import { didCancel, dropTask, rawTimeout, task } from 'ember-concurrency';

--- a/app/routes/categories.js
+++ b/app/routes/categories.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CategoriesRoute extends Route {
   @service store;

--- a/app/routes/category-slugs.js
+++ b/app/routes/category-slugs.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CategorySlugsRoute extends Route {
   @service store;

--- a/app/routes/category.js
+++ b/app/routes/category.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CategoryRoute extends Route {
   @service router;

--- a/app/routes/category/index.js
+++ b/app/routes/category/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CategoryIndexRoute extends Route {
   @service store;

--- a/app/routes/confirm.js
+++ b/app/routes/confirm.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import ajax from '../utils/ajax';
 

--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 
 export default class CrateRoute extends Route {

--- a/app/routes/crate/delete.js
+++ b/app/routes/crate/delete.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import AuthenticatedRoute from '../-authenticated-route';
 

--- a/app/routes/crate/dependencies.js
+++ b/app/routes/crate/dependencies.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class VersionRoute extends Route {
   @service router;

--- a/app/routes/crate/docs.js
+++ b/app/routes/crate/docs.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CrateDocsRoute extends Route {
   @service notifications;

--- a/app/routes/crate/owners.js
+++ b/app/routes/crate/owners.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class OwnersRoute extends Route {
   @service router;

--- a/app/routes/crate/range.js
+++ b/app/routes/crate/range.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import maxSatisfying from 'semver/ranges/max-satisfying';
 

--- a/app/routes/crate/repo.js
+++ b/app/routes/crate/repo.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class RepoRoute extends Route {
   @service notifications;

--- a/app/routes/crate/reverse-dependencies.js
+++ b/app/routes/crate/reverse-dependencies.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ReverseDependenciesRoute extends Route {
   @service notifications;

--- a/app/routes/crate/settings.js
+++ b/app/routes/crate/settings.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import AuthenticatedRoute from '../-authenticated-route';
 

--- a/app/routes/crate/version-dependencies.js
+++ b/app/routes/crate/version-dependencies.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class VersionRoute extends Route {
   @service store;

--- a/app/routes/crate/version.js
+++ b/app/routes/crate/version.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { waitForPromise } from '@ember/test-waiters';
 
 import { didCancel } from 'ember-concurrency';

--- a/app/routes/crates.js
+++ b/app/routes/crates.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class CratesRoute extends Route {
   @service router;

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -1,5 +1,5 @@
 import { A } from '@ember/array';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import RSVP from 'rsvp';
 
 import { didCancel } from 'ember-concurrency';

--- a/app/routes/install.js
+++ b/app/routes/install.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class InstallRoute extends Route {
   @service redirector;

--- a/app/routes/keyword.js
+++ b/app/routes/keyword.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KeywordIndexRoute extends Route {
   @service router;

--- a/app/routes/keywords.js
+++ b/app/routes/keywords.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class KeywordsRoute extends Route {
   @service store;

--- a/app/routes/me/crates.js
+++ b/app/routes/me/crates.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import AuthenticatedRoute from '../-authenticated-route';
 

--- a/app/routes/me/following.js
+++ b/app/routes/me/following.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import AuthenticatedRoute from '../-authenticated-route';
 

--- a/app/routes/me/index.js
+++ b/app/routes/me/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class MeIndexRoute extends Route {
   @service router;

--- a/app/routes/me/pending-invites.js
+++ b/app/routes/me/pending-invites.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import AuthenticatedRoute from '../-authenticated-route';
 

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SearchRoute extends Route {
   @service header;

--- a/app/routes/security.js
+++ b/app/routes/security.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SecurityRoute extends Route {
   @service router;

--- a/app/routes/settings/email-notifications.js
+++ b/app/routes/settings/email-notifications.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import AuthenticatedRoute from '../-authenticated-route';
 

--- a/app/routes/settings/index.js
+++ b/app/routes/settings/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class SettingsRoute extends Route {
   @service router;

--- a/app/routes/settings/profile.js
+++ b/app/routes/settings/profile.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import AuthenticatedRoute from '../-authenticated-route';
 

--- a/app/routes/settings/tokens/index.js
+++ b/app/routes/settings/tokens/index.js
@@ -1,5 +1,5 @@
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { TrackedArray } from 'tracked-built-ins';
 

--- a/app/routes/settings/tokens/new.js
+++ b/app/routes/settings/tokens/new.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TokenListRoute extends Route {
   @service router;

--- a/app/routes/team.js
+++ b/app/routes/team.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class TeamRoute extends Route {
   @service notifications;

--- a/app/routes/user.js
+++ b/app/routes/user.js
@@ -1,6 +1,6 @@
 import { NotFoundError } from '@ember-data/adapter/error';
 import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class UserRoute extends Route {
   @service notifications;

--- a/app/services/progress.js
+++ b/app/services/progress.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
 import Ember from 'ember';

--- a/app/services/session.js
+++ b/app/services/session.js
@@ -1,5 +1,5 @@
 import { debug } from '@ember/debug';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import { dropTask, race, rawTimeout, restartableTask, task, waitForEvent } from 'ember-concurrency';


### PR DESCRIPTION
Importing `inject` instead is deprecated now. Unfortunately several addons are still importing `inject`, so the deprecation is still quite noisy in the test suite output.