### PR TITLE
Add an API route for admins to assess crates

### DIFF
--- a/src/controllers.rs
+++ b/src/controllers.rs
@@ -1,6 +1,7 @@
 pub mod helpers;
 pub mod util;
 
+pub mod admin;
 pub mod category;
 pub mod crate_owner_invitation;
 pub mod git;

--- a/src/controllers/admin.rs
+++ b/src/controllers/admin.rs
@@ -1,0 +1,124 @@
+use crate::{
+    app::AppState,
+    auth::AuthCheck,
+    models::{CrateOwner, OwnerKind, User, Version},
+    schema::*,
+    util::errors::{AppResult, custom},
+};
+use axum::{Json, extract::Path};
+use chrono::{DateTime, Utc};
+use diesel::{dsl::count_star, prelude::*};
+use diesel_async::RunQueryDsl;
+use http::{StatusCode, request::Parts};
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Handles the `GET /api/private/admin_list/{username}` endpoint.
+pub async fn list(
+    state: AppState,
+    Path(username): Path<String>,
+    req: Parts,
+) -> AppResult<Json<AdminListResponse>> {
+    let mut conn = state.db_write().await?;
+
+    let auth = AuthCheck::default().check(&req, &mut conn).await?;
+    let logged_in_user = auth.user();
+
+    if !logged_in_user.is_admin {
+        return Err(custom(
+            StatusCode::FORBIDDEN,
+            "must be an admin to use this route",
+        ));
+    }
+
+    let (user, verified, email) = users::table
+        .left_join(emails::table)
+        .filter(users::gh_login.eq(username))
+        .select((
+            User::as_select(),
+            emails::verified.nullable(),
+            emails::email.nullable(),
+        ))
+        .first::<(User, Option<bool>, Option<String>)>(&mut conn)
+        .await?;
+
+    let crates: Vec<(i32, String, DateTime<Utc>, i64)> = CrateOwner::by_owner_kind(OwnerKind::User)
+        .inner_join(crates::table)
+        .filter(crate_owners::owner_id.eq(user.id))
+        .select((
+            crates::id,
+            crates::name,
+            crates::updated_at,
+            rev_deps_subquery(),
+        ))
+        .order(crates::name.asc())
+        .load(&mut conn)
+        .await?;
+
+    let crate_ids: Vec<_> = crates.iter().map(|(id, ..)| id).collect();
+
+    let versions: Vec<Version> = versions::table
+        .filter(versions::crate_id.eq_any(crate_ids))
+        .select(Version::as_select())
+        .load(&mut conn)
+        .await?;
+    let mut versions_by_crate_id: HashMap<i32, Vec<Version>> = HashMap::new();
+    for version in versions {
+        let crate_versions = versions_by_crate_id.entry(version.crate_id).or_default();
+        crate_versions.push(version);
+    }
+
+    let verified = verified.unwrap_or(false);
+    let crates = crates
+        .into_iter()
+        .map(|(crate_id, name, updated_at, num_rev_deps)| {
+            let versions = versions_by_crate_id.get(&crate_id);
+            let last_version = versions.and_then(|v| v.last());
+            AdminCrateInfo {
+                name,
+                updated_at,
+                num_rev_deps,
+                num_versions: versions.map(|v| v.len()).unwrap_or(0),
+                crate_size: last_version.map(|v| v.crate_size).unwrap_or(0),
+                bin_names: last_version
+                    .map(|v| v.bin_names.clone())
+                    .unwrap_or_default(),
+            }
+        })
+        .collect();
+    Ok(Json(AdminListResponse {
+        user_email: verified.then_some(email).flatten(),
+        crates,
+    }))
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminListResponse {
+    user_email: Option<String>,
+    crates: Vec<AdminCrateInfo>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AdminCrateInfo {
+    pub name: String,
+    pub updated_at: DateTime<Utc>,
+    pub num_rev_deps: i64,
+    pub num_versions: usize,
+    pub crate_size: i32,
+    pub bin_names: Option<Vec<Option<String>>>,
+}
+
+/// A subquery that returns the number of reverse dependencies of a crate.
+///
+/// **Warning:** this is an incorrect reverse dependencies query, since it
+/// includes the `dependencies` rows for all versions, not just the
+/// "default version" per crate. However, it's good enough for our
+/// purposes here.
+#[diesel::dsl::auto_type]
+fn rev_deps_subquery() -> _ {
+    dependencies::table
+        .select(count_star())
+        .filter(dependencies::crate_id.eq(crates::id))
+        .single_value()
+        .assume_not_null()
+}

--- a/src/router.rs
+++ b/src/router.rs
@@ -103,6 +103,8 @@ pub fn build_axum_router(state: AppState) -> Router<()> {
     let mut router = router
         // Metrics
         .route("/api/private/metrics/{kind}", get(metrics::prometheus))
+        // Listing a user's crates for admin/support purposes
+        .route("/api/private/admin_list/{username}", get(admin::list))
         // Alerts from GitHub scanning for exposed API tokens
         .route(
             "/api/github/secret-scanning/verify",

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -84,7 +84,17 @@ pub struct OkBool {
     #[allow(dead_code)]
     ok: bool,
 }
-
+#[derive(Deserialize)]
+pub struct AdminListResponse {
+    user_email: Option<String>,
+    crates: Vec<AdminCrateInfo>,
+}
+#[derive(Deserialize)]
+pub struct AdminCrateInfo {
+    name: String,
+    num_versions: usize,
+    num_rev_deps: i64,
+}
 #[derive(Deserialize, Debug)]
 pub struct OwnerResp {
     // server must include `ok: true` to support old cargo clients

--- a/src/tests/routes/crates/admin.rs
+++ b/src/tests/routes/crates/admin.rs
@@ -1,0 +1,79 @@
+use crate::{
+    schema::users,
+    tests::{
+        builders::{CrateBuilder, VersionBuilder},
+        util::{RequestHelper, TestApp},
+    },
+};
+use diesel::prelude::*;
+use diesel_async::RunQueryDsl;
+use insta::assert_snapshot;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_list_by_a_non_admin_fails() {
+    let (_app, anon, user) = TestApp::init().with_user().await;
+
+    let response = anon.admin_list("anything").await;
+    assert_snapshot!(response.status(), @"403 Forbidden");
+    assert_snapshot!(
+        response.text(),
+        @r#"{"errors":[{"detail":"this action requires authentication"}]}"#
+    );
+
+    let response = user.admin_list("anything").await;
+    assert_snapshot!(response.status(), @"403 Forbidden");
+    assert_snapshot!(
+        response.text(),
+        @r#"{"errors":[{"detail":"must be an admin to use this route"}]}"#
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn index_include_yanked() -> anyhow::Result<()> {
+    let (app, _anon, user) = TestApp::init().with_user().await;
+    let mut conn = app.db_conn().await;
+    let user = user.as_model();
+
+    let admin = app.db_new_user("admin").await;
+
+    diesel::update(admin.as_model())
+        .set(users::is_admin.eq(true))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let crate_1 = CrateBuilder::new("unyanked", user.id)
+        .version(VersionBuilder::new("0.1.0").yanked(true))
+        .version(VersionBuilder::new("1.0.0"))
+        .version(VersionBuilder::new("2.0.0"))
+        .expect_build(&mut conn)
+        .await;
+
+    CrateBuilder::new("all_yanked", user.id)
+        .version(VersionBuilder::new("1.0.0").yanked(true))
+        .version(VersionBuilder::new("2.0.0").yanked(true))
+        .expect_build(&mut conn)
+        .await;
+
+    CrateBuilder::new("someone_elses_crate", admin.as_model().id)
+        .version(VersionBuilder::new("1.0.0").dependency(&crate_1, None))
+        .expect_build(&mut conn)
+        .await;
+
+    // Include fully yanked (all versions were yanked) crates
+    let username = &user.gh_login;
+    let json = admin.admin_list(username).await.good();
+
+    assert_eq!(json.user_email.unwrap(), "foo@example.com");
+    assert_eq!(json.crates.len(), 2);
+
+    assert_eq!(json.crates[0].name, "all_yanked");
+    assert_eq!(json.crates[0].num_versions, 2);
+    assert_eq!(json.crates[0].num_rev_deps, 0);
+
+    assert_eq!(json.crates[1].name, "unyanked");
+    assert_eq!(json.crates[1].num_versions, 3);
+    assert_eq!(json.crates[1].num_rev_deps, 1);
+
+    Ok(())
+}

--- a/src/tests/routes/crates/mod.rs
+++ b/src/tests/routes/crates/mod.rs
@@ -1,3 +1,4 @@
+mod admin;
 pub mod downloads;
 mod following;
 mod list;

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -21,8 +21,8 @@
 
 use crate::models::{ApiToken, User};
 use crate::tests::{
-    CategoryListResponse, CategoryResponse, CrateList, CrateResponse, GoodCrate, OwnerResp,
-    OwnersResponse, VersionResponse,
+    AdminListResponse, CategoryListResponse, CategoryResponse, CrateList, CrateResponse, GoodCrate,
+    OwnerResp, OwnersResponse, VersionResponse,
 };
 use std::future::Future;
 
@@ -184,6 +184,12 @@ pub trait RequestHelper {
     /// Search for crates matching a query string
     async fn search(&self, query: &str) -> CrateList {
         self.get_with_query("/api/v1/crates", query).await.good()
+    }
+
+    /// Request the JSON used for the admin list page
+    async fn admin_list(&self, owner: &str) -> Response<AdminListResponse> {
+        let url = format!("/api/private/admin_list/{owner}");
+        self.get(&url).await
     }
 
     /// Publish the crate and run background jobs to completion


### PR DESCRIPTION
Connects to #10387.

This API route, under `/private/` rather than `v1`, will make it a lot easier to assess whether crates contain useful functionality or are squatting.

This is only the backend; some of the functionality described in the issue will be frontend-only, but I wanted to get the API in first.

The API route will only return data if the currently authenticated user is an admin. This is important because the crate owner's verified email address is part of the returned data so that the admin can contact the owner if necessary.

Another reason this route is limited to admins is that some of the queries may be slow.