### PR TITLE
Add automotive category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -101,6 +101,12 @@ description = """
 Crates to help with the process of confirming identities.\
 """
 
+[automotive]
+name = "Automotive"
+description = """
+Crates related to the automotive industry, including vehicle control and diagnostics.
+"""
+
 [caching]
 name = "Caching"
 description = """


### PR DESCRIPTION
This change adds the additional automotive category.

It seems there is no category for automotive industry.

I think [kuksa-rust-sdk] is a good example for automotive category.
[kuksa-rust-sdk] is the Rust SDK for the Eclipse KUKSA Databroker,  
and [the open Eclipse KUKSA project aims to provide shared building blocks for the Software Defined Vehicles that can be shared across the industry](https://eclipse-kuksa.github.io/kuksa-website/about/). 

If I should make a issue about this, please let me know.

Thank you!

[kuksa-rust-sdk]: https://crates.io/crates/kuksa-rust-sdk