### PR TITLE
trustpub: Change `PUT /api/v1/trusted_publishing/tokens` endpoint to `POST`

### DIFF
--- a/src/controllers/trustpub/tokens/exchange/mod.rs
+++ b/src/controllers/trustpub/tokens/exchange/mod.rs
@@ -20,7 +20,7 @@ mod tests;
 
 /// Exchange an OIDC token for a temporary access token.
 #[utoipa::path(
-    put,
+    post,
     path = "/api/v1/trusted_publishing/tokens",
     request_body = inline(json::ExchangeRequest),
     tag = "trusted_publishing",

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
@@ -4328,7 +4328,7 @@ expression: response.json()
           "trusted_publishing"
         ]
       },
-      "put": {
+      "post": {
         "operationId": "exchange_trustpub_token",
         "requestBody": {
           "content": {

--- a/src/tests/krate/publish/trustpub.rs
+++ b/src/tests/krate/publish/trustpub.rs
@@ -109,7 +109,7 @@ async fn test_full_flow() -> anyhow::Result<()> {
 
     let body = serde_json::to_vec(&json!({ "jwt": jwt }))?;
     let response = client
-        .put::<()>("/api/v1/trusted_publishing/tokens", body)
+        .post::<()>("/api/v1/trusted_publishing/tokens", body)
         .await;
     let json = response.json();
     assert_json_snapshot!(json, { ".token" => "[token]" }, @r#"


### PR DESCRIPTION
`PUT` should be used for updates, not for resource creation. The conventional HTTP method for resource creation in REST APIs is `POST`. This also matches what PyPI is using.

The endpoint is already used by the experimental GitHub Action, but since we control that and are aware of the change we can easily fix it on that side :)

Related:

- https://github.com/rust-lang/crates.io/issues/10247
- https://github.com/rust-lang/crates.io/pull/11131
- https://github.com/rust-lang/crates.io/pull/11390