### PR TITLE
webpack: Avoid SVG file inlining

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -105,7 +105,7 @@ module.exports = function (defaults) {
             },
             {
               test: /\.svg$/,
-              type: 'asset',
+              type: 'asset/resource',
             },
           ],
         },


### PR DESCRIPTION
While this works and can be beneficial, it conflicts with our Content Security Policy (https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) setting in production, so let's avoid the inlining for now until we can figure out a way to improve compatibility between the two.

This is how the token expiry dropdown is supposed to look like:

<img width="180" height="95" alt="Bildschirmfoto 2025-09-18 um 11 20 45" src="https://github.com/user-attachments/assets/b69f5854-307a-4d4c-9409-652b11cb5bdb" />


and this is how it currently looks like in production:

<img width="211" height="112" alt="Bildschirmfoto 2025-09-18 um 11 20 55" src="https://github.com/user-attachments/assets/6b63fb52-7d0d-49d8-8d64-073595ebb928" />


This PR fixes the issue :)