### PR TITLE
tests/util: Change `MockTokenUser::plaintext` to `String`

### DIFF
--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -40,7 +40,7 @@ async fn updating_existing_user_doesnt_change_api_token() -> anyhow::Result<()> 
     assert_ok!(session::save_user_to_database(&gh_user, "bar_token", emails, &mut conn).await);
 
     // Use the original API token to find the now updated user
-    let hashed_token = assert_ok!(HashedToken::parse(token.expose_secret()));
+    let hashed_token = assert_ok!(HashedToken::parse(token));
     let api_token = assert_ok!(ApiToken::find_by_api_token(&mut conn, &hashed_token).await);
     let user = assert_ok!(User::find(&mut conn, api_token.user_id).await);
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -336,7 +336,7 @@ impl MockCookieUser {
         MockTokenUser {
             app: self.app.clone(),
             token,
-            plaintext,
+            plaintext: plaintext.expose_secret().into(),
         }
     }
 }
@@ -345,13 +345,13 @@ impl MockCookieUser {
 pub struct MockTokenUser {
     app: TestApp,
     token: ApiToken,
-    plaintext: PlainToken,
+    plaintext: String,
 }
 
 impl RequestHelper for MockTokenUser {
     fn request_builder(&self, method: Method, path: &str) -> MockRequest {
         let mut request = req(method, path);
-        request.header(header::AUTHORIZATION, self.plaintext.expose_secret());
+        request.header(header::AUTHORIZATION, &self.plaintext);
         request
     }
 
@@ -366,7 +366,7 @@ impl MockTokenUser {
         &self.token
     }
 
-    pub fn plaintext(&self) -> &PlainToken {
+    pub fn plaintext(&self) -> &str {
         &self.plaintext
     }
 }


### PR DESCRIPTION
We only use this struct for testing, where we don't want to hide the plaintext token for debugging purposes. This will also make it easier in the future to construct `MockTokenUser` instances from an existing plaintext token, without going through the `PlainToken` struct.