### PR TITLE
worker/typosquat: Improve typosquat logging

### DIFF
--- a/src/worker/jobs/typosquat.rs
+++ b/src/worker/jobs/typosquat.rs
@@ -57,7 +57,14 @@ async fn check(
         if !squats.is_empty() {
             // Well, well, well. For now, the only action we'll take is to e-mail people who
             // hopefully care to check into things more closely.
-            info!(?squats, "Found potential typosquatting");
+
+            let squats_formatted = squats
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            info!("Found potential typosquatting by new crate `{name}`: {squats_formatted}");
 
             let squats_data: Vec<_> = squats
                 .iter()
@@ -114,6 +121,8 @@ mod tests {
 
     #[tokio::test]
     async fn integration() -> anyhow::Result<()> {
+        crate::util::tracing::init_for_test();
+
         let emails = Emails::new_in_memory();
         let test_db = TestDatabase::new();
         let mut conn = test_db.async_connect().await;


### PR DESCRIPTION
Using structured debug logging for this isn't particularly useful when using Datadog. Instead, we format the squat info properly and print it as the message.