### PR TITLE
tracing: Consistently use `krate.name` field naming convention

### DIFF
--- a/crates/crates_io_og_image/src/lib.rs
+++ b/crates/crates_io_og_image/src/lib.rs
@@ -223,7 +223,7 @@ impl OgImageGenerator {
     /// This method handles both asset-based avatars (which are copied from the bundled assets)
     /// and URL-based avatars (which are downloaded from the internet).
     /// Returns a mapping from avatar source to the local filename.
-    #[instrument(skip(self, data), fields(crate.name = %data.name))]
+    #[instrument(skip(self, data), fields(krate.name = %data.name))]
     async fn process_avatars<'a>(
         &self,
         data: &'a OgImageData<'_>,

--- a/src/worker/jobs/generate_og_image.rs
+++ b/src/worker/jobs/generate_og_image.rs
@@ -39,7 +39,7 @@ impl BackgroundJob for GenerateOgImage {
 
     type Context = Arc<Environment>;
 
-    #[instrument(skip_all, fields(crate.name = %self.crate_name))]
+    #[instrument(skip_all, fields(krate.name = %self.crate_name))]
     async fn run(&self, ctx: Self::Context) -> anyhow::Result<()> {
         let crate_name = &self.crate_name;
 


### PR DESCRIPTION
We should probably change the rest to `crate.name` instead, but let's do that in a dedicated step to not confuse downstream tools.