### PR TITLE
ember-fetch: Remove obsolete config object

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -49,10 +49,6 @@ module.exports = function (defaults) {
       throwUnlessParallelizable: true,
     },
 
-    'ember-fetch': {
-      preferNative: true,
-    },
-
     cssModules: {
       extension: 'module.css',
       // see https://github.com/salsify/ember-css-modules/blob/v2.0.1/docs/ORDERING.md


### PR DESCRIPTION
We don't use `ember-fetch` anymore, so we can remove the corresponding config object.