### PR TITLE
sentry: remove `Authorization` header values before send

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,5 +147,6 @@ diesel = { version = "=2.2.9", features = ["r2d2"] }
 googletest = "=0.14.0"
 insta = { version = "=1.42.2", features = ["glob", "json", "redactions"] }
 regex = "=1.11.1"
+sentry = { version = "=0.37.0", features = ["test"] }
 tokio = "=1.44.2"
 zip = { version = "=2.6.1", default-features = false, features = ["deflate"] }

--- a/src/config/sentry.rs
+++ b/src/config/sentry.rs
@@ -3,6 +3,7 @@ use crates_io_env_vars::{required_var, var, var_parsed};
 use sentry::IntoDsn;
 use sentry::types::Dsn;
 
+#[cfg_attr(test, derive(Default))]
 pub struct SentryConfig {
     pub dsn: Option<Dsn>,
     pub environment: Option<String>,


### PR DESCRIPTION
These get redacted in the Sentry ingest, but why send them at all?