### PR TITLE
linecount: Fix dependency declaration

### DIFF
--- a/crates/crates_io_linecount/Cargo.toml
+++ b/crates/crates_io_linecount/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 workspace = true
 
 [dependencies]
-serde = { version = "=1.0.223", features = ["derive"] }
+serde = { version = "=1.0.225", features = ["derive"] }
 tokei = "=13.0.0-alpha.9"
 
 [dev-dependencies]


### PR DESCRIPTION
serde got updated since the last update of #11453, so merging the latter caused an unintentional merge conflict.