### PR TITLE
Replace yank button with a drop down menu

### DIFF
--- a/app/components/privileged-action.hbs
+++ b/app/components/privileged-action.hbs
@@ -1,14 +1,14 @@
 {{#if this.isPrivileged}}
-  <div>
+  <div ...attributes>
     {{yield}}
   </div>
 {{else if this.canBePrivileged}}
   {{#if (has-block 'placeholder')}}
-    <div>
+    <div ...attributes>
       {{yield to='placeholder'}}
     </div>
   {{else}}
-    <div local-class='placeholder'>
+    <div local-class='placeholder' ...attributes>
       <fieldset data-test-placeholder-fieldset disabled="disabled">
         {{yield}}
       </fieldset>
@@ -18,7 +18,7 @@
     </div>
   {{/if}}
 {{else}}
-  <div>
+  <div ...attributes>
     {{#if (has-block 'unprivileged')}}
       {{yield to='unprivileged'}}
     {{/if}}

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -117,7 +117,18 @@
     {{/if}}
   </div>
 
-  <PrivilegedAction @userAuthorised={{this.isOwner}}>
-    <YankButton @version={{@version}} local-class="yank-button" />
-  </PrivilegedAction>
+  <Dropdown local-class="dropdown" data-test-actions-menu as |dd|>
+    <dd.Trigger @hideArrow={{true}} local-class="trigger" data-test-actions-toggle>
+      {{svg-jar "ellipsis-circle" local-class="icon"}}
+      <span class="sr-only">Actions</span>
+    </dd.Trigger>
+
+    <dd.Menu local-class="menu" as |menu|>
+      <menu.Item>
+        <PrivilegedAction @userAuthorised={{this.isOwner}}>
+          <YankButton @version={{@version}} class="button-reset" local-class="menu-button" />
+        </PrivilegedAction>
+      </menu.Item>
+    </dd.Menu>
+  </Dropdown>
 </div>

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -117,7 +117,7 @@
     {{/if}}
   </div>
 
-  <PrivilegedAction @userAuthorised={{this.isOwner}}>
+  <PrivilegedAction @userAuthorised={{this.isOwner}} local-class="actions">
     <Dropdown local-class="dropdown" data-test-actions-menu as |dd|>
       <dd.Trigger @hideArrow={{true}} local-class="trigger" data-test-actions-toggle>
         {{svg-jar "ellipsis-circle" local-class="icon"}}

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -117,18 +117,20 @@
     {{/if}}
   </div>
 
-  <Dropdown local-class="dropdown" data-test-actions-menu as |dd|>
-    <dd.Trigger @hideArrow={{true}} local-class="trigger" data-test-actions-toggle>
-      {{svg-jar "ellipsis-circle" local-class="icon"}}
-      <span class="sr-only">Actions</span>
-    </dd.Trigger>
+  <PrivilegedAction @userAuthorised={{this.isOwner}}>
+    <Dropdown local-class="dropdown" data-test-actions-menu as |dd|>
+      <dd.Trigger @hideArrow={{true}} local-class="trigger" data-test-actions-toggle>
+        {{svg-jar "ellipsis-circle" local-class="icon"}}
+        <span class="sr-only">Actions</span>
+      </dd.Trigger>
 
-    <dd.Menu local-class="menu" as |menu|>
-      <menu.Item>
-        <PrivilegedAction @userAuthorised={{this.isOwner}}>
-          <YankButton @version={{@version}} class="button-reset" local-class="menu-button" />
-        </PrivilegedAction>
-      </menu.Item>
-    </dd.Menu>
-  </Dropdown>
+      <dd.Menu local-class="menu" as |menu|>
+        <menu.Item>
+          <PrivilegedAction @userAuthorised={{this.isOwner}}>
+            <YankButton @version={{@version}} class="button-reset" local-class="menu-button" />
+          </PrivilegedAction>
+        </menu.Item>
+      </dd.Menu>
+    </Dropdown>
+  </PrivilegedAction>
 </div>

--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -126,9 +126,7 @@
 
       <dd.Menu local-class="menu" as |menu|>
         <menu.Item>
-          <PrivilegedAction @userAuthorised={{this.isOwner}}>
-            <YankButton @version={{@version}} class="button-reset" local-class="menu-button" />
-          </PrivilegedAction>
+          <YankButton @version={{@version}} class="button-reset" local-class="menu-button" />
         </menu.Item>
       </dd.Menu>
     </Dropdown>

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -240,7 +240,7 @@
 }
 
 .icon {
-    width: 1.4em;
+    width: 2em;
     height: auto;
 }
 

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -235,11 +235,37 @@
     margin-top: var(--space-2xs);
 }
 
-.yank-button {
-    position: relative;
-    margin-left: var(--space-xs);
+.dropdown {
+    line-height: 1rem;
+}
 
-    @media only screen and (max-width: 550px) {
-        display: none;
+.icon {
+    width: 1.4em;
+    height: auto;
+}
+
+.trigger {
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+.menu {
+    right: 0;
+    min-width: max-content;
+}
+
+.menu-button {
+    align-items: center;
+    gap: var(--space-2xs);
+    cursor: pointer;
+    text-transform: capitalize;
+
+    /* This duplicates the styles in .button[disabled] as there's no
+     * obvious way to compose them, given the target selectors. */
+    &[disabled] {
+        background: linear-gradient(to bottom, var(--bg-color-top-light) 0%, var(--bg-color-bottom-light) 100%);
+        color: var(--disabled-text-color) !important;
+        cursor: not-allowed;
     }
 }

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -248,6 +248,14 @@
     background: none;
     border: none;
     padding: 0;
+    border-radius: 99999px;
+    color: var(--grey600);
+
+    :hover {
+        border-radius: 99999px;
+        color: var(--grey900);
+        background-color: white;
+    }
 }
 
 .menu {

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -235,7 +235,12 @@
     margin-top: var(--space-2xs);
 }
 
+.actions {
+    display: flex;
+}
+
 .dropdown {
+    display: flex;
     font-size: initial;
     line-height: 1rem;
 }
@@ -260,6 +265,7 @@
 }
 
 .menu {
+    top: 100%;
     right: 0;
     min-width: max-content;
 }

--- a/app/components/version-list/row.module.css
+++ b/app/components/version-list/row.module.css
@@ -236,6 +236,7 @@
 }
 
 .dropdown {
+    font-size: initial;
     line-height: 1rem;
 }
 

--- a/app/components/yank-button.hbs
+++ b/app/components/yank-button.hbs
@@ -1,7 +1,6 @@
 {{#if @version.yanked}}
   <button
     type="button"
-    class="button button--small"
     ...attributes
     data-test-version-unyank-button={{@version.num}}
     disabled={{@version.unyankTask.isRunning}}
@@ -16,7 +15,6 @@
 {{else}}
   <button
     type="button"
-    class="button button--small"
     ...attributes
     data-test-version-yank-button={{@version.num}}
     disabled={{@version.yankTask.isRunning}}

--- a/e2e/acceptance/sudo.spec.ts
+++ b/e2e/acceptance/sudo.spec.ts
@@ -52,6 +52,8 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-disable-admin-actions]')).toHaveCount(0);
     await expect(page.locator('[data-test-enable-admin-actions]')).toBeVisible();
 
+    await page.locator('[data-test-actions-toggle]').click();
+
     // Test that the fieldset is present and disabled.
     await expect(page.locator('[data-test-placeholder-fieldset]')).toBeVisible();
     // NOTE: `toBeDisabled()` is not working as expected because the element is not a form control element.
@@ -93,6 +95,8 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
     });
     expect(seen).toBe(1);
 
+    await page.locator('[data-test-actions-toggle]').click();
+
     // Test that the fieldset is not present.
     await expect(page.locator('[data-test-placeholder-fieldset]')).toHaveCount(0);
     await expect(page.locator('[data-test-version-yank-button="0.1.0"]')).toBeVisible();
@@ -105,6 +109,8 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
 
     await page.locator('[data-test-user-menu]').getByRole('button').click();
     await page.getByRole('button', { name: 'Enable admin actions' }).click();
+
+    await page.locator('[data-test-actions-toggle]').click();
 
     const yankButton = page.locator('[data-test-version-yank-button="0.1.0"]');
     const unyankButton = page.locator('[data-test-version-unyank-button="0.1.0"]');

--- a/e2e/acceptance/sudo.spec.ts
+++ b/e2e/acceptance/sudo.spec.ts
@@ -36,6 +36,8 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-disable-admin-actions]')).toHaveCount(0);
     await expect(page.locator('[data-test-enable-admin-actions]')).toHaveCount(0);
 
+    // Assert that there's no dropdown menu toggle, disabled, enabled, or in any state.
+    await expect(page.locator('[data-test-actions-toggle]')).toHaveCount(0);
     // Assert that there's no yank button, disabled, enabled, or in any state.
     await expect(page.locator('[data-test-version-yank-button="0.1.0"]')).toHaveCount(0);
   });
@@ -52,17 +54,14 @@ test.describe('Acceptance | sudo', { tag: '@acceptance' }, () => {
     await expect(page.locator('[data-test-disable-admin-actions]')).toHaveCount(0);
     await expect(page.locator('[data-test-enable-admin-actions]')).toBeVisible();
 
-    await page.locator('[data-test-actions-toggle]').click();
-
     // Test that the fieldset is present and disabled.
-    await expect(page.locator('[data-test-placeholder-fieldset]')).toBeVisible();
+    await expect(page.locator('[data-test-placeholder-fieldset]').first()).toBeVisible();
     // NOTE: `toBeDisabled()` is not working as expected because the element is not a form control element.
     // Ref: https://github.com/microsoft/playwright/issues/13583#issuecomment-1101704985
-    await expect(page.locator('[data-test-placeholder-fieldset]')).toHaveAttribute('disabled', 'disabled');
+    await expect(page.locator('[data-test-placeholder-fieldset]').first()).toHaveAttribute('disabled', 'disabled');
 
-    // From the perspective of the actual button, it isn't disabled, even though
-    // the fieldset effectively makes it unclickable.
-    await expect(page.locator('[data-test-version-yank-button="0.1.0"]')).toBeVisible();
+    await expect(page.locator('[data-test-actions-toggle]')).toBeDisabled();
+    await expect(page.locator('[data-test-version-yank-button="0.1.0"]')).toBeHidden();
   });
 
   test('admin user can enter sudo mode', async ({ page, msw }) => {

--- a/e2e/acceptance/versions.spec.ts
+++ b/e2e/acceptance/versions.spec.ts
@@ -52,6 +52,8 @@ test.describe('Acceptance | crate versions page', { tag: '@acceptance' }, () => 
     await expect(v020).not.toHaveClass(/.*latest/);
     await expect(v020).not.toHaveClass(/.yanked/);
 
+    await v021.locator('[data-test-actions-toggle]').click();
+
     // yanking
     await page.locator('[data-test-version-yank-button="0.2.1"]').click();
     await expect(v021).not.toHaveClass(/.*latest/);

--- a/public/assets/ellipsis-circle.svg
+++ b/public/assets/ellipsis-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M8.625 12a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H8.25m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0H12m4.125 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm0 0h-.375M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+</svg>

--- a/tests/acceptance/sudo-test.js
+++ b/tests/acceptance/sudo-test.js
@@ -43,6 +43,8 @@ module('Acceptance | sudo', function (hooks) {
     assert.dom('[data-test-disable-admin-actions]').doesNotExist();
     assert.dom('[data-test-enable-admin-actions]').doesNotExist();
 
+    // Assert that there's no dropdown menu toggle, disabled, enabled, or in any state.
+    assert.dom('[data-test-actions-toggle]').doesNotExist();
     // Assert that there's no yank button, disabled, enabled, or in any state.
     assert.dom('[data-test-version-yank-button="0.1.0"]').doesNotExist();
   });
@@ -57,13 +59,12 @@ module('Acceptance | sudo', function (hooks) {
     assert.dom('[data-test-disable-admin-actions]').doesNotExist();
     assert.dom('[data-test-enable-admin-actions]').exists();
 
-    await click('[data-test-actions-toggle]');
-
     // Test that the fieldset is present and disabled.
     assert.dom('[data-test-placeholder-fieldset]').exists().isDisabled();
 
     // From the perspective of the actual button, it isn't disabled, even though
     // the fieldset effectively makes it unclickable.
+    assert.dom('[data-test-actions-toggle]').exists();
     assert.dom('[data-test-version-yank-button="0.1.0"]').exists();
   });
 

--- a/tests/acceptance/sudo-test.js
+++ b/tests/acceptance/sudo-test.js
@@ -57,6 +57,8 @@ module('Acceptance | sudo', function (hooks) {
     assert.dom('[data-test-disable-admin-actions]').doesNotExist();
     assert.dom('[data-test-enable-admin-actions]').exists();
 
+    await click('[data-test-actions-toggle]');
+
     // Test that the fieldset is present and disabled.
     assert.dom('[data-test-placeholder-fieldset]').exists().isDisabled();
 
@@ -90,6 +92,8 @@ module('Acceptance | sudo', function (hooks) {
     }
     assert.strictEqual(seen, 1);
 
+    await click('[data-test-actions-toggle]');
+
     // Test that the fieldset is not present.
     assert.dom('[data-test-placeholder-fieldset]').doesNotExist();
     assert.dom('[data-test-version-yank-button="0.1.0"]').exists();
@@ -100,6 +104,8 @@ module('Acceptance | sudo', function (hooks) {
 
     await visit('/crates/foo/versions');
     await click('[data-test-enable-admin-actions]');
+
+    await click('[data-test-actions-toggle]');
 
     await click('[data-test-version-yank-button="0.1.0"]');
 

--- a/tests/acceptance/versions-test.js
+++ b/tests/acceptance/versions-test.js
@@ -57,6 +57,8 @@ module('Acceptance | crate versions page', function (hooks) {
       .hasNoClass(/.*latest/)
       .hasNoClass(/.yanked/);
 
+    await click('[data-test-actions-toggle]');
+
     // yanking
     await click('[data-test-version-yank-button="0.2.1"]');
     assert


### PR DESCRIPTION
We plan to add more actions in the future, and to prevent too many buttons from showing on each row and on small-screen devices, @Turbo87 suggests we should use a drop down menu instead.

Resolves #11139.