### PR TITLE
tests: Inline `assert_not_found()` and `assert_forbidden()` fns

### DIFF
--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -421,10 +421,8 @@ async fn invitations_are_empty_by_default_v1() {
 async fn api_token_cannot_list_invitations_v1() {
     let (_, _, _, token) = TestApp::init().with_token().await;
 
-    token
-        .get("/api/v1/me/crate_owner_invitations")
-        .await
-        .assert_forbidden();
+    let response = token.get::<()>("/api/v1/me/crate_owner_invitations").await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -5,6 +5,7 @@ use crate::tests::util::{MockAnonymousUser, RequestHelper, TestApp};
 use crates_io_database::schema::categories;
 use diesel::insert_into;
 use diesel_async::RunQueryDsl;
+use http::StatusCode;
 use insta::assert_json_snapshot;
 use serde_json::Value;
 
@@ -16,7 +17,8 @@ async fn show() -> anyhow::Result<()> {
     let url = "/api/v1/categories/foo-bar";
 
     // Return not found if a category doesn't exist
-    anon.get(url).await.assert_not_found();
+    let response = anon.get::<()>(url).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     // Create a category and a subcategory
     let cats = vec![

--- a/src/tests/routes/crates/following.rs
+++ b/src/tests/routes/crates/following.rs
@@ -1,13 +1,14 @@
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
+use http::StatusCode;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn diesel_not_found_results_in_404() {
     let (_, _, user) = TestApp::init().with_user().await;
 
-    user.get("/api/v1/crates/foo_following/following")
-        .await
-        .assert_not_found();
+    let url = "/api/v1/crates/foo_following/following";
+    let response = user.get::<()>(url).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -23,8 +24,7 @@ async fn disallow_api_token_auth_for_get_crate_following_status() {
         .await;
 
     // Token auth on GET for get following status is disallowed
-    token
-        .get(&format!("/api/v1/crates/{a_crate}/following"))
-        .await
-        .assert_forbidden();
+    let url = format!("/api/v1/crates/{a_crate}/following");
+    let response = token.get::<()>(&url).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -2,6 +2,7 @@ use crate::models::Keyword;
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::EncodableKeyword;
+use http::StatusCode;
 
 #[derive(Deserialize)]
 struct GoodKeyword {
@@ -14,7 +15,8 @@ async fn show() -> anyhow::Result<()> {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn().await;
 
-    anon.get(url).await.assert_not_found();
+    let response = anon.get::<()>(url).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     Keyword::find_or_create_all(&mut conn, &["foo"]).await?;
 
@@ -30,7 +32,8 @@ async fn uppercase() -> anyhow::Result<()> {
     let (app, anon) = TestApp::init().empty().await;
     let mut conn = app.db_conn().await;
 
-    anon.get(url).await.assert_not_found();
+    let response = anon.get::<()>(url).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 
     Keyword::find_or_create_all(&mut conn, &["UPPER"]).await?;
 

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -14,9 +14,8 @@ static NEW_BAR: &[u8] = br#"{ "api_token": { "name": "bar" } }"#;
 #[tokio::test(flavor = "multi_thread")]
 async fn create_token_logged_out() {
     let (_, anon) = TestApp::init().empty().await;
-    anon.put("/api/v1/me/tokens", NEW_BAR)
-        .await
-        .assert_forbidden();
+    let response = anon.put::<()>("/api/v1/me/tokens", NEW_BAR).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -8,7 +8,8 @@ use insta::assert_json_snapshot;
 async fn show_token_non_existing() {
     let url = "/api/v1/me/tokens/10086";
     let (_, _, user, _) = TestApp::init().with_token().await;
-    user.get(url).await.assert_not_found();
+    let response = user.get::<()>(url).await;
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -58,7 +59,8 @@ async fn show_token_with_scopes() {
 async fn show_with_anonymous_user() {
     let url = "/api/v1/me/tokens/1";
     let (_, anon) = TestApp::init().empty().await;
-    anon.get(url).await.assert_forbidden();
+    let response = anon.get::<()>(url).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -9,13 +9,15 @@ use serde_json::json;
 #[tokio::test(flavor = "multi_thread")]
 async fn list_logged_out() {
     let (_, anon) = TestApp::init().empty().await;
-    anon.get("/api/v1/me/tokens").await.assert_forbidden();
+    let response = anon.get::<()>("/api/v1/me/tokens").await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_with_api_token_is_forbidden() {
     let (_, _, _, token) = TestApp::init().with_token().await;
-    token.get("/api/v1/me/tokens").await.assert_forbidden();
+    let response = token.get::<()>("/api/v1/me/tokens").await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -13,7 +13,8 @@ use insta::assert_snapshot;
 #[tokio::test(flavor = "multi_thread")]
 async fn api_token_cannot_get_user_updates() {
     let (_, _, _, token) = TestApp::init().with_token().await;
-    token.get("/api/v1/me/updates").await.assert_forbidden();
+    let response = token.get::<()>("/api/v1/me/updates").await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -12,7 +12,8 @@ async fn using_token_updates_last_used_at() {
     let (app, anon, user, token) = TestApp::init().with_token().await;
     let mut conn = app.db_conn().await;
 
-    anon.get(url).await.assert_forbidden();
+    let response = anon.get::<()>(url).await;
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
     user.get::<EncodableMe>(url).await.good();
     assert_none!(token.as_model().last_used_at);
 

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -83,20 +83,6 @@ impl<T> Response<T> {
     }
 }
 
-impl Response<()> {
-    /// Assert that the status code is 404
-    #[track_caller]
-    pub fn assert_not_found(&self) {
-        assert_eq!(self.status(), StatusCode::NOT_FOUND);
-    }
-
-    /// Assert that the status code is 403
-    #[track_caller]
-    pub fn assert_forbidden(&self) {
-        assert_eq!(self.status(), StatusCode::FORBIDDEN);
-    }
-}
-
 fn json<T>(r: &hyper::Response<Bytes>) -> T
 where
     for<'de> T: serde::Deserialize<'de>,


### PR DESCRIPTION
These functions are somewhat inflexible, and while they use a more fluent chaining API, the rest of our assertions don't, which makes these a bit harder to use in some cases where other assertions are running on the same response instances.