### PR TITLE
tests/builders: Replace `AppResult` with `anyhow`

### DIFF
--- a/src/tests/builders/krate.rs
+++ b/src/tests/builders/krate.rs
@@ -1,6 +1,5 @@
 use crate::models::{Category, Crate, Keyword, NewCrate, update_default_version};
 use crate::schema::{crate_downloads, crates, version_downloads};
-use crate::util::errors::AppResult;
 
 use super::VersionBuilder;
 use chrono::{DateTime, Utc};
@@ -114,7 +113,7 @@ impl<'a> CrateBuilder<'a> {
         self
     }
 
-    pub async fn build(mut self, connection: &mut AsyncPgConnection) -> AppResult<Crate> {
+    pub async fn build(mut self, connection: &mut AsyncPgConnection) -> anyhow::Result<Crate> {
         use diesel::{insert_into, select, update};
 
         let mut krate = self.krate.create(connection, self.owner_id).await?;

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -1,6 +1,5 @@
 use crate::models::{Crate, NewVersion, Version};
 use crate::schema::dependencies;
-use crate::util::errors::AppResult;
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
@@ -94,7 +93,7 @@ impl VersionBuilder {
         crate_id: i32,
         published_by: i32,
         connection: &mut AsyncPgConnection,
-    ) -> AppResult<Version> {
+    ) -> anyhow::Result<Version> {
         use diesel::insert_into;
 
         let version = self.num.to_string();

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -60,8 +60,7 @@ async fn download_requests_with_unhealthy_database_succeed() -> anyhow::Result<(
     CrateBuilder::new("foo", token.as_model().user_id)
         .version("1.0.0")
         .build(&mut conn)
-        .await
-        .unwrap();
+        .await?;
 
     app.primary_db_chaosproxy().break_networking()?;
 


### PR DESCRIPTION
There is no need anymore for these functions to return an `AppResult`, we can use generic `anyhow::Result` instead 🎉 