### PR TITLE
Fix unintentional `crate.newest_version` reset

### DIFF
--- a/app/serializers/crate.js
+++ b/app/serializers/crate.js
@@ -1,6 +1,6 @@
 import ApplicationSerializer from './application';
 
-const SKIP_NULL_FIELDS = new Set(['categories', 'keywords']);
+const SKIP_NULL_FIELDS = new Set(['categories', 'keywords', 'max_stable_version']);
 
 export default class CrateSerializer extends ApplicationSerializer {
   isNewSerializerAPI = true;
@@ -17,15 +17,33 @@ export default class CrateSerializer extends ApplicationSerializer {
     // We don't want existing relationships overwritten by results with null values.
     // See: https://github.com/rust-lang/crates.io/issues/10711
     if (payload.crates) {
-      payload.crates = payload.crates.map(crate => {
-        for (const rel of SKIP_NULL_FIELDS) {
-          if (crate[rel] === null) {
-            delete crate[rel];
-          }
-        }
-        return crate;
-      });
+      payload.crates.forEach(crate => removeNullFields(crate));
     }
+
     return super.normalizeQueryResponse(...arguments);
+  }
+
+  normalizeQueryRecordResponse(_store, _modelClass, payload) {
+    if (payload.crate) {
+      removeNullFields(payload.crate);
+    }
+
+    return super.normalizeQueryResponse(...arguments);
+  }
+}
+
+function removeNullFields(crate) {
+  for (let rel of SKIP_NULL_FIELDS) {
+    if (crate[rel] === null) {
+      delete crate[rel];
+    }
+  }
+
+  if (crate.max_version == '0.0.0') {
+    delete crate.max_version;
+  }
+
+  if (crate.newest_version == '0.0.0') {
+    delete crate.newest_version;
   }
 }

--- a/e2e/bugs/11772.spec.ts
+++ b/e2e/bugs/11772.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@/e2e/helper';
+
+test.describe('Bug #11772', { tag: '@bugs' }, () => {
+  function prepare(msw: any) {
+    // Create a crate that will appear in "New Crates" section
+    let newCrate = msw.db.crate.create({ name: 'test-crate' });
+    msw.db.version.create({ crate: newCrate, num: '1.2.3' });
+  }
+
+  test('crate versions should remain correct after navigating back from crate details', async ({ page, msw }) => {
+    prepare(msw);
+
+    // Visit homepage
+    await page.goto('/');
+    await expect(page).toHaveURL('/');
+
+    // Verify initial correct version displays
+    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
+    await expect(page.locator('[data-test-just-updated] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
+
+    // Click on a crate to navigate to its details page
+    await page.click('[data-test-new-crates] [data-test-crate-link]');
+
+    // Verify we're on the crate details page
+    await expect(page).toHaveURL('/crates/test-crate');
+
+    await page.goto('/'); // Re-visit to simulate the back navigation
+
+    // Versions should still be displayed correctly, not v0.0.0
+    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
+    await expect(page.locator('[data-test-just-updated] [data-test-crate-link]')).toContainText('test-crate v1.2.3');
+  });
+
+  test('crates with actual v0.0.0 versions should display correctly', async ({ page, msw }) => {
+    // Create a crate with an actual v0.0.0 version
+    let zeroCrate = msw.db.crate.create({ name: 'test-zero-crate' });
+    msw.db.version.create({ crate: zeroCrate, num: '0.0.0' });
+
+    // Visit homepage
+    await page.goto('/');
+    await expect(page).toHaveURL('/');
+
+    // Should correctly display v0.0.0 for crates that actually have that version
+    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-zero-crate v0.0.0');
+
+    // Click on the crate to navigate to its details page
+    await page.click('[data-test-new-crates] [data-test-crate-link]');
+
+    // Verify we're on the crate details page
+    await expect(page).toHaveURL('/crates/test-zero-crate');
+
+    await page.goto('/'); // Re-visit to simulate the back navigation
+
+    // Should still display v0.0.0 correctly (this is the intended behavior)
+    await expect(page.locator('[data-test-new-crates] [data-test-crate-link]')).toContainText('test-zero-crate v0.0.0');
+  });
+});

--- a/tests/bugs/11772-test.js
+++ b/tests/bugs/11772-test.js
@@ -1,0 +1,66 @@
+import { click, currentURL, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'crates-io/tests/helpers';
+
+module('Bug #11772', function (hooks) {
+  setupApplicationTest(hooks);
+
+  function prepare(context) {
+    let { db } = context;
+
+    // Create a crate that will appear in "New Crates" section
+    let newCrate = db.crate.create({ name: 'test-crate' });
+    db.version.create({ crate: newCrate, num: '1.2.3' });
+  }
+
+  test('crate versions should remain correct after navigating back from crate details', async function (assert) {
+    prepare(this);
+
+    // Visit homepage
+    await visit('/');
+    assert.strictEqual(currentURL(), '/');
+
+    // Verify initial correct version displays
+    assert.dom('[data-test-new-crates] [data-test-crate-link]').containsText('test-crate v1.2.3');
+    assert.dom('[data-test-just-updated] [data-test-crate-link]').containsText('test-crate v1.2.3');
+
+    // Click on a crate to navigate to its details page
+    await click('[data-test-new-crates] [data-test-crate-link]');
+
+    // Verify we're on the crate details page
+    assert.strictEqual(currentURL(), '/crates/test-crate');
+
+    await visit('/'); // Re-visit to simulate the back navigation
+
+    // Versions should still be displayed correctly, not v0.0.0
+    assert.dom('[data-test-new-crates] [data-test-crate-link]').containsText('test-crate v1.2.3');
+    assert.dom('[data-test-just-updated] [data-test-crate-link]').containsText('test-crate v1.2.3');
+  });
+
+  test('crates with actual v0.0.0 versions should display correctly', async function (assert) {
+    let { db } = this;
+
+    // Create a crate with an actual v0.0.0 version
+    let zeroCrate = db.crate.create({ name: 'test-zero-crate' });
+    db.version.create({ crate: zeroCrate, num: '0.0.0' });
+
+    // Visit homepage
+    await visit('/');
+    assert.strictEqual(currentURL(), '/');
+
+    // Should correctly display v0.0.0 for crates that actually have that version
+    assert.dom('[data-test-new-crates] [data-test-crate-link]').containsText('test-zero-crate v0.0.0');
+
+    // Click on the crate to navigate to its details page
+    await click('[data-test-new-crates] [data-test-crate-link]');
+
+    // Verify we're on the crate details page
+    assert.strictEqual(currentURL(), '/crates/test-zero-crate');
+
+    await visit('/'); // Re-visit to simulate the back navigation
+
+    // Should still display v0.0.0 correctly (this is the intended behavior)
+    assert.dom('[data-test-new-crates] [data-test-crate-link]').containsText('test-zero-crate v0.0.0');
+  });
+});


### PR DESCRIPTION
The `GET /summary` call correctly initialized the `newest_version` fields of the crates, but when navigating to the crate page, the `GET /crate/foo` call by default uses an `include` query parameter that excludes the `newest_version` field from being loaded on the backend, which causes it to be returned with a value of `0.0.0` (for legacy reasons). This then reset the field on the model, causing it to be displayed incorrectly when navigating back to the front page.

This commit fixes the issue by adjusting the crate serializer to ignore `0.0.0` values for `max_version` and `newest_version`, so that they won't override previously loaded values.

Resolves https://github.com/rust-lang/crates.io/issues/11772