### PR TITLE
Revert "CI: Use `cargo-binstall` for pre-compiled binary installation (#11472)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - master
-      - binstall
 
   pull_request:
 
@@ -17,8 +16,6 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  # renovate: datasource=github-releases depName=cargo-bins/cargo-binstall
-  BINSTALL_VERSION: 1.14.3
   # renovate: datasource=crate depName=cargo-deny versioning=semver
   CARGO_DENY_VERSION: 0.18.4
   # renovate: datasource=crate depName=cargo-machete versioning=semver
@@ -146,12 +143,10 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/v${BINSTALL_VERSION}/install-from-binstall-release.sh | bash
-
-      - run: cargo binstall cargo-deny@${CARGO_DENY_VERSION}
+      - run: cargo install cargo-deny --vers ${CARGO_DENY_VERSION}
       - run: cargo deny check
 
-      - run: cargo binstall cargo-machete@${CARGO_MACHETE_VERSION}
+      - run: cargo install cargo-machete --vers ${CARGO_MACHETE_VERSION}
       - run: cargo machete
 
   backend-test:


### PR DESCRIPTION

This reverts commit 40456f5aafac8a4ff60967f9598c988d785086e3.

For unknown reasons this seems to be causing "error: no such command: `deny`" errors on CI.