### PR TITLE
Derive `Builder` for `App` struct

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -51,9 +51,11 @@ pub struct App {
     pub storage: Arc<Storage>,
 
     /// Metrics related to the service as a whole
+    #[builder(default = ServiceMetrics::new().expect("could not initialize service metrics"))]
     pub service_metrics: ServiceMetrics,
 
     /// Metrics related to this specific instance of the service
+    #[builder(default = InstanceMetrics::new().expect("could not initialize instance metrics"))]
     pub instance_metrics: InstanceMetrics,
 
     /// Rate limit select actions.
@@ -70,9 +72,6 @@ impl App {
     /// - A `git2::Repository` instance from the index repo checkout (that server.rs ensures exists)
     pub fn new(config: config::Server, emails: Emails, github: Box<dyn GitHubClient>) -> App {
         use oauth2::{AuthUrl, TokenUrl};
-
-        let instance_metrics =
-            InstanceMetrics::new().expect("could not initialize instance metrics");
 
         let auth_url = "https://github.com/login/oauth/authorize";
         let auth_url = AuthUrl::new(auth_url.into()).unwrap();
@@ -137,8 +136,6 @@ impl App {
             .github_oauth(github_oauth)
             .emails(emails)
             .storage(Arc::new(Storage::from_config(&config.storage)))
-            .service_metrics(ServiceMetrics::new().expect("could not initialize service metrics"))
-            .instance_metrics(instance_metrics)
             .rate_limiter(RateLimiter::new(config.rate_limiter.clone()))
             .config(Arc::new(config))
             .build()

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::email::Emails;
 use crate::metrics::{InstanceMetrics, ServiceMetrics};
 use crate::rate_limiter::RateLimiter;
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageConfig};
 use axum::extract::{FromRef, FromRequestParts, State};
 use bon::Builder;
 use crates_io_github::GitHubClient;
@@ -142,6 +142,16 @@ impl<S: app_builder::State> AppBuilder<S> {
         self.primary_database(primary_database)
             .maybe_replica_database(replica_database)
     }
+
+    pub fn storage_from_config(
+        self,
+        config: &StorageConfig,
+    ) -> AppBuilder<app_builder::SetStorage<S>>
+    where
+        S::Storage: app_builder::IsUnset,
+    {
+        self.storage(Arc::new(Storage::from_config(config)))
+    }
 }
 
 impl App {
@@ -158,7 +168,7 @@ impl App {
             .github(github)
             .github_oauth_from_config(&config)
             .emails(emails)
-            .storage(Arc::new(Storage::from_config(&config.storage)))
+            .storage_from_config(&config.storage)
             .rate_limiter(RateLimiter::new(config.rate_limiter.clone()))
             .config(Arc::new(config))
             .build()

--- a/src/app.rs
+++ b/src/app.rs
@@ -166,25 +166,6 @@ impl<S: app_builder::State> AppBuilder<S> {
 }
 
 impl App {
-    /// Creates a new `App` with a given `Config` and an optional HTTP `Client`
-    ///
-    /// Configures and sets up:
-    ///
-    /// - GitHub OAuth
-    /// - Database connection pools
-    /// - A `git2::Repository` instance from the index repo checkout (that server.rs ensures exists)
-    pub fn new(config: config::Server, emails: Emails, github: Box<dyn GitHubClient>) -> App {
-        App::builder()
-            .databases_from_config(&config.db)
-            .github(github)
-            .github_oauth_from_config(&config)
-            .emails(emails)
-            .storage_from_config(&config.storage)
-            .rate_limiter_from_config(config.rate_limiter.clone())
-            .config(Arc::new(config))
-            .build()
-    }
-
     /// A unique key to generate signed cookies
     pub fn session_key(&self) -> &cookie::Key {
         &self.config.session_key

--- a/src/bin/server.rs
+++ b/src/bin/server.rs
@@ -33,7 +33,17 @@ fn main() -> anyhow::Result<()> {
     let github = RealGitHubClient::new(client);
     let github = Box::new(github);
 
-    let app = Arc::new(App::new(config, emails, github));
+    let app = App::builder()
+        .databases_from_config(&config.db)
+        .github(github)
+        .github_oauth_from_config(&config)
+        .emails(emails)
+        .storage_from_config(&config.storage)
+        .rate_limiter_from_config(config.rate_limiter.clone())
+        .config(Arc::new(config))
+        .build();
+
+    let app = Arc::new(app);
 
     // Start the background thread periodically logging instance metrics.
     log_instance_metrics_thread(app.clone());

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -488,7 +488,15 @@ fn build_app(config: config::Server, github: Option<MockGitHubClient>) -> (Arc<A
     let github = github.unwrap_or_else(|| MOCK_GITHUB_DATA.as_mock_client());
     let github = Box::new(github);
 
-    let app = App::new(config, emails, github);
+    let app = App::builder()
+        .databases_from_config(&config.db)
+        .github(github)
+        .github_oauth_from_config(&config)
+        .emails(emails)
+        .storage_from_config(&config.storage)
+        .rate_limiter_from_config(config.rate_limiter.clone())
+        .config(Arc::new(config))
+        .build();
 
     let app = Arc::new(app);
     let router = crate::build_handler(Arc::clone(&app));


### PR DESCRIPTION
With every mockable subsystem the `App::new()` fn becomes more complicated. This PR proposes the introduction of a derived `AppBuilder` struct, replacing `App::new()` and making the construction of `App` instances more flexible.