### PR TITLE
Use same database pool creation code for API server and background worker

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -122,7 +122,7 @@ impl<S: app_builder::State> AppBuilder<S> {
     }
 }
 
-fn create_database_pool(config: &config::DbPoolConfig) -> DeadpoolPool<AsyncPgConnection> {
+pub fn create_database_pool(config: &config::DbPoolConfig) -> DeadpoolPool<AsyncPgConnection> {
     let connection_config = ConnectionConfig {
         statement_timeout: config.statement_timeout,
         read_only: config.read_only_mode,

--- a/src/app.rs
+++ b/src/app.rs
@@ -94,47 +94,8 @@ impl<S: app_builder::State> AppBuilder<S> {
         S::PrimaryDatabase: app_builder::IsUnset,
         S::ReplicaDatabase: app_builder::IsUnset,
     {
-        let primary_database = {
-            let primary_db_connection_config = ConnectionConfig {
-                statement_timeout: config.primary.statement_timeout,
-                read_only: config.primary.read_only_mode,
-            };
-
-            let url = connection_url(&config.primary);
-            let manager_config = make_manager_config(config.primary.enforce_tls);
-            let manager = AsyncDieselConnectionManager::new_with_config(url, manager_config);
-
-            DeadpoolPool::builder(manager)
-                .runtime(Runtime::Tokio1)
-                .max_size(config.primary.pool_size)
-                .wait_timeout(Some(config.primary.connection_timeout))
-                .post_create(primary_db_connection_config)
-                .build()
-                .unwrap()
-        };
-
-        let replica_database = if let Some(pool_config) = config.replica.as_ref() {
-            let replica_db_connection_config = ConnectionConfig {
-                statement_timeout: pool_config.statement_timeout,
-                read_only: pool_config.read_only_mode,
-            };
-
-            let url = connection_url(pool_config);
-            let manager_config = make_manager_config(pool_config.enforce_tls);
-            let manager = AsyncDieselConnectionManager::new_with_config(url, manager_config);
-
-            let pool = DeadpoolPool::builder(manager)
-                .runtime(Runtime::Tokio1)
-                .max_size(pool_config.pool_size)
-                .wait_timeout(Some(pool_config.connection_timeout))
-                .post_create(replica_db_connection_config)
-                .build()
-                .unwrap();
-
-            Some(pool)
-        } else {
-            None
-        };
+        let primary_database = create_database_pool(&config.primary);
+        let replica_database = config.replica.as_ref().map(create_database_pool);
 
         self.primary_database(primary_database)
             .maybe_replica_database(replica_database)
@@ -159,6 +120,25 @@ impl<S: app_builder::State> AppBuilder<S> {
     {
         self.rate_limiter(RateLimiter::new(config))
     }
+}
+
+fn create_database_pool(config: &config::DbPoolConfig) -> DeadpoolPool<AsyncPgConnection> {
+    let connection_config = ConnectionConfig {
+        statement_timeout: config.statement_timeout,
+        read_only: config.read_only_mode,
+    };
+
+    let url = connection_url(config);
+    let manager_config = make_manager_config(config.enforce_tls);
+    let manager = AsyncDieselConnectionManager::new_with_config(url, manager_config);
+
+    DeadpoolPool::builder(manager)
+        .runtime(Runtime::Tokio1)
+        .max_size(config.pool_size)
+        .wait_timeout(Some(config.connection_timeout))
+        .post_create(connection_config)
+        .build()
+        .unwrap()
 }
 
 impl App {

--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -29,7 +29,6 @@ use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::deadpool::Pool;
 use object_store::prefix::PrefixStore;
 use reqwest::Client;
-use secrecy::ExposeSecret;
 use std::sync::Arc;
 use std::thread::sleep;
 use std::time::Duration;
@@ -61,7 +60,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let db_url = db::connection_url(&config.db, config.db.primary.url.expose_secret());
+    let db_url = db::connection_url(&config.db.primary);
 
     if var("HEROKU")?.is_some() {
         ssh::write_known_hosts_file()?;
@@ -84,7 +83,7 @@ fn main() -> anyhow::Result<()> {
     let fastly = Fastly::from_environment(client.clone());
     let team_repo = TeamRepoImpl::default();
 
-    let manager_config = make_manager_config(config.db.enforce_tls);
+    let manager_config = make_manager_config(config.db.primary.enforce_tls);
     let manager = AsyncDieselConnectionManager::new_with_config(db_url, manager_config);
     let deadpool = Pool::builder(manager).max_size(10).build()?;
 

--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -24,6 +24,14 @@ pub struct DatabasePools {
     pub primary: DbPoolConfig,
     /// An optional follower database. Always read-only.
     pub replica: Option<DbPoolConfig>,
+}
+
+#[derive(Debug)]
+pub struct DbPoolConfig {
+    pub url: SecretString,
+    pub read_only_mode: bool,
+    pub pool_size: usize,
+    pub min_idle: Option<u32>,
     /// Number of seconds to wait for unacknowledged TCP packets before treating the connection as
     /// broken. This value will determine how long crates.io stays unavailable in case of full
     /// packet loss between the application and the database: setting it too high will result in an
@@ -41,14 +49,6 @@ pub struct DatabasePools {
     pub helper_threads: usize,
     /// Whether to enforce that all the database connections are encrypted with TLS.
     pub enforce_tls: bool,
-}
-
-#[derive(Debug)]
-pub struct DbPoolConfig {
-    pub url: SecretString,
-    pub read_only_mode: bool,
-    pub pool_size: usize,
-    pub min_idle: Option<u32>,
 }
 
 impl DatabasePools {
@@ -102,13 +102,13 @@ impl DatabasePools {
                     read_only_mode: true,
                     pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
+                    tcp_timeout_ms,
+                    connection_timeout,
+                    statement_timeout,
+                    helper_threads,
+                    enforce_tls,
                 },
                 replica: None,
-                tcp_timeout_ms,
-                connection_timeout,
-                statement_timeout,
-                helper_threads,
-                enforce_tls,
             },
             // The follower is down, don't configure the replica.
             Some("follower") => Self {
@@ -117,13 +117,13 @@ impl DatabasePools {
                     read_only_mode,
                     pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
+                    tcp_timeout_ms,
+                    connection_timeout,
+                    statement_timeout,
+                    helper_threads,
+                    enforce_tls,
                 },
                 replica: None,
-                tcp_timeout_ms,
-                connection_timeout,
-                statement_timeout,
-                helper_threads,
-                enforce_tls,
             },
             _ => Self {
                 primary: DbPoolConfig {
@@ -131,6 +131,11 @@ impl DatabasePools {
                     read_only_mode,
                     pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
+                    tcp_timeout_ms,
+                    connection_timeout,
+                    statement_timeout,
+                    helper_threads,
+                    enforce_tls,
                 },
                 replica: follower_url.map(|url| DbPoolConfig {
                     url,
@@ -140,12 +145,12 @@ impl DatabasePools {
                     read_only_mode: true,
                     pool_size: replica_async_pool_size,
                     min_idle: replica_min_idle,
+                    tcp_timeout_ms,
+                    connection_timeout,
+                    statement_timeout,
+                    helper_threads,
+                    enforce_tls,
                 }),
-                tcp_timeout_ms,
-                connection_timeout,
-                statement_timeout,
-                helper_threads,
-                enforce_tls,
             },
         })
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -14,8 +14,8 @@ use crate::config;
 pub async fn oneoff_connection_with_config(
     config: &config::DatabasePools,
 ) -> ConnectionResult<AsyncPgConnection> {
-    let url = connection_url(config, config.primary.url.expose_secret());
-    establish_async_connection(&url, config.enforce_tls).await
+    let url = connection_url(&config.primary);
+    establish_async_connection(&url, config.primary.enforce_tls).await
 }
 
 pub async fn oneoff_connection() -> anyhow::Result<AsyncPgConnection> {
@@ -23,8 +23,8 @@ pub async fn oneoff_connection() -> anyhow::Result<AsyncPgConnection> {
     Ok(oneoff_connection_with_config(&config).await?)
 }
 
-pub fn connection_url(config: &config::DatabasePools, url: &str) -> String {
-    let mut url = Url::parse(url).expect("Invalid database URL");
+pub fn connection_url(config: &config::DbPoolConfig) -> String {
+    let mut url = Url::parse(config.url.expose_secret()).expect("Invalid database URL");
 
     if config.enforce_tls {
         maybe_append_url_param(&mut url, "sslmode", "require");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use tikv_jemallocator::Jemalloc;
 #[global_allocator]
 static ALLOC: Jemalloc = Jemalloc;
 
-mod app;
+pub mod app;
 pub mod auth;
 pub mod boot;
 pub mod certs;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -401,6 +401,11 @@ impl TestAppBuilder {
             read_only_mode: true,
             pool_size: primary.pool_size,
             min_idle: primary.min_idle,
+            tcp_timeout_ms: primary.tcp_timeout_ms,
+            connection_timeout: primary.connection_timeout,
+            statement_timeout: primary.statement_timeout,
+            helper_threads: primary.helper_threads,
+            enforce_tls: primary.enforce_tls,
         });
 
         self
@@ -419,13 +424,13 @@ fn simple_config() -> config::Server {
             read_only_mode: false,
             pool_size: 5,
             min_idle: None,
+            tcp_timeout_ms: 1000, // 1 second
+            connection_timeout: Duration::from_secs(1),
+            statement_timeout: Duration::from_secs(1),
+            helper_threads: 1,
+            enforce_tls: false,
         },
         replica: None,
-        tcp_timeout_ms: 1000, // 1 second
-        connection_timeout: Duration::from_secs(1),
-        statement_timeout: Duration::from_secs(1),
-        helper_threads: 1,
-        enforce_tls: false,
     };
 
     let mut storage = StorageConfig::in_memory();


### PR DESCRIPTION
This PR extracts a `create_database_pool()` fn from the API server initialization code and then subsequently uses it in the `bin/background-worker` binary.

This ensures that things like the `connection_timeout` and `statement_timeout` are consistently applied to both the API server and the background worker.