### PR TITLE
config/database_pools: Change `tcp_timeout` field to `Duration`

### DIFF
--- a/src/config/database_pools.rs
+++ b/src/config/database_pools.rs
@@ -37,7 +37,7 @@ pub struct DbPoolConfig {
     /// packet loss between the application and the database: setting it too high will result in an
     /// unnecessarily long outage (before the unhealthy database logic kicks in), while setting it
     /// too low might result in healthy connections being dropped.
-    pub tcp_timeout_ms: u64,
+    pub tcp_timeout: Duration,
     /// Time to wait for a connection to become available from the connection
     /// pool before returning an error.
     pub connection_timeout: Duration,
@@ -78,7 +78,8 @@ impl DatabasePools {
         let primary_min_idle = var_parsed("DB_PRIMARY_MIN_IDLE")?;
         let replica_min_idle = var_parsed("DB_REPLICA_MIN_IDLE")?;
 
-        let tcp_timeout_ms = var_parsed("DB_TCP_TIMEOUT_MS")?.unwrap_or(15 * 1000);
+        let tcp_timeout = var_parsed("DB_TCP_TIMEOUT_MS")?.unwrap_or(15 * 1000);
+        let tcp_timeout = Duration::from_millis(tcp_timeout);
 
         let connection_timeout = var_parsed("DB_TIMEOUT")?.unwrap_or(30);
         let connection_timeout = Duration::from_secs(connection_timeout);
@@ -102,7 +103,7 @@ impl DatabasePools {
                     read_only_mode: true,
                     pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
-                    tcp_timeout_ms,
+                    tcp_timeout,
                     connection_timeout,
                     statement_timeout,
                     helper_threads,
@@ -117,7 +118,7 @@ impl DatabasePools {
                     read_only_mode,
                     pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
-                    tcp_timeout_ms,
+                    tcp_timeout,
                     connection_timeout,
                     statement_timeout,
                     helper_threads,
@@ -131,7 +132,7 @@ impl DatabasePools {
                     read_only_mode,
                     pool_size: primary_async_pool_size,
                     min_idle: primary_min_idle,
-                    tcp_timeout_ms,
+                    tcp_timeout,
                     connection_timeout,
                     statement_timeout,
                     helper_threads,
@@ -145,7 +146,7 @@ impl DatabasePools {
                     read_only_mode: true,
                     pool_size: replica_async_pool_size,
                     min_idle: replica_min_idle,
-                    tcp_timeout_ms,
+                    tcp_timeout,
                     connection_timeout,
                     statement_timeout,
                     helper_threads,

--- a/src/db.rs
+++ b/src/db.rs
@@ -35,7 +35,7 @@ pub fn connection_url(config: &config::DbPoolConfig) -> String {
     maybe_append_url_param(
         &mut url,
         "tcp_user_timeout",
-        &config.tcp_timeout_ms.to_string(),
+        &config.tcp_timeout.as_millis().to_string(),
     );
 
     url.into()

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -401,7 +401,7 @@ impl TestAppBuilder {
             read_only_mode: true,
             pool_size: primary.pool_size,
             min_idle: primary.min_idle,
-            tcp_timeout_ms: primary.tcp_timeout_ms,
+            tcp_timeout: primary.tcp_timeout,
             connection_timeout: primary.connection_timeout,
             statement_timeout: primary.statement_timeout,
             helper_threads: primary.helper_threads,
@@ -424,7 +424,7 @@ fn simple_config() -> config::Server {
             read_only_mode: false,
             pool_size: 5,
             min_idle: None,
-            tcp_timeout_ms: 1000, // 1 second
+            tcp_timeout: Duration::from_secs(1),
             connection_timeout: Duration::from_secs(1),
             statement_timeout: Duration::from_secs(1),
             helper_threads: 1,


### PR DESCRIPTION
We may as well use a proper type, instead of a raw `u64` 😅 