### PR TITLE
GitHub: Add support for "Get a repository" requests

### DIFF
--- a/crates/crates_io_github/examples/test_github_client.rs
+++ b/crates/crates_io_github/examples/test_github_client.rs
@@ -12,6 +12,12 @@ enum Request {
         #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
         access_token: SecretString,
     },
+    GetRepository {
+        owner: String,
+        repo: String,
+        #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
+        access_token: SecretString,
+    },
     OrgByName {
         org_name: String,
         #[clap(long, env = "GITHUB_ACCESS_TOKEN", hide_env_values = true)]
@@ -56,6 +62,17 @@ async fn main() -> Result<()> {
         Request::CurrentUser { access_token } => {
             let access_token = AccessToken::new(access_token.expose_secret().into());
             let response = github_client.current_user(&access_token).await?;
+            println!("{response:#?}");
+        }
+        Request::GetRepository {
+            owner,
+            repo,
+            access_token,
+        } => {
+            let access_token = AccessToken::new(access_token.expose_secret().into());
+            let response = github_client
+                .get_repository(&owner, &repo, &access_token)
+                .await?;
             println!("{response:#?}");
         }
         Request::OrgByName {

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -20,6 +20,12 @@ type Result<T> = std::result::Result<T, GitHubError>;
 #[async_trait]
 pub trait GitHubClient: Send + Sync {
     async fn current_user(&self, auth: &AccessToken) -> Result<GithubUser>;
+    async fn get_repository(
+        &self,
+        owner: &str,
+        repo: &str,
+        auth: &AccessToken,
+    ) -> Result<GitHubRepository>;
     async fn org_by_name(&self, org_name: &str, auth: &AccessToken) -> Result<GitHubOrganization>;
     async fn team_by_name(
         &self,
@@ -100,6 +106,16 @@ impl RealGitHubClient {
 impl GitHubClient for RealGitHubClient {
     async fn current_user(&self, auth: &AccessToken) -> Result<GithubUser> {
         self.request("/user", auth).await
+    }
+
+    async fn get_repository(
+        &self,
+        owner: &str,
+        repo: &str,
+        auth: &AccessToken,
+    ) -> Result<GitHubRepository> {
+        let url = format!("/repos/{owner}/{repo}");
+        self.request(&url, auth).await
     }
 
     async fn org_by_name(&self, org_name: &str, auth: &AccessToken) -> Result<GitHubOrganization> {
@@ -189,6 +205,19 @@ pub struct GithubUser {
     pub id: i32,
     pub login: String,
     pub name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubRepository {
+    pub id: i64,
+    pub name: String,
+    pub owner: GitHubRepositoryOwner,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GitHubRepositoryOwner {
+    pub login: String,
+    pub id: i32,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
see https://docs.github.com/en/rest/repos/repos#get-a-repository

This can be used in the future to lookup the GitHub ID of repositories to avoid account resurrection attacks.