### PR TITLE
og_image: Add support for JPEG avatars

### DIFF
--- a/crates/crates_io_og_image/examples/test_generator.rs
+++ b/crates/crates_io_og_image/examples/test_generator.rs
@@ -32,6 +32,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "Turbo87",
                 "https://avatars.githubusercontent.com/u/141300",
             ),
+            OgImageAuthorData::with_url(
+                "carols10cents",
+                "https://avatars.githubusercontent.com/u/193874",
+            ),
         ],
         lines_of_code: Some(2000),
         crate_size: 75,


### PR DESCRIPTION
Turns out some GitHub users have JPEG avatars instead of PNG and that confuses Typst. This PR fixes the issue by detecting the image type and saving them with the correct filename extensions.