### PR TITLE
trustpub: Extract `ConfigCreatedEmail` and `ConfigDeletedEmail` structs

### DIFF
--- a/crates/crates_io_database/src/models/krate.rs
+++ b/crates/crates_io_database/src/models/krate.rs
@@ -35,7 +35,7 @@ pub struct Crate {
     pub homepage: Option<String>,
     pub documentation: Option<String>,
     pub repository: Option<String>,
-    max_upload_size: Option<i32>,
+    pub max_upload_size: Option<i32>,
     pub max_features: Option<i16>,
 }
 

--- a/src/controllers/trustpub/emails.rs
+++ b/src/controllers/trustpub/emails.rs
@@ -4,9 +4,13 @@ use crates_io_database::models::{Crate, User};
 
 #[derive(serde::Serialize)]
 pub struct ConfigCreatedEmail<'a> {
+    /// The GitHub login of the email recipient.
     pub recipient: &'a str,
+    /// The user who created the trusted publishing configuration.
     pub auth_user: &'a User,
+    /// The crate for which the trusted publishing configuration was created.
     pub krate: &'a Crate,
+    /// The trusted publishing configuration that was created.
     pub saved_config: &'a GitHubConfig,
 }
 
@@ -18,9 +22,13 @@ impl ConfigCreatedEmail<'_> {
 
 #[derive(serde::Serialize)]
 pub struct ConfigDeletedEmail<'a> {
+    /// The GitHub login of the email recipient.
     pub recipient: &'a str,
+    /// The user who deleted the trusted publishing configuration.
     pub auth_user: &'a User,
+    /// The crate for which the trusted publishing configuration was deleted.
     pub krate: &'a Crate,
+    /// The trusted publishing configuration that was deleted.
     pub config: &'a GitHubConfig,
 }
 

--- a/src/controllers/trustpub/emails.rs
+++ b/src/controllers/trustpub/emails.rs
@@ -1,0 +1,31 @@
+use crate::email::EmailMessage;
+use crates_io_database::models::trustpub::GitHubConfig;
+use crates_io_database::models::{Crate, User};
+
+#[derive(serde::Serialize)]
+pub struct ConfigCreatedEmail<'a> {
+    pub recipient: &'a str,
+    pub auth_user: &'a User,
+    pub krate: &'a Crate,
+    pub saved_config: &'a GitHubConfig,
+}
+
+impl ConfigCreatedEmail<'_> {
+    pub fn render(&self) -> Result<EmailMessage, minijinja::Error> {
+        EmailMessage::from_template("trustpub_config_created", self)
+    }
+}
+
+#[derive(serde::Serialize)]
+pub struct ConfigDeletedEmail<'a> {
+    pub recipient: &'a str,
+    pub auth_user: &'a User,
+    pub krate: &'a Crate,
+    pub config: &'a GitHubConfig,
+}
+
+impl ConfigDeletedEmail<'_> {
+    pub fn render(&self) -> Result<EmailMessage, minijinja::Error> {
+        EmailMessage::from_template("trustpub_config_deleted", self)
+    }
+}

--- a/src/controllers/trustpub/emails.rs
+++ b/src/controllers/trustpub/emails.rs
@@ -37,3 +37,138 @@ impl ConfigDeletedEmail<'_> {
         EmailMessage::from_template("trustpub_config_deleted", self)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use claims::assert_ok;
+    use insta::assert_snapshot;
+
+    fn test_user() -> User {
+        User {
+            id: 1,
+            gh_login: "octocat".into(),
+            name: Some("The Octocat".into()),
+            gh_id: 123,
+            gh_avatar: None,
+            gh_encrypted_token: vec![],
+            account_lock_reason: None,
+            account_lock_until: None,
+            is_admin: false,
+            publish_notifications: true,
+        }
+    }
+
+    fn test_crate() -> Crate {
+        Crate {
+            id: 1,
+            name: "my-crate".into(),
+            updated_at: Utc::now(),
+            created_at: Utc::now(),
+            description: None,
+            homepage: None,
+            documentation: None,
+            repository: None,
+            max_upload_size: None,
+            max_features: None,
+        }
+    }
+
+    fn test_github_config(environment: Option<&str>) -> GitHubConfig {
+        GitHubConfig {
+            id: 1,
+            created_at: Utc::now(),
+            crate_id: 1,
+            repository_owner_id: 42,
+            repository_owner: "rust-lang".into(),
+            repository_name: "rust".into(),
+            workflow_filename: "publish.yml".into(),
+            environment: environment.map(String::from),
+        }
+    }
+
+    #[test]
+    fn test_config_created_email() {
+        let email = ConfigCreatedEmail {
+            recipient: "octocat",
+            auth_user: &test_user(),
+            krate: &test_crate(),
+            saved_config: &test_github_config(None),
+        };
+
+        let rendered = assert_ok!(email.render());
+        assert_snapshot!(rendered.subject, @"crates.io: Trusted Publishing configuration added to my-crate");
+        assert_snapshot!(rendered.body_text);
+    }
+
+    #[test]
+    fn test_config_created_email_with_environment() {
+        let email = ConfigCreatedEmail {
+            recipient: "octocat",
+            auth_user: &test_user(),
+            krate: &test_crate(),
+            saved_config: &test_github_config(Some("production")),
+        };
+
+        let rendered = assert_ok!(email.render());
+        assert_snapshot!(rendered.subject, @"crates.io: Trusted Publishing configuration added to my-crate");
+        assert_snapshot!(rendered.body_text);
+    }
+
+    #[test]
+    fn test_config_created_email_different_recipient() {
+        let email = ConfigCreatedEmail {
+            recipient: "team-member",
+            auth_user: &test_user(),
+            krate: &test_crate(),
+            saved_config: &test_github_config(None),
+        };
+
+        let rendered = assert_ok!(email.render());
+        assert_snapshot!(rendered.subject, @"crates.io: Trusted Publishing configuration added to my-crate");
+        assert_snapshot!(rendered.body_text);
+    }
+
+    #[test]
+    fn test_config_deleted_email() {
+        let email = ConfigDeletedEmail {
+            recipient: "octocat",
+            auth_user: &test_user(),
+            krate: &test_crate(),
+            config: &test_github_config(None),
+        };
+
+        let rendered = assert_ok!(email.render());
+        assert_snapshot!(rendered.subject, @"crates.io: Trusted Publishing configuration removed from my-crate");
+        assert_snapshot!(rendered.body_text);
+    }
+
+    #[test]
+    fn test_config_deleted_email_with_environment() {
+        let email = ConfigDeletedEmail {
+            recipient: "octocat",
+            auth_user: &test_user(),
+            krate: &test_crate(),
+            config: &test_github_config(Some("production")),
+        };
+
+        let rendered = assert_ok!(email.render());
+        assert_snapshot!(rendered.subject, @"crates.io: Trusted Publishing configuration removed from my-crate");
+        assert_snapshot!(rendered.body_text);
+    }
+
+    #[test]
+    fn test_config_deleted_email_different_recipient() {
+        let email = ConfigDeletedEmail {
+            recipient: "team-member",
+            auth_user: &test_user(),
+            krate: &test_crate(),
+            config: &test_github_config(None),
+        };
+
+        let rendered = assert_ok!(email.render());
+        assert_snapshot!(rendered.subject, @"crates.io: Trusted Publishing configuration removed from my-crate");
+        assert_snapshot!(rendered.body_text);
+    }
+}

--- a/src/controllers/trustpub/github_configs/create/mod.rs
+++ b/src/controllers/trustpub/github_configs/create/mod.rs
@@ -1,14 +1,14 @@
 use crate::app::AppState;
 use crate::auth::AuthCheck;
 use crate::controllers::krate::load_crate;
+use crate::controllers::trustpub::emails::ConfigCreatedEmail;
 use crate::controllers::trustpub::github_configs::json;
-use crate::email::EmailMessage;
 use crate::util::errors::{AppResult, bad_request, forbidden, server_error};
 use anyhow::Context;
 use axum::Json;
+use crates_io_database::models::OwnerKind;
 use crates_io_database::models::token::EndpointScope;
-use crates_io_database::models::trustpub::{GitHubConfig, NewGitHubConfig};
-use crates_io_database::models::{Crate, OwnerKind, User};
+use crates_io_database::models::trustpub::NewGitHubConfig;
 use crates_io_database::schema::{crate_owners, emails, users};
 use crates_io_github::GitHubError;
 use crates_io_trustpub::github::validation::{
@@ -141,20 +141,6 @@ pub async fn create_trustpub_github_config(
     };
 
     Ok(Json(json::CreateResponse { github_config }))
-}
-
-#[derive(serde::Serialize)]
-struct ConfigCreatedEmail<'a> {
-    recipient: &'a str,
-    auth_user: &'a User,
-    krate: &'a Crate,
-    saved_config: &'a GitHubConfig,
-}
-
-impl ConfigCreatedEmail<'_> {
-    fn render(&self) -> Result<EmailMessage, minijinja::Error> {
-        EmailMessage::from_template("trustpub_config_created", self)
-    }
 }
 
 async fn send_notification_email(

--- a/src/controllers/trustpub/github_configs/delete/mod.rs
+++ b/src/controllers/trustpub/github_configs/delete/mod.rs
@@ -1,12 +1,12 @@
 use crate::app::AppState;
 use crate::auth::AuthCheck;
-use crate::email::EmailMessage;
+use crate::controllers::trustpub::emails::ConfigDeletedEmail;
 use crate::util::errors::{AppResult, bad_request, not_found};
 use anyhow::Context;
 use axum::extract::Path;
 use crates_io_database::models::token::EndpointScope;
 use crates_io_database::models::trustpub::GitHubConfig;
-use crates_io_database::models::{Crate, OwnerKind, User};
+use crates_io_database::models::{Crate, OwnerKind};
 use crates_io_database::schema::{crate_owners, crates, emails, trustpub_configs_github, users};
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -95,20 +95,6 @@ pub async fn delete_trustpub_github_config(
     }
 
     Ok(StatusCode::NO_CONTENT)
-}
-
-#[derive(serde::Serialize)]
-struct ConfigDeletedEmail<'a> {
-    recipient: &'a str,
-    auth_user: &'a User,
-    krate: &'a Crate,
-    config: &'a GitHubConfig,
-}
-
-impl ConfigDeletedEmail<'_> {
-    fn render(&self) -> Result<EmailMessage, minijinja::Error> {
-        EmailMessage::from_template("trustpub_config_deleted", self)
-    }
 }
 
 async fn send_notification_email(

--- a/src/controllers/trustpub/mod.rs
+++ b/src/controllers/trustpub/mod.rs
@@ -1,2 +1,3 @@
+pub mod emails;
 pub mod github_configs;
 pub mod tokens;

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email-2.snap
@@ -1,0 +1,21 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You added a new "Trusted Publishing" configuration for GitHub Actions to your crate "my-crate". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: rust
+- Workflow filename: publish.yml
+- Environment: (not set)
+
+If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
+
+If you are unable to revert the change and need to do so, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_different_recipient-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_different_recipient-2.snap
@@ -1,0 +1,21 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello team-member!
+
+crates.io user octocat added a new "Trusted Publishing" configuration for GitHub Actions to a crate that you manage ("my-crate"). Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: rust
+- Workflow filename: publish.yml
+- Environment: (not set)
+
+If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
+
+If you are unable to revert the change and need to do so, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_with_environment-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_created_email_with_environment-2.snap
@@ -1,0 +1,21 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You added a new "Trusted Publishing" configuration for GitHub Actions to your crate "my-crate". Trusted publishers act as trusted users and can publish new versions of the crate automatically.
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: rust
+- Workflow filename: publish.yml
+- Environment: production
+
+If you did not make this change and you think it was made maliciously, you can remove the configuration from the crate via the "Settings" tab on the crate's page.
+
+If you are unable to revert the change and need to do so, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email-2.snap
@@ -1,0 +1,19 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "my-crate".
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: rust
+- Workflow filename: publish.yml
+- Environment: (not set)
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_different_recipient-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_different_recipient-2.snap
@@ -1,0 +1,19 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello team-member!
+
+crates.io user octocat removed a "Trusted Publishing" configuration for GitHub Actions from a crate that you manage ("my-crate").
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: rust
+- Workflow filename: publish.yml
+- Environment: (not set)
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team

--- a/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_with_environment-2.snap
+++ b/src/controllers/trustpub/snapshots/crates_io__controllers__trustpub__emails__tests__config_deleted_email_with_environment-2.snap
@@ -1,0 +1,19 @@
+---
+source: src/controllers/trustpub/emails.rs
+expression: rendered.body_text
+---
+Hello octocat!
+
+You removed a "Trusted Publishing" configuration for GitHub Actions from your crate "my-crate".
+
+Trusted Publishing configuration:
+
+- Repository owner: rust-lang
+- Repository name: rust
+- Workflow filename: publish.yml
+- Environment: production
+
+If you did not make this change and you think it was made maliciously, you can email help@crates.io for assistance.
+
+--
+The crates.io Team


### PR DESCRIPTION
This improves type safety for these templates since the passed in template context is now less dynamic. This PR also adds a couple of rendering tests for these emails to ensure that they match our expectations.