### PR TITLE
Implement Trusted Publishing token exposure notifications

### DIFF
--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token-3.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token-3.snap
@@ -1,0 +1,21 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: app.emails_snapshot().await
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Your Trusted Publishing token has been revoked
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+GitHub has notified us that one of your crates.io Trusted Publishing tokens has been exposed publicly. We have revoked this token as a precaution.
+
+This token was only authorized to publish the "foo" crate.
+
+Please review your account at https://crates.io and your GitHub repository settings to confirm that no unexpected changes have been made to your crates or trusted publishing configurations.
+
+Source type: some_source
+
+URL where the token was found: some_url
+
+Trusted Publishing tokens are temporary and used for automated publishing from GitHub Actions. If this exposure was unexpected, please review your repository's workflow files and secrets.

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token_multiple_users-2.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token_multiple_users-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: response.json()
+---
+[
+  {
+    "label": "true_positive",
+    "token_raw": "[token]",
+    "token_type": "some_type"
+  }
+]

--- a/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token_multiple_users-3.snap
+++ b/src/tests/snapshots/crates_io__tests__github_secret_scanning__github_secret_alert_revokes_trustpub_token_multiple_users-3.snap
@@ -1,0 +1,40 @@
+---
+source: src/tests/github_secret_scanning.rs
+expression: app.emails_snapshot().await
+---
+To: user1@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Your Trusted Publishing token has been revoked
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+GitHub has notified us that one of your crates.io Trusted Publishing tokens has been exposed publicly. We have revoked this token as a precaution.
+
+This token was authorized to publish the following crates: "crate1", "crate2".
+
+Please review your account at https://crates.io and your GitHub repository settings to confirm that no unexpected changes have been made to your crates or trusted publishing configurations.
+
+Source type: some_source
+
+URL where the token was found: some_url
+
+Trusted Publishing tokens are temporary and used for automated publishing from GitHub Actions. If this exposure was unexpected, please review your repository's workflow files and secrets.
+----------------------------------------
+
+To: user2@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Your Trusted Publishing token has been revoked
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+GitHub has notified us that one of your crates.io Trusted Publishing tokens has been exposed publicly. We have revoked this token as a precaution.
+
+This token was only authorized to publish the "crate2" crate.
+
+Please review your account at https://crates.io and your GitHub repository settings to confirm that no unexpected changes have been made to your crates or trusted publishing configurations.
+
+Source type: some_source
+
+URL where the token was found: some_url
+
+Trusted Publishing tokens are temporary and used for automated publishing from GitHub Actions. If this exposure was unexpected, please review your repository's workflow files and secrets.


### PR DESCRIPTION
As requested in https://github.com/rust-lang/crates.io/pull/11405, this PR implements email notifications to all related crate owners if a Trusted Publishing token is publicly exposed and reported to us by the GitHub secret scanning program.

One thing to note with the proposed implementation: In the scenario where user 1 is an owner of crate 1 and 2, and user 2 is an owner of only crate 2, then the notification of user 2 will only mention crate 2. I wonder if that is the right thing to do or not. We could also expose the list of all publishable crates to all users, independent from their ownership status 🤔 