### PR TITLE
trustpub: Prefill repo owner and name for crates with GitHub repo URLs

### DIFF
--- a/app/routes/crate/settings/new-trusted-publisher.js
+++ b/app/routes/crate/settings/new-trusted-publisher.js
@@ -5,4 +5,27 @@ export default class NewTrustedPublisherRoute extends Route {
     let crate = this.modelFor('crate');
     return { crate };
   }
+
+  setupController(controller, model) {
+    super.setupController(controller, model);
+
+    controller.repositoryOwner = '';
+    controller.repositoryName = '';
+    controller.workflowFilename = '';
+    controller.environment = '';
+
+    let repository = model.crate.repository;
+    if (repository && repository.startsWith('https://github.com/')) {
+      try {
+        let url = new URL(repository);
+        let pathParts = url.pathname.slice(1).split('/');
+        if (pathParts.length >= 2) {
+          controller.repositoryOwner = pathParts[0];
+          controller.repositoryName = pathParts[1].replace(/.git$/, '');
+        }
+      } catch {
+        // ignore malformed URLs
+      }
+    }
+  }
 }


### PR DESCRIPTION
When the user visits the form to create a new Trusted Publishing configuration, we look at the `repository` field of the crate, and if it is a GitHub URL (e.g. https://github.com/rust-lang/crates.io) we extract the repository owner and name from the URL and prefill the input fields accordingly. This should make the configuration creation a slightly more enjoyable experience.