### PR TITLE
add proxy-server as a subcategory of web-programming

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -635,3 +635,11 @@ name = "WebSocket"
 description = """
 Crates to communicate over the WebSocket protocol.\
 """
+
+[web-programming.categories.proxy-server]
+name = "Proxy server"
+description = """
+Crates for building and managing proxies,\
+including HTTP, HTTPS, SOCKS5, transparent, reverse, and forward proxies.\
+Useful for traffic inspection, anonymization, load balancing, and network routing in web applications.\
+"""


### PR DESCRIPTION
This change adds a new proxies subcategory under web-programming to better classify crates focused on building or managing various types of proxies (such as HTTP, HTTPS, SOCKS5, transparent, forward, and reverse proxies).

I believe this addition is justified because proxy-related functionality is distinct from existing http-client and http-server categories. While it is closely related to web protocols, proxy crates serve unique use cases like traffic routing, interception, anonymization, or load balancing. These use cases span from development tools to production-grade networking infrastructure, and a dedicated category will help crate authors and users better discover relevant tooling.