### PR TITLE
Added crate ID for background jobs

### DIFF
--- a/src/controllers/krate/delete.rs
+++ b/src/controllers/krate/delete.rs
@@ -134,7 +134,7 @@ pub async fn delete_crate(
 
             let git_index_job = jobs::SyncToGitIndex::new(&krate.name);
             let sparse_index_job = jobs::SyncToSparseIndex::new(&krate.name);
-            let delete_from_storage_job = jobs::DeleteCrateFromStorage::new(path.name);
+            let delete_from_storage_job = jobs::DeleteCrateFromStorage::new(path.name, krate.id);
 
             tokio::try_join!(
                 git_index_job.enqueue(conn),

--- a/src/worker/jobs/delete_crate.rs
+++ b/src/worker/jobs/delete_crate.rs
@@ -12,11 +12,15 @@ use tracing::info;
 #[derive(Serialize, Deserialize)]
 pub struct DeleteCrateFromStorage {
     name: String,
+    crate_id: Option<i32>,
 }
 
 impl DeleteCrateFromStorage {
-    pub fn new(name: String) -> Self {
-        Self { name }
+    pub fn new(name: String, crate_id: i32) -> Self {
+        Self {
+            name,
+            crate_id: Some(crate_id),
+        }
     }
 }
 


### PR DESCRIPTION
Should the jobs store crate names for logging purposes? Or should they just show the provided ID instead?