### PR TITLE
msw: Avoid unnecessary setup and teardown

### DIFF
--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -8,9 +8,11 @@ import { setup } from 'qunit-dom';
 import Application from '../app';
 import config from '../config/environment';
 import registerMatchJsonAssertion from './helpers/match-json';
+import { registerQUnitCallbacks } from './helpers/setup-msw';
 
 setup(QUnit.assert);
 registerMatchJsonAssertion(QUnit.assert);
+registerQUnitCallbacks(QUnit);
 
 setApplication(Application.create(config.APP));
 


### PR DESCRIPTION
Instead of creating, starting and tearing down the worker for each test module, we can create it once, start it once for the full test suite and then tear it down at the end of the test suite. This also ensures that we don't accidentally perform network calls in tests that didn't explicitly set up MSW.

Additionally, this might fix the flakiness we've been seeing with the test suite when run on the CI runners, and is generally recommended by the MSW devs.

This PR should also unblock https://github.com/rust-lang/crates.io/pull/11876