### PR TITLE
bin/background-worker: Increase database statement timeout to one hour

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -46,6 +46,10 @@ fn main() -> anyhow::Result<()> {
     // Override the pool size to 10 for the background worker
     config.db.primary.pool_size = 10;
 
+    // We run some long-running queries in the background worker, so we need to
+    // increase the statement timeout a bit…
+    config.db.primary.statement_timeout = Duration::from_secs(60 * 60);
+
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()


### PR DESCRIPTION
Turns out unifying the database connection pool initialization had some unintended side effects for jobs in the background worker that use long-running database queries (e.g. `SELECT refresh_recent_crate_downloads()`).

This commit fixes the issue by explicitly overriding the timeout to be one hour instead of the default 30 sec.