### PR TITLE
Require verified email address to accept a crate ownership invitation

### DIFF
--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -415,6 +415,14 @@ impl From<AcceptError> for BoxedAppError {
 
                 custom(StatusCode::GONE, detail)
             }
+            AcceptError::EmailNotVerified { crate_name } => {
+                let detail = format!(
+                    "You need to verify your email address before you can accept the invitation \
+                    to become an owner of the {crate_name} crate.",
+                );
+
+                custom(StatusCode::FORBIDDEN, detail)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR implements https://github.com/rust-lang/crates.io/issues/6335, by returning errors to users with unverified email addresses that attempt to accept ownership invitations.