### PR TITLE
trustpub: Add `GITLAB_ISSUER_URL` constant

### DIFF
--- a/crates/crates_io_trustpub/examples/load_jwks.rs
+++ b/crates/crates_io_trustpub/examples/load_jwks.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, ValueEnum};
 use crates_io_trustpub::github::GITHUB_ISSUER_URL;
+use crates_io_trustpub::gitlab::GITLAB_ISSUER_URL;
 use crates_io_trustpub::keystore::load_jwks::load_jwks;
 use reqwest::Client;
 
@@ -15,7 +16,7 @@ impl Provider {
     fn issuer_url(&self) -> &'static str {
         match self {
             Provider::GitHub => GITHUB_ISSUER_URL,
-            Provider::GitLab => "https://gitlab.com",
+            Provider::GitLab => GITLAB_ISSUER_URL,
         }
     }
 }

--- a/crates/crates_io_trustpub/src/gitlab/mod.rs
+++ b/crates/crates_io_trustpub/src/gitlab/mod.rs
@@ -1,0 +1,1 @@
+pub const GITLAB_ISSUER_URL: &str = "https://gitlab.com";

--- a/crates/crates_io_trustpub/src/lib.rs
+++ b/crates/crates_io_trustpub/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod access_token;
 pub mod github;
+pub mod gitlab;
 pub mod keystore;
 #[cfg(any(test, feature = "test-helpers"))]
 pub mod test_keys;


### PR DESCRIPTION
... and support for it in the `load_jwks` example binary

### Related

- https://github.com/rust-lang/crates.io/issues/11987