### PR TITLE
Adjust "Index cloned" log message duration output

### DIFF
--- a/src/worker/environment.rs
+++ b/src/worker/environment.rs
@@ -56,7 +56,7 @@ impl Environment {
             *repo = Some(Repository::open(&self.repository_config)?);
 
             let clone_duration = clone_start.elapsed();
-            info!(duration = ?clone_duration, "Index cloned");
+            info!(duration = clone_duration.as_nanos(), "Index cloned");
         }
 
         let repo_lock = RepositoryLock { repo };


### PR DESCRIPTION
Datadog expects the `duration` fields to be sent in nanoseconds, so let's do that...