### PR TITLE
database/models/krate: Remove unused `QueryableByName` trait

### DIFF
--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -24,9 +24,7 @@ pub struct CrateName {
     pub name: String,
 }
 
-#[derive(
-    Debug, Clone, Queryable, Identifiable, AsChangeset, QueryableByName, Selectable, Serialize,
-)]
+#[derive(Debug, Clone, Queryable, Identifiable, AsChangeset, Selectable, Serialize)]
 #[diesel(table_name = crates, check_for_backend(diesel::pg::Pg))]
 pub struct Crate {
     pub id: i32,


### PR DESCRIPTION
This does not appear to be needed (anymore?).