### PR TITLE
OpenAPI: Add `trustpub_token` security scheme

### DIFF
--- a/src/controllers/trustpub/tokens/revoke/mod.rs
+++ b/src/controllers/trustpub/tokens/revoke/mod.rs
@@ -16,6 +16,7 @@ mod tests;
 #[utoipa::path(
     delete,
     path = "/api/v1/trusted_publishing/tokens",
+    security(("trustpub_token" = [])),
     tag = "trusted_publishing",
     responses((status = 204, description = "Successful Response")),
 )]

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,6 +1,6 @@
 use crates_io_session::COOKIE_NAME;
 use http::header;
-use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, Http, HttpAuthScheme, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 use utoipa_axum::router::OpenApiRouter;
 
@@ -72,6 +72,14 @@ impl Modify for SecurityAddon {
             "The API token is used to authenticate requests from cargo and other clients.";
         let api_token = ApiKey::Header(ApiKeyValue::with_description(name, description));
         components.add_security_scheme("api_token", SecurityScheme::ApiKey(api_token));
+
+        let description = "Temporary access tokens are used by the \"Trusted Publishing\" flow.";
+        let trustpub_token = Http::builder()
+            .scheme(HttpAuthScheme::Bearer)
+            .description(Some(description))
+            .build();
+
+        components.add_security_scheme("trustpub_token", SecurityScheme::Http(trustpub_token));
     }
 }
 

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -4315,6 +4315,11 @@ expression: response.json()
             "description": "Successful Response"
           }
         },
+        "security": [
+          {
+            "trustpub_token": []
+          }
+        ],
         "summary": "Revoke a temporary access token.",
         "tags": [
           "trusted_publishing"

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot.snap
@@ -1252,6 +1252,11 @@ expression: response.json()
         "in": "cookie",
         "name": "cargo_session",
         "type": "apiKey"
+      },
+      "trustpub_token": {
+        "description": "Temporary access tokens are used by the \"Trusted Publishing\" flow.",
+        "scheme": "bearer",
+        "type": "http"
       }
     }
   },


### PR DESCRIPTION
The `DELETE /api/v1/trusted_publishing/tokens` endpoint requires a Trusted Publishing token, so let's document it accordingly.