### PR TITLE
controllers/site_metadata: Avoid unnecessary allocation

### DIFF
--- a/src/controllers/site_metadata.rs
+++ b/src/controllers/site_metadata.rs
@@ -29,12 +29,12 @@ pub struct MetadataResponse<'a> {
 pub async fn get_site_metadata(state: AppState) -> impl IntoResponse {
     let read_only = state.config.db.are_all_read_only();
 
-    let deployed_sha =
-        dotenvy::var("HEROKU_SLUG_COMMIT").unwrap_or_else(|_| String::from("unknown"));
+    let deployed_sha = dotenvy::var("HEROKU_SLUG_COMMIT");
+    let deployed_sha = deployed_sha.as_deref().unwrap_or("unknown");
 
     Json(MetadataResponse {
-        deployed_sha: &deployed_sha,
-        commit: &deployed_sha,
+        deployed_sha,
+        commit: deployed_sha,
         read_only,
     })
     .into_response()


### PR DESCRIPTION
No need for `String::from(...)` if we can just work with `&str` instead :)