### PR TITLE
frontend: Redirect when space in crate name

### DIFF
--- a/app/routes/crate.js
+++ b/app/routes/crate.js
@@ -10,6 +10,11 @@ export default class CrateRoute extends Route {
 
   async model(params, transition) {
     let crateName = params.crate_id;
+    if (crateName.trim() != crateName) {
+      // If the crate name has leading/trailing whitespace, redirect to the trimmed version.
+      this.router.transitionTo('crate', crateName.trim());
+      return;
+    }
 
     try {
       // We would like the peeked crate to include information (such as keywords) for further


### PR DESCRIPTION
Hi

When there is leading or trailing space in the crate name, the crate is not found (obviously)

https://crates.io/crates/syn Working

https://crates.io/crates/%20syn Not found

I think this could be useful, mostly if we paste a crate name