### PR TITLE
Add API token support to endpoints for managing Trusted Publishing configurations

### DIFF
--- a/app/controllers/settings/tokens/new.js
+++ b/app/controllers/settings/tokens/new.js
@@ -23,7 +23,7 @@ export default class NewTokenController extends Controller {
   @tracked scopesInvalid;
   @tracked crateScopes;
 
-  ENDPOINT_SCOPES = ['change-owners', 'publish-new', 'publish-update', 'yank'];
+  ENDPOINT_SCOPES = ['change-owners', 'publish-new', 'publish-update', 'trusted-publishing', 'yank'];
 
   scopeDescription = scopeDescription;
 

--- a/app/utils/token-scopes.js
+++ b/app/utils/token-scopes.js
@@ -2,6 +2,7 @@ const DESCRIPTIONS = {
   'change-owners': 'Invite new crate owners or remove existing ones',
   'publish-new': 'Publish new crates',
   'publish-update': 'Publish new versions of existing crates',
+  'trusted-publishing': 'Manage trusted publishing configurations',
   yank: 'Yank and unyank crate versions',
 };
 

--- a/crates/crates_io_database/src/models/token/scopes.rs
+++ b/crates/crates_io_database/src/models/token/scopes.rs
@@ -13,6 +13,7 @@ use std::io::Write;
 pub enum EndpointScope {
     PublishNew,
     PublishUpdate,
+    TrustedPublishing,
     Yank,
     ChangeOwners,
 }
@@ -22,6 +23,7 @@ impl From<&EndpointScope> for &[u8] {
         match scope {
             EndpointScope::PublishNew => b"publish-new",
             EndpointScope::PublishUpdate => b"publish-update",
+            EndpointScope::TrustedPublishing => b"trusted-publishing",
             EndpointScope::Yank => b"yank",
             EndpointScope::ChangeOwners => b"change-owners",
         }
@@ -42,6 +44,7 @@ impl TryFrom<&[u8]> for EndpointScope {
         match bytes {
             b"publish-new" => Ok(EndpointScope::PublishNew),
             b"publish-update" => Ok(EndpointScope::PublishUpdate),
+            b"trusted-publishing" => Ok(EndpointScope::TrustedPublishing),
             b"yank" => Ok(EndpointScope::Yank),
             b"change-owners" => Ok(EndpointScope::ChangeOwners),
             _ => Err("Unrecognized enum variant".to_string()),
@@ -140,6 +143,7 @@ mod tests {
         assert(EndpointScope::ChangeOwners, "\"change-owners\"");
         assert(EndpointScope::PublishNew, "\"publish-new\"");
         assert(EndpointScope::PublishUpdate, "\"publish-update\"");
+        assert(EndpointScope::TrustedPublishing, "\"trusted-publishing\"");
         assert(EndpointScope::Yank, "\"yank\"");
     }
 

--- a/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__legacy_token_auth-2.snap
+++ b/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__legacy_token_auth-2.snap
@@ -1,0 +1,16 @@
+---
+source: src/controllers/trustpub/github_configs/create/tests.rs
+expression: response.json()
+---
+{
+  "github_config": {
+    "crate": "foo",
+    "created_at": "[datetime]",
+    "environment": null,
+    "id": 1,
+    "repository_name": "foo-rs",
+    "repository_owner": "rust-lang",
+    "repository_owner_id": 42,
+    "workflow_filename": "publish.yml"
+  }
+}

--- a/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__token_auth_with_trusted_publishing_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__token_auth_with_trusted_publishing_scope-2.snap
@@ -1,0 +1,16 @@
+---
+source: src/controllers/trustpub/github_configs/create/tests.rs
+expression: response.json()
+---
+{
+  "github_config": {
+    "crate": "foo",
+    "created_at": "[datetime]",
+    "environment": null,
+    "id": 1,
+    "repository_name": "foo-rs",
+    "repository_owner": "rust-lang",
+    "repository_owner_id": 42,
+    "workflow_filename": "publish.yml"
+  }
+}

--- a/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__token_auth_with_wildcard_crate_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/create/snapshots/crates_io__controllers__trustpub__github_configs__create__tests__token_auth_with_wildcard_crate_scope-2.snap
@@ -1,0 +1,16 @@
+---
+source: src/controllers/trustpub/github_configs/create/tests.rs
+expression: response.json()
+---
+{
+  "github_config": {
+    "crate": "foo",
+    "created_at": "[datetime]",
+    "environment": null,
+    "id": 1,
+    "repository_name": "foo-rs",
+    "repository_owner": "rust-lang",
+    "repository_owner_id": 42,
+    "workflow_filename": "publish.yml"
+  }
+}

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__legacy_token_auth-2.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__legacy_token_auth-2.snap
@@ -1,0 +1,26 @@
+---
+source: src/controllers/trustpub/github_configs/delete/tests.rs
+expression: app.emails_snapshot().await
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Trusted Publishing configuration removed from foo
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+
+Hello foo!
+
+You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "foo".
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: foo-rs
+- Workflow filename: publish.yml
+- Environment: (not set)
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_trusted_publishing_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_trusted_publishing_scope-2.snap
@@ -1,0 +1,26 @@
+---
+source: src/controllers/trustpub/github_configs/delete/tests.rs
+expression: app.emails_snapshot().await
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Trusted Publishing configuration removed from foo
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+
+Hello foo!
+
+You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "foo".
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: foo-rs
+- Workflow filename: publish.yml
+- Environment: (not set)
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_wildcard_crate_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/delete/snapshots/crates_io__controllers__trustpub__github_configs__delete__tests__token_auth_with_wildcard_crate_scope-2.snap
@@ -1,0 +1,26 @@
+---
+source: src/controllers/trustpub/github_configs/delete/tests.rs
+expression: app.emails_snapshot().await
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: Trusted Publishing configuration removed from foo
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+
+Hello foo!
+
+You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "foo".
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: foo-rs
+- Workflow filename: publish.yml
+- Environment: (not set)
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/github_configs/list/snapshots/crates_io__controllers__trustpub__github_configs__list__tests__legacy_token_auth-2.snap
+++ b/src/controllers/trustpub/github_configs/list/snapshots/crates_io__controllers__trustpub__github_configs__list__tests__legacy_token_auth-2.snap
@@ -1,0 +1,18 @@
+---
+source: src/controllers/trustpub/github_configs/list/tests.rs
+expression: response.json()
+---
+{
+  "github_configs": [
+    {
+      "crate": "foo",
+      "created_at": "[datetime]",
+      "environment": null,
+      "id": 1,
+      "repository_name": "foo-rs",
+      "repository_owner": "rust-lang",
+      "repository_owner_id": 42,
+      "workflow_filename": "publish.yml"
+    }
+  ]
+}

--- a/src/controllers/trustpub/github_configs/list/snapshots/crates_io__controllers__trustpub__github_configs__list__tests__token_auth_with_trusted_publishing_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/list/snapshots/crates_io__controllers__trustpub__github_configs__list__tests__token_auth_with_trusted_publishing_scope-2.snap
@@ -1,0 +1,18 @@
+---
+source: src/controllers/trustpub/github_configs/list/tests.rs
+expression: response.json()
+---
+{
+  "github_configs": [
+    {
+      "crate": "foo",
+      "created_at": "[datetime]",
+      "environment": null,
+      "id": 1,
+      "repository_name": "foo-rs",
+      "repository_owner": "rust-lang",
+      "repository_owner_id": 42,
+      "workflow_filename": "publish.yml"
+    }
+  ]
+}

--- a/src/controllers/trustpub/github_configs/list/snapshots/crates_io__controllers__trustpub__github_configs__list__tests__token_auth_with_wildcard_crate_scope-2.snap
+++ b/src/controllers/trustpub/github_configs/list/snapshots/crates_io__controllers__trustpub__github_configs__list__tests__token_auth_with_wildcard_crate_scope-2.snap
@@ -1,0 +1,18 @@
+---
+source: src/controllers/trustpub/github_configs/list/tests.rs
+expression: response.json()
+---
+{
+  "github_configs": [
+    {
+      "crate": "foo",
+      "created_at": "[datetime]",
+      "environment": null,
+      "id": 1,
+      "repository_name": "foo-rs",
+      "repository_owner": "rust-lang",
+      "repository_owner_id": 42,
+      "workflow_filename": "publish.yml"
+    }
+  ]
+}

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
@@ -593,6 +593,7 @@ expression: response.json()
         "enum": [
           "publish-new",
           "publish-update",
+          "trusted-publishing",
           "yank",
           "change-owners"
         ],

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
@@ -4315,6 +4315,9 @@ expression: response.json()
         "security": [
           {
             "cookie": []
+          },
+          {
+            "api_token": []
           }
         ],
         "summary": "Delete Trusted Publishing configuration for GitHub Actions.",

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
@@ -4278,6 +4278,9 @@ expression: response.json()
         "security": [
           {
             "cookie": []
+          },
+          {
+            "api_token": []
           }
         ],
         "summary": "Create a new Trusted Publishing configuration for GitHub Actions.",

--- a/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
+++ b/src/snapshots/crates_io__openapi__tests__openapi_snapshot-2.snap
@@ -4228,6 +4228,9 @@ expression: response.json()
         "security": [
           {
             "cookie": []
+          },
+          {
+            "api_token": []
           }
         ],
         "summary": "List Trusted Publishing configurations for GitHub Actions.",

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_trusted_publishing_scope-2.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_trusted_publishing_scope-2.snap
@@ -1,0 +1,21 @@
+---
+source: src/tests/routes/me/tokens/create.rs
+expression: response.json()
+---
+{
+  "api_token": {
+    "crate_scopes": [
+      "my-crate",
+      "my-*"
+    ],
+    "created_at": "[datetime]",
+    "endpoint_scopes": [
+      "trusted-publishing"
+    ],
+    "expired_at": null,
+    "id": "[id]",
+    "last_used_at": "[datetime]",
+    "name": "trusted-publishing-token",
+    "token": "[token]"
+  }
+}

--- a/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_trusted_publishing_scope-3.snap
+++ b/src/tests/routes/me/tokens/snapshots/crates_io__tests__routes__me__tokens__create__create_token_with_trusted_publishing_scope-3.snap
@@ -1,0 +1,19 @@
+---
+source: src/tests/routes/me/tokens/create.rs
+expression: app.emails_snapshot().await
+---
+To: foo@example.com
+From: crates.io <noreply@crates.io>
+Subject: crates.io: New API token "trusted-publishing-token" created
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+
+Hello foo!
+
+A new API token with the name "trusted-publishing-token" was recently added to your crates.io account.
+
+If you did not create this token, you should revoke it immediately: https://crates.io/settings/tokens.
+
+--
+The crates.io Team

--- a/tests/routes/settings/tokens/new-test.js
+++ b/tests/routes/settings/tokens/new-test.js
@@ -346,4 +346,30 @@ module('/settings/tokens/new', function (hooks) {
     assert.strictEqual(currentURL(), '/settings/tokens/new?from=1');
     assert.dom('[data-test-title]').hasText('Token not found');
   });
+
+  test('trusted-publishing scope', async function (assert) {
+    prepare(this);
+
+    await visit('/settings/tokens/new');
+    assert.strictEqual(currentURL(), '/settings/tokens/new');
+
+    await fillIn('[data-test-name]', 'trusted-publishing-token');
+    await select('[data-test-expiry]', 'none');
+    await click('[data-test-scope="trusted-publishing"]');
+    await click('[data-test-generate]');
+
+    let token = this.db.apiToken.findFirst({ where: { name: { equals: 'trusted-publishing-token' } } });
+    assert.ok(Boolean(token), 'API token has been created in the backend database');
+    assert.strictEqual(token.name, 'trusted-publishing-token');
+    assert.strictEqual(token.expiredAt, null);
+    assert.strictEqual(token.crateScopes, null);
+    assert.deepEqual(token.endpointScopes, ['trusted-publishing']);
+
+    assert.strictEqual(currentURL(), '/settings/tokens');
+    assert.dom('[data-test-api-token="1"] [data-test-name]').hasText('trusted-publishing-token');
+    assert.dom('[data-test-api-token="1"] [data-test-token]').hasText(token.token);
+    assert.dom('[data-test-api-token="1"] [data-test-endpoint-scopes]').hasText('Scopes: trusted-publishing');
+    assert.dom('[data-test-api-token="1"] [data-test-crate-scopes]').doesNotExist();
+    assert.dom('[data-test-api-token="1"] [data-test-expired-at]').doesNotExist();
+  });
 });


### PR DESCRIPTION
This PR adds a new `trusted-publishing` endpoint scope to our API tokens. If this scope is used, then the API token can be used to create, list and delete Trusted Publishing configurations for the configured crates. As with the other scopes, a legacy token without any scopes can also be used for the same purpose now.

This change will allow our users with larger workspaces to automate the setup of creating Trusted Publishing configurations, which should help with adoption of Trusted Publishing by power users.