### PR TITLE
gitignore: Add insta pending snapshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ docker-compose.override.yml
 *~
 src/schema.rs.orig
 
+# insta
+*.pending-snap
+
 # playwright
 /test-results/
 /playwright-report/


### PR DESCRIPTION
Not sure how, but sometimes these appear to end up in my working tree without getting cleaned up correctly. Ignoring them doesn't hurt, so let's just do that :)