### PR TITLE
insta: Update snapshots

### DIFF
--- a/crates/crates_io_database/tests/semver_ord.rs
+++ b/crates/crates_io_database/tests/semver_ord.rs
@@ -26,7 +26,7 @@ async fn test_jsonb_output() {
             .unwrap_or_default()
     };
 
-    insta::assert_snapshot!(check("0.0.0").await, @r#"[0, 0, 0, {}]"#);
+    insta::assert_snapshot!(check("0.0.0").await, @"[0, 0, 0, {}]");
     insta::assert_snapshot!(check("1.0.0-alpha.1").await, @r#"[1, 0, 0, [true, "alpha", false, 1, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, ""]]"#);
 
     // see https://crates.io/crates/cursed-trying-to-break-cargo/1.0.0-0.HDTV-BluRay.1020p.YTSUB.L33TRip.mkv – thanks @Gankra!

--- a/crates/crates_io_trustpub/src/github/claims.rs
+++ b/crates/crates_io_trustpub/src/github/claims.rs
@@ -191,7 +191,7 @@ mod tests {
         }))?;
 
         let error = GitHubClaims::decode(&jwt, AUDIENCE, &DECODING_KEY).unwrap_err();
-        assert_compact_debug_snapshot!(error, @r"Error(InvalidAudience)");
+        assert_compact_debug_snapshot!(error, @"Error(InvalidAudience)");
 
         Ok(())
     }

--- a/src/tests/krate/publish/dependencies.rs
+++ b/src/tests/krate/publish/dependencies.rs
@@ -313,7 +313,7 @@ async fn new_krate_with_patch() {
 
     let response = token.publish_crate(crate_to_publish).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    assert_snapshot!(response.text(), @r###"{"errors":[{"detail":"failed to parse `Cargo.toml` manifest file\n\ncrates cannot be published with `[patch]` tables"}]}"###);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"failed to parse `Cargo.toml` manifest file\n\ncrates cannot be published with `[patch]` tables"}]}"#);
     assert_that!(app.stored_files().await, empty());
 }
 


### PR DESCRIPTION
This is the result of running `cargo insta test --all --force-update-snapshots --unreferenced delete`. It updated a couple of snapshots to use less verbose escaping.