### PR TITLE
crate/settings: Improve "Trusted Publishing" section styling on mobile devices

### DIFF
--- a/app/styles/crate/settings/index.module.css
+++ b/app/styles/crate/settings/index.module.css
@@ -72,6 +72,37 @@
     .actions {
         text-align: right;
     }
+
+    @media only screen and (max-width: 550px) {
+        thead {
+            display: none;
+        }
+
+        tbody > tr > td:first-child {
+            padding-bottom: 0;
+        }
+
+        tbody > tr:not(:first-child) > td:first-child {
+            border-top: 1px solid light-dark(hsla(51, 90%, 42%, .25), #232321);
+        }
+
+        tbody > tr > td {
+            border: none;
+        }
+
+        td {
+            display: block;
+            width: 100%;
+        }
+
+        .details {
+            padding-bottom: 0;
+        }
+
+        .actions {
+            text-align: left;
+        }
+    }
 }
 
 .email-column {


### PR DESCRIPTION
### Before

<img width="389" alt="Bildschirmfoto 2025-07-07 um 18 39 08" src="https://github.com/user-attachments/assets/45a5b965-2201-4182-84a6-0d87b45165ff" />

### After

<img width="371" alt="Bildschirmfoto 2025-07-07 um 18 39 17" src="https://github.com/user-attachments/assets/8e221984-555a-4d98-b42f-28d0bbf0027b" />
