### PR TITLE
Remove `RecentCrateDownloads` struct

### DIFF
--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -18,18 +18,6 @@ use tracing::instrument;
 
 use super::Team;
 
-#[derive(Debug, Queryable, Identifiable, Associations, Clone, Copy)]
-#[diesel(
-    table_name = recent_crate_downloads,
-    check_for_backend(diesel::pg::Pg),
-    primary_key(crate_id),
-    belongs_to(Crate),
-)]
-pub struct RecentCrateDownloads {
-    pub crate_id: i32,
-    pub downloads: i32,
-}
-
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name = crates, check_for_backend(diesel::pg::Pg))]
 pub struct CrateName {

--- a/crates/crates_io_database/src/models/mod.rs
+++ b/crates/crates_io_database/src/models/mod.rs
@@ -10,7 +10,7 @@ pub use self::download::VersionDownload;
 pub use self::email::{Email, NewEmail};
 pub use self::follow::Follow;
 pub use self::keyword::{CrateKeyword, Keyword};
-pub use self::krate::{Crate, CrateName, NewCrate, RecentCrateDownloads};
+pub use self::krate::{Crate, CrateName, NewCrate};
 pub use self::owner::{CrateOwner, Owner, OwnerKind};
 pub use self::team::{NewTeam, Team};
 pub use self::token::ApiToken;

--- a/src/controllers/krate/metadata.rs
+++ b/src/controllers/krate/metadata.rs
@@ -7,8 +7,8 @@
 use crate::app::AppState;
 use crate::controllers::krate::CratePath;
 use crate::models::{
-    Category, Crate, CrateCategory, CrateKeyword, Keyword, RecentCrateDownloads, TopVersions, User,
-    Version, VersionOwnerAction,
+    Category, Crate, CrateCategory, CrateKeyword, Keyword, TopVersions, User, Version,
+    VersionOwnerAction,
 };
 use crate::schema::*;
 use crate::util::errors::{
@@ -294,7 +294,8 @@ fn load_recent_downloads<'a>(
         return always_ready(|| Ok(None)).boxed();
     }
 
-    let fut = RecentCrateDownloads::belonging_to(&krate)
+    let fut = recent_crate_downloads::table
+        .filter(recent_crate_downloads::crate_id.eq(krate.id))
         .select(recent_crate_downloads::downloads)
         .get_result(conn);
     async move { Ok(fut.await.optional()?) }.boxed()


### PR DESCRIPTION
We were only using it for the `belonging_to()` association, but we can easily achieve the same with a simple `filter()` call. Since each model struct is generating a considerate amount of code lets remove it until we actually need it.