### PR TITLE
pretty-bytes: Use locale-aware formatting via `intl` service

### DIFF
--- a/app/helpers/pretty-bytes.js
+++ b/app/helpers/pretty-bytes.js
@@ -1,13 +1,19 @@
-import { helper } from '@ember/component/helper';
+import Helper from '@ember/component/helper';
+import { service } from '@ember/service';
 
 import prettyBytes from 'pretty-bytes';
 
 /**
  * See https://github.com/rust-lang/crates.io/discussions/7177
  */
-export default helper(([bytes], options) =>
-  prettyBytes(bytes, {
-    binary: true,
-    ...options,
-  }),
-);
+export default class PrettyBytesHelper extends Helper {
+  @service intl;
+
+  compute([bytes], options) {
+    return prettyBytes(bytes, {
+      binary: true,
+      locale: this.intl.locale ?? true,
+      ...options,
+    });
+  }
+}


### PR DESCRIPTION
This fixes the formatting mismatch between the SLoC and crate size values, that were using different rules right next to each other.

### Before

<img width="144" height="79" alt="Bildschirmfoto 2025-10-02 um 05 24 12" src="https://github.com/user-attachments/assets/fa8f34a9-f107-4083-bbc1-7ad3bd786f93" />

### After 

<img width="174" height="80" alt="Bildschirmfoto 2025-10-02 um 05 24 02" src="https://github.com/user-attachments/assets/e310a3f9-5b9c-4307-92a1-7d3e33400e92" />
