### PR TITLE
og_image: Skip CDN invalidations for backfill operation

### DIFF
--- a/src/bin/crates-admin/backfill_og_images.rs
+++ b/src/bin/crates-admin/backfill_og_images.rs
@@ -79,7 +79,7 @@ pub async fn run(opts: Opts) -> Result<()> {
         // Create batch of jobs
         let jobs = crate_names
             .into_iter()
-            .map(GenerateOgImage::new)
+            .map(GenerateOgImage::without_cdn_invalidation)
             .map(|job| {
                 Ok((
                     background_jobs::job_type.eq(GenerateOgImage::JOB_NAME),


### PR DESCRIPTION
The backfill operation on production caused a lot of CDN validations, leading to rate limiting from CloudFront, which then prevented sparse index updates. This PR ensures that the backfill operation runs without CDN invalidations, to not block the more important background jobs from finishing.