### PR TITLE
worker: Adjust `ProcessCloudfrontInvalidationQueue` to run in dedicated single-worker queue

### DIFF
--- a/src/bin/background-worker.rs
+++ b/src/bin/background-worker.rs
@@ -121,6 +121,7 @@ fn main() -> anyhow::Result<()> {
         .configure_default_queue(|queue| queue.num_workers(5))
         .configure_queue("downloads", |queue| queue.num_workers(1))
         .configure_queue("repository", |queue| queue.num_workers(1))
+        .configure_queue("cloudfront", |queue| queue.num_workers(1))
         .register_crates_io_job_types();
 
     runtime.block_on(async {

--- a/src/worker/jobs/process_cloudfront_invalidation_queue.rs
+++ b/src/worker/jobs/process_cloudfront_invalidation_queue.rs
@@ -96,6 +96,7 @@ impl ProcessCloudfrontInvalidationQueue {
 impl BackgroundJob for ProcessCloudfrontInvalidationQueue {
     const JOB_NAME: &'static str = "process_cloudfront_invalidation_queue";
     const DEDUPLICATED: bool = true;
+    const QUEUE: &'static str = "cloudfront";
 
     type Context = Arc<Environment>;
 


### PR DESCRIPTION


This should avoid multiple instances of the background job from running in parallel due to them running on the multi-worker default queue. Having the jobs run in parallel is not breaking anything, but is causing unnecessary duplicate invalidations that we should avoid.