### PR TITLE
Force `@babel/runtime` to 7.27.6 to resolve security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "webpack": "5.99.9"
   },
   "resolutions": {
+    "@babel/runtime": "7.27.6",
     "ember-auto-import": "2.10.0",
     "ember-get-config": "2.1.1",
     "ember-inflector": "6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@babel/runtime': 7.27.6
   ember-auto-import: 2.10.0
   ember-get-config: 2.1.1
   ember-inflector: 6.0.0
@@ -904,9 +905,6 @@ packages:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-
-  '@babel/runtime@7.12.18':
-    resolution: {integrity: sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==}
 
   '@babel/runtime@7.27.6':
     resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
@@ -9209,10 +9207,6 @@ snapshots:
       '@babel/types': 7.28.0
       esutils: 2.0.3
 
-  '@babel/runtime@7.12.18':
-    dependencies:
-      regenerator-runtime: 0.13.11
-
   '@babel/runtime@7.27.6': {}
 
   '@babel/template@7.27.2':
@@ -13074,7 +13068,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@babel/polyfill': 7.12.1
       '@babel/preset-env': 7.28.0(@babel/core@7.28.0)(supports-color@8.1.1)
-      '@babel/runtime': 7.12.18
+      '@babel/runtime': 7.27.6
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
       babel-plugin-ember-data-packages-polyfill: 0.1.2
@@ -13109,7 +13103,7 @@ snapshots:
       '@babel/plugin-transform-runtime': 7.28.0(@babel/core@7.28.0)
       '@babel/plugin-transform-typescript': 7.28.0(@babel/core@7.28.0)
       '@babel/preset-env': 7.28.0(@babel/core@7.28.0)(supports-color@8.1.1)
-      '@babel/runtime': 7.12.18
+      '@babel/runtime': 7.27.6
       amd-name-resolver: 1.3.1
       babel-plugin-debug-macros: 0.3.4(@babel/core@7.28.0)
       babel-plugin-ember-data-packages-polyfill: 0.1.2


### PR DESCRIPTION
see https://github.com/advisories/GHSA-968p-4wvh-cqc8