### PR TITLE
msw: Implement simplified docs rebuild endpoint

### DIFF
--- a/packages/crates-io-msw/handlers/versions.js
+++ b/packages/crates-io-msw/handlers/versions.js
@@ -5,6 +5,7 @@ import getVersion from './versions/get.js';
 import listVersions from './versions/list.js';
 import patchVersion from './versions/patch.js';
 import readme from './versions/readme.js';
+import rebuildDocs from './versions/rebuild-docs.js';
 import unyankVersion from './versions/unyank.js';
 import yankVersion from './versions/yank.js';
 
@@ -17,5 +18,6 @@ export default [
   dependencies,
   downloads,
   readme,
+  rebuildDocs,
   followUpdates,
 ];

--- a/packages/crates-io-msw/handlers/versions/rebuild-docs.js
+++ b/packages/crates-io-msw/handlers/versions/rebuild-docs.js
@@ -1,0 +1,25 @@
+import { http, HttpResponse } from 'msw';
+
+import { db } from '../../index.js';
+import { notFound } from '../../utils/handlers.js';
+import { getSession } from '../../utils/session.js';
+
+export default http.post('/api/v1/crates/:name/:version/rebuild_docs', async ({ params }) => {
+  let { user } = getSession();
+  if (!user) {
+    return HttpResponse.json({ errors: [{ detail: 'must be logged in to perform that action' }] }, { status: 403 });
+  }
+
+  let crate = db.crate.findFirst({ where: { name: { equals: params.name } } });
+  if (!crate) return notFound();
+
+  let version = db.version.findFirst({
+    where: {
+      crate: { id: { equals: crate.id } },
+      num: { equals: params.version },
+    },
+  });
+  if (!version) return notFound();
+
+  return new HttpResponse(null, { status: 201 });
+});

--- a/packages/crates-io-msw/handlers/versions/rebuild-docs.test.js
+++ b/packages/crates-io-msw/handlers/versions/rebuild-docs.test.js
@@ -1,0 +1,43 @@
+import { assert, test } from 'vitest';
+
+import { db } from '../../index.js';
+
+test('returns 403 if unauthenticated', async function () {
+  let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
+  assert.strictEqual(response.status, 403);
+  assert.deepEqual(await response.json(), {
+    errors: [{ detail: 'must be logged in to perform that action' }],
+  });
+});
+
+test('returns 404 for unknown crates', async function () {
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+});
+
+test('returns 404 for unknown versions', async function () {
+  db.crate.create({ name: 'foo' });
+
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
+  assert.strictEqual(response.status, 404);
+  assert.deepEqual(await response.json(), { errors: [{ detail: 'Not Found' }] });
+});
+
+test('triggers a rebuild for the crate documentation', async function () {
+  let crate = db.crate.create({ name: 'foo' });
+  db.version.create({ crate, num: '1.0.0' });
+
+  let user = db.user.create();
+  db.mswSession.create({ user });
+
+  let response = await fetch('/api/v1/crates/foo/1.0.0/rebuild_docs', { method: 'POST' });
+  assert.strictEqual(response.status, 201);
+  assert.deepEqual(await response.text(), '');
+});


### PR DESCRIPTION
This commit implements the `/api/v1/crates/{name}/{version}/rebuild_docs` endpoint, which is relatively simple but good enough for frontend testing.