### PR TITLE
Fix `diesel` schema patch file update instructions

### DIFF
--- a/crates/crates_io_database/README.md
+++ b/crates/crates_io_database/README.md
@@ -20,7 +20,8 @@ regular tables, so we have to manually add them to the schema file.
 If you need to update the patch file, you can do so by following these steps:
 
 1. prefix `patch_file = "src/schema.patch"` in `diesel.toml` with a `#` to comment it out.
-2. use `diesel print-schema` and save the output to `src/schema.rs.orig`
-3. use `patch -o src/schema.rs src/schema.rs.orig src/schema.patch` to apply the patch file and solve remaining issues in the `src/schema.rs` file
-4. use `diff -Naur src/schema.rs.orig src/schema.rs` to generate the new content for the `src/schema.patch` file
-5. enable the `patch_file` option in the `diesel.toml` file again.
+2. use `diesel print-schema` and save the output to `src/schema.rs`
+3. use `cp src/schema.rs src/schema.rs.orig` to create a backup of the original file
+4. use `patch src/schema.rs src/schema.patch` to apply the patch file and solve remaining issues in the `src/schema.rs` file
+5. use `diff -Naur --label original --label patched src/schema.rs.orig src/schema.rs` to generate the new content for the `src/schema.patch` file
+6. enable the `patch_file` option in the `diesel.toml` file again.

--- a/crates/crates_io_database/src/schema.patch
+++ b/crates/crates_io_database/src/schema.patch
@@ -1,5 +1,5 @@
---- crates/crates_io_database/schema.rs.orig	2024-03-04 10:34:35
-+++ crates/crates_io_database/schema.rs	2024-03-04 10:33:35
+--- original
++++ patched
 @@ -21,9 +21,7 @@
      /// The `pg_catalog.tsvector` SQL type
      ///


### PR DESCRIPTION
`patch -o` does not appear to work quite as intended on my machine, so let's adjust the instructions to make them actually work correctly.

This also introduces `--label` arguments to the `diff` call, to avoid the unnecessary datetime headers.