### PR TITLE
database: Add index to optimize background job queue processing

### DIFF
--- a/migrations/2025-09-22-090805_add_background_jobs_priority_id_index/down.sql
+++ b/migrations/2025-09-22-090805_add_background_jobs_priority_id_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY background_jobs_priority_id_index;

--- a/migrations/2025-09-22-090805_add_background_jobs_priority_id_index/metadata.toml
+++ b/migrations/2025-09-22-090805_add_background_jobs_priority_id_index/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2025-09-22-090805_add_background_jobs_priority_id_index/up.sql
+++ b/migrations/2025-09-22-090805_add_background_jobs_priority_id_index/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY background_jobs_priority_id_index
+    ON background_jobs (priority DESC, id ASC);


### PR DESCRIPTION
This commit creates a composite index on `(priority DESC, id ASC)` to improve performance of job selection queries that order by priority and id for queue processing.

This improved the job selection query performance from roughly [800ms](https://explain.dalibo.com/plan/9c9d43bb6d74e78g) to [0.07ms](https://explain.dalibo.com/plan/b1e72a231gg78a1h) after enqueuing all of the `analyze-crate-file` backfill background jobs.

---

Without the index, the background worker got increasingly faster the less jobs were in the database:

<img width="720" height="435" alt="grafik" src="https://github.com/user-attachments/assets/81be2ed1-cb84-4f6b-9406-833007921cca" />

With this index we should have seen a mostly linear graph.
