### PR TITLE
Only use jemalloc without MSVC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ spdx = "=0.10.9"
 tar = "=0.4.44"
 tempfile = "=3.20.0"
 thiserror = "=2.0.12"
-tikv-jemallocator = { version = "=0.6.0", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 tokio = { version = "=1.47.1", features = ["net", "signal", "io-std", "io-util", "rt-multi-thread", "macros", "process"]}
 tokio-postgres = "=0.7.13"
 tokio-util = "=0.7.16"
@@ -138,6 +137,9 @@ typomania = { version = "=0.1.2", default-features = false }
 url = "=2.5.4"
 utoipa = { version = "=5.4.0", features = ["chrono"] }
 utoipa-axum = "=0.2.0"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "=0.6.0", features = ['unprefixed_malloc_on_supported_platforms', 'profiling'] }
 
 [dev-dependencies]
 bytes = "=1.10.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,10 @@ use std::sync::Arc;
 
 use crate::app::AppState;
 use crate::router::build_axum_router;
+#[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
 static ALLOC: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
On windows crates-io won't build because of this

According to the [jemalloc_sys documentation](https://crates.io/crates/tikv-jemallocator), this should be on the cargo.toml and global allocator declaration anyway, so I hope this counts under "windows development experience despite not being officially supported"