### PR TITLE
admin: Rename `backfill-og-images` to `render-og-images`

### DIFF
--- a/src/bin/crates-admin/main.rs
+++ b/src/bin/crates-admin/main.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate tracing;
 
-mod backfill_og_images;
 mod default_versions;
 mod delete_crate;
 mod delete_version;
@@ -9,6 +8,7 @@ mod dialoguer;
 mod enqueue_job;
 mod migrate;
 mod populate;
+mod render_og_images;
 mod render_readmes;
 mod transfer_crates;
 mod upload_index;
@@ -18,7 +18,7 @@ mod yank_version;
 #[derive(clap::Parser, Debug)]
 #[command(name = "crates-admin")]
 enum Command {
-    BackfillOgImages(backfill_og_images::Opts),
+    RenderOgImages(render_og_images::Opts),
     DeleteCrate(delete_crate::Opts),
     DeleteVersion(delete_version::Opts),
     Populate(populate::Opts),
@@ -48,7 +48,7 @@ async fn main() -> anyhow::Result<()> {
     span.record("command", tracing::field::debug(&command));
 
     match command {
-        Command::BackfillOgImages(opts) => backfill_og_images::run(opts).await,
+        Command::RenderOgImages(opts) => render_og_images::run(opts).await,
         Command::DeleteCrate(opts) => delete_crate::run(opts).await,
         Command::DeleteVersion(opts) => delete_version::run(opts).await,
         Command::Populate(opts) => populate::run(opts).await,

--- a/src/bin/crates-admin/render_og_images.rs
+++ b/src/bin/crates-admin/render_og_images.rs
@@ -24,6 +24,10 @@ pub struct Opts {
     #[arg(long)]
     /// Offset to start enqueueing from (useful for resuming)
     offset: Option<i64>,
+
+    #[arg(long)]
+    /// Skip CDN cache invalidation when generating OG images
+    skip_invalidation: bool,
 }
 
 pub async fn run(opts: Opts) -> Result<()> {
@@ -79,7 +83,13 @@ pub async fn run(opts: Opts) -> Result<()> {
         // Create batch of jobs
         let jobs = crate_names
             .into_iter()
-            .map(GenerateOgImage::without_cdn_invalidation)
+            .map(|crate_name| {
+                if opts.skip_invalidation {
+                    GenerateOgImage::without_cdn_invalidation(crate_name)
+                } else {
+                    GenerateOgImage::new(crate_name)
+                }
+            })
             .map(|job| {
                 Ok((
                     background_jobs::job_type.eq(GenerateOgImage::JOB_NAME),

--- a/src/bin/crates-admin/render_og_images.rs
+++ b/src/bin/crates-admin/render_og_images.rs
@@ -9,8 +9,8 @@ use tracing::{info, warn};
 
 #[derive(clap::Parser, Debug)]
 #[command(
-    name = "backfill-og-images",
-    about = "Enqueue OG image generation jobs for existing crates"
+    name = "render-og-images",
+    about = "Enqueue OG image generation jobs for crates"
 )]
 pub struct Opts {
     #[arg(long, default_value = "1000")]
@@ -29,7 +29,7 @@ pub struct Opts {
 pub async fn run(opts: Opts) -> Result<()> {
     let mut conn = db::oneoff_connection().await?;
 
-    info!("Starting OG image backfill with options: {opts:?}");
+    info!("Starting OG image rendering with options: {opts:?}");
 
     // Helper function to build query
     let build_query = |offset: i64| {


### PR DESCRIPTION
The initial backfill is finished, but this tool can still be useful to manually trigger rerenders, so we will rename to reflect that new purpose.

This PR also adds a new `--skip-invalidation` option, that now defaults to not skipping the invalidation (previously we skipped it for the initial backfill).