### PR TITLE
Skip running a job if the crate/version deleted

### DIFF
--- a/src/worker/jobs/readmes.rs
+++ b/src/worker/jobs/readmes.rs
@@ -9,7 +9,7 @@ use diesel_async::AsyncConnection;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RenderAndUploadReadme {
@@ -70,13 +70,31 @@ impl BackgroundJob for RenderAndUploadReadme {
         let mut conn = env.deadpool.get().await?;
         conn.transaction(|conn| {
             async move {
-                Version::record_readme_rendering(job.version_id, conn).await?;
-                let (crate_name, vers): (String, String) = versions::table
-                    .find(job.version_id)
-                    .inner_join(crates::table)
-                    .select((crates::name, versions::num))
-                    .first(conn)
-                    .await?;
+                let (crate_name, vers): (String, String) =
+                    match Version::record_readme_rendering(job.version_id, conn)
+                        .await
+                        .and(
+                            versions::table
+                                .find(job.version_id)
+                                .inner_join(crates::table)
+                                .select((crates::name, versions::num))
+                                .first(conn)
+                                .await,
+                        ) {
+                        Ok(r) => r,
+                        Err(diesel::result::Error::DatabaseError(
+                            diesel::result::DatabaseErrorKind::ForeignKeyViolation,
+                            ..,
+                        ))
+                        | Err(diesel::result::Error::NotFound) => {
+                            warn!(
+                                "Skipping rendering README for vesion {}: no version found",
+                                job.version_id
+                            );
+                            return Ok(());
+                        }
+                        Err(err) => return Err(err.into()),
+                    };
 
                 tracing::Span::current().record("krate.name", tracing::field::display(&crate_name));
 

--- a/src/worker/jobs/send_publish_notifications.rs
+++ b/src/worker/jobs/send_publish_notifications.rs
@@ -39,7 +39,12 @@ impl BackgroundJob for SendPublishNotificationsJob {
         let mut conn = ctx.deadpool.get().await?;
 
         // Get crate name, version and other publish details
-        let publish_details = PublishDetails::for_version(version_id, &mut conn).await?;
+        let Some(publish_details) = PublishDetails::for_version(version_id, &mut conn).await?
+        else {
+            warn!("Skipping publish notifications for {version_id}: no version found",);
+
+            return Ok(());
+        };
 
         let publish_time = publish_details
             .publish_time
@@ -157,7 +162,10 @@ struct PublishDetails {
 }
 
 impl PublishDetails {
-    async fn for_version(version_id: i32, conn: &mut AsyncPgConnection) -> QueryResult<Self> {
+    async fn for_version(
+        version_id: i32,
+        conn: &mut AsyncPgConnection,
+    ) -> QueryResult<Option<Self>> {
         versions::table
             .find(version_id)
             .inner_join(crates::table)
@@ -165,5 +173,6 @@ impl PublishDetails {
             .select(PublishDetails::as_select())
             .first(conn)
             .await
+            .optional()
     }
 }

--- a/src/worker/jobs/update_default_version.rs
+++ b/src/worker/jobs/update_default_version.rs
@@ -3,7 +3,7 @@ use crate::worker::Environment;
 use crates_io_worker::BackgroundJob;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Serialize, Deserialize)]
 pub struct UpdateDefaultVersion {
@@ -28,8 +28,16 @@ impl BackgroundJob for UpdateDefaultVersion {
 
         info!("Updating default version for crate {crate_id}");
         let mut conn = ctx.deadpool.get().await?;
-        update_default_version(crate_id, &mut conn).await?;
+        let res = update_default_version(crate_id, &mut conn).await;
+        if let Err(diesel::result::Error::DatabaseError(
+            diesel::result::DatabaseErrorKind::ForeignKeyViolation,
+            ..,
+        )) = res
+        {
+            warn!("Skipping update default version for crate for {crate_id}: no crate found",);
+            return Ok(());
+        }
 
-        Ok(())
+        res.map_err(|e| e.into())
     }
 }


### PR DESCRIPTION
Fixes #11348.

After diffing in I found only 3 jobs that can fail because of deleted data. The rest should be fine.