### PR TITLE
crate/settings: Fix "Save" button caption to read "Add" instead

### DIFF
--- a/app/templates/crate/settings.hbs
+++ b/app/templates/crate/settings.hbs
@@ -15,7 +15,7 @@
       Username
     </label>
     <Input @type="text" id="new-owner-username" @value={{this.username}} placeholder="Username" local-class="email-input" name="username" />
-    <button type="submit" disabled={{not this.username}} class="button button--small" data-test-save-button>Save</button>
+    <button type="submit" disabled={{not this.username}} class="button button--small" data-test-save-button>Add</button>
   </form>
 {{/if}}
 


### PR DESCRIPTION
"Save" makes no sense in this context and appears to be a copy-paste mistake back from when the user email change form was copied...

Related:

- https://github.com/rust-lang/crates.io/pull/11301#discussion_r2129506871