### PR TITLE
Simplify `.load-more` CSS classes

### DIFF
--- a/app/styles/dashboard.module.css
+++ b/app/styles/dashboard.module.css
@@ -118,19 +118,4 @@
 :global(.load-more) {
     padding: var(--space-s);
     border-top: 1px solid light-dark(hsla(51, 90%, 42%, .25), #232321);
-
-    button {
-        display: block;
-        text-align: center;
-        width: 100%;
-        padding: var(--space-2xs);
-        outline: 0;
-        border: 0;
-        background-color: light-dark(#dbd9cf, #202023);
-        color: light-dark(#525252, #f9f7ec);
-
-        &:hover, &:focus {
-            background-color: light-dark(#c5c2b2, #26262b);
-        }
-    }
 }

--- a/app/styles/dashboard.module.css
+++ b/app/styles/dashboard.module.css
@@ -115,7 +115,7 @@
     text-align: right;
 }
 
-:global(.load-more) {
+.load-more {
     padding: var(--space-s);
     border-top: 1px solid light-dark(hsla(51, 90%, 42%, .25), #232321);
 }

--- a/app/styles/shared/buttons.module.css
+++ b/app/styles/shared/buttons.module.css
@@ -84,3 +84,18 @@
 :global(.button--small) {
     padding: var(--space-2xs) var(--space-s);
 }
+
+:global(.load-more-button) {
+    display: block;
+    text-align: center;
+    width: 100%;
+    padding: var(--space-2xs);
+    outline: 0;
+    border: 0;
+    background-color: light-dark(#dbd9cf, #202023);
+    color: light-dark(#525252, #f9f7ec);
+
+    &:hover, &:focus {
+        background-color: light-dark(#c5c2b2, #26262b);
+    }
+}

--- a/app/templates/crate/versions.hbs
+++ b/app/templates/crate/versions.hbs
@@ -30,6 +30,7 @@
   <div local-class="load-more" class="load-more">
     <button
       type="button"
+      class="load-more-button"
       data-test-id={{if this.loadMoreTask.isRunning "loading" "load-more"}}
       disabled={{this.loadMoreTask.isRunning}}
       {{on "click" (perform this.loadMoreTask)}}

--- a/app/templates/crate/versions.hbs
+++ b/app/templates/crate/versions.hbs
@@ -27,7 +27,7 @@
   {{/each}}
 </ul>
 {{#if (or this.loadMoreTask.isRunning this.next_page)}}
-  <div local-class="load-more" class="load-more">
+  <div local-class="load-more">
     <button
       type="button"
       class="load-more-button"

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -60,7 +60,7 @@
       </ul>
 
       {{#if this.hasMore}}
-        <div class="load-more">
+        <div local-class="load-more">
           <button type="button" class="load-more-button" disabled={{this.loadMoreTask.isRunning}} {{on "click" (perform this.loadMoreTask)}}>
             Load More
             {{#if this.loadMoreTask.isRunning}}

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -61,7 +61,7 @@
 
       {{#if this.hasMore}}
         <div class="load-more">
-          <button type="button" disabled={{this.loadMoreTask.isRunning}} {{on "click" (perform this.loadMoreTask)}}>
+          <button type="button" class="load-more-button" disabled={{this.loadMoreTask.isRunning}} {{on "click" (perform this.loadMoreTask)}}>
             Load More
             {{#if this.loadMoreTask.isRunning}}
               <LoadingSpinner />

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -59,8 +59,6 @@ module.exports = function (defaults) {
         'crates-io/styles/shared/sort-by',
         'crates-io/styles/shared/typography',
         'crates-io/styles/application',
-        // for the `.load-more` class
-        'crates-io/styles/dashboard',
         // for the `.scopes-list` class
         'crates-io/styles/settings/tokens/new',
         // for the `.box-link` class


### PR DESCRIPTION
It's fine to share the styles for the button itself, but the surrounding elements don't need to be shared between the two instances. This allows us to remove the dashboard styles from the `headerModules` list, since the shared styles now live in the `shared/buttons.module.css` file.