### PR TITLE
tarball: Use snapshot testing for more tests

### DIFF
--- a/crates/crates_io_tarball/src/lib.rs
+++ b/crates/crates_io_tarball/src/lib.rs
@@ -183,7 +183,6 @@ impl AbstractFilesystem for PathsFileSystem {
 mod tests {
     use super::process_tarball;
     use crate::TarballBuilder;
-    use cargo_manifest::{MaybeInherited, StringOrBool};
     use insta::{assert_debug_snapshot, assert_snapshot};
 
     const MANIFEST: &[u8] = b"[package]\nname = \"foo\"\nversion = \"0.0.1\"\n";
@@ -196,10 +195,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        assert_none!(tarball_info.vcs_info);
-        assert_none!(tarball_info.manifest.lib);
-        assert_eq!(tarball_info.manifest.bin, vec![]);
-        assert_eq!(tarball_info.manifest.example, vec![]);
+        assert_debug_snapshot!(tarball_info);
 
         let err = assert_err!(process_tarball("bar-0.0.1", &*tarball, MAX_SIZE).await);
         assert_snapshot!(err, @"invalid path found: foo-0.0.1/Cargo.toml");
@@ -224,8 +220,8 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let vcs_info = assert_some!(tarball_info.vcs_info);
-        assert_eq!(vcs_info.path_in_vcs, "");
+        assert_some!(&tarball_info.vcs_info);
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -237,8 +233,8 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let vcs_info = assert_some!(tarball_info.vcs_info);
-        assert_eq!(vcs_info.path_in_vcs, "path/in/vcs");
+        assert_some!(&tarball_info.vcs_info);
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -256,10 +252,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let package = assert_some!(tarball_info.manifest.package);
-        assert_matches!(package.readme, Some(MaybeInherited::Local(StringOrBool::String(s))) if s == "README.md");
-        assert_matches!(package.repository, Some(MaybeInherited::Local(s)) if s ==  "https://github.com/foo/bar");
-        assert_matches!(package.rust_version, Some(MaybeInherited::Local(s)) if s == "1.59");
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -275,8 +268,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let package = assert_some!(tarball_info.manifest.package);
-        assert_matches!(package.rust_version, Some(MaybeInherited::Local(s)) if s == "1.23");
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -286,8 +278,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let package = assert_some!(tarball_info.manifest.package);
-        assert_none!(package.readme);
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -303,8 +294,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let package = assert_some!(tarball_info.manifest.package);
-        assert_matches!(package.readme, Some(MaybeInherited::Local(StringOrBool::Bool(b))) if !b);
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -320,8 +310,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let package = assert_some!(tarball_info.manifest.package);
-        assert_matches!(package.repository, Some(MaybeInherited::Local(s)) if s ==  "https://github.com/foo/bar");
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -372,10 +361,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let lib = assert_some!(tarball_info.manifest.lib);
-        assert_debug_snapshot!(lib);
-        assert_eq!(tarball_info.manifest.bin, vec![]);
-        assert_eq!(tarball_info.manifest.example, vec![]);
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -389,10 +375,7 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        let lib = assert_some!(tarball_info.manifest.lib);
-        assert_debug_snapshot!(lib);
-        assert_debug_snapshot!(tarball_info.manifest.bin);
-        assert_debug_snapshot!(tarball_info.manifest.example);
+        assert_debug_snapshot!(tarball_info);
     }
 
     #[tokio::test]
@@ -403,8 +386,6 @@ mod tests {
             .build();
 
         let tarball_info = assert_ok!(process_tarball("foo-0.0.1", &*tarball, MAX_SIZE).await);
-        assert_none!(tarball_info.manifest.lib);
-        assert_debug_snapshot!(tarball_info.manifest.bin);
-        assert_eq!(tarball_info.manifest.example, vec![]);
+        assert_debug_snapshot!(tarball_info);
     }
 }

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib.snap
@@ -1,26 +1,83 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
-expression: lib
+expression: tarball_info
 ---
-Product {
-    path: Some(
-        "src/lib.rs",
-    ),
-    name: Some(
-        "foo",
-    ),
-    test: true,
-    doctest: true,
-    bench: true,
-    doc: true,
-    plugin: false,
-    proc_macro: false,
-    harness: true,
-    edition: None,
-    required_features: [],
-    crate_type: Some(
-        [
-            "lib",
-        ],
-    ),
+TarballInfo {
+    manifest: Manifest {
+        package: Some(
+            Package {
+                name: "foo",
+                edition: None,
+                version: Some(
+                    Local(
+                        "0.0.1",
+                    ),
+                ),
+                build: None,
+                workspace: None,
+                authors: None,
+                links: None,
+                description: None,
+                homepage: None,
+                documentation: None,
+                readme: None,
+                keywords: None,
+                categories: None,
+                license: None,
+                license_file: None,
+                repository: None,
+                metadata: None,
+                rust_version: None,
+                exclude: None,
+                include: None,
+                default_run: None,
+                autolib: None,
+                autobins: None,
+                autoexamples: None,
+                autotests: None,
+                autobenches: None,
+                publish: None,
+                resolver: None,
+            },
+        ),
+        cargo_features: None,
+        workspace: None,
+        dependencies: None,
+        dev_dependencies: None,
+        build_dependencies: None,
+        target: None,
+        features: None,
+        bin: [],
+        bench: [],
+        test: [],
+        example: [],
+        patch: None,
+        lib: Some(
+            Product {
+                path: Some(
+                    "src/lib.rs",
+                ),
+                name: Some(
+                    "foo",
+                ),
+                test: true,
+                doctest: true,
+                bench: true,
+                doc: true,
+                plugin: false,
+                proc_macro: false,
+                harness: true,
+                edition: None,
+                required_features: [],
+                crate_type: Some(
+                    [
+                        "lib",
+                    ],
+                ),
+            },
+        ),
+        profile: None,
+        badges: None,
+    },
+    vcs_info: None,
 }

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__lib_with_bins_and_example.snap
@@ -1,26 +1,143 @@
 ---
 source: crates/crates_io_tarball/src/lib.rs
-expression: lib
+expression: tarball_info
 ---
-Product {
-    path: Some(
-        "src/lib.rs",
-    ),
-    name: Some(
-        "foo",
-    ),
-    test: true,
-    doctest: true,
-    bench: true,
-    doc: true,
-    plugin: false,
-    proc_macro: false,
-    harness: true,
-    edition: None,
-    required_features: [],
-    crate_type: Some(
-        [
-            "lib",
+TarballInfo {
+    manifest: Manifest {
+        package: Some(
+            Package {
+                name: "foo",
+                edition: None,
+                version: Some(
+                    Local(
+                        "0.0.1",
+                    ),
+                ),
+                build: None,
+                workspace: None,
+                authors: None,
+                links: None,
+                description: None,
+                homepage: None,
+                documentation: None,
+                readme: None,
+                keywords: None,
+                categories: None,
+                license: None,
+                license_file: None,
+                repository: None,
+                metadata: None,
+                rust_version: None,
+                exclude: None,
+                include: None,
+                default_run: None,
+                autolib: None,
+                autobins: None,
+                autoexamples: None,
+                autotests: None,
+                autobenches: None,
+                publish: None,
+                resolver: None,
+            },
+        ),
+        cargo_features: None,
+        workspace: None,
+        dependencies: None,
+        dev_dependencies: None,
+        build_dependencies: None,
+        target: None,
+        features: None,
+        bin: [
+            Product {
+                path: Some(
+                    "src/bin/bar.rs",
+                ),
+                name: Some(
+                    "bar",
+                ),
+                test: true,
+                doctest: true,
+                bench: true,
+                doc: true,
+                plugin: false,
+                proc_macro: false,
+                harness: true,
+                edition: None,
+                required_features: [],
+                crate_type: None,
+            },
+            Product {
+                path: Some(
+                    "src/bin/foo.rs",
+                ),
+                name: Some(
+                    "foo",
+                ),
+                test: true,
+                doctest: true,
+                bench: true,
+                doc: true,
+                plugin: false,
+                proc_macro: false,
+                harness: true,
+                edition: None,
+                required_features: [],
+                crate_type: None,
+            },
         ],
-    ),
+        bench: [],
+        test: [],
+        example: [
+            Product {
+                path: Some(
+                    "examples/how-to-use-foo.rs",
+                ),
+                name: Some(
+                    "how-to-use-foo",
+                ),
+                test: true,
+                doctest: true,
+                bench: true,
+                doc: true,
+                plugin: false,
+                proc_macro: false,
+                harness: true,
+                edition: None,
+                required_features: [],
+                crate_type: Some(
+                    [
+                        "bin",
+                    ],
+                ),
+            },
+        ],
+        patch: None,
+        lib: Some(
+            Product {
+                path: Some(
+                    "src/lib.rs",
+                ),
+                name: Some(
+                    "foo",
+                ),
+                test: true,
+                doctest: true,
+                bench: true,
+                doc: true,
+                plugin: false,
+                proc_macro: false,
+                harness: true,
+                edition: None,
+                required_features: [],
+                crate_type: Some(
+                    [
+                        "lib",
+                    ],
+                ),
+            },
+        ),
+        profile: None,
+        badges: None,
+    },
+    vcs_info: None,
 }

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test.snap
@@ -47,26 +47,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_incomplete_vcs_info.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_incomplete_vcs_info.snap
@@ -47,26 +47,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],
@@ -75,5 +56,9 @@ TarballInfo {
         profile: None,
         badges: None,
     },
-    vcs_info: None,
+    vcs_info: Some(
+        CargoVcsInfo {
+            path_in_vcs: "",
+        },
+    ),
 }

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_lowercase_manifest.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_lowercase_manifest.snap
@@ -25,7 +25,11 @@ TarballInfo {
                 categories: None,
                 license: None,
                 license_file: None,
-                repository: None,
+                repository: Some(
+                    Local(
+                        "https://github.com/foo/bar",
+                    ),
+                ),
                 metadata: None,
                 rust_version: None,
                 exclude: None,
@@ -47,26 +51,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest.snap
@@ -20,14 +20,28 @@ TarballInfo {
                 description: None,
                 homepage: None,
                 documentation: None,
-                readme: None,
+                readme: Some(
+                    Local(
+                        String(
+                            "README.md",
+                        ),
+                    ),
+                ),
                 keywords: None,
                 categories: None,
                 license: None,
                 license_file: None,
-                repository: None,
+                repository: Some(
+                    Local(
+                        "https://github.com/foo/bar",
+                    ),
+                ),
                 metadata: None,
-                rust_version: None,
+                rust_version: Some(
+                    Local(
+                        "1.59",
+                    ),
+                ),
                 exclude: None,
                 include: None,
                 default_run: None,
@@ -47,26 +61,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest_with_boolean_readme.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest_with_boolean_readme.snap
@@ -20,7 +20,13 @@ TarballInfo {
                 description: None,
                 homepage: None,
                 documentation: None,
-                readme: None,
+                readme: Some(
+                    Local(
+                        Bool(
+                            false,
+                        ),
+                    ),
+                ),
                 keywords: None,
                 categories: None,
                 license: None,
@@ -47,26 +53,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest_with_default_readme.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest_with_default_readme.snap
@@ -47,26 +47,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest_with_project.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_manifest_with_project.snap
@@ -27,7 +27,11 @@ TarballInfo {
                 license_file: None,
                 repository: None,
                 metadata: None,
-                rust_version: None,
+                rust_version: Some(
+                    Local(
+                        "1.23",
+                    ),
+                ),
                 exclude: None,
                 include: None,
                 default_run: None,
@@ -47,26 +51,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],

--- a/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_vcs_info.snap
+++ b/crates/crates_io_tarball/src/snapshots/crates_io_tarball__tests__process_tarball_test_vcs_info.snap
@@ -47,26 +47,7 @@ TarballInfo {
         build_dependencies: None,
         target: None,
         features: None,
-        bin: [
-            Product {
-                path: Some(
-                    "src/main.rs",
-                ),
-                name: Some(
-                    "foo",
-                ),
-                test: true,
-                doctest: true,
-                bench: true,
-                doc: true,
-                plugin: false,
-                proc_macro: false,
-                harness: true,
-                edition: None,
-                required_features: [],
-                crate_type: None,
-            },
-        ],
+        bin: [],
         bench: [],
         test: [],
         example: [],
@@ -75,5 +56,9 @@ TarballInfo {
         profile: None,
         badges: None,
     },
-    vcs_info: None,
+    vcs_info: Some(
+        CargoVcsInfo {
+            path_in_vcs: "path/in/vcs",
+        },
+    ),
 }


### PR DESCRIPTION
None of these tests were asserting on the full output of the `process_tarball()` fn so far. This PR changes that, by using snapshot testing for most of these tests. This should ensure that we don't unintentionally introduce any changes to the `TarballInfo` struct or any of its children.