### PR TITLE
Dedupe expired JTI deletion job

### DIFF
--- a/src/worker/jobs/trustpub/delete_jtis.rs
+++ b/src/worker/jobs/trustpub/delete_jtis.rs
@@ -13,6 +13,7 @@ pub struct DeleteExpiredJtis;
 
 impl BackgroundJob for DeleteExpiredJtis {
     const JOB_NAME: &'static str = "trustpub::delete_expired_jtis";
+    const DEDUPLICATED: bool = true;
 
     type Context = Arc<Environment>;
 


### PR DESCRIPTION
It's a job without any parameters that always cleanups tokens expired to the moment of running. Therefore, there's no reason to enqueue another one if the existing hasn't been executed yet.