### PR TITLE
tests: Decode emails before snapshotting them in `emails_snapshot()` fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,7 @@ dependencies = [
  "paste",
  "postgres-native-tls",
  "prometheus",
+ "quoted_printable",
  "rand 0.9.1",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,6 +151,7 @@ diesel = { version = "=2.2.10", features = ["r2d2"] }
 googletest = "=0.14.1"
 insta = { version = "=1.43.1", features = ["glob", "json", "redactions"] }
 jsonwebtoken = "=9.3.1"
+quoted_printable = "=0.5.1"
 regex = "=1.11.1"
 sentry = { version = "=0.38.1", features = ["test"] }
 tokio = "=1.45.1"

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_new_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_new_crate-2.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: foo@example.com
@@ -28,5 +25,4 @@ Hi foo,
 
 Your "foo" crate has been deleted, per your request.
 
-If you did not initiate this deletion, your account may have been compromis=
-ed. Please contact us at help@crates.io.
+If you did not initiate this deletion, your account may have been compromised. Please contact us at help@crates.io.

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_old_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_old_crate-2.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: foo@example.com
@@ -28,5 +25,4 @@ Hi foo,
 
 Your "foo" crate has been deleted, per your request.
 
-If you did not initiate this deletion, your account may have been compromis=
-ed. Please contact us at help@crates.io.
+If you did not initiate this deletion, your account may have been compromised. Please contact us at help@crates.io.

--- a/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_really_old_crate-2.snap
+++ b/src/controllers/krate/snapshots/crates_io__controllers__krate__delete__tests__happy_path_really_old_crate-2.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: foo@example.com
@@ -28,5 +25,4 @@ Hi foo,
 
 Your "foo" crate has been deleted, per your request.
 
-If you did not initiate this deletion, your account may have been compromis=
-ed. Please contact us at help@crates.io.
+If you did not initiate this deletion, your account may have been compromised. Please contact us at help@crates.io.

--- a/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__happy_path-2.snap
+++ b/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__happy_path-2.snap
@@ -10,9 +10,7 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-crates.io user foo has added a new "Trusted Publishing" configuration for G=
-itHub Actions to a crate that you manage (foo). Trusted publishers act as t=
-rusted users and can publish new versions of the crate automatically.
+crates.io user foo has added a new "Trusted Publishing" configuration for GitHub Actions to a crate that you manage (foo). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
 
 Trusted Publishing configuration:
 
@@ -21,9 +19,6 @@ Trusted Publishing configuration:
 - Workflow filename: publish.yml
 - Environment: (not set)
 
-If you did not make this change and you think it was made maliciously, you =
-can remove the configuration from the crate via the "Settings" tab on the c=
-rate's page.
+If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
 
-If you are unable to revert the change and need to do so, you can email hel=
-p@crates.io to communicate with the crates.io support team.
+If you are unable to revert the change and need to do so, you can email help@crates.io to communicate with the crates.io support team.

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__happy_path.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__happy_path.snap
@@ -10,8 +10,7 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-crates.io user foo has remove a "Trusted Publishing" configuration for GitH=
-ub Actions from a crate that you manage (foo).
+crates.io user foo has remove a "Trusted Publishing" configuration for GitHub Actions from a crate that you manage (foo).
 
 Trusted Publishing configuration:
 
@@ -20,5 +19,4 @@ Trusted Publishing configuration:
 - Workflow filename: publish.yml
 - Environment: (not set)
 
-If you did not make this change and you think it was made maliciously, you =
-can email help@crates.io to communicate with the crates.io support team.
+If you did not make this change and you think it was made maliciously, you can email help@crates.io to communicate with the crates.io support team.

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-4.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__basics__new_krate-4.snap
@@ -10,9 +10,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_new (1.0.0) was published by your account =
-(https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo_new (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_success-2.snap
@@ -10,8 +10,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new API token with the name "bar" was recently added to your crates.io ac=
-count.
+A new API token with the name "bar" was recently added to your crates.io account.
 
-If this wasn't you, you should revoke the token immediately: https://crates=
-.io/settings/tokens
+If this wasn't you, you should revoke the token immediately: https://crates.io/settings/tokens

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_expiry_date-2.snap
@@ -10,8 +10,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new API token with the name "bar" was recently added to your crates.io ac=
-count.
+A new API token with the name "bar" was recently added to your crates.io account.
 
-If this wasn't you, you should revoke the token immediately: https://crates=
-.io/settings/tokens
+If this wasn't you, you should revoke the token immediately: https://crates.io/settings/tokens

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_null_scopes-2.snap
@@ -10,8 +10,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new API token with the name "bar" was recently added to your crates.io ac=
-count.
+A new API token with the name "bar" was recently added to your crates.io account.
 
-If this wasn't you, you should revoke the token immediately: https://crates=
-.io/settings/tokens
+If this wasn't you, you should revoke the token immediately: https://crates.io/settings/tokens

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_scopes-2.snap
@@ -10,8 +10,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new API token with the name "bar" was recently added to your crates.io ac=
-count.
+A new API token with the name "bar" was recently added to your crates.io account.
 
-If this wasn't you, you should revoke the token immediately: https://crates=
-.io/settings/tokens
+If this wasn't you, you should revoke the token immediately: https://crates.io/settings/tokens

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-3.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-3.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: foo@example.com
@@ -28,5 +25,4 @@ Hello foo!
 
 You have been unsubscribed from publish notifications.
 
-If you would like to resubscribe, please visit https://crates.io/settings/p=
-rofile
+If you would like to resubscribe, please visit https://crates.io/settings/profile

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-4.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-4.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: foo@example.com
@@ -28,5 +25,4 @@ Hello foo!
 
 You have been unsubscribed from publish notifications.
 
-If you would like to resubscribe, please visit https://crates.io/settings/p=
-rofile
+If you would like to resubscribe, please visit https://crates.io/settings/profile

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-6.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe-6.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: foo@example.com
@@ -28,8 +25,7 @@ Hello foo!
 
 You have been unsubscribed from publish notifications.
 
-If you would like to resubscribe, please visit https://crates.io/settings/p=
-rofile
+If you would like to resubscribe, please visit https://crates.io/settings/profile
 ----------------------------------------
 
 To: foo@example.com
@@ -40,9 +36,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.2.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.2.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.

--- a/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe.snap
+++ b/src/tests/routes/users/update/snapshots/crates_io__tests__routes__users__update__publish_notifications__unsubscribe_and_resubscribe.snap
@@ -10,9 +10,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo (1.0.0) was published by your account (htt=
-ps://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token-2.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_token-2.snap
@@ -8,11 +8,9 @@ Subject: crates.io: Your API token "bar" has been revoked
 Content-Type: text/plain; charset=utf-8
 Content-Transfer-Encoding: quoted-printable
 
-GitHub has notified us that your crates.io API token bar has been exposed p=
-ublicly. We have revoked this token as a precaution.
+GitHub has notified us that your crates.io API token bar has been exposed publicly. We have revoked this token as a precaution.
 
-Please review your account at https://crates.io to confirm that no unexpect=
-ed changes have been made to your settings or crates.
+Please review your account at https://crates.io to confirm that no unexpected changes have been made to your settings or crates.
 
 Source type: some_source
 

--- a/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners-6.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners-6.snap
@@ -10,10 +10,8 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate owners_multiple!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.
 ----------------------------------------
 
 To: user3@example.com
@@ -24,10 +22,8 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate owners_multiple!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.
 ----------------------------------------
 
 To: user2@example.com
@@ -38,10 +34,8 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate owners_multiple!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.
 ----------------------------------------
 
 To: user3@example.com
@@ -52,7 +46,5 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate owners_multiple!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.

--- a/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__modify_multiple_owners.snap
@@ -10,10 +10,8 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate owners_multiple!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.
 ----------------------------------------
 
 To: user3@example.com
@@ -24,7 +22,5 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate owners_multiple!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.

--- a/src/tests/snapshots/crates_io__tests__owners__new_crate_owner-2.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__new_crate_owner-2.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_owner (1.0.0) was published by your accoun=
-t (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo_owner (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: Bar@example.com
@@ -26,10 +23,8 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate foo_owner!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.
 ----------------------------------------
 
 To: foo@example.com
@@ -40,12 +35,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_owner (2.0.0) was published by Bar (https:=
-//crates.io/users/Bar) at [0000-00-00T00:00:00Z].
+A new version of the package foo_owner (2.0.0) was published by Bar (https://crates.io/users/Bar) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: Bar@example.com
@@ -56,9 +48,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello Bar!
 
-A new version of the package foo_owner (2.0.0) was published by your accoun=
-t (https://crates.io/users/Bar) at [0000-00-00T00:00:00Z].
+A new version of the package foo_owner (2.0.0) was published by your account (https://crates.io/users/Bar) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.

--- a/src/tests/snapshots/crates_io__tests__owners__new_crate_owner.snap
+++ b/src/tests/snapshots/crates_io__tests__owners__new_crate_owner.snap
@@ -10,12 +10,9 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello foo!
 
-A new version of the package foo_owner (1.0.0) was published by your accoun=
-t (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
+A new version of the package foo_owner (1.0.0) was published by your account (https://crates.io/users/foo) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.
 ----------------------------------------
 
 To: Bar@example.com
@@ -26,7 +23,5 @@ Content-Transfer-Encoding: quoted-printable
 
 foo has invited you to become an owner of the crate foo_owner!
 
-Visit https://crates.io/accept-invite/[invite-token] to accept =
-this invitation,
-or go to https://crates.io/me/pending-invites to manage all of your crate o=
-wnership invitations.
+Visit https://crates.io/accept-invite/[invite-token] to accept this invitation,
+or go to https://crates.io/me/pending-invites to manage all of your crate ownership invitations.

--- a/src/tests/snapshots/crates_io__tests__team__publish_owned.snap
+++ b/src/tests/snapshots/crates_io__tests__team__publish_owned.snap
@@ -10,9 +10,6 @@ Content-Transfer-Encoding: quoted-printable
 
 Hello user-all-teams!
 
-A new version of the package foo_team_owned (2.0.0) was published by user-o=
-ne-team (https://crates.io/users/user-one-team) at [0000-00-00T00:00:00Z].
+A new version of the package foo_team_owned (2.0.0) was published by user-one-team (https://crates.io/users/user-one-team) at [0000-00-00T00:00:00Z].
 
-If you have questions or security concerns, you can contact us at help@crat=
-es.io. If you would like to stop receiving these security notifications, yo=
-u can disable them in your account settings.
+If you have questions or security concerns, you can contact us at help@crates.io. If you would like to stop receiving these security notifications, you can disable them in your account settings.

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -194,6 +194,11 @@ impl TestApp {
             .await
             .into_iter()
             .map(|email| {
+                use quoted_printable::{ParseMode, decode};
+
+                let decoded_email = decode(&email, ParseMode::Robust).unwrap();
+                let email = String::from_utf8_lossy(&decoded_email);
+
                 let email = EMAIL_HEADER_REGEX.replace_all(&email, "");
                 let email = DATE_TIME_REGEX.replace_all(&email, "[0000-00-00T00:00:00Z]");
                 let email = EMAIL_CONFIRM_REGEX.replace_all(&email, "/confirm/[confirm-token]");


### PR DESCRIPTION
This ensures that the regex redactions also work across encoding linebreaks...

in other words, this should unblock https://github.com/rust-lang/crates.io/pull/11294 :)