### PR TITLE
Set `theme-color` to `header-bg-color`

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -25,6 +25,8 @@
 
     <meta property="og:image" content="{{og_image_url}}">
     <meta name="twitter:card" content="summary_large_image">
+
+    <meta name="theme-color" content="var(--header-bg-color)">
   </head>
   <body>
     <noscript>

--- a/config/manifest.js
+++ b/config/manifest.js
@@ -8,7 +8,6 @@ module.exports = function (/* environment, appConfig */) {
     start_url: '/',
     display: 'standalone',
     background_color: '#3b6837',
-    theme_color: '#f9f7ec',
     icons: [
       {
         src: '/assets/cargo.png',


### PR DESCRIPTION
Set `theme-color` to `header-bg-color` so that it respects the current theme color and user preference which seems to fix the upper part of the page being inconsistent on Safari (tested on iPhone 15):

<details>
<summary>System theme in light mode</summary>
<img src="https://github.com/user-attachments/assets/43c9f3c9-e6fa-45dc-a8da-022280c86082" height="700" />
</details>

<details>
<summary>Light theme in dark mode</summary>
<img src="https://github.com/user-attachments/assets/2b1740fb-9b44-48c8-ac4e-74c3798e0c83" height="700" />
</details>

<details>
<summary>System theme in dark mode</summary>
<img src="https://github.com/user-attachments/assets/9c22befa-746e-43da-aa36-2b73e18e4ef1" height="700" />
</details>

<details>
<summary>Dark mode in light theme</summary>
<img src="https://github.com/user-attachments/assets/83851baa-faeb-4e58-a789-87840ea2609b" height="700" />
</details>

Closes #11026