### PR TITLE
renovatebot: Remove label assignments

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,14 +14,6 @@
     ],
     packageRules: [
         {
-            matchCategories: ["rust"],
-            labels: ["A-backend ⚙️"],
-        },
-        {
-            matchCategories: ["js"],
-            labels: ["A-frontend 🐹"],
-        },
-        {
             matchDepNames: ["ember-cli", "ember-data", "ember-source"],
             separateMinorPatch: true,
         },
@@ -55,7 +47,6 @@
             matchManagers: ["custom.regex"],
             matchDepNames: ["rust"],
             commitMessageTopic: "Rust",
-            labels: ["A-backend ⚙️"],
         },
         {
             matchDepNames: ["/^diesel$/", "/^diesel_/"],

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -32,4 +32,5 @@ trigger_files = [
     "migrations/",
     "Cargo.toml",
     "Cargo.lock",
+    "rust-toolchain.toml",
 ]


### PR DESCRIPTION
We can let triagebot handle the labeling instead of duplicating the logic for just the renovatebot PRs.