### PR TITLE
Derive `Selectable` trait for more model structs

### DIFF
--- a/crates/crates_io_database/src/models/action.rs
+++ b/crates/crates_io_database/src/models/action.rs
@@ -34,7 +34,7 @@ impl From<VersionAction> for String {
     }
 }
 
-#[derive(Debug, Clone, Copy, Queryable, Identifiable, Associations)]
+#[derive(Debug, Clone, Copy, Queryable, Identifiable, Selectable, Associations)]
 #[diesel(
     table_name = version_owner_actions,
     check_for_backend(diesel::pg::Pg),

--- a/crates/crates_io_database/src/models/action.rs
+++ b/crates/crates_io_database/src/models/action.rs
@@ -66,6 +66,7 @@ impl VersionOwnerAction {
         version_owner_actions::table
             .filter(version_id.eq(version.id))
             .inner_join(users::table)
+            .select((VersionOwnerAction::as_select(), User::as_select()))
             .order(version_owner_actions::dsl::id)
             .load(conn)
             .boxed()
@@ -77,6 +78,7 @@ impl VersionOwnerAction {
     ) -> QueryResult<Vec<Vec<(Self, User)>>> {
         Ok(Self::belonging_to(versions)
             .inner_join(users::table)
+            .select((VersionOwnerAction::as_select(), User::as_select()))
             .order(version_owner_actions::dsl::id)
             .load(conn)
             .await?

--- a/crates/crates_io_database/src/models/crate_owner_invitation.rs
+++ b/crates/crates_io_database/src/models/crate_owner_invitation.rs
@@ -103,7 +103,11 @@ impl CrateOwnerInvitation {
         }
 
         // Get the user and check if they have a verified email
-        let user: User = users::table.find(self.invited_user_id).first(conn).await?;
+        let user: User = users::table
+            .find(self.invited_user_id)
+            .select(User::as_select())
+            .first(conn)
+            .await?;
 
         let verified_email = user.verified_email(conn).await?;
         if verified_email.is_none() {

--- a/crates/crates_io_database/src/models/crate_owner_invitation.rs
+++ b/crates/crates_io_database/src/models/crate_owner_invitation.rs
@@ -43,6 +43,7 @@ impl NewCrateOwnerInvitation {
             // already exists. This does not cause problems with expired invitation as those are
             // deleted before doing this INSERT.
             .on_conflict_do_nothing()
+            .returning(CrateOwnerInvitation::as_returning())
             .get_result(conn)
             .await
             .optional()?;
@@ -57,7 +58,7 @@ impl NewCrateOwnerInvitation {
 }
 
 /// The model representing a row in the `crate_owner_invitations` database table.
-#[derive(Clone, Debug, Identifiable, Queryable)]
+#[derive(Clone, Debug, Identifiable, Queryable, Selectable)]
 #[diesel(primary_key(invited_user_id, crate_id))]
 pub struct CrateOwnerInvitation {
     pub invited_user_id: i32,
@@ -77,6 +78,7 @@ impl CrateOwnerInvitation {
     ) -> QueryResult<Self> {
         crate_owner_invitations::table
             .find((user_id, crate_id))
+            .select(CrateOwnerInvitation::as_select())
             .first::<Self>(conn)
             .await
     }
@@ -84,6 +86,7 @@ impl CrateOwnerInvitation {
     pub async fn find_by_token(token: &str, conn: &mut AsyncPgConnection) -> QueryResult<Self> {
         crate_owner_invitations::table
             .filter(crate_owner_invitations::token.eq(token))
+            .select(CrateOwnerInvitation::as_select())
             .first::<Self>(conn)
             .await
     }

--- a/crates/crates_io_database/src/models/download.rs
+++ b/crates/crates_io_database/src/models/download.rs
@@ -4,7 +4,7 @@ use chrono::NaiveDate;
 use crates_io_diesel_helpers::SemverVersion;
 use diesel::prelude::*;
 
-#[derive(Queryable, Identifiable, Associations, Debug, Clone, Copy)]
+#[derive(Queryable, Identifiable, Selectable, Associations, Debug, Clone, Copy)]
 #[diesel(
     primary_key(version_id, date),
     belongs_to(FullVersion, foreign_key=version_id),
@@ -12,10 +12,8 @@ use diesel::prelude::*;
 )]
 pub struct VersionDownload {
     pub version_id: i32,
-    pub downloads: i32,
-    pub counted: i32,
     pub date: NaiveDate,
-    pub processed: bool,
+    pub downloads: i32,
 }
 
 /// A subset of the columns of the `versions` table.

--- a/crates/crates_io_database/src/models/email.rs
+++ b/crates/crates_io_database/src/models/email.rs
@@ -1,5 +1,4 @@
 use bon::Builder;
-use chrono::{DateTime, Utc};
 use diesel::prelude::*;
 use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use secrecy::SecretString;
@@ -7,7 +6,7 @@ use secrecy::SecretString;
 use crate::models::User;
 use crate::schema::emails;
 
-#[derive(Debug, Queryable, Identifiable, Associations)]
+#[derive(Debug, Queryable, Identifiable, Selectable, Associations)]
 #[diesel(belongs_to(User))]
 pub struct Email {
     pub id: i32,
@@ -16,7 +15,6 @@ pub struct Email {
     pub verified: bool,
     #[diesel(deserialize_as = String, serialize_as = String)]
     pub token: SecretString,
-    pub token_generated_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Insertable, AsChangeset, Builder)]

--- a/crates/crates_io_database/src/models/user.rs
+++ b/crates/crates_io_database/src/models/user.rs
@@ -16,13 +16,13 @@ use crates_io_diesel_helpers::lower;
 #[derive(Clone, Debug, Queryable, Identifiable, Selectable, Serialize)]
 pub struct User {
     pub id: i32,
+    pub name: Option<String>,
+    pub gh_id: i32,
+    pub gh_login: String,
+    pub gh_avatar: Option<String>,
     #[diesel(deserialize_as = String)]
     #[serde(skip)]
     pub gh_access_token: SecretString,
-    pub gh_login: String,
-    pub name: Option<String>,
-    pub gh_avatar: Option<String>,
-    pub gh_id: i32,
     pub account_lock_reason: Option<String>,
     pub account_lock_until: Option<DateTime<Utc>>,
     pub is_admin: bool,

--- a/crates/crates_io_database/src/models/version.rs
+++ b/crates/crates_io_database/src/models/version.rs
@@ -10,7 +10,6 @@ use serde::Deserialize;
 use crate::models::{Crate, TrustpubData, User};
 use crate::schema::{readme_renderings, users, versions};
 
-// Queryable has a custom implementation below
 #[derive(Clone, Identifiable, Associations, Debug, Queryable, Selectable)]
 #[diesel(belongs_to(Crate), belongs_to(crate::models::download::Version, foreign_key=id))]
 pub struct Version {

--- a/crates/crates_io_database/src/models/version.rs
+++ b/crates/crates_io_database/src/models/version.rs
@@ -59,7 +59,12 @@ impl Version {
     /// Not for use when you have a group of versions you need the publishers for.
     pub async fn published_by(&self, conn: &mut AsyncPgConnection) -> QueryResult<Option<User>> {
         match self.published_by {
-            Some(pb) => users::table.find(pb).first(conn).await.optional(),
+            Some(pb) => users::table
+                .find(pb)
+                .select(User::as_select())
+                .first(conn)
+                .await
+                .optional(),
             None => Ok(None),
         }
     }

--- a/src/bin/crates-admin/transfer_crates.rs
+++ b/src/bin/crates-admin/transfer_crates.rs
@@ -27,11 +27,13 @@ pub async fn run(opts: Opts) -> anyhow::Result<()> {
 async fn transfer(opts: Opts, conn: &mut AsyncPgConnection) -> anyhow::Result<()> {
     let from: User = users::table
         .filter(users::gh_login.eq(opts.from_user))
+        .select(User::as_select())
         .first(conn)
         .await?;
 
     let to: User = users::table
         .filter(users::gh_login.eq(opts.to_user))
+        .select(User::as_select())
         .first(conn)
         .await?;
 

--- a/src/controllers/crate_owner_invitation.rs
+++ b/src/controllers/crate_owner_invitation.rs
@@ -266,6 +266,7 @@ async fn prepare_list(
     if !missing_users.is_empty() {
         let new_users: Vec<User> = users::table
             .filter(users::id.eq_any(missing_users))
+            .select(User::as_select())
             .load(conn)
             .await?;
         for user in new_users.into_iter() {

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -111,6 +111,7 @@ pub async fn get_crate_downloads(
     let (downloads, extra_downloads, versions_and_publishers, actions) = tokio::try_join!(
         VersionDownload::belonging_to(latest_five)
             .filter(version_downloads::date.gt(date(now - 90.days())))
+            .select(VersionDownload::as_select())
             .order((
                 version_downloads::date.asc(),
                 version_downloads::version_id.desc(),

--- a/src/controllers/krate/downloads.rs
+++ b/src/controllers/krate/downloads.rs
@@ -187,6 +187,7 @@ fn load_actions<'a>(
     }
     VersionOwnerAction::belonging_to(versions)
         .inner_join(users::table)
+        .select((VersionOwnerAction::as_select(), User::as_select()))
         .order(version_owner_actions::id)
         .load(conn)
         .boxed()

--- a/src/controllers/session.rs
+++ b/src/controllers/session.rs
@@ -204,6 +204,7 @@ async fn create_or_update_user(
 async fn find_user_by_gh_id(conn: &mut AsyncPgConnection, gh_id: i32) -> QueryResult<Option<User>> {
     users::table
         .filter(users::gh_id.eq(gh_id))
+        .select(User::as_select())
         .first(conn)
         .await
         .optional()

--- a/src/controllers/user/email_verification.rs
+++ b/src/controllers/user/email_verification.rs
@@ -74,6 +74,7 @@ pub async fn resend_email_verification(
         async move {
             let email: Email = diesel::update(Email::belonging_to(auth.user()))
                 .set(emails::token.eq(sql("DEFAULT")))
+                .returning(Email::as_returning())
                 .get_result(conn)
                 .await
                 .optional()?

--- a/src/controllers/user/other.rs
+++ b/src/controllers/user/other.rs
@@ -37,6 +37,7 @@ pub async fn find_user(
     let name = lower(&user_name);
     let user: User = users
         .filter(lower(gh_login).eq(name))
+        .select(User::as_select())
         .order(id.desc())
         .first(&mut conn)
         .await?;

--- a/src/controllers/version/downloads.rs
+++ b/src/controllers/version/downloads.rs
@@ -93,6 +93,7 @@ pub async fn get_version_downloads(
 
     let version_downloads = VersionDownload::belonging_to(&version)
         .filter(version_downloads::date.between(cutoff_start_date, cutoff_end_date))
+        .select(VersionDownload::as_select())
         .order(version_downloads::date)
         .load(&mut conn)
         .await?


### PR DESCRIPTION
`Selectable` allows us to not query all of the columns of a table, or to have the fields in a different order than the columns. It also ensures that e.g. multiple i32 fields are pointing to their correct corresponding columns.