### PR TITLE
Create database index to speed up `trustpub_configs_github` table queries

### DIFF
--- a/migrations/2025-09-29-161354_add_index_trustpub_configs_github_repo/down.sql
+++ b/migrations/2025-09-29-161354_add_index_trustpub_configs_github_repo/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX idx_trustpub_configs_github_repo;

--- a/migrations/2025-09-29-161354_add_index_trustpub_configs_github_repo/metadata.toml
+++ b/migrations/2025-09-29-161354_add_index_trustpub_configs_github_repo/metadata.toml
@@ -1,0 +1,1 @@
+run_in_transaction = false

--- a/migrations/2025-09-29-161354_add_index_trustpub_configs_github_repo/up.sql
+++ b/migrations/2025-09-29-161354_add_index_trustpub_configs_github_repo/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_trustpub_configs_github_repo
+ON trustpub_configs_github (LOWER(repository_owner), LOWER(repository_name));


### PR DESCRIPTION
With less than 1000 Trusted Publishing configurations created so far, a full table scan isn't too bad, but using an index should still result in much better performance long term.