### PR TITLE
Simplify `NewVersion::save()` fn

### DIFF
--- a/crates/crates_io_database/src/models/mod.rs
+++ b/crates/crates_io_database/src/models/mod.rs
@@ -36,3 +36,4 @@ pub mod token;
 pub mod trustpub;
 pub mod user;
 pub mod version;
+pub mod versions_published_by;

--- a/crates/crates_io_database/src/models/version.rs
+++ b/crates/crates_io_database/src/models/version.rs
@@ -8,7 +8,7 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use serde::Deserialize;
 
-use crate::models::{Crate, User, versions_published_by};
+use crate::models::{Crate, User};
 use crate::schema::{readme_renderings, users, versions};
 
 // Queryable has a custom implementation below
@@ -107,11 +107,7 @@ pub struct NewVersion<'a> {
 }
 
 impl NewVersion<'_> {
-    pub async fn save(
-        &self,
-        conn: &mut AsyncPgConnection,
-        published_by_email: &str,
-    ) -> QueryResult<Version> {
+    pub async fn save(&self, conn: &mut AsyncPgConnection) -> QueryResult<Version> {
         use diesel::insert_into;
 
         conn.transaction(|conn| {
@@ -121,8 +117,6 @@ impl NewVersion<'_> {
                     .returning(Version::as_returning())
                     .get_result(conn)
                     .await?;
-
-                versions_published_by::insert(version.id, published_by_email, conn).await?;
 
                 Ok(version)
             }

--- a/crates/crates_io_database/src/models/version.rs
+++ b/crates/crates_io_database/src/models/version.rs
@@ -8,8 +8,8 @@ use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use serde::Deserialize;
 
-use crate::models::{Crate, User};
-use crate::schema::*;
+use crate::models::{Crate, User, versions_published_by};
+use crate::schema::{readme_renderings, users, versions};
 
 // Queryable has a custom implementation below
 #[derive(Clone, Identifiable, Associations, Debug, Queryable, Selectable)]
@@ -122,13 +122,7 @@ impl NewVersion<'_> {
                     .get_result(conn)
                     .await?;
 
-                insert_into(versions_published_by::table)
-                    .values((
-                        versions_published_by::version_id.eq(version.id),
-                        versions_published_by::email.eq(published_by_email),
-                    ))
-                    .execute(conn)
-                    .await?;
+                versions_published_by::insert(version.id, published_by_email, conn).await?;
 
                 Ok(version)
             }

--- a/crates/crates_io_database/src/models/versions_published_by.rs
+++ b/crates/crates_io_database/src/models/versions_published_by.rs
@@ -1,0 +1,17 @@
+use crate::schema::versions_published_by;
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+
+pub async fn insert(
+    version_id: i32,
+    email: &str,
+    conn: &mut AsyncPgConnection,
+) -> QueryResult<usize> {
+    diesel::insert_into(versions_published_by::table)
+        .values((
+            versions_published_by::version_id.eq(version_id),
+            versions_published_by::email.eq(email),
+        ))
+        .execute(conn)
+        .await
+}

--- a/src/tests/builders/version.rs
+++ b/src/tests/builders/version.rs
@@ -3,6 +3,7 @@ use crate::schema::dependencies;
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
+use crates_io_database::models::versions_published_by;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 
@@ -110,7 +111,8 @@ impl VersionBuilder {
             .maybe_created_at(self.created_at.as_ref())
             .build();
 
-        let vers = new_version.save(connection, "someone@example.com").await?;
+        let vers = new_version.save(connection).await?;
+        versions_published_by::insert(vers.id, "someone@example.com", connection).await?;
 
         let new_deps = self
             .dependencies

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -107,6 +107,7 @@ mod tests {
     use super::*;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
     use crate::schema::{crate_downloads, crates, versions};
+    use crates_io_database::models::versions_published_by;
     use crates_io_test_db::TestDatabase;
     use diesel::sql_types::Timestamptz;
     use diesel_async::AsyncConnection;
@@ -136,7 +137,12 @@ mod tests {
             .checksum("0000000000000000000000000000000000000000000000000000000000000000")
             .build();
 
-        let version = version.save(conn, "someone@example.com").await.unwrap();
+        let version = version.save(conn).await.unwrap();
+
+        versions_published_by::insert(version.id, "someone@example.com", conn)
+            .await
+            .unwrap();
+
         (krate, version)
     }
 

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -107,7 +107,6 @@ mod tests {
     use super::*;
     use crate::models::{Crate, NewCrate, NewUser, NewVersion, User, Version};
     use crate::schema::{crate_downloads, crates, versions};
-    use crates_io_database::models::versions_published_by;
     use crates_io_test_db::TestDatabase;
     use diesel::sql_types::Timestamptz;
     use diesel_async::AsyncConnection;
@@ -138,10 +137,6 @@ mod tests {
             .build();
 
         let version = version.save(conn).await.unwrap();
-
-        versions_published_by::insert(version.id, "someone@example.com", conn)
-            .await
-            .unwrap();
 
         (krate, version)
     }


### PR DESCRIPTION
There is no need for this function to use a transaction since the only place that this is used in production is already using an outer transaction.

It is also questionable whether the `INSERT INTO versions_published_by` needs to happen in the same function, since there are plenty of other inserts that need to happen when a new version is published, but neither of them are part of this function either.

In the effort of making `crates_io_database` an easy to reason about data access layer, this PR adjusts the `NewVersion::save()` fn to only save the new version to the `versions` table, and moves the `versions_published_by` insert code outside of the function.