### PR TITLE
rebuild-docs: Fix styling in dark mode

### DIFF
--- a/app/styles/crate/rebuild-docs.module.css
+++ b/app/styles/crate/rebuild-docs.module.css
@@ -8,11 +8,11 @@
 }
 
 .crate-info {
-    background-color: var(--orange-50);
+    background-color: light-dark(var(--orange-50), var(--orange-900));
     border-radius: 8px;
     padding: var(--space-m);
     margin: var(--space-m) 0;
-    border: 1px solid var(--orange-200);
+    border: 1px solid light-dark(var(--orange-200), var(--orange-600));
 
     h2 {
         margin: 0 0 var(--space-s);


### PR DESCRIPTION
<img width="672" height="449" alt="Bildschirmfoto 2025-07-13 um 12 23 35" src="https://github.com/user-attachments/assets/aac1e23a-4784-4333-890b-ad158a9e123a" />

Resolves #11565 