### PR TITLE
CI: Ensure that the build fails if the lockfile needs an update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,7 @@ jobs:
       - run: sudo systemctl start postgresql.service
       - run: sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD 'postgres'"
 
+      - run: cargo fetch --locked
       - run: cargo build --tests --workspace
       - run: cargo test --workspace
         env:


### PR DESCRIPTION
For pnpm this is the default behavior on CI systems, but for cargo this does not appear to be the case.