### PR TITLE
settings/tokens: Fix scope list formatting

### DIFF
--- a/app/components/tooltip.gjs
+++ b/app/components/tooltip.gjs
@@ -64,10 +64,12 @@ export default class Tooltip extends Component {
     return () => cleanup();
   });
 
+  // The `{{~@x~}}` is used for whitespace control to ensure we don't insert a leading whitespace element
   <template>
+    {{~@x~}}
     <span class='anchor' {{this.onInsertAnchor this}} />
 
-    {{#if this.visible}}
+    {{~#if this.visible}}
       {{#in-element this.containerElement}}
         <div class='tooltip' ...attributes {{this.attachTooltip this side=@side}}>
           {{#if (has-block)}}
@@ -77,6 +79,6 @@ export default class Tooltip extends Component {
           {{/if}}
         </div>
       {{/in-element}}
-    {{/if}}
+    {{/if~}}
   </template>
 }

--- a/e2e/routes/settings/tokens/index.spec.ts
+++ b/e2e/routes/settings/tokens/index.spec.ts
@@ -49,8 +49,8 @@ test.describe('/settings/tokens', { tag: '@routes' }, () => {
     await expect(page).toHaveURL('/settings/tokens');
     await expect(page.locator('[data-test-api-token]')).toHaveCount(1);
     await expect(page.locator('[data-test-endpoint-scopes]')).toHaveText(
-      'Scopes: publish-new , publish-update , and yank',
+      'Scopes: publish-new, publish-update, and yank',
     );
-    await expect(page.locator('[data-test-crate-scopes]')).toHaveText('Crates: serde , serde-* , and serde_*');
+    await expect(page.locator('[data-test-crate-scopes]')).toHaveText('Crates: serde, serde-*, and serde_*');
   });
 });

--- a/tests/routes/settings/tokens/index-test.js
+++ b/tests/routes/settings/tokens/index-test.js
@@ -54,7 +54,7 @@ module('/settings/tokens', function (hooks) {
     await visit('/settings/tokens');
     assert.strictEqual(currentURL(), '/settings/tokens');
     assert.dom('[data-test-api-token]').exists({ count: 1 });
-    assert.dom('[data-test-endpoint-scopes]').hasText('Scopes: publish-new , publish-update , and yank');
-    assert.dom('[data-test-crate-scopes]').hasText('Crates: serde , serde-* , and serde_*');
+    assert.dom('[data-test-endpoint-scopes]').hasText('Scopes: publish-new, publish-update, and yank');
+    assert.dom('[data-test-crate-scopes]').hasText('Crates: serde, serde-*, and serde_*');
   });
 });

--- a/tests/routes/settings/tokens/index-test.js
+++ b/tests/routes/settings/tokens/index-test.js
@@ -41,4 +41,20 @@ module('/settings/tokens', function (hooks) {
     assert.dom('[data-test-name]', tokens[1]).hasText('token-1');
     assert.dom('[data-test-token]', tokens[1]).doesNotExist();
   });
+
+  test('scope formatting', async function (assert) {
+    let { user } = prepare(this);
+
+    this.db.apiToken.create({
+      user,
+      endpointScopes: ['publish-new', 'publish-update', 'yank'],
+      crateScopes: ['serde', 'serde-*', 'serde_*'],
+    });
+
+    await visit('/settings/tokens');
+    assert.strictEqual(currentURL(), '/settings/tokens');
+    assert.dom('[data-test-api-token]').exists({ count: 1 });
+    assert.dom('[data-test-endpoint-scopes]').hasText('Scopes: publish-new , publish-update , and yank');
+    assert.dom('[data-test-crate-scopes]').hasText('Crates: serde , serde-* , and serde_*');
+  });
 });


### PR DESCRIPTION
Previously the page would show lists of crate name patterns as: `Crates: serde , serde-* , and serde_*` (with an additional whitespace in front of the comma). This was apparently introduced unintentionally when we refactored our tooltip implementation.

This PR removes the excess whitespace so that the page now shows `Crates: serde, serde-*, and serde_*`. This PR also adds corresponding tests to avoid future regressions.