### PR TITLE
GitHub: Improve `tracing` usage

### DIFF
--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -59,7 +59,7 @@ impl RealGitHubClient {
         T: DeserializeOwned,
     {
         let url = format!("https://api.github.com{url}");
-        info!("GITHUB HTTP: {url}");
+        info!("GitHub request: GET {url}");
 
         let response = self
             .client


### PR DESCRIPTION
This adds debug logging for the remaining rate limit and slightly improves the existing per-request log message.