### PR TITLE
msw: Implement relevant Trusted Publishing endpoints

### DIFF
--- a/packages/crates-io-msw/handlers/trustpub.js
+++ b/packages/crates-io-msw/handlers/trustpub.js
@@ -1,0 +1,3 @@
+import gitHubConfigs from './trustpub/github-configs.js';
+
+export default [...gitHubConfigs];

--- a/packages/crates-io-msw/handlers/trustpub/github-configs.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs.js
@@ -1,0 +1,5 @@
+import createGitHubConfig from './github-configs/create.js';
+import deleteGitHubConfig from './github-configs/delete.js';
+import listGitHubConfigs from './github-configs/list.js';
+
+export default [listGitHubConfigs, createGitHubConfig, deleteGitHubConfig];

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/create.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/create.js
@@ -1,0 +1,60 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../../index.js';
+import { serializeGitHubConfig } from '../../../serializers/trustpub/github-config.js';
+import { notFound } from '../../../utils/handlers.js';
+import { getSession } from '../../../utils/session.js';
+
+export default http.post('/api/v1/trusted_publishing/github_configs', async ({ request }) => {
+  let { user } = getSession();
+  if (!user) {
+    return HttpResponse.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
+  }
+
+  let body = await request.json();
+
+  let { github_config } = body;
+  if (!github_config) {
+    return HttpResponse.json({ errors: [{ detail: 'invalid request body' }] }, { status: 400 });
+  }
+
+  let { crate: crateName, repository_owner, repository_name, workflow_filename, environment } = github_config;
+  if (!crateName || !repository_owner || !repository_name || !workflow_filename) {
+    return HttpResponse.json({ errors: [{ detail: 'missing required fields' }] }, { status: 400 });
+  }
+
+  let crate = db.crate.findFirst({ where: { name: { equals: crateName } } });
+  if (!crate) return notFound();
+
+  // Check if the user is an owner of the crate
+  let isOwner = db.crateOwnership.findFirst({
+    where: {
+      crate: { id: { equals: crate.id } },
+      user: { id: { equals: user.id } },
+    },
+  });
+  if (!isOwner) {
+    return HttpResponse.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
+  }
+
+  // Check if the user has a verified email
+  let hasVerifiedEmail = user.emailVerified;
+  if (!hasVerifiedEmail) {
+    let detail = 'You must verify your email address to create a Trusted Publishing config';
+    return HttpResponse.json({ errors: [{ detail }] }, { status: 403 });
+  }
+
+  // Create a new GitHub config
+  let config = db.trustpubGithubConfig.create({
+    crate,
+    repository_owner,
+    repository_name,
+    workflow_filename,
+    environment: environment ?? null,
+    created_at: new Date().toISOString(),
+  });
+
+  return HttpResponse.json({
+    github_config: serializeGitHubConfig(config),
+  });
+});

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/create.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/create.test.js
@@ -1,0 +1,227 @@
+import { afterEach, assert, beforeEach, test, vi } from 'vitest';
+
+import { db } from '../../../index.js';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test('happy path', async function () {
+  vi.setSystemTime(new Date('2023-01-01T00:00:00Z'));
+
+  let crate = db.crate.create({ name: 'test-crate' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ emailVerified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({
+      github_config: {
+        crate: crate.name,
+        repository_owner: 'rust-lang',
+        repository_name: 'crates.io',
+        workflow_filename: 'ci.yml',
+      },
+    }),
+  });
+
+  assert.strictEqual(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    github_config: {
+      id: 1,
+      crate: crate.name,
+      repository_owner: 'rust-lang',
+      repository_owner_id: 5_430_905,
+      repository_name: 'crates.io',
+      workflow_filename: 'ci.yml',
+      environment: null,
+      created_at: '2023-01-01T00:00:00.000Z',
+    },
+  });
+});
+
+test('happy path with environment', async function () {
+  vi.setSystemTime(new Date('2023-02-01T00:00:00Z'));
+
+  let crate = db.crate.create({ name: 'test-crate-env' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ emailVerified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({
+      github_config: {
+        crate: crate.name,
+        repository_owner: 'rust-lang',
+        repository_name: 'crates.io',
+        workflow_filename: 'ci.yml',
+        environment: 'production',
+      },
+    }),
+  });
+
+  assert.strictEqual(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    github_config: {
+      id: 1,
+      crate: crate.name,
+      repository_owner: 'rust-lang',
+      repository_owner_id: 5_430_905,
+      repository_name: 'crates.io',
+      workflow_filename: 'ci.yml',
+      environment: 'production',
+      created_at: '2023-02-01T00:00:00.000Z',
+    },
+  });
+});
+
+test('returns 403 if unauthenticated', async function () {
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({
+      github_config: {
+        crate: 'test-crate',
+        repository_owner: 'rust-lang',
+        repository_name: 'crates.io',
+        workflow_filename: 'ci.yml',
+      },
+    }),
+  });
+
+  assert.strictEqual(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'must be logged in to perform that action' }],
+  });
+});
+
+test('returns 400 if request body is invalid', async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'invalid request body' }],
+  });
+});
+
+test('returns 400 if required fields are missing', async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({
+      github_config: {
+        crate: 'test-crate',
+      },
+    }),
+  });
+
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'missing required fields' }],
+  });
+});
+
+test("returns 404 if crate can't be found", async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({
+      github_config: {
+        crate: 'nonexistent',
+        repository_owner: 'rust-lang',
+        repository_name: 'crates.io',
+        workflow_filename: 'ci.yml',
+      },
+    }),
+  });
+
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'Not Found' }],
+  });
+});
+
+test('returns 400 if user is not an owner of the crate', async function () {
+  let crate = db.crate.create({ name: 'test-crate-not-owner' });
+  db.version.create({ crate });
+
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({
+      github_config: {
+        crate: crate.name,
+        repository_owner: 'rust-lang',
+        repository_name: 'crates.io',
+        workflow_filename: 'ci.yml',
+      },
+    }),
+  });
+
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'You are not an owner of this crate' }],
+  });
+});
+
+test('returns 403 if user email is not verified', async function () {
+  let crate = db.crate.create({ name: 'test-crate-unverified' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ emailVerified: false });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs', {
+    method: 'POST',
+    body: JSON.stringify({
+      github_config: {
+        crate: crate.name,
+        repository_owner: 'rust-lang',
+        repository_name: 'crates.io',
+        workflow_filename: 'ci.yml',
+      },
+    }),
+  });
+
+  assert.strictEqual(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'You must verify your email address to create a Trusted Publishing config' }],
+  });
+});

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/delete.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/delete.js
@@ -1,0 +1,32 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../../index.js';
+import { notFound } from '../../../utils/handlers.js';
+import { getSession } from '../../../utils/session.js';
+
+export default http.delete('/api/v1/trusted_publishing/github_configs/:id', ({ params }) => {
+  let { user } = getSession();
+  if (!user) {
+    return HttpResponse.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
+  }
+
+  let id = parseInt(params.id);
+  let config = db.trustpubGithubConfig.findFirst({ where: { id: { equals: id } } });
+  if (!config) return notFound();
+
+  // Check if the user is an owner of the crate
+  let isOwner = db.crateOwnership.findFirst({
+    where: {
+      crate: { id: { equals: config.crate.id } },
+      user: { id: { equals: user.id } },
+    },
+  });
+  if (!isOwner) {
+    return HttpResponse.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
+  }
+
+  // Delete the config
+  db.trustpubGithubConfig.delete({ where: { id: { equals: id } } });
+
+  return new HttpResponse(null, { status: 204 });
+});

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/delete.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/delete.test.js
@@ -1,0 +1,109 @@
+import { assert, test } from 'vitest';
+
+import { db } from '../../../index.js';
+
+test('happy path', async function () {
+  let crate = db.crate.create({ name: 'test-crate' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ email_verified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  // Create GitHub config
+  let config = db.trustpubGithubConfig.create({
+    crate,
+    repository_owner: 'rust-lang',
+    repository_name: 'crates.io',
+    workflow_filename: 'ci.yml',
+    created_at: '2023-01-01T00:00:00Z',
+  });
+
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs/${config.id}`, {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 204);
+  assert.strictEqual(await response.text(), '');
+
+  // Verify the config was deleted
+  let deletedConfig = db.trustpubGithubConfig.findFirst({ where: { id: { equals: config.id } } });
+  assert.strictEqual(deletedConfig, null);
+});
+
+test('returns 403 if unauthenticated', async function () {
+  let response = await fetch('/api/v1/trusted_publishing/github_configs/1', {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'must be logged in to perform that action' }],
+  });
+});
+
+test('returns 404 if config ID is invalid', async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs/invalid', {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'Not Found' }],
+  });
+});
+
+test("returns 404 if config can't be found", async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/trusted_publishing/github_configs/999999', {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'Not Found' }],
+  });
+});
+
+test('returns 400 if user is not an owner of the crate', async function () {
+  let crate = db.crate.create({ name: 'test-crate-not-owner' });
+  db.version.create({ crate });
+
+  let owner = db.user.create();
+  db.crateOwnership.create({
+    crate,
+    user: owner,
+  });
+
+  // Create GitHub config
+  let config = db.trustpubGithubConfig.create({
+    crate,
+    repository_owner: 'rust-lang',
+    repository_name: 'crates.io',
+    workflow_filename: 'ci.yml',
+    created_at: '2023-01-01T00:00:00Z',
+  });
+
+  // Login as a different user
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs/${config.id}`, {
+    method: 'DELETE',
+  });
+
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'You are not an owner of this crate' }],
+  });
+});

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/list.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/list.js
@@ -1,0 +1,42 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../../index.js';
+import { serializeGitHubConfig } from '../../../serializers/trustpub/github-config.js';
+import { notFound } from '../../../utils/handlers.js';
+import { getSession } from '../../../utils/session.js';
+
+export default http.get('/api/v1/trusted_publishing/github_configs', ({ request }) => {
+  let url = new URL(request.url);
+
+  let { user } = getSession();
+  if (!user) {
+    return HttpResponse.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
+  }
+
+  let crateName = url.searchParams.get('crate');
+  if (!crateName) {
+    return HttpResponse.json({ errors: [{ detail: 'missing or invalid filter' }] }, { status: 400 });
+  }
+
+  let crate = db.crate.findFirst({ where: { name: { equals: crateName } } });
+  if (!crate) return notFound();
+
+  // Check if the user is an owner of the crate
+  let isOwner = db.crateOwnership.findFirst({
+    where: {
+      crate: { id: { equals: crate.id } },
+      user: { id: { equals: user.id } },
+    },
+  });
+  if (!isOwner) {
+    return HttpResponse.json({ errors: [{ detail: 'You are not an owner of this crate' }] }, { status: 400 });
+  }
+
+  let configs = db.trustpubGithubConfig.findMany({
+    where: { crate: { id: { equals: crate.id } } },
+  });
+
+  return HttpResponse.json({
+    github_configs: configs.map(config => serializeGitHubConfig(config)),
+  });
+});

--- a/packages/crates-io-msw/handlers/trustpub/github-configs/list.test.js
+++ b/packages/crates-io-msw/handlers/trustpub/github-configs/list.test.js
@@ -1,0 +1,128 @@
+import { assert, test } from 'vitest';
+
+import { db } from '../../../index.js';
+
+test('happy path', async function () {
+  let crate = db.crate.create({ name: 'test-crate' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ email_verified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  // Create GitHub configs
+  let config1 = db.trustpubGithubConfig.create({
+    crate,
+    repository_owner: 'rust-lang',
+    repository_owner_id: 1,
+    repository_name: 'crates.io',
+    workflow_filename: 'ci.yml',
+    created_at: '2023-01-01T00:00:00Z',
+  });
+
+  let config2 = db.trustpubGithubConfig.create({
+    crate,
+    repository_owner: 'rust-lang',
+    repository_owner_id: 42,
+    repository_name: 'cargo',
+    workflow_filename: 'release.yml',
+    environment: 'production',
+    created_at: '2023-02-01T00:00:00Z',
+  });
+
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs?crate=${crate.name}`);
+  assert.strictEqual(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    github_configs: [
+      {
+        id: Number(config1.id),
+        crate: crate.name,
+        repository_owner: 'rust-lang',
+        repository_owner_id: 1,
+        repository_name: 'crates.io',
+        workflow_filename: 'ci.yml',
+        environment: null,
+        created_at: '2023-01-01T00:00:00Z',
+      },
+      {
+        id: Number(config2.id),
+        crate: crate.name,
+        repository_owner: 'rust-lang',
+        repository_owner_id: 42,
+        repository_name: 'cargo',
+        workflow_filename: 'release.yml',
+        environment: 'production',
+        created_at: '2023-02-01T00:00:00Z',
+      },
+    ],
+  });
+});
+
+test('happy path with no configs', async function () {
+  let crate = db.crate.create({ name: 'test-crate-empty' });
+  db.version.create({ crate });
+
+  let user = db.user.create({ email_verified: true });
+  db.mswSession.create({ user });
+
+  // Create crate ownership
+  db.crateOwnership.create({
+    crate,
+    user,
+  });
+
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs?crate=${crate.name}`);
+  assert.strictEqual(response.status, 200);
+  assert.deepEqual(await response.json(), {
+    github_configs: [],
+  });
+});
+
+test('returns 403 if unauthenticated', async function () {
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs?crate=test-crate`);
+  assert.strictEqual(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'must be logged in to perform that action' }],
+  });
+});
+
+test('returns 400 if query params are missing', async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs`);
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'missing or invalid filter' }],
+  });
+});
+
+test("returns 404 if crate can't be found", async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs?crate=nonexistent`);
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'Not Found' }],
+  });
+});
+
+test('returns 400 if user is not an owner of the crate', async function () {
+  let crate = db.crate.create({ name: 'test-crate-not-owner' });
+  db.version.create({ crate });
+
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch(`/api/v1/trusted_publishing/github_configs?crate=${crate.name}`);
+  assert.strictEqual(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'You are not an owner of this crate' }],
+  });
+});

--- a/packages/crates-io-msw/index.js
+++ b/packages/crates-io-msw/index.js
@@ -9,6 +9,7 @@ import playgroundHandlers from './handlers/playground.js';
 import sessionHandlers from './handlers/sessions.js';
 import summaryHandlers from './handlers/summary.js';
 import teamHandlers from './handlers/teams.js';
+import trustpubHandlers from './handlers/trustpub.js';
 import userHandlers from './handlers/users.js';
 import versionHandlers from './handlers/versions.js';
 import apiToken from './models/api-token.js';
@@ -20,6 +21,7 @@ import dependency from './models/dependency.js';
 import keyword from './models/keyword.js';
 import mswSession from './models/msw-session.js';
 import team from './models/team.js';
+import trustpubGithubConfig from './models/trustpub/github-config.js';
 import user from './models/user.js';
 import versionDownload from './models/version-download.js';
 import version from './models/version.js';
@@ -37,6 +39,7 @@ export const handlers = [
   ...sessionHandlers,
   ...summaryHandlers,
   ...teamHandlers,
+  ...trustpubHandlers,
   ...userHandlers,
   ...versionHandlers,
 ];
@@ -51,6 +54,7 @@ export const db = factory({
   keyword,
   mswSession,
   team,
+  trustpubGithubConfig,
   user,
   versionDownload,
   version,

--- a/packages/crates-io-msw/models/trustpub/github-config.js
+++ b/packages/crates-io-msw/models/trustpub/github-config.js
@@ -1,0 +1,25 @@
+import { nullable, oneOf, primaryKey } from '@mswjs/data';
+
+import { applyDefault } from '../../utils/defaults.js';
+
+export default {
+  id: primaryKey(Number),
+
+  crate: oneOf('crate'),
+  repository_owner: String,
+  repository_owner_id: Number,
+  repository_name: String,
+  workflow_filename: String,
+  environment: nullable(String),
+  created_at: String,
+
+  preCreate(attrs, counter) {
+    applyDefault(attrs, 'id', () => counter);
+    applyDefault(attrs, 'repository_owner', () => 'rust-lang');
+    applyDefault(attrs, 'repository_owner_id', () => 5_430_905);
+    applyDefault(attrs, 'repository_name', () => `repo-${attrs.id}`);
+    applyDefault(attrs, 'workflow_filename', () => 'ci.yml');
+    applyDefault(attrs, 'environment', () => null);
+    applyDefault(attrs, 'created_at', () => '2023-01-01T00:00:00Z');
+  },
+};

--- a/packages/crates-io-msw/serializers/trustpub/github-config.js
+++ b/packages/crates-io-msw/serializers/trustpub/github-config.js
@@ -1,0 +1,10 @@
+import { serializeModel } from '../../utils/serializers.js';
+
+export function serializeGitHubConfig(config) {
+  let serialized = serializeModel(config);
+
+  // Extract crate name from the crate relationship
+  serialized.crate = serialized.crate.name;
+
+  return serialized;
+}


### PR DESCRIPTION
This commit implements the three `/api/v1/trusted_publishing/github_configs` endpoints (list, create, delete). It adds a dedicated `trustpubGithubConfig` model and corresponding serializer and then uses them to implement the endpoints. As usual with msw, this is a relatively simple implementation, but good enough for our frontend test suite.