### PR TITLE
Allow empty and `Bearer` auth schemes in `Authorization` headers

### DIFF
--- a/crates/crates_io_trustpub/src/access_token.rs
+++ b/crates/crates_io_trustpub/src/access_token.rs
@@ -30,36 +30,6 @@ impl AccessToken {
         Self(raw.into())
     }
 
-    /// Parse a byte string into an access token.
-    ///
-    /// This can be used to convert an HTTP header value into an access token.
-    pub fn from_byte_str(byte_str: &[u8]) -> Result<Self, AccessTokenError> {
-        let suffix = byte_str
-            .strip_prefix(Self::PREFIX.as_bytes())
-            .ok_or(AccessTokenError::MissingPrefix)?;
-
-        if suffix.len() != Self::RAW_LENGTH + 1 {
-            return Err(AccessTokenError::InvalidLength);
-        }
-
-        let suffix = std::str::from_utf8(suffix).map_err(|_| AccessTokenError::InvalidCharacter)?;
-        if !suffix.chars().all(|c| char::is_ascii_alphanumeric(&c)) {
-            return Err(AccessTokenError::InvalidCharacter);
-        }
-
-        let raw = suffix.chars().take(Self::RAW_LENGTH).collect::<String>();
-        let claimed_checksum = suffix.chars().nth(Self::RAW_LENGTH).unwrap();
-        let actual_checksum = checksum(raw.as_bytes());
-        if claimed_checksum != actual_checksum {
-            return Err(AccessTokenError::InvalidChecksum {
-                claimed: claimed_checksum,
-                actual: actual_checksum,
-            });
-        }
-
-        Ok(Self(raw.into()))
-    }
-
     /// Wrap the raw access token with the token prefix and a checksum.
     ///
     /// This turns e.g. `ABC` into `cio_tp_ABC{checksum}`.
@@ -82,10 +52,30 @@ impl FromStr for AccessToken {
     type Err = AccessTokenError;
 
     /// Parse a string into an access token.
-    ///
-    /// This is equivalent to `AccessToken::from_byte_str`.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::from_byte_str(s.as_bytes())
+        let suffix = s
+            .strip_prefix(Self::PREFIX)
+            .ok_or(AccessTokenError::MissingPrefix)?;
+
+        if suffix.len() != Self::RAW_LENGTH + 1 {
+            return Err(AccessTokenError::InvalidLength);
+        }
+
+        if !suffix.chars().all(|c| char::is_ascii_alphanumeric(&c)) {
+            return Err(AccessTokenError::InvalidCharacter);
+        }
+
+        let raw = suffix.chars().take(Self::RAW_LENGTH).collect::<String>();
+        let claimed_checksum = suffix.chars().nth(Self::RAW_LENGTH).unwrap();
+        let actual_checksum = checksum(raw.as_bytes());
+        if claimed_checksum != actual_checksum {
+            return Err(AccessTokenError::InvalidChecksum {
+                claimed: claimed_checksum,
+                actual: actual_checksum,
+            });
+        }
+
+        Ok(Self(raw.into()))
     }
 }
 
@@ -141,42 +131,33 @@ mod tests {
     }
 
     #[test]
-    fn test_from_byte_str() {
+    fn test_from_str() {
         let token = AccessToken::generate().finalize();
         let token = token.expose_secret();
-        let token2 = assert_ok!(AccessToken::from_byte_str(token.as_bytes()));
+        let token2 = assert_ok!(token.parse::<AccessToken>());
         assert_eq!(token2.finalize().expose_secret(), token);
 
-        let bytes = b"cio_tp_0000000000000000000000000000000w";
-        assert_ok!(AccessToken::from_byte_str(bytes));
+        let str = "cio_tp_0000000000000000000000000000000w";
+        assert_ok!(str.parse::<AccessToken>());
 
-        let bytes = b"invalid_token";
-        assert_err_eq!(
-            AccessToken::from_byte_str(bytes),
-            AccessTokenError::MissingPrefix
-        );
+        let str = "invalid_token";
+        assert_err_eq!(str.parse::<AccessToken>(), AccessTokenError::MissingPrefix);
 
-        let bytes = b"cio_tp_invalid_token";
-        assert_err_eq!(
-            AccessToken::from_byte_str(bytes),
-            AccessTokenError::InvalidLength
-        );
+        let str = "cio_tp_invalid_token";
+        assert_err_eq!(str.parse::<AccessToken>(), AccessTokenError::InvalidLength);
 
-        let bytes = b"cio_tp_00000000000000000000000000";
-        assert_err_eq!(
-            AccessToken::from_byte_str(bytes),
-            AccessTokenError::InvalidLength
-        );
+        let str = "cio_tp_00000000000000000000000000";
+        assert_err_eq!(str.parse::<AccessToken>(), AccessTokenError::InvalidLength);
 
-        let bytes = b"cio_tp_000000@0000000000000000000000000";
+        let str = "cio_tp_000000@0000000000000000000000000";
         assert_err_eq!(
-            AccessToken::from_byte_str(bytes),
+            str.parse::<AccessToken>(),
             AccessTokenError::InvalidCharacter
         );
 
-        let bytes = b"cio_tp_00000000000000000000000000000000";
+        let str = "cio_tp_00000000000000000000000000000000";
         assert_err_eq!(
-            AccessToken::from_byte_str(bytes),
+            str.parse::<AccessToken>(),
             AccessTokenError::InvalidChecksum {
                 claimed: '0',
                 actual: 'w',

--- a/crates/crates_io_trustpub/src/access_token.rs
+++ b/crates/crates_io_trustpub/src/access_token.rs
@@ -2,6 +2,7 @@ use rand::distr::{Alphanumeric, SampleString};
 use secrecy::{ExposeSecret, SecretString};
 use sha2::digest::Output;
 use sha2::{Digest, Sha256};
+use std::str::FromStr;
 
 /// A temporary access token used to publish crates to crates.io using
 /// the "Trusted Publishing" feature.
@@ -74,6 +75,17 @@ impl AccessToken {
     /// the database to avoid storing the plaintext token.
     pub fn sha256(&self) -> Output<Sha256> {
         Sha256::digest(self.0.expose_secret())
+    }
+}
+
+impl FromStr for AccessToken {
+    type Err = AccessTokenError;
+
+    /// Parse a string into an access token.
+    ///
+    /// This is equivalent to `AccessToken::from_byte_str`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_byte_str(s.as_bytes())
     }
 }
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -25,13 +25,15 @@ impl AuthHeader {
         };
 
         let auth_header = auth_header.to_str().map_err(|_| {
-            let message = "Invalid authorization header";
+            let message = "Invalid `Authorization` header: Found unexpected non-ASCII characters";
             custom(StatusCode::UNAUTHORIZED, message)
         })?;
 
         let (scheme, token) = auth_header.split_once(' ').unwrap_or(("", auth_header));
         if !(scheme.eq_ignore_ascii_case("Bearer") || scheme.is_empty()) {
-            let message = "Invalid authorization header";
+            let message = format!(
+                "Invalid `Authorization` header: Found unexpected authentication scheme `{scheme}`"
+            );
             return Err(custom(StatusCode::UNAUTHORIZED, message));
         }
 
@@ -42,7 +44,7 @@ impl AuthHeader {
     pub async fn from_request_parts(parts: &Parts) -> Result<Self, BoxedAppError> {
         let auth = Self::optional_from_request_parts(parts).await?;
         auth.ok_or_else(|| {
-            let message = "Missing authorization header";
+            let message = "Missing `Authorization` header";
             custom(StatusCode::UNAUTHORIZED, message)
         })
     }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,7 +8,7 @@ use crate::util::errors::{
     internal,
 };
 use crate::util::token::HashedToken;
-use axum::extract::{FromRequestParts, OptionalFromRequestParts};
+use axum::extract::FromRequestParts;
 use chrono::Utc;
 use crates_io_session::SessionExtension;
 use diesel_async::AsyncPgConnection;
@@ -30,7 +30,7 @@ impl AuthHeader {
         })?;
 
         let (scheme, token) = auth_header.split_once(' ').unwrap_or(("", auth_header));
-        if !scheme.eq_ignore_ascii_case("Bearer") {
+        if !(scheme.eq_ignore_ascii_case("Bearer") || scheme.is_empty()) {
             let message = "Invalid authorization header";
             return Err(custom(StatusCode::UNAUTHORIZED, message));
         }
@@ -49,14 +49,6 @@ impl AuthHeader {
 
     pub fn token(&self) -> &SecretString {
         &self.0
-    }
-}
-
-impl<S: Send + Sync> OptionalFromRequestParts<S> for AuthHeader {
-    type Rejection = BoxedAppError;
-
-    async fn from_request_parts(parts: &mut Parts, _: &S) -> Result<Option<Self>, Self::Rejection> {
-        Self::optional_from_request_parts(parts).await
     }
 }
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -155,7 +155,7 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
                 return None;
             }
 
-            Some(AccessToken::from_byte_str(token.as_bytes()).map_err(|_| {
+            Some(token.parse::<AccessToken>().map_err(|_| {
                 let message = "Invalid `Authorization` header: Failed to parse token";
                 custom(StatusCode::UNAUTHORIZED, message)
             }))

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -1,7 +1,7 @@
 //! Functionality related to publishing a new crate or version of a crate.
 
 use crate::app::AppState;
-use crate::auth::{AuthCheck, Authentication};
+use crate::auth::{AuthCheck, AuthHeader, Authentication};
 use crate::worker::jobs::{
     self, CheckTyposquat, SendPublishNotificationsJob, UpdateDefaultVersion,
 };
@@ -19,8 +19,9 @@ use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use futures_util::TryFutureExt;
 use futures_util::TryStreamExt;
 use hex::ToHex;
+use http::StatusCode;
 use http::request::Parts;
-use http::{StatusCode, header};
+use secrecy::ExposeSecret;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use tokio::io::{AsyncRead, AsyncReadExt};
@@ -146,21 +147,20 @@ pub async fn publish(app: AppState, req: Parts, body: Body) -> AppResult<Json<Go
         .await
         .optional()?;
 
-    // Trusted publishing tokens are distinguished from regular crates.io API
-    // tokens because they use the `Bearer` auth scheme, so we look for that
-    // specific prefix.
-    let trustpub_token = req
-        .headers
-        .get(header::AUTHORIZATION)
-        .and_then(|h| {
-            let mut split = h.as_bytes().splitn(2, |b| *b == b' ');
-            Some((split.next()?, split.next()?))
+    let auth_header = AuthHeader::optional_from_request_parts(&req).await?;
+    let trustpub_token = auth_header
+        .and_then(|auth| {
+            let token = auth.token().expose_secret();
+            if !token.starts_with(AccessToken::PREFIX) {
+                return None;
+            }
+
+            Some(AccessToken::from_byte_str(token.as_bytes()).map_err(|_| {
+                let message = "Invalid `Authorization` header: Failed to parse token";
+                custom(StatusCode::UNAUTHORIZED, message)
+            }))
         })
-        .filter(|(scheme, _token)| scheme.eq_ignore_ascii_case(b"Bearer"))
-        .map(|(_scheme, token)| token.trim_ascii())
-        .map(AccessToken::from_byte_str)
-        .transpose()
-        .map_err(|_| forbidden("Invalid authentication token"))?;
+        .transpose()?;
 
     let auth = if let Some(trustpub_token) = trustpub_token {
         let Some(existing_crate) = &existing_crate else {

--- a/src/controllers/trustpub/tokens/exchange/tests.rs
+++ b/src/controllers/trustpub/tokens/exchange/tests.rs
@@ -83,7 +83,7 @@ async fn test_happy_path() -> anyhow::Result<()> {
     "#);
 
     let token = json["token"].as_str().unwrap();
-    let token = assert_ok!(AccessToken::from_byte_str(token.as_bytes()));
+    let token = assert_ok!(token.parse::<AccessToken>());
     let hashed_token = token.sha256();
 
     let mut conn = client.app().db_conn().await;

--- a/src/controllers/trustpub/tokens/revoke/mod.rs
+++ b/src/controllers/trustpub/tokens/revoke/mod.rs
@@ -1,10 +1,12 @@
 use crate::app::AppState;
+use crate::auth::AuthHeader;
 use crate::util::errors::{AppResult, custom};
 use crates_io_database::schema::trustpub_tokens;
 use crates_io_trustpub::access_token::AccessToken;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
-use http::{HeaderMap, StatusCode, header};
+use http::StatusCode;
+use secrecy::ExposeSecret;
 
 #[cfg(test)]
 mod tests;
@@ -20,18 +22,9 @@ mod tests;
     tag = "trusted_publishing",
     responses((status = 204, description = "Successful Response")),
 )]
-pub async fn revoke_trustpub_token(app: AppState, headers: HeaderMap) -> AppResult<StatusCode> {
-    let Some(auth_header) = headers.get(header::AUTHORIZATION) else {
-        let message = "Missing authorization header";
-        return Err(custom(StatusCode::UNAUTHORIZED, message));
-    };
-
-    let Some(bearer) = auth_header.as_bytes().strip_prefix(b"Bearer ") else {
-        let message = "Invalid authorization header";
-        return Err(custom(StatusCode::UNAUTHORIZED, message));
-    };
-
-    let Ok(token) = AccessToken::from_byte_str(bearer) else {
+pub async fn revoke_trustpub_token(app: AppState, auth: AuthHeader) -> AppResult<StatusCode> {
+    let token = auth.token().expose_secret();
+    let Ok(token) = AccessToken::from_byte_str(token.as_bytes()) else {
         let message = "Invalid authorization header";
         return Err(custom(StatusCode::UNAUTHORIZED, message));
     };

--- a/src/controllers/trustpub/tokens/revoke/mod.rs
+++ b/src/controllers/trustpub/tokens/revoke/mod.rs
@@ -24,7 +24,7 @@ mod tests;
 )]
 pub async fn revoke_trustpub_token(app: AppState, auth: AuthHeader) -> AppResult<StatusCode> {
     let token = auth.token().expose_secret();
-    let Ok(token) = AccessToken::from_byte_str(token.as_bytes()) else {
+    let Ok(token) = token.parse::<AccessToken>() else {
         let message = "Invalid `Authorization` header: Failed to parse token";
         return Err(custom(StatusCode::UNAUTHORIZED, message));
     };

--- a/src/controllers/trustpub/tokens/revoke/mod.rs
+++ b/src/controllers/trustpub/tokens/revoke/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 pub async fn revoke_trustpub_token(app: AppState, auth: AuthHeader) -> AppResult<StatusCode> {
     let token = auth.token().expose_secret();
     let Ok(token) = AccessToken::from_byte_str(token.as_bytes()) else {
-        let message = "Invalid authorization header";
+        let message = "Invalid `Authorization` header: Failed to parse token";
         return Err(custom(StatusCode::UNAUTHORIZED, message));
     };
 

--- a/src/controllers/trustpub/tokens/revoke/tests.rs
+++ b/src/controllers/trustpub/tokens/revoke/tests.rs
@@ -88,7 +88,7 @@ async fn test_missing_authorization_header() -> anyhow::Result<()> {
 
     let response = client.delete::<()>(URL).await;
     assert_snapshot!(response.status(), @"401 Unauthorized");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Missing authorization header"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Missing `Authorization` header"}]}"#);
 
     Ok(())
 }
@@ -103,7 +103,7 @@ async fn test_invalid_authorization_header_format() -> anyhow::Result<()> {
 
     let response = token_client.delete::<()>(URL).await;
     assert_snapshot!(response.status(), @"401 Unauthorized");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Invalid authorization header"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Invalid `Authorization` header: Failed to parse token"}]}"#);
 
     Ok(())
 }
@@ -118,7 +118,7 @@ async fn test_invalid_token_format() -> anyhow::Result<()> {
 
     let response = token_client.delete::<()>(URL).await;
     assert_snapshot!(response.status(), @"401 Unauthorized");
-    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Invalid authorization header"}]}"#);
+    assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Invalid `Authorization` header: Failed to parse token"}]}"#);
 
     Ok(())
 }

--- a/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__auth__new_krate_with_bearer_token-2.snap
+++ b/src/tests/krate/publish/snapshots/crates_io__tests__krate__publish__auth__new_krate_with_bearer_token-2.snap
@@ -1,0 +1,42 @@
+---
+source: src/tests/krate/publish/auth.rs
+expression: response.json()
+---
+{
+  "crate": {
+    "badges": [],
+    "categories": null,
+    "created_at": "[datetime]",
+    "default_version": "1.0.0",
+    "description": "description",
+    "documentation": null,
+    "downloads": 0,
+    "exact_match": false,
+    "homepage": null,
+    "id": "foo_new",
+    "keywords": null,
+    "links": {
+      "owner_team": "/api/v1/crates/foo_new/owner_team",
+      "owner_user": "/api/v1/crates/foo_new/owner_user",
+      "owners": "/api/v1/crates/foo_new/owners",
+      "reverse_dependencies": "/api/v1/crates/foo_new/reverse_dependencies",
+      "version_downloads": "/api/v1/crates/foo_new/downloads",
+      "versions": "/api/v1/crates/foo_new/versions"
+    },
+    "max_stable_version": "1.0.0",
+    "max_version": "1.0.0",
+    "name": "foo_new",
+    "newest_version": "1.0.0",
+    "num_versions": 1,
+    "recent_downloads": null,
+    "repository": null,
+    "updated_at": "[datetime]",
+    "versions": null,
+    "yanked": false
+  },
+  "warnings": {
+    "invalid_badges": [],
+    "invalid_categories": [],
+    "other": []
+  }
+}


### PR DESCRIPTION
`cargo publish` was built without using an auth scheme in the `Authorization` header. Regular HTTP client libraries often only support either basic or bearer authentication, but not empty auth schemes.

The regular API tokens currently only support an empty auth scheme, while Trusted Publishing was (mistakenly) built in a way to only support the `Bearer` auth scheme.

This PR adjusts both code paths to use a shared `Authorization` header extractor which allows usage of an empty auth scheme, or the `Bearer` auth scheme, regardless of the type of token that is used or the API endpoint it is used on.

Related:

- Resolves https://github.com/rust-lang/crates.io/issues/11347

