### PR TITLE
trustpub: Change `PUT /api/v1/trusted_publishing/github_configs` endpoint to `POST`

### DIFF
--- a/src/controllers/trustpub/github_configs/create/mod.rs
+++ b/src/controllers/trustpub/github_configs/create/mod.rs
@@ -23,7 +23,7 @@ mod tests;
 
 /// Create a new Trusted Publishing configuration for GitHub Actions.
 #[utoipa::path(
-    put,
+    post,
     path = "/api/v1/trusted_publishing/github_configs",
     security(("cookie" = [])),
     request_body = inline(json::CreateRequest),

--- a/src/controllers/trustpub/github_configs/create/tests.rs
+++ b/src/controllers/trustpub/github_configs/create/tests.rs
@@ -41,7 +41,7 @@ async fn run_test(payload: impl Into<Bytes>) -> (TestApp, Response<()>) {
             .await
             .unwrap();
 
-        (app, cookie_client.put::<()>(URL, payload).await)
+        (app, cookie_client.post::<()>(URL, payload).await)
     }
 
     inner(payload.into()).await
@@ -213,7 +213,7 @@ async fn test_unauthenticated() -> anyhow::Result<()> {
         }
     }))?;
 
-    let response = client.put::<()>(URL, body).await;
+    let response = client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"403 Forbidden");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action requires authentication"}]}"#);
 
@@ -243,7 +243,7 @@ async fn test_token_auth() -> anyhow::Result<()> {
         }
     }))?;
 
-    let response = token_client.put::<()>(URL, body).await;
+    let response = token_client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"403 Forbidden");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"this action can only be performed on the crates.io website"}]}"#);
 
@@ -267,7 +267,7 @@ async fn test_missing_crate() -> anyhow::Result<()> {
         }
     }))?;
 
-    let response = cookie_client.put::<()>(URL, body).await;
+    let response = cookie_client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"404 Not Found");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"crate `foo` does not exist"}]}"#);
 
@@ -299,7 +299,7 @@ async fn test_non_owner() -> anyhow::Result<()> {
         }
     }))?;
 
-    let response = other_client.put::<()>(URL, body).await;
+    let response = other_client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"400 Bad Request");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"You are not an owner of this crate"}]}"#);
 
@@ -331,7 +331,7 @@ async fn test_unknown_github_user() -> anyhow::Result<()> {
         }
     }))?;
 
-    let response = cookie_client.put::<()>(URL, body).await;
+    let response = cookie_client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"400 Bad Request");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Unknown GitHub user or organization"}]}"#);
 
@@ -363,7 +363,7 @@ async fn test_github_error() -> anyhow::Result<()> {
         }
     }))?;
 
-    let response = cookie_client.put::<()>(URL, body).await;
+    let response = cookie_client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"500 Internal Server Error");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"Internal Server Error"}]}"#);
 
@@ -398,7 +398,7 @@ async fn test_unverified_email() -> anyhow::Result<()> {
         }
     }))?;
 
-    let response = cookie_client.put::<()>(URL, body).await;
+    let response = cookie_client.post::<()>(URL, body).await;
     assert_snapshot!(response.status(), @"403 Forbidden");
     assert_snapshot!(response.text(), @r#"{"errors":[{"detail":"You must verify your email address to create a Trusted Publishing config"}]}"#);
 

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
@@ -4227,7 +4227,7 @@ expression: response.json()
           "trusted_publishing"
         ]
       },
-      "put": {
+      "post": {
         "operationId": "create_trustpub_github_config",
         "requestBody": {
           "content": {

--- a/src/tests/krate/publish/trustpub.rs
+++ b/src/tests/krate/publish/trustpub.rs
@@ -77,7 +77,7 @@ async fn test_full_flow() -> anyhow::Result<()> {
     }))?;
 
     let url = "/api/v1/trusted_publishing/github_configs";
-    let response = cookie_client.put::<()>(url, body).await;
+    let response = cookie_client.post::<()>(url, body).await;
 
     assert_json_snapshot!(response.json(), { ".github_config.created_at" => "[datetime]" }, @r#"
     {


### PR DESCRIPTION
`PUT` should be used for updates, not for resource creation. The conventional HTTP method for resource creation in REST APIs is `POST`.

The endpoint is currently limited to cookie authentication and not used yet by the frontend, so this change can still be made without it breaking anyone :)

Related:

- https://github.com/rust-lang/crates.io/issues/10247
- https://github.com/rust-lang/crates.io/pull/11113