### PR TITLE
crate/settings: Add links back to the repository

### DIFF
--- a/app/controllers/crate/settings/new-trusted-publisher.js
+++ b/app/controllers/crate/settings/new-trusted-publisher.js
@@ -27,6 +27,12 @@ export default class NewTrustedPublisherController extends Controller {
     return ['GitHub'];
   }
 
+  get repository() {
+    if (this.repositoryOwner && this.repositoryName) {
+      return `${this.repositoryOwner}/${this.repositoryName}`;
+    }
+  }
+
   saveConfigTask = task(async () => {
     if (!this.validate()) return;
 

--- a/app/templates/crate/settings/index.hbs
+++ b/app/templates/crate/settings/index.hbs
@@ -81,8 +81,8 @@
       <tr data-test-github-config={{config.id}}>
         <td>GitHub</td>
         <td local-class="details">
-          <strong>Repository:</strong> {{config.repository_owner}}/{{config.repository_name}}<br>
-          <strong>Workflow:</strong> {{config.workflow_filename}}<br>
+          <strong>Repository:</strong> <a href="https://github.com/{{config.repository_owner}}/{{config.repository_name}}" target="_blank" rel="noopener noreferrer">{{config.repository_owner}}/{{config.repository_name}}</a><br>
+          <strong>Workflow:</strong> <a href="https://github.com/{{config.repository_owner}}/{{config.repository_name}}/blob/HEAD/.github/workflows/{{config.workflow_filename}}" target="_blank" rel="noopener noreferrer">{{config.workflow_filename}}</a><br>
           {{#if config.environment}}
             <strong>Environment:</strong> {{config.environment}}
           {{/if}}

--- a/app/templates/crate/settings/new-trusted-publisher.hbs
+++ b/app/templates/crate/settings/new-trusted-publisher.hbs
@@ -106,7 +106,18 @@
           </div>
         {{else}}
           <div local-class="note">
-            The filename of the publishing workflow. This file should be present in the <code>.github/workflows/</code> directory of the repository configured above. For example: <code>release.yml</code> or <code>publish.yml</code>.
+            The filename of the publishing workflow. This file should be present in the
+            <code>
+              {{#if this.repository}}
+                <a href="https://github.com/{{this.repository}}/blob/HEAD/.github/workflows/" target="_blank" rel="noopener noreferrer">.github/workflows/</a>
+              {{else}}
+                .github/workflows/
+              {{/if}}
+            </code>
+            directory of the
+            {{#if this.repository}}<a href="https://github.com/{{this.repository}}/" target="_blank" rel="noopener noreferrer">{{this.repository}}</a> {{/if}}
+            repository{{unless this.repository " configured above"}}.
+            For example: <code>release.yml</code> or <code>publish.yml</code>.
           </div>
         {{/if}}
       {{/let}}


### PR DESCRIPTION
see commit messages 😉 

<img width="668" alt="Bildschirmfoto 2025-07-07 um 19 00 06" src="https://github.com/user-attachments/assets/992ec777-6d0e-436e-adbe-edc80965ced1" />

This should help a bit when filling out the form because it's easier to quickly find the right file name in the repository.