### PR TITLE
Add `archives` category

### DIFF
--- a/src/boot/categories.toml
+++ b/src/boot/categories.toml
@@ -88,6 +88,12 @@ Rust. Includes HTTP API wrappers as well. Non-idiomatic or unsafe \
 bindings can be found in External FFI bindings.\
 """
 
+[archives]
+name = "Archives"
+description = """
+Crates for reading and writing archive formats.\
+"""
+
 [asynchronous]
 name = "Asynchronous"
 description = """


### PR DESCRIPTION
This pull request adds a category for crates that implement archives formats such as tar and ZIP.

It seems there is no category for archives formats. For this reason, the following crates are either not assigned to any category, or crates for file formats that can both archive and compress, such as LHA/LZH, are assigned the [`compression`](https://crates.io/categories/compression) category.

## Examples of crates

- [`ar`](https://crates.io/crates/ar) -  a library for encoding/decoding Unix archive files.
- [`cab`](https://crates.io/crates/cab) -  Read/write Windows cabinet (CAB) files.
- [`cpio-archive`](https://crates.io/crates/cpio-archive) -  cpio archive reading and writing.
- [`delharc`](https://crates.io/crates/delharc) -  a library for parsing and extracting files from LHA/LZH archives.
- [`ouch`](https://crates.io/crates/ouch) - a command-line utility for easily compressing and decompressing files and directories.
- [`sevenz-rust2`](https://crates.io/crates/sevenz-rust2) -  a 7z decompressor/compressor written in pure Rust.
- [`tar`](https://crates.io/crates/tar) - a Rust implementation of a TAR file reader and writer.
- [`unrar`](https://crates.io/crates/unrar) -  list and extract RAR archives.
- [`zip`](https://crates.io/crates/zip) - library to support the reading and writing of zip files.