### PR TITLE
Fix "Github" spelling

### DIFF
--- a/crates/crates_io_database/src/models/team.rs
+++ b/crates/crates_io_database/src/models/team.rs
@@ -5,14 +5,14 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use crate::models::{Crate, CrateOwner, Owner, OwnerKind};
 use crate::schema::{crate_owners, teams};
 
-/// For now, just a Github Team. Can be upgraded to other teams
+/// For now, just a GitHub Team. Can be upgraded to other teams
 /// later if desirable.
 #[derive(Queryable, Identifiable, serde::Serialize, serde::Deserialize, Debug, Selectable)]
 pub struct Team {
     /// Unique table id
     pub id: i32,
     /// "github:org:team"
-    /// An opaque unique ID, that was at one point parsed out to query Github.
+    /// An opaque unique ID, that was at one point parsed out to query GitHub.
     /// We only query membership with github using the github_id, though.
     /// This is the only name we should ever talk to Cargo about.
     pub login: String,

--- a/crates/crates_io_github/src/lib.rs
+++ b/crates/crates_io_github/src/lib.rs
@@ -19,7 +19,7 @@ type Result<T> = std::result::Result<T, GitHubError>;
 #[cfg_attr(feature = "mock", mockall::automock)]
 #[async_trait]
 pub trait GitHubClient: Send + Sync {
-    async fn current_user(&self, auth: &AccessToken) -> Result<GithubUser>;
+    async fn current_user(&self, auth: &AccessToken) -> Result<GitHubUser>;
     async fn org_by_name(&self, org_name: &str, auth: &AccessToken) -> Result<GitHubOrganization>;
     async fn team_by_name(
         &self,
@@ -53,7 +53,7 @@ impl RealGitHubClient {
         Self { client }
     }
 
-    /// Does all the nonsense for sending a GET to Github.
+    /// Does all the nonsense for sending a GET to GitHub.
     async fn _request<T, A>(&self, url: &str, apply_auth: A) -> Result<T>
     where
         T: DeserializeOwned,
@@ -98,7 +98,7 @@ impl RealGitHubClient {
 
 #[async_trait]
 impl GitHubClient for RealGitHubClient {
-    async fn current_user(&self, auth: &AccessToken) -> Result<GithubUser> {
+    async fn current_user(&self, auth: &AccessToken) -> Result<GitHubUser> {
         self.request("/user", auth).await
     }
 
@@ -183,7 +183,7 @@ impl From<reqwest::Error> for GitHubError {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct GithubUser {
+pub struct GitHubUser {
     pub avatar_url: Option<String>,
     pub email: Option<String>,
     pub id: i32,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -548,7 +548,7 @@ docker compose up -d
 The Compose file is filled out with a sane set of defaults that should Just
 Work™ out of the box without any modification. Individual settings can be
 overridden by creating a `docker-compose.override.yml` with the updated config.
-For example, in order to specify a set of Github OAuth Client credentials, a
+For example, in order to specify a set of GitHub OAuth Client credentials, a
 `docker-compose.override.yml` file might look like this:
 
 ```yaml

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -390,7 +390,7 @@ async fn add_team_owner(
     Ok(NewOwnerInvite::Team(team))
 }
 
-/// Tries to create or update a Github Team. Assumes `org` and `team` are
+/// Tries to create or update a GitHub Team. Assumes `org` and `team` are
 /// correctly parsed out of the full `name`. `name` is passed as a
 /// convenience to avoid rebuilding it.
 pub async fn create_or_update_github_team(

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -15,7 +15,7 @@ use crate::schema::users;
 use crate::util::diesel::is_read_only_error;
 use crate::util::errors::{AppResult, bad_request, server_error};
 use crate::views::EncodableMe;
-use crates_io_github::GithubUser;
+use crates_io_github::GitHubUser;
 use crates_io_session::SessionExtension;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -124,7 +124,7 @@ pub async fn authorize_session(
 }
 
 pub async fn save_user_to_database(
-    user: &GithubUser,
+    user: &GitHubUser,
     access_token: &str,
     emails: &Emails,
     conn: &mut AsyncPgConnection,
@@ -220,7 +220,7 @@ mod tests {
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;
 
-        let gh_user = GithubUser {
+        let gh_user = GitHubUser {
             email: Some("String.Format(\"{0}.{1}@live.com\", FirstName, LastName)".into()),
             name: Some("My Name".into()),
             login: "github_user".into(),

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -5,7 +5,7 @@ use crate::tests::util::github::next_gh_id;
 use crate::tests::util::{MockCookieUser, RequestHelper};
 use crate::util::token::HashedToken;
 use chrono::{DateTime, Utc};
-use crates_io_github::GithubUser;
+use crates_io_github::GitHubUser;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
@@ -30,7 +30,7 @@ async fn updating_existing_user_doesnt_change_api_token() -> anyhow::Result<()> 
     let token = token.plaintext();
 
     // Reuse gh_id but use new gh_login and gh_access_token
-    let gh_user = GithubUser {
+    let gh_user = GitHubUser {
         id: gh_id,
         login: "bar".to_string(),
         name: None,
@@ -67,10 +67,10 @@ async fn github_without_email_does_not_overwrite_email() -> anyhow::Result<()> {
 
     // Simulate logging in via GitHub with an account that has no email.
 
-    // Because faking GitHub is terrible, call what GithubUser::save_to_database does directly.
+    // Because faking GitHub is terrible, call what GitHubUser::save_to_database does directly.
     // Don't use app.db_new_user because it adds a verified email.
     let gh_id = next_gh_id();
-    let gh_user = GithubUser {
+    let gh_user = GitHubUser {
         id: gh_id,
         login: "arbitrary_username".to_string(),
         name: None,
@@ -94,7 +94,7 @@ async fn github_without_email_does_not_overwrite_email() -> anyhow::Result<()> {
 
     // Simulate the same user logging in via GitHub again, still with no email in GitHub.
 
-    let gh_user = GithubUser {
+    let gh_user = GitHubUser {
         id: gh_id,
         login: "arbitrary_username".to_string(),
         name: None,
@@ -135,7 +135,7 @@ async fn github_with_email_does_not_overwrite_email() -> anyhow::Result<()> {
 
     let emails = app.as_inner().emails.clone();
 
-    let gh_user = GithubUser {
+    let gh_user = GitHubUser {
         // Use the same github ID to link to the existing account
         id: model.gh_id,
         login: "arbitrary_username".to_string(),
@@ -193,7 +193,7 @@ async fn test_confirm_user_email() -> anyhow::Result<()> {
 
     let emails = &app.as_inner().emails;
 
-    let gh_user = GithubUser {
+    let gh_user = GitHubUser {
         id: next_gh_id(),
         login: "arbitrary_username".to_string(),
         name: None,
@@ -239,7 +239,7 @@ async fn test_existing_user_email() -> anyhow::Result<()> {
 
     let emails = &app.as_inner().emails;
 
-    let gh_user = GithubUser {
+    let gh_user = GitHubUser {
         id: next_gh_id(),
         login: "arbitrary_username".to_string(),
         name: None,

--- a/src/tests/util/github.rs
+++ b/src/tests/util/github.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use crates_io_github::{
     GitHubError, GitHubOrgMembership, GitHubOrganization, GitHubTeam, GitHubTeamMembership,
-    GithubUser, MockGitHubClient,
+    GitHubUser, MockGitHubClient,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -75,9 +75,9 @@ impl MockData {
         mock
     }
 
-    fn current_user(&self) -> Result<GithubUser, GitHubError> {
+    fn current_user(&self) -> Result<GitHubUser, GitHubError> {
         let user = &self.users[0];
-        Ok(GithubUser {
+        Ok(GitHubUser {
             id: user.id,
             login: user.login.into(),
             name: Some(user.name.into()),


### PR DESCRIPTION
It's called "GitHub", not "Github"… 😅