### PR TITLE
og-image: Handle 404 errors from avatar downloads gracefully

### DIFF
--- a/crates/crates_io_og_image/template/og-image.typ
+++ b/crates/crates_io_og_image/template/og-image.typ
@@ -283,7 +283,10 @@
             let authors-with-avatars = data.authors.map(author => {
                 let avatar = none
                 if author.avatar != none {
-                    avatar = "assets/" + avatar_map.at(author.avatar)
+                    let avatar_path = avatar_map.at(author.avatar, default: none)
+                    if avatar_path != none {
+                        avatar = "assets/" + avatar_path
+                    }
                 }
                 (name: author.name, avatar: avatar)
             })


### PR DESCRIPTION
Some of our users appear to have avatar URLs like `https://private-avatars.githubusercontent.com/u/123095?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MzQ1MjkwMjAsIm5iZiI6MTczNDUyNzgyMCwicGF0aCI6Ii91LzEyMzA5NSJ9.qPHLwlZHda1ApuLzL5FfADxTiOsNjpp85IGvljRx9bM&v=4&s=64` which result in 404 errors when attempting to download them. This commit adjusts the code to log a warning in such cases and then show the author name without an avatar instead.