### PR TITLE
Fix <picture> sources not follow color scheme preference

### DIFF
--- a/app/components/rendered-html.gjs
+++ b/app/components/rendered-html.gjs
@@ -16,7 +16,7 @@ export default class extends Component {
     <TextContent
       ...attributes
       {{highlightSyntax @html selector='pre > code:not(.language-mermaid)'}}
-      {{updateSourceMedia @html this.colorScheme.resolvedScheme}}
+      {{updateSourceMedia this.colorScheme.resolvedScheme @html}}
       {{renderMermaids @html}}
     >
       {{htmlSafe @html}}


### PR DESCRIPTION
This PR fix `<picture>` element not follow colorPreference, see my crate [simpleicons-rs](https://crates.io/crates/simpleicons-rs), it has a <picture> element in front of README, and I prepare two color pictures for it:

```
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/cscnk52/simpleicons-rs/raw/refs/heads/main/assets/img/simpleicons-rs-banner-dark.png" />
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/cscnk52/simpleicons-rs/raw/refs/heads/main/assets/img/simpleicons-rs-banner-light.png" />
  <img alt="simpleicons-rs banner" src="https://github.com/cscnk52/simpleicons-rs/raw/refs/heads/main/assets/img/simpleicons-rs-banner-light.png" />
</picture>
```

It should follow crates.io theme to change, but not.

After attach debug to it, I found just wrong order of `colorPreference` and `input`, just swap them to fix.

<img width="668" height="373" alt="image" src="https://github.com/user-attachments/assets/7fe23824-80e5-43b3-960a-5a72635a3fbe" />

After fix, it looks good.

![PixPin_2025-10-03_12-52-40](https://github.com/user-attachments/assets/b17cd4b2-b706-47a9-964c-825a45520af4)

Related to https://github.com/rust-lang/crates.io/commit/a216b9f7ad35821011b86030559315b8da44e76e#diff-e24e30bcf8defc9f1a68733bae25f89198502daa94e3a20ae0dc4d5a8f971a3fL9-R9
