### PR TITLE
CI: Adjust `actions/upload-artifact` version tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
       - if: github.repository == 'rust-lang/crates.io'
         run: pnpm percy exec --parallel -- pnpm e2e
 
-      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !cancelled() }}
         with:
           name: playwright-report


### PR DESCRIPTION
This resolves a [zizmor warning](https://docs.zizmor.sh/audits/#ref-version-mismatch) due to `v4` and SHA1 hash mismatch