### PR TITLE
Replace `#[macro_use]` with explicit imports

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -21,6 +21,7 @@ use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::pooled_connection::deadpool::Pool as DeadpoolPool;
 use oauth2::basic::BasicClient;
 use oauth2::{EndpointNotSet, EndpointSet};
+use tracing::{instrument, warn};
 
 type DeadpoolResult = Result<
     diesel_async::pooled_connection::deadpool::Object<AsyncPgConnection>,

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -15,6 +15,7 @@ use diesel_async::AsyncPgConnection;
 use http::request::Parts;
 use http::{StatusCode, header};
 use secrecy::{ExposeSecret, SecretString};
+use tracing::instrument;
 
 pub struct AuthHeader(SecretString);
 

--- a/src/cloudfront.rs
+++ b/src/cloudfront.rs
@@ -3,6 +3,7 @@ use aws_sdk_cloudfront::config::retry::RetryConfig;
 use aws_sdk_cloudfront::config::{BehaviorVersion, Region};
 use aws_sdk_cloudfront::types::{InvalidationBatch, Paths};
 use aws_sdk_cloudfront::{Client, Config};
+use tracing::{debug, instrument, warn};
 
 pub struct CloudFront {
     client: Client,

--- a/src/config/cdn_log_queue.rs
+++ b/src/config/cdn_log_queue.rs
@@ -1,5 +1,6 @@
 use crates_io_env_vars::{required_var, var};
 use secrecy::SecretString;
+use tracing::warn;
 
 #[derive(Debug, Clone)]
 pub enum CdnLogQueueConfig {

--- a/src/config/cdn_log_storage.rs
+++ b/src/config/cdn_log_storage.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use crates_io_env_vars::{required_var, var};
 use secrecy::SecretString;
 use std::path::PathBuf;
+use tracing::{info, warn};
 
 #[derive(Debug, Clone)]
 pub enum CdnLogStorageConfig {

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -329,6 +329,7 @@ impl FromStr for AllowedOrigins {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claims::{assert_err, assert_none, assert_ok_eq};
 
     #[test]
     fn parse_traffic_patterns_splits_on_comma_and_looks_for_equal_sign() {

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -10,6 +10,7 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use futures_util::FutureExt;
 use http::request::Parts;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]

--- a/src/controllers/category.rs
+++ b/src/controllers/category.rs
@@ -6,7 +6,7 @@ use crate::util::errors::AppResult;
 use crate::views::EncodableCategory;
 use axum::Json;
 use axum::extract::{FromRequestParts, Path, Query};
-use diesel::QueryDsl;
+use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use futures_util::FutureExt;
 use http::request::Parts;

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -22,6 +22,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use http::StatusCode;
 use http::request::Parts;
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Serialize, utoipa::ToSchema)]

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -27,7 +27,7 @@ use std::str::FromStr;
 use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::Mutex;
-use tracing::warn;
+use tracing::{debug, warn};
 
 // Minimum number of seconds to wait before refreshing cache of GitHub's public keys
 const PUBLIC_KEY_CACHE_LIFETIME: Duration = Duration::from_secs(60 * 60 * 24); // 24 hours

--- a/src/controllers/github/secret_scanning.rs
+++ b/src/controllers/github/secret_scanning.rs
@@ -20,6 +20,7 @@ use minijinja::context;
 use p256::PublicKey;
 use p256::ecdsa::VerifyingKey;
 use p256::ecdsa::signature::Verifier;
+use serde::{Deserialize, Serialize};
 use serde_json as json;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::str::FromStr;

--- a/src/controllers/helpers.rs
+++ b/src/controllers/helpers.rs
@@ -1,5 +1,6 @@
 use axum::Json;
 use axum::response::{IntoResponse, Response};
+use serde::Serialize;
 
 pub mod authorization;
 pub(crate) mod pagination;

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -544,6 +544,7 @@ pub(crate) use seek;
 mod tests {
     use super::*;
     use chrono::Utc;
+    use claims::assert_ok_eq;
     use http::{Method, Request, StatusCode};
     use insta::assert_snapshot;
 

--- a/src/controllers/helpers/pagination.rs
+++ b/src/controllers/helpers/pagination.rs
@@ -449,13 +449,13 @@ macro_rules! seek {
         $($(#[$field_meta:meta])? $field:ident: $ty:ty),* $(,)?
     }) => {
         paste::item! {
-            #[derive(Debug, Default, Deserialize, PartialEq)]
+            #[derive(Debug, Default, serde::Deserialize, PartialEq)]
             #[serde(from = $variant "Helper")]
             $vis struct $variant {
                 $($(#[$field_meta])? pub(super) $field: $ty),*
             }
 
-            #[derive(Debug, Default, Deserialize, Serialize, PartialEq)]
+            #[derive(Debug, Default, serde::Deserialize, serde::Serialize, PartialEq)]
             struct [<$variant Helper>]($($(#[$field_meta])? pub(super) $ty),*);
 
             impl From<[<$variant Helper>]> for $variant {
@@ -487,7 +487,7 @@ macro_rules! seek {
             seek!(@variant_struct $vis $variant $fields);
         )*
         paste::item! {
-            #[derive(Debug, Deserialize, Serialize, PartialEq)]
+            #[derive(Debug, serde::Deserialize, serde::Serialize, PartialEq)]
             #[serde(untagged)]
             $vis enum [<$name Payload>] {
                 $(

--- a/src/controllers/keyword.rs
+++ b/src/controllers/keyword.rs
@@ -8,6 +8,7 @@ use axum::Json;
 use axum::extract::{FromRequestParts, Path, Query};
 use diesel::prelude::*;
 use http::request::Parts;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]
 #[from_request(via(Query))]

--- a/src/controllers/krate.rs
+++ b/src/controllers/krate.rs
@@ -4,6 +4,7 @@ use axum::extract::{FromRequestParts, Path};
 use crates_io_database::schema::crates;
 use diesel::{OptionalExtension, QueryDsl};
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::Deserialize;
 use utoipa::IntoParams;
 
 pub mod delete;

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -205,6 +205,7 @@ mod tests {
     use crate::tests::builders::{DependencyBuilder, PublishBuilder};
     use crate::tests::util::{RequestHelper, Response, TestApp};
     use axum::RequestPartsExt;
+    use claims::{assert_none, assert_some};
     use crates_io_database::schema::crate_owners;
     use diesel_async::AsyncPgConnection;
     use http::{Request, StatusCode};

--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -19,6 +19,7 @@ use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
 use http::StatusCode;
 use http::request::Parts;
 use minijinja::context;
+use serde::Deserialize;
 use tracing::error;
 
 const DOWNLOADS_PER_MONTH_LIMIT: u64 = 500;

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -19,6 +19,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::FutureExt;
 use futures_util::future::BoxFuture;
+use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::str::FromStr;
 

--- a/src/controllers/krate/follow.rs
+++ b/src/controllers/krate/follow.rs
@@ -11,6 +11,7 @@ use axum::Json;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use http::request::Parts;
+use serde::Serialize;
 
 async fn follow_target(
     crate_name: &str,

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -21,6 +21,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::FutureExt;
 use futures_util::future::{BoxFuture, always_ready};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]

--- a/src/controllers/krate/owners.rs
+++ b/src/controllers/krate/owners.rs
@@ -23,6 +23,7 @@ use http::request::Parts;
 use minijinja::context;
 use oauth2::AccessToken;
 use secrecy::ExposeSecret;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracing::warn;
 

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -1024,6 +1024,7 @@ impl From<TarballError> for BoxedAppError {
 #[cfg(test)]
 mod tests {
     use super::{missing_metadata_error_message, validate_url};
+    use claims::assert_err;
 
     #[test]
     fn deny_relative_urls() {

--- a/src/controllers/krate/publish.rs
+++ b/src/controllers/krate/publish.rs
@@ -26,6 +26,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_util::io::StreamReader;
+use tracing::{error, instrument};
 use url::Url;
 
 use crate::models::{

--- a/src/controllers/krate/rev_deps.rs
+++ b/src/controllers/krate/rev_deps.rs
@@ -9,6 +9,7 @@ use crates_io_database::schema::{crates, users, versions};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::request::Parts;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct RevDepsResponse {

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -12,6 +12,7 @@ use diesel::sql_types::Bool;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use diesel_full_text_search::{configuration::TsConfigurationByName, *};
 use http::request::Parts;
+use serde::{Deserialize, Serialize};
 use tracing::Instrument;
 use utoipa::IntoParams;
 

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -13,7 +13,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use diesel_full_text_search::{configuration::TsConfigurationByName, *};
 use http::request::Parts;
 use serde::{Deserialize, Serialize};
-use tracing::Instrument;
+use tracing::{Instrument, info_span};
 use utoipa::IntoParams;
 
 use crate::app::AppState;

--- a/src/controllers/krate/search.rs
+++ b/src/controllers/krate/search.rs
@@ -5,6 +5,7 @@ use axum::Json;
 use axum::extract::FromRequestParts;
 use axum_extra::extract::Query;
 use derive_more::Deref;
+use diesel::alias;
 use diesel::dsl::{InnerJoinQuerySource, LeftJoinQuerySource, exists};
 use diesel::prelude::*;
 use diesel::sql_types::Bool;

--- a/src/controllers/krate/versions.rs
+++ b/src/controllers/krate/versions.rs
@@ -21,6 +21,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::{TryStreamExt, future};
 use http::request::Parts;
 use indexmap::{IndexMap, IndexSet};
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Debug, Deserialize, FromRequestParts, utoipa::IntoParams)]

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -19,6 +19,7 @@ use minijinja::context;
 use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BeginResponse {

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -1,13 +1,3 @@
-use axum::Json;
-use axum::extract::{FromRequestParts, Query};
-use diesel::prelude::*;
-use diesel_async::scoped_futures::ScopedFutureExt;
-use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
-use http::request::Parts;
-use minijinja::context;
-use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
-use secrecy::ExposeSecret;
-
 use crate::app::AppState;
 use crate::email::EmailMessage;
 use crate::email::Emails;
@@ -17,8 +7,18 @@ use crate::schema::users;
 use crate::util::diesel::is_read_only_error;
 use crate::util::errors::{AppResult, bad_request, server_error};
 use crate::views::EncodableMe;
+use axum::Json;
+use axum::extract::{FromRequestParts, Query};
 use crates_io_github::GitHubUser;
 use crates_io_session::SessionExtension;
+use diesel::prelude::*;
+use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use http::request::Parts;
+use minijinja::context;
+use oauth2::{AuthorizationCode, CsrfToken, Scope, TokenResponse};
+use secrecy::ExposeSecret;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct BeginResponse {

--- a/src/controllers/site_metadata.rs
+++ b/src/controllers/site_metadata.rs
@@ -1,6 +1,7 @@
 use crate::app::AppState;
 use axum::Json;
 use axum::response::IntoResponse;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct MetadataResponse<'a> {

--- a/src/controllers/summary.rs
+++ b/src/controllers/summary.rs
@@ -9,6 +9,7 @@ use axum::Json;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::FutureExt;
+use serde::Serialize;
 use std::future::Future;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/controllers/team.rs
+++ b/src/controllers/team.rs
@@ -6,6 +6,7 @@ use axum::Json;
 use axum::extract::Path;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct GetResponse {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -25,6 +25,7 @@ use http::request::Parts;
 use minijinja::context;
 use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
+use tracing::error;
 
 #[derive(Deserialize)]
 pub struct GetParams {

--- a/src/controllers/token.rs
+++ b/src/controllers/token.rs
@@ -24,7 +24,7 @@ use http::StatusCode;
 use http::request::Parts;
 use minijinja::context;
 use secrecy::ExposeSecret;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
 pub struct GetParams {

--- a/src/controllers/trustpub/github_configs/create/mod.rs
+++ b/src/controllers/trustpub/github_configs/create/mod.rs
@@ -19,6 +19,7 @@ use http::request::Parts;
 use minijinja::context;
 use oauth2::AccessToken;
 use secrecy::ExposeSecret;
+use tracing::warn;
 
 #[cfg(test)]
 mod tests;

--- a/src/controllers/trustpub/github_configs/json.rs
+++ b/src/controllers/trustpub/github_configs/json.rs
@@ -1,6 +1,7 @@
 use axum::Json;
 use axum::extract::FromRequest;
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct GitHubConfig {

--- a/src/controllers/trustpub/github_configs/list/mod.rs
+++ b/src/controllers/trustpub/github_configs/list/mod.rs
@@ -12,6 +12,7 @@ use diesel::dsl::{exists, select};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::request::Parts;
+use serde::Deserialize;
 
 #[cfg(test)]
 mod tests;

--- a/src/controllers/trustpub/tokens/exchange/mod.rs
+++ b/src/controllers/trustpub/tokens/exchange/mod.rs
@@ -14,6 +14,7 @@ use diesel::result::Error::DatabaseError;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncConnection, RunQueryDsl};
 use secrecy::ExposeSecret;
+use tracing::warn;
 
 #[cfg(test)]
 mod tests;

--- a/src/controllers/trustpub/tokens/exchange/tests.rs
+++ b/src/controllers/trustpub/tokens/exchange/tests.rs
@@ -1,5 +1,6 @@
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{MockAnonymousUser, RequestHelper, TestApp};
+use claims::assert_ok;
 use crates_io_database::models::trustpub::NewGitHubConfig;
 use crates_io_database::schema::trustpub_tokens;
 use crates_io_trustpub::access_token::AccessToken;

--- a/src/controllers/trustpub/tokens/json.rs
+++ b/src/controllers/trustpub/tokens/json.rs
@@ -1,5 +1,6 @@
 use axum::Json;
 use axum::extract::FromRequest;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, FromRequest, utoipa::ToSchema)]
 #[from_request(via(Json))]

--- a/src/controllers/user/email_notifications.rs
+++ b/src/controllers/user/email_notifications.rs
@@ -8,6 +8,7 @@ use axum::Json;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::request::Parts;
+use serde::Deserialize;
 use std::collections::HashMap;
 
 #[derive(Deserialize)]

--- a/src/controllers/user/me.rs
+++ b/src/controllers/user/me.rs
@@ -1,11 +1,5 @@
-use crate::auth::AuthCheck;
-use axum::Json;
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-use futures_util::FutureExt;
-use http::request::Parts;
-
 use crate::app::AppState;
+use crate::auth::AuthCheck;
 use crate::controllers::helpers::Paginate;
 use crate::controllers::helpers::pagination::{Paginated, PaginationOptions};
 use crate::models::krate::CrateName;
@@ -13,6 +7,12 @@ use crate::models::{CrateOwner, Follow, OwnerKind, User, Version, VersionOwnerAc
 use crate::schema::{crate_owners, crates, emails, follows, users, versions};
 use crate::util::errors::AppResult;
 use crate::views::{EncodableMe, EncodablePrivateUser, EncodableVersion, OwnedCrate};
+use axum::Json;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use futures_util::FutureExt;
+use http::request::Parts;
+use serde::Serialize;
 
 /// Get the currently authenticated user.
 #[utoipa::path(

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -1,15 +1,15 @@
-use axum::Json;
-use axum::extract::Path;
-use bigdecimal::{BigDecimal, ToPrimitive};
-use diesel::prelude::*;
-use diesel_async::RunQueryDsl;
-
 use crate::app::AppState;
 use crate::models::{CrateOwner, OwnerKind, User};
 use crate::schema::{crate_downloads, crate_owners, crates};
 use crate::util::errors::AppResult;
 use crate::views::EncodablePublicUser;
+use axum::Json;
+use axum::extract::Path;
+use bigdecimal::{BigDecimal, ToPrimitive};
 use crates_io_diesel_helpers::lower;
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct GetResponse {

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -13,6 +13,7 @@ use http::request::Parts;
 use lettre::Address;
 use minijinja::context;
 use secrecy::ExposeSecret;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct UserUpdate {

--- a/src/controllers/user/update.rs
+++ b/src/controllers/user/update.rs
@@ -14,6 +14,7 @@ use lettre::Address;
 use minijinja::context;
 use secrecy::ExposeSecret;
 use serde::Deserialize;
+use tracing::warn;
 
 #[derive(Deserialize)]
 pub struct UserUpdate {

--- a/src/controllers/version/dependencies.rs
+++ b/src/controllers/version/dependencies.rs
@@ -7,6 +7,7 @@ use axum::Json;
 use crates_io_database::schema::{crates, dependencies};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct Response {

--- a/src/controllers/version/docs.rs
+++ b/src/controllers/version/docs.rs
@@ -9,6 +9,7 @@ use crate::worker::jobs;
 use crates_io_worker::BackgroundJob as _;
 use http::StatusCode;
 use http::request::Parts;
+use tracing::error;
 
 /// Trigger a rebuild for the crate documentation on docs.rs.
 #[utoipa::path(

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -17,6 +17,7 @@ use chrono::{Duration, NaiveDate, Utc};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::request::Parts;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct UrlResponse {

--- a/src/controllers/version/metadata.rs
+++ b/src/controllers/version/metadata.rs
@@ -4,12 +4,12 @@
 //! index or cached metadata which was extracted (client side) from the
 //! `Cargo.toml` file.
 
-use axum::Json;
-
 use crate::app::AppState;
 use crate::models::VersionOwnerAction;
 use crate::util::errors::AppResult;
 use crate::views::EncodableVersion;
+use axum::Json;
+use serde::Serialize;
 
 use super::CrateVersionPath;
 

--- a/src/controllers/version/readme.rs
+++ b/src/controllers/version/readme.rs
@@ -4,6 +4,7 @@ use crate::util::{RequestUtils, redirect};
 use axum::Json;
 use axum::response::{IntoResponse, Response};
 use http::request::Parts;
+use serde::Serialize;
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct UrlResponse {

--- a/src/controllers/version/update.rs
+++ b/src/controllers/version/update.rs
@@ -15,7 +15,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use http::StatusCode;
 use http::request::Parts;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize)]
 pub struct VersionUpdate {

--- a/src/controllers/version/update.rs
+++ b/src/controllers/version/update.rs
@@ -16,6 +16,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use http::StatusCode;
 use http::request::Parts;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 
 #[derive(Deserialize)]
 pub struct VersionUpdate {

--- a/src/email.rs
+++ b/src/email.rs
@@ -233,6 +233,7 @@ pub struct StoredEmail {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claims::{assert_err, assert_ok};
 
     #[tokio::test]
     async fn sending_to_invalid_email_fails() {

--- a/src/external_urls.rs
+++ b/src/external_urls.rs
@@ -49,6 +49,7 @@ fn domain_is_subdomain(potential_subdomain: &str, root: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claims::assert_some_eq;
 
     #[test]
     fn domain_blocked_no_url_provided() {

--- a/src/fastly.rs
+++ b/src/fastly.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, anyhow};
 use reqwest::Client;
 use reqwest::header::{HeaderMap, HeaderValue};
 use secrecy::{ExposeSecret, SecretString};
+use tracing::{debug, instrument, trace};
 
 #[derive(Debug)]
 pub struct Fastly {

--- a/src/index.rs
+++ b/src/index.rs
@@ -9,6 +9,7 @@ use crates_io_index::features::split_features;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use sentry::Level;
+use tracing::{debug, instrument};
 
 #[instrument(skip_all, fields(krate.name = ?name))]
 pub async fn get_index_data(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,6 @@
 //! implemented in the [category](category/index.html), [keyword](keyword/index.html),
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 
-#[macro_use]
-extern crate tracing;
-
 pub use crate::{app::App, email::Emails};
 pub use crates_io_database::{models, schema};
 use std::sync::Arc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 
 #[macro_use]
-extern crate diesel;
-#[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate tracing;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,6 @@
 //! implemented in the [category](category/index.html), [keyword](keyword/index.html),
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 
-#[cfg(test)]
-#[macro_use]
-extern crate claims;
 #[macro_use]
 extern crate diesel;
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 //! [krate](krate/index.html), [user](user/index.html) and [version](version/index.html) modules.
 
 #[macro_use]
-extern crate serde;
-#[macro_use]
 extern crate tracing;
 
 pub use crate::{app::App, email::Emails};

--- a/src/licenses.rs
+++ b/src/licenses.rs
@@ -14,6 +14,7 @@ pub fn parse_license_expr(s: &str) -> Result<Expression, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::parse_license_expr;
+    use claims::{assert_err, assert_ok};
 
     #[test]
     fn licenses() {

--- a/src/metrics/log_encoder.rs
+++ b/src/metrics/log_encoder.rs
@@ -9,6 +9,7 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::io::Write;
 use std::rc::Rc;
+use tracing::{info, warn};
 
 const CHUNKS_MAX_SIZE_BYTES: usize = 5000;
 

--- a/src/middleware/cargo_compat.rs
+++ b/src/middleware/cargo_compat.rs
@@ -4,6 +4,7 @@ use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use http::{Method, StatusCode, header};
 use std::str::FromStr;
+use tracing::error;
 
 #[derive(Clone, Copy, Debug)]
 pub enum StatusCodeConfig {

--- a/src/middleware/debug.rs
+++ b/src/middleware/debug.rs
@@ -3,6 +3,7 @@
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::IntoResponse;
+use tracing::debug;
 
 pub async fn debug_requests(req: Request, next: Next) -> impl IntoResponse {
     debug!("  version: {:?}", req.version());

--- a/src/middleware/log_request.rs
+++ b/src/middleware/log_request.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::Level;
+use tracing::{Level, event};
 
 #[derive(Clone, Debug)]
 pub struct ErrorField(pub String);

--- a/src/middleware/normalize_path.rs
+++ b/src/middleware/normalize_path.rs
@@ -69,6 +69,7 @@ mod tests {
     use super::{OriginalPath, normalize_path_inner};
     use axum::body::Body;
     use axum::extract::Request;
+    use claims::assert_some;
 
     #[test]
     fn path_normalization() {

--- a/src/middleware/real_ip.rs
+++ b/src/middleware/real_ip.rs
@@ -4,6 +4,7 @@ use axum::middleware::Next;
 use axum::response::IntoResponse;
 use derive_more::Deref;
 use std::net::{IpAddr, SocketAddr};
+use tracing::debug;
 
 #[derive(Copy, Clone, Debug, Deref)]
 pub struct RealIp(IpAddr);

--- a/src/real_ip.rs
+++ b/src/real_ip.rs
@@ -4,6 +4,7 @@ use std::iter::Iterator;
 use std::net::IpAddr;
 use std::str::from_utf8;
 use std::sync::LazyLock;
+use tracing::warn;
 
 const X_FORWARDED_FOR: &str = "X-Forwarded-For";
 

--- a/src/sentry/mod.rs
+++ b/src/sentry/mod.rs
@@ -88,6 +88,7 @@ fn options(config: SentryConfig) -> ClientOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claims::{assert_none, assert_some};
 
     use sentry::{
         capture_error,

--- a/src/sentry/mod.rs
+++ b/src/sentry/mod.rs
@@ -3,6 +3,7 @@ use http::header::{AUTHORIZATION, COOKIE};
 use sentry::protocol::Event;
 use sentry::{ClientInitGuard, ClientOptions, TransactionContext};
 use std::sync::Arc;
+use tracing::warn;
 
 /// Initializes the Sentry SDK from the environment variables.
 ///

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -15,6 +15,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
+use tracing::{instrument, warn};
 
 const PREFIX_CRATES: &str = "crates";
 const PREFIX_READMES: &str = "readmes";

--- a/src/tests/categories.rs
+++ b/src/tests/categories.rs
@@ -1,4 +1,5 @@
 use crate::schema::categories;
+use claims::assert_ok;
 use crates_io_test_db::TestDatabase;
 use diesel::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};

--- a/src/tests/github_secret_scanning.rs
+++ b/src/tests/github_secret_scanning.rs
@@ -6,6 +6,7 @@ use crate::util::token::HashedToken;
 use crate::{models::ApiToken, schema::api_tokens};
 use base64::{Engine as _, engine::general_purpose};
 use chrono::{TimeDelta, Utc};
+use claims::assert_ok;
 use crates_io_database::models::CrateOwner;
 use crates_io_database::models::trustpub::NewToken;
 use crates_io_database::schema::trustpub_tokens;

--- a/src/tests/issues/issue2736.rs
+++ b/src/tests/issues/issue2736.rs
@@ -1,6 +1,7 @@
 use crate::models::CrateOwner;
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
+use claims::assert_none;
 use crates_io_database::schema::users;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;

--- a/src/tests/krate/publish/max_size.rs
+++ b/src/tests/krate/publish/max_size.rs
@@ -1,5 +1,6 @@
 use crate::tests::builders::{CrateBuilder, PublishBuilder};
 use crate::tests::util::{RequestHelper, TestApp};
+use claims::assert_ok;
 use crates_io_tarball::TarballBuilder;
 use flate2::Compression;
 use googletest::prelude::*;

--- a/src/tests/krate/publish/tarball.rs
+++ b/src/tests/krate/publish/tarball.rs
@@ -1,6 +1,7 @@
 use crate::tests::builders::PublishBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
 use bytes::{BufMut, BytesMut};
+use claims::assert_ok;
 use crates_io_tarball::TarballBuilder;
 use googletest::prelude::*;
 use insta::assert_snapshot;

--- a/src/tests/krate/yanking.rs
+++ b/src/tests/krate/yanking.rs
@@ -5,6 +5,7 @@ use crate::tests::builders::PublishBuilder;
 use crate::tests::routes::crates::versions::yank_unyank::YankRequestHelper;
 use crate::tests::util::{RequestHelper, TestApp};
 use chrono::Utc;
+use claims::assert_some_eq;
 use diesel::ExpressionMethods;
 use diesel_async::RunQueryDsl;
 use googletest::prelude::*;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -8,6 +8,7 @@ use crate::views::{
 use crate::tests::util::github::next_gh_id;
 use diesel::prelude::*;
 use diesel_async::AsyncPgConnection;
+use serde::{Deserialize, Serialize};
 
 mod account_lock;
 mod authentication;

--- a/src/tests/owners.rs
+++ b/src/tests/owners.rs
@@ -14,6 +14,7 @@ use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
 use insta::assert_snapshot;
+use serde::Deserialize;
 use serde_json::json;
 
 #[derive(Deserialize)]

--- a/src/tests/read_only_mode.rs
+++ b/src/tests/read_only_mode.rs
@@ -1,6 +1,6 @@
 use crate::tests::builders::CrateBuilder;
 use crate::tests::{RequestHelper, TestApp};
-
+use claims::assert_ok_eq;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use insta::{assert_json_snapshot, assert_snapshot};

--- a/src/tests/routes/categories/get.rs
+++ b/src/tests/routes/categories/get.rs
@@ -2,6 +2,7 @@ use crate::models::Category;
 use crate::tests::builders::CrateBuilder;
 use crate::tests::new_category;
 use crate::tests::util::{MockAnonymousUser, RequestHelper, TestApp};
+use claims::assert_ok;
 use crates_io_database::schema::categories;
 use diesel::insert_into;
 use diesel_async::RunQueryDsl;

--- a/src/tests/routes/crates/downloads.rs
+++ b/src/tests/routes/crates/downloads.rs
@@ -7,6 +7,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use http::StatusCode;
 use insta::{assert_json_snapshot, assert_snapshot};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Downloads {

--- a/src/tests/routes/crates/versions/dependencies.rs
+++ b/src/tests/routes/crates/versions/dependencies.rs
@@ -2,6 +2,7 @@ use crate::tests::builders::{CrateBuilder, VersionBuilder};
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::EncodableDependency;
 use insta::assert_snapshot;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct Deps {

--- a/src/tests/routes/crates/versions/list.rs
+++ b/src/tests/routes/crates/versions/list.rs
@@ -6,6 +6,7 @@ use diesel::{prelude::*, update};
 use diesel_async::RunQueryDsl;
 use googletest::prelude::*;
 use insta::{assert_json_snapshot, assert_snapshot};
+use serde::Deserialize;
 use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/keywords/list.rs
+++ b/src/tests/routes/keywords/list.rs
@@ -1,6 +1,7 @@
 use crate::models::Keyword;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::EncodableKeyword;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct KeywordList {

--- a/src/tests/routes/keywords/read.rs
+++ b/src/tests/routes/keywords/read.rs
@@ -3,6 +3,7 @@ use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::EncodableKeyword;
 use insta::assert_snapshot;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct GoodKeyword {

--- a/src/tests/routes/me/email_notifications.rs
+++ b/src/tests/routes/me/email_notifications.rs
@@ -5,6 +5,7 @@ use crate::tests::util::{RequestHelper, TestApp};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use http::StatusCode;
+use serde::Serialize;
 use serde_json::json;
 
 #[derive(Serialize)]

--- a/src/tests/routes/me/get.rs
+++ b/src/tests/routes/me/get.rs
@@ -2,6 +2,7 @@ use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::{EncodablePrivateUser, OwnedCrate};
 use insta::{assert_json_snapshot, assert_snapshot};
+use serde::Deserialize;
 
 impl crate::tests::util::MockCookieUser {
     pub async fn show_me(&self) -> UserShowPrivateResponse {

--- a/src/tests/routes/me/tokens/create.rs
+++ b/src/tests/routes/me/tokens/create.rs
@@ -2,6 +2,7 @@ use crate::models::ApiToken;
 use crate::models::token::{CrateScope, EndpointScope, NewApiToken};
 use crate::tests::util::insta::{self, assert_json_snapshot};
 use crate::tests::util::{RequestHelper, TestApp};
+use claims::assert_ok;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use googletest::prelude::*;

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -4,6 +4,7 @@ use crate::tests::util::{RequestHelper, TestApp};
 use claims::assert_ok;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct RevokedResponse {}

--- a/src/tests/routes/me/tokens/delete.rs
+++ b/src/tests/routes/me/tokens/delete.rs
@@ -1,6 +1,7 @@
 use crate::models::ApiToken;
 use crate::schema::api_tokens;
 use crate::tests::util::{RequestHelper, TestApp};
+use claims::assert_ok;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 

--- a/src/tests/routes/me/tokens/delete_current.rs
+++ b/src/tests/routes/me/tokens/delete_current.rs
@@ -1,6 +1,7 @@
 use crate::models::ApiToken;
 use crate::schema::api_tokens;
 use crate::tests::util::{RequestHelper, TestApp};
+use claims::assert_ok;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use insta::assert_snapshot;

--- a/src/tests/routes/me/tokens/get.rs
+++ b/src/tests/routes/me/tokens/get.rs
@@ -1,6 +1,7 @@
 use crate::models::token::{CrateScope, EndpointScope, NewApiToken};
 use crate::tests::util::{RequestHelper, TestApp};
 use chrono::{Duration, Utc};
+use claims::assert_ok;
 use insta::{assert_json_snapshot, assert_snapshot};
 
 #[tokio::test(flavor = "multi_thread")]

--- a/src/tests/routes/me/tokens/list.rs
+++ b/src/tests/routes/me/tokens/list.rs
@@ -2,6 +2,7 @@ use crate::models::token::{CrateScope, EndpointScope, NewApiToken};
 use crate::tests::util::insta::{self, assert_json_snapshot};
 use crate::tests::util::{RequestHelper, TestApp};
 use chrono::{Duration, Utc};
+use claims::{assert_ok, assert_some};
 use insta::assert_snapshot;
 use serde_json::json;
 

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -9,6 +9,7 @@ use diesel::update;
 use diesel_async::RunQueryDsl;
 use googletest::prelude::*;
 use insta::assert_snapshot;
+use serde::Deserialize;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn api_token_cannot_get_user_updates() {

--- a/src/tests/routes/me/updates.rs
+++ b/src/tests/routes/me/updates.rs
@@ -3,6 +3,7 @@ use crate::tests::OkBool;
 use crate::tests::builders::{CrateBuilder, VersionBuilder};
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::EncodableVersion;
+use claims::assert_none;
 use diesel::prelude::*;
 use diesel::update;
 use diesel_async::RunQueryDsl;

--- a/src/tests/routes/private/crate_owner_invitations.rs
+++ b/src/tests/routes/private/crate_owner_invitations.rs
@@ -4,6 +4,7 @@ use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{MockCookieUser, RequestHelper, TestApp};
 use crate::views::{EncodableCrateOwnerInvitation, EncodablePublicUser};
 use http::StatusCode;
+use serde::Deserialize;
 use serde_json::json;
 
 #[derive(Deserialize, Debug, PartialEq, Eq)]

--- a/src/tests/routes/session/begin.rs
+++ b/src/tests/routes/session/begin.rs
@@ -1,4 +1,5 @@
 use crate::tests::util::{RequestHelper, TestApp};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct AuthResponse {

--- a/src/tests/routes/summary.rs
+++ b/src/tests/routes/summary.rs
@@ -8,6 +8,7 @@ use crates_io_database::schema::categories;
 use diesel::{ExpressionMethods, insert_into, update};
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::{AsyncConnection, RunQueryDsl};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct SummaryResponse {

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -2,6 +2,7 @@ use crate::models::NewUser;
 use crate::schema::users;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::EncodablePublicUser;
+use claims::assert_ok;
 use diesel_async::RunQueryDsl;
 
 #[derive(Deserialize)]

--- a/src/tests/routes/users/read.rs
+++ b/src/tests/routes/users/read.rs
@@ -4,6 +4,7 @@ use crate::tests::util::{RequestHelper, TestApp};
 use crate::views::EncodablePublicUser;
 use claims::assert_ok;
 use diesel_async::RunQueryDsl;
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct UserShowPublicResponse {

--- a/src/tests/routes/users/stats.rs
+++ b/src/tests/routes/users/stats.rs
@@ -1,4 +1,5 @@
 use crate::tests::util::{RequestHelper, TestApp};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct UserStats {

--- a/src/tests/token.rs
+++ b/src/tests/token.rs
@@ -2,6 +2,7 @@ use crate::tests::builders::PublishBuilder;
 use crate::tests::util::MockTokenUser;
 use crate::tests::{RequestHelper, TestApp};
 use crate::{models::ApiToken, views::EncodableMe};
+use claims::{assert_none, assert_ok, assert_some};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use insta::assert_snapshot;

--- a/src/tests/unhealthy_database.rs
+++ b/src/tests/unhealthy_database.rs
@@ -1,5 +1,6 @@
 use crate::tests::builders::CrateBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
+use claims::{assert_ok, assert_some};
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::Pool;
 use googletest::assert_that;

--- a/src/tests/user.rs
+++ b/src/tests/user.rs
@@ -5,6 +5,7 @@ use crate::tests::util::github::next_gh_id;
 use crate::tests::util::{MockCookieUser, RequestHelper};
 use crate::util::token::HashedToken;
 use chrono::{DateTime, Utc};
+use claims::assert_ok;
 use crates_io_github::GitHubUser;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;

--- a/src/tests/util/insta.rs
+++ b/src/tests/util/insta.rs
@@ -1,4 +1,5 @@
 pub use ::insta::*;
+use claims::assert_some;
 use googletest::prelude::*;
 
 pub fn id_redaction(expected_id: i32) -> insta::internals::Redaction {

--- a/src/tests/util/response.rs
+++ b/src/tests/util/response.rs
@@ -1,5 +1,6 @@
 use crate::tests::util::matchers::is_success;
 use bytes::Bytes;
+use claims::{assert_ok, assert_some, assert_some_eq};
 use googletest::prelude::*;
 use serde_json::Value;
 use std::marker::PhantomData;

--- a/src/tests/util/test_app.rs
+++ b/src/tests/util/test_app.rs
@@ -11,6 +11,7 @@ use crate::tests::util::chaosproxy::ChaosProxy;
 use crate::tests::util::github::MOCK_GITHUB_DATA;
 use crate::worker::{Environment, RunnerExt};
 use crate::{App, Emails, Env};
+use claims::assert_some;
 use crates_io_docs_rs::MockDocsRsClient;
 use crates_io_github::MockGitHubClient;
 use crates_io_index::testing::UpstreamIndex;

--- a/src/tests/worker/git.rs
+++ b/src/tests/worker/git.rs
@@ -2,6 +2,7 @@ use crate::models::Crate;
 use crate::tests::builders::PublishBuilder;
 use crate::tests::util::{RequestHelper, TestApp};
 use crate::worker::jobs;
+use claims::{assert_ok, assert_ok_eq};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;

--- a/src/typosquat/cache.rs
+++ b/src/typosquat/cache.rs
@@ -1,6 +1,7 @@
 use diesel_async::AsyncPgConnection;
 use std::sync::Arc;
 use thiserror::Error;
+use tracing::{instrument, warn};
 use typomania::Harness;
 use typomania::checks::{Bitflips, Omitted, SwappedWords, Typos};
 

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn http_error_responses() {
-        use crate::serde::de::Error;
+        use serde::de::Error;
 
         // Types for handling common error status codes
         assert_eq!(bad_request("").response().status(), StatusCode::BAD_REQUEST);

--- a/src/util/errors.rs
+++ b/src/util/errors.rs
@@ -19,13 +19,13 @@ use std::borrow::Cow;
 use std::error::Error;
 use std::fmt;
 
+use crate::middleware::log_request::ErrorField;
 use axum::Extension;
 use chrono::{DateTime, Utc};
 use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use http::StatusCode;
 use tokio::task::JoinError;
-
-use crate::middleware::log_request::ErrorField;
+use tracing::error;
 
 mod json;
 

--- a/src/util/tracing.rs
+++ b/src/util/tracing.rs
@@ -1,7 +1,6 @@
 use crates_io_env_vars::var;
 use sentry::integrations::tracing::EventFilter;
-use tracing::Level;
-use tracing::Metadata;
+use tracing::{Level, Metadata, warn};
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::{EnvFilter, Layer, prelude::*};
 

--- a/src/views.rs
+++ b/src/views.rs
@@ -1026,6 +1026,7 @@ pub struct PublishWarnings {
 mod tests {
     use super::*;
     use chrono::NaiveDate;
+    use claims::assert_some;
 
     #[test]
     fn category_dates_serializes_to_rfc3339() {

--- a/src/views.rs
+++ b/src/views.rs
@@ -1,11 +1,11 @@
-use chrono::{DateTime, Utc};
-
 use crate::external_urls::remove_blocked_urls;
 use crate::models::{
     ApiToken, Category, Crate, Dependency, DependencyKind, Keyword, Owner, ReverseDependency, Team,
     TopVersions, User, Version, VersionDownload, VersionOwnerAction,
 };
+use chrono::{DateTime, Utc};
 use crates_io_github as github;
+use serde::{Deserialize, Serialize};
 
 pub mod krate_publish;
 pub use self::krate_publish::{EncodableCrateDependency, PublishMetadata};

--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -16,6 +16,7 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::OnceCell;
+use tracing::{info, instrument};
 
 #[derive(Builder)]
 pub struct Environment {

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -10,6 +10,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use futures_util::StreamExt;
 use object_store::ObjectStore;
 use secrecy::{ExposeSecret, SecretString};
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::path::Path;

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -250,6 +250,7 @@ async fn delete(conn: &mut AsyncPgConnection, dates: Vec<NaiveDate>) -> anyhow::
 mod tests {
     use super::*;
     use crate::schema::{crates, version_downloads, versions};
+    use claims::assert_err;
     use crates_io_test_db::TestDatabase;
     use insta::assert_snapshot;
 

--- a/src/worker/jobs/archive_version_downloads.rs
+++ b/src/worker/jobs/archive_version_downloads.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 use tempfile::tempdir;
+use tracing::{debug, error, info, warn};
 
 const FILE_NAME: &str = "version_downloads.csv";
 

--- a/src/worker/jobs/daily_db_maintenance.rs
+++ b/src/worker/jobs/daily_db_maintenance.rs
@@ -2,6 +2,7 @@ use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
 use diesel::sql_query;
 use diesel_async::RunQueryDsl;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize)]

--- a/src/worker/jobs/daily_db_maintenance.rs
+++ b/src/worker/jobs/daily_db_maintenance.rs
@@ -4,6 +4,7 @@ use diesel::sql_query;
 use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::info;
 
 #[derive(Serialize, Deserialize)]
 pub struct DailyDbMaintenance;

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -3,6 +3,7 @@ use crate::worker::Environment;
 use crate::worker::jobs::InvalidateCdns;
 use anyhow::Context;
 use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::try_join;
 

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -6,6 +6,7 @@ use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::try_join;
+use tracing::info;
 
 /// A background job that deletes all files associated with a crate from the storage backend.
 #[derive(Serialize, Deserialize)]

--- a/src/worker/jobs/docs_rs_queue_rebuild.rs
+++ b/src/worker/jobs/docs_rs_queue_rebuild.rs
@@ -4,6 +4,7 @@ use crates_io_docs_rs::DocsRsError;
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{error, warn};
 
 /// A background job that queues a docs rebuild for a specific release
 #[derive(Serialize, Deserialize)]

--- a/src/worker/jobs/docs_rs_queue_rebuild.rs
+++ b/src/worker/jobs/docs_rs_queue_rebuild.rs
@@ -2,6 +2,7 @@ use crate::worker::Environment;
 use anyhow::anyhow;
 use crates_io_docs_rs::DocsRsError;
 use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// A background job that queues a docs rebuild for a specific release

--- a/src/worker/jobs/downloads/clean_processed_log_files.rs
+++ b/src/worker/jobs/downloads/clean_processed_log_files.rs
@@ -3,6 +3,7 @@ use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// This job is responsible for cleaning up old entries in the

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -412,6 +412,7 @@ async fn save_as_processed(
 mod tests {
     use super::*;
     use crate::schema::{crates, version_downloads, versions};
+    use claims::assert_ok;
     use crates_io_test_db::TestDatabase;
     use diesel_async::pooled_connection::AsyncDieselConnectionManager;
     use insta::assert_debug_snapshot;

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::io::BufReader;
+use tracing::{debug, info, instrument, warn};
 
 /// A background job that loads a CDN log file from an object store (aka. S3),
 /// counts the number of downloads for each crate and version, and then inserts

--- a/src/worker/jobs/downloads/process_log.rs
+++ b/src/worker/jobs/downloads/process_log.rs
@@ -16,6 +16,7 @@ use object_store::local::LocalFileSystem;
 use object_store::memory::InMemory;
 use object_store::path::Path;
 use semver::Version;
+use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::io::BufReader;

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -9,6 +9,7 @@ use aws_sdk_sqs::types::Message;
 use crates_io_worker::BackgroundJob;
 use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::Pool;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// A background job that processes messages from the CDN log queue.

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -225,6 +225,7 @@ mod tests {
     use aws_sdk_sqs::operation::receive_message::builders::ReceiveMessageOutputBuilder;
     use aws_sdk_sqs::types::Message;
     use aws_sdk_sqs::types::builders::MessageBuilder;
+    use claims::assert_ok;
     use crates_io_test_db::TestDatabase;
     use crates_io_worker::schema::background_jobs;
     use diesel::prelude::*;

--- a/src/worker/jobs/downloads/queue/job.rs
+++ b/src/worker/jobs/downloads/queue/job.rs
@@ -11,6 +11,7 @@ use diesel_async::AsyncPgConnection;
 use diesel_async::pooled_connection::deadpool::Pool;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{debug, info, instrument, warn};
 
 /// A background job that processes messages from the CDN log queue.
 ///

--- a/src/worker/jobs/downloads/queue/message.rs
+++ b/src/worker/jobs/downloads/queue/message.rs
@@ -40,6 +40,7 @@ impl FromStr for Message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use claims::assert_ok;
     use insta::assert_debug_snapshot;
 
     #[test]

--- a/src/worker/jobs/downloads/queue/message.rs
+++ b/src/worker/jobs/downloads/queue/message.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -7,6 +7,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tracing::{info, instrument};
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateDownloads;

--- a/src/worker/jobs/downloads/update_metadata.rs
+++ b/src/worker/jobs/downloads/update_metadata.rs
@@ -4,6 +4,7 @@ use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel::sql_types::BigInt;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -3,6 +3,7 @@ use crate::worker::Environment;
 use crates_io_database_dump::{DumpDirectory, create_archives};
 use crates_io_worker::BackgroundJob;
 use secrecy::ExposeSecret;
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/src/worker/jobs/dump_db.rs
+++ b/src/worker/jobs/dump_db.rs
@@ -6,6 +6,7 @@ use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::Arc;
+use tracing::{info, warn};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct DumpDb;

--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -8,6 +8,7 @@ use diesel::prelude::*;
 use diesel::sql_types::Timestamptz;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use minijinja::context;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// The threshold for the expiry notification.

--- a/src/worker/jobs/expiry_notification.rs
+++ b/src/worker/jobs/expiry_notification.rs
@@ -10,6 +10,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use minijinja::context;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{debug, error, info, instrument, warn};
 
 /// The threshold for the expiry notification.
 const EXPIRY_THRESHOLD: chrono::TimeDelta = chrono::TimeDelta::days(3);

--- a/src/worker/jobs/index/normalize.rs
+++ b/src/worker/jobs/index/normalize.rs
@@ -2,6 +2,7 @@ use crate::tasks::spawn_blocking;
 use crate::worker::Environment;
 use crates_io_index::Crate;
 use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::Command;

--- a/src/worker/jobs/index/normalize.rs
+++ b/src/worker/jobs/index/normalize.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::io::{BufRead, BufReader};
 use std::process::Command;
 use std::sync::Arc;
+use tracing::info;
 
 #[derive(Serialize, Deserialize)]
 pub struct NormalizeIndex {

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -3,6 +3,7 @@ use crate::worker::Environment;
 use chrono::Utc;
 use crates_io_env_vars::var_parsed;
 use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 use std::sync::Arc;
 use url::Url;

--- a/src/worker/jobs/index/squash.rs
+++ b/src/worker/jobs/index/squash.rs
@@ -6,6 +6,7 @@ use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 use std::sync::Arc;
+use tracing::{info, instrument};
 use url::Url;
 
 #[derive(Serialize, Deserialize)]

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::fs::File;
 use std::io::{ErrorKind, Write};
 use std::sync::Arc;
+use tracing::{debug, info, instrument};
 
 #[derive(Serialize, Deserialize)]
 pub struct SyncToGitIndex {

--- a/src/worker/jobs/index/sync.rs
+++ b/src/worker/jobs/index/sync.rs
@@ -4,6 +4,7 @@ use crate::worker::Environment;
 use anyhow::Context;
 use crates_io_index::Repository;
 use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
 use std::fs;
 use std::fs::File;
 use std::io::{ErrorKind, Write};

--- a/src/worker/jobs/index_version_downloads_archive/mod.rs
+++ b/src/worker/jobs/index_version_downloads_archive/mod.rs
@@ -6,6 +6,7 @@ use crates_io_worker::BackgroundJob;
 use futures_util::TryStreamExt;
 use object_store::{ObjectMeta, ObjectStore};
 use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
 
 const INDEX_PATH: &str = "archive/version-downloads/index.html";
 const INDEX_JSON_PATH: &str = "archive/version-downloads/index.json";

--- a/src/worker/jobs/index_version_downloads_archive/mod.rs
+++ b/src/worker/jobs/index_version_downloads_archive/mod.rs
@@ -1,11 +1,11 @@
 use std::{collections::BTreeSet, sync::Arc};
 
+use crate::worker::Environment;
 use anyhow::Context;
 use crates_io_worker::BackgroundJob;
 use futures_util::TryStreamExt;
 use object_store::{ObjectMeta, ObjectStore};
-
-use crate::worker::Environment;
+use serde::{Deserialize, Serialize};
 
 const INDEX_PATH: &str = "archive/version-downloads/index.html";
 const INDEX_JSON_PATH: &str = "archive/version-downloads/index.json";

--- a/src/worker/jobs/invalidate_cdns.rs
+++ b/src/worker/jobs/invalidate_cdns.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
 
 use crate::worker::Environment;
 

--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -9,6 +9,7 @@ use diesel_async::AsyncConnection;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{info, instrument};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RenderAndUploadReadme {

--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -7,6 +7,7 @@ use crates_io_markdown::text_to_html;
 use crates_io_worker::BackgroundJob;
 use diesel_async::AsyncConnection;
 use diesel_async::scoped_futures::ScopedFutureExt;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Clone, Serialize, Deserialize)]

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -5,6 +5,7 @@ use chrono::{Duration, Utc};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Items younger than this will always be included in the feed.

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -7,6 +7,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{info, warn};
 
 /// Items younger than this will always be included in the feed.
 const ALWAYS_INCLUDE_AGE: Duration = Duration::hours(24);

--- a/src/worker/jobs/rss/sync_crate_feed.rs
+++ b/src/worker/jobs/rss/sync_crate_feed.rs
@@ -178,6 +178,7 @@ impl VersionUpdate {
 mod tests {
     use super::*;
     use chrono::DateTime;
+    use claims::assert_ok;
     use crates_io_test_db::TestDatabase;
     use futures_util::future::join_all;
     use insta::assert_debug_snapshot;

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -5,6 +5,7 @@ use chrono::{Duration, Utc};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize)]

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -7,6 +7,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{info, warn};
 
 #[derive(Serialize, Deserialize)]
 pub struct SyncCratesFeed;

--- a/src/worker/jobs/rss/sync_crates_feed.rs
+++ b/src/worker/jobs/rss/sync_crates_feed.rs
@@ -152,6 +152,7 @@ impl NewCrate {
 mod tests {
     use super::*;
     use chrono::DateTime;
+    use claims::assert_ok;
     use crates_io_test_db::TestDatabase;
     use diesel_async::AsyncPgConnection;
     use futures_util::future::join_all;

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -5,6 +5,7 @@ use chrono::{Duration, Utc};
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize)]

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -168,6 +168,7 @@ impl VersionUpdate {
 mod tests {
     use super::*;
     use chrono::{DateTime, Utc};
+    use claims::assert_ok;
     use crates_io_test_db::TestDatabase;
     use futures_util::future::join_all;
     use insta::assert_debug_snapshot;

--- a/src/worker/jobs/rss/sync_updates_feed.rs
+++ b/src/worker/jobs/rss/sync_updates_feed.rs
@@ -7,6 +7,7 @@ use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::{info, warn};
 
 #[derive(Serialize, Deserialize)]
 pub struct SyncUpdatesFeed;

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -10,7 +10,7 @@ use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use minijinja::context;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{debug, info, warn};
 
 /// Background job that sends email notifications to all crate owners when a
 /// new crate version is published.

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -8,6 +8,7 @@ use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use minijinja::context;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::warn;
 

--- a/src/worker/jobs/sync_admins.rs
+++ b/src/worker/jobs/sync_admins.rs
@@ -6,6 +6,7 @@ use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
 use minijinja::context;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
 

--- a/src/worker/jobs/sync_admins.rs
+++ b/src/worker/jobs/sync_admins.rs
@@ -9,6 +9,7 @@ use minijinja::context;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
+use tracing::{debug, info, warn};
 
 /// See <https://github.com/rust-lang/team/pull/1197>.
 const PERMISSION_NAME: &str = "crates_io_admin";

--- a/src/worker/jobs/trustpub/delete_jtis.rs
+++ b/src/worker/jobs/trustpub/delete_jtis.rs
@@ -3,6 +3,7 @@ use crates_io_database::schema::trustpub_used_jtis;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// A background job that deletes expired JSON Web Token IDs (JTIs)

--- a/src/worker/jobs/trustpub/delete_tokens.rs
+++ b/src/worker/jobs/trustpub/delete_tokens.rs
@@ -3,6 +3,7 @@ use crates_io_database::schema::trustpub_tokens;
 use crates_io_worker::BackgroundJob;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// A background job that deletes expired temporary access

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -10,6 +10,7 @@ use crate::typosquat::{Cache, Crate};
 use crate::worker::Environment;
 use anyhow::Context;
 use minijinja::context;
+use serde::{Deserialize, Serialize};
 use tracing::{error, info};
 
 /// A job to check the name of a newly published crate against the most popular crates to see if

--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -11,7 +11,7 @@ use crate::worker::Environment;
 use anyhow::Context;
 use minijinja::context;
 use serde::{Deserialize, Serialize};
-use tracing::{error, info};
+use tracing::{error, info, instrument};
 
 /// A job to check the name of a newly published crate against the most popular crates to see if
 /// the new crate might be typosquatting an existing, popular crate.

--- a/src/worker/jobs/update_default_version.rs
+++ b/src/worker/jobs/update_default_version.rs
@@ -3,6 +3,7 @@ use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use tracing::info;
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateDefaultVersion {

--- a/src/worker/jobs/update_default_version.rs
+++ b/src/worker/jobs/update_default_version.rs
@@ -1,6 +1,7 @@
 use crate::models::update_default_version;
 use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
The `#[macro_use]` attribute was the original way to import macros, but is no longer necessary. Some editors and development tools don't work well with `#[macro_use]` attributes and introduce explicit imports regardless.

This change removes all `#[macro_use]` declarations for claims, diesel, serde, and tracing crates, replacing them with explicit imports throughout the codebase.
