### PR TITLE
Add ARIA heading role to crate search results

### DIFF
--- a/app/components/crate-row.gjs
+++ b/app/components/crate-row.gjs
@@ -16,7 +16,7 @@ import truncateText from 'crates-io/helpers/truncate-text';
 <template>
   <div data-test-crate-row ...attributes class='crate-row'>
     <div class='description-box'>
-      <div class='crate-spec'>
+      <div data-test-crate-spec class='crate-spec' role='heading' aria-level='2'>
         {{#let (link_ 'crate' @crate.id) as |l|}}
           <a href={{l.url}} class='name' data-test-crate-link {{on 'click' l.transitionTo}}>
             {{@crate.name}}

--- a/e2e/acceptance/search.spec.ts
+++ b/e2e/acceptance/search.spec.ts
@@ -21,6 +21,7 @@ test.describe('Acceptance | search', { tag: '@acceptance' }, () => {
     );
     await expect(page.locator('[data-test-crate-row="0"] [data-test-crate-link]')).toHaveText('kinetic-rust');
     await expect(page.locator('[data-test-crate-row="0"] [data-test-version]')).toHaveText('v0.0.16');
+    await expect(page.locator('[data-test-crate-row="0"] [data-test-crate-spec]')).toHaveRole('heading');
 
     await expect(page.locator('[data-test-crate-row="0"] [data-test-description]')).toHaveText(
       'A Kinetic protocol library written in Rust',


### PR DESCRIPTION
Closes #11759 

Making name and version appear as headings inside search results list is important for screen-reader users. It allows for jumping between elements of a list by pressing a single key on the keyboard.

Level 2 headings seem to be more appropriate given the current site structure.

I went with ARIA roles and attributes rather than `h2` tag so as to not mess up the visual appearance. If using the semantic tag is preferred, please provide the right CSS rules as I am not able to verify this myself.