### PR TITLE
controllers/github/secret_scanning: Add support for Trusted Publishing tokens

### DIFF
--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_unknown_trustpub_token-2.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_for_unknown_trustpub_token-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: response.json()
+---
+[
+  {
+    "label": "false_positive",
+    "token_raw": "[token]",
+    "token_type": "some_type"
+  }
+]

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token-2.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: response.json()
+---
+[
+  {
+    "label": "true_positive",
+    "token_raw": "[token]",
+    "token_type": "some_type"
+  }
+]


### PR DESCRIPTION
This implements the final todo item of the Trusted Publishing backend work (see https://github.com/rust-lang/crates.io/issues/10247).

If a passed in token is successfully parsed as a Trusted Publishing token, the token is automatically revoked and a warning is logged.

Since these tokens belong to a crate (or multiple) instead of a user I have not implemented email notifications for them (yet). Should we email all owners of the crate in case a Trusted Publishing token is leaked? I guess we could also implement that in a follow-up PR, if we decide that we want that.