### PR TITLE
trustpub: Improve config creation form

### DIFF
--- a/app/styles/crate/settings/new-trusted-publisher.module.css
+++ b/app/styles/crate/settings/new-trusted-publisher.module.css
@@ -1,9 +1,14 @@
+.form {
+    max-width: 600px;
+    margin: var(--space-m) auto;
+}
+
 .form-group, .buttons {
     margin: var(--space-m) 0;
 }
 
 .publisher-select {
-    max-width: 440px;
+    max-width: 600px;
     width: 100%;
     padding-right: var(--space-m);
     background-image: url("/assets/dropdown.svg");
@@ -19,7 +24,7 @@
 }
 
 .input {
-    max-width: 440px;
+    max-width: 600px;
     width: 100%;
 }
 

--- a/app/templates/crate/settings/new-trusted-publisher.hbs
+++ b/app/templates/crate/settings/new-trusted-publisher.hbs
@@ -106,7 +106,7 @@
           </div>
         {{else}}
           <div local-class="note">
-            The filename of the publishing workflow. This file should be present in the <code>.github/workflows/</code> directory of the repository configured above.
+            The filename of the publishing workflow. This file should be present in the <code>.github/workflows/</code> directory of the repository configured above. For example: <code>release.yml</code> or <code>publish.yml</code>.
           </div>
         {{/if}}
       {{/let}}

--- a/app/templates/crate/settings/new-trusted-publisher.hbs
+++ b/app/templates/crate/settings/new-trusted-publisher.hbs
@@ -1,6 +1,6 @@
-<h2>Add a new Trusted Publisher</h2>
+<form local-class="form" {{on "submit" (prevent-default (perform this.saveConfigTask))}}>
+  <h2>Add a new Trusted Publisher</h2>
 
-<form {{on "submit" (prevent-default (perform this.saveConfigTask))}}>
   <div local-class="form-group">
     {{#let (unique-id) as |id|}}
       <label for={{id}} class="form-group-name">Publisher</label>


### PR DESCRIPTION
![Bildschirmfoto 2025-07-03 um 19 36 34](https://github.com/user-attachments/assets/53061d13-a028-4640-b53d-9c1f9157a5cf)

This PR slightly adjusts the Trusted Publishing config creation form. It adds examples to the filename input help text and slightly tweaks the layout to be a bit easier on the eyes on large screens.

Related:

- https://github.com/bytecodealliance/wasm-component-ld/pull/69#issuecomment-3032604217
- https://github.com/rust-lang/crates.io/issues/10247