### PR TITLE
Downgrade axum-extra to v0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -790,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.11.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "543f0799d22486525744f06a3580b64f3e51d97aba73ea0e09040969c0034722"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
  "axum",
  "axum-core",
@@ -806,13 +806,14 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "serde",
+ "rustversion",
+ "serde_core",
  "serde_html_form",
  "serde_json",
  "serde_path_to_error",
- "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "typed-json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ aws-ip-ranges = "=0.1436.0"
 aws-sdk-cloudfront = "=1.95.0"
 aws-sdk-sqs = "=1.84.1"
 axum = { version = "=0.8.6", features = ["macros", "matched-path"] }
-axum-extra = { version = "=0.11.0", features = ["erased-json", "query", "typed-header"] }
+axum-extra = { version = "=0.10.3", features = ["erased-json", "query", "typed-header"] }
 base64 = "=0.22.1"
 bigdecimal = { version = "=0.4.8", features = ["serde"] }
 bon = "=3.7.2"

--- a/crates/crates_io_session/Cargo.toml
+++ b/crates/crates_io_session/Cargo.toml
@@ -9,7 +9,7 @@ workspace = true
 
 [dependencies]
 axum = { version = "=0.8.6", features = ["macros"] }
-axum-extra = { version = "=0.11.0", features = ["cookie-signed"] }
+axum-extra = { version = "=0.10.3", features = ["cookie-signed"] }
 base64 = "=0.22.1"
 cookie = { version = "=0.18.1", features = ["secure"] }
 parking_lot = "=0.12.4"


### PR DESCRIPTION
v0.11.0 was yanked due to an unintentional breaking change that didn't affect us