### PR TITLE
Add `Rebuild Docs` action button

### DIFF
--- a/app/components/version-list/row.hbs
+++ b/app/components/version-list/row.hbs
@@ -128,6 +128,18 @@
         <menu.Item>
           <YankButton @version={{@version}} class="button-reset" local-class="menu-button" />
         </menu.Item>
+        <menu.Item>
+          <button
+            class="button-reset"
+            local-class="menu-button"
+            type="button"
+            disabled={{@version.rebuildDocsTask.isRunning}}
+            data-test-id="btn-rebuild-docs"
+            {{on 'click' (perform this.rebuildDocsTask)}}
+          >
+            Rebuild Docs
+          </button>
+        </menu.Item>
       </dd.Menu>
     </Dropdown>
   </PrivilegedAction>

--- a/app/components/version-list/row.js
+++ b/app/components/version-list/row.js
@@ -4,9 +4,12 @@ import { htmlSafe } from '@ember/template';
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
 
+import { keepLatestTask } from 'ember-concurrency';
+
 import styles from './row.module.css';
 
 export default class VersionRow extends Component {
+  @service notifications;
   @service session;
 
   @tracked focused = false;
@@ -59,4 +62,16 @@ export default class VersionRow extends Component {
   @action setFocused(value) {
     this.focused = value;
   }
+
+  rebuildDocsTask = keepLatestTask(async () => {
+    let { version } = this.args;
+    try {
+      await version.rebuildDocs();
+      this.notifications.success('Docs rebuild task was enqueued successfully!');
+    } catch (error) {
+      let reason = error?.errors?.[0]?.detail ?? 'Failed to equeue docs rebuild task.';
+      let msg = `Error: ${reason}`;
+      this.notifications.error(msg);
+    }
+  });
 }

--- a/app/models/version.js
+++ b/app/models/version.js
@@ -200,4 +200,8 @@ export default class Version extends Model {
     this.store.pushPayload(payload);
     await waitForPromise(this.releaseTracks.refreshTask.perform(this.crateName, false));
   });
+
+  async rebuildDocs() {
+    return await waitForPromise(apiAction(this, { method: 'POST', path: 'rebuild_docs' }));
+  }
 }


### PR DESCRIPTION
This PR implements the frontend part of #11169, which adds a `Rebuild Docs` action button to allow owners to enqueue the rebuild task.

cc @syphar 